### PR TITLE
Fix Codex and OpenCode indexed session titles in recent activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ CI changes, and documentation that no user acts on stay out — see
   even past a reading that comes back without a percentage — so a limit you
   are genuinely drawing on never looks like it disappeared.
 
+### Fixed
+
+- **Session names in recent activity.** antiburn now reads authoritative names
+  from each agent's indexed session store when available, while keeping mounted
+  WSL sessions isolated from native stores. Renames appear on the next scan,
+  and a missing title can no longer leave mismatched title provenance behind.
+
 ## [0.1.0-rc.4] - 2026-08-17
 
 A release-candidate rehearsal build, not a supported release. The macOS and

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -69,8 +69,10 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use antiburn_local::discovery::scanner::TitleSource;
 use antiburn_local::discovery::{
-    Explorers, SessionLog, SessionSource, session_log_metadata, session_source_preview,
+    Explorers, ResolvedTitle, SessionLog, SessionSource, TitleLookupKind, session_log_metadata,
+    session_source_preview,
 };
 use antiburn_local::model::AgentKind;
 use antiburn_local::paths::{home_dir, ignored_paths};
@@ -348,6 +350,7 @@ async fn describe(
     home: &std::path::Path,
     ignored: &std::collections::HashSet<String>,
 ) -> Described {
+    let indexed_titles = indexed_titles_for_logs(&logs).await;
     let mut records = Vec::with_capacity(logs.len());
     let mut rejected = Vec::new();
     for chunk in logs.chunks(METADATA_CONCURRENCY) {
@@ -355,7 +358,9 @@ async fn describe(
         for log in chunk {
             let log = log.clone();
             let home = home.to_path_buf();
-            set.spawn(async move { describe_one(log, &home).await });
+            let indexed_title = recovered_id(&log)
+                .and_then(|session_id| indexed_titles.get(&(log.agent_type, session_id)).cloned());
+            set.spawn(async move { describe_one(log, &home, indexed_title).await });
         }
         while let Some(joined) = set.join_next().await {
             match joined {
@@ -376,6 +381,34 @@ async fn describe(
     Described { records, rejected }
 }
 
+/// Read each durable vendor title store once for the sessions in this pass.
+/// Transcript fallback stays inside `describe_one`, which already has bounded
+/// metadata and preview reads for the same log.
+async fn indexed_titles_for_logs(
+    logs: &[SessionLog],
+) -> std::collections::HashMap<(AgentKind, String), ResolvedTitle> {
+    let mut indexed = std::collections::HashMap::new();
+    for agent in AgentKind::ALL {
+        let mut session_ids: Vec<String> = logs
+            .iter()
+            .filter(|log| log.agent_type == *agent && should_lookup_indexed_title(log))
+            .filter_map(recovered_id)
+            .collect();
+        session_ids.sort_unstable();
+        session_ids.dedup();
+        if session_ids.is_empty() {
+            continue;
+        }
+        for (session_id, title) in Explorers::DISK
+            .indexed_session_titles_for(agent, &session_ids)
+            .await
+        {
+            indexed.insert((*agent, session_id), title);
+        }
+    }
+    indexed
+}
+
 enum DescribeOutcome {
     Session(Box<SessionRecord>),
     /// A sub-agent transcript: never listed, and evicted if an earlier,
@@ -384,7 +417,11 @@ enum DescribeOutcome {
     Skip,
 }
 
-async fn describe_one(log: SessionLog, home: &std::path::Path) -> DescribeOutcome {
+async fn describe_one(
+    log: SessionLog,
+    home: &std::path::Path,
+    indexed_title: Option<ResolvedTitle>,
+) -> DescribeOutcome {
     let metadata = session_log_metadata(&log).await;
     let Some(session_id) = metadata
         .as_ref()
@@ -411,10 +448,17 @@ async fn describe_one(log: SessionLog, home: &std::path::Path) -> DescribeOutcom
         return DescribeOutcome::Subagent(key);
     }
 
-    let title = sanitized_title(
+    let resolved_title = if should_lookup_indexed_title(&log) {
+        indexed_title
+    } else {
+        None
+    };
+    let (title, title_source) = select_title_pair(
+        resolved_title,
         metadata
             .as_ref()
             .and_then(|metadata| metadata.title.clone()),
+        metadata.as_ref().and_then(|metadata| metadata.title_source),
         &log.agent_type,
         preview.as_deref(),
     );
@@ -435,10 +479,7 @@ async fn describe_one(log: SessionLog, home: &std::path::Path) -> DescribeOutcom
         source_label: log.source_label(),
         wsl_distro: log.environment.wsl_distro().map(str::to_string),
         title,
-        title_source: metadata
-            .as_ref()
-            .and_then(|metadata| metadata.title_source)
-            .map(|source| source.as_str().to_string()),
+        title_source,
         cwd: metadata.and_then(|metadata| metadata.cwd),
         surface: log.surface_label(home).to_string(),
         updated_at_epoch: log.updated_at,
@@ -448,6 +489,47 @@ async fn describe_one(log: SessionLog, home: &std::path::Path) -> DescribeOutcom
         // would cost far more than the relationship is worth here.
         fork_parent_session_id: None,
     }))
+}
+
+/// Native stores with a point-query index are authoritative for session names.
+/// Mounted WSL sessions deliberately stay on their transcript-local metadata:
+/// a native store may contain the same vendor id but belongs to another
+/// environment.
+fn should_lookup_indexed_title(log: &SessionLog) -> bool {
+    log.environment.is_native()
+        && matches!(
+            Explorers::DISK.title_lookup_kind_for(&log.agent_type),
+            TitleLookupKind::Direct
+        )
+}
+
+/// Keep the title and its provenance coupled. Indexed, renamed, and explicit
+/// vendor titles win directly; first-message provenance remains transcript
+/// fallback and still passes through sanitization.
+fn select_title_pair(
+    resolved: Option<ResolvedTitle>,
+    fallback_title: Option<String>,
+    fallback_source: Option<TitleSource>,
+    agent: &AgentKind,
+    preview: Option<&str>,
+) -> (Option<String>, Option<String>) {
+    if let Some(resolved) = resolved {
+        let source = resolved.source;
+        let title = if source == TitleSource::FirstMessage {
+            sanitized_title(Some(resolved.text), agent, preview)
+        } else {
+            Some(resolved.text)
+        };
+        let source = title.as_ref().map(|_| source.as_str().to_string());
+        return (title, source);
+    }
+
+    let title = sanitized_title(fallback_title, agent, preview);
+    let source = title
+        .as_ref()
+        .and(fallback_source)
+        .map(|source| source.as_str().to_string());
+    (title, source)
 }
 
 /// Whether this transcript belongs to a sub-agent rather than a top-level
@@ -744,6 +826,8 @@ mod tests {
                     r#"{{"timestamp":"2026-08-01T10:00:00Z","type":"session_meta","#,
                     r#""payload":{{"id":"{id}","cwd":"/home/avery/code/gadgets"}}}}"#,
                     "\n",
+                    r#"{{"type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"Fallback transcript request"}}]}}}}"#,
+                    "\n",
                 ),
                 id = session_id
             ),
@@ -759,6 +843,174 @@ mod tests {
             updated_at: Some(updated_at),
             environment: DiscoveryEnvironment::Native,
         }
+    }
+
+    #[test]
+    fn only_native_direct_agents_are_eligible_for_indexed_title_lookups() {
+        let direct = [AgentKind::Claude, AgentKind::Codex, AgentKind::OpenCode];
+        for agent in AgentKind::ALL {
+            let native = SessionLog {
+                agent_type: *agent,
+                source: SessionSource::Inline {
+                    label: "synthetic".into(),
+                    content: String::new(),
+                },
+                updated_at: None,
+                environment: DiscoveryEnvironment::Native,
+            };
+            assert_eq!(
+                should_lookup_indexed_title(&native),
+                direct.contains(agent),
+                "unexpected lookup route for {agent}"
+            );
+
+            let in_wsl = SessionLog {
+                environment: DiscoveryEnvironment::Wsl {
+                    distribution: "SyntheticLinux".into(),
+                    user: "avery".into(),
+                },
+                ..native
+            };
+            assert!(
+                !should_lookup_indexed_title(&in_wsl),
+                "WSL {agent} must not query native stores"
+            );
+        }
+    }
+
+    #[test]
+    fn direct_titles_are_authoritative_and_keep_their_source() {
+        let first = select_title_pair(
+            Some(ResolvedTitle::new(
+                "Generated session name",
+                TitleSource::AiGenerated,
+            )),
+            Some("<injected transcript context>".into()),
+            Some(TitleSource::FirstMessage),
+            &AgentKind::Codex,
+            None,
+        );
+        assert_eq!(
+            first,
+            (
+                Some("Generated session name".into()),
+                Some("aiGenerated".into())
+            )
+        );
+
+        let renamed = select_title_pair(
+            Some(ResolvedTitle::new(
+                "Reader renamed session",
+                TitleSource::UserRename,
+            )),
+            Some("old transcript fallback".into()),
+            Some(TitleSource::FirstMessage),
+            &AgentKind::Codex,
+            None,
+        );
+        assert_eq!(
+            renamed,
+            (
+                Some("Reader renamed session".into()),
+                Some("userRename".into())
+            )
+        );
+
+        let transcript_fallback = select_title_pair(
+            Some(ResolvedTitle::new(
+                "<recommended_plugins> injected context",
+                TitleSource::FirstMessage,
+            )),
+            None,
+            None,
+            &AgentKind::Claude,
+            Some(concat!(
+                r#"{"type":"user","message":{"role":"user","content":"<recommended_plugins> injected context"}}"#,
+                "\n",
+                r#"{"type":"user","message":{"role":"user","content":"Reader's actual request"}}"#,
+                "\n",
+            )),
+        );
+        assert_eq!(
+            transcript_fallback,
+            (
+                Some("Reader's actual request".into()),
+                Some("firstMessage".into())
+            )
+        );
+    }
+
+    #[test]
+    fn a_direct_lookup_miss_keeps_the_transcript_fallback_pair() {
+        assert_eq!(
+            select_title_pair(
+                None,
+                Some("First reader request".into()),
+                Some(TitleSource::FirstMessage),
+                &AgentKind::Codex,
+                None,
+            ),
+            (
+                Some("First reader request".into()),
+                Some("firstMessage".into())
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn a_native_codex_title_refreshes_while_wsl_keeps_its_own_fallback() {
+        let home = tempfile::TempDir::new().unwrap();
+        let session_id = "same-id-in-two-environments";
+        let path = write_codex_session(home.path(), session_id);
+        let native_log = log(AgentKind::Codex, path.clone(), 1_800_000_000);
+        let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+
+        for (title, source) in [
+            ("Indexed session name", TitleSource::AiGenerated),
+            ("Reader renamed session", TitleSource::UserRename),
+        ] {
+            let DescribeOutcome::Session(record) = describe_one(
+                native_log.clone(),
+                home.path(),
+                Some(ResolvedTitle::new(title, source)),
+            )
+            .await
+            else {
+                panic!("native Codex session should be described");
+            };
+            store.upsert_sessions(&[*record]).unwrap();
+        }
+
+        let native = store
+            .session(&SessionKey::new("native", "codex", session_id))
+            .unwrap()
+            .expect("native session");
+        assert_eq!(native.title.as_deref(), Some("Reader renamed session"));
+        assert_eq!(native.title_source.as_deref(), Some("userRename"));
+
+        let wsl_log = SessionLog {
+            environment: DiscoveryEnvironment::Wsl {
+                distribution: "SyntheticLinux".into(),
+                user: "avery".into(),
+            },
+            ..log(AgentKind::Codex, path, 1_800_000_100)
+        };
+        let DescribeOutcome::Session(wsl) = describe_one(
+            wsl_log,
+            home.path(),
+            // A same-id native hit is available but must be ignored for WSL.
+            Some(ResolvedTitle::new(
+                "Native title must not leak",
+                TitleSource::UserRename,
+            )),
+        )
+        .await
+        else {
+            panic!("WSL Codex session should be described");
+        };
+        assert_eq!(wsl.key.environment_key, "wsl:syntheticlinux");
+        assert_eq!(wsl.title.as_deref(), Some("Fallback transcript request"));
+        assert_eq!(wsl.title_source.as_deref(), Some("firstMessage"));
     }
 
     #[tokio::test]
@@ -1037,6 +1289,30 @@ mod tests {
             ),
             None
         );
+
+        let home = tempfile::TempDir::new().unwrap();
+        let project = home
+            .path()
+            .join(".claude/projects/-home-avery-code-widgets");
+        std::fs::create_dir_all(&project).unwrap();
+        let path = project.join("only-context.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"sessionId":"only-context","cwd":"/home/avery/code/widgets","type":"user","message":{"role":"user","content":"<recommended_plugins> list"}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let described = describe(
+            vec![log(AgentKind::Claude, path, 1_800_000_000)],
+            home.path(),
+            &HashSet::new(),
+        )
+        .await;
+        assert_eq!(described.records.len(), 1);
+        assert_eq!(described.records[0].title, None);
+        assert_eq!(described.records[0].title_source, None);
     }
 
     #[tokio::test]
@@ -1141,6 +1417,24 @@ mod tests {
             environment: Default::default(),
         };
         assert_eq!(recovered_id(&log).as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn a_codex_rollout_recovers_its_canonical_uuid_before_title_prefetch() {
+        let session_id = "01a01251-9875-7121-ac24-0d99fd8ccbe1";
+        let log = SessionLog {
+            agent_type: AgentKind::Codex,
+            source: SessionSource::File(
+                format!(
+                    "/home/avery/.codex/sessions/2026/08/18/rollout-2026-08-18T10-42-12-{session_id}.jsonl"
+                )
+                .into(),
+            ),
+            updated_at: Some(1_000),
+            environment: Default::default(),
+        };
+
+        assert_eq!(recovered_id(&log).as_deref(), Some(session_id));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -934,13 +934,19 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
              environment_key, agent, session_id, source_kind, source_label, wsl_distro,
              title, title_source, cwd, surface, updated_at_epoch, subagent_count,
              first_seen_at, last_seen_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?13)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7,
+                 CASE WHEN ?7 IS NOT NULL THEN ?8 ELSE NULL END,
+                 ?9, ?10, ?11, ?12, ?13, ?13)
          ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
              source_kind = excluded.source_kind,
              source_label = excluded.source_label,
              wsl_distro = excluded.wsl_distro,
              title = COALESCE(excluded.title, session.title),
-             title_source = COALESCE(excluded.title_source, session.title_source),
+             title_source = CASE
+                 WHEN excluded.title IS NOT NULL THEN excluded.title_source
+                 WHEN session.title IS NOT NULL THEN session.title_source
+                 ELSE NULL
+             END,
              cwd = COALESCE(excluded.cwd, session.cwd),
              surface = excluded.surface,
              updated_at_epoch = MAX(COALESCE(excluded.updated_at_epoch, 0),

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -335,6 +335,61 @@ fn a_session_round_trips_and_a_rescan_updates_it_in_place() {
 }
 
 #[test]
+fn title_and_source_are_replaced_or_preserved_as_one_pair() {
+    let store = store();
+
+    let mut source_without_title = session("orphan-source", 500);
+    source_without_title.title = None;
+    source_without_title.title_source = Some("firstMessage".into());
+    store.upsert_sessions(&[source_without_title]).unwrap();
+    let stored = store
+        .session(&SessionKey::new("native", "claude-code", "orphan-source"))
+        .unwrap()
+        .expect("session");
+    assert_eq!((stored.title, stored.title_source), (None, None));
+
+    // Heal rows written by the older independent-COALESCE upsert, where a
+    // sanitized-away title could leave provenance behind.
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET title_source = 'firstMessage'\
+             WHERE environment_key = 'native' AND agent = 'claude-code'\
+               AND session_id = 'orphan-source'",
+            [],
+        )
+        .unwrap();
+    let mut no_title_again = session("orphan-source", 750);
+    no_title_again.title = None;
+    no_title_again.title_source = None;
+    store.upsert_sessions(&[no_title_again]).unwrap();
+    let healed = store
+        .session(&SessionKey::new("native", "claude-code", "orphan-source"))
+        .unwrap()
+        .expect("session");
+    assert_eq!((healed.title, healed.title_source), (None, None));
+
+    store.upsert_sessions(&[session("abc", 1_000)]).unwrap();
+
+    let mut renamed = session("abc", 2_000);
+    renamed.title = Some("Reader supplied title".into());
+    renamed.title_source = Some("userRename".into());
+    store.upsert_sessions(&[renamed]).unwrap();
+
+    let mut missing = session("abc", 3_000);
+    missing.title = None;
+    missing.title_source = Some("firstMessage".into());
+    store.upsert_sessions(&[missing]).unwrap();
+
+    let stored = store
+        .session(&SessionKey::new("native", "claude-code", "abc"))
+        .unwrap()
+        .expect("session");
+    assert_eq!(stored.title.as_deref(), Some("Reader supplied title"));
+    assert_eq!(stored.title_source.as_deref(), Some("userRename"));
+}
+
+#[test]
 fn the_same_session_id_in_two_environments_stays_two_sessions() {
     let store = store();
     store.upsert_sessions(&[session("abc", 1_000)]).unwrap();

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,6 +21,14 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+### Added
+
+- `AgentExplorer::indexed_session_titles` and
+  `Explorers::indexed_session_titles_for` batch title lookups from durable
+  vendor indexes without falling through to transcript content. Shared indexes
+  are opened once per batch, so background discovery can reuse its bounded
+  transcript metadata on misses.
+
 ## [0.1.2] - 2026-08-17
 
 ### Added

--- a/crates/antiburn-local/src/discovery/agents/codex.rs
+++ b/crates/antiburn-local/src/discovery/agents/codex.rs
@@ -9,6 +9,7 @@
 //! specific repo path -- all sessions live in a flat directory.
 
 use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -93,6 +94,33 @@ impl AgentExplorer for CodexExplorer {
         TitleLookupKind::Direct
     }
 
+    fn recover_session_id_from_path(&self, file: &Path) -> Option<String> {
+        super::codex_subagents::thread_id_from_rollout_path(file)
+    }
+
+    /// Resolve from Codex's indexed stores without opening a rollout:
+    /// `state_5.sqlite#threads.title`, then `session_index.jsonl#thread_name`.
+    async fn indexed_session_title(&self, agent_session_id: &str) -> Option<ResolvedTitle> {
+        if let Some(text) = session_title_from_sqlite(agent_session_id).await {
+            return Some(ResolvedTitle::new(text, TitleSource::UserRename));
+        }
+        if let Some(text) = session_title_from_index(agent_session_id).await {
+            return Some(ResolvedTitle::new(text, TitleSource::AiGenerated));
+        }
+        None
+    }
+
+    async fn indexed_session_titles(
+        &self,
+        agent_session_ids: &[String],
+    ) -> HashMap<String, ResolvedTitle> {
+        let Some(home) = home_dir() else {
+            return HashMap::new();
+        };
+        let codex_home = std::env::var("CODEX_HOME").ok().map(PathBuf::from);
+        indexed_session_titles_in(&home, codex_home.as_deref(), agent_session_ids).await
+    }
+
     /// Resolve a Codex session title from Codex's own stores, in order of
     /// authority:
     ///
@@ -104,11 +132,8 @@ impl AgentExplorer for CodexExplorer {
     /// 3. Rollout JSONL scan — last-resort fallback for CLI-only users with
     ///    neither store. Source provenance flows through from the scanner.
     async fn session_title(&self, agent_session_id: &str) -> Option<ResolvedTitle> {
-        if let Some(text) = session_title_from_sqlite(agent_session_id).await {
-            return Some(ResolvedTitle::new(text, TitleSource::UserRename));
-        }
-        if let Some(text) = session_title_from_index(agent_session_id).await {
-            return Some(ResolvedTitle::new(text, TitleSource::AiGenerated));
+        if let Some(title) = self.indexed_session_title(agent_session_id).await {
+            return Some(title);
         }
 
         let dirs = all_log_dirs().await;
@@ -721,6 +746,31 @@ fn query_thread_title(path: &Path, session_id: &str) -> Option<String> {
     }
 }
 
+fn query_thread_titles(path: &Path, session_ids: &[String]) -> HashMap<String, String> {
+    let Ok(conn) = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) else {
+        return HashMap::new();
+    };
+    let _ = conn.busy_timeout(Duration::from_millis(200));
+    let Ok(mut statement) = conn.prepare("SELECT title FROM threads WHERE id = ?1 LIMIT 1") else {
+        return HashMap::new();
+    };
+    let mut titles = HashMap::new();
+    for session_id in session_ids {
+        let Ok(title) = statement.query_row(params![session_id], |row| row.get::<_, String>(0))
+        else {
+            continue;
+        };
+        let trimmed = title.trim();
+        if !trimmed.is_empty() {
+            titles.insert(session_id.clone(), trimmed.to_string());
+        }
+    }
+    titles
+}
+
 async fn session_title_from_index(session_id: &str) -> Option<String> {
     let home = home_dir()?;
     let codex_home = std::env::var("CODEX_HOME").ok().map(PathBuf::from);
@@ -776,6 +826,70 @@ async fn read_session_title_from_index(path: &Path, session_id: &str) -> Option<
     }
 
     latest_title
+}
+
+async fn indexed_session_titles_in(
+    home: &Path,
+    codex_home: Option<&Path>,
+    session_ids: &[String],
+) -> HashMap<String, ResolvedTitle> {
+    let mut resolved = HashMap::new();
+    for path in state_db_paths(home, codex_home) {
+        if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
+            continue;
+        }
+        let ids = session_ids.to_vec();
+        let titles = tokio::task::spawn_blocking(move || query_thread_titles(&path, &ids))
+            .await
+            .unwrap_or_default();
+        for (session_id, text) in titles {
+            resolved
+                .entry(session_id)
+                .or_insert_with(|| ResolvedTitle::new(text, TitleSource::UserRename));
+        }
+    }
+
+    let wanted: HashSet<String> = session_ids.iter().cloned().collect();
+    for path in session_index_paths(home, codex_home) {
+        let wanted = wanted.clone();
+        let latest = tokio::task::spawn_blocking(move || query_index_titles(&path, &wanted))
+            .await
+            .unwrap_or_default();
+        for (session_id, text) in latest {
+            resolved
+                .entry(session_id)
+                .or_insert_with(|| ResolvedTitle::new(text, TitleSource::AiGenerated));
+        }
+    }
+    resolved
+}
+
+fn query_index_titles(path: &Path, wanted: &HashSet<String>) -> HashMap<String, String> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return HashMap::new();
+    };
+    let mut latest = HashMap::new();
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let Ok(row) = serde_json::from_str::<SessionIndexRow>(&line) else {
+            continue;
+        };
+        if !wanted.contains(&row.id) {
+            continue;
+        }
+        let title = row
+            .thread_name
+            .map(|title| title.trim().to_string())
+            .filter(|title| !title.is_empty());
+        match title {
+            Some(title) => {
+                latest.insert(row.id, title);
+            }
+            None => {
+                latest.remove(&row.id);
+            }
+        }
+    }
+    latest
 }
 
 /// Find the rollout file for a given Codex session UUID by filename suffix.
