### PR TITLE
perf(desktop): split frontend routes and omit release maps

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -81,7 +81,9 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(screen.getByRole('tablist', { name: 'Settings sections' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('tablist', { name: 'Settings sections' }),
+    ).toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: 'General' })).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,22 +2,43 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { lazy, Suspense } from 'react';
+
 import { useRoute } from './lib/route';
 import { NudgeView } from './views/NudgeView';
-import { OnboardingView } from './views/OnboardingView';
-import { PopoverView } from './views/PopoverView';
-import { SettingsView } from './views/SettingsView';
+
+// Keep the nudge view in the entry chunk. The shell prewarms this webview and
+// can deliver a pending nudge immediately after startup; making the listener
+// wait for a route chunk would add an avoidable readiness race. The larger,
+// user-facing windows are loaded only by the webview that owns their route.
+const OnboardingView = lazy(() =>
+  import('./views/OnboardingView').then(({ OnboardingView: view }) => ({ default: view })),
+);
+const PopoverView = lazy(() =>
+  import('./views/PopoverView').then(({ PopoverView: view }) => ({ default: view })),
+);
+const SettingsView = lazy(() =>
+  import('./views/SettingsView').then(({ SettingsView: view }) => ({ default: view })),
+);
+
+function RouteLoading() {
+  return <div className="h-full" aria-busy="true" data-testid="route-loading" />;
+}
 
 export function App() {
   const route = useRoute();
-  switch (route) {
-    case 'settings':
-      return <SettingsView />;
-    case 'nudge':
-      return <NudgeView />;
-    case 'onboarding':
-      return <OnboardingView />;
-    default:
-      return <PopoverView />;
-  }
+  if (route === 'nudge') return <NudgeView />;
+
+  const view = (() => {
+    switch (route) {
+      case 'settings':
+        return <SettingsView />;
+      case 'onboarding':
+        return <OnboardingView />;
+      default:
+        return <PopoverView />;
+    }
+  })();
+
+  return <Suspense fallback={<RouteLoading />}>{view}</Suspense>;
 }

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 
 import { AlertTriangle } from 'lucide-react';
 
@@ -45,8 +45,15 @@ import {
   type PopoverSurface,
 } from '../lib/popoverHeight';
 import type { LocalRepositoryItem, LocalRepositoryStatus } from '../lib/types/repository';
-import { SessionPane, type SessionSubject } from './popover/SessionPane';
 import { UsageView } from './popover/UsageView';
+import type { SessionSubject } from './popover/SessionPane';
+
+// Session analytics pulls in the charting library and a substantial set of
+// presentation components. Keep it out of the activity surface's initial
+// chunk; opening a session is the only action that needs this code.
+const SessionPane = lazy(() =>
+  import('./popover/SessionPane').then(({ SessionPane: pane }) => ({ default: pane })),
+);
 
 /**
  * The tray popover.
@@ -95,6 +102,22 @@ function ActivitySkeleton() {
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+/** Placeholder while the session analytics chunk is fetched on first open. */
+function SessionPaneLoading() {
+  return (
+    <div className="flex h-full flex-col" aria-busy="true" data-testid="session-pane-loading">
+      <header className="flex h-11 shrink-0 items-center px-4">
+        <h1 data-view-heading tabIndex={-1} className="type-headline text-label outline-none">
+          Session Analytics
+        </h1>
+      </header>
+      <div className="min-h-0 flex-1 px-4 pt-4">
+        <Skeleton className="h-24 w-full" />
+      </div>
     </div>
   );
 }
@@ -396,17 +419,19 @@ export function PopoverView() {
       };
 
       return (
-        <SessionPane
-          subject={current}
-          onBack={goBack}
-          onPrev={neighbour(-1)}
-          onNext={neighbour(1)}
-          onOpenSession={openSession}
-          onDeleted={() => {
-            goBack();
-            void refreshEntries(windowDays).catch(() => {});
-          }}
-        />
+        <Suspense fallback={<SessionPaneLoading />}>
+          <SessionPane
+            subject={current}
+            onBack={goBack}
+            onPrev={neighbour(-1)}
+            onNext={neighbour(1)}
+            onOpenSession={openSession}
+            onDeleted={() => {
+              goBack();
+              void refreshEntries(windowDays).catch(() => {});
+            }}
+          />
+        </Suspense>
       );
     }
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -10,7 +10,7 @@ import { defineConfig } from 'vitest/config';
 /** Port the Tauri shell expects for the dev server (see `tauri.conf.json`). */
 const DEV_SERVER_PORT = 1420;
 
-export default defineConfig({
+export default defineConfig(({ command, mode }) => ({
   plugins: [react(), tailwindcss()],
 
   // Tauri reads the shell's stderr, so Vite must not clear it, and the dev
@@ -29,7 +29,13 @@ export default defineConfig({
     // The shell is the only consumer, so target the bundled webviews rather
     // than the browser matrix Vite defaults to.
     target: process.env.TAURI_ENV_PLATFORM === 'windows' ? 'chrome110' : 'safari15',
-    sourcemap: true,
+    // Source maps are useful for Vite's dev server and Tauri debug bundles,
+    // but shipping them alongside every embedded webview multiplies the
+    // frontend payload without helping an installed reader. Tauri exposes
+    // `TAURI_ENV_DEBUG` to its build hook; the mode check keeps direct
+    // `vite --mode development` builds equally debuggable.
+    sourcemap:
+      command === 'serve' || mode !== 'production' || process.env.TAURI_ENV_DEBUG === 'true',
     emptyOutDir: true,
   },
 
@@ -40,4 +46,4 @@ export default defineConfig({
     // (see tests/no-exfiltration.test.ts).
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.ts'],
   },
-});
+}));


### PR DESCRIPTION
## Summary

- Keep `NudgeView` eager in the entry chunk so the prewarmed notification webview can attach its listener immediately and preserve pending-nudge readiness.
- Lazy-load Popover, Settings, and Onboarding route views.
- Lazy-load `SessionPane`, keeping session analytics and Recharts out of the initial activity surface.
- Keep source maps for Vite dev/non-production modes and Tauri debug builds (`TAURI_ENV_DEBUG=true`); omit them from normal production builds.

## Bundle measurements

Baseline production build:
- Entry JavaScript: 904.2 kB
- Source maps: approximately 9.5 MB

This branch:
- Entry JavaScript: 209.6 kB
- Source maps: none
- Session analytics: separate 427.6 kB chunk, loaded only when a session is opened

## Verification

- Frontend lint
- Type-check
- 66 test files / 650 tests
- Prettier format check
- Production build
- Independent production/debug build verification

Commit includes DCO sign-off.