### PR TITLE
chore: ignore local agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 node_modules/
 .DS_Store
 
+# Local agent worktrees and metadata are not repository content.
+/.claude/
+
 # Signing material must never enter the tree. The updater keypair is minted
 # with an absolute path outside the repository (see
 # docs/runbooks/updater-key-recovery.md); this is the backstop.


### PR DESCRIPTION
## Summary
- ignore the root-local `/.claude/` agent worktree area
- keep signing-material ignore rules unchanged

This prevents nested tool worktrees and metadata from polluting repository status and repository-wide searches.

## Verification
- `git diff --check`
- `git check-ignore -v .claude/worktrees/example/README.md`
- confirmed `updater.key` and `updater.key.pub` remain ignored
- confirmed unrelated `claude/README.md` is not ignored

Do not merge automatically.