### PR TITLE
fix(desktop): upgrade tauri-nspanel to v2.1

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -135,7 +135,7 @@ name = "antiburn-nudge"
 version = "0.1.0"
 dependencies = [
  "core-foundation",
- "core-graphics 0.25.0",
+ "core-graphics",
  "gtk",
  "serde",
  "tauri",
@@ -384,12 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,35 +600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics 0.24.0",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "core-foundation",
- "core-graphics-types",
- "objc",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,19 +643,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
 
 [[package]]
 name = "core-graphics"
@@ -2472,15 +2424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,26 +2666,6 @@ checksum = "60a6096447d657bfba01c49d38338b6c8e68e0e34d595360345375b798a4a765"
 dependencies = [
  "generic-array 1.4.5",
  "num-traits",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
 ]
 
 [[package]]
@@ -3050,15 +2973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,6 +3078,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -4596,7 +4516,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2",
  "core-foundation",
- "core-graphics 0.25.0",
+ "core-graphics",
  "crossbeam-channel",
  "dbus",
  "dispatch2",
@@ -4771,17 +4691,13 @@ dependencies = [
 
 [[package]]
 name = "tauri-nspanel"
-version = "2.0.1"
-source = "git+https://github.com/ahkohd/tauri-nspanel?rev=18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a#18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a"
+version = "2.1.0"
+source = "git+https://github.com/ahkohd/tauri-nspanel?rev=a3122e894383aa068ec5365a42994e3ac94ba1b6#a3122e894383aa068ec5365a42994e3ac94ba1b6"
 dependencies = [
- "bitflags 2.13.1",
- "block",
- "cocoa",
- "core-foundation",
- "core-graphics 0.25.0",
- "objc",
- "objc-foundation",
- "objc_id",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "pastey",
  "tauri",
 ]
 

--- a/apps/desktop/src-tauri/crates/nudge/Cargo.lock
+++ b/apps/desktop/src-tauri/crates/nudge/Cargo.lock
@@ -46,7 +46,7 @@ name = "antiburn-nudge"
 version = "0.1.0"
 dependencies = [
  "core-foundation",
- "core-graphics 0.25.0",
+ "core-graphics",
  "gtk",
  "serde",
  "serde_json",
@@ -138,12 +138,6 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -343,35 +337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics 0.24.0",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "core-foundation",
- "core-graphics-types",
- "objc",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,19 +371,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
 
 [[package]]
 name = "core-graphics"
@@ -1817,15 +1769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,26 +1910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,9 +1927,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2026,6 +1957,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2087,6 +2019,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2054,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2182,15 +2128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,6 +2186,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -3092,7 +3035,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2",
  "core-foundation",
- "core-graphics 0.25.0",
+ "core-graphics",
  "crossbeam-channel",
  "dbus",
  "dispatch2",
@@ -3255,17 +3198,13 @@ dependencies = [
 
 [[package]]
 name = "tauri-nspanel"
-version = "2.0.1"
-source = "git+https://github.com/ahkohd/tauri-nspanel?rev=18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a#18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a"
+version = "2.1.0"
+source = "git+https://github.com/ahkohd/tauri-nspanel?rev=a3122e894383aa068ec5365a42994e3ac94ba1b6#a3122e894383aa068ec5365a42994e3ac94ba1b6"
 dependencies = [
- "bitflags 2.13.1",
- "block",
- "cocoa",
- "core-foundation",
- "core-graphics 0.25.0",
- "objc",
- "objc-foundation",
- "objc_id",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "pastey",
  "tauri",
 ]
 

--- a/apps/desktop/src-tauri/crates/nudge/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/nudge/Cargo.toml
@@ -30,12 +30,11 @@ tracing = "0.1"
 [target.'cfg(target_os = "macos")'.dependencies]
 # Subclasses the notification window into a non-activating floating NSPanel so
 # it never steals key focus from the user's frontmost app. Not published to
-# crates.io; pinned to a v2 commit for reproducibility.
-tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a" }
+# crates.io; pinned to a v2.1 commit for reproducibility.
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "a3122e894383aa068ec5365a42994e3ac94ba1b6" }
 # Finds the display showing the frontmost window (`CGWindowListCopyWindowInfo` +
 # `CGDisplay`), so the notification appears where the user is actually looking
-# rather than always on the primary display. Versions match what `cocoa` (via
-# tauri-nspanel) already pulls in, so this doesn't add a second copy.
+# rather than always on the primary display.
 core-foundation = "0.10"
 core-graphics = "0.25"
 
@@ -54,12 +53,3 @@ gtk = { version = "0.18", features = ["v3_24"] }
 
 [dev-dependencies]
 serde_json = "1"
-
-[lints.rust]
-# `objc` 0.2's `msg_send!` (used for the notification's animated resize in
-# `macos.rs`) expands to a `cfg(feature = "cargo-clippy")` gate that check-cfg
-# flags at our call sites. Declare that value expected so real cfg typos are
-# still caught.
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(feature, values("cargo-clippy"))',
-] }

--- a/apps/desktop/src-tauri/crates/nudge/src/macos.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/macos.rs
@@ -13,12 +13,6 @@
 //! thread-safe, and [`crate::NudgeManager::reveal`] calls them from the IPC
 //! command thread.
 //!
-//! `tauri-nspanel`'s `set_collection_behaviour` takes the (now-deprecated)
-//! `cocoa::appkit::NSWindowCollectionBehavior`, so interfacing with its API
-//! unavoidably touches deprecated items — the crate itself does the same. Scope
-//! the allow here rather than chasing a type the upstream API doesn't accept.
-#![allow(deprecated)]
-
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -35,44 +29,48 @@ use core_graphics::window::{
     kCGWindowOwnerPID,
 };
 use tauri::{Emitter, Manager, WebviewWindow};
-use tauri_nspanel::cocoa::appkit::NSWindowCollectionBehavior;
-use tauri_nspanel::cocoa::base::{BOOL, id};
-use tauri_nspanel::cocoa::foundation::{NSPoint, NSRect, NSSize};
-use tauri_nspanel::objc::runtime::YES;
-use tauri_nspanel::objc::{class, msg_send, sel, sel_impl};
+use tauri_nspanel::objc2_app_kit::{NSWindowCollectionBehavior, NSWindowStyleMask, NSWorkspace};
+use tauri_nspanel::objc2_foundation::NSThread;
 use tauri_nspanel::{ManagerExt, WebviewPanelManager, WebviewWindowExt};
 
 use crate::geometry::{self, Point, Rect};
 
-/// `NSWindowStyleMaskNonactivatingPanel` (`1 << 7`). Keeps the panel borderless
-/// while ensuring that becoming key never activates antiburn — clicks on the CTAs
-/// work without pulling focus from the user's active app.
-const STYLE_MASK_NONACTIVATING_PANEL: i32 = 1 << 7;
+tauri_nspanel::tauri_panel! {
+    panel!(NudgePanel {
+        config: {
+            can_become_key_window: true,
+            can_become_main_window: false
+        }
+    })
+}
 
 /// `NSStatusWindowLevel` — float above normal and floating windows (still below
 /// menus / pop-ups), so the notification reliably sits on top.
-const STATUS_WINDOW_LEVEL: i32 = 25;
+const STATUS_WINDOW_LEVEL: i64 = 25;
 
 /// Convert the notification window into a non-activating floating panel and
 /// apply the notification behaviors. Requires the nspanel plugin (registered via
 /// [`crate::register`]); a no-op if it isn't present. Safe to call from any
 /// thread — the work is marshaled onto the main thread.
 pub(crate) fn to_nonactivating_panel(window: &WebviewWindow) {
-    if window.try_state::<WebviewPanelManager>().is_none() {
+    if window
+        .try_state::<WebviewPanelManager<tauri::Wry>>()
+        .is_none()
+    {
         return;
     }
     let window = window.clone();
     let _ = window.clone().run_on_main_thread(move || {
-        let Ok(panel) = window.to_panel() else {
+        let Ok(panel) = window.to_panel::<NudgePanel>() else {
             return;
         };
         // Borderless + never activate the app on key.
-        panel.set_style_mask(STYLE_MASK_NONACTIVATING_PANEL);
+        panel.set_style_mask(NSWindowStyleMask::NonactivatingPanel);
         // Float above other windows; show on every Space and above fullscreen apps.
         panel.set_level(STATUS_WINDOW_LEVEL);
-        panel.set_collection_behaviour(
-            NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
-                | NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary,
+        panel.set_collection_behavior(
+            NSWindowCollectionBehavior::CanJoinAllSpaces
+                | NSWindowCollectionBehavior::FullScreenAuxiliary,
         );
     });
 }
@@ -84,9 +82,10 @@ pub(crate) fn to_nonactivating_panel(window: &WebviewWindow) {
 /// AppKit still lets a nonactivating panel hold real key-window status and
 /// receive genuine keyboard input while some other app stays frontmost — so a
 /// forced `makeKeyWindow` on every show could swallow keystrokes the user is
-/// mid-typing into their editor or terminal. `RawNSPanel::show()` calls
-/// `makeKeyWindow` unconditionally, so this calls the lower-level
-/// `order_front_regardless()` instead — visually front, key status untouched.
+/// mid-typing into their editor or terminal. `tauri-nspanel` v2.0's
+/// `RawNSPanel::show()` called `makeKeyWindow` unconditionally, so this calls
+/// the lower-level `order_front_regardless()` instead — visually front, key
+/// status untouched.
 /// Key is acquired later, lazily, only once the user's mouse has genuinely
 /// entered the notification (see [`set_hovered`]), by which point their
 /// attention has already shifted there.
@@ -102,12 +101,11 @@ pub(crate) fn show(window: &WebviewWindow) {
                 // `window.show()` here would make the window key and steal focus
                 // from the user's frontmost app, the very thing this crate avoids.
                 if let Ok(ptr) = window.ns_window() {
-                    let ns_window = ptr as id;
                     // SAFETY: on the main thread; `ns_window` is the live NSWindow
                     // backing the notification. `orderFrontRegardless` takes no
                     // arguments and returns void.
                     unsafe {
-                        let _: () = msg_send![ns_window, orderFrontRegardless];
+                        (&*ptr.cast::<NSWindow>()).orderFrontRegardless();
                     }
                 }
             }
@@ -140,7 +138,8 @@ pub(crate) fn set_hovered(window: &WebviewWindow, hovered: bool) {
     let _ = window.clone().run_on_main_thread(move || {
         if let Ok(panel) = window.get_webview_panel(crate::NUDGE_LABEL) {
             if hovered {
-                panel.make_first_responder(Some(panel.content_view()));
+                let content_view = panel.content_view();
+                panel.make_first_responder(Some(&content_view));
                 panel.make_key_window();
             } else if is_key(&window) {
                 // Only resign key we actually hold. `resignKeyWindow` is
@@ -275,19 +274,15 @@ pub(crate) fn is_key(window: &WebviewWindow) -> bool {
     let Ok(ptr) = window.ns_window() else {
         return false;
     };
-    let ns_window = ptr as id;
     unsafe {
-        // SAFETY: `isMainThread` takes no arguments and returns BOOL.
-        let on_main_thread: BOOL = msg_send![class!(NSThread), isMainThread];
         debug_assert!(
-            on_main_thread == YES,
+            NSThread::isMainThread_class(),
             "antiburn_nudge::macos::is_key called off the main thread — AppKit calls are undefined behavior there"
         );
         // SAFETY: on the main thread (asserted above); `ns_window` is the live
         // NSWindow backing the notification. `isKeyWindow` takes no arguments
         // and returns BOOL.
-        let is_key: BOOL = msg_send![ns_window, isKeyWindow];
-        is_key == YES
+        (&*ptr.cast::<NSWindow>()).isKeyWindow()
     }
 }
 
@@ -306,21 +301,21 @@ pub(crate) fn animate_resize(window: &WebviewWindow, height: f64) {
         let Ok(ptr) = window.ns_window() else {
             return;
         };
-        let ns_window = ptr as id;
         let new_h = height.max(1.0);
         // SAFETY: on the main thread; `ns_window` is the live NSWindow backing the
         // notification. Reading `frame` and messaging the `animator` proxy are
         // standard AppKit calls with fixed, well-typed signatures.
         unsafe {
-            let frame: NSRect = msg_send![ns_window, frame];
+            let ns_window = &*ptr.cast::<NSWindow>();
+            let frame = ns_window.frame();
             // AppKit is y-up: `origin.y + height` is the top edge — keep it fixed.
             let max_y = frame.origin.y + frame.size.height;
             let new_frame = NSRect::new(
                 NSPoint::new(frame.origin.x, max_y - new_h),
                 NSSize::new(frame.size.width, new_h),
             );
-            let animator: id = msg_send![ns_window, animator];
-            let _: () = msg_send![animator, setFrame: new_frame display: YES];
+            let animator: Retained<NSWindow> = msg_send![ns_window, animator];
+            animator.setFrame_display(new_frame, true);
         }
     });
 }
@@ -330,7 +325,7 @@ pub(crate) fn hide(window: &WebviewWindow) {
     let window = window.clone();
     let _ = window.clone().run_on_main_thread(move || {
         match window.get_webview_panel(crate::NUDGE_LABEL) {
-            Ok(panel) => panel.order_out(None),
+            Ok(panel) => panel.hide(),
             Err(_) => {
                 let _ = window.hide();
             }
@@ -428,21 +423,10 @@ fn frontmost_app_window_center() -> Option<Point> {
 
 /// PID of `NSWorkspace.frontmostApplication`.
 fn frontmost_app_pid() -> Option<i64> {
-    // SAFETY: `sharedWorkspace` and `frontmostApplication` are standard AppKit
-    // accessors with fixed signatures; both may return nil, which we check.
-    // `processIdentifier` returns `pid_t` (`i32`).
-    unsafe {
-        let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
-        if workspace.is_null() {
-            return None;
-        }
-        let app: id = msg_send![workspace, frontmostApplication];
-        if app.is_null() {
-            return None;
-        }
-        let pid: i32 = msg_send![app, processIdentifier];
-        (pid > 0).then_some(pid as i64)
-    }
+    let workspace = NSWorkspace::sharedWorkspace();
+    let app = workspace.frontmostApplication()?;
+    let pid = app.processIdentifier();
+    (pid > 0).then_some(pid as i64)
 }
 
 /// The cursor, in global screen space (top-left origin, points). Always
@@ -455,9 +439,9 @@ fn frontmost_app_pid() -> Option<i64> {
 /// different coordinate spaces and the hit-test silently fails.
 fn cursor_point() -> Point {
     let main_height = CGDisplay::main().bounds().size.height;
-    // SAFETY: `+[NSEvent mouseLocation]` is a thread-safe class method returning
-    // an `NSPoint` in AppKit's bottom-left-origin global screen space.
-    let location: NSPoint = unsafe { msg_send![class!(NSEvent), mouseLocation] };
+    // `+[NSEvent mouseLocation]` is a thread-safe class method returning an
+    // `NSPoint` in AppKit's bottom-left-origin global screen space.
+    let location = NSEvent::mouseLocation();
     Point {
         x: location.x,
         y: main_height - location.y,


### PR DESCRIPTION
## Summary

- pin tauri-nspanel to the v2.1.0 default-branch revision
- migrate the nudge NSPanel integration from cocoa/objc to the objc2 API
- remove the legacy block, cocoa, and objc dependency chain and its obsolete check-cfg workaround

## Verification

- cargo check (desktop Rust workspace)
- cargo test (antiburn-nudge: 25 passed)
- cargo clippy --all-targets -- -D warnings (antiburn-nudge)
- cargo fmt --all -- --check
- git diff --check
- cargo tree -i block confirms the legacy block package is absent