### PR TITLE
feat(usage): hide unused model-scoped weekly limits until used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ CI changes, and documentation that no user acts on stay out — see
   whether a newer version exists — is a convenience it never depends on, and
   it hands your data to no one who doesn't already have it.
 
+### Changed
+
+- **A per-model weekly limit stays out of the way until you use that
+  model.** Your provider can report a supplemental weekly allowance scoped to
+  one model alongside your account-wide limits. Most readers never touch that
+  model, so its row used to sit at the bottom of the Usage screen reading 0%
+  forever. It is now hidden until you actually use the model it tracks, and
+  once it shows real usage it stays on screen for the rest of that week —
+  even past a reading that comes back without a percentage — so a limit you
+  are genuinely drawing on never looks like it disappeared.
+
 ## [0.1.0-rc.4] - 2026-08-17
 
 A release-candidate rehearsal build, not a supported release. The macOS and

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -384,10 +384,13 @@ pub enum LiveUsageFreshness {
 
 /// One provider-reported allowance.
 ///
-/// Every field is either something the provider stated or `null`. Nothing here
-/// is derived, interpolated, or defaulted — in particular `used_percent` is
-/// `null` rather than `0.0` when the provider did not say, because a meter
-/// reading empty and a meter reading unknown are different facts.
+/// Every field through `resets_at` is either something the provider stated or
+/// `null`. Nothing there is derived, interpolated, or defaulted — in
+/// particular `used_percent` is `null` rather than `0.0` when the provider did
+/// not say, because a meter reading empty and a meter reading unknown are
+/// different facts. The last two fields are the exception, and both are
+/// derived from this window's own sample history rather than stated by
+/// anyone.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LiveUsageWindow {
@@ -405,6 +408,13 @@ pub struct LiveUsageWindow {
     pub starts_at: Option<String>,
     /// ISO-8601 reset, when the provider stated one.
     pub resets_at: Option<String>,
+    /// Whether trustworthy history shows non-zero usage anywhere in this
+    /// window's current allowance period. The views consult this only for a
+    /// supplemental, model-scoped window — most readers never touch that
+    /// model, so it stays hidden until this turns true, then stays visible
+    /// for the rest of the period even past a reading that comes back with
+    /// no percentage at all.
+    pub has_nonzero_usage_in_current_period: bool,
     /// What this window's own history supports saying about it.
     pub forecast: LiveUsageForecast,
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/metrics.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/metrics.rs
@@ -320,6 +320,46 @@ pub fn estimated_exhaustion_at(
     ))
 }
 
+/// Whether trustworthy history shows non-zero usage anywhere in a window's
+/// current allowance period.
+///
+/// This exists for one purpose: a supplemental, model-scoped weekly window
+/// (a per-model limit alongside the account-wide one) sits at 0% for most
+/// readers, who never touch that model. The views hide such a window until
+/// it has something to say and, once it does, keep showing it for the rest
+/// of that period even if a later reading comes back unknown — see
+/// `liveUsage.ts::isUsageWindowVisible` on the frontend, which this feeds.
+///
+/// "Current period" reuses exactly what [`usage_forecast`] already means by
+/// it — the tail of the series since the most recent percentage drop
+/// ([`latest_stable_segment`]) — rather than inventing a second definition.
+/// That choice is deliberate: a [`UsageSample`] here carries no reset
+/// timestamp of its own, so there is only one place "which period is this"
+/// can be answered, and no second copy to drift out of sync with it. (A
+/// sibling app that shipped this same behaviour kept a `reset_epoch` on each
+/// stored sample and matched it against the window's `resets_at`; the two
+/// independently-derived answers disagreed and hid windows that were
+/// genuinely in use.)
+///
+/// `resets_at` still earns a role, as a sanity check rather than a boundary:
+/// a reset already behind `now` means the provider's own account of this
+/// window has rolled, or gone stale, since anything below was read, and no
+/// percentage-drop in the history can be trusted to describe the period that
+/// is current *now*. Missing reset metadata is treated the same way, for the
+/// same reason — there is no period here to bound.
+pub fn has_nonzero_usage_in_current_period(
+    samples: &[UsageSample],
+    resets_at: Option<OffsetDateTime>,
+    now: OffsetDateTime,
+) -> bool {
+    if resets_at.is_none_or(|reset| reset <= now) {
+        return false;
+    }
+    latest_stable_segment(samples)
+        .iter()
+        .any(|sample| sample.used_percent.is_some_and(|percent| percent > 0.0))
+}
+
 /// How many percentage points of a window were consumed since local midnight.
 ///
 /// Only fresh, non-decreasing pairs count. A pair spanning a reset
