### PR TITLE
Fix the tarball-listing SIGPIPE failure in the engine release

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -141,7 +141,11 @@ jobs:
             --directory "${RUNNER_TEMP}/stage" \
             --file "dist/${name}.tar.gz" \
             "$name"
-          tar --list --file "dist/${name}.tar.gz" | head -n 20
+          # Listed to a file first: piping straight into `head` closes the pipe
+          # after 20 lines and, under pipefail, tar's resulting write error
+          # fails the step.
+          tar --list --file "dist/${name}.tar.gz" > "${RUNNER_TEMP}/tarball-listing.txt"
+          head -n 20 "${RUNNER_TEMP}/tarball-listing.txt"
 
       - name: Inventory the engine dependency tree
         env:


### PR DESCRIPTION
## What

The packaging step piped the tarball listing straight into `head -n 20` under `set -o pipefail`; `head` closes the pipe after 20 lines and `tar`'s resulting write error (exit 2) failed the step. Surfaced on the first-ever `antiburn-local-v0.1.0` run. The listing now goes to a file first, then `head` reads the file.

## Why

The `antiburn-local-v0.1.0` release run failed at "Package the source tarball" after the archive itself was built correctly — the failure is purely the display of its first 20 entries.

## Verification

- `node scripts/check-boundary.mjs` — clean
- The failed run's log shows exactly 20 listing lines followed by `tar: stdout: write error`, matching the diagnosis; the other `| head` uses in the workflows read short `find` output that fits the pipe buffer and completes before `head` exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)