### PR TITLE
Open About's legal documents as views, not accordions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+### Changed
+
+- The legal documents in Settings → About now open as their own pages, with a
+  back arrow, instead of expanding in place and burying the rest of the pane.
+  Each one is reached by an "Open" button on its row, and the attributions for
+  bundled third-party material have moved out of "Legal notices" onto a row of
+  their own.
+
 ## [0.1.0-rc.3] - 2026-08-15
 
 A release-candidate rehearsal build, not a supported release. The macOS and

--- a/apps/desktop/src/components/ui/Pane.tsx
+++ b/apps/desktop/src/components/ui/Pane.tsx
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import type { ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
 
 /** Title bar of a content pane: an optional leading control (a back arrow, say),
  *  the pane title, and an optional trailing action.
@@ -19,17 +19,31 @@ export function PaneHeader({
   title,
   leading,
   trailing,
+  headingRef,
   className = '',
 }: {
   title: string;
   leading?: ReactNode;
   trailing?: ReactNode;
+  /** Set by a pane that pushes a subview, so it can move focus to the new
+   *  title when the surface changes. Taking the ref is what makes the heading
+   *  programmatically focusable — `tabIndex={-1}` follows it rather than
+   *  sitting on every pane title, since a pane nobody navigates *into* has no
+   *  reason to be a focus target. */
+  headingRef?: Ref<HTMLHeadingElement>;
   className?: string;
 }) {
   return (
     <div className={`mb-6 flex items-center gap-2 ${className}`.trimEnd()}>
       {leading}
-      <h1 className="type-title-2 min-w-0 flex-1 text-balance text-label">{title}</h1>
+      <h1
+        ref={headingRef}
+        data-view-heading={headingRef ? '' : undefined}
+        tabIndex={headingRef ? -1 : undefined}
+        className="type-title-2 min-w-0 flex-1 text-balance text-label outline-none"
+      >
+        {title}
+      </h1>
       {trailing}
     </div>
   );

--- a/apps/desktop/src/components/ui/PushButton.tsx
+++ b/apps/desktop/src/components/ui/PushButton.tsx
@@ -22,6 +22,7 @@ export function PushButton({
   variant = 'secondary',
   disabled = false,
   ariaLabel,
+  id,
   className = '',
 }: {
   children: ReactNode;
@@ -31,6 +32,9 @@ export function PushButton({
   disabled?: boolean;
   /** Only needed when the visible label isn't a sufficient accessible name. */
   ariaLabel?: string;
+  /** For a caller that has to find this button again — a pane returning focus
+   *  to the control that opened a subview, after the subview unmounted it. */
+  id?: string;
   className?: string;
 }) {
   const variantClass =
@@ -40,6 +44,7 @@ export function PushButton({
   return (
     <button
       type="button"
+      id={id}
       aria-label={ariaLabel}
       disabled={disabled}
       onClick={onClick}

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -396,7 +396,7 @@ describe('SettingsView', () => {
     render(<SettingsView />);
 
     fireEvent.click(screen.getByRole('tab', { name: 'About' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Licence text' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Open licence text' }));
 
     // A phrase from the licence body proper, not from any label or summary.
     expect(
@@ -406,27 +406,76 @@ describe('SettingsView', () => {
     expect(document.querySelectorAll('a')).toHaveLength(0);
   });
 
-  it('shows the notice and third-party attributions under Legal notices', async () => {
+  it('shows the notice in its own view under Legal notices', async () => {
     render(<SettingsView />);
 
     fireEvent.click(screen.getByRole('tab', { name: 'About' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Legal notices' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Open legal notices' }));
 
     // The NOTICE body is asserted by containment rather than by quoting it
     // here: its text is exempt from the source-boundary scan, this file is
     // not.
     const notices = await screen.findByText(/Copyright \(c\) 2026/);
     expect(notices.textContent).toBe(NOTICE_TEXT.trim());
-    expect(screen.getByText('simple-icons')).toBeInTheDocument();
+    expect(document.querySelectorAll('a')).toHaveLength(0);
+  });
+
+  it('names the bundled third-party material in its own view', async () => {
+    render(<SettingsView />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'About' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Open third-party attributions' }),
+    );
+
+    expect(await screen.findByText('simple-icons')).toBeInTheDocument();
     expect(screen.getByText(/CC0-1\.0/)).toBeInTheDocument();
     expect(document.querySelectorAll('a')).toHaveLength(0);
+  });
+
+  it('lands the reader on the document heading and takes them back to About', async () => {
+    render(<SettingsView />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'About' }));
+    const opener = await screen.findByRole('button', { name: 'Open legal notices' });
+    fireEvent.click(opener);
+
+    // Focus follows the surface: the button that opened this view no longer
+    // exists, so leaving it behind would drop a keyboard reader onto <body>.
+    const heading = await screen.findByRole('heading', { name: 'Legal notices' });
+    expect(heading).toHaveFocus();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to About' }));
+
+    // Back to the card, with focus on the row that was pressed.
+    expect(
+      await screen.findByRole('button', { name: 'Open licence text' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open legal notices' })).toHaveFocus();
+  });
+
+  it('leaves a document behind when the reader changes section', async () => {
+    render(<SettingsView />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'About' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Open licence text' }));
+    expect(await screen.findByRole('heading', { name: 'Licence text' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'General' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'About' }));
+
+    // About opens on itself, not on the document somebody read last time.
+    expect(await screen.findByRole('heading', { name: 'About' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Licence text' })).not.toBeInTheDocument();
   });
 
   it('links About to the privacy pane instead of a support URL', async () => {
     render(<SettingsView />);
 
     fireEvent.click(screen.getByRole('tab', { name: 'About' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Open' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Open privacy and data handling' }),
+    );
 
     expect(
       await screen.findByRole('button', { name: 'Only derived analysis is stored' }),

--- a/apps/desktop/src/views/settings/AboutDocumentView.tsx
+++ b/apps/desktop/src/views/settings/AboutDocumentView.tsx
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { ChevronLeft } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+
+import { PaneHeader } from '../../components/ui/Pane';
+import { ATTRIBUTIONS, LICENSE_TEXT, NOTICE_TEXT } from '../../lib/legalNotices';
+
+/** The legal documents About can open. */
+export type AboutDocumentId = 'licence' | 'notices' | 'attributions';
+
+/** Titles, shared so a row and the view it opens can never drift apart. */
+export const ABOUT_DOCUMENTS: Record<AboutDocumentId, { title: string }> = {
+  licence: { title: 'Licence text' },
+  notices: { title: 'Legal notices' },
+  attributions: { title: 'Third-party attributions' },
+};
+
+/** Long-form legal prose. Plain text, never anchors — the licence body carries
+ *  bare URLs and About's no-external-links rule covers them too. */
+function DocumentBody({ id }: { id: AboutDocumentId }) {
+  if (id === 'licence') {
+    return (
+      <p className="type-footnote whitespace-pre-wrap text-label-secondary">
+        {LICENSE_TEXT.trim()}
+      </p>
+    );
+  }
+  if (id === 'notices') {
+    return (
+      <p className="type-footnote whitespace-pre-wrap text-label-secondary">
+        {NOTICE_TEXT.trim()}
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      {ATTRIBUTIONS.map((attribution) => (
+        <div key={attribution.title}>
+          <p className="type-footnote font-medium text-label">{attribution.title}</p>
+          <p className="type-footnote text-label-secondary">{attribution.body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One legal document, read on its own surface.
+ *
+ * These were disclosures inside About until the obvious problem with that
+ * showed itself: expanding the licence dropped seventeen kilobytes of MPL into
+ * the middle of the pane and pushed everything after it past the fold. A
+ * document is not an aside, so it gets a view — reached by an `Open` row, left
+ * by the back arrow, and mounted only while it is being read.
+ *
+ * `PaneHeader` is composed directly rather than going through `Pane`: the
+ * `leading` slot exists for exactly this arrow, and `Pane` does not forward it.
+ * No `ScrollPane` here — the settings window owns one around the whole panel,
+ * and a second would nest two scrollers inside one column.
+ */
+export function AboutDocumentView({ id, onBack }: { id: AboutDocumentId; onBack: () => void }) {
+  const heading = useRef<HTMLHeadingElement>(null);
+
+  // Move focus into the view as it takes over the pane. Two jobs at once: a
+  // keyboard or screen-reader user lands on the document instead of being left
+  // on the button that just vanished, and the shared viewport scrolls back to
+  // the top rather than opening a fresh document mid-page.
+  useEffect(() => {
+    heading.current?.focus();
+  }, [id]);
+
+  return (
+    <>
+      {/* The arrow and the title are two things. Wrapping the heading text
+          inside the button would make a screen reader announce the whole title
+          as the name of the control that leaves the view, and leave the view
+          with no heading at all. */}
+      <PaneHeader
+        headingRef={heading}
+        title={ABOUT_DOCUMENTS[id].title}
+        leading={
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back to About"
+            className="-ml-1 inline-flex h-7 shrink-0 items-center rounded-control px-1 text-label-secondary transition-colors duration-[120ms] ease-out hover:bg-surface-hover hover:text-label"
+          >
+            <ChevronLeft size={18} strokeWidth={2} aria-hidden="true" className="shrink-0" />
+          </button>
+        }
+      />
+      <DocumentBody id={id} />
+    </>
+  );
+}

--- a/apps/desktop/src/views/settings/AboutPane.tsx
+++ b/apps/desktop/src/views/settings/AboutPane.tsx
@@ -2,16 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { useEffect, useRef, useState } from 'react';
+
 import { Card } from '../../components/ui/Card';
-import { Disclosure, DisclosureGroup } from '../../components/ui/Disclosure';
 import { Pane } from '../../components/ui/Pane';
 import { Row } from '../../components/ui/Row';
 import { SectionGroup } from '../../components/ui/SectionGroup';
-import { ATTRIBUTIONS, LICENSE_TEXT, NOTICE_TEXT } from '../../lib/legalNotices';
 import { revealSource, type AppInfo } from '../../lib/ipc';
 import { detectPlatform, type Platform } from '../../lib/platform';
 import type { SettingsPane } from '../../lib/settingsPanes';
 import { PushButton } from '../../components/ui/PushButton';
+import { AboutDocumentView, type AboutDocumentId } from './AboutDocumentView';
 import { UpdatesSection } from './UpdatesSection';
 import type { AppSettingsController } from './useAppSettings';
 
@@ -41,6 +42,10 @@ const PLATFORM_LABELS: Record<Platform, string> = {
  * the app — the licence it is under, and the privacy pane that says what it
  * does with your data. The deferral is recorded in `docs/deviations.md` and the
  * links land with publication.
+ *
+ * Every one of those destinations is reached the same way: a row with an `Open`
+ * button. Three of them push an `AboutDocumentView` over this pane; the fourth
+ * moves the window to the Privacy pane, which is a section in its own right.
  */
 export interface AboutPaneProps extends AppSettingsController {
   info: AppInfo | null;
@@ -48,7 +53,40 @@ export interface AboutPaneProps extends AppSettingsController {
   onOpenPane?: (pane: SettingsPane) => void;
 }
 
+/** Ids of the `Open` buttons, so focus can return to the one that was pressed
+ *  once its document closes — by then React has unmounted the original node. */
+const OPEN_BUTTON_ID: Record<AboutDocumentId, string> = {
+  licence: 'about-open-licence',
+  notices: 'about-open-notices',
+  attributions: 'about-open-attributions',
+};
+
 export function AboutPane({ settings, update, loaded, info, onOpenPane }: AboutPaneProps) {
+  const [openDocument, setOpenDocument] = useState<AboutDocumentId | null>(null);
+  // A ref, not state: which row to hand focus back to is a note to the next
+  // effect, and nothing renders differently for it.
+  const returnFocusTo = useRef<AboutDocumentId | null>(null);
+
+  // Back from a document returns focus to the row that opened it, so a keyboard
+  // reader resumes where they left the card rather than at the top of About.
+  useEffect(() => {
+    if (openDocument || !returnFocusTo.current) return;
+    document.getElementById(OPEN_BUTTON_ID[returnFocusTo.current])?.focus();
+    returnFocusTo.current = null;
+  }, [openDocument]);
+
+  if (openDocument) {
+    return (
+      <AboutDocumentView
+        id={openDocument}
+        onBack={() => {
+          returnFocusTo.current = openDocument;
+          setOpenDocument(null);
+        }}
+      />
+    );
+  }
+
   return (
     <Pane title="About">
       {/* The app identity sits directly on the window surface rather than in a
@@ -99,51 +137,74 @@ export function AboutPane({ settings, update, loaded, info, onOpenPane }: AboutP
         </Card>
       </SectionGroup>
 
+      {/* Four peer rows, every one of them a door. The two legal documents were
+          disclosures here until it became clear what that meant in practice:
+          expanding the licence dropped seventeen kilobytes of MPL into the
+          middle of the pane and pushed Data past the fold. Each `Open` carries
+          its own accessible name — four buttons all called "Open" is a list a
+          screen-reader user cannot navigate. */}
       <SectionGroup title="Licence and data handling">
         <Card>
           <Row
             label="Licence"
             // Stated and readable here, never linked. Keeping the full text in
-            // the pane makes it checkable without a browser — which is the
+            // the app makes it checkable without a browser — which is the
             // point of putting it in an offline app.
-            description="antiburn is free software under the Mozilla Public License 2.0. The full text is readable below, and every source file carries its header."
+            description="antiburn is free software under the Mozilla Public License 2.0. The full text is readable here, and every source file carries its header."
             trailing={
-              <span className="type-body tabular-nums text-label-secondary">MPL-2.0</span>
+              <div className="flex items-center gap-2">
+                <span className="type-body tabular-nums text-label-secondary">MPL-2.0</span>
+                <PushButton
+                  id={OPEN_BUTTON_ID.licence}
+                  ariaLabel="Open licence text"
+                  onClick={() => setOpenDocument('licence')}
+                >
+                  Open
+                </PushButton>
+              </div>
             }
           />
           {onOpenPane && (
             <Row
               label="Privacy and data handling"
               description="What antiburn reads, what it stores, how long it keeps it, and the one time it uses the network. The long form lives in Privacy."
-              trailing={<PushButton onClick={() => onOpenPane('privacy')}>Open</PushButton>}
+              trailing={
+                <PushButton
+                  ariaLabel="Open privacy and data handling"
+                  onClick={() => onOpenPane('privacy')}
+                >
+                  Open
+                </PushButton>
+              }
             />
           )}
+          <Row
+            label="Legal notices"
+            description="Who holds the copyright in antiburn and where the work came from."
+            trailing={
+              <PushButton
+                id={OPEN_BUTTON_ID.notices}
+                ariaLabel="Open legal notices"
+                onClick={() => setOpenDocument('notices')}
+              >
+                Open
+              </PushButton>
+            }
+          />
+          <Row
+            label="Third-party attributions"
+            description="The third-party material bundled with the app, and the terms it is used under."
+            trailing={
+              <PushButton
+                id={OPEN_BUTTON_ID.attributions}
+                ariaLabel="Open third-party attributions"
+                onClick={() => setOpenDocument('attributions')}
+              >
+                Open
+              </PushButton>
+            }
+          />
         </Card>
-        {/* Disclosures rather than rows: legal text is explanatory prose, and
-            the bodies stay unmounted while collapsed so two long documents do
-            not sit in the accessibility tree of every About visit. Plain text
-            only — the pane's no-external-links rule applies to the licence's
-            own URLs too, so nothing here is an anchor. */}
-        <DisclosureGroup>
-          <Disclosure label="Legal notices">
-            <div className="flex flex-col gap-3">
-              <p className="type-footnote whitespace-pre-wrap text-label-secondary">
-                {NOTICE_TEXT.trim()}
-              </p>
-              {ATTRIBUTIONS.map((attribution) => (
-                <div key={attribution.title}>
-                  <p className="type-footnote font-medium text-label">{attribution.title}</p>
-                  <p className="type-footnote text-label-secondary">{attribution.body}</p>
-                </div>
-              ))}
-            </div>
-          </Disclosure>
-          <Disclosure label="Licence text">
-            <p className="type-footnote whitespace-pre-wrap text-label-secondary">
-              {LICENSE_TEXT.trim()}
-            </p>
-          </Disclosure>
-        </DisclosureGroup>
       </SectionGroup>
 
       <SectionGroup title="Data">


### PR DESCRIPTION
## What changed

Settings → About's "Licence and data handling" section had two disclosures — **Legal notices** and **Licence text**. Expanding either dropped a long legal document inline, inside the pane's shared scroll column, pushing the rest of About far below the fold. Expanding the licence meant seventeen kilobytes of MPL between the reader and the Data section.

The section already had the right pattern next to them: the Privacy row with an `Open` button. Every document now behaves that way.

The card is four peer rows:

| Row | Trailing | Destination |
| --- | --- | --- |
| Licence | `MPL-2.0` + Open | Licence text view |
| Privacy and data handling | Open | Privacy pane (unchanged) |
| Legal notices | Open | Legal notices view |
| Third-party attributions | Open | Attributions view |

Third-party attributions split out of "Legal notices", which used to carry the NOTICE body and the attributions together.

## Why it's built this way

- **New `AboutDocumentView`** holds all three documents. It composes `PaneHeader` directly to use its `leading` slot — that slot was already documented as being for a back arrow — rather than going through `Pane`, which doesn't forward it. The back arrow follows the existing `UsageView` / `SessionAnalyticsPresentation` pattern, including the a11y note there about not wrapping the heading text inside the button.
- **No new `ScrollPane`.** The settings window owns one around the whole panel; a second would nest two scrollers in one column.
- **Distinct accessible names.** The visible label stays "Open" on all four, but each passes `PushButton`'s `ariaLabel` — four identically-named buttons in one card is a list a screen-reader user cannot navigate.
- **No new pane ids or sidebar entries.** The subview is `AboutPane`'s own state, so `SettingsView` is untouched. Its existing `key={pane}` remount means leaving About and coming back lands on the root, not on whatever document was open last.

## Focus behaviour

Opening a document focuses its heading, which both lands keyboard and screen-reader users in the view and returns the shared viewport to the top. The back arrow hands focus back to the `Open` row that was pressed. Two small enabling changes: `PaneHeader` gains an optional `headingRef` (passing it is what makes the title programmatically focusable, so `tabIndex={-1}` doesn't land on every pane title), and `PushButton` gains an optional `id`.

Escape stays unbound. The settings window deliberately refuses Escape, and giving it a "go back" meaning only inside a subview would be an inconsistency.

## Constraints preserved

- **About still has zero anchors.** The licence body contains bare URLs; none became links. Every document-view test asserts `document.querySelectorAll('a')` is 0.
- **NOTICE text is still only imported**, never inlined — `scripts/check-boundary.mjs` exempts that file by path only, and it passes.

## Testing

- `pnpm desktop test` — 514 passed / 57 files. The three tests that pinned the accordion contract were rewritten; notices and attributions split into separate cases; new coverage for focus-on-open, back-with-focus-return, and "changing sidebar section leaves the document behind".
- `type-check`, `lint`, `format`, and `check-boundary` all clean.
- Drove the real UI in a browser: all three views render, the back arrow works, scroll resets to top on open, focus lands where intended, no console errors.

## For the reviewer

The Licence row's trailing slot now holds two elements (badge + button). It renders cleanly at the settings window's fixed width, but it's the only row in the app shaped that way — worth a look if the window ever becomes resizable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)