### PR TITLE
Report the canonical path, not the identity key, from scan-down

### DIFF
--- a/crates/antiburn-local/src/repositories/sessions.rs
+++ b/crates/antiburn-local/src/repositories/sessions.rs
@@ -912,10 +912,15 @@ pub async fn resolve_granted_repos(
             scan_dir_for_repos(dir, &owner_lower, SCAN_DEPTH, consent, &mut by_root).await;
         }
         for located in by_root.into_values() {
+            // The identity key deduplicates; it is not a path. On Windows it
+            // folds case and separators, so the reported root/suspected path
+            // below carries the canonical path instead — matching the
+            // session-resolved arm above and `LocalRepoStatus`'s contract.
             let root_key = repo_root_identity(&located.repo_root);
-            if !seen.insert(root_key.clone()) {
+            if !seen.insert(root_key) {
                 continue;
             }
+            let root_str = located.repo_root.to_string_lossy().to_string();
             let repo_name = parse_repo_name_from_url(&located.remote_url).unwrap_or_else(|| {
                 located
                     .repo_root
@@ -931,7 +936,7 @@ pub async fn resolve_granted_repos(
                     repo_name,
                     full_name,
                     status: RepoAccessStatus::Accessible,
-                    repo_root: Some(root_key),
+                    repo_root: Some(root_str),
                     suspected_path: None,
                     worktree_count: located.worktree_count,
                     session_count: located.session_count,
@@ -946,7 +951,7 @@ pub async fn resolve_granted_repos(
                     full_name,
                     status: RepoAccessStatus::PermissionDenied,
                     repo_root: None,
-                    suspected_path: Some(root_key),
+                    suspected_path: Some(root_str),
                     worktree_count: located.worktree_count,
                     session_count: located.session_count,
                     enabled: true,

--- a/crates/antiburn-local/src/repositories/tests/scan_tests.rs
+++ b/crates/antiburn-local/src/repositories/tests/scan_tests.rs
@@ -330,6 +330,15 @@ async fn resolve_granted_scans_parent_downward() {
         results[0].session_count, 0,
         "a scan-only granted repository has no sessions"
     );
+    // The reported root is the canonical *path*, not the folded identity key —
+    // on Windows the key lowercases and slash-normalizes, and `repo_root`'s
+    // contract is a filesystem path. Matches the session-resolved arm.
+    let canonical = crate::platform::git::canonical_main_repo_root(&repo_dir).await;
+    assert_eq!(
+        results[0].repo_root.as_deref(),
+        Some(canonical.to_string_lossy().as_ref()),
+        "scan-down must report the canonical path, not the identity key"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Repository discovery now reports the canonical repository path instead of the normalized identity key used for deduplication. This keeps path display correct and prevents future file operations from receiving a lowercased or normalized Windows path.

The change affects both accessible and denied scan results. The identity key remains limited to deduplication.

## Validation

- Repository tests passed.
- Rust formatting and Clippy passed.
- The regression test verifies the canonical path on Windows.