### PR TITLE
fix(desktop): live-usage freshness — period markers, visibility-aware refetch, popover-shown refresh

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -402,6 +402,20 @@ pub fn get_provider_usage(
     Ok(provider_usage::summarize(&evidence, now, offset))
 }
 
+/// How fresh a reading this command asks each source's cooldown for.
+///
+/// This command is called from the popover, which polls it roughly once a
+/// minute for as long as the popover stays visible — see
+/// `scan::TICK` and `popover::note_shown`. Fifty seconds sits just under that
+/// polling interval, so an open popover's own ordinary polling is what keeps
+/// the reading current: every visible tick is close enough to the cooldown's
+/// edge to trigger a real fetch, without this command itself running a timer
+/// or a background task. The aggressive freshness is bounded by someone
+/// actually looking — once the popover closes, nothing here keeps polling on
+/// its behalf, and the background monitor's own, much longer, `max_age`
+/// takes back over (see `usage_alerts::MILESTONE_MAX_AGE`).
+const POPOVER_LIVE_USAGE_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(50);
+
 /// The provider's own limit figures, when a registered source can prove them.
 ///
 /// Deliberately a second command rather than a field on
@@ -434,6 +448,7 @@ pub fn get_live_usage(
         app.try_state::<Store>().as_deref(),
         now,
         utc_offset_minutes.unwrap_or(0),
+        POPOVER_LIVE_USAGE_MAX_AGE,
     ))
 }
 

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -42,12 +42,18 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use tauri::{
-    AppHandle, LogicalPosition, LogicalSize, Manager, Rect, WebviewUrl, WebviewWindow,
+    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Rect, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder, Window,
 };
 
 /// Window label. Also listed in `capabilities/default.json`.
 pub const LABEL: &str = "popover";
+
+/// Emitted the moment the popover reaches the screen, following the same
+/// `module:event` naming [`crate::scan`]'s events use. The webview listens
+/// for this to refresh live usage — see [`note_shown`] for why that refresh
+/// does not simply ride the scan events this same function also kicks.
+pub const EVENT_SHOWN: &str = "popover:shown";
 
 /// Popover width in logical pixels. Fixed: the views size themselves to it.
 const WIDTH: f64 = 380.0;
@@ -596,6 +602,21 @@ fn note_shown(app: &AppHandle) {
         // looking, so refresh immediately instead of waiting out a tick.
         controller.request();
     }
+    // A separate signal from the scan kick just above, on purpose, rather
+    // than something the webview infers from `scan:finished`. Two things
+    // about the scan kick make it the wrong vehicle for a usage refresh:
+    // `request()` itself always wakes the scheduler loop, but the pass that
+    // wake-up would run is silently skipped whenever discovery is paused or
+    // onboarding has not finished (`scheduled_scanning_allowed` in
+    // `crate::scan`), which would leave usage silently stuck too even
+    // though nothing about reading a provider's own limits depends on
+    // whether local disk discovery is allowed to run; and even when a scan
+    // does run, it is a full disk walk, so gating the usage refresh on its
+    // completion would make "reopen the popover" mean "wait out a scan" for
+    // a figure that has nothing to do with what is on disk. Emitting this
+    // unconditionally, the instant the popover is on screen, keeps the two
+    // refreshes independent the way the data they show already is.
+    let _ = app.emit(EVENT_SHOWN, ());
     crate::tray::set_highlight(app, true);
 }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -102,7 +102,14 @@ pub trait LiveUsageSource: Send + Sync {
     }
 
     /// Collect whatever this source can currently prove.
-    fn fetch(&self) -> SourceOutcome;
+    ///
+    /// `max_age` is how old a successful reading the caller is willing to
+    /// accept before it wants a real refetch rather than the cached last-good
+    /// snapshot — see the `Cooldown` type every direct-fetch source is built
+    /// on, in `sources::cooldown`. A source that reads a local file rather
+    /// than a network endpoint is free to ignore it: there is no round trip
+    /// there for a cooldown to gate.
+    fn fetch(&self, max_age: std::time::Duration) -> SourceOutcome;
 }
 
 /// One source's answer for one collection pass.