@@ -578,5 +618,80 @@ mod tests {
         // "10 more then a reset", which would over-count exactly when the
         // provider's reset metadata is least stable.
         assert_eq!(used_since(&samples, at(-10_800)), Some(7.0));
+    }
+
+    /* ---------------------------------------------------------------------
+     * Whether a window's current period has shown any usage
+     * ------------------------------------------------------------------- */
+
+    #[test]
+    fn hides_a_window_whose_current_period_never_showed_usage() {
+        let samples = [sample(-7_200, 0.0), sample(-3_600, 0.0), sample(0, 0.0)];
+        assert!(!has_nonzero_usage_in_current_period(
+            &samples,
+            Some(at(3_600)),
+            at(0)
+        ));
+    }
+
+    #[test]
+    fn shows_a_window_once_its_current_period_has_any_nonzero_reading() {
+        let samples = [sample(-7_200, 0.0), sample(-3_600, 4.0), sample(0, 4.0)];
+        assert!(has_nonzero_usage_in_current_period(
+            &samples,
+            Some(at(3_600)),
+            at(0)
+        ));
+    }
+
+    #[test]
+    fn a_reset_since_the_nonzero_reading_drops_it_from_the_current_period() {
+        // Used 20 points last period, then reset to 0. This period alone has
+        // shown nothing yet, so last period's usage must not leak forward.
+        let samples = [sample(-7_200, 20.0), sample(-3_600, 0.0), sample(0, 0.0)];
+        assert!(!has_nonzero_usage_in_current_period(
+            &samples,
+            Some(at(3_600)),
+            at(0)
+        ));
+    }
+
+    #[test]
+    fn stays_visible_when_the_latest_reading_in_the_period_is_unknown() {
+        // The sticky case this feature exists for: a later reading with no
+        // percentage must not erase what an earlier one in the same period
+        // already proved.
+        let samples = [
+            sample(-3_600, 12.0),
+            UsageSample {
+                observed_at: at(0),
+                used_percent: None,
+                freshness: Freshness::Fresh,
+            },
+        ];
+        assert!(has_nonzero_usage_in_current_period(
+            &samples,
+            Some(at(3_600)),
+            at(0)
+        ));
+    }
+
+    #[test]
+    fn a_reset_already_behind_now_cannot_be_trusted() {
+        // The provider's own account of this window has rolled (or gone
+        // stale) since the sample was read; no drop in the history can prove
+        // which period is current now.
+        let samples = [sample(-3_600, 40.0)];
+        assert!(!has_nonzero_usage_in_current_period(
+            &samples,
+            Some(at(-1)),
+            at(0)
+        ));
+    }
+
+    #[test]
+    fn missing_reset_metadata_cannot_be_trusted_either() {
+        let samples = [sample(-3_600, 40.0)];
+        assert!(!has_nonzero_usage_in_current_period(&samples, None, at(0)));
     }
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -232,6 +232,8 @@ fn window(
         snapshot.source.freshness,
         snapshot.source.confidence,
     );
+    let has_nonzero_usage_in_current_period =
+        metrics::has_nonzero_usage_in_current_period(samples, window.resets_at, now);
     // Only on a window longer than a day. "How much of your five-hour limit
     // you used today" is a question about a period that has already rolled
     // several times, and the answer would be nonsense dressed as a metric.
