### PR TITLE
Unset empty Apple signing env vars on unsigned builds

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -472,6 +472,15 @@ jobs:
           APPIMAGE_EXTRACT_AND_RUN: '1'
         run: |
           set -euo pipefail
+          # The bundler triggers its macOS signing path on the *presence* of
+          # APPLE_CERTIFICATE, so on an unsigned build these must be absent,
+          # not empty — an empty value reaches `security import`, which
+          # rejects it and fails the bundle (the rc.1 rehearsal failure).
+          for var in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [[ -z "${!var:-}" ]]; then
+              unset "$var"
+            fi
+          done
           if [[ -n "${TAURI_SIGNING_CONFIG:-}" ]]; then
             pnpm --filter @antiburn/desktop exec tauri build \
               --target "$TARGET" --bundles "$BUNDLES" --config "$TAURI_SIGNING_CONFIG"


### PR DESCRIPTION
## What

The "Build and sign" step's env block resolves the `APPLE_*` variables to empty strings when `platform_signing != 'developer-id'` (`&& secrets.X || ''`), but Tauri's bundler triggers its macOS signing path on the **presence** of `APPLE_CERTIFICATE` alone. The empty value reached `security import`, which failed with `SecKeychainItemImport: One or more parameters passed to a function were not valid` — killing both macOS legs of the `antiburn-v0.1.0-rc.1` rehearsal after a successful compile. The step now unsets any empty signing variable before invoking the build, so an unsigned build is actually unsigned.

The Windows path needs no change: the Authenticode import step is gated on `platform_signing == 'authenticode'`, so `TAURI_SIGNING_CONFIG` never exists for unsigned builds.

## Verification

- `node scripts/check-boundary.mjs` — clean
- Real verification is the next rc rehearsal run: with the fix, `platform_signing=unsigned` produces an ad-hoc/unsigned bundle instead of attempting a certificate import. (Developer-id mode is unaffected — non-empty values stay set.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)