### PR TITLE
fix(repositories): ask consent before resolving a working directory

### DIFF
--- a/apps/desktop/src-tauri/src/repositories.rs
+++ b/apps/desktop/src-tauri/src/repositories.rs
@@ -28,11 +28,11 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use antiburn_local::paths::{home_dir, ignored_paths};
+use antiburn_local::paths::{home_dir, ignored_paths, protected};
 use antiburn_local::platform::git;
 use antiburn_local::repositories::{
-    LocatedRepo, NoConsentGrants, merge_located_repos, normalize_remote_url,
-    parse_repo_name_from_url, repo_root_identity, scan_roots_for_repos,
+    DeferredProtectedPath, LocatedRepo, NoConsentGrants, merge_located_repos, normalize_remote_url,
+    parse_repo_name_from_url, partition_cwds_by_grants, repo_root_identity, scan_roots_for_repos,
 };
 use tauri::{AppHandle, Manager};
 
@@ -62,8 +62,18 @@ pub async fn refresh(app: &AppHandle) -> anyhow::Result<()> {
     let known: Vec<RepositoryRecord> = store.repositories()?;
     let scan_roots: Vec<PathBuf> = store.scan_roots()?.into_iter().map(PathBuf::from).collect();
 
+    // Nothing is granted yet: the record of which protected directories the user
+    // allowed arrives with the consent flow. Until then this pass treats every
+    // one of them as off limits, which is the safe direction — a repository the
+    // user cannot see listed is a lesser problem than a permission dialog they
+    // never asked for.
+    let granted: HashSet<String> = HashSet::new();
+
     let cwds: Vec<String> = distinct_cwds(&sessions);
-    let located = locate_from_cwds(&cwds, &known).await;
+    // `deferred` names the protected directories this pass deliberately left
+    // untouched. Offering the user a way to grant them is the consent flow's
+    // job; the guarantee that matters here is that none of them were read.
+    let (located, _deferred) = locate_from_cwds(&cwds, &known, &granted).await;
     let counted = count_sessions(located, &sessions);
 
     let owners = top_owners(&counted);
@@ -75,7 +85,7 @@ pub async fn refresh(app: &AppHandle) -> anyhow::Result<()> {
         records.push(to_record(repo, &sessions, &known, &ignored).await);
     }
     retain_disabled(&mut records, known);
-    surface_orphaned_opt_outs(&mut records, store.state_dir()).await;
+    surface_orphaned_opt_outs(&mut records, store.state_dir(), &granted).await;
     store.replace_repositories(&records)?;
     Ok(())
 }
