### PR TITLE
fix(tray): keep the menu-bar item lit while the popover is open

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -129,13 +129,18 @@ Three independent checks, none of which relies on review:
   same Quit action — an agent application has no Dock icon and no application
   menu, so those two are the only places a reader can look for the way out.
   Both go through the shell's `exit(0)`, which is what distinguishes a
-  deliberate quit from the window closes the shell suppresses.
+  deliberate quit from the window closes the shell suppresses. On macOS the
+  item stays highlighted for as long as the popover is open: the system's own
+  highlight is momentary and lets go on mouse-up, so the shell drives it, and
+  clears it again on every path that puts the popover away.
 - **Popover.** 380pt wide, frameless, always on top, hidden from the taskbar.
   It is created once at startup and anchored under its menu-bar item on each
   open, flipping above the item and clamping to the display when there is no
-  room below. It hides when it loses focus, when Escape is pressed, and on a
-  second click of the menu-bar item.
-- **Pin.** The tray menu's first item suspends all three of those dismissals,
+  room below. It hides when it loses focus, when Escape is pressed, on a
+  second click of the menu-bar item, and — on macOS — on a click anywhere
+  outside the app, which catches the Finder desktop: clicking it makes no
+  window key, so no focus change is reported at all.
+- **Pin.** The tray menu's first item suspends all four of those dismissals,
   and reads Unpin Window while it does. The state is in memory only: a pin
   means "keep this on screen while I work", and a relaunch ends that work.
   Pinning also re-shows the popover, because opening the tray menu is what

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "antiburn-sound",
  "anyhow",
  "async-trait",
+ "block2",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -987,7 +988,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2571,7 +2572,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4148,7 +4149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5319,9 +5320,8 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
+version = "0.24.1"
+source = "git+https://github.com/tauri-apps/tray-icon.git?rev=0ada43072646fe4454b1f969f4f446dc401fa1aa#0ada43072646fe4454b1f969f4f446dc401fa1aa"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -5336,7 +5336,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5365,7 +5365,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -72,13 +72,19 @@ tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tauri-plugin-updater = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# The menu-bar free-space readout (`src/tray_title.rs`, `src/disk_monitor.rs`):
-# an attributed-string title on the status item's button, and the startup
-# volume's available capacity as Finder reports it. Feature lists are the
-# exact set those two files touch.
+# Three pieces of AppKit the shell reaches for directly: the menu-bar
+# free-space readout (`src/tray_title.rs`, `src/disk_monitor.rs`) — an
+# attributed-string title on the status item's button, and the startup volume's
+# available capacity as Finder reports it; the persistent highlight on that same
+# button (`src/tray.rs`); and the global click monitor that dismisses the
+# popover (`src/global_click.rs`). Feature lists are the exact set those files
+# touch.
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSCell", "NSControl", "NSView", "NSResponder", "NSColor", "NSFont", "NSFontDescriptor", "NSAttributedString"] }
-objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSAttributedString", "NSDictionary", "NSValue", "NSObject", "NSURL", "NSError"] }
+# Block construction for the global monitor and the resign-active observer
+# (the `block2` features below).
+block2 = "0.6"
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSCell", "NSControl", "NSView", "NSResponder", "NSColor", "NSFont", "NSFontDescriptor", "NSAttributedString", "NSEvent", "block2"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSAttributedString", "NSDictionary", "NSValue", "NSObject", "NSURL", "NSError", "NSNotification", "NSOperation", "block2"] }
 
 [dev-dependencies]
 # Synthetic agent stores for the scan-pipeline tests.
@@ -90,3 +96,35 @@ lto = true
 opt-level = "s"
 panic = "abort"
 strip = true
