### PR TITLE
refactor(settings): share settings controller with sources pane

### DIFF
--- a/apps/desktop/src/lib/route.test.ts
+++ b/apps/desktop/src/lib/route.test.ts
@@ -34,8 +34,8 @@ describe('routeFromHash', () => {
   });
 
   it('does not resolve a route from an inherited object property', () => {
-    // The table is a plain object, so a fragment like "constructor" must not
-    // resolve to anything just because `Object.prototype` has that key.
+    // A fragment like "constructor" must not resolve to anything just because
+    // it is an inherited object property rather than a known route.
     expect(routeFromHash('#/constructor')).toBe('popover');
     expect(routeFromHash('#/toString')).toBe('popover');
   });

--- a/apps/desktop/src/views/SettingsView.tsx
+++ b/apps/desktop/src/views/SettingsView.tsx
@@ -197,7 +197,9 @@ export function SettingsView() {
           >
             {pane === 'general' && <GeneralPane {...controller} info={info} />}
             {pane === 'appearance' && <AppearancePane {...controller} />}
-            {pane === 'sources' && <SourcesPane />}
+            {pane === 'sources' && (
+              <SourcesPane discoveryPaused={controller.settings.discoveryPaused} />
+            )}
             {pane === 'privacy' && <PrivacyPane />}
             {pane === 'notifications' && <NotificationsPane {...controller} />}
             {pane === 'usage' && <UsagePane {...controller} />}

--- a/apps/desktop/src/views/settings/SourcesPane.test.tsx
+++ b/apps/desktop/src/views/settings/SourcesPane.test.tsx
@@ -22,15 +22,6 @@ vi.mock('@tauri-apps/api/event', () => ({
 }));
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: openDialog }));
 
-const SETTINGS = {
-  theme: 'system' as const,
-  activityWindowDays: 7,
-  onboardingCompleted: true,
-  launchAtLogin: false,
-  autoUpdate: true,
-  discoveryPaused: false,
-};
-
 const SCAN_STATUS = {
   running: false,
   completedAgents: 11,
@@ -46,8 +37,6 @@ function mockCommands(overrides: Record<string, unknown> = {}) {
   invoke.mockImplementation((command: string) => {
     if (command in overrides) return Promise.resolve(overrides[command]);
     switch (command) {
-      case 'get_settings':
-        return Promise.resolve(SETTINGS);
       case 'get_scan_status':
       case 'scan_now':
         return Promise.resolve(SCAN_STATUS);
@@ -67,7 +56,7 @@ beforeEach(() => {
 
 describe('SourcesPane scanning', () => {
   it('shows when the index was last refreshed and can rescan on demand', async () => {
-    render(<SourcesPane />);
+    render(<SourcesPane discoveryPaused={false} />);
 
     expect(await screen.findByText(/scanned 2m ago/i)).toBeInTheDocument();
 
@@ -76,8 +65,7 @@ describe('SourcesPane scanning', () => {
   });
 
   it('says so plainly while discovery is paused', async () => {
-    mockCommands({ get_settings: { ...SETTINGS, discoveryPaused: true } });
-    render(<SourcesPane />);
+    render(<SourcesPane discoveryPaused />);
 
     expect(await screen.findByText('Scanning paused')).toBeInTheDocument();
     // Pausing background work never removes the way to ask for a pass.
@@ -88,7 +76,7 @@ describe('SourcesPane scanning', () => {
     mockCommands({
       get_scan_status: { ...SCAN_STATUS, running: true, finishedAt: null },
     });
-    render(<SourcesPane />);
+    render(<SourcesPane discoveryPaused={false} />);
 
     const button = await screen.findByRole('button', { name: /scanning/i });
     expect(button).toBeDisabled();

--- a/apps/desktop/src/views/settings/SourcesPane.tsx
+++ b/apps/desktop/src/views/settings/SourcesPane.tsx
@@ -37,7 +37,6 @@ import type {
 } from '../../lib/types/repository';
 import { useFolderPermissionFlow } from '../../lib/useFolderPermissionFlow';
 import { scanStatusLabel } from '../popover/ScanStatusBar';
-import { useAppSettings } from './useAppSettings';
 
 /**
  * Sources: which repositories antiburn watches, and where it looks for them.
@@ -76,8 +75,11 @@ function toItems(payloads: readonly RepositoryItemPayload[]): LocalRepositoryIte
   }));
 }
 
-export function SourcesPane() {
-  const { settings: appSettings } = useAppSettings();
+export interface SourcesPaneProps {
+  discoveryPaused: boolean;
+}
+
+export function SourcesPane({ discoveryPaused }: SourcesPaneProps) {
   const [repositories, setRepositories] = useState<LocalRepositoryItem[]>([]);
   const [scanRoots, setScanRoots] = useState<string[]>([]);
   const [scanning, setScanning] = useState(true);
@@ -233,7 +235,7 @@ export function SourcesPane() {
           title="Scanning"
           trailing={
             <StatusText tone="secondary">
-              {scanStatusLabel(scanStatus, appSettings.discoveryPaused)}
+              {scanStatusLabel(scanStatus, discoveryPaused)}
             </StatusText>
           }
         >

--- a/apps/desktop/src/views/settings/useAppSettings.ts
+++ b/apps/desktop/src/views/settings/useAppSettings.ts
@@ -48,8 +48,9 @@ export function useAppSettings(): AppSettingsController {
       .catch(() => {
         if (active) setLoaded(true);
       });
-    // Writes can come from another window (onboarding runs in the popover);
-    // the broadcast keeps this window's copy — and its theme — current too.
+    // Writes can come from another window (onboarding and the popover share the
+    // same settings store); the broadcast keeps this window's copy — and its
+    // theme — current too.
     const pending = onSettingsChanged((stored) => {
       if (!active) return;
       applyTheme(stored.theme);


### PR DESCRIPTION
## Summary

- Remove the duplicate `useAppSettings()` subscription from `SourcesPane`; pass `discoveryPaused` from the existing `SettingsView` controller via typed props.
- Update direct Sources pane tests and remove obsolete settings mocks.
- Correct stale onboarding synchronization and route-test comments.

## Checks

- Focused tests: 49 passed
- Full desktop tests: 650 passed
- Prettier, ESLint, and TypeScript type-check passed

Signed-off-by: Dave Slutzkin <daveslutzkin@fastmail.fm>