### PR TITLE
docs(desktop): say what the notification surface actually is now

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -111,13 +111,16 @@ Three independent checks, none of which relies on review:
   launch (after onboarding), whenever the popover is opened, every 60s while it
   stays open, paused entirely while it is hidden, and on demand. Passes never
   overlap and are bounded — see the policy at the top of `src-tauri/src/scan.rs`.
-- **Notifications.** Exactly two, both posted by the shell and never by the
-  webview (which is granted no notification permission): an automatic update
-  check that found a version, and the first scan failure of a run. Each is gated
-  by the master preference _and_ its own, both default on, and neither repeats —
-  see the policy at the top of `src-tauri/src/notifications.rs`. Delivery is the
-  platform's own notification centre; nothing about a notification leaves the
-  machine.
+- **Notifications.** Six kinds, all posted by the shell and never by the webview
+  (which is granted no notification permission): an available update, a failed
+  scan, low disk space, a spend anomaly, a crossed usage milestone, and the
+  settings pane's own test. Each is gated by the master preference _and_ its own
+  — the test alone bypasses the master switch, because pressing it is the reader
+  asking to see one — and nothing repeats. See the policy at the top of
+  `src-tauri/src/notifications.rs`. Delivery is antiburn's own always-on-top
+  window rather than the platform's notification centre: the `antiburn-nudge`
+  crate under `src-tauri/crates/nudge/`, applied at the seam in
+  `src-tauri/src/nudges.rs`. Nothing about a notification leaves the machine.
 - **Attention.** The popover shows a banner above the activity list when a
   repository cannot be read (which opens Settings at Sources) or when the local
   database rejects a write (which retries with a scan). Both are derived from


### PR DESCRIPTION
## Summary

Update the desktop README to describe the notification system accurately.

- List the six supported notification kinds.
- Explain that notifications use the application's own floating window.
- State that only the Settings test action bypasses the master notification switch.
- Point readers to the notification policy module instead of duplicating implementation details.

Documentation only. No runtime behavior changed.

## Validation

- The documented kinds were checked against the desktop and notification-window enums.