### PR TITLE
Select the platform's updater format before requiring one signature

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -518,8 +518,8 @@ jobs:
 
       # Collection is driven by the detached signatures rather than by a table
       # of expected filenames: whatever the bundler decided to call the updater
-      # artifact, it is the file sitting next to a `.sig`. That keeps this step
-      # correct across Tauri's own naming changes.
+      # artifact, it is the file sitting next to the platform's updater-format
+      # `.sig`. That keeps this step correct across Tauri's own naming changes.
       #
       # The macOS updater bundle is the one name that must be rewritten: both
       # architectures produce `antiburn.app.tar.gz`, and a release cannot hold
@@ -541,11 +541,21 @@ jobs:
           staging="release-artifacts"
           mkdir -p "$staging"
 
-          signatures=$(find "$bundle" -type f -name '*.sig' | sort)
+          # The bundler signs every bundle format it produces, but only one
+          # format per platform participates in the update flow — on Linux the
+          # AppImage updates while the .deb is install-only, so its signature
+          # is surplus. Select the platform's updater format first, then
+          # require exactly one.
+          case "$UPDATER_PLATFORM" in
+            linux-*) updater_sig_glob='*.AppImage.sig' ;;
+            darwin-*) updater_sig_glob='*.app.tar.gz.sig' ;;
+            *) updater_sig_glob='*.sig' ;;
+          esac
+          signatures=$(find "$bundle" -type f -name "$updater_sig_glob" | sort)
           count=$(printf '%s' "$signatures" | grep -c . || true)
           if [[ "$count" != "1" ]]; then
-            echo "::error::Expected exactly one signed updater artifact for ${TARGET}, found ${count}."
-            printf '%s\n' "$signatures"
+            echo "::error::Expected exactly one signed updater artifact matching ${updater_sig_glob} for ${TARGET}, found ${count}."
+            find "$bundle" -type f -name '*.sig' | sort
             exit 1
           fi
 


### PR DESCRIPTION
## What

The "Collect the built artifacts" step counted every `.sig` under the bundle directory and required exactly one. Linux legitimately produces two — `createUpdaterArtifacts` signs both the AppImage and the `.deb` — so the rc.1 rehearsal's Linux leg failed *after* building everything correctly. The step now selects the platform's updater format first (`*.AppImage.sig` on Linux, `*.app.tar.gz.sig` on macOS, any `.sig` on Windows's single format) and requires exactly one of those. On a mismatch it prints every signature found, so the next surprise is diagnosable from the log.

The `.deb` is unaffected as a release asset — the installer staging block copies it independently.

## Why

Third pipeline defect surfaced by the `antiburn-v0.1.0-rc.1` rehearsal (after the tarball SIGPIPE and the empty-cert import). Notably the Linux leg's failure was *downstream of success*: both bundles built and both signatures verified-signable; only the count assertion was wrong.

## Verification

- `node scripts/check-boundary.mjs` — clean
- Real verification is the rc.2 rehearsal: Linux should now stage `antiburn_<v>_amd64.AppImage` + `.sig` as the updater artifact and the `.deb` as an installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)