+
+# Temporary, and the whole reason it exists is one line of AppKit.
+#
+# tray-icon attaches the status item's `NSMenu` once, at construction, and
+# leaves it attached. Through macOS 26 that is harmless — the item's primary
+# button still delivers its clicks and the menu only opens on the secondary
+# one. On **macOS 27** an always-attached menu swallows the primary click
+# outright, so antiburn's menu-bar item would stop opening the popover at all:
+# a menu-bar app with no way into it. The pinned revision moves the attachment
+# to the moment the menu is actually being shown and detaches it again straight
+# after (upstream https://github.com/tauri-apps/tray-icon/pull/341).
+#
+# The revision is 0.24.1 plus that change, and it is the *only* change: diffed
+# against the 0.24.2 this replaces, `platform_impl/macos/mod.rs` is the sole
+# differing file and this fix is its entire delta. So the version going
+# backwards costs nothing.
+#
+# Remove this — do not bump the rev — as soon as the fix ships in a release,
+# and keep whatever replaces it on the same major/minor line as Tauri's own
+# transitive tray-icon.
+#
+# One thing this deliberately does *not* fix. tray-icon's `mouseUp:` calls
+# `NSStatusBarButton.highlight(false)` unconditionally, before handing the
+# click on, so `tray::set_highlight` re-lights a button that went dark ~185µs
+# earlier — a single visible blink when the popover opens, because AppKit's
+# highlight drawing is flushed immediately rather than deferred to the next
+# frame. Removing it would mean carrying a fork rather than tracking upstream,
+# which is a bigger commitment than a one-frame blink is worth. Decided
+# knowingly; see the note on `tray::set_highlight` for the measurements and
+# for the two alternatives that were tried and did not work.
+[patch.crates-io]
+tray-icon = { git = "https://github.com/tauri-apps/tray-icon.git", rev = "0ada43072646fe4454b1f969f4f446dc401fa1aa" }