@@ -150,6 +157,13 @@ impl SourceOutcome {
 /// Passing `None` skips both — used by tests that are only exercising the
 /// shaping, and by the fallback path where no store is mounted.
 ///
+/// `max_age` states how fresh *this caller* needs a reading to be, and is
+/// passed straight through to [`sources::collect`] — see
+/// [`LiveUsageSource::fetch`]. The popover, polling while visible, and the
+/// background milestone monitor want different answers to "how old a reading
+/// is acceptable", and this is the one place both meet, so it is the one
+/// place that has to ask.
+///
 /// The ordering is by provider id so a re-render never reshuffles equal rows;
 /// within a provider, windows keep the order the parser found them, which is
 /// the provider's own order — shortest window first in practice, and not
@@ -159,6 +173,7 @@ pub fn summarize(
     store: Option<&crate::store::Store>,
     now: i64,
     utc_offset_minutes: i32,
+    max_age: std::time::Duration,
 ) -> LiveUsageSummary {
     // Read fresh, and default to *not* acting: an unreadable preference is not
     // permission, the same rule every notifier in this app follows. Both
@@ -168,7 +183,7 @@ pub fn summarize(
     let online = store
         .and_then(|store| store.settings().ok())
         .is_some_and(|settings| settings.live_usage_active());
-    let collected = sources::collect(sources, online);
+    let collected = sources::collect(sources, online, max_age);
     let history = store
         .map(|store| history::record(store, &collected.snapshots))
         .unwrap_or_default();

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -44,8 +44,9 @@
 //! Every other failure — a rejected credential, a rate limit, an
 //! unreachable network, a response this build cannot parse — goes through
 //! [`Cooldown`], which is what keeps this source from opening a connection on
-//! every five-minute scheduler tick: see that module for the retry and
-//! last-good-reading contract every direct-fetch source shares.
+//! every poll: see that module for the retry and last-good-reading contract
+//! every direct-fetch source shares, and for how a caller's own `max_age`
+//! decides how often "every poll" actually reaches the network.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -270,13 +271,13 @@ impl LiveUsageSource for ClaudeDirectFetch {
         true
     }
 
-    fn fetch(&self) -> SourceOutcome {
+    fn fetch(&self, max_age: std::time::Duration) -> SourceOutcome {
         let now = OffsetDateTime::now_utc();
         // The credential read sits inside the cooldown gate on purpose: on
-        // macOS it spawns a `security` subprocess, and a scheduler tick that
-        // the cooldown is going to skip anyway should not pay for one — nor
+        // macOS it spawns a `security` subprocess, and a poll that the
+        // cooldown is going to skip anyway should not pay for one — nor
         // re-raise a Keychain access prompt the reader has already seen.
-        self.cooldown.poll(now, || {
+        self.cooldown.poll(now, max_age, || {
             let Some(credentials) = self.read_credentials() else {
                 return Ok(None);
             };
@@ -337,6 +338,11 @@ mod tests {
 
     const NOW: i64 = 1_800_000_000;
 
+    /// A background-caller-shaped `max_age` for tests that only exercise
+    /// whether a reading is found, not how the cooldown's freshness budget
+    /// behaves — `cooldown.rs`'s own suite owns that.
+    const TEST_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(600);
+
     fn credentials_file(expires_at_ms: i64, subscription_type: &str) -> String {
         format!(
             r#"{{"claudeAiOauth": {{"accessToken": "synthetic-token",
@@ -348,7 +354,7 @@ mod tests {
     #[test]
     fn a_missing_credentials_file_is_absent_not_an_error() {
         let source = ClaudeDirectFetch::at(PathBuf::from("/nonexistent/.credentials.json"));
-        let outcome = source.fetch();
+        let outcome = source.fetch(TEST_MAX_AGE);
         assert!(outcome.snapshots.is_empty());
         assert_eq!(outcome.error, None);
     }
@@ -358,7 +364,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join(".credentials.json");
         fs::write(&path, "not json at all").expect("write");
-        let outcome = ClaudeDirectFetch::at(path).fetch();
+        let outcome = ClaudeDirectFetch::at(path).fetch(TEST_MAX_AGE);
         assert!(outcome.snapshots.is_empty());
         assert_eq!(outcome.error, None);
     }
@@ -368,7 +374,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join(".credentials.json");
         fs::write(&path, r#"{"somethingElse": true}"#).expect("write");
-        let outcome = ClaudeDirectFetch::at(path).fetch();
+        let outcome = ClaudeDirectFetch::at(path).fetch(TEST_MAX_AGE);
         assert!(outcome.snapshots.is_empty());
         assert_eq!(outcome.error, None);
     }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -275,14 +275,14 @@ impl LiveUsageSource for CodexDirectFetch {
         true
     }
 
-    fn fetch(&self) -> SourceOutcome {
+    fn fetch(&self, max_age: std::time::Duration) -> SourceOutcome {
         let now = OffsetDateTime::now_utc();
         let Some(path) = &self.auth_path else {
             return SourceOutcome::absent();
         };
-        // Read inside the cooldown gate, mirroring the Claude source: a tick
+        // Read inside the cooldown gate, mirroring the Claude source: a poll
         // the cooldown is going to skip should not touch the disk either.
-        self.cooldown.poll(now, || {
+        self.cooldown.poll(now, max_age, || {
             let Some(auth) = read_auth(path) else {
                 return Ok(None);
             };
@@ -387,6 +387,12 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     const NOW: i64 = 1_800_000_000;
+
+    /// A background-caller-shaped `max_age` for tests that only exercise
+    /// whether a reading is found, not the cooldown's freshness budget —
+    /// `cooldown.rs`'s own suite owns that.
+    const TEST_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(600);
+
     const WHAM_BODY: &str = r#"{"rate_limit": {
       "primary_window": {"used_percent": 20, "limit_window_seconds": 18000},
       "secondary_window": {"used_percent": 55, "limit_window_seconds": 604800},
@@ -497,7 +503,7 @@ mod tests {
     #[test]
     fn a_missing_credential_file_is_absent_not_an_error() {
         let source = CodexDirectFetch::at(PathBuf::from("/nonexistent/auth.json"));
-        let outcome = source.fetch();
+        let outcome = source.fetch(TEST_MAX_AGE);
         assert!(outcome.snapshots.is_empty());
         assert_eq!(outcome.error, None);
     }
@@ -507,7 +513,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("auth.json");
         fs::write(&path, "not json").expect("write");
-        let outcome = CodexDirectFetch::at(path).fetch();
+        let outcome = CodexDirectFetch::at(path).fetch(TEST_MAX_AGE);
         assert!(outcome.snapshots.is_empty());
         assert_eq!(outcome.error, None);
     }
@@ -533,7 +539,7 @@ mod tests {
         }
 
         let source = CodexDirectFetch::with_transport(path, Box::new(WorksFirstTry));
-        let outcome = source.fetch();
+        let outcome = source.fetch(TEST_MAX_AGE);
         assert_eq!(outcome.error, None);
         assert_eq!(outcome.snapshots.len(), 1);
         assert_eq!(

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -6,15 +6,25 @@
 //! the direct-fetch sources.
 //!
 //! A fetch here is never free: it is at least one HTTPS round trip, and for
-//! the Codex fallback it can mean spawning a whole process. The scheduler
-//! asks every source to [`fetch`](super::super::LiveUsageSource::fetch) every
-//! five minutes while the opt-in is on, so a source built on this type only
-//! actually calls its own network code once [`SUCCESS_COOLDOWN`] or
-//! [`FAILURE_COOLDOWN`] has elapsed since the last attempt. Every other tick
-//! it reports the same outcome again — the last good snapshot, restamped for
-//! how old it now is, and the last attempt's error if that attempt failed.
-//! Never a blank while a good reading exists, and never one pretending to be
-//! fresher than it is.
+//! the Codex fallback it can mean spawning a whole process. Two callers ask
+//! every source to [`fetch`](super::super::LiveUsageSource::fetch) while the
+//! opt-in is on: the background monitor, every five minutes, and
+//! [`crate::commands::get_live_usage`], every time the popover — while it is
+//! visible — polls for a reading. Those two callers do not want the same
+//! thing. The monitor is not shown to anyone and can happily read a
+//! ten-minute-old figure; the popover is on screen right now, being polled
+//! *because* someone is looking at it, and a fixed ten-minute cooldown would
+//! mean up to ten minutes of that polling doing nothing.
+//!
+//! So the cooldown is not fixed. Each call to [`Cooldown::poll`] states its
+//! own `max_age` — how old a successful reading that particular caller is
+//! willing to accept — and a source built on this type only actually calls
+//! its own network code once `max_age` (or the failure cooldown derived from
+//! it; see [`MIN_FAILURE_COOLDOWN`] and [`FAILURE_COOLDOWN`]) has elapsed
+//! since the last attempt. Every other call reports the same outcome again —
+//! the last good snapshot, restamped for how old it now is, and the last
+//! attempt's error if that attempt failed. Never a blank while a good
+//! reading exists, and never one pretending to be fresher than it is.
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -24,23 +34,31 @@ use time::OffsetDateTime;
 use super::super::SourceOutcome;
 use super::super::model::{Freshness, ProviderUsageError, ProviderUsageSnapshot};
 
-/// How long to leave a source alone after a reading succeeded.
+/// The floor under a caller-requested failure cooldown.
 ///
-/// Ten minutes: against a five-hour window that is indistinguishable from
-/// current, and it keeps every source's traffic to a small, predictable
-/// trickle rather than one request every five-minute scheduler tick.
-pub const SUCCESS_COOLDOWN: Duration = Duration::from_secs(600);
+/// A caller may ask for a `max_age` far below a minute — the popover, once
+/// shown, does — but a failure is not a success arriving late, and retrying
+/// a broken endpoint on every visible tick teaches nobody anything and
+/// answers nobody sooner. A minute is short enough that a reader who just
+/// fixed whatever was wrong finds out quickly, and long enough that an open
+/// panel does not turn one bad response into a request storm.
+const MIN_FAILURE_COOLDOWN: Duration = Duration::from_secs(60);
 
-/// …and after one failed. Shorter than a success's cooldown, so a reader who
-/// just fixed whatever was wrong — signed back in, restored their connection
-/// — does not wait as long to find out.
+/// The ceiling on a caller-requested failure cooldown — what a caller with no
+/// particular urgency, asking for a `max_age` well past this, actually gets.
+/// Matches the fixed cooldown this type used to apply to every failure
+/// unconditionally; it is now a ceiling rather than the whole rule because a
+/// caller who wants fresher successes should not be made to wait as long for
+/// a retry after a failure either.
 pub const FAILURE_COOLDOWN: Duration = Duration::from_secs(300);
 
 /// How old a fetched reading may be and still describe the present.
 ///
 /// An hour, the same budget the file-based source this replaces used: past
 /// that, a five-hour figure has had time to move without a reader hearing
-/// about it.
+/// about it. This is unrelated to a caller's `max_age` above — it governs
+/// when a reading already on screen is marked stale, not when the next fetch
+/// is allowed to run.
 pub const MAX_AGE: time::Duration = time::Duration::minutes(60);
 
 /// Cooldown-gated retry state for one direct-fetch source.
@@ -64,6 +82,14 @@ impl Cooldown {
     /// Ask `fetch` for a fresh reading if the cooldown has elapsed; otherwise
     /// reuse the last outcome without calling it at all.
     ///
+    /// `max_age` is this call's own statement of how old a successful
+    /// reading it is willing to accept — the popover asks for something close
+    /// to its own polling interval, the background monitor asks for
+    /// something close to its own tick, and both share the same cached state
+    /// underneath. A failed attempt's retry is derived from `max_age` too,
+    /// clamped to [`MIN_FAILURE_COOLDOWN`, [`FAILURE_COOLDOWN`]] — see
+    /// [`off_cooldown`].
+    ///
     /// `fetch` returns `Ok(None)` for a real, negative answer — "asked, and
     /// there is nothing to report" (an account type with no rate limit, say)
     /// — which this treats as a success for cooldown purposes and clears
@@ -80,13 +106,14 @@ impl Cooldown {
     pub fn poll(
         &self,
         now: OffsetDateTime,
+        max_age: Duration,
         fetch: impl FnOnce() -> Result<Option<ProviderUsageSnapshot>, ProviderUsageError>,
     ) -> SourceOutcome {
         let mut inner = self
             .inner
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if off_cooldown(inner.last_attempt) {
+        if off_cooldown(inner.last_attempt, max_age) {
             match fetch() {
                 Ok(snapshot) => {
                     inner.snapshot = snapshot;
@@ -115,15 +142,24 @@ impl Cooldown {
     }
 }
 
-fn off_cooldown(last: Option<(Instant, bool)>) -> bool {
+/// Whether the last attempt is old enough that `poll` should try again.
+///
+/// A success is measured against `max_age` exactly as the caller stated it —
+/// that is the whole point of threading it through. A failure is measured
+/// against `max_age` too, but clamped: never less than
+/// [`MIN_FAILURE_COOLDOWN`], so an eager caller cannot turn a broken endpoint
+/// into a request on every tick, and never more than [`FAILURE_COOLDOWN`], so
+/// a caller with no urgency still finds out about a fixed problem within five
+/// minutes.
+fn off_cooldown(last: Option<(Instant, bool)>, max_age: Duration) -> bool {
     match last {
         None => true,
         Some((at, succeeded)) => {
             at.elapsed()
                 >= if succeeded {
-                    SUCCESS_COOLDOWN
+                    max_age
                 } else {
-                    FAILURE_COOLDOWN
+                    max_age.clamp(MIN_FAILURE_COOLDOWN, FAILURE_COOLDOWN)
                 }
         }
     }
@@ -150,6 +186,15 @@ mod tests {
     fn at(seconds: i64) -> OffsetDateTime {
         OffsetDateTime::from_unix_timestamp(seconds).expect("valid timestamp")
     }
+
+    /// A background-caller-shaped `max_age`, for tests that only care that
+    /// *some* cooldown applies and not about its exact length.
+    const DEFAULT_MAX_AGE: Duration = Duration::from_secs(600);
+
+    /// A popover-shaped `max_age` — well under a minute, the way an open
+    /// panel polling every tick asks for something close to its own
+    /// interval.
+    const SHORT_MAX_AGE: Duration = Duration::from_secs(50);
 
     fn snapshot(observed_at: OffsetDateTime, percent: f64) -> ProviderUsageSnapshot {
         ProviderUsageSnapshot {
@@ -182,7 +227,7 @@ mod tests {
         let cooldown = Cooldown::new();
         let calls = Arc::new(AtomicUsize::new(0));
         let counted = Arc::clone(&calls);
-        let outcome = cooldown.poll(at(1_000), move || {
+        let outcome = cooldown.poll(at(1_000), DEFAULT_MAX_AGE, move || {
             counted.fetch_add(1, Ordering::SeqCst);
             Ok(Some(snapshot(at(1_000), 40.0)))
         });
@@ -192,12 +237,12 @@ mod tests {
     }
 
     #[test]
-    fn a_second_poll_inside_the_success_cooldown_never_calls_fetch_again() {
+    fn a_second_poll_inside_the_requested_max_age_never_calls_fetch_again() {
         let cooldown = Cooldown::new();
         let calls = Arc::new(AtomicUsize::new(0));
         for _ in 0..2 {
             let counted = Arc::clone(&calls);
-            cooldown.poll(at(1_000), move || {
+            cooldown.poll(at(1_000), DEFAULT_MAX_AGE, move || {
                 counted.fetch_add(1, Ordering::SeqCst);
                 Ok(Some(snapshot(at(1_000), 40.0)))
             });
@@ -208,9 +253,43 @@ mod tests {
     }
 
     #[test]
+    fn a_caller_asking_for_a_shorter_max_age_refetches_where_a_fixed_cooldown_would_have_cached() {
+        // This is the popover's whole reason for threading `max_age` through:
+        // against the old fixed ten-minute success cooldown, a poll seconds
+        // later would have been served the cache. A caller stating a shorter
+        // `max_age` gets a real refetch instead.
+        let cooldown = Cooldown::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counted = Arc::clone(&calls);
+        cooldown.poll(at(1_000), SHORT_MAX_AGE, move || {
+            counted.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(snapshot(at(1_000), 40.0)))
+        });
+
+        // Backdate past `SHORT_MAX_AGE` but nowhere near the old fixed
+        // `SUCCESS_COOLDOWN` (ten minutes) this replaces.
+        {
+            let mut inner = cooldown.inner.lock().unwrap();
+            inner.last_attempt = Some((
+                Instant::now() - SHORT_MAX_AGE - Duration::from_secs(1),
+                true,
+            ));
+        }
+        let counted = Arc::clone(&calls);
+        cooldown.poll(at(1_000), SHORT_MAX_AGE, move || {
+            counted.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(snapshot(at(1_000), 90.0)))
+        });
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
     fn the_last_good_snapshot_survives_a_failed_retry() {
         let cooldown = Cooldown::new();
-        cooldown.poll(at(1_000), || Ok(Some(snapshot(at(1_000), 40.0))));
+        cooldown.poll(at(1_000), DEFAULT_MAX_AGE, || {
+            Ok(Some(snapshot(at(1_000), 40.0)))
+        });
 
         // Force the cooldown open by backdating the last attempt, the same
         // way `off_cooldown`'s own unit test below does — a real wait would
@@ -219,7 +298,9 @@ mod tests {
             let mut inner = cooldown.inner.lock().unwrap();
             inner.last_attempt = Some((Instant::now() - FAILURE_COOLDOWN, false));
         }
-        let outcome = cooldown.poll(at(2_000), || Err(ProviderUsageError::Unavailable));
+        let outcome = cooldown.poll(at(2_000), DEFAULT_MAX_AGE, || {
+            Err(ProviderUsageError::Unavailable)
+        });
 
         assert_eq!(outcome.error, Some(ProviderUsageError::Unavailable));
         // The stale snapshot is still there — a failed refresh must never
@@ -230,7 +311,9 @@ mod tests {
     #[test]
     fn a_snapshot_past_the_age_budget_restamps_as_stale_without_moving_its_observed_at() {
         let cooldown = Cooldown::new();
-        cooldown.poll(at(1_000), || Ok(Some(snapshot(at(1_000), 40.0))));
+        cooldown.poll(at(1_000), DEFAULT_MAX_AGE, || {
+            Ok(Some(snapshot(at(1_000), 40.0)))
+        });
         {
             let mut inner = cooldown.inner.lock().unwrap();
             // Keep the cooldown closed so this poll cannot trigger a refetch;
@@ -238,7 +321,9 @@ mod tests {
             inner.last_attempt = Some((Instant::now(), true));
         }
         let far_future = at(1_000 + 3 * 60 * 60);
-        let outcome = cooldown.poll(far_future, || Ok(Some(snapshot(far_future, 90.0))));
+        let outcome = cooldown.poll(far_future, DEFAULT_MAX_AGE, || {
+            Ok(Some(snapshot(far_future, 90.0)))
+        });
 
         let snapshot = outcome
             .snapshots
@@ -254,42 +339,73 @@ mod tests {
     #[test]
     fn a_real_negative_answer_clears_a_previous_snapshot_without_an_error() {
         let cooldown = Cooldown::new();
-        cooldown.poll(at(1_000), || Ok(Some(snapshot(at(1_000), 40.0))));
+        cooldown.poll(at(1_000), DEFAULT_MAX_AGE, || {
+            Ok(Some(snapshot(at(1_000), 40.0)))
+        });
         {
             let mut inner = cooldown.inner.lock().unwrap();
-            inner.last_attempt = Some((Instant::now() - SUCCESS_COOLDOWN, true));
+            inner.last_attempt = Some((Instant::now() - DEFAULT_MAX_AGE, true));
         }
         // "Asked, and there is nothing to report" — an account type with no
         // rate limit, say — must not leave the previous account's reading on
         // screen, and it is not an error either.
-        let outcome = cooldown.poll(at(2_000), || Ok(None));
+        let outcome = cooldown.poll(at(2_000), DEFAULT_MAX_AGE, || Ok(None));
 
         assert!(outcome.snapshots.is_empty());
         assert_eq!(outcome.error, None);
     }
 
     #[test]
-    fn a_failure_cooldown_is_shorter_than_a_success_cooldown() {
-        // A reader who just fixed whatever was wrong should not wait as long
-        // as a routine, working refresh does.
-        assert!(FAILURE_COOLDOWN < SUCCESS_COOLDOWN);
+    fn off_cooldown_reopens_once_its_own_budget_has_elapsed() {
+        assert!(off_cooldown(None, DEFAULT_MAX_AGE));
+        assert!(!off_cooldown(Some((Instant::now(), true)), DEFAULT_MAX_AGE));
+        assert!(off_cooldown(
+            Some((Instant::now() - DEFAULT_MAX_AGE, true)),
+            DEFAULT_MAX_AGE
+        ));
+        assert!(!off_cooldown(
+            Some((Instant::now() - FAILURE_COOLDOWN, true)),
+            DEFAULT_MAX_AGE
+        ));
+        assert!(off_cooldown(
+            Some((Instant::now() - FAILURE_COOLDOWN, false)),
+            DEFAULT_MAX_AGE
+        ));
     }
 
     #[test]
-    fn off_cooldown_reopens_once_its_own_budget_has_elapsed() {
-        assert!(off_cooldown(None));
-        assert!(!off_cooldown(Some((Instant::now(), true))));
-        assert!(off_cooldown(Some((
-            Instant::now() - SUCCESS_COOLDOWN,
-            true
-        ))));
-        assert!(!off_cooldown(Some((
-            Instant::now() - FAILURE_COOLDOWN,
-            true
-        ))));
-        assert!(off_cooldown(Some((
-            Instant::now() - FAILURE_COOLDOWN,
-            false
-        ))));
+    fn a_failed_retry_never_waits_less_than_the_failure_floor_however_short_max_age_is() {
+        // A caller asking for a ten-second `max_age` still gets
+        // `MIN_FAILURE_COOLDOWN` for a failure, not ten seconds — see
+        // `MIN_FAILURE_COOLDOWN`'s doc for why.
+        let eager = Duration::from_secs(10);
+        assert!(!off_cooldown(
+            Some((Instant::now() - eager - Duration::from_secs(1), false)),
+            eager
+        ));
+        assert!(off_cooldown(
+            Some((Instant::now() - MIN_FAILURE_COOLDOWN, false)),
+            eager
+        ));
+    }
+
+    #[test]
+    fn a_failed_retry_never_waits_longer_than_the_failure_ceiling_however_patient_max_age_is() {
+        // A background caller asking for a `max_age` well past
+        // `FAILURE_COOLDOWN` still gets `FAILURE_COOLDOWN` for a failure —
+        // today's behaviour, preserved as a ceiling rather than the whole
+        // rule.
+        let patient = Duration::from_secs(3_600);
+        assert!(!off_cooldown(
+            Some((
+                Instant::now() - FAILURE_COOLDOWN + Duration::from_secs(1),
+                false
+            )),
+            patient
+        ));
+        assert!(off_cooldown(
+            Some((Instant::now() - FAILURE_COOLDOWN, false)),
+            patient
+        ));
     }
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -42,6 +42,8 @@ pub mod codex_fetch;
 mod cooldown;
 mod http;
 
+use std::time::Duration;
+
 use super::LiveUsageSource;
 use super::model::{Freshness, ProviderUsageSnapshot};
 
@@ -66,13 +68,19 @@ pub fn registered() -> Vec<Box<dyn LiveUsageSource>> {
 /// (see [`crate::store::AppSettings::live_usage_active`]). A source that
 /// declared [`LiveUsageSource::requires_online_opt_in`] is not merely ignored
 /// while it is false — it is never called, so nothing it would do can happen.
-pub fn collect(sources: &[Box<dyn LiveUsageSource>], online: bool) -> Collected {
+///
+/// `max_age` is passed straight through to every source's
+/// [`LiveUsageSource::fetch`] — see that method's doc for what it means. One
+/// value for the whole pass, because a pass answers one question ("what do
+/// the sources say right now, for this caller's freshness need") and every
+/// source in it should be answering the same question.
+pub fn collect(sources: &[Box<dyn LiveUsageSource>], online: bool, max_age: Duration) -> Collected {
     let mut collected = Collected::default();
     for source in sources {
         if source.requires_online_opt_in() && !online {
             continue;
         }
-        let outcome = source.fetch();
+        let outcome = source.fetch(max_age);
         if let Some(error) = outcome.error {
             collected.errors.push((source.id(), error));
         }

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -22,6 +22,11 @@ use super::{LiveUsageSource, SourceOutcome, sources, summarize};
 
 const NOW: i64 = 1_800_000_000;
 
+/// A background-caller-shaped `max_age` for tests that only exercise the
+/// source ladder and payload shaping, not the cooldown's freshness budget —
+/// `sources/cooldown.rs`'s own suite owns that.
+const MAX_AGE: std::time::Duration = std::time::Duration::from_secs(600);
+
 fn at(seconds: i64) -> OffsetDateTime {
     OffsetDateTime::from_unix_timestamp(seconds).expect("valid timestamp")
 }
@@ -245,7 +250,7 @@ impl LiveUsageSource for Fixed {
     fn id(&self) -> &'static str {
         self.0
     }
-    fn fetch(&self) -> SourceOutcome {
+    fn fetch(&self, _max_age: std::time::Duration) -> SourceOutcome {
         SourceOutcome::found(self.1.clone())
     }
 }
@@ -256,7 +261,7 @@ impl LiveUsageSource for Broken {
     fn id(&self) -> &'static str {
         self.0
     }
-    fn fetch(&self) -> SourceOutcome {
+    fn fetch(&self, _max_age: std::time::Duration) -> SourceOutcome {
         SourceOutcome::failed(self.1)
     }
 }
@@ -296,7 +301,7 @@ fn between_two_stated_figures_the_fresher_one_wins() {
         )),
         Box::new(Fixed("new", vec![snapshot(Freshness::Fresh, NOW, 81.0)])),
     ];
-    let summary = summarize(&sources, None, NOW, 0);
+    let summary = summarize(&sources, None, NOW, 0, MAX_AGE);
     assert_eq!(summary.providers[0].windows[0].used_percent, Some(81.0));
 }
 
@@ -308,7 +313,7 @@ fn two_accounts_at_one_provider_never_merge() {
         "both",
         vec![snapshot(Freshness::Fresh, NOW, 81.0), other],
     ))];
-    let collected = sources::collect(&sources, true);
+    let collected = sources::collect(&sources, true, MAX_AGE);
     assert_eq!(collected.snapshots.len(), 2);
 }
 
@@ -321,7 +326,7 @@ fn a_failed_source_reports_its_category_without_erasing_a_working_one() {
         )),
         Box::new(Broken("signed-out", ProviderUsageError::Authentication)),
     ];
-    let summary = summarize(&sources, None, NOW, 0);
+    let summary = summarize(&sources, None, NOW, 0, MAX_AGE);
     assert_eq!(summary.providers.len(), 1);
     assert_eq!(summary.errors.len(), 1);
     assert_eq!(summary.errors[0].source, "signed-out");
@@ -330,7 +335,7 @@ fn a_failed_source_reports_its_category_without_erasing_a_working_one() {
 
 #[test]
 fn no_sources_is_an_empty_summary_and_not_an_error() {
-    let summary = summarize(&[], None, NOW, 0);
+    let summary = summarize(&[], None, NOW, 0, MAX_AGE);
     assert!(summary.providers.is_empty());
     assert!(summary.errors.is_empty());
     assert_eq!(summary.generated_at, "2027-01-15T08:00:00Z");
@@ -349,7 +354,7 @@ fn the_live_payload_states_percentages_and_says_where_they_came_from() {
         "fixture",
         vec![snapshot(Freshness::Fresh, NOW, 81.0)],
     ))];
-    let json = serde_json::to_string(&summarize(&sources, None, NOW, 0)).unwrap();
+    let json = serde_json::to_string(&summarize(&sources, None, NOW, 0, MAX_AGE)).unwrap();
 
     for required in [
         "usedPercent",
@@ -386,7 +391,7 @@ impl LiveUsageSource for Counted {
     fn requires_online_opt_in(&self) -> bool {
         true
     }
-    fn fetch(&self) -> SourceOutcome {
+    fn fetch(&self, _max_age: std::time::Duration) -> SourceOutcome {
         self.0.fetch_add(1, Ordering::SeqCst);
         SourceOutcome::found(vec![snapshot(Freshness::Fresh, NOW, 99.0)])
     }
@@ -407,14 +412,14 @@ fn a_gated_source_is_never_called_while_the_opt_in_is_off() {
         Box::new(Counted(Arc::clone(&calls))),
     ];
 
-    let off = sources::collect(&sources, false);
+    let off = sources::collect(&sources, false, MAX_AGE);
     assert_eq!(calls.load(Ordering::SeqCst), 0);
     // The ungated source still ran, so turning the opt-in off costs the
     // reader the gated source's readings and nothing else.
     assert_eq!(off.snapshots.len(), 1);
     assert_eq!(off.snapshots[0].windows[0].used_percent, Some(40.0));
 
-    sources::collect(&sources, true);
+    sources::collect(&sources, true, MAX_AGE);
     assert_eq!(calls.load(Ordering::SeqCst), 1);
 }
 
@@ -449,7 +454,7 @@ fn a_gated_source_stays_uncalled_before_onboarding_finishes_even_with_the_switch
             ..crate::store::AppSettings::default()
         })
         .unwrap();
-    summarize(&sources, Some(&store), NOW, 0);
+    summarize(&sources, Some(&store), NOW, 0, MAX_AGE);
     assert_eq!(
         calls.load(Ordering::SeqCst),
         0,
@@ -463,7 +468,7 @@ fn a_gated_source_stays_uncalled_before_onboarding_finishes_even_with_the_switch
             ..crate::store::AppSettings::default()
         })
         .unwrap();
-    summarize(&sources, Some(&store), NOW, 0);
+    summarize(&sources, Some(&store), NOW, 0, MAX_AGE);
     assert_eq!(
         calls.load(Ordering::SeqCst),
         1,
@@ -527,7 +532,7 @@ fn a_supplemental_window_turns_on_and_stays_on_through_the_period() {
         "fixture",
         vec![weekly_scoped_snapshot(NOW - 7_200, Some(0.0), reset)],
     ))];
-    let summary = summarize(&quiet, Some(&store), NOW - 7_200, 0);
+    let summary = summarize(&quiet, Some(&store), NOW - 7_200, 0, MAX_AGE);
     assert!(!summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
 
     // A real reading arrives.
@@ -535,7 +540,7 @@ fn a_supplemental_window_turns_on_and_stays_on_through_the_period() {
         "fixture",
         vec![weekly_scoped_snapshot(NOW - 3_600, Some(6.0), reset)],
     ))];
-    let summary = summarize(&used, Some(&store), NOW - 3_600, 0);
+    let summary = summarize(&used, Some(&store), NOW - 3_600, 0, MAX_AGE);
     assert!(summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
 
     // A later reading with no percentage at all must not erase what the
@@ -544,7 +549,7 @@ fn a_supplemental_window_turns_on_and_stays_on_through_the_period() {
         "fixture",
         vec![weekly_scoped_snapshot(NOW, None, reset)],
     ))];
-    let summary = summarize(&unknown, Some(&store), NOW, 0);
+    let summary = summarize(&unknown, Some(&store), NOW, 0, MAX_AGE);
     assert!(summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
 }
 
@@ -557,7 +562,7 @@ fn a_reset_clears_the_flag_for_the_new_period() {
         "fixture",
         vec![weekly_scoped_snapshot(NOW - 3_600, Some(30.0), first_reset)],
     ))];
-    let summary = summarize(&used, Some(&store), NOW - 3_600, 0);
+    let summary = summarize(&used, Some(&store), NOW - 3_600, 0, MAX_AGE);
     assert!(summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
 
     // The window reset: the percentage dropped, and the provider now states a
@@ -568,6 +573,6 @@ fn a_reset_clears_the_flag_for_the_new_period() {
         "fixture",
         vec![weekly_scoped_snapshot(NOW, Some(0.0), second_reset)],
     ))];
-    let summary = summarize(&rolled, Some(&store), NOW, 0);
+    let summary = summarize(&rolled, Some(&store), NOW, 0, MAX_AGE);
     assert!(!summary.providers[0].windows[0].has_nonzero_usage_in_current_period);
 }

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -69,6 +69,18 @@ const EPISODE_SECS: i64 = 6 * 60 * 60;
 /// Where the last-fired moment survives a relaunch.
 const FIRED_KEY: &str = "internal:usageAnomalyFiredEpoch";
 
+/// How fresh a reading the milestone pass asks each source's cooldown for.
+///
+/// This pass is not shown to anyone — it runs on [`TICK`], whether or not the
+/// popover is even open — so there is no reason to pay for a fetch more
+/// often than the pass itself runs, and every reason not to: it is exactly
+/// the traffic the sources' cooldown (`provider_usage::live::sources::cooldown`)
+/// exists to keep to a small, predictable trickle. Ten minutes matches what
+/// every source's cooldown fixed unconditionally before `max_age` existed,
+/// so this pass's background traffic is unchanged by the popover's own,
+/// much shorter, `max_age` — see `crate::commands::POPOVER_LIVE_USAGE_MAX_AGE`.
+const MILESTONE_MAX_AGE: Duration = Duration::from_secs(600);
+
 /// Spawn the monitor loop; the handle joins the shell's scheduler registry.
 pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> {
     let app = app.clone();
@@ -163,11 +175,15 @@ fn milestone_pass(app: &AppHandle, settings: &crate::store::AppSettings) {
         return;
     };
     let snapshots: Vec<provider_usage::live::milestones::LiveUsageSnapshot> =
-        provider_usage::live::sources::collect(&live.sources, settings.live_usage_active())
-            .snapshots
-            .iter()
-            .map(milestone_snapshot)
-            .collect();
+        provider_usage::live::sources::collect(
+            &live.sources,
+            settings.live_usage_active(),
+            MILESTONE_MAX_AGE,
+        )
+        .snapshots
+        .iter()
+        .map(milestone_snapshot)
+        .collect();
     let mut ledger = live
         .ledger
         .lock()

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1077,6 +1077,24 @@ export async function onSessionsInvalidated(handler: () => void): Promise<Unlist
   return listen(SESSIONS_INVALIDATED_EVENT, () => handler());
 }
 
+/**
+ * Event the shell emits the instant the popover reaches the screen. Mirrors
+ * `popover::EVENT_SHOWN` in `src-tauri/src/popover.rs`.
+ *
+ * Deliberately not folded into `onScanEvent`: the scan it also kicks is
+ * gated on discovery being unpaused and can take as long as a full disk
+ * walk, neither of which has anything to do with a provider's own stated
+ * limits. This is what a view subscribes to when what it wants is "the
+ * popover just opened," full stop.
+ */
+export const POPOVER_SHOWN_EVENT = 'popover:shown';
+
+/** Subscribe to the popover reaching the screen. The result unsubscribes. */
+export async function onPopoverShown(handler: () => void): Promise<UnlistenFn> {
+  if (!hasShell()) return () => {};
+  return listen(POPOVER_SHOWN_EVENT, () => handler());
+}
+
 /** Event the shell emits when storage health changes. Mirrors `src-tauri/src/storage_health.rs`. */
 export const STORAGE_HEALTH_EVENT = 'storage:health';
 

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -34,6 +34,8 @@ import {
 } from './liveUsage';
 
 const NOW = Date.parse('2027-01-15T12:00:00Z');
+const DAY_MS = 24 * 3_600_000;
+const WEEK_MS = 7 * DAY_MS;
 
 /** Sparse history is the resting state of a source that only moves when an
     agent runs, so it is what a fixture defaults to. */
@@ -142,6 +144,54 @@ describe('the elapsed marker', () => {
       liveWindowElapsed(
         window({
           id: 'five-hour',
+          startsAt: '2027-01-15T11:00:00Z',
+          resetsAt: '2027-01-15T13:00:00Z',
+        }),
+        NOW,
+      ),
+    ).toBeCloseTo(0.5);
+  });
+
+  it('takes a weekly period from the window’s kind, the same way five-hour comes from its id', () => {
+    // Seven days is what "weekly" means, not a guess about this particular
+    // window's boundary.
+    const resetsAt = new Date(NOW + 0.4 * WEEK_MS).toISOString();
+    expect(
+      liveWindowElapsed(
+        window({
+          id: 'seven-day',
+          role: 'primaryLong',
+          kind: 'weekly',
+          startsAt: null,
+          resetsAt,
+        }),
+        NOW,
+      ),
+    ).toBeCloseTo(0.6);
+  });
+
+  it('takes a daily period from the window’s kind', () => {
+    const resetsAt = new Date(NOW + 0.25 * DAY_MS).toISOString();
+    expect(
+      liveWindowElapsed(window({ id: 'daily', kind: 'daily', startsAt: null, resetsAt }), NOW),
+    ).toBeCloseTo(0.75);
+  });
+
+  it('still refuses to guess a monthly period: a month’s length genuinely varies', () => {
+    expect(
+      liveWindowElapsed(window({ id: 'monthly', kind: 'monthly', startsAt: null }), NOW),
+    ).toBeNull();
+    expect(
+      liveWindowElapsed(window({ id: 'billing', kind: 'billingCycle', startsAt: null }), NOW),
+    ).toBeNull();
+  });
+
+  it('prefers a stated start over a kind-implied one', () => {
+    expect(
+      liveWindowElapsed(
+        window({
+          id: 'seven-day',
+          kind: 'weekly',
           startsAt: '2027-01-15T11:00:00Z',
           resetsAt: '2027-01-15T13:00:00Z',
         }),

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -59,18 +59,45 @@ export function liveWindowValueLabel(window: LiveUsageWindowPayload): string {
 }
 
 /**
- * The length of a window whose own name states it, in milliseconds.
+ * The length of a window whose own *id* states it, in milliseconds, keyed by
+ * that id.
  *
- * This is arithmetic, not inference. A window identified as `five-hour` has a
+ * This is arithmetic, not inference: a window identified as `five-hour` has a
  * five-hour period by definition, so its start is five hours before its reset
- * — that is not a fact we are missing, it is one the id already gave us.
- * Anything whose duration is *not* stated by its identity is absent from this
- * table on purpose: a weekly window's boundary is the provider's own, and
- * "seven days before the reset" would be a guess dressed as a measurement.
+ * — that is not a fact we are missing, it is one the id already gave us. The
+ * broader case — a period implied by the window's `kind` rather than its
+ * specific id — is handled separately below, in `impliedPeriodMs`; this table
+ * only covers the recurrence that does not fit that pattern.
  */
 const IMPLIED_PERIOD_MS: Readonly<Record<string, number>> = {
   'five-hour': 5 * 3_600_000,
 };
+
+const DAY_MS = 24 * 3_600_000;
+const WEEK_MS = 7 * DAY_MS;
+
+/**
+ * The length of a window's period implied by its own identity, in
+ * milliseconds, or null when nothing about the window states one.
+ *
+ * An id-keyed period (`IMPLIED_PERIOD_MS`) wins when there is one, since it is
+ * the more specific fact. Failing that, a window's `kind` still states a
+ * recurrence for two of the four kinds the provider sends: `weekly` is seven
+ * days and `daily` is twenty-four hours by definition of what those words
+ * mean, the same way `five-hour` is five hours — this is reading the window's
+ * own name, not assuming a period nobody stated. `monthly` and
+ * `billingCycle` are deliberately excluded: a month's length genuinely
+ * varies (28 to 31 days, and a billing cycle can be shorter still), so
+ * "thirty days before the reset" would be a guess dressed as a measurement,
+ * exactly the thing this module exists to avoid.
+ */
+function impliedPeriodMs(window: LiveUsageWindowPayload): number | null {
+  const byId = IMPLIED_PERIOD_MS[window.id];
+  if (byId != null) return byId;
+  if (window.kind === 'weekly') return WEEK_MS;
+  if (window.kind === 'daily') return DAY_MS;
+  return null;
+}
 
 /**
  * How far into the window's own period the clock has travelled, 0–1, or null
@@ -82,7 +109,7 @@ const IMPLIED_PERIOD_MS: Readonly<Record<string, number>> = {
  *
  * It needs both ends of the window. The provider states the reset but usually
  * not the start, so the start comes from the window's own stated duration
- * where it has one — see `IMPLIED_PERIOD_MS`. A window with neither a stated
+ * where it has one — see `impliedPeriodMs`. A window with neither a stated
  * start nor an implied duration gets no marker at all, rather than one drawn
  * from an assumed period.
  */
@@ -92,7 +119,7 @@ export function liveWindowElapsed(window: LiveUsageWindowPayload, now: number): 
   if (Number.isNaN(end)) return null;
 
   const stated = window.startsAt ? new Date(window.startsAt).getTime() : Number.NaN;
-  const implied = IMPLIED_PERIOD_MS[window.id];
+  const implied = impliedPeriodMs(window);
   const start = Number.isNaN(stated) ? (implied == null ? Number.NaN : end - implied) : stated;
   if (Number.isNaN(start) || end <= start) return null;
 

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -341,6 +341,27 @@ describe('PopoverView', () => {
     expect(screen.getByText('No provider usage today')).toBeInTheDocument();
   });
 
+  it('refreshes usage on the shell’s popover-shown signal, independent of any scan', async () => {
+    render(<PopoverView />);
+    await screen.findByTestId('provider-usage-cluster');
+
+    const callsBeforeShown = invoke.mock.calls.filter(
+      ([command]) => command === 'get_live_usage',
+    ).length;
+
+    // `popover:shown` carries no payload — it is a pure signal, unlike the
+    // scan events, which carry a status.
+    emit('popover:shown', undefined);
+
+    await waitFor(() =>
+      expect(
+        invoke.mock.calls.filter(([command]) => command === 'get_live_usage').length,
+      ).toBeGreaterThan(callsBeforeShown),
+    );
+    // Not riding the scan pipeline: no scan command was ever asked for.
+    expect(invoke).not.toHaveBeenCalledWith('scan_now', expect.anything());
+  });
+
   it('never renders the first-run flow, whatever the flag says', async () => {
     // The flow has its own window now (D-25, `views/OnboardingView.tsx`), and
     // the shell sends the tray click there instead of here. A popover that

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -20,6 +20,7 @@ import {
   hidePopover,
   listRecentSessions,
   listRepositories,
+  onPopoverShown,
   onScanEvent,
   onSessionsInvalidated,
   onSettingsChanged,
@@ -142,6 +143,7 @@ export class PopoverSession {
   private stopSessionsInvalidatedListening: (() => void) | null = null;
   private stopStorageHealthListening: (() => void) | null = null;
   private stopScanListening: (() => void) | null = null;
+  private stopPopoverShownListening: (() => void) | null = null;
 
   private snapshot: PopoverSnapshot = {
     settings: null,
@@ -225,6 +227,7 @@ export class PopoverSession {
     void this.listenSessionsInvalidated(generation);
     void this.listenStorageHealth(generation);
     void this.listenScanEvent(generation);
+    void this.listenPopoverShown(generation);
 
     // ⌘, opens Settings — the platform's standard preferences shortcut, which
     // an accessory app with no application menu has to own itself. Bound
@@ -245,6 +248,8 @@ export class PopoverSession {
     this.stopStorageHealthListening = null;
     this.stopScanListening?.();
     this.stopScanListening = null;
+    this.stopPopoverShownListening?.();
+    this.stopPopoverShownListening = null;
     window.removeEventListener('keydown', this.onWindowKeyDown);
   }
 
@@ -346,6 +351,26 @@ export class PopoverSession {
       return;
     }
     this.stopScanListening = unlisten;
+  };
+
+  // The shell's own signal that the popover just reached the screen —
+  // separate from the scan events above on purpose. `note_shown` also kicks
+  // a disk scan, but that kick is silently skipped while discovery is
+  // paused or onboarding is unfinished, and even a scan that does run can
+  // take a while to finish. Neither has any bearing on a provider's own
+  // stated limits, so usage gets its own refresh here rather than waiting on
+  // — or being silenced by — the scan pipeline. Only usage: entries and the
+  // repository list are already covered by `listenScanEvent` above.
+  private listenPopoverShown = async (generation: number): Promise<void> => {
+    const unlisten = await onPopoverShown(() => {
+      if (generation !== this.generation) return;
+      void this.refreshUsage();
+    });
+    if (generation !== this.generation) {
+      unlisten();
+      return;
+    }
+    this.stopPopoverShownListening = unlisten;
   };
 
   private onWindowKeyDown = (event: KeyboardEvent): void => {

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -265,10 +265,11 @@ describe('UsageView — plan limits layered over local estimates', () => {
     expect(screen.queryByTestId('live-usage-fill-five-hour')).not.toBeInTheDocument();
   });
 
-  it('omits the marker for a window whose period is not stated or implied', () => {
-    // A weekly window with no start: its boundary is the provider's own, and
-    // "seven days before the reset" would be a guess dressed as a measurement.
-    const unbounded = live({
+  it('marks a weekly window from its kind alone, with no stated start', () => {
+    // Seven days is what "weekly" means, the same way five hours is what
+    // "five-hour" means — this is arithmetic on the window's own identity,
+    // not a guess.
+    const bounded = live({
       providers: [
         {
           ...liveProvider(),
@@ -278,6 +279,37 @@ describe('UsageView — plan limits layered over local estimates', () => {
               role: 'primaryLong',
               kind: 'weekly',
               startsAt: null,
+              resetsAt: '2027-01-19T18:00:00Z',
+            }),
+          ],
+        },
+      ],
+    });
+    render(<UsageView summary={summary()} live={bounded} now={NOW} onBack={vi.fn()} />);
+
+    // 2027-01-12T18:00 → 2027-01-19T18:00, clock at 2027-01-15T12:00: 66 of
+    // 168 hours into a seven-day period.
+    expect(screen.getByRole('progressbar', { name: 'Weekly limit' })).toHaveAttribute(
+      'aria-valuetext',
+      '81% used; 39% of the period elapsed',
+    );
+    expect(screen.getByTestId('live-usage-elapsed-seven-day')).toBeInTheDocument();
+  });
+
+  it('omits the marker for a window whose period is not stated or implied', () => {
+    // A monthly window with no start: a month's length genuinely varies, so
+    // "thirty days before the reset" would be a guess dressed as a
+    // measurement — unlike weekly or daily, monthly gets no marker.
+    const unbounded = live({
+      providers: [
+        {
+          ...liveProvider(),
+          windows: [
+            liveWindow({
+              id: 'monthly-window',
+              role: 'other',
+              kind: 'monthly',
+              startsAt: null,
             }),
           ],
         },
@@ -285,8 +317,8 @@ describe('UsageView — plan limits layered over local estimates', () => {
     });
     render(<UsageView summary={summary()} live={unbounded} now={NOW} onBack={vi.fn()} />);
 
-    expect(screen.queryByTestId('live-usage-elapsed-seven-day')).not.toBeInTheDocument();
-    expect(screen.getByRole('progressbar', { name: 'Weekly limit' })).toHaveAttribute(
+    expect(screen.queryByTestId('live-usage-elapsed-monthly-window')).not.toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Monthly limit' })).toHaveAttribute(
       'aria-valuetext',
       '81% used',
     );


### PR DESCRIPTION
## Weekly and daily elapsed markers from window kind

**What was wrong:** The period-elapsed marker on a usage bar only appeared when the provider stated a window's `startsAt`, or when the window's *id* was in a small hardcoded table (`five-hour` only). A weekly or daily window with a stated reset but no stated start never got a marker at all, even though its period is implied by its own cadence.

**What changed:** `liveWindowElapsed` (in `src/lib/presentation/liveUsage.ts`) now also infers a window's period from its `kind`: `weekly` → 7 days, `daily` → 24 hours, checked after the existing id-keyed table. `monthly` and `billingCycle` are deliberately excluded, since a month's length genuinely varies.

**Why:** A window's cadence is arithmetic on its own identity, the same way `five-hour` already was — `weekly` means seven days by definition, not a guess about where a particular window's boundary falls. Monthly/billing-cycle windows keep no marker because inferring a fixed length there really would be a guess dressed as a measurement.

## Visibility-aware cooldown max-age

**What was wrong:** The popover re-queries `get_live_usage` roughly once a minute while it's open, but every live-usage source held a successful reading behind a fixed 10-minute cooldown (`SUCCESS_COOLDOWN`). A visible, actively-polled panel could therefore sit on a reading up to 10 minutes stale.

**What changed:** `Cooldown::poll` (in `provider_usage/live/sources/cooldown.rs`) now takes a caller-stated `max_age: Duration` in place of the fixed cooldown, threaded through `LiveUsageSource::fetch`, `sources::collect`, and `summarize`. The failure-retry cooldown is derived from the same `max_age`, clamped to **[60s, 300s]**. `get_live_usage` (`commands.rs`) asks for 50 seconds — just under the popover's own polling interval, so an open popover's ordinary polling is what keeps the reading current. The background milestone pass (`usage_alerts.rs`) is unchanged: it still asks for 600 seconds, so background traffic is exactly what it was before.

## Popover-shown event decouples usage refresh from the scan

**What was wrong:** The on-open usage refresh rode the scan pipeline — `note_shown` kicked the scan scheduler, and the frontend refreshed usage on `scan:finished`. Two problems: `ScanController::request()` always wakes the scheduler loop, but the *pass* that wake-up would run is silently skipped whenever discovery is paused or onboarding hasn't finished, which silenced the usage refresh too even though it has nothing to do with local disk discovery; and even when a pass does run, it's a full disk walk the usage refresh had to wait out for no reason.

**What changed:** `note_shown` now also emits `popover:shown` unconditionally, the instant the popover reaches the screen, following the same `module:event` naming and emit mechanism as `scan.rs`'s events. The webview's new `onPopoverShown` listener (`ipc.ts`) refreshes only live usage; entries and the repository list stay on the existing scan-finished path.

---

Rebased onto main after #42 (tauri-nspanel v2.1 upgrade); full verification suite re-run clean on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)