### PR TITLE
fix(settings): reset scroll on pane changes

### DIFF
--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -533,6 +533,18 @@ describe('SettingsView', () => {
     );
   });
 
+  it('resets the shared content viewport to the top when the pane changes', async () => {
+    const { container } = render(<SettingsView />);
+
+    await screen.findByRole('switch', { name: 'Open antiburn at login' });
+    const viewport = container.querySelector('.ui-scroll-viewport') as HTMLDivElement;
+    viewport.scrollTop = 240;
+
+    fireEvent.click(screen.getByRole('tab', { name: 'About' }));
+
+    expect(viewport.scrollTop).toBe(0);
+  });
+
   it('ignores a pane id it does not recognize rather than rendering nothing', async () => {
     render(<SettingsView />);
 

--- a/apps/desktop/src/views/SettingsView.tsx
+++ b/apps/desktop/src/views/SettingsView.tsx
@@ -12,7 +12,7 @@ import {
   FolderGit2,
   Gauge,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { ScrollPane } from '../components/ui/ScrollPane';
 import { SidebarNav, type SidebarNavItem } from '../components/ui/SidebarNav';
@@ -73,7 +73,12 @@ const PANES: readonly (SidebarNavItem & { id: SettingsPane })[] = [
 export function SettingsView() {
   const [pane, setPane] = useState<SettingsPane>('general');
   const [info, setInfo] = useState<AppInfo | null>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const controller = useAppSettings();
+
+  useLayoutEffect(() => {
+    if (viewportRef.current) viewportRef.current.scrollTop = 0;
+  }, [pane]);
 
   useEffect(() => {
     let active = true;
@@ -179,7 +184,7 @@ export function SettingsView() {
       />
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <ScrollPane viewportClassName={contentPadding}>
+        <ScrollPane viewportClassName={contentPadding} viewportRef={viewportRef}>
           {/* Keyed by pane so a section switch remounts the panel and plays
               the entrance once; the global reduced-motion clamp in
               styles/motion.css neutralizes it for readers who asked. */}


### PR DESCRIPTION
## Summary

- reset the shared Settings viewport before paint whenever the active pane changes
- preserve the existing keyed pane animation
- add a regression test for retained scroll position

## Validation

- `prettier --check .`
- `eslint .`
- `tsc --build --force`
- `vitest run` — 66 files, 638 tests passed
- `vite build`
- CI control-plane tests — 14 passed
- whole-tree source-boundary scan
- local smoke test: sidebar, keyboard, and About → Privacy navigation each reset a scrolled viewport to `0`

## Repository rules

- based on current `origin/main`
- one independently reviewable frontend fix
- commit includes the required DCO sign-off
