### PR TITLE
fix: scope session analytics by local identity

### DIFF
--- a/apps/desktop/src/views/popover/SessionPane.test.tsx
+++ b/apps/desktop/src/views/popover/SessionPane.test.tsx
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SessionAnalyticsPayload } from '../../lib/ipc';
+import { SessionPane, type SessionSubject } from './SessionPane';
+
+const getSessionAnalytics = vi.hoisted(() => vi.fn());
+const getSubagentAnalytics = vi.hoisted(() => vi.fn());
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  confirm: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock('../../components/session/SessionAnalyticsPresentation', () => ({
+  SessionAnalyticsPresentation: ({
+    loading,
+    session,
+  }: {
+    loading?: boolean;
+    session?: { title?: string; wslDistro?: string | null };
+  }) => (
+    <div>
+      <span data-testid="analytics-state">{loading ? 'loading' : session?.title}</span>
+      <span data-testid="analytics-environment">{session?.wslDistro ?? 'native'}</span>
+    </div>
+  ),
+}));
+
+vi.mock('../../lib/ipc', () => ({
+  deleteSessionData: vi.fn(),
+  exportSession: vi.fn(),
+  getSessionAnalytics,
+  getSubagentAnalytics,
+  revealSource: vi.fn(),
+  withPopoverHold: vi.fn((callback: () => unknown) => callback()),
+}));
+
+function analytics(title: string, wslDistro: string | null): SessionAnalyticsPayload {
+  return {
+    summary: null,
+    supportsAnalytics: true,
+    title,
+    wslDistro,
+    isActive: false,
+    cost: null,
+    models: [],
+    skills: [],
+    orchestration: null,
+    relations: null,
+    sourcePath: null,
+  };
+}
+
+function subject(overrides: Partial<SessionSubject> = {}): SessionSubject {
+  return {
+    agent: 'claude-code',
+    sessionId: 'same-session-id',
+    title: 'fallback title',
+    wslDistro: null,
+    ...overrides,
+  };
+}
+
+const noop = () => undefined;
+
+function renderPane(current: SessionSubject) {
+  return render(
+    <SessionPane subject={current} onBack={noop} onOpenSession={noop} onDeleted={noop} />,
+  );
+}
+
+describe('SessionPane analytics identity', () => {
+  beforeEach(() => {
+    getSessionAnalytics.mockReset();
+    getSubagentAnalytics.mockReset();
+  });
+
+  it('refetches instead of reusing analytics when the same id moves between native and WSL', async () => {
+    getSessionAnalytics.mockImplementation(
+      async (_agent: string, _sessionId: string, wslDistro: string | null) =>
+        analytics(wslDistro ?? 'native analytics', wslDistro),
+    );
+
+    const view = renderPane(subject());
+    await waitFor(() =>
+      expect(screen.getByTestId('analytics-state')).toHaveTextContent('native analytics'),
+    );
+    expect(getSessionAnalytics).toHaveBeenCalledTimes(1);
+    expect(getSessionAnalytics).toHaveBeenLastCalledWith(
+      'claude-code',
+      'same-session-id',
+      null,
+    );
+
+    view.rerender(
+      <SessionPane
+        subject={subject({ wslDistro: 'Ubuntu' })}
+        onBack={noop}
+        onOpenSession={noop}
+        onDeleted={noop}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('analytics-state')).toHaveTextContent('Ubuntu'),
+    );
+    expect(getSessionAnalytics).toHaveBeenCalledTimes(2);
+    expect(getSessionAnalytics).toHaveBeenLastCalledWith(
+      'claude-code',
+      'same-session-id',
+      'Ubuntu',
+    );
+  });
+
+  it('refetches sub-agent analytics when the launching session changes', async () => {
+    getSubagentAnalytics.mockImplementation(
+      async (
+        _agent: string,
+        parentSessionId: string,
+        _subagentId: string,
+        wslDistro: string | null,
+      ) => analytics(parentSessionId, wslDistro),
+    );
+
+    const initial = subject({
+      subagent: { parentSessionId: 'parent-one', subagentId: 'same-subagent-id' },
+      sessionId: 'same-subagent-id',
+    });
+    const view = renderPane(initial);
+    await waitFor(() =>
+      expect(screen.getByTestId('analytics-state')).toHaveTextContent('parent-one'),
+    );
+    expect(getSubagentAnalytics).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <SessionPane
+        subject={subject({
+          subagent: { parentSessionId: 'parent-two', subagentId: 'same-subagent-id' },
+          sessionId: 'same-subagent-id',
+        })}
+        onBack={noop}
+        onOpenSession={noop}
+        onDeleted={noop}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('analytics-state')).toHaveTextContent('parent-two'),
+    );
+    expect(getSubagentAnalytics).toHaveBeenCalledTimes(2);
+    expect(getSubagentAnalytics).toHaveBeenLastCalledWith(
+      'claude-code',
+      'parent-two',
+      'same-subagent-id',
+      null,
+    );
+  });
+});

