### PR TITLE
Prepare the 0.1.2 engine release

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -988,7 +988,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1183,7 +1183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2572,7 +2572,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3698,7 +3698,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3754,7 +3754,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4149,7 +4149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4946,7 +4946,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5336,7 +5336,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5365,7 +5365,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5753,7 +5753,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,6 +21,26 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-08-17
+
+### Added
+
+- `repositories::partition_cwds_by_grants` lets an embedding application split
+  working directories into immediately safe and consent-deferred paths without
+  touching the filesystem. `repositories::verify_dir_access` exposes the same
+  directory-read check discovery uses, including stale-grant revocation and
+  probe diagnostics.
+
+### Fixed
+
+- Repository resolution no longer starts `git` inside an ungranted macOS
+  protected directory. Working directories under Documents, Desktop, and
+  Downloads are deferred before any filesystem or child-process access, so a
+  background scan cannot raise the operating system's consent dialog.
+- A grant revoked outside the application is removed when a directory read is
+  denied, and its diagnostic probe now uses the same `denied` outcome vocabulary
+  as an application-requested consent check.
+
 ## [0.1.1] - 2026-08-14
 
 ### Fixed

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MPL-2.0"


### PR DESCRIPTION
## What

Bumps antiburn-local to 0.1.2 in its manifest and lockfile, refreshes the desktop lockfile path dependency, and adds the release notes required by the engine workflow.

The notes cover the new public consent partition/access helpers, protected-directory resolution that refuses to start git before consent, and stale-grant revocation diagnostics.

## Verification

- engine release-version check: passed
- whole-tree boundary scan in a clean tracked-tree snapshot: passed
- locked engine tests: 649 unit tests passed, 4 boundary tests passed, 1 doc test passed, 1 platform integration test ignored
- workflow release-note extraction: passed
- git diff check: passed