--- a/apps/desktop/src-tauri/src/global_click.rs
+++ b/apps/desktop/src-tauri/src/global_click.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Dismissing the popover on clicks that happen outside antiburn entirely.
+//!
+//! **Why focus loss is not enough.** The popover is put away when it stops
+//! being the key window, which covers most of what "look somewhere else" means
+//! — another app's window, antiburn's own settings window. It does not cover
+//! clicking the **Finder desktop**: no window becomes key, so no window
+//! resigns key, so Tauri reports no focus change and the popover just sits
+//! there. That was always slightly wrong; with the menu-bar item now staying
+//! lit for as long as the popover is open (see [`crate::tray::set_highlight`])
+//! it would also strand the icon on, which is worse than the surface being
+//! open — a lit menu bar with nothing under it.
+//!
+//! So this module watches for two things the window layer cannot see:
+//!
+//! - a **global mouse-down**, which is any press that landed outside every
+//!   window this process owns; and
+//! - the app **resigning active**, which catches a switch away that arrives
+//!   without a click at all (⌘-Tab, Mission Control).
+//!
+//! Both land on [`crate::popover::hide_on_outside_click`], which is a no-op
+//! unless the popover is actually on screen.
+//!
+//! **The menu-bar item is not one of these clicks.** The status item belongs to
+//! this process, so a press on it is delivered locally and a *global* monitor
+//! never sees it — which is the whole reason the monitor can be this simple.
+//! Clicking the item while the popover is open still closes it the way it
+//! always did: focus loss fires, and the reopen-suppression window in
+//! [`crate::popover`] keeps the tray's own mouse-up from reading as a fresh
+//! open.
+//!
+//! macOS-only; a no-op elsewhere.
+
+/// Install the global mouse-down monitor and the resign-active observer for
+/// the app's lifetime.
+///
+/// Call once from `setup`, on the main thread, after the tray and the popover
+/// exist.
+#[cfg(target_os = "macos")]
+pub fn install(app: &tauri::AppHandle) {
+    use block2::RcBlock;
+    use objc2_app_kit::{NSApplicationDidResignActiveNotification, NSEvent, NSEventMask};
+    use objc2_foundation::{NSNotification, NSNotificationCenter};
+
+    let click_app = app.clone();
+    let click_handler = RcBlock::new(move |_event: core::ptr::NonNull<NSEvent>| {
+        crate::popover::hide_on_outside_click(&click_app);
+    });
+
+    // Right-click as well as left: a secondary press on some other app's
+    // window opens its context menu, which is just as much "looking away" as a
+    // plain click.
+    let mask = NSEventMask::LeftMouseDown | NSEventMask::RightMouseDown;
+    let token = NSEvent::addGlobalMonitorForEventsMatchingMask_handler(mask, &click_handler);
+
+    // The token exists only to *remove* the monitor later, and this monitor is
+    // meant to outlive everything. Leaking it says so plainly; the alternative
+    // is parking a non-`Send` AppKit handle in shared state for no reason,
+    // because dropping the token would not stop the monitor either way.
+    std::mem::forget(token);
+
+    let resign_app = app.clone();
+    let resign_handler = RcBlock::new(move |_notification: core::ptr::NonNull<NSNotification>| {
+        crate::popover::hide_on_outside_click(&resign_app);
+    });
+    let center = NSNotificationCenter::defaultCenter();
+    // SAFETY: the notification name and the block's signature match
+    // Foundation's API. `None` for the queue means the block runs on the
+    // posting thread, which for this notification is AppKit's main thread. The
+    // block captures only an `AppHandle`, which is `Send + Sync`.
+    let observer = unsafe {
+        center.addObserverForName_object_queue_usingBlock(
+            Some(NSApplicationDidResignActiveNotification),
+            None,
+            None,
+            &resign_handler,
+        )
+    };
+    // Kept for the app's lifetime, for the same reason as the monitor token
+    // above. The notification center holds its own copy of the block.
+    std::mem::forget(observer);
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn install(_app: &tauri::AppHandle) {}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@
 //! - [`disk_monitor`] — free-space polling, the tray readout, the low edge.
 //! - [`dto`] — the shapes that cross that boundary.
 //! - [`export`] — the derived-only session export document.
+//! - [`global_click`] — dismissing the popover on clicks outside the app.
 //! - [`notifications`] — the policy on what may interrupt a reader.
 //! - [`nudges`] — presentation glue between that policy and the window.
 //! - [`popover`] — the tray-anchored popover window and its show/hide policy.
@@ -52,6 +53,7 @@ mod consent;
 mod disk_monitor;
 mod dto;
 mod export;
+mod global_click;
 mod notifications;
 mod nudges;
 mod popover;
@@ -175,6 +177,10 @@ pub fn run() {
 
             popover::create(app.handle())?;
             tray::create(app.handle())?;
+            // After both, and on the main thread: the monitor dismisses the
+            // popover and reaches the menu-bar item to unlight it, so neither
+            // may be missing by the time a click can arrive.
+            global_click::install(app.handle());
 
             // Registered before the update scheduler starts, so the first
             // automatic check can see whether there is anything to check with.

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -25,11 +25,17 @@
 //!
 //! # Dismissal
 //!
-//! Three things put the popover away: looking at something else
+//! Three things put the popover away everywhere: looking at something else
 //! ([`hide_on_focus_loss`]), Escape ([`hide`], reached from the webview), and a
-//! second click on the menu-bar item ([`toggle`]). All three answer to
-//! [`set_pinned`] — while the popover is pinned none of them fire, and the tray
-//! menu's Unpin item is what gives them back.
+//! second click on the menu-bar item ([`toggle`]). On macOS a fourth joins
+//! them — a click anywhere outside the application (`hide_on_outside_click`,
+//! driven by [`crate::global_click`]), which is the one case that reports no
+//! focus change at all, because clicking the Finder desktop makes no window
+//! key. All of them answer to [`set_pinned`]: while the popover is pinned none
+//! fire, and the tray menu's Unpin item is what gives them back.
+//!
+//! Whichever way it goes, it leaves through [`note_hidden`], which is also
+//! where the menu-bar item is unlit; [`note_shown`] is the other half.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -405,14 +411,58 @@ fn apply_height(window: &WebviewWindow, height: f64) {
 /// Both cases return *before* recording the dismissal: nothing was dismissed,
 /// so the next tray click is a fresh open and must not be suppressed.
 pub fn hide_on_focus_loss(window: &Window) {
-    if let Some(state) = window.app_handle().try_state::<PopoverState>() {
+    dismiss(window.app_handle());
+}
+
+/// Hides the popover after a click somewhere else on the desktop.
+///
+/// Focus loss is not enough on its own. Clicking the Finder desktop makes no
+/// window key, so Tauri reports no focus change and the popover would stay on
+/// screen — with, now, the menu-bar item stranded lit. The global click
+/// monitor in [`crate::global_click`] closes that gap and lands here.
+///
+/// Answers to the pin like the other three dismissals, through [`dismiss`].
+///
+/// Only acts on a popover that is actually on screen. Nothing here should
+/// touch the reopen suppression on a popover that is already away: the tray
+/// click that just closed it must still be able to reopen it on the press
+/// after next.
+///
+/// macOS-only, because its caller is: the monitor that drives it exists
+/// nowhere else, and an uncalled dismissal on the other platforms is dead code
+/// rather than a dormant feature.
+#[cfg(target_os = "macos")]
+pub fn hide_on_outside_click(app: &AppHandle) {
+    let visible = app
+        .get_webview_window(LABEL)
+        .and_then(|window| window.is_visible().ok())
+        .unwrap_or(false);
+    if !visible {
+        return;
+    }
+    dismiss(app);
+}
+
+/// Puts the popover away because the reader looked elsewhere, and records when
+/// — so the tray click that may have caused it is not read as a fresh open.
+///
+/// No-op while a focus hold is active: a native dialog the popover opened is
+/// about to take (or has taken) focus, and the popover must survive it. Also a
+/// no-op while pinned — looking away is exactly what a pin is for.
+///
+/// Both cases return *before* recording the dismissal: nothing was dismissed,
+/// so the next tray click is a fresh open and must not be suppressed.
+fn dismiss(app: &AppHandle) {
+    if let Some(state) = app.try_state::<PopoverState>() {
         if state.holds_focus() || state.is_pinned() {
             return;
         }
         state.record_auto_hide();
     }
-    let _ = window.hide();
-    note_hidden(window.app_handle());
+    if let Some(window) = app.get_webview_window(LABEL) {
+        let _ = window.hide();
+    }
+    note_hidden(app);
 }
 
 /// Begin a focus hold. Paired with [`end_focus_hold`] around a native dialog.
@@ -502,12 +552,19 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
     }
 }
 
-/// Tell the scan scheduler the popover is on screen.
+/// Everything that has to happen when the popover reaches the screen, whichever
+/// way it got there.
 ///
 /// The popover *is* the view of the scanned data, so its visibility is what
 /// gates the periodic rescan (see [`crate::scan`]). Reported from here rather
 /// than inferred from window events, because a hidden window that was never
 /// shown produces no event at all.
+///
+/// The menu-bar highlight is lit here for the same reason [`note_hidden`]
+/// clears it: both open paths already run through this one — the toggle, and a
+/// pin re-showing a window the tray menu had dismissed — so pairing the
+/// highlight with visibility is structural rather than something each caller
+/// has to remember.
 fn note_shown(app: &AppHandle) {
     if let Some(controller) = app.try_state::<crate::scan::ScanController>() {
         controller.set_popover_visible(true);
@@ -515,13 +572,24 @@ fn note_shown(app: &AppHandle) {
         // looking, so refresh immediately instead of waiting out a tick.
         controller.request();
     }
+    crate::tray::set_highlight(app, true);
 }
 
-/// Tell the scan scheduler the popover is gone.
+/// The close-side counterpart: everything that has to happen when the popover
+/// leaves the screen, whichever way it left.
+///
+/// Every close path already runs through here — the toggle, the webview's
+/// Escape, dismissal on focus loss or an outside click, and the shell's
+/// suppressed window close — which is why the menu-bar highlight is cleared
+/// here rather than at each of them.
+///
+/// Unconditional: clearing a highlight that is already off costs nothing, and
+/// a state that somehow drifted out of step is corrected rather than kept.
 pub fn note_hidden(app: &AppHandle) {
     if let Some(controller) = app.try_state::<crate::scan::ScanController>() {
         controller.set_popover_visible(false);
     }
+    crate::tray::set_highlight(app, false);
 }
 
 /// Records the menu-bar item's rectangle and places the popover against it.

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -138,6 +138,73 @@ fn on_menu_event(app: &AppHandle, event: MenuEvent) {
     }
 }
 
+/// Light the menu-bar item, or put it out.
+///
+/// macOS only draws a *momentary* highlight on a status item: it appears on
+/// mouse-down and lets go on mouse-up. So the icon would go flat the instant
+/// the popover appeared, and the popover would read as a window floating near
+/// the menu bar rather than as this item's surface. Every native menu-bar
+/// popover stays lit for as long as it is open; this is how antiburn does the
+/// same.
+///
+/// The state has to stay paired with the popover's visibility, and the pairing
+/// lives in [`crate::popover`]: lit in `note_shown`, cleared in `note_hidden`.
+/// Every open and every close already runs through that pair, so no caller —
+/// including the tray menu's own pin — has to remember the icon separately.
+///
+/// # A known flicker on the opening click
+///
+/// tray-icon's `mouseUp:` calls `highlight(false)` and only then hands the
+/// click on, so this function re-lights a button that went dark ~185µs
+/// earlier. That gap is visible: `NSCell`'s highlight drawing is immediate and
+/// flushed, not deferred to the next frame, so the dark state reaches the
+/// screen as its own paint. Opening the popover therefore blinks once.
+///
+/// Measured, not guessed — Tauri delivers the tray event ~13µs after
+/// `mouseUp:` begins, so this is not event-loop latency and no reordering on
+/// this side can close it. Two alternatives were tried and rejected against
+/// the running app: driving the button's `state` instead (a status button is
+/// momentary, so `state` has no rendering at all), and forcing
+/// `PushOnPushOff` so `state` would paint a background (it still does not).
+/// `highlight(_:)` is the only property that renders, and tray-icon clears it
+/// on every mouse-up.
+///
+/// Removing the blink means stopping that call, which means carrying a fork of
+/// tray-icon rather than tracking the upstream revision already pinned in
+/// `Cargo.toml`. Judged not worth it for one frame, deliberately rather than by
+/// omission; the `[patch.crates-io]` note records the same decision.
+///
+/// macOS-only; a no-op elsewhere. Stateless — the caller says what the icon
+/// should look like, not what to change.
+#[cfg(target_os = "macos")]
+pub fn set_highlight(app: &AppHandle, on: bool) {
+    use objc2::MainThreadMarker;
+
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+    // Tauri marshals the closure onto the main thread either way: inline when
+    // the caller is already there (the tray click, the window-event handler,
+    // the global click monitor), or via a blocking event-loop round-trip when
+    // it isn't (the `hide_popover` command, which runs on the async runtime).
+    // The closure takes no lock, so neither path can deadlock.
+    let _ = tray.with_inner_tray_icon(move |inner| {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return;
+        };
+        let Some(item) = inner.ns_status_item() else {
+            return;
+        };
+        let Some(button) = item.button(mtm) else {
+            return;
+        };
+        button.highlight(on);
+    });
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn set_highlight(_app: &AppHandle, _on: bool) {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Keep the menu-bar item highlighted while the popover is open. The highlight now follows the real window lifecycle, including focus changes and close events, instead of relying only on the tray click.

## Validation

- Desktop tests passed.
- The menu-bar and popover interaction was checked manually on macOS.