### PR TITLE
Skip provenance attestation while the repository is private

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -686,13 +686,19 @@ jobs:
           echo "Release contents:"
           ls -l dist
 
+      # Attestation persistence is plan-gated on private repositories, so while
+      # the repository is private these two steps skip themselves; they activate
+      # automatically the day the repository becomes public. No other step
+      # consumes their outputs.
       - name: Attest the build provenance
         id: attest
+        if: ${{ !github.event.repository.private }}
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/*
 
       - name: Add the provenance bundle to the release
+        if: ${{ !github.event.repository.private }}
         env:
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
           VERSION: ${{ needs.verify.outputs.version }}

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -176,13 +176,19 @@ jobs:
           mv "${RUNNER_TEMP}/SHA256SUMS" dist/SHA256SUMS
           ls -l dist
 
+      # Attestation persistence is plan-gated on private repositories, so while
+      # the repository is private these two steps skip themselves; they activate
+      # automatically the day the repository becomes public. No other step
+      # consumes their outputs.
       - name: Attest the build provenance
         id: attest
+        if: ${{ !github.event.repository.private }}
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/*
 
       - name: Add the provenance bundle to the release
+        if: ${{ !github.event.repository.private }}
         env:
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
           VERSION: ${{ needs.verify.outputs.version }}

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -280,7 +280,10 @@ and a provenance record.
    `NOTICE` alongside it, inventories the dependency tree, attests provenance,
    and drafts the release.
 4. Review the draft: the tarball extracts, `cargo test` passes inside it, the
-   checksum matches, provenance verifies.
+   checksum matches, provenance verifies. (While the repository is private, the
+   two provenance steps skip themselves — attestation persistence is plan-gated
+   on private repositories — and activate automatically once the repository is
+   public; a private-phase draft has no provenance bundle to verify.)
 5. Publish. **Leave "Set as the latest release" unchecked** — the workflow
    already sets `--latest=false`, and for good reason: "latest" is a property of
    the repository, and the application's updater reads


### PR DESCRIPTION
## What

Gates the "Attest the build provenance" and "Add the provenance bundle to the release" steps in both release workflows on `!github.event.repository.private`. While the repository is private the steps skip themselves; they activate automatically the day the repository becomes public. The runbook's draft-review checklist now notes that a private-phase draft has no provenance bundle to verify.

## Why

The `antiburn-local-v0.1.0` release run (after the tarball-listing fix) failed at attestation with "Feature not available for the antiburn organization. To enable this feature, please upgrade the billing plan, or make this repository public." — attestation persistence is plan-gated on private repositories. The workflow's own design note already says public repositories get this for free; this makes the private staging phase survivable without weakening the public end state.

## Verification

- `node scripts/check-boundary.mjs` — clean
- No other step consumes the attest outputs (`bundle-path` is only read by the gated bundle-copy step), so skipping both leaves the draft assembly unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)