### PR TITLE
Prepare antiburn 0.1.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.1.0-rc.4] - 2026-08-17
+
+A release-candidate rehearsal build, not a supported release. The macOS and
+Windows binaries are **unsigned** — your operating system will warn you, and it
+is right to. Install it only if you are testing the release pipeline itself.
+
+On macOS, open the app for the first time with right-click → Open rather than a
+double-click. The build is sealed but has no Developer ID signature, so macOS
+shows its unidentified-developer warning.
+
 ### Added
 
 - **Your plan's limits, on the Usage screen.** When one of your agents has
@@ -76,9 +86,30 @@ CI changes, and documentation that no user acts on stay out — see
   because a milestone is a threshold being *crossed* and that needs readings
   that keep moving. With it off you still see your limits; antiburn just never
   interrupts you about them. The switch says both of these things.
-||||||| 37bd357
+
+- **Folder access asks before macOS does.** If sessions point into Documents,
+  Desktop, or Downloads, antiburn explains why it needs that folder and waits
+  for you to choose before it attempts a read. You can review deferred folders
+  and grant them later from Settings → Sources. If access is revoked outside
+  antiburn, the stale grant is noticed and the folder returns to the consent
+  flow instead of being treated as readable.
+
+- **Recognisable agent marks.** Codex and OpenAI now use their own marks, and
+  the agent palette has stronger, more consistent colours wherever agents are
+  identified.
+
+- **A popover that can stay put.** The tray menu can pin the popover open while
+  you work elsewhere, then unpin it to restore the usual click-away behaviour.
+
+- **A dedicated first-run window.** Setup now opens in a regular window rather
+  than borrowing the menu-bar popover. It explains that antiburn lives in the
+  menu bar after setup, and clicking the menu-bar item brings setup back while
+  it is unfinished.
 
 ### Changed
+
+- The menu-bar item remains highlighted for as long as the popover is visible,
+  including while it is pinned, so its open state is clear.
 
 - The legal documents in Settings → About now open as their own pages, with a
   back arrow, instead of expanding in place and burying the rest of the pane.
@@ -86,6 +117,11 @@ CI changes, and documentation that no user acts on stay out — see
   bundled third-party material have moved out of "Legal notices" onto a row of
   their own.
 
+### Fixed
+
+- Pinning is unavailable until first-run setup is complete, so setup cannot be
+  hidden behind an empty popover and always remains reachable from the menu
+  bar.
 
 ## [0.1.0-rc.3] - 2026-08-15
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.3",
+  "version": "0.1.0-rc.4",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 dependencies = [
  "antiburn-local",
  "antiburn-nudge",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/nudge", "crates/sound"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.3",
+  "version": "0.1.0-rc.4",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary
- set all desktop version sources to 0.1.0-rc.4
- turn Unreleased into the dated rc.4 reader-facing release notes
- retain the explicit unsigned macOS and Windows rehearsal warning

## Validation
- both release-version checks
- exact changelog extraction and updater configuration
- whole-tree source boundary in a clean tracked-tree snapshot
- locked antiburn-local tests: 649 passed, 1 ignored; 4 boundary tests; 1 doc test
- git diff --check and conflict-marker scan

The release workflow will stop at a draft for human review; this PR does not publish a release.