@@ -1219,6 +1333,78 @@ mod tests {
             session_title_from_sqlite_in(home.path(), None, "33333333-aaaa-bbbb-cccc-444444444444")
                 .await;
         assert!(title.is_none());
+    }
+
+    #[test]
+    fn explorer_recovers_the_canonical_thread_id_from_a_rollout_path() {
+        let session_id = "01a01251-9875-7121-ac24-0d99fd8ccbe1";
+        let path = PathBuf::from(format!(
+            "/home/avery/.codex/sessions/2026/08/18/rollout-2026-08-18T10-42-12-{session_id}.jsonl"
+        ));
+
+        assert_eq!(
+            CodexExplorer.recover_session_id_from_path(&path).as_deref(),
+            Some(session_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn indexed_title_batch_reads_stores_once_and_keeps_precedence() {
+        let home = TempDir::new().unwrap();
+        let codex_dir = home.path().join(".codex");
+        tokio::fs::create_dir_all(&codex_dir).await.unwrap();
+        seed_state_db(
+            &codex_dir.join("state_5.sqlite"),
+            &[("renamed", "Reader rename")],
+        );
+        tokio::fs::write(
+            codex_dir.join("session_index.jsonl"),
+            concat!(
+                r#"{"id":"renamed","thread_name":"Generated name"}"#,
+                "\n",
+                r#"{"id":"indexed","thread_name":"Old generated name"}"#,
+                "\n",
+                r#"{"id":"ignored","thread_name":"Not requested"}"#,
+                "\n",
+                r#"{"id":"indexed","thread_name":"Latest generated name"}"#,
+                "\n",
+                r#"{"id":"cleared","thread_name":"Old generated name"}"#,
+                "\n",
+                r#"{"id":"cleared","thread_name":null}"#,
+                "\n",
+            ),
+        )
+        .await
+        .unwrap();
+
+        let titles = indexed_session_titles_in(
+            home.path(),
+            None,
+            &[
+                "renamed".into(),
+                "indexed".into(),
+                "cleared".into(),
+                "missing".into(),
+            ],
+        )
+        .await;
+        assert_eq!(
+            titles.get("renamed"),
+            Some(&ResolvedTitle::new(
+                "Reader rename",
+                TitleSource::UserRename
+            ))
+        );
+        assert_eq!(
+            titles.get("indexed"),
+            Some(&ResolvedTitle::new(
+                "Latest generated name",
+                TitleSource::AiGenerated
+            ))
+        );
+        assert!(!titles.contains_key("ignored"));
+        assert!(!titles.contains_key("cleared"));
+        assert!(!titles.contains_key("missing"));
     }
 
     #[test]

--- a/crates/antiburn-local/src/discovery/agents/opencode.rs
+++ b/crates/antiburn-local/src/discovery/agents/opencode.rs
@@ -221,11 +221,10 @@ impl AgentExplorer for OpenCodeExplorer {
         TitleLookupKind::Direct
     }
 
-    /// Point-query lookup against `opencode.db#session.title` keyed by id.
-    /// Avoids the default's full-table scan when the frontend only needs a
-    /// handful of titles. OpenCode has no rename concept, so every hit is
-    /// tagged [`TitleSource::Explicit`].
-    async fn session_title(&self, agent_session_id: &str) -> Option<ResolvedTitle> {
+    /// Point-query lookup against `opencode.db#session.title` keyed by id,
+    /// without opening transcript content. OpenCode has no rename concept, so
+    /// every hit is tagged [`TitleSource::Explicit`].
+    async fn indexed_session_title(&self, agent_session_id: &str) -> Option<ResolvedTitle> {
         for root in data_roots() {
             let db_path = root.join("opencode.db");
             if !tokio::fs::try_exists(&db_path).await.unwrap_or(false) {
@@ -243,6 +242,39 @@ impl AgentExplorer for OpenCodeExplorer {
             }
         }
         None
+    }
+
+    async fn indexed_session_titles(
+        &self,
+        agent_session_ids: &[String],
+    ) -> HashMap<String, ResolvedTitle> {
+        let wanted: HashSet<String> = agent_session_ids.iter().cloned().collect();
+        let mut resolved = HashMap::new();
+        for root in data_roots() {
+            let db_path = root.join("opencode.db");
+            if !tokio::fs::try_exists(&db_path).await.unwrap_or(false) {
+                continue;
+            }
+            let rows =
+                tokio::task::spawn_blocking(move || query_all_session_titles_from_db(&db_path))
+                    .await
+                    .unwrap_or_default();
+            for (session_id, title) in rows {
+                if !wanted.contains(&session_id) {
+                    continue;
+                }
+                if let Some(text) = title {
+                    resolved
+                        .entry(session_id)
+                        .or_insert_with(|| ResolvedTitle::new(text, TitleSource::Explicit));
+                }
+            }
+        }
+        resolved
+    }
+
+    async fn session_title(&self, agent_session_id: &str) -> Option<ResolvedTitle> {
+        self.indexed_session_title(agent_session_id).await
     }
 
     /// Owns the per-platform OpenCode data dir (XDG `share/opencode/`, macOS

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -173,9 +173,12 @@ pub struct ResolvedTitle {
 }
 
 impl ResolvedTitle {
+    /// Construct a title through the same whitespace and length policy used by
+    /// transcript-derived metadata. Vendor indexes can contain full prompts,
+    /// so every resolved-title path must enforce the boundary here as well.
     pub fn new(text: impl Into<String>, source: TitleSource) -> Self {
         Self {
-            text: text.into(),
+            text: scanner::normalize_title(&text.into()),
             source,
         }
     }
@@ -298,6 +301,30 @@ pub trait AgentExplorer: Send + Sync {
     /// behavior without an explicit override.
     fn title_lookup_kind(&self) -> TitleLookupKind {
         TitleLookupKind::Scan
+    }
+
+    /// Resolve a title only from a durable vendor index or database, without
+    /// opening transcript content. Background scanners can combine this with
+    /// metadata they already read, avoiding a second unbounded transcript
+    /// pass when an index has no row. Agents without a separate title store
+    /// return `None`.
+    async fn indexed_session_title(&self, _agent_session_id: &str) -> Option<ResolvedTitle> {
+        None
+    }
+
+    /// Batch variant of [`Self::indexed_session_title`]. Adapters backed by a
+    /// shared index should override this so the index is opened once per scan.
+    async fn indexed_session_titles(
+        &self,
+        agent_session_ids: &[String],
+    ) -> std::collections::HashMap<String, ResolvedTitle> {
+        let mut titles = std::collections::HashMap::new();
+        for session_id in agent_session_ids {
+            if let Some(title) = self.indexed_session_title(session_id).await {
+                titles.insert(session_id.clone(), title);
+            }
+        }
+        titles
     }
 
     /// Resolve a single session's title by id, returning a [`ResolvedTitle`]
@@ -759,6 +786,15 @@ impl Explorers {
         session_id: &str,
     ) -> Option<ResolvedTitle> {
         self.get(agent).session_title(session_id).await
+    }
+
+    /// Resolve a batch from one agent's durable index or database only.
+    pub async fn indexed_session_titles_for(
+        &self,
+        agent: &AgentKind,
+        session_ids: &[String],
+    ) -> std::collections::HashMap<String, ResolvedTitle> {
+        self.get(agent).indexed_session_titles(session_ids).await
     }
 
     /// The lookup-kind hint, so a caller can route between per-id point queries

--- a/crates/antiburn-local/src/discovery/scanner.rs
+++ b/crates/antiburn-local/src/discovery/scanner.rs
@@ -110,7 +110,7 @@ impl TitleSource {
     }
 }
 
-const TITLE_MAX_CHARS: usize = 200;
+pub(super) const TITLE_MAX_CHARS: usize = 200;
 
 // The Claude-flavored hyphenated-path decoder lives in `agents::path_codec`.
 // Re-exported here so `scanner::…` stays the single import for callers that
@@ -732,7 +732,7 @@ fn extract_content_text(content: Option<&serde_json::Value>) -> Option<String> {
     None
 }
 
-fn normalize_title(raw: &str) -> String {
+pub(super) fn normalize_title(raw: &str) -> String {
     let collapsed: String = raw.split_whitespace().collect::<Vec<_>>().join(" ");
     if collapsed.chars().count() > TITLE_MAX_CHARS {
         collapsed.chars().take(TITLE_MAX_CHARS).collect()

--- a/crates/antiburn-local/src/discovery/tests.rs
+++ b/crates/antiburn-local/src/discovery/tests.rs
@@ -12,6 +12,17 @@ use std::sync::atomic::Ordering;
 use tempfile::TempDir;
 
 #[test]
+fn resolved_titles_are_normalized_and_unicode_safely_bounded() {
+    let raw = format!("  Reader\n\trequest  {}  ", "🧪".repeat(250));
+    let resolved = ResolvedTitle::new(raw, TitleSource::AiGenerated);
+
+    assert_eq!(resolved.text.chars().count(), 200);
+    assert!(resolved.text.starts_with("Reader request 🧪"));
+    assert!(!resolved.text.contains('\n'));
+    assert!(!resolved.text.contains('\t'));
+}
+
+#[test]
 fn cwd_occurrences_merge_native_and_wsl_counts() {
     let mut counts = std::collections::HashMap::new();
     add_cwd_occurrences(&mut counts, ["/repo".into(), "/repo".into()]);


### PR DESCRIPTION
## Summary

- Batch indexed Codex and OpenCode title reads during desktop scans.
- Recover canonical Codex session identifiers from rollout filenames.
- Preserve title-source precedence and native/WSL isolation.
- Normalize stored titles to the documented 200-character limit.
- Keep title text and provenance updates atomic.

## Validation

- Engine and desktop Rust tests passed.
- Rust formatting and Clippy passed.
- A live debug scan titled all detected Codex sessions and found no overlong titles or orphan source rows.