### PR TITLE
Prepare the 0.1.0-rc.2 release rehearsal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
-## [0.1.0-rc.1] - 2026-08-14
+## [0.1.0-rc.2] - 2026-08-14
 
 A release-candidate rehearsal build, not a supported release. The macOS and
 Windows binaries are **unsigned** — your operating system will warn you, and it

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "antiburn-local",
  "antiburn-nudge",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/nudge", "crates/sound"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## What

Manifests and lockfile move to `0.1.0-rc.2`, and the changelog section renames from rc.1 — which never produced a draft (its tag carries the empty-cert and signature-count bugs fixed in #11/#13), so there is no build for that section to describe.

## Verification

- `node scripts/verify-release-version.mjs app antiburn-v0.1.0-rc.2` — all four sources agree, pre-release detected
- `node scripts/check-boundary.mjs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)