### PR TITLE
feat: retain local session data without expiry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ antiburn is local-first by contract, and CI enforces it mechanically:
 - Test fixtures must be **synthetic**: no real transcripts, usernames, home
   paths, repository names, or captured machine output — redaction is not
   sufficient.
+- **Performance and memory use are product constraints.** antiburn is an
+  always-running background utility: avoid eager or repeated work, keep reads,
+  allocations, concurrency, and retained data bounded, and do not load the
+  reader's machine beyond what the visible feature actually needs.
 - The source-boundary manifests in `docs/oss/` are governance records; changes
   to them require a maintainer-approved governance decision, not a routine PR.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ documented files, read-only databases, and bounded WSL paths only. The desktop a
 useful fully offline; its only internet exception is checking GitHub Releases for a
 newer version. There is no analytics or telemetry of any kind in this application.
 
+**Resource boundary:** antiburn is a background utility, so CPU, memory, and disk I/O
+are product constraints. Work must be lazy, bounded, and no more frequent or
+memory-intensive than the visible feature requires. It should not materially load a
+reader's machine merely because it is running.
+
 ## Repository layout
 
 ```text

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,8 @@ antiburn runs entirely on-device. Reports of particular interest:
 - discovery escaping its documented provider roots, following symlinks out of
   an approved root, or writing to provider-owned stores;
 - reads of credential, cookie, token, account, or billing data;
-- transcript content leaking into logs, derived storage, or analytics.
+- transcript content leaving app-controlled local storage, appearing in logs,
+  or being exposed outside a visibility or analysis feature that needs it.
 
 ## Supported versions
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -158,14 +158,17 @@ Three independent checks, none of which relies on review:
   through immediately, so there is no Save button and no dirty state.
 - **Local store.** One SQLite database under the app data directory
   (`ai.antiburn.desktop`, or `ai.antiburn.desktop.debug` for a development
-  build — see above) holds preferences, scan roots, a session metadata
-  cache, and the engine-derived analysis. **It never stores transcript
-  content** — see the contract in `src-tauri/src/store/schema.rs`. Migrations
-  are embedded and versioned by the `user_version` pragma.
+  build — see above) holds preferences, scan roots, and the local session data
+  needed for visibility and analysis. That data may include content copied
+  from a transcript, but remains on the device; the agent's source transcript
+  is never modified or deleted. Migrations are embedded and versioned by the
+  `user_version` pragma.
 - **Scanning.** A single background task refreshes what the app knows: once at
   launch (after onboarding), whenever the popover is opened, every 60s while it
   stays open, paused entirely while it is hidden, and on demand. Passes never
-  overlap and are bounded — see the policy at the top of `src-tauri/src/scan.rs`.
+  overlap and are bounded. CPU, memory, and disk I/O are product constraints:
+  background work must be no more frequent or intensive than the visible
+  feature requires. See the policy at the top of `src-tauri/src/scan.rs`.
 - **Notifications.** Six kinds, all posted by the shell and never by the webview
   (which is granted no notification permission): an available update, a failed
   scan, low disk space, a spend anomaly, a crossed usage milestone, and the

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -840,11 +840,11 @@ pub fn delete_session_data(
     app.state::<Store>().delete_session(&key).map_err(fail)
 }
 
-/// Forget antiburn's entire derived index.
+/// Forget all session data in antiburn's local store.
 ///
 /// **antiburn's own records only.** Not one provider file is touched: the
-/// transcripts this index was derived from are the agents' files, they stay
-/// exactly where they are, and a later scan rebuilds everything this removed.
+/// the agents' source transcripts stay exactly where they are, and a later
+/// scan rebuilds everything this removed.
 /// Preferences, scan folders, and repository include choices are kept — this is
 /// "forget what you worked out", not "forget who I am".
 ///
@@ -852,7 +852,10 @@ pub fn delete_session_data(
 /// number rather than a shrug.
 #[tauri::command]
 pub fn clear_local_index(app: tauri::AppHandle) -> CommandResult<usize> {
-    let removed = app.state::<Store>().clear_derived_index().map_err(fail)?;
+    let removed = app
+        .state::<Store>()
+        .clear_local_session_data()
+        .map_err(fail)?;
     // The index is empty and the popover is showing it. Refill it rather than
     // leaving a reader looking at an empty list until the next tick.
     app.state::<ScanController>().request();

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -322,15 +322,6 @@ pub struct ProviderUsageSummary {
     pub providers: Vec<ProviderUsage>,
     /// ISO-8601 stamp of the moment this snapshot was computed.
     pub generated_at: String,
-    /// How many days of session history the app keeps.
-    ///
-    /// Load-bearing, not trivia: it is shorter than a calendar month, so the
-    /// `month` window is truncated for most of every month and a view that did
-    /// not say so would be quietly wrong.
-    pub retention_days: u32,
-    /// ISO-8601 stamp of the earliest activity these windows can include.
-    /// Later than the start of the month whenever retention bites.
-    pub coverage_since: String,
 }
 
 /// Where the app came from and what it is running against.

--- a/apps/desktop/src-tauri/src/provider_usage/live/history.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/history.rs
@@ -42,13 +42,6 @@ use crate::store::Store;
 /// Where the series live.
 const KEY: &str = "internal:liveUsageHistory";
 
-/// The calculation window for samples.
-///
-/// A week, because the longest window a provider reports is a week: history
-/// older than the window it describes cannot inform anything about it. This is
-/// an ephemeral forecast cache bound, not session-data retention.
-const EVIDENCE_WINDOW_SECS: i64 = 7 * 24 * 60 * 60;
-
 /// A ceiling on the whole forecast cache.
 ///
 /// Guards the pathological case — many providers, many windows, an agent
@@ -127,20 +120,16 @@ pub fn load(store: &Store) -> History {
         .unwrap_or_default()
 }
 
-/// Append anything new in `snapshots`, prune, and write back.
+/// Append anything new in `snapshots`, enforce the capacity ceiling, and write back.
 ///
 /// Returns the history *including* the new readings, so a caller that is
 /// about to compute a forecast does not have to read it back.
-pub fn record(store: &Store, snapshots: &[ProviderUsageSnapshot], now: i64) -> History {
+pub fn record(store: &Store, snapshots: &[ProviderUsageSnapshot]) -> History {
     let mut history = load(store);
     let mut changed = false;
 
     for snapshot in snapshots {
         let at = snapshot.observed_at.unix_timestamp();
-        // A reading outside the forecast window cannot inform a calculation.
-        if now.saturating_sub(at) > EVIDENCE_WINDOW_SECS {
-            continue;
-        }
         for window in &snapshot.windows {
             let series = history
                 .series
@@ -162,7 +151,7 @@ pub fn record(store: &Store, snapshots: &[ProviderUsageSnapshot], now: i64) -> H
         }
     }
 
-    if prune(&mut history, now) {
+    if enforce_ceiling(&mut history) {
         changed = true;
     }
     if changed {
@@ -174,18 +163,12 @@ pub fn record(store: &Store, snapshots: &[ProviderUsageSnapshot], now: i64) -> H
     history
 }
 
-/// Drop what is too old, then what is over the ceiling. Returns whether
+/// Drop the oldest samples until the cache is at its ceiling. Returns whether
 /// anything went.
-fn prune(history: &mut History, now: i64) -> bool {
-    let horizon = now - EVIDENCE_WINDOW_SECS;
+fn enforce_ceiling(history: &mut History) -> bool {
     let before: usize = history.series.values().map(Vec::len).sum();
 
-    for series in history.series.values_mut() {
-        series.retain(|sample| sample.at >= horizon);
-    }
-    history.series.retain(|_, series| !series.is_empty());
-
-    let mut total: usize = history.series.values().map(Vec::len).sum();
+    let mut total = before;
     while total > MAX_SAMPLES {
         // Oldest first, across every series: the ceiling is a property of the
         // whole cache, so one busy window must not evict a quiet window's
@@ -258,9 +241,9 @@ mod tests {
         let store = store();
         let key = window_key(&snapshot(NOW - 60, 40.0), "five-hour");
 
-        record(&store, &[snapshot(NOW - 60, 40.0)], NOW);
-        record(&store, &[snapshot(NOW - 60, 40.0)], NOW);
-        let history = record(&store, &[snapshot(NOW - 60, 40.0)], NOW);
+        record(&store, &[snapshot(NOW - 60, 40.0)]);
+        record(&store, &[snapshot(NOW - 60, 40.0)]);
+        let history = record(&store, &[snapshot(NOW - 60, 40.0)]);
 
         assert_eq!(history.samples(&key).len(), 1);
     }
@@ -271,9 +254,9 @@ mod tests {
         let key = window_key(&snapshot(NOW, 40.0), "five-hour");
 
         // Recorded out of order on purpose.
-        record(&store, &[snapshot(NOW - 60, 45.0)], NOW);
-        record(&store, &[snapshot(NOW - 3_600, 40.0)], NOW);
-        let history = record(&store, &[snapshot(NOW - 30, 50.0)], NOW);
+        record(&store, &[snapshot(NOW - 60, 45.0)]);
+        record(&store, &[snapshot(NOW - 3_600, 40.0)]);
+        let history = record(&store, &[snapshot(NOW - 30, 50.0)]);
 
         let samples = history.samples(&key);
         assert_eq!(samples.len(), 3);
@@ -290,28 +273,8 @@ mod tests {
     fn the_series_survives_a_reload_through_the_store() {
         let store = store();
         let key = window_key(&snapshot(NOW, 40.0), "five-hour");
-        record(&store, &[snapshot(NOW - 60, 40.0)], NOW);
+        record(&store, &[snapshot(NOW - 60, 40.0)]);
         assert_eq!(load(&store).samples(&key).len(), 1);
-    }
-
-    #[test]
-    fn readings_past_the_horizon_are_dropped_and_never_stored() {
-        let store = store();
-        let key = window_key(&snapshot(NOW, 40.0), "five-hour");
-
-        // Too old to store at all.
-        record(
-            &store,
-            &[snapshot(NOW - EVIDENCE_WINDOW_SECS - 1, 10.0)],
-            NOW,
-        );
-        assert!(load(&store).samples(&key).is_empty());
-
-        // Stored, then aged out by a later pass.
-        record(&store, &[snapshot(NOW - 60, 40.0)], NOW);
-        assert_eq!(load(&store).samples(&key).len(), 1);
-        let later = record(&store, &[], NOW + EVIDENCE_WINDOW_SECS + 120);
-        assert!(later.samples(&key).is_empty());
     }
 
     #[test]
@@ -319,7 +282,7 @@ mod tests {
         let mut other = snapshot(NOW - 60, 90.0);
         other.account = Some("account-b".into());
         let store = store();
-        let history = record(&store, &[snapshot(NOW - 60, 40.0), other.clone()], NOW);
+        let history = record(&store, &[snapshot(NOW - 60, 40.0), other.clone()]);
 
         assert_eq!(
             history.samples(&window_key(&snapshot(NOW, 0.0), "five-hour"))[0].used_percent,
@@ -355,7 +318,7 @@ mod tests {
             }],
         );
 
-        prune(&mut history, NOW);
+        enforce_ceiling(&mut history);
 
         assert_eq!(
             history.series.values().map(Vec::len).sum::<usize>(),

--- a/apps/desktop/src-tauri/src/provider_usage/live/history.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/history.rs
@@ -42,13 +42,14 @@ use crate::store::Store;
 /// Where the series live.
 const KEY: &str = "internal:liveUsageHistory";
 
-/// How far back samples are kept.
+/// The calculation window for samples.
 ///
 /// A week, because the longest window a provider reports is a week: history
-/// older than the window it describes cannot inform anything about it.
-const RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
+/// older than the window it describes cannot inform anything about it. This is
+/// an ephemeral forecast cache bound, not session-data retention.
+const EVIDENCE_WINDOW_SECS: i64 = 7 * 24 * 60 * 60;
 
-/// A ceiling on the whole store, whatever the retention says.
+/// A ceiling on the whole forecast cache.
 ///
 /// Guards the pathological case — many providers, many windows, an agent
 /// refetching constantly — from turning a convenience cache into an unbounded
@@ -136,8 +137,8 @@ pub fn record(store: &Store, snapshots: &[ProviderUsageSnapshot], now: i64) -> H
 
     for snapshot in snapshots {
         let at = snapshot.observed_at.unix_timestamp();
-        // A reading older than retention is not worth storing even once.
-        if now.saturating_sub(at) > RETENTION_SECS {
+        // A reading outside the forecast window cannot inform a calculation.
+        if now.saturating_sub(at) > EVIDENCE_WINDOW_SECS {
             continue;
         }
         for window in &snapshot.windows {
@@ -176,7 +177,7 @@ pub fn record(store: &Store, snapshots: &[ProviderUsageSnapshot], now: i64) -> H
 /// Drop what is too old, then what is over the ceiling. Returns whether
 /// anything went.
 fn prune(history: &mut History, now: i64) -> bool {
-    let horizon = now - RETENTION_SECS;
+    let horizon = now - EVIDENCE_WINDOW_SECS;
     let before: usize = history.series.values().map(Vec::len).sum();
 
     for series in history.series.values_mut() {
@@ -299,13 +300,17 @@ mod tests {
         let key = window_key(&snapshot(NOW, 40.0), "five-hour");
 
         // Too old to store at all.
-        record(&store, &[snapshot(NOW - RETENTION_SECS - 1, 10.0)], NOW);
+        record(
+            &store,
+            &[snapshot(NOW - EVIDENCE_WINDOW_SECS - 1, 10.0)],
+            NOW,
+        );
         assert!(load(&store).samples(&key).is_empty());
 
         // Stored, then aged out by a later pass.
         record(&store, &[snapshot(NOW - 60, 40.0)], NOW);
         assert_eq!(load(&store).samples(&key).len(), 1);
-        let later = record(&store, &[], NOW + RETENTION_SECS + 120);
+        let later = record(&store, &[], NOW + EVIDENCE_WINDOW_SECS + 120);
         assert!(later.samples(&key).is_empty());
     }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -153,7 +153,7 @@ pub fn summarize(
         .is_some_and(|settings| settings.live_usage_enabled);
     let collected = sources::collect(sources, online);
     let history = store
-        .map(|store| history::record(store, &collected.snapshots, now))
+        .map(|store| history::record(store, &collected.snapshots))
         .unwrap_or_default();
     let midnight = local_midnight(now, utc_offset_minutes);
     let at =

--- a/apps/desktop/src-tauri/src/provider_usage/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/mod.rs
@@ -23,17 +23,12 @@
 //! balance, and a reset time are all unavailable — and are therefore absent
 //! from the payload rather than estimated into it.
 //!
-//! # Two honest limitations, both surfaced rather than hidden
+//! # An honest limitation, surfaced rather than hidden
 //!
 //! 1. **A session lands in one window: the one its last activity falls in.**
 //!    The store keeps a per-session heartbeat, not a per-turn timeline, so a
 //!    session that ran across midnight counts entirely in the day it last
 //!    touched. The views say so.
-//! 2. **`month` is truncated by retention.** The app keeps
-//!    [`RETENTION_DAYS`](crate::scan::RETENTION_DAYS) of history, which is
-//!    shorter than a calendar month, so for most of every month the month
-//!    window starts later than the first. [`ProviderUsageSummary::coverage_since`]
-//!    carries the real start, and the views print it.
 
 pub mod live;
 pub mod providers;
@@ -51,7 +46,6 @@ use crate::dto::{
     ProviderUsage, ProviderUsageStaleness, ProviderUsageState, ProviderUsageSummary,
     ProviderUsageWindow, ProviderUsageWindows,
 };
-use crate::scan::RETENTION_DAYS;
 use crate::store::{UsageEvidenceRecord, iso_from_epoch};
 
 use providers::Route;
@@ -447,7 +441,5 @@ pub fn summarize(
     ProviderUsageSummary {
         providers,
         generated_at: iso_from_epoch(Some(now)),
-        retention_days: RETENTION_DAYS as u32,
-        coverage_since: iso_from_epoch(Some(bounds.earliest().max(now - RETENTION_DAYS * 86_400))),
     }
 }

--- a/apps/desktop/src-tauri/src/provider_usage/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/tests.rs
@@ -454,7 +454,7 @@ fn providers_come_back_most_recently_used_first() {
  * ---------------------------------------------------------------------- */
 
 #[test]
-fn the_snapshot_is_dated_and_has_no_retention_contract() {
+fn an_empty_snapshot_is_dated_and_has_no_providers() {
     let summary = summarize(&[], NOW, 0);
     assert_eq!(summary.generated_at, "2027-01-15T08:00:00Z");
     assert!(summary.providers.is_empty());

--- a/apps/desktop/src-tauri/src/provider_usage/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/tests.rs
@@ -454,16 +454,9 @@ fn providers_come_back_most_recently_used_first() {
  * ---------------------------------------------------------------------- */
 
 #[test]
-fn the_snapshot_says_how_far_back_it_can_actually_see() {
+fn the_snapshot_is_dated_and_has_no_retention_contract() {
     let summary = summarize(&[], NOW, 0);
     assert_eq!(summary.generated_at, "2027-01-15T08:00:00Z");
-    assert_eq!(summary.retention_days, RETENTION_DAYS as u32);
-    // Mid-January the month began before retention did, so coverage starts at
-    // the retention horizon and not at the first of the month. A view that
-    // printed "this month" without this would be quietly wrong.
-    let month_start = window_bounds(NOW, 0).month_start;
-    assert!(NOW - RETENTION_DAYS * 86_400 > month_start);
-    assert_eq!(summary.coverage_since, "2027-01-01T08:00:00Z");
     assert!(summary.providers.is_empty());
 }
 

--- a/apps/desktop/src-tauri/src/repositories.rs
+++ b/apps/desktop/src-tauri/src/repositories.rs
@@ -39,7 +39,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::consent::StoreConsentGrants;
 use crate::dto::{DeferredPermissionDir, RepositoryItem};
-use crate::scan::{IGNORE_SCOPE, RETENTION_DAYS, unix_now};
+use crate::scan::IGNORE_SCOPE;
 use crate::store::{RepositoryRecord, Store};
 
 /// Owners the forward scan runs for, most sessions first. A machine that works
@@ -59,8 +59,10 @@ pub async fn refresh(app: &AppHandle) -> anyhow::Result<()> {
     let store = app.state::<Store>();
     let ignored = ignored_paths::load_ignored(store.state_dir(), IGNORE_SCOPE);
 
-    let since = unix_now() - RETENTION_DAYS * 86_400;
-    let sessions = store.recent_sessions(since, MAX_SESSIONS_CONSIDERED)?;
+    // Repository counts use the newest bounded slice of everything indexed,
+    // with no age-based expiry. The cap protects an always-running utility
+    // from loading an unbounded history into memory at once.
+    let sessions = store.recent_sessions(0, MAX_SESSIONS_CONSIDERED)?;
     let known: Vec<RepositoryRecord> = store.repositories()?;
     let scan_roots: Vec<PathBuf> = store.scan_roots()?.into_iter().map(PathBuf::from).collect();
 
@@ -267,8 +269,8 @@ pub async fn set_enabled(store: &Store, key: &str, enabled: bool) -> anyhow::Res
         } else {
             ignored_paths::ignore_path(store.state_dir(), IGNORE_SCOPE, path).await?;
             // Excluded means excluded: rows already indexed for this
-            // repository leave the store now, not at the next retention
-            // prune. Re-checked against the full opt-out set as the scan
+            // repository leave the store now rather than remaining stale.
+            // Re-checked against the full opt-out set as the scan
             // does, so normalization matches exactly — which also sweeps any
             // stragglers from earlier opt-outs.
             purge_ignored_sessions(store)?;

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -12,6 +12,11 @@
 //! a request that arrives while one is running is dropped rather than queued,
 //! because the next tick would produce the same answer.
 //!
+//! antiburn is an always-running background utility. CPU time, memory, open
+//! files, and disk I/O are therefore correctness constraints, not optional
+//! optimizations: a scan must do no more work, retain no more data in memory,
+//! and run no more often than the visible feature requires.
+//!
 //! When a pass runs:
 //!
 //! - **At launch**, once, if onboarding is finished. A first-run install has no
@@ -52,11 +57,13 @@
 //! a retry), and [`crate::notifications`] once per run of the app, for someone
 //! who is not looking at antiburn at all.
 //!
-//! Every pass is bounded: discovery is windowed to the retention horizon, the
+//! Every pass is bounded: discovery is windowed to the widest activity view, the
 //! per-session metadata reads run at a fixed concurrency, and analysis is
 //! capped at [`MAX_ANALYSES_PER_PASS`] sessions so one pass cannot grow with
-//! the size of the machine. The scheduler is a single task whose handle the app
-//! aborts on exit, so nothing outlives the process.
+//! the size of the machine. Sessions already indexed are retained until the
+//! reader explicitly clears them; the bounded discovery window is not a data
+//! expiry policy. The scheduler is a single task whose handle the app aborts on
+//! exit, so nothing outlives the process.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -79,11 +86,6 @@ use crate::store::{SessionKey, SessionRecord, Store};
 
 /// How often the scheduler wakes up.
 pub const TICK: Duration = Duration::from_secs(60);
-
-/// Days of session history the store retains, regardless of how narrow the
-/// user's activity window is. Widening the window then has data to show
-/// immediately instead of waiting for a scan.
-pub const RETENTION_DAYS: i64 = 14;
 
 /// How many session logs have their metadata read at once. Bounds open files
 /// and blocking-pool pressure during a whole-machine pass.
@@ -261,7 +263,10 @@ async fn pass(app: &AppHandle) -> anyhow::Result<usize> {
     let store = app.state::<Store>();
     let settings = store.settings()?;
     let now = unix_now();
-    let window_days = i64::from(settings.activity_window_days).max(RETENTION_DAYS);
+    // Discovery always covers the widest list the UI can request, so changing
+    // the display window is instant. Previously indexed sessions outside this
+    // lookback remain in the store indefinitely.
+    let window_days = i64::from(crate::store::MAX_ACTIVITY_DAYS);
     let since_secs = window_days * 86_400;
 
     let ignored = ignored_paths::load_ignored(store.state_dir(), IGNORE_SCOPE);
@@ -293,7 +298,7 @@ async fn pass(app: &AppHandle) -> anyhow::Result<usize> {
 
     // A transcript the gate rejected may have been indexed by an earlier
     // version of the app that did not gate; the row is removed rather than
-    // left to mislead until retention ages it out.
+    // left to mislead indefinitely.
     for key in &rejected {
         checked(
             app,
@@ -309,12 +314,6 @@ async fn pass(app: &AppHandle) -> anyhow::Result<usize> {
             store.record_agent_scan(&agent, cursor, seen),
         )?;
     }
-
-    checked(
-        app,
-        "The retention prune",
-        store.prune_sessions_before(now - RETENTION_DAYS * 86_400),
-    )?;
 
     // Everything discovered so far is already persisted, so a cancel here keeps
     // the reader's results and only skips the work still ahead.
@@ -1170,11 +1169,5 @@ mod tests {
         controller.running.store(true, Ordering::SeqCst);
         controller.request_cancel();
         assert!(controller.cancelled());
-    }
-
-    #[test]
-    fn retention_is_never_narrower_than_the_widest_activity_window() {
-        // The store must be able to answer a widened window without a rescan.
-        assert!(RETENTION_DAYS >= i64::from(crate::store::model::DEFAULT_ACTIVITY_DAYS));
     }
 }

--- a/apps/desktop/src-tauri/src/storage_health.rs
+++ b/apps/desktop/src-tauri/src/storage_health.rs
@@ -150,7 +150,7 @@ mod tests {
         // A *different* failure is news again, because it names something else.
         let other = StorageHealthStatus {
             failing: true,
-            message: Some("the retention prune could not be written: database is locked".into()),
+            message: Some("the scan bookkeeping could not be written: database is locked".into()),
         };
         assert!(health.replace(other).is_some());
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -9,14 +9,14 @@
 //! the scanner at, a metadata cache of the sessions discovery has seen, and the
 //! analysis the engine derived from them.
 //!
-//! # What is *not* here
-//!
-//! Transcript bodies. No message text, no tool arguments, no file contents. The
-//! database stores identities, locations, derived numbers, and two short
-//! derived excerpts — a session's title and each skill's one-line description,
-//! both length-capped before they are written. A session's messages stay in the
-//! file its vendor wrote and are re-read on demand. [`schema`] states that as a
-//! schema-level contract, and [`crate::export`] honors the same rule.
+//! The database is allowed to retain any local session content needed for
+//! visibility and analysis. The current schema stores identities, locations,
+//! derived numbers, a session title, and capped skill descriptions; future
+//! migrations may add transcript content deliberately. All such data remains
+//! app-controlled and on-device, and clear/delete paths apply to it. Provider
+//! source transcripts are never modified or deleted. [`schema`] carries the
+//! detailed contract. Exports have their own, narrower content policy in
+//! [`crate::export`].
 //!
 //! # Concurrency
 //!
@@ -539,42 +539,16 @@ impl Store {
             .optional()?)
     }
 
-    /// Drop sessions whose heartbeat predates `before_epoch` and everything
-    /// derived from them.
-    ///
-    /// Retention, not deletion-on-behalf: these rows describe transcripts that
-    /// have aged out of every window the app can show. The provider's own files
-    /// are untouched.
-    pub fn prune_sessions_before(&self, before_epoch: i64) -> Result<usize> {
-        let mut connection = self.lock();
-        let tx = connection.transaction()?;
-        let stale: Vec<(String, String, String)> = {
-            let mut statement = tx.prepare(
-                "SELECT environment_key, agent, session_id FROM session
-                  WHERE COALESCE(updated_at_epoch, 0) < ?1",
-            )?;
-            let rows = statement.query_map(params![before_epoch], |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-            })?;
-            rows.collect::<rusqlite::Result<Vec<_>>>()?
-        };
-        for (environment_key, agent, session_id) in &stale {
-            delete_session_in(&tx, &SessionKey::new(environment_key, agent, session_id))?;
-        }
-        tx.commit()?;
-        Ok(stale.len())
-    }
-
-    /// Forget the entire derived index: every session, its analysis, its
+    /// Forget all locally stored session data: every session, its analysis, its
     /// relations, and the per-agent scan bookkeeping. Returns how many sessions
     /// were dropped.
     ///
     /// **antiburn's own tables only.** Not one provider file is opened, let
-    /// alone written — the transcripts this index was derived *from* are the
-    /// agents' files and stay exactly where they are, which is why a later scan
-    /// finds all of it again.
+    /// alone written — the agents' source transcripts stay exactly where they
+    /// are, which is why a later scan finds all of it again.
     ///
-    /// Deliberately spared, because none of it is derived data:
+    /// Deliberately spared, because it represents preferences and source
+    /// configuration rather than indexed session data:
     ///
     /// - `setting` — the reader's preferences, including whether onboarding is
     ///   done. Clearing the index is not a factory reset.
@@ -582,7 +556,7 @@ impl Store {
     /// - `repository` — the include/ignore choices the reader made. Their
     ///   session counts *are* derived, so those are zeroed here and refilled by
     ///   the next pass.
-    pub fn clear_derived_index(&self) -> Result<usize> {
+    pub fn clear_local_session_data(&self) -> Result<usize> {
         let mut connection = self.lock();
         let tx = connection.transaction()?;
         tx.execute("DELETE FROM session_relation", [])?;

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -58,8 +58,8 @@ pub fn environment_key(wsl_distro: Option<&str>) -> String {
     }
 }
 
-/// Cached metadata for one discovered session. No transcript content: the
-/// `source_*` pair points at the provider's own file rather than copying it.
+/// Cached metadata for one discovered session. The `source_*` pair identifies
+/// the provider's source even if other session content is also cached locally.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SessionRecord {
     pub key: SessionKey,
@@ -327,8 +327,8 @@ impl Milestones {
 }
 
 /// Narrowest and widest activity windows the settings pane offers, in days.
-/// The ceiling equals the store's retention window: offering more days than
-/// the store keeps would render a header over data that cannot exist.
+/// These control presentation and recent discovery, not storage: sessions
+/// already indexed remain until the reader clears them.
 pub const MIN_ACTIVITY_DAYS: u32 = 1;
 pub const MAX_ACTIVITY_DAYS: u32 = 14;
 /// Days of activity a fresh install shows.

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -20,32 +20,17 @@ pub const MIGRATIONS: &[&str] = &[V1, V2];
 ///
 /// # Data policy (schema-level contract)
 ///
-/// **No transcript bodies are stored in this database: no message text, no tool
-/// arguments, and no file contents.** Every table below holds normalized
-/// identity (agent, session id, environment), locations (paths that point *at*
-/// the provider's own file), or values derived by the engine's analysis (counts,
-/// durations, token totals, phase distributions, cost estimates). The
-/// transcripts themselves stay where their vendor wrote them and are re-read on
-/// demand.
+/// This is app-controlled, on-device storage. The schema may retain session
+/// content as well as derived values when a visibility or analysis feature
+/// needs it. Keeping a local copy never transfers ownership of the source:
+/// provider files are not modified or deleted.
 ///
-/// Two columns carry a **short derived excerpt** of a transcript, and they are
-/// named here rather than left to be discovered, because a contract that
-/// overstates itself is worse than one that admits its edges:
-///
-/// - `session.title` — the session's own title. Vendors that record one supply
-///   it; where none exists the engine derives one from the first user message,
-///   capped at 200 characters (`title_source` says which happened, and
-///   `firstMessage` is the derived case).
-/// - `session_analysis.metrics_json` → each `skillUses[].description` — the
-///   one-line description a transcript's own skill listing carries, capped at
-///   [`crate::analytics::SKILL_DESCRIPTION_MAX_CHARS`] characters before it is
-///   ever written.
-///
-/// Everything else in `metrics_json` is
-/// `antiburn_local::analysis::SessionMetrics`: counts, timings, distributions,
-/// token totals, and skill *names*. Beyond those two bounded excerpts, a column
-/// carrying message text, prompts, tool arguments, or file contents does not
-/// belong in this schema.
+/// The v1 schema below stores normalized identity, provider-file locations,
+/// derived metrics, a session title, and capped skill descriptions. That is its
+/// current shape, not a prohibition on future migrations storing messages,
+/// tool activity, or file content recorded in a transcript. Any such migration
+/// must still be deliberate, bounded, covered by the local-data clear/delete
+/// paths, and must not create a network or logging path for the content.
 const V1: &str = r#"
 -- App settings, one row per key. Values are JSON scalars so a new preference
 -- is additive and needs no migration.
@@ -69,8 +54,7 @@ CREATE TABLE session (
     environment_key  TEXT NOT NULL,
     agent            TEXT NOT NULL,
     session_id       TEXT NOT NULL,
-    -- Where the transcript lives. A REFERENCE to the provider's file, never a
-    -- copy of it.
+    -- Where the provider's source transcript lives.
     source_kind      TEXT NOT NULL,
     source_label     TEXT NOT NULL,
     wsl_distro       TEXT,
@@ -118,7 +102,7 @@ CREATE TABLE session_analysis (
 
 -- Local relationships between sessions: orchestration (a session's sub-agents)
 -- and lineage (the session a fork branched from). Labels are the vendor's own
--- short display label, not transcript content.
+-- short display label.
 CREATE TABLE session_relation (
     environment_key TEXT NOT NULL,
     agent           TEXT NOT NULL,

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -158,12 +158,10 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     assert!(saved.notify_scan_failure);
 }
 
-/// The schema's data policy says which columns may hold free text. This is the
-/// mechanical half of that promise: a column added to `session` without a
-/// deliberate decision fails here rather than quietly becoming the place
-/// transcript text ends up.
+/// Pin the shipped v1 shape so migrations remain deliberate. This is not a
+/// restriction on what a future local visibility feature may store.
 #[test]
-fn the_session_table_holds_exactly_the_columns_the_data_policy_names() {
+fn the_v1_session_table_shape_is_stable() {
     let store = store();
     let connection = store.lock();
     let mut statement = connection
@@ -184,8 +182,6 @@ fn the_session_table_holds_exactly_the_columns_the_data_policy_names() {
             "source_kind",
             "source_label",
             "wsl_distro",
-            // The one declared free-text excerpt on this table. Everything else
-            // is identity, a location, or bookkeeping.
             "title",
             "title_source",
             "cwd",
@@ -199,7 +195,7 @@ fn the_session_table_holds_exactly_the_columns_the_data_policy_names() {
 }
 
 #[test]
-fn clearing_the_index_forgets_the_derived_records_and_keeps_the_readers_choices() {
+fn clearing_local_data_forgets_session_records_and_keeps_the_readers_choices() {
     let store = store();
     store.upsert_sessions(&[session("abc", 2_000)]).unwrap();
     store
@@ -251,7 +247,7 @@ fn clearing_the_index_forgets_the_derived_records_and_keeps_the_readers_choices(
         }])
         .unwrap();
 
-    assert_eq!(store.clear_derived_index().unwrap(), 1);
+    assert_eq!(store.clear_local_session_data().unwrap(), 1);
 
     assert!(store.recent_sessions(0, 100).unwrap().is_empty());
     assert!(
@@ -286,8 +282,8 @@ fn clearing_the_index_forgets_the_derived_records_and_keeps_the_readers_choices(
 #[test]
 fn clearing_an_already_empty_index_is_a_no_op() {
     let store = store();
-    assert_eq!(store.clear_derived_index().unwrap(), 0);
-    assert_eq!(store.clear_derived_index().unwrap(), 0);
+    assert_eq!(store.clear_local_session_data().unwrap(), 0);
+    assert_eq!(store.clear_local_session_data().unwrap(), 0);
 }
 
 #[test]
@@ -515,18 +511,6 @@ fn deleting_a_session_takes_its_derived_records_with_it() {
     assert!(store.relations(&key).unwrap().is_empty());
     // Deleting again is a no-op rather than an error.
     assert!(!store.delete_session(&key).unwrap());
-}
-
-#[test]
-fn pruning_drops_only_sessions_older_than_the_retention_horizon() {
-    let store = store();
-    store.upsert_sessions(&[session("old", 1_000)]).unwrap();
-    store.upsert_sessions(&[session("new", 5_000)]).unwrap();
-
-    assert_eq!(store.prune_sessions_before(2_000).unwrap(), 1);
-    let remaining = store.recent_sessions(0, 100).unwrap();
-    assert_eq!(remaining.len(), 1);
-    assert_eq!(remaining[0].key.session_id, "new");
 }
 
 #[test]

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -260,10 +260,6 @@ export interface ProviderUsagePayload {
 export interface ProviderUsageSummaryPayload {
   providers: ProviderUsagePayload[];
   generatedAt: string;
-  /** Days of session history the app keeps — shorter than a calendar month. */
-  retentionDays: number;
-  /** Earliest activity these windows can include. */
-  coverageSince: string;
 }
 
 /* -------------------------------------------------------------------------
@@ -742,8 +738,6 @@ export async function getProviderUsage(): Promise<ProviderUsageSummaryPayload> {
 export const EMPTY_PROVIDER_USAGE: ProviderUsageSummaryPayload = {
   providers: [],
   generatedAt: '',
-  retentionDays: 0,
-  coverageSince: '',
 };
 
 /**
@@ -796,7 +790,7 @@ export async function cancelScan(): Promise<ScanStatus | null> {
 }
 
 /**
- * Forget antiburn's entire derived index, returning how many sessions went.
+ * Forget all session data in antiburn's local store, returning how many sessions went.
  *
  * antiburn's own records only. The agents' transcripts are never touched, and a
  * later scan finds all of this again.

--- a/apps/desktop/src/lib/presentation/providerUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/providerUsage.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from 'vitest';
 
 import type { ProviderUsagePayload, ProviderUsageWindowPayload } from '../ipc';
 import {
-  coverageNote,
   EMPTY_WINDOW,
   providerInitial,
   providersForWindow,
@@ -185,20 +184,6 @@ describe('ranking and totals', () => {
 
   it('reads a window off a provider without the caller indexing it', () => {
     expect(providerWindow(openai, 'month').estimatedUsd).toBe(4);
-  });
-});
-
-describe('coverage', () => {
-  it('says how far back the windows can actually see', () => {
-    const note = coverageNote('2027-01-01T08:00:00Z', 14);
-    expect(note).toMatch(/keeps 14 days of session history/);
-    expect(note).toMatch(/start at/);
-  });
-
-  it('says nothing when the shell reported no coverage', () => {
-    expect(coverageNote('', 14)).toBeNull();
-    expect(coverageNote('2027-01-01T08:00:00Z', 0)).toBeNull();
-    expect(coverageNote('not a date', 14)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/lib/presentation/providerUsage.ts
+++ b/apps/desktop/src/lib/presentation/providerUsage.ts
@@ -207,22 +207,6 @@ export function totalForWindow(
   }, EMPTY_WINDOW);
 }
 
-/**
- * How far back the snapshot can actually see, as a sentence — or null when the
- * shell reported no coverage at all.
- *
- * This exists because the month window is a lie without it: the app keeps two
- * weeks of session history, so for most of any month "this month" starts later
- * than the first.
- */
-export function coverageNote(coverageSince: string, retentionDays: number): string | null {
-  if (!coverageSince || retentionDays <= 0) return null;
-  const since = new Date(coverageSince);
-  if (Number.isNaN(since.getTime())) return null;
-  const day = since.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  return `antiburn keeps ${retentionDays} days of session history, so these windows start at ${day}.`;
-}
-
 /** The token rows a detail panel lists, in a fixed order. */
 export function tokenRows(
   window: ProviderUsageWindowPayload,

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -130,8 +130,6 @@ const PROVIDER_USAGE = {
     },
   ],
   generatedAt: '2027-01-15T08:00:00Z',
-  retentionDays: 14,
-  coverageSince: '2027-01-01T08:00:00Z',
 };
 
 const HEALTHY_STORAGE = { failing: false, message: null };
@@ -478,7 +476,7 @@ describe('PopoverView — attention banners', () => {
     emit('storage:health', { failing: false, message: null });
     emit('storage:health', {
       failing: true,
-      message: 'The retention prune could not be written: database is locked',
+      message: 'The scan bookkeeping could not be written: database is locked',
     });
 
     expect(await screen.findByRole('status')).toHaveTextContent(/database is locked/);

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -304,7 +304,7 @@ describe('SettingsView', () => {
     expect(screen.getByText(/last checked/i)).toBeInTheDocument();
   });
 
-  it('clears the derived index after confirming, and says what went', async () => {
+  it('clears local session data after confirming, and says what went', async () => {
     confirmDialog.mockResolvedValue(true);
     mockCommands({ clear_local_index: 12 });
     render(<SettingsView />);
@@ -333,14 +333,14 @@ describe('SettingsView', () => {
     expect(invoke).not.toHaveBeenCalledWith('clear_local_index');
   });
 
-  it('states the data-handling contract, including the two derived excerpts', async () => {
+  it('states the local data-handling contract', async () => {
     render(<SettingsView />);
 
     fireEvent.click(screen.getByRole('tab', { name: 'Privacy' }));
 
     // The contract's headlines are always on screen as disclosure labels…
     const stored = await screen.findByRole('button', {
-      name: 'Only derived analysis is stored',
+      name: 'Visibility data stays on this machine',
     });
     expect(screen.getByRole('button', { name: 'Nothing is uploaded' })).toBeInTheDocument();
 
@@ -348,10 +348,9 @@ describe('SettingsView', () => {
     // the specifics genuinely appear on expansion rather than being hidden.
     fireEvent.click(stored);
     expect(
-      await screen.findByText(/no message text, no tool arguments, no file contents/i),
+      await screen.findByText(/may keep session content and derived analysis/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/capped at 200 characters/i)).toBeInTheDocument();
-    expect(screen.getByText(/capped at 300 characters/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing in this store is uploaded/i)).toBeInTheDocument();
     // Deleting a provider's own files is named as a non-feature rather than
     // left as a silence a reader would have to test for.
     expect(screen.getByText(/antiburn cannot do this, by design/i)).toBeInTheDocument();
@@ -479,7 +478,7 @@ describe('SettingsView', () => {
     );
 
     expect(
-      await screen.findByRole('button', { name: 'Only derived analysis is stored' }),
+      await screen.findByRole('button', { name: 'Visibility data stays on this machine' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Privacy' })).toHaveAttribute(
       'aria-selected',

--- a/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
+++ b/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
@@ -97,8 +97,8 @@ type Step = (typeof STEPS)[number];
 /** Steps that want a discovery pass to have run by the time they are read. */
 const STEPS_NEEDING_DISCOVERY: readonly Step[] = ['repositories', 'scan'];
 
-/** The two history windows the flow offers. Both fit inside the two weeks the
- *  store retains, so neither is a promise the app cannot keep. */
+/** The two recent-activity windows the popover offers. They affect the list,
+ *  not how long indexed sessions remain stored. */
 const WINDOW_OPTIONS = [
   { value: '7', label: '7 days' },
   { value: '14', label: '14 days' },
@@ -357,9 +357,8 @@ function Repositories({
  * pass run, and stop it if it is taking too long.
  *
  * The window choice is deliberately described as what it *is* — how far back
- * the list reaches — rather than as how far back the scan goes. antiburn keeps
- * two weeks of history whichever option is picked, and saying otherwise would
- * be a nicer sentence about a thing that is not true.
+ * the list reaches — rather than as a retention policy. Indexed sessions remain
+ * stored until the reader explicitly clears them.
  */
 function HistoricalScan({
   scanStatus,
@@ -380,8 +379,8 @@ function HistoricalScan({
         Historical scan
       </h2>
       <p className="mt-1 type-footnote text-label-secondary">
-        antiburn keeps two weeks of local history. Choose how much of it the popover lists — you
-        can change this later.
+        Choose how much recent activity the popover lists. Indexed sessions stay on this machine
+        until you clear them; you can change this view later.
       </p>
 
       {/* Capped rather than `w-full`: two options stretched across 680pt read

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -118,7 +118,7 @@ describe('UsageView', () => {
     expect(within(card!).getByText(/Easing · <0\.1×/)).toBeInTheDocument();
   });
 
-  it('states how sessions are assigned to windows without a retention disclaimer', () => {
+  it('explains how local spend estimates are calculated', () => {
     render(<UsageView summary={summary()} onBack={vi.fn()} />);
 
     expect(screen.getByText(/window of its most recent activity/)).toBeInTheDocument();

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -62,8 +62,6 @@ function summary(
   return {
     providers: [ANTHROPIC, OPENAI],
     generatedAt: '2027-01-15T08:00:00Z',
-    retentionDays: 14,
-    coverageSince: '2027-01-01T08:00:00Z',
     ...overrides,
   };
 }
@@ -120,10 +118,9 @@ describe('UsageView', () => {
     expect(within(card!).getByText(/Easing · <0\.1×/)).toBeInTheDocument();
   });
 
-  it('says how far back the windows can see, because retention is shorter than a month', () => {
+  it('states how sessions are assigned to windows without a retention disclaimer', () => {
     render(<UsageView summary={summary()} onBack={vi.fn()} />);
 
-    expect(screen.getByText(/keeps 14 days of session history/)).toBeInTheDocument();
     expect(screen.getByText(/window of its most recent activity/)).toBeInTheDocument();
     expect(screen.getByText(/Not a bill/)).toBeInTheDocument();
   });

--- a/apps/desktop/src/views/popover/UsageView.tsx
+++ b/apps/desktop/src/views/popover/UsageView.tsx
@@ -18,7 +18,6 @@ import type {
 import { EMPTY_LIVE_USAGE } from '../../lib/ipc';
 import { liveAuthNote, liveForProvider } from '../../lib/presentation/liveUsage';
 import {
-  coverageNote,
   providerWindow,
   rankByWindow,
   stalenessNote,
@@ -82,7 +81,6 @@ export function UsageView({ summary, live = EMPTY_LIVE_USAGE, now, onBack }: Usa
   // section to render, so nothing consumes this.
   const at = now ?? (Date.parse(live.generatedAt) || 0);
   const { recent, rest } = sectioned(summary.providers);
-  const coverage = coverageNote(summary.coverageSince, summary.retentionDays);
   const empty = recent.length === 0 && rest.length === 0;
   const authNote = liveAuthNote(live);
 
@@ -138,7 +136,6 @@ export function UsageView({ summary, live = EMPTY_LIVE_USAGE, now, onBack }: Usa
         </p>
         <p className="type-caption text-label-tertiary">
           Each session counts in the window of its most recent activity.
-          {coverage ? ` ${coverage}` : ''}
         </p>
       </footer>
     </div>

--- a/apps/desktop/src/views/settings/AboutPane.tsx
+++ b/apps/desktop/src/views/settings/AboutPane.tsx
@@ -123,11 +123,7 @@ export function AboutPane({ settings, update, loaded, info, onOpenPane }: AboutP
           />
           <Row
             label="Local database"
-            // Narrower than "never transcript content", because that was not
-            // true: the store keeps a session's title and each skill's
-            // one-line description, both capped. Privacy settings carry the
-            // long form; this says enough to not mislead.
-            description="Schema version of antiburn's own store. It holds derived analysis, plus short capped excerpts for titles and skill descriptions — no message text, tool arguments, or file contents. See Privacy."
+            description="Schema version of antiburn's own store. It keeps local session data needed for visibility and analysis; nothing in it is uploaded. See Privacy."
             trailing={
               <span className="type-body tabular-nums text-label-secondary">
                 v{info?.schemaVersion ?? '—'}

--- a/apps/desktop/src/views/settings/GeneralPane.tsx
+++ b/apps/desktop/src/views/settings/GeneralPane.tsx
@@ -22,9 +22,9 @@ import {
 import { relativeTime } from '../../lib/presentation/relativeTime';
 import type { AppSettingsController } from './useAppSettings';
 
-/** Narrowest and widest activity windows, mirroring the store's own clamp. */
+/** Narrowest and widest activity-list windows, mirroring the store's clamp. */
 // Mirrors the shell's MIN/MAX_ACTIVITY_DAYS: the ceiling equals the store's
-// two-week retention, so the slider can never promise days that cannot exist.
+// display range only; indexed sessions outside it remain stored.
 const MIN_DAYS = 1;
 const MAX_DAYS = 14;
 
@@ -135,7 +135,7 @@ export function GeneralPane({ settings, update, info }: GeneralPaneProps) {
             label="Show the last"
             description={`The popover lists sessions from the last ${dayLabel(
               settings.activityWindowDays,
-            )}. antiburn keeps two weeks of history; widening this shows it right away and asks the next scan to fill anything missing.`}
+            )}. This changes the list, not storage; indexed sessions outside the window remain on this machine.`}
             trailing={
               <span className="type-body tabular-nums text-label-secondary">
                 {dayLabel(settings.activityWindowDays)}
@@ -159,7 +159,7 @@ export function GeneralPane({ settings, update, info }: GeneralPaneProps) {
         <Card>
           <Row
             label="Indexed sessions"
-            description="What antiburn currently has on this machine. Sessions older than two weeks are dropped automatically; your agents' own files are never touched. Settings → Privacy can clear all of it."
+            description="What antiburn currently has on this machine. Indexed sessions do not expire based on age; Settings → Privacy can clear them. Your agents' own files are never touched."
             trailing={
               <span className="type-body tabular-nums text-label-secondary">
                 {info ? `${info.indexedSessions} · ${byteLabel(info.databaseBytes)}` : '—'}

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -19,8 +19,8 @@ import { clearLocalIndex } from '../../lib/ipc';
  * to make it forget.
  *
  * This pane is the long form of a promise the rest of the app only has room to
- * gesture at. It is deliberately specific — naming the two derived excerpts,
- * the retention horizon, and the single network exception — because a
+ * gesture at. It is deliberately specific — naming what can be stored, the
+ * absence of automatic expiry, and the single network exception — because a
  * local-first app's privacy page is worth nothing if it is written in the same
  * reassuring generalities as everyone else's.
  */
@@ -61,8 +61,8 @@ export function PrivacyPane() {
       <div className="space-y-3">
         <p className="type-body text-pretty text-label-secondary">
           antiburn reads the session files your coding agents already keep on this machine,
-          stores only derived analysis, and uploads nothing. Each promise below opens into the
-          specifics a reader could reasonably want to check.
+          keeps the data it needs locally, and uploads nothing. Each promise below opens into
+          the specifics a reader could reasonably want to check.
         </p>
         {/* Disclosures rather than Card rows: this is explanatory prose, and a
             card of five paragraph-length rows read as settings that could not
@@ -71,21 +71,19 @@ export function PrivacyPane() {
         <DisclosureGroup>
           <Disclosure label="Sources are read, never written">
             antiburn reads the session files and read-only databases your coding agents already
-            keep on this machine. It never modifies them, never deletes them, and never copies a
-            transcript anywhere.
+            keep on this machine. It may copy data into its own local store, but it never
+            modifies or deletes the source transcripts.
           </Disclosure>
-          <Disclosure label="Only derived analysis is stored">
-            The local database holds identities, file locations, and numbers the analysis
-            produced — counts, durations, token totals, cost estimates. It holds no transcript
-            bodies: no message text, no tool arguments, no file contents. Two short excerpts are
-            kept so sessions are recognizable: a session&rsquo;s title (for agents that record
-            none, the opening of your first message, capped at 200 characters) and each
-            skill&rsquo;s one-line description, capped at 300 characters.
+          <Disclosure label="Visibility data stays on this machine">
+            antiburn may keep session content and derived analysis in its own local store when
+            they are needed for visibility or analysis. That can include messages, tool
+            activity, file content recorded in a transcript, identities, paths, counts,
+            durations, token totals, and cost estimates. Nothing in this store is uploaded.
           </Disclosure>
-          <Disclosure label="History is kept for two weeks">
-            Sessions older than 14 days are dropped from the index automatically. The
-            agents&rsquo; own files are left exactly where they are — antiburn simply stops
-            describing them.
+          <Disclosure label="History stays until you clear it">
+            Indexed sessions do not expire based on age. antiburn keeps its local session data
+            until you clear it; the agents&rsquo; own source files are left exactly where they
+            are.
           </Disclosure>
           <Disclosure label="Nothing is uploaded">
             There is no account, no server, and no usage data collected. antiburn itself opens

--- a/docs/runbooks/security-releases.md
+++ b/docs/runbooks/security-releases.md
@@ -30,8 +30,8 @@ Reports arrive as private GitHub security advisories. On arrival:
    - discovery escaping its documented provider roots, following a symlink out
      of an approved root, or writing to a provider-owned store;
    - reads of credential, cookie, token, account, or billing data;
-   - transcript content reaching logs, derived storage, or an export that did
-     not ask;
+   - transcript content leaving app-controlled local storage, reaching logs,
+     or appearing in an export that did not ask;
    - anything reachable through the updater, which is the one channel that can
      cause code to run on someone else's machine.
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -82,36 +82,27 @@ and when it resets. Those are the provider's numbers, not ours:
 
 ## What antiburn stores
 
-antiburn keeps one SQLite database in its own application data directory. Settings →
-About shows the exact path.
+antiburn keeps its own local data under the application's data directory. Settings →
+About shows the exact path. It may retain the session content and derived data it
+needs to provide visibility and analysis, including messages, tool activity, file
+content recorded in a transcript, session identity and locations, counts, durations,
+token totals, phase distributions, cost estimates, skill details, and session
+relations. This data stays on the device and is never uploaded.
 
-**It stores:** session identity (agent, session id, environment), the *path* of the
-agent's own transcript, the working directory and repository a session ran in, and
-values derived by the analysis — counts, durations, token totals, phase
-distributions, cost estimates, skill names, and sub-agent relations.
+The coding agents' source transcripts remain their files. antiburn may copy data from
+them into its own local store, but it never modifies or deletes the source files.
 
-**It does not store transcript bodies:** no message text, no tool arguments, and no
-file contents.
-
-**Two short derived excerpts are stored**, because a session with no title is not
-recognizable:
-
-- a session's **title**. Agents that record one supply it. For agents that do not,
-  the engine derives one from the opening of the first user message, capped at 200
-  characters.
-- each skill's **one-line description**, taken from the transcript's own skill
-  listing and capped at 300 characters.
-
-**Retention** is 14 days. Older sessions are dropped from the index automatically;
-the agents' own files are never touched. Settings → Privacy has a control that clears
-the entire derived index at once.
+**There is no age-based retention limit.** Once a session is indexed, antiburn keeps
+its local data until the reader explicitly clears it. The agents' own files are never
+touched. Settings → Privacy clears all locally stored session data at once.
 
 **Deletion.** antiburn removes only records it created itself. It cannot and will not
 delete a coding agent's own transcript — that is the agent's file, and removing a
 conversation belongs in the agent's own interface.
 
-**Exports** carry derived analysis, the paths a session ran in, and the two excerpts
-above. The export flow warns before it writes and always asks where to put the file.
+**Exports** currently carry derived analysis, the paths a session ran in, its title,
+and skill descriptions. They do not include transcript bodies. The export flow warns
+before it writes and always asks where to put the file.
 
 **Folder permissions (macOS).** macOS guards Documents, Desktop, and Downloads behind
 your explicit consent. antiburn never reads one of them until you have allowed it: a


### PR DESCRIPTION
## Purpose

This change lets antiburn keep local session data that its visibility and analysis features need. It removes age-based deletion from the local session index. Agent source transcripts remain unchanged, and antiburn does not upload the stored data.

## Detailed summary

- Change the storage policy to permit local copies of session content.
- Remove the automatic 14-day session prune.
- Keep indexed sessions until the user clears them.
- Keep the 7-day and 14-day controls as activity-view and recent-discovery limits only.
- Remove retention fields and notices from the provider usage data contract.
- Count repository activity from a bounded set of indexed sessions without an age limit.
- State that CPU, memory, file, and disk use are product constraints.
- Update the support, security, onboarding, Settings, Privacy, and contributor text.
- Keep the current export format unchanged. It still excludes transcript bodies.

## Important review points

- Confirm that all local clear and delete paths still leave agent source transcripts unchanged.
- Confirm that the scan no longer removes sessions because of age.
- Confirm that the recent-discovery window still limits background work.
- Confirm that the Rust and TypeScript provider usage types remain synchronized.
- Confirm that the forecast sample window is an internal calculation bound, not session retention.

## Test plan

- Run `pnpm --filter @antiburn/desktop test`.
- Run `pnpm --filter @antiburn/desktop type-check`.
- Run `pnpm --filter @antiburn/desktop lint`.
- Run `pnpm --filter @antiburn/desktop format`.
- Run `cargo fmt --check` in `apps/desktop/src-tauri`.
- Run `cargo test` in `apps/desktop/src-tauri`.
- Run `cargo clippy --all-targets -- -D warnings` in `apps/desktop/src-tauri`.
- Run `node scripts/check-boundary.mjs`.