@@ -266,6 +268,7 @@ fn window(
         used_percent: window.used_percent,
         starts_at: window.starts_at.map(iso),
         resets_at: window.resets_at.map(iso),
+        has_nonzero_usage_in_current_period,
         forecast: LiveUsageForecast {
             unavailable_reason: forecast
                 .unavailable_reason

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -446,3 +446,105 @@ fn an_offline_source_is_ungated_by_default() {
     // which is why the refresh source overrides it explicitly.
     assert!(!Fixed("offline", Vec::new()).requires_online_opt_in());
 }
+
+/* -------------------------------------------------------------------------
+ * Whether a supplemental, model-scoped window is worth showing
+ *
+ * `has_nonzero_usage_in_current_period` (see `metrics.rs`) is what the
+ * frontend consults to hide a per-model weekly limit until it has something
+ * to say. Exercised here end to end, through `summarize`'s real store, so
+ * the wiring — not just the arithmetic underneath it — is covered.
+ * ---------------------------------------------------------------------- */
+
+use crate::store::Store;
+
+fn weekly_scoped_snapshot(
+    observed: i64,
+    percent: Option<f64>,
+    resets_at: i64,
+) -> ProviderUsageSnapshot {
+    ProviderUsageSnapshot {
+        provider: crate::provider_usage::providers::ANTHROPIC,
+        account: Some("account-a".into()),
+        plan: None,
+        observed_at: at(observed),
+        source: UsageSource {
+            id: "fixture",
+            label: "fixture".into(),
+            confidence: Confidence::High,
+            freshness: Freshness::Fresh,
+        },
+        support: SupportTier::Live,
+        windows: vec![super::UsageWindow {
+            id: "weekly-some-model".into(),
+            role: WindowRole::Supplemental,
+            kind: UsageWindowKind::Weekly,
+            scope: UsageScope::Model("Some Model".into()),
+            used_percent: percent,
+            starts_at: None,
+            resets_at: Some(at(resets_at)),
+            authoritative: true,
+        }],
+        supplemental: None,
+    }
+}
+
+fn in_memory_store() -> Store {
+    Store::open_in_memory(std::path::Path::new("/tmp/antiburn-live-usage-test"))
+        .expect("in-memory store")
+}
+
+#[test]
+fn a_supplemental_window_turns_on_and_stays_on_through_the_period() {
+    let store = in_memory_store();
+    let reset = NOW + 3_600;
+
+    // Sits at 0%, same as most readers who never touch this model.
+    let quiet: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
+        "fixture",
+        vec![weekly_scoped_snapshot(NOW - 7_200, Some(0.0), reset)],
+    ))];
+    let summary = summarize(&quiet, Some(&store), NOW - 7_200, 0);
+    assert!(!summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
+
+    // A real reading arrives.
+    let used: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
+        "fixture",
+        vec![weekly_scoped_snapshot(NOW - 3_600, Some(6.0), reset)],
+    ))];
+    let summary = summarize(&used, Some(&store), NOW - 3_600, 0);
+    assert!(summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
+
+    // A later reading with no percentage at all must not erase what the
+    // period already proved — sticky for the rest of the period.
+    let unknown: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
+        "fixture",
+        vec![weekly_scoped_snapshot(NOW, None, reset)],
+    ))];
+    let summary = summarize(&unknown, Some(&store), NOW, 0);
+    assert!(summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
+}
+
+#[test]
+fn a_reset_clears_the_flag_for_the_new_period() {
+    let store = in_memory_store();
+    let first_reset = NOW + 3_600;
+
+    let used: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
+        "fixture",
+        vec![weekly_scoped_snapshot(NOW - 3_600, Some(30.0), first_reset)],
+    ))];
+    let summary = summarize(&used, Some(&store), NOW - 3_600, 0);
+    assert!(summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
+
+    // The window reset: the percentage dropped, and the provider now states a
+    // reset further out than before. Nothing this period has used anything
+    // yet, so the flag must not still be reporting last period's usage.
+    let second_reset = NOW + 604_800;
+    let rolled: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
+        "fixture",
+        vec![weekly_scoped_snapshot(NOW, Some(0.0), second_reset)],
+    ))];
+    let summary = summarize(&rolled, Some(&store), NOW, 0);
+    assert!(!summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
+}

