### PR TITLE
Prepare the 0.1.0-rc.3 release rehearsal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.1.0-rc.3] - 2026-08-15
+
+A release-candidate rehearsal build, not a supported release. The macOS and
+Windows binaries are **unsigned** — your operating system will warn you, and it
+is right to. Install it only if you are testing the release pipeline itself.
+
+On macOS, opening it the first time takes a right-click → Open rather than a
+double-click: the build is sealed but carries no Developer ID, so the warning
+is the system doing its job. If you installed rc.2 and were told the app was
+damaged, this is the release that fixes it — remove the old copy first, or
+clear its quarantine with
+`xattr -dr com.apple.quarantine /Applications/antiburn.app`.
+
 ### Fixed
 
 - The macOS app opens after download. Unsigned rehearsal builds are now sealed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "antiburn-local",
  "antiburn-nudge",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/nudge", "crates/sound"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## What

Manifests and lockfile → `0.1.0-rc.3`; the changelog's Unreleased entries (ad-hoc seal fix, no installer licence gate, in-app legal notices) become the dated `## [0.1.0-rc.3]` section. rc.2 keeps its own section — it produced a real draft with artifacts.

The preamble states what the ad-hoc seal means for a reader (right-click → Open rather than a double-click) and how to recover from rc.2's "damaged" state, since this section becomes the release notes and `latest.json` notes.

## Verification

- `node scripts/verify-release-version.mjs app antiburn-v0.1.0-rc.3` — four sources agree, pre-release detected
- `node scripts/check-boundary.mjs` — clean
- Notes extraction sanity-checked with the workflow's own awk range

🤖 Generated with [Claude Code](https://claude.com/claude-code)