### PR TITLE
Commit the updater public key and guard signing material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 **/target/
 node_modules/
 .DS_Store
+
+# Signing material must never enter the tree. The updater keypair is minted
+# with an absolute path outside the repository (see
+# docs/runbooks/updater-key-recovery.md); this is the backstop.
+*.key
+*.key.pub

--- a/apps/desktop/src-tauri/src/updates.rs
+++ b/apps/desktop/src-tauri/src/updates.rs
@@ -29,13 +29,14 @@
 //!
 //! # The signing key is a release requirement, not a nicety
 //!
-//! `plugins.updater.pubkey` in `tauri.conf.json` is deliberately **empty** in
-//! the committed configuration, and `bundle.createUpdaterArtifacts` is **true**
-//! — so a release build produces signed updater bundles, and this build refuses
-//! to claim update support until the matching public key is committed. The two
-//! halves are one decision: an updater with artifacts but no key would download
-//! something it cannot verify, and an updater with a key but no artifacts would
-//! have nothing to check.
+//! `plugins.updater.pubkey` in `tauri.conf.json` carries the updater key's
+//! public half (minted 2026-08-14; custody in
+//! `docs/runbooks/updater-key-recovery.md`), and
+//! `bundle.createUpdaterArtifacts` is **true** — so a release build produces
+//! signed updater bundles, and this build claims update support only while a
+//! key is present. The two halves are one decision: an updater with artifacts
+//! but no key would download something it cannot verify, and an updater with a
+//! key but no artifacts would have nothing to check.
 //!
 //! A real release therefore **requires** the key pair to exist: the private
 //! half in the release environment as `TAURI_SIGNING_PRIVATE_KEY`, the public

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -48,7 +48,7 @@
       "endpoints": [
         "https://github.com/antiburn/antiburn/releases/latest/download/latest.json"
       ],
-      "pubkey": "",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDgyNjFDODg5MTQ1OTVBNjgKUldSb1dsa1VpY2hoZ3NYYXREYVNnYlVjK1FXTVRRMGlucTRpOW5ZWHZZdWp0ZU5TbE11aVdpOEIK",
       "windows": {
         "installMode": "passive"
       }

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -58,7 +58,7 @@ Placeholders below show the shape, never a real value.
 
 | Secret | Required | What it is | How to produce it |
 | --- | --- | --- | --- |
-| `TAURI_SIGNING_PRIVATE_KEY` | **Always** | The updater's private signing key. Signs every updater bundle; the app verifies against the public half compiled into it. | `pnpm --filter @antiburn/desktop exec tauri signer generate -w ./antiburn.key`, then paste the contents of `antiburn.key`. Placeholder: `dW50cnVzdGVkIGNvbW1lbnQ6…` |
+| `TAURI_SIGNING_PRIVATE_KEY` | **Always** | The updater's private signing key. Signs every updater bundle; the app verifies against the public half compiled into it. | `pnpm --filter @antiburn/desktop exec tauri signer generate -w "$HOME/antiburn.key"` (absolute path — a relative one lands in the working tree), then paste the contents of `antiburn.key`. Placeholder: `dW50cnVzdGVkIGNvbW1lbnQ6…` |
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | If the key has one | The passphrase for the above. Give the key a passphrase. | Chosen when generating the key. Placeholder: `<passphrase>` |
 | `APPLE_CERTIFICATE` | For signed macOS builds | Base64 of the **Developer ID Application** certificate and its private key, exported as `.p12`. | `base64 -i DeveloperID.p12 \| pbcopy`. Placeholder: `MIIM…` |
 | `APPLE_CERTIFICATE_PASSWORD` | With the above | The `.p12` export passphrase. | Chosen during export. Placeholder: `<passphrase>` |

--- a/docs/runbooks/updater-key-recovery.md
+++ b/docs/runbooks/updater-key-recovery.md
@@ -46,8 +46,13 @@ is parsed as strict JSON, so a comment there fails the build.)
 ## Minting it, once
 
 ```bash
-pnpm --filter @antiburn/desktop exec tauri signer generate -w ./antiburn-updater.key
+pnpm --filter @antiburn/desktop exec tauri signer generate -w "$HOME/antiburn-updater.key"
 ```
+
+The `-w` path is deliberately absolute: `pnpm --filter` runs the tool inside
+`apps/desktop`, so a relative path would drop both halves into the working
+tree. `.gitignore` guards `*.key` as a backstop, but the private half should
+never touch the repository at all.
 
 Give it a passphrase. Then:
 


### PR DESCRIPTION
## Summary

- Add the updater public key to the desktop configuration so release builds can produce verifiable update bundles.
- Report updater support when the public key is configured.
- Ignore private key files as a safeguard against accidental commits.
- Update key-generation guidance to write keys outside the working tree.

Only the public key is committed. Release signing material remains in protected environment secrets.

## Validation

- Desktop Rust tests and formatting passed.
- The desktop configuration parses and contains a valid updater public-key block.