--- a/apps/desktop/src/components/providerUsage/ProviderUsageCluster.test.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageCluster.test.tsx
@@ -331,6 +331,7 @@ function liveSummary(usedPercent: number | null = 88): LiveUsageSummaryPayload {
             usedPercent: 12,
             startsAt: null,
             resetsAt: null,
+            hasNonzeroUsageInCurrentPeriod: false,
             forecast,
           },
           {
@@ -341,6 +342,7 @@ function liveSummary(usedPercent: number | null = 88): LiveUsageSummaryPayload {
             usedPercent,
             startsAt: null,
             resetsAt: null,
+            hasNonzeroUsageInCurrentPeriod: false,
             forecast,
           },
         ],

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -287,10 +287,12 @@ export type LiveUsageFreshness = 'fresh' | 'stale';
 /**
  * One provider-reported allowance.
  *
- * Every field is either something the provider stated or null. In particular
- * `usedPercent` is null — never 0 — when the provider did not say, because a
- * meter reading empty and a meter reading unknown are different facts and the
- * views render them differently.
+ * Every field through `resetsAt` is either something the provider stated or
+ * null. In particular `usedPercent` is null — never 0 — when the provider did
+ * not say, because a meter reading empty and a meter reading unknown are
+ * different facts and the views render them differently. The last two fields
+ * are the exception: both are derived from this window's own sample history
+ * rather than stated by anyone.
  */
 export interface LiveUsageWindowPayload {
   /** `five-hour`, `seven-day`, `weekly-<model>`, or the provider's own name. */
@@ -305,6 +307,12 @@ export interface LiveUsageWindowPayload {
   usedPercent: number | null;
   startsAt: string | null;
   resetsAt: string | null;
+  /**
+   * Whether trustworthy history shows non-zero usage anywhere in this
+   * window's current allowance period. Consulted only for a supplemental,
+   * model-scoped window — see `isUsageWindowVisible` in `liveUsage.ts`.
+   */
+  hasNonzeroUsageInCurrentPeriod: boolean;
   /** What this window's own history supports saying about it. */
   forecast: LiveUsageForecastPayload;
 }

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -27,6 +27,8 @@ import {
   liveWindows,
   forecastUnavailableNote,
   headlineWindow,
+  isConditionallyVisibleUsageWindow,
+  isUsageWindowVisible,
   paceState,
   paceStateLabel,
   runwayLabel,
@@ -60,6 +62,7 @@ function window(overrides: Partial<LiveUsageWindowPayload> = {}): LiveUsageWindo
     usedPercent: 81,
     startsAt: null,
     resetsAt: '2027-01-15T14:30:00Z',
+    hasNonzeroUsageInCurrentPeriod: false,
     forecast: NO_FORECAST,
     ...overrides,
   };
@@ -253,6 +256,76 @@ describe('ordering and lookup', () => {
   it('joins to the estimate payload by provider id', () => {
     expect(liveForProvider(summary(), 'anthropic')?.displayName).toBe('Anthropic');
     expect(liveForProvider(summary(), 'openai')).toBeNull();
+  });
+});
+
+describe('hiding unused model quota limits', () => {
+  it('only treats a supplemental window naming a model as conditionally visible', () => {
+    expect(
+      isConditionallyVisibleUsageWindow(window({ role: 'supplemental', scopeModel: 'Fable' })),
+    ).toBe(true);
+    // The account-wide windows describe overall standing and are never
+    // conditional, whatever role or scope they otherwise carry.
+    expect(isConditionallyVisibleUsageWindow(window({ role: 'primaryShort' }))).toBe(false);
+    expect(isConditionallyVisibleUsageWindow(window({ role: 'primaryLong' }))).toBe(false);
+    // A supplemental window with no model to name is not what this hides.
+    expect(
+      isConditionallyVisibleUsageWindow(window({ role: 'supplemental', scopeModel: null })),
+    ).toBe(false);
+  });
+
+  it('hides a quiet per-model limit and shows one that has actually been used', () => {
+    const quiet = window({ role: 'supplemental', scopeModel: 'Fable', usedPercent: 0 });
+    expect(isUsageWindowVisible(quiet)).toBe(false);
+    expect(isUsageWindowVisible({ ...quiet, usedPercent: null })).toBe(false);
+    expect(isUsageWindowVisible({ ...quiet, usedPercent: 0.1 })).toBe(true);
+    expect(isUsageWindowVisible({ ...quiet, usedPercent: 14 })).toBe(true);
+  });
+
+  it('never hides a primary window, however empty', () => {
+    expect(isUsageWindowVisible(window({ role: 'primaryShort', usedPercent: 0 }))).toBe(true);
+    expect(isUsageWindowVisible(window({ role: 'primaryLong', usedPercent: null }))).toBe(true);
+  });
+
+  it('keeps a per-model limit visible for the rest of a period it has already used', () => {
+    // The reading this pass carries no percentage at all, but the window's
+    // own history already proved this period is not the quiet case — it must
+    // not disappear just because the latest reading came back unknown.
+    const usedEarlierThisPeriod = window({
+      role: 'supplemental',
+      scopeModel: 'Fable',
+      usedPercent: null,
+      hasNonzeroUsageInCurrentPeriod: true,
+    });
+    expect(isUsageWindowVisible(usedEarlierThisPeriod)).toBe(true);
+  });
+
+  it('drops a hidden per-model limit out of the rendered list, and restores it once used', () => {
+    const provider_ = provider({
+      windows: [
+        window({ id: 'five-hour', role: 'primaryShort' }),
+        window({ id: 'seven-day', role: 'primaryLong' }),
+        window({
+          id: 'weekly-fable',
+          role: 'supplemental',
+          scopeModel: 'Fable',
+          usedPercent: 0,
+        }),
+      ],
+    });
+    expect(liveWindows(provider_).map((entry) => entry.id)).toEqual(['five-hour', 'seven-day']);
+
+    const used = {
+      ...provider_,
+      windows: provider_.windows.map((entry) =>
+        entry.id === 'weekly-fable' ? { ...entry, usedPercent: 3 } : entry,
+      ),
+    };
+    expect(liveWindows(used).map((entry) => entry.id)).toEqual([
+      'five-hour',
+      'seven-day',
+      'weekly-fable',
+    ]);
   });
 });
 

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -186,6 +186,36 @@ export function liveStalenessNote(provider: LiveProviderUsagePayload): string | 
   return `These figures are from ${relativeTime(provider.observedAt)} and may have moved since.`;
 }
 