@@ -87,7 +97,11 @@ pub async fn refresh(app: &AppHandle) -> anyhow::Result<()> {
 /// opt-out active with no toggle to undo it. Any ignored path that exists on
 /// disk and matches no listed record is surfaced as a disabled row: name from
 /// its git remote when one answers, its folder name otherwise.
-async fn surface_orphaned_opt_outs(records: &mut Vec<RepositoryRecord>, state_dir: &Path) {
+async fn surface_orphaned_opt_outs(
+    records: &mut Vec<RepositoryRecord>,
+    state_dir: &Path,
+    granted: &HashSet<String>,
+) {
     let listed: HashSet<String> = records
         .iter()
         .flat_map(|record| {
@@ -109,11 +123,19 @@ async fn surface_orphaned_opt_outs(records: &mut Vec<RepositoryRecord>, state_di
             .and_then(|name| name.to_str())
             .unwrap_or("repository")
             .to_string();
-        let remote_name = git::first_remote_url_at(root)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|url| parse_repo_name_from_url(&normalize_remote_url(&url)));
+        // An opted-out repository inside an ungranted protected directory keeps
+        // its row, named after its folder: reading its remote would mean running
+        // git in there, and the row exists precisely so the user can act on a
+        // repository antiburn is not otherwise touching.
+        let remote_name = if protected::cwd_resolution_blocked(root, granted) {
+            None
+        } else {
+            git::first_remote_url_at(root)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|url| parse_repo_name_from_url(&normalize_remote_url(&url)))
+        };
         let (repo_name, full_name) = match remote_name {
             Some(name) => (name.rsplit('/').next().unwrap_or(&name).to_string(), name),
             None => (folder_name.clone(), folder_name),
@@ -249,12 +271,24 @@ fn distinct_cwds(sessions: &[crate::store::SessionRecord]) -> Vec<String> {
 
 /// Resolve working directories to canonical repository roots, reusing roots the
 /// last pass already established.
-async fn locate_from_cwds(cwds: &[String], known: &[RepositoryRecord]) -> Vec<LocatedRepo> {
+///
+/// `granted` names the consent-protected directories the user has allowed.
+/// Working directories under any other protected directory are returned as
+/// deferred rather than resolved: this pass runs in the background, and both a
+/// directory read and a `git` process whose working directory sits inside one
+/// would raise a permission dialog with nothing on screen to explain it.
+async fn locate_from_cwds(
+    cwds: &[String],
+    known: &[RepositoryRecord],
+    granted: &HashSet<String>,
+) -> (Vec<LocatedRepo>, Vec<DeferredProtectedPath>) {
     let mut by_key: HashMap<String, LocatedRepo> = HashMap::new();
     let mut resolved = 0usize;
+    let mut unresolved: Vec<&str> = Vec::new();
 
     for cwd in cwds {
-        // Already under a repository the last pass found: no git call needed.
+        // Already under a repository the last pass found: answered from the
+        // store, so no filesystem access and no consent question to ask.
         if let Some(record) = known.iter().find(|record| {
             record
                 .repo_root
@@ -276,6 +310,21 @@ async fn locate_from_cwds(cwds: &[String], known: &[RepositoryRecord]) -> Vec<Lo
             continue;
         }
 
+        unresolved.push(cwd);
+    }
+
+    // Everything past this point shells out to git, so consent is settled first.
+    // Without a home directory nothing can be classified as protected, which
+    // matches how the engine's own guards fail open.
+    let (admitted, mut deferred) = match home_dir() {
+        Some(home) => partition_cwds_by_grants(&home, unresolved, granted),
+        None => (
+            unresolved.into_iter().map(str::to_string).collect(),
+            Vec::new(),
+        ),
+    };
+
+    for cwd in &admitted {
         if resolved >= MAX_NEW_ROOTS_PER_PASS {
             continue;
         }
@@ -285,6 +334,18 @@ async fn locate_from_cwds(cwds: &[String], known: &[RepositoryRecord]) -> Vec<Lo
             continue;
         };
         let root = git::canonical_main_repo_root(&root).await;
+        // A worktree outside the protected directories can still be owned by a
+        // main repository inside one, so the root gets its own check before the
+        // reads below.
+        if protected::cwd_resolution_blocked(&root, granted) {
+            if let Some(protected_dir) = protected::protected_dir_name(&root) {
+                deferred.push(DeferredProtectedPath {
+                    cwd: root.to_string_lossy().to_string(),
+                    protected_dir,
+                });
+            }
+            continue;
+        }
         let key = repo_root_identity(&root);
         if by_key.contains_key(&key) {
             continue;
@@ -306,7 +367,7 @@ async fn locate_from_cwds(cwds: &[String], known: &[RepositoryRecord]) -> Vec<Lo
         );
     }
 
-    by_key.into_values().collect()
+    (by_key.into_values().collect(), deferred)
 }
 
 /// Attach the per-repository session count, keeping each root's own sessions.
@@ -485,7 +546,7 @@ mod tests {
             .unwrap();
 
         let mut records = vec![repo_record("widgets", true)];
-        surface_orphaned_opt_outs(&mut records, dir.path()).await;
+        surface_orphaned_opt_outs(&mut records, dir.path(), &HashSet::new()).await;
 
         assert_eq!(records.len(), 2);
         let orphan = &records[1];
@@ -495,7 +556,7 @@ mod tests {
 
         // Idempotent: a second pass sees the row listed and adds nothing.
         let mut again = records.clone();
-        surface_orphaned_opt_outs(&mut again, dir.path()).await;
+        surface_orphaned_opt_outs(&mut again, dir.path(), &HashSet::new()).await;
         assert_eq!(again.len(), 2);
     }
 

--- a/crates/antiburn-local/src/paths/protected.rs
+++ b/crates/antiburn-local/src/paths/protected.rs
@@ -14,6 +14,7 @@
 //! list and never touch the filesystem. Persisting *which* directories the user
 //! granted is the embedding application's job.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 /// Directory names, relative to the home directory, that the current platform
@@ -73,6 +74,44 @@ pub fn protected_dir_name_in(home: &Path, path: &Path) -> Option<String> {
         .map(|name| (*name).to_string())
 }
 
+/// Whether `path` must be left untouched because it sits under a
+/// consent-protected directory absent from `granted`.
+///
+/// This is the question to ask before *any* filesystem probe or `git`
+/// invocation aimed at a path the caller did not choose — a working directory
+/// recorded in a session, say. A `stat` against such a path is harmless, but a
+/// directory read or a `git` process whose working directory sits inside one is
+/// exactly what raises the consent dialog.
+///
+/// The `None` arm returns `false` because [`is_access_protected`] and
+/// [`protected_dir_name`] share one home-directory lookup and one protected-name
+/// list. If the first says "protected" but the second cannot map the path back
+/// to a name, that is a list mismatch — a test environment whose home directory
+/// shifted between the two calls, for instance — rather than a real protected
+/// path, so failing open is safe.
+#[must_use]
+pub fn cwd_resolution_blocked(path: &Path, granted: &HashSet<String>) -> bool {
+    if !is_access_protected(path) {
+        return false;
+    }
+    match protected_dir_name(path) {
+        Some(name) => !granted.contains(&name),
+        None => false,
+    }
+}
+
+/// [`cwd_resolution_blocked`] against an explicit home directory.
+///
+/// One lookup answers both halves here, so this has none of the fail-open
+/// ambiguity its home-resolving counterpart documents.
+#[must_use]
+pub fn cwd_resolution_blocked_in(home: &Path, path: &Path, granted: &HashSet<String>) -> bool {
+    match protected_dir_name_in(home, path) {
+        Some(name) => !granted.contains(&name),
+        None => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,6 +154,55 @@ mod tests {
             protected_dir_name_in(&home, &home.join("dev").join("repo")),
             None
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn resolution_is_blocked_only_inside_ungranted_protected_dirs() {
+        let home = PathBuf::from("/Users/avery");
+        let documents = home.join("Documents").join("GitHub").join("repo");
+        let unprotected = home.join("dev").join("repo");
+
+        let nothing_granted = HashSet::new();
+        assert!(cwd_resolution_blocked_in(
+            &home,
+            &documents,
+            &nothing_granted
+        ));
+        assert!(!cwd_resolution_blocked_in(
+            &home,
+            &unprotected,
+            &nothing_granted
+        ));
+
+        let documents_granted = HashSet::from(["Documents".to_string()]);
+        assert!(!cwd_resolution_blocked_in(
+            &home,
+            &documents,
+            &documents_granted
+        ));
+        // A grant covers one directory, not every protected directory.
+        assert!(cwd_resolution_blocked_in(
+            &home,
+            &home.join("Desktop").join("repo"),
+            &documents_granted
+        ));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn platforms_without_consent_controls_never_block_resolution() {
+        let home = PathBuf::from("/home/avery");
+
+        assert!(!cwd_resolution_blocked(
+            &home.join("Documents"),
+            &HashSet::new()
+        ));
+        assert!(!cwd_resolution_blocked_in(
+            &home,
+            &home.join("Documents"),
+            &HashSet::new()
+        ));
     }
 
     #[test]

--- a/crates/antiburn-local/src/platform/git.rs
+++ b/crates/antiburn-local/src/platform/git.rs
@@ -234,6 +234,13 @@ pub struct RepoRootResolutionDiagnostics {
     pub alternative_repo_roots: Vec<PathBuf>,
     /// Which strategy produced the answer.
     pub resolved_via: Option<&'static str>,
+    /// Whether a probe was skipped because its path sits under a
+    /// consent-protected directory the user has not granted.
+    ///
+    /// A resolution can fail for this reason alone, which means the repository
+    /// is *unknown*, not absent: the caller should offer the user a way to grant
+    /// access rather than report a missing repository.
+    pub consent_blocked: bool,
 }
 
 /// A resolved repository root plus the diagnostics that produced it.
@@ -254,8 +261,13 @@ struct WorktreeEntry {
 /// ancestor and then to the repository that owns a since-deleted worktree.
 ///
 /// `granted` is the set of consent-protected directory names the user has
-/// already allowed (see [`crate::paths::protected`]); probing skips protected
-/// directories that are not in it.
+/// already allowed (see [`crate::paths::protected`]). Every strategy here is
+/// gated on it — including resolving `cwd` itself — so a working directory
+/// inside an ungranted protected directory runs no `git` process at all and
+/// comes back with
+/// [`consent_blocked`](RepoRootResolutionDiagnostics::consent_blocked) set.
+/// Resolution still succeeds when a *granted* ancestor or owning repository can
+/// answer for an ungranted `cwd`.
 pub async fn resolve_repo_root_with_fallbacks(
     cwd: &Path,
     granted: &HashSet<String>,
@@ -266,23 +278,10 @@ pub async fn resolve_repo_root_with_fallbacks(
         ..RepoRootResolutionDiagnostics::default()
     };
 
-    match repo_root_at(cwd).await {
-        Ok(repo_root) => {
-            diagnostics.resolved_via = Some("cwd");
-            diagnostics.alternative_repo_roots = alternative_repo_roots_for_repo(&repo_root).await;
-            return Ok(RepoRootResolution {
-                repo_root,
-                diagnostics,
-            });
-        }
-        Err(err) => diagnostics.direct_error = Some(err.to_string()),
-    }
-
-    if let Some(existing_ancestor) = nearest_existing_ancestor(cwd).await {
-        diagnostics.nearest_existing_ancestor = Some(existing_ancestor.clone());
-        match repo_root_at(&existing_ancestor).await {
+    if is_probe_allowed(cwd, granted) {
+        match repo_root_at(cwd).await {
             Ok(repo_root) => {
-                diagnostics.resolved_via = Some("existing_ancestor");
+                diagnostics.resolved_via = Some("cwd");
                 diagnostics.alternative_repo_roots =
                     alternative_repo_roots_for_repo(&repo_root).await;
                 return Ok(RepoRootResolution {
@@ -290,7 +289,32 @@ pub async fn resolve_repo_root_with_fallbacks(
                     diagnostics,
                 });
             }
-            Err(err) => diagnostics.ancestor_error = Some(err.to_string()),
+            Err(err) => diagnostics.direct_error = Some(err.to_string()),
+        }
+    } else {
+        diagnostics.consent_blocked = true;
+    }
+
+    // Walking up to the nearest existing ancestor only ever calls `try_exists`,
+    // which the consent controls permit; the `git` invocation that follows is
+    // the part that needs the gate.
+    if let Some(existing_ancestor) = nearest_existing_ancestor(cwd).await {
+        diagnostics.nearest_existing_ancestor = Some(existing_ancestor.clone());
+        if is_probe_allowed(&existing_ancestor, granted) {
+            match repo_root_at(&existing_ancestor).await {
+                Ok(repo_root) => {
+                    diagnostics.resolved_via = Some("existing_ancestor");
+                    diagnostics.alternative_repo_roots =
+                        alternative_repo_roots_for_repo(&repo_root).await;
+                    return Ok(RepoRootResolution {
+                        repo_root,
+                        diagnostics,
+                    });
+                }
+                Err(err) => diagnostics.ancestor_error = Some(err.to_string()),
+            }
+        } else {
+            diagnostics.consent_blocked = true;
         }
     }
 
@@ -490,26 +514,15 @@ async fn candidate_owner_repo_roots(
 }
 
 // Skip probing inside consent-protected directories (e.g. ~/Documents on macOS)
-// the user has not granted access to — a bare `try_exists` against those paths
-// can trip the native consent dialog on modern macOS and, if the file does
-// exist, the follow-up `git` invocation with `cwd` inside the protected
-// directory definitely will.
+// the user has not granted access to — a `git` invocation whose working
+// directory sits inside one raises the native consent dialog, and so does
+// reading the directory itself.
 //
-// The `None` arm falls through to `true` because `is_access_protected` and
-// `protected_dir_name` share one home-directory lookup and one protected-name
-// list. If one says "protected" but the other cannot map the path back to a
-// name, that is a list mismatch (e.g. a test environment where the home
-// directory shifts between calls) rather than a real protected path, so failing
-// open is safe.
+// See [`protected::cwd_resolution_blocked`] for why an unmappable protected
+// path fails open.
 #[must_use]
 fn is_probe_allowed(path: &Path, granted: &HashSet<String>) -> bool {
-    if !protected::is_access_protected(path) {
-        return true;
-    }
-    match protected::protected_dir_name(path) {
-        Some(name) => granted.contains(&name),
-        None => true,
-    }
+    !protected::cwd_resolution_blocked(path, granted)
 }
 
 /// Existing repositories under `home` that could own a since-deleted worktree
@@ -1770,6 +1783,62 @@ mod tests {
         );
 
         std::env::set_current_dir(original_cwd).unwrap();
+    }
+
+    /// The working directory is a real, resolvable repository. Only consent is
+    /// missing — so resolution must fail, and it must fail without having run
+    /// `git` at all. A recorded `direct_error` would mean a process ran inside
+    /// the protected directory, which is exactly what raises the consent dialog.
+    #[tokio::test]
+    #[serial]
+    #[cfg(target_os = "macos")]
+    async fn resolve_repo_root_with_fallbacks_refuses_an_ungranted_protected_cwd() {
+        let home_dir = TempDir::new().unwrap();
+        let home = home_dir.path();
+        let guard = EnvGuard::new("HOME");
+        guard.set_path(home);
+
+        let repo_root = home.join("Documents").join("GitHub").join("myrepo");
+        init_repo_with_branch(&repo_root, "myrepo").await;
+
+        let diagnostics = resolve_repo_root_with_fallbacks(&repo_root, &HashSet::new())
+            .await
+            .expect_err("an ungranted protected cwd must not resolve");
+
+        assert!(
+            diagnostics.consent_blocked,
+            "the refusal must be attributed to consent, not to a missing repository"
+        );
+        assert!(
+            diagnostics.direct_error.is_none(),
+            "no git process may run against an ungranted protected cwd; got {:?}",
+            diagnostics.direct_error
+        );
+        assert!(diagnostics.ancestor_error.is_none());
+        assert_eq!(diagnostics.resolved_via, None);
+    }
+
+    /// The same repository, once the user has granted its directory.
+    #[tokio::test]
+    #[serial]
+    #[cfg(target_os = "macos")]
+    async fn resolve_repo_root_with_fallbacks_resolves_a_granted_protected_cwd() {
+        let home_dir = TempDir::new().unwrap();
+        let home = home_dir.path();
+        let guard = EnvGuard::new("HOME");
+        guard.set_path(home);
+
+        let repo_root = home.join("Documents").join("GitHub").join("myrepo");
+        init_repo_with_branch(&repo_root, "myrepo").await;
+
+        let granted = HashSet::from(["Documents".to_string()]);
+        let resolution = resolve_repo_root_with_fallbacks(&repo_root, &granted)
+            .await
+            .expect("a granted protected cwd should resolve");
+
+        assert_eq!(resolution.repo_root, canonical_test_path(&repo_root).await);
+        assert_eq!(resolution.diagnostics.resolved_via, Some("cwd"));
+        assert!(!resolution.diagnostics.consent_blocked);
     }
 
     #[tokio::test]

--- a/crates/antiburn-local/src/repositories/consent.rs
+++ b/crates/antiburn-local/src/repositories/consent.rs
@@ -26,6 +26,9 @@ use std::path::Path;
 
 use async_trait::async_trait;
 
+use super::model::DeferredProtectedPath;
+use crate::paths::protected;
+
 /// The embedding application's record of consent-protected directories the user
 /// has granted, plus the hooks discovery uses to keep that record honest.
 #[async_trait]
@@ -85,5 +88,110 @@ pub struct NoConsentGrants;
 impl ConsentGrants for NoConsentGrants {
     fn granted_dirs(&self) -> HashSet<String> {
         HashSet::new()
+    }
+}
+
+/// Split working directories into those safe to resolve now and those held back
+/// pending the user's consent.
+///
+/// Anything under a protected directory absent from `granted` lands in the
+/// second list and must not be read, `stat`-ed for repository markers, or handed
+/// to `git` — that is what raises the dialog. The deferred entries carry the
+/// directory name responsible so the caller can ask for exactly that grant.
+///
+/// Pure and home-explicit: it touches no filesystem and resolves no home
+/// directory, so it behaves identically in tests on every platform. On platforms
+/// without consent controls nothing is ever deferred.
+#[must_use]
+pub fn partition_cwds_by_grants<I, S>(
+    home: &Path,
+    cwds: I,
+    granted: &HashSet<String>,
+) -> (Vec<String>, Vec<DeferredProtectedPath>)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut admitted = Vec::new();
+    let mut deferred = Vec::new();
+
+    for cwd in cwds {
+        let cwd = cwd.as_ref();
+        match protected::protected_dir_name_in(home, Path::new(cwd)) {
+            Some(protected_dir) if !granted.contains(&protected_dir) => {
+                deferred.push(DeferredProtectedPath {
+                    cwd: cwd.to_string(),
+                    protected_dir,
+                });
+            }
+            _ => admitted.push(cwd.to_string()),
+        }
+    }
+
+    super::matching::dedup_deferred_by_cwd(&mut deferred);
+    (admitted, deferred)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn protected_cwds_defer_until_their_directory_is_granted() {
+        let home = PathBuf::from("/Users/avery");
+        let documents = home.join("Documents/GitHub/repo").display().to_string();
+        let desktop = home.join("Desktop/scratch").display().to_string();
+        let plain = home.join("dev/repo").display().to_string();
+
+        let (admitted, deferred) = partition_cwds_by_grants(
+            &home,
+            [documents.clone(), desktop.clone(), plain.clone()],
+            &HashSet::new(),
+        );
+        assert_eq!(admitted, vec![plain.clone()]);
+        assert_eq!(
+            deferred
+                .iter()
+                .map(|entry| entry.protected_dir.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Documents", "Desktop"]
+        );
+
+        // Granting one directory admits its paths and holds the others back.
+        let (admitted, deferred) = partition_cwds_by_grants(
+            &home,
+            [documents.clone(), desktop.clone(), plain.clone()],
+            &HashSet::from(["Documents".to_string()]),
+        );
+        assert_eq!(admitted, vec![documents, plain]);
+        assert_eq!(deferred.len(), 1);
+        assert_eq!(deferred[0].cwd, desktop);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn repeated_cwds_defer_once() {
+        let home = PathBuf::from("/Users/avery");
+        let documents = home.join("Documents/GitHub/repo").display().to_string();
+
+        let (_, deferred) =
+            partition_cwds_by_grants(&home, [&documents, &documents], &HashSet::new());
+
+        assert_eq!(deferred.len(), 1);
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn platforms_without_consent_controls_defer_nothing() {
+        let home = PathBuf::from("/home/avery");
+        let documents = home.join("Documents/repo").display().to_string();
+
+        let (admitted, deferred) =
+            partition_cwds_by_grants(&home, [documents.clone()], &HashSet::new());
+
+        assert_eq!(admitted, vec![documents]);
+        assert!(deferred.is_empty());
     }
 }

--- a/crates/antiburn-local/src/repositories/mod.rs
+++ b/crates/antiburn-local/src/repositories/mod.rs
@@ -52,7 +52,7 @@ mod tests;
 use std::collections::HashSet;
 use std::path::Path;
 
-pub use consent::{ConsentGrants, NoConsentGrants};
+pub use consent::{ConsentGrants, NoConsentGrants, partition_cwds_by_grants};
 pub use identity::{
     normalize_for_prefix, normalize_remote_url, parse_repo_name_from_url, repo_root_identity,
     repo_root_identity_for_platform,


### PR DESCRIPTION
antiburn could raise a macOS folder-permission dialog with nothing on screen to explain it. It is a menu-bar process whose scan scheduler runs a pass at launch, and that pass resolved every working directory the store had seen — so one session recorded under `~/Documents`, `~/Desktop`, or `~/Downloads` put a `git` process inside a protected directory seconds after login, before the app had drawn a window.

## Two places allowed it

**The app** resolved raw session working directories with no consent grants at all: four `git` helpers and a `read_dir` on paths it had never checked.

**The engine** consulted its `granted` argument only when probing for a worktree's owning repository — resolving `cwd` itself, and its nearest existing ancestor, ran ahead of the gate. It was relying on every caller to partition working directories before calling in, which is a convention, not a guarantee.

## What changed

`paths::protected` grows `cwd_resolution_blocked`, the single rule for "may I touch this path", and `is_probe_allowed` becomes its negation so there is one source of truth. Resolution gates each strategy on it, reports `consent_blocked` in its diagnostics so a refusal reads as *unknown* rather than *absent*, and still resolves an ungranted `cwd` through a granted ancestor or owning repository.

The app partitions through the engine's new `partition_cwds_by_grants` before any `git` call, and separately checks the canonical root, since a worktree outside the protected directories can be owned by a repository inside one. Working directories already under a known root are still answered from the store: no filesystem access, so no consent question. Opted-out rows inside an ungranted directory keep their folder name rather than reading a remote.

## Scope

Nothing is granted yet — the record of what the user allowed arrives with the consent flow in a following change. Until then every protected directory is treated as off limits, so repositories there go quietly missing instead of prompting. That is the safe direction and reversible by the flow that follows.

This is a self-contained safety fix: it copies nothing, needs no governance decision, and can land on its own.

## Verification

`cargo clippy --all-targets --locked -- -D warnings` clean and `cargo test` green on both crates (649 engine, 231 app). Two new engine tests cover the gate — including one asserting a real, resolvable repository under an ungranted protected directory runs no `git` process at all.

Verified manually on a bundled build with folder permissions reset and a session seeded under `~/Documents`: no dialog at launch, the directory reported as deferred, and repositories outside protected folders still resolved normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)