--- a/apps/desktop/src/views/popover/SessionPane.tsx
+++ b/apps/desktop/src/views/popover/SessionPane.tsx
@@ -17,6 +17,7 @@ import {
   type SessionAnalyticsPayload,
 } from '../../lib/ipc';
 import { agentSupportsAnalytics } from '../../lib/presentation/agents';
+import { localSessionKey } from '../../lib/presentation/localIdentity';
 import { costBreakdownRows, costFigureLabel } from '../../lib/presentation/sessionAnalytics';
 import {
   topLevelCostSubject,
@@ -109,16 +110,17 @@ function toLocalCost(
 }
 
 /** Load one subject's analytics. Sub-agents come from their own command. */
-async function loadAnalytics(subject: SessionSubject): Promise<SessionAnalyticsPayload | null> {
-  if (subject.subagent) {
-    return getSubagentAnalytics(
-      subject.agent,
-      subject.subagent.parentSessionId,
-      subject.subagent.subagentId,
-      subject.wslDistro,
-    );
+async function loadAnalytics(
+  agent: string,
+  sessionId: string,
+  wslDistro: string | null | undefined,
+  parentSessionId?: string,
+  subagentId?: string,
+): Promise<SessionAnalyticsPayload | null> {
+  if (parentSessionId !== undefined && subagentId !== undefined) {
+    return getSubagentAnalytics(agent, parentSessionId, subagentId, wslDistro);
   }
-  return getSessionAnalytics(subject.agent, subject.sessionId, subject.wslDistro);
+  return getSessionAnalytics(agent, sessionId, wslDistro);
 }
 
 export function SessionPane({
@@ -144,11 +146,25 @@ export function SessionPane({
     error: boolean;
   } | null>(null);
 
-  const key = `${subject.agent}|${subject.sessionId}|${subject.subagent?.subagentId ?? ''}`;
+  const agent = subject.agent;
+  const sessionId = subject.sessionId;
+  const wslDistro = subject.wslDistro;
+  const parentSessionId = subject.subagent?.parentSessionId;
+  const subagentId = subject.subagent?.subagentId;
+  // A sub-agent id is only unique within its launching session. Keep the
+  // parent identity in the key as well as the environment-aware session key.
+  const key =
+    parentSessionId !== undefined && subagentId !== undefined
+      ? JSON.stringify([
+          'subagent',
+          localSessionKey(agent, parentSessionId, wslDistro),
+          subagentId,
+        ])
+      : localSessionKey(agent, sessionId, wslDistro);
 
   useEffect(() => {
     let active = true;
-    loadAnalytics(subject)
+    loadAnalytics(agent, sessionId, wslDistro, parentSessionId, subagentId)
       .then((result) => {
         if (active) setSettled({ key, payload: result, error: false });
       })
@@ -158,10 +174,10 @@ export function SessionPane({
     return () => {
       active = false;
     };
-    // `subject` is rebuilt on every render by the host, so the identity key is
-    // what actually changes when a different session is opened.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
+    // `subject` is rebuilt on every render by the host, so the primitive
+    // identity fields are what actually change when a different session is
+    // opened.
+  }, [agent, sessionId, wslDistro, parentSessionId, subagentId, key]);
 
   const current = settled?.key === key ? settled : null;
   const payload = current?.payload ?? null;


### PR DESCRIPTION
## Summary

Fixes a session analytics cache identity collision where native and WSL sessions could share the same agent/session ID and incorrectly reuse settled analytics.

The identity now includes:
- agent + session ID + normalized native/WSL environment
- parent session ID + subagent ID for subagent analytics

The exhaustive-deps suppression was removed; the IPC-loading effect depends on the primitive identity fields.

## Checks

- Focused Vitest: 36 tests
- ESLint
- TypeScript type-check
- Prettier
- `git diff --check`

DCO sign-off included (`git commit -s`).