+/**
+ * Whether a window is a supplemental, model-scoped limit — the kind that
+ * sits at 0% for most readers because it tracks a model they never touch.
+ *
+ * The account-wide primary windows (session, weekly-all-models) are never
+ * conditional: they describe the account's overall standing and belong on
+ * screen unconditionally, whatever they read.
+ */
+export function isConditionallyVisibleUsageWindow(window: LiveUsageWindowPayload): boolean {
+  return window.role === 'supplemental' && window.scopeModel != null;
+}
+
+/**
+ * Whether a window belongs on screen at all.
+ *
+ * A supplemental per-model weekly limit is noise beside the limits a reader
+ * actually hits until they touch that model, so it stays hidden until then.
+ * Once it shows non-zero usage — this reading or an earlier one in the same
+ * allowance period — it stays visible for the rest of that period, even past
+ * a reading that comes back with no percentage at all: a window that was
+ * genuinely in use must never look like it vanished.
+ */
+export function isUsageWindowVisible(window: LiveUsageWindowPayload): boolean {
+  return (
+    !isConditionallyVisibleUsageWindow(window) ||
+    (window.usedPercent ?? 0) > 0 ||
+    window.hasNonzeroUsageInCurrentPeriod
+  );
+}
+
 /** Windows worth rendering, primary ones first. */
 export function liveWindows(provider: LiveProviderUsagePayload): LiveUsageWindowPayload[] {
   const rank = (window: LiveUsageWindowPayload) => {
@@ -195,7 +225,7 @@ export function liveWindows(provider: LiveProviderUsagePayload): LiveUsageWindow
   };
   // A stable sort over a copy, so the provider's own order breaks ties and two
   // supplemental windows never swap places between renders.
-  return [...provider.windows].sort((a, b) => rank(a) - rank(b));
+  return provider.windows.filter(isUsageWindowVisible).sort((a, b) => rank(a) - rank(b));
 }
 
 /** The live reading for one provider id, or null when there is none. */

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -178,6 +178,7 @@ function liveWindow(overrides: Partial<LiveUsageWindowPayload> = {}): LiveUsageW
     usedPercent: 81,
     startsAt: '2027-01-15T09:30:00Z',
     resetsAt: '2027-01-15T14:30:00Z',
+    hasNonzeroUsageInCurrentPeriod: false,
     forecast: NO_FORECAST,
     ...overrides,
   };


### PR DESCRIPTION
## What

Supplemental, model-scoped weekly limits (e.g. a per-model "weekly" window a provider reports alongside the account-wide one) sit at 0% for most readers, who never touch that model. They add noise to the Plan limits block. This hides such a window until it shows non-zero usage in the current allowance period, then keeps it visible for the rest of that period — even past a later reading that comes back with no percentage — so a window that was genuinely in use never looks like it vanished.

Primary windows (session, weekly-all-models) are always visible and unaffected.

## How

- Backend: `has_nonzero_usage_in_current_period(samples, resets_at, now)` in `provider_usage/live/metrics.rs`. "Current period" reuses the existing `latest_stable_segment` (the tail since the most recent percentage drop) rather than a second period definition — a `UsageSample` carries no reset timestamp of its own, so there's nothing to drift out of sync. `resets_at` is used only as a sanity gate: a reset already behind `now`, or missing, is untrustworthy, so the flag returns false. Exposed as `hasNonzeroUsageInCurrentPeriod` on the window DTO.
- Frontend: `isConditionallyVisibleUsageWindow` (supplemental + model-scoped) and `isUsageWindowVisible` (visible if not conditional, or current % > 0, or the sticky flag), applied at the single `liveWindows()` choke point.

## Tests

6 Rust unit tests (hide-when-zero, show-on-nonzero, reset-drops-prior-period, sticky-through-unknown, untrustworthy/missing reset) + 2 end-to-end tests through `summarize()`, and 5 frontend tests. Full suite green: cargo fmt/clippy/test, pnpm lint/type-check/test, boundary check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)