### PR TITLE
chore: remove abandoned Rust dead code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,9 @@ These instructions apply to the entire repository.
 Avoid `useEffect` by default. Prefer deriving values during render, handling work in the event that caused it, or moving synchronization to the external-system boundary.
 
 Only add a `useEffect` when it is strictly necessary to synchronize React with an external system and no simpler design provides the required behavior. Before adding one, explain why it is necessary and get explicit agreement from the developer. Existing effects are not precedent for adding more, and reviews should call out effects that can be removed.
+
+## Rust dead and deprecated code
+
+Do not add or retain Rust lint suppressions for dead or deprecated code. This includes item-level forms such as `#[allow(dead_code)]` and `#[allow(deprecated)]`, crate- or module-level forms such as `#![allow(dead_code)]` and `#![allow(deprecated)]`, and the corresponding `#[expect(...)]` forms.
+
+Delete dead code and migrate away from deprecated APIs instead. A suppression is permitted only after explaining the concrete need and receiving explicit agreement from the developer. Existing suppressions are not precedent for adding or retaining more, and reviews should call them out.

--- a/apps/desktop/src-tauri/crates/sound/src/synth.rs
+++ b/apps/desktop/src-tauri/crates/sound/src/synth.rs
@@ -22,12 +22,6 @@ use fundsp::prelude32::*;
 /// from it cleanly.
 pub const SR: f64 = 48_000.0;
 
-#[derive(Clone, Copy, PartialEq)]
-pub enum Wave4 {
-    Sine,
-    Triangle,
-}
-
 /// One sound's parameters, one-to-one with the lab's panel.
 #[derive(Clone, Copy)]
 pub struct Voice {
@@ -37,7 +31,6 @@ pub struct Voice {
     pub root: f32,
     /// Semitone offsets played together. `UNISON` is a single note.
     pub chord: &'static [f32],
-    pub wave: Wave4,
     /// Spread between the three copies, in cents.
     pub detune: f32,
     /// How much the detune narrows as notes get higher, 0 to 1.
@@ -108,26 +101,16 @@ fn note_layer(v: &Voice, f: f32, gain: f32) -> Wave {
     // FM modulates the carrier frequency, with the index decaying faster than the
     // amplitude — the asymmetry that makes it read as struck rather than blown.
     let (fm_a, fm_r) = (v.fm_amount, v.fm_ratio);
-    let wave = v.wave;
-
-    // Type-erased so both waveforms and the FM branch share one chain.
+    // Type-erased so the FM and non-FM branches share one chain.
     let osc = |fd: f32| -> Box<dyn AudioUnit> {
         if fm_a > 0.0 {
-            // The modulator sums into the carrier frequency, then drives whichever
-            // waveform the patch selected. Hardcoding a sine here was a bug once:
-            // the warning specifies a triangle, and a sine carrier produces far
-            // fewer sidebands, so the port was not the same instrument.
+            // The modulator sums into the carrier frequency before the sine
+            // carrier, matching the sound-lab patch used by the app.
             let m = sine_hz(fd * fm_r) * envelope(move |t: f32| fm_a * (-t * rel * 2.2).exp()) + fd;
             let e = envelope(move |t: f32| shape(t, att, rel));
-            match wave {
-                Wave4::Sine => Box::new((m >> sine()) * e * gain),
-                Wave4::Triangle => Box::new((m >> triangle()) * e * gain),
-            }
+            Box::new((m >> sine()) * e * gain)
         } else {
-            match wave {
-                Wave4::Sine => Box::new(sine_hz(fd) * envelope(env) * gain),
-                Wave4::Triangle => Box::new(triangle_hz(fd) * envelope(env) * gain),
-            }
+            Box::new(sine_hz(fd) * envelope(env) * gain)
         }
     };
 

--- a/apps/desktop/src-tauri/crates/sound/src/voices.rs
+++ b/apps/desktop/src-tauri/crates/sound/src/voices.rs
@@ -11,7 +11,7 @@
 //! in `prototypes/sound-lab/lab.html`, listen, and paste the result back — that
 //! loop is the entire reason the lab exists.
 
-use crate::synth::{UNISON, Voice, Wave4};
+use crate::synth::{UNISON, Voice};
 
 /// Warm and low, opening rather than striking. Used for ActorUpdate, Own-update ready and
 /// Tune up — the three that are informational rather than a problem.
@@ -24,7 +24,6 @@ pub const SOFT_UPDATE: Voice = Voice {
     release: 5.8,
     root: 196.0,
     chord: UNISON,
-    wave: Wave4::Sine,
     detune: 8.1,
     detune_track: 0.0,
     cutoff: 4924.0,
@@ -38,50 +37,5 @@ pub const SOFT_UPDATE: Voice = Voice {
     air_gain: 0.04,
     air_band: 8689.0,
     air_att: 0.19,
-    level: 0.14,
-};
-
-/// **Not currently used.** Notification was going to be the harsh voice below, and
-/// on a listen it wasn't wanted: it now plays the same warm arpeggio as everything
-/// else, just on fixed notes. Kept rather than deleted because it represents real
-/// tuning work and is the obvious starting point if a sound ever does need to read
-/// as bad news. Delete it if that stops being plausible.
-///
-/// Short and hard: 400 ms with a fast attack and a filter that *closes*
-/// (`sweep` below 1) rather than opening. Darkening as it decays is what gives it
-/// the falling, deflating shape that reads as something being wrong.
-#[allow(dead_code)]
-///
-/// Inharmonic FM at ratio 2.7 supplies the metallic edge — an integer ratio would
-/// add harmonics that fold into the note and sound musical instead of urgent.
-///
-/// **Brightness is not calibrated against the lab.** The Rust render measures
-/// 1708 Hz against the browser's 662, a 2.6x gap that three separate hypotheses
-/// failed to explain (drive-stage oversampling, the FM carrier waveform, and the
-/// filter settings — a 14x6 grid search could get no closer than 1294 Hz). Web
-/// Audio's biquad and fundsp's state-variable filter simply do not interpret
-/// resonance the same way. Left at the browser's own values pending a listen,
-/// rather than tuned to a number nobody understands. Loudness *is* matched, via the
-/// per-sound normalisation in `finish_to`.
-pub const WARNING: Voice = Voice {
-    dur: 0.4,
-    attack: 0.035,
-    release: 10.7,
-    root: 1049.0,
-    chord: UNISON,
-    wave: Wave4::Triangle,
-    detune: 2.0,
-    detune_track: 0.0,
-    cutoff: 530.0,
-    q: 0.9,
-    sweep: 0.5,
-    fm_amount: 265.0,
-    fm_ratio: 2.7,
-    drive: 0.16,
-    sub_gain: 0.12,
-    sub_att: 0.323,
-    air_gain: 0.1,
-    air_band: 1650.0,
-    air_att: 0.047,
     level: 0.14,
 };

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -357,21 +357,12 @@ pub struct AppInfo {
  * the limit path, and the views can layer two payloads perfectly well.
  * ---------------------------------------------------------------------- */
 
-/// How trustworthy a live reading is, as a word the view can print.
-///
-/// Deliberately the same vocabulary as [`ProviderUsageState`], so a reader who
-/// has learnt "Live" and "Observed" on one surface has learnt them on both.
+/// Marks figures stated directly by a provider rather than locally estimated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum LiveUsageSupport {
     /// The provider stated this allowance. A determinate meter is honest.
     Live,
-    /// The allowance is modelled rather than stated.
-    Estimated,
-    /// Activity is known; no trustworthy allowance is.
-    Observed,
-    /// An account was found, with nothing quantified.
-    Detected,
 }
 
 /// Whether a reading still describes the present.

--- a/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
@@ -36,8 +36,8 @@ use serde_json::Value;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::model::{
-    CreditBalance, ProviderUsageError, SchemaReason, SupplementalUsage, SupplementalUsageKind,
-    UsageScope, UsageUnit, UsageWindow, UsageWindowKind, WindowRole,
+    CreditBalance, ProviderUsageError, SchemaReason, SupplementalUsage, UsageScope, UsageWindow,
+    UsageWindowKind, WindowRole,
 };
 use super::normalize::{slugify, used_percent, used_percent_or_fraction};
 
@@ -209,7 +209,6 @@ fn extra_usage(value: &Value) -> Result<SupplementalUsage, ProviderUsageError> {
     }
 
     Ok(SupplementalUsage {
-        kind: SupplementalUsageKind::ExtraUsage,
         enabled,
         used_percent: used_percent(value.get("utilization").and_then(Value::as_f64))?,
         balance: (used.is_some() || limit.is_some()).then(|| CreditBalance {
@@ -219,7 +218,6 @@ fn extra_usage(value: &Value) -> Result<SupplementalUsage, ProviderUsageError> {
                 _ => None,
             },
             limit,
-            unit: UsageUnit::CurrencyMinor,
             currency,
         }),
     })

--- a/apps/desktop/src-tauri/src/provider_usage/live/history.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/history.rs
@@ -198,7 +198,7 @@ fn enforce_ceiling(history: &mut History) -> bool {
 mod tests {
     use super::*;
     use crate::provider_usage::live::model::{
-        Confidence, SupportTier, UsageScope, UsageSource, UsageWindow, UsageWindowKind, WindowRole,
+        Confidence, UsageScope, UsageSource, UsageWindow, UsageWindowKind, WindowRole,
     };
 
     const NOW: i64 = 1_800_000_000;
@@ -215,7 +215,6 @@ mod tests {
                 confidence: Confidence::High,
                 freshness: Freshness::Fresh,
             },
-            support: SupportTier::Live,
             windows: vec![UsageWindow {
                 id: "five-hour".into(),
                 role: WindowRole::PrimaryShort,

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -60,8 +60,8 @@ mod tests;
 
 pub use milestones::{MilestoneContent, MilestoneLedger, milestone_content};
 pub use model::{
-    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, SupportTier, UsageScope,
-    UsageWindow, UsageWindowKind, WindowRole,
+    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, UsageScope, UsageWindow,
+    UsageWindowKind, WindowRole,
 };
 
 use crate::dto::{
@@ -182,12 +182,7 @@ pub fn summarize(
         .map(|snapshot| LiveProviderUsage {
             display_name: super::providers::display_name(snapshot.provider).to_string(),
             provider: snapshot.provider.to_string(),
-            support: match snapshot.support {
-                SupportTier::Live => LiveUsageSupport::Live,
-                SupportTier::Estimated => LiveUsageSupport::Estimated,
-                SupportTier::Observed => LiveUsageSupport::Observed,
-                SupportTier::Detected => LiveUsageSupport::Detected,
-            },
+            support: LiveUsageSupport::Live,
             freshness: match snapshot.source.freshness {
                 Freshness::Fresh => LiveUsageFreshness::Fresh,
                 Freshness::Stale => LiveUsageFreshness::Stale,
@@ -251,12 +246,9 @@ fn window(
     // Only on a window longer than a day. "How much of your five-hour limit
     // you used today" is a question about a period that has already rolled
     // several times, and the answer would be nonsense dressed as a metric.
-    let used_today = matches!(
-        window.kind,
-        UsageWindowKind::Weekly | UsageWindowKind::Monthly | UsageWindowKind::BillingCycle
-    )
-    .then(|| metrics::used_since(samples, local_midnight))
-    .flatten();
+    let used_today = matches!(window.kind, UsageWindowKind::Weekly)
+        .then(|| metrics::used_since(samples, local_midnight))
+        .flatten();
 
     LiveUsageWindow {
         id: window.id,
@@ -268,16 +260,12 @@ fn window(
         },
         kind: match window.kind {
             UsageWindowKind::Rolling => "rolling".to_string(),
-            UsageWindowKind::Daily => "daily".to_string(),
             UsageWindowKind::Weekly => "weekly".to_string(),
-            UsageWindowKind::Monthly => "monthly".to_string(),
-            UsageWindowKind::BillingCycle => "billingCycle".to_string(),
             UsageWindowKind::Other(other) => other,
         },
         scope_model: match window.scope {
             UsageScope::Model(model) => Some(model),
-            UsageScope::ModelGroup(group) => Some(group),
-            UsageScope::Account | UsageScope::Other(_) => None,
+            UsageScope::Account => None,
         },
         used_percent: window.used_percent,
         starts_at: window.starts_at.map(iso),
@@ -289,7 +277,6 @@ fn window(
                 .map(|reason| reason.as_str().to_string()),
             confidence: forecast.confidence.map(|confidence| {
                 match confidence {
-                    Confidence::Low => "low",
                     Confidence::Medium => "medium",
                     Confidence::High => "high",
                 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/model.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/model.rs
@@ -21,27 +21,11 @@
 //!    structurally trustworthy and six hours old; those are different
 //!    questions and the surfaces answer them separately.
 
-// The vocabulary is the contract, and it is wider than any one source. The
-// two sources that ship today state five-hour and weekly percentages and
-// nothing else, so most of the tiers, units, and failure modes below are
-// declared and not yet constructed — which is the point: a view must already
-// render `Estimated`, and the error surface must already group
-// `Authentication`, on the day a source produces one. Narrowing these enums to
-// what the first sources happen to emit would make the next source a
-// refactor rather than a registration.
-//
-// The allow is module-wide because these are pure data types with no logic to
-// hide behind it; anything here that stops being reachable stops being
-// reachable in `git log`, not in a compiler warning.
-#![allow(dead_code)]
-
 use time::{Duration, OffsetDateTime};
 
 /// Epistemic strength of a fact, independent of how recently it was observed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Confidence {
-    /// Weak or indirect evidence; consequential calculations stay disabled.
-    Low,
     /// Corroborated evidence, good enough for guarded calculations.
     Medium,
     /// Direct structured evidence from a trusted source.
@@ -71,23 +55,6 @@ impl Freshness {
             Freshness::Stale
         }
     }
-}
-
-/// The strongest level of detail the available evidence justifies.
-///
-/// This is the ladder the views degrade down, and it is deliberately the same
-/// vocabulary as the local-estimate path's `ProviderUsageState`, so a reader
-/// who has learnt one word has learnt both.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SupportTier {
-    /// The provider stated this allowance. A determinate meter is honest.
-    Live,
-    /// The allowance is modelled rather than stated, and must say so.
-    Estimated,
-    /// Activity is known; no trustworthy account-wide allowance is.
-    Observed,
-    /// An account or route was found, with nothing quantified.
-    Detected,
 }
 
 /// Why a payload was rejected outright rather than partly believed.
@@ -152,14 +119,8 @@ pub enum WindowRole {
 pub enum UsageWindowKind {
     /// A continuously moving interval, not a calendar boundary.
     Rolling,
-    /// A calendar-day allowance.
-    Daily,
     /// A weekly allowance, on the provider's own boundary.
     Weekly,
-    /// A monthly allowance.
-    Monthly,
-    /// A billing period that need not align with a calendar month.
-    BillingCycle,
     /// Provider semantics retained without coercion.
     Other(String),
 }
@@ -171,21 +132,6 @@ pub enum UsageScope {
     Account,
     /// A single model, keeping the provider's own display name.
     Model(String),
-    /// A provider-defined family or shared bucket of models.
-    ModelGroup(String),
-    /// A scope the provider named that we decline to map onto a standard one.
-    Other(String),
-}
-
-/// The unit attached to raw amounts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UsageUnit {
-    /// A percentage, which in this module always means capacity consumed.
-    Percent,
-    /// Provider-defined credits, with no assumed currency conversion.
-    Credits,
-    /// Minor currency units, read with the accompanying currency code.
-    CurrencyMinor,
 }
 
 /// One provider allowance.
@@ -197,7 +143,7 @@ pub struct UsageWindow {
     pub role: WindowRole,
     /// Reset behaviour.
     pub kind: UsageWindowKind,
-    /// Account, model, or group this limit covers.
+    /// Account or model this limit covers.
     pub scope: UsageScope,
     /// Consumed capacity in `0..=100`. `None` stays unknown; it is never zero.
     pub used_percent: Option<f64>,
@@ -220,26 +166,13 @@ pub struct CreditBalance {
     pub remaining: Option<f64>,
     /// The ceiling, when disclosed. Absence does not imply unlimited.
     pub limit: Option<f64>,
-    /// The unit every populated amount above is in.
-    pub unit: UsageUnit,
-    /// Currency code when the unit is monetary.
+    /// ISO 4217 currency code for monetary amounts, when disclosed.
     pub currency: Option<String>,
-}
-
-/// Metered capacity that can sit alongside a subscription allowance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SupplementalUsageKind {
-    /// Optional spend beyond the included allowance.
-    ExtraUsage,
-    /// On-demand or overage billing once a primary pool is consumed.
-    Overage,
 }
 
 /// Independent metered usage. Must never replace or downgrade primary quota.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SupplementalUsage {
-    /// Which billing behaviour this meter represents.
-    pub kind: SupplementalUsageKind,
     /// Whether the account permits this path. False differs from missing.
     pub enabled: bool,
     /// Consumed supplemental allowance in `0..=100`.
@@ -277,8 +210,6 @@ pub struct ProviderUsageSnapshot {
     pub observed_at: OffsetDateTime,
     /// Provenance, confidence, and freshness.
     pub source: UsageSource,
-    /// The strongest tier this snapshot's evidence justifies.
-    pub support: SupportTier,
     /// The provider's windows, in the order the parser found them.
     pub windows: Vec<UsageWindow>,
     /// Metered usage alongside the windows, when the provider reports it.

--- a/apps/desktop/src-tauri/src/provider_usage/live/normalize.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/normalize.rs
@@ -21,27 +21,6 @@ pub fn used_percent(value: Option<f64>) -> Result<Option<f64>, ProviderUsageErro
     validate_percent(value)
 }
 
-/// Convert a remaining percentage into the consumed percentage this module
-/// stores.
-///
-/// Presentation may invert it again; storage and arithmetic never do.
-#[allow(dead_code)] // Awaits the first source that reports remaining rather than used.
-pub fn remaining_percent(value: Option<f64>) -> Result<Option<f64>, ProviderUsageError> {
-    Ok(validate_percent(value)?.map(|remaining| 100.0 - remaining))
-}
-
-/// Convert a remaining fraction in `0..=1` into consumed percent in `0..=100`.
-#[allow(dead_code)] // Awaits the first source that reports a fraction.
-pub fn remaining_fraction(value: Option<f64>) -> Result<Option<f64>, ProviderUsageError> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    if !value.is_finite() || !(0.0..=1.0).contains(&value) {
-        return Err(ProviderUsageError::Schema(SchemaReason::InvalidValue));
-    }
-    Ok(Some((1.0 - value) * 100.0))
-}
-
 /// Convert a value that might be a `0..=1` fraction or an already-consumed
 /// percentage into the `0..=100` domain this module stores.
 ///
@@ -68,27 +47,6 @@ pub fn used_percent_or_fraction(value: Option<f64>) -> Result<Option<f64>, Provi
         value
     };
     used_percent(Some(percent))
-}
-
-/// Derive a consumed percentage, but only when both a non-negative usage and
-/// a positive limit are known.
-///
-/// A partial input stays unknown rather than becoming a guess; an invalid one
-/// fails.
-#[allow(dead_code)] // Awaits the first source that discloses raw amounts.
-pub fn percent_from_amounts(
-    used: Option<f64>,
-    limit: Option<f64>,
-) -> Result<Option<f64>, ProviderUsageError> {
-    match (used, limit) {
-        (Some(used), Some(limit))
-            if used.is_finite() && limit.is_finite() && used >= 0.0 && limit > 0.0 =>
-        {
-            validate_percent(Some(used / limit * 100.0))
-        }
-        (None, _) | (_, None) => Ok(None),
-        _ => Err(ProviderUsageError::Schema(SchemaReason::InvalidValue)),
-    }
 }
 
 fn validate_percent(value: Option<f64>) -> Result<Option<f64>, ProviderUsageError> {
@@ -144,13 +102,6 @@ mod tests {
     }
 
     #[test]
-    fn remaining_inverts_into_consumed() {
-        assert_eq!(remaining_percent(Some(25.0)), Ok(Some(75.0)));
-        assert_eq!(remaining_fraction(Some(0.25)), Ok(Some(75.0)));
-        assert_eq!(remaining_fraction(Some(1.5)), Err(INVALID));
-    }
-
-    #[test]
     fn a_fraction_at_or_below_one_is_scaled_up_into_a_percent() {
         assert_eq!(used_percent_or_fraction(Some(0.81)), Ok(Some(81.0)));
         assert_eq!(used_percent_or_fraction(Some(0.0)), Ok(Some(0.0)));
@@ -181,17 +132,5 @@ mod tests {
     fn slugify_trims_leading_and_trailing_hyphens() {
         assert_eq!(slugify("  Fable  "), "fable");
         assert_eq!(slugify("--already--hyphenated--"), "already-hyphenated");
-    }
-
-    #[test]
-    fn amounts_need_both_halves_before_they_become_a_percentage() {
-        assert_eq!(percent_from_amounts(Some(5.0), Some(20.0)), Ok(Some(25.0)));
-        // Half the pair is not a quarter of an answer.
-        assert_eq!(percent_from_amounts(Some(5.0), None), Ok(None));
-        assert_eq!(percent_from_amounts(None, Some(20.0)), Ok(None));
-        // A zero limit is not an infinite percentage.
-        assert_eq!(percent_from_amounts(Some(5.0), Some(0.0)), Err(INVALID));
-        // And an over-limit amount is a payload we did not understand.
-        assert_eq!(percent_from_amounts(Some(30.0), Some(20.0)), Err(INVALID));
     }
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -55,8 +55,7 @@ use time::OffsetDateTime;
 
 use crate::provider_usage::live::anthropic;
 use crate::provider_usage::live::model::{
-    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, SupportTier,
-    UsageSource,
+    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, UsageSource,
 };
 use crate::provider_usage::live::{LiveUsageSource, SourceOutcome};
 
@@ -327,7 +326,6 @@ fn fetch_live(
             // function returns is always describing the instant it was built.
             freshness: Freshness::Fresh,
         },
-        support: SupportTier::Live,
         windows: usage.windows,
         supplemental: usage.supplemental,
     })

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_app_server.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_app_server.rs
@@ -55,8 +55,8 @@ use time::OffsetDateTime;
 
 use crate::provider_usage::live::codex::is_sliding_reset_projection;
 use crate::provider_usage::live::model::{
-    Confidence, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, SupportTier, UsageScope,
-    UsageSource, UsageWindow, UsageWindowKind, WindowRole,
+    Confidence, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, UsageScope, UsageSource,
+    UsageWindow, UsageWindowKind, WindowRole,
 };
 
 use super::CODEX_SOURCE_ID;
@@ -129,7 +129,6 @@ pub fn fetch(now: OffsetDateTime) -> Result<Option<ProviderUsageSnapshot>, Provi
             confidence: Confidence::High,
             freshness: crate::provider_usage::live::model::Freshness::Fresh,
         },
-        support: SupportTier::Live,
         windows,
         supplemental: None,
     }))

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -66,8 +66,7 @@ use time::OffsetDateTime;
 
 use crate::provider_usage::live::codex;
 use crate::provider_usage::live::model::{
-    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, SupportTier,
-    UsageSource,
+    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, UsageSource,
 };
 use crate::provider_usage::live::{LiveUsageSource, SourceOutcome};
 
@@ -377,7 +376,6 @@ fn build_snapshot(
             // Recomputed on every read by `Cooldown::poll`.
             freshness: Freshness::Fresh,
         },
-        support: SupportTier::Live,
         windows: usage.windows,
         supplemental: None,
     })

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -144,7 +144,7 @@ mod tests {
 
     use super::*;
     use crate::provider_usage::live::model::{
-        Confidence, SupportTier, UsageScope, UsageSource, UsageWindow, UsageWindowKind, WindowRole,
+        Confidence, UsageScope, UsageSource, UsageWindow, UsageWindowKind, WindowRole,
     };
 
     fn at(seconds: i64) -> OffsetDateTime {
@@ -163,7 +163,6 @@ mod tests {
                 confidence: Confidence::High,
                 freshness: Freshness::Fresh,
             },
-            support: SupportTier::Live,
             windows: vec![UsageWindow {
                 id: "five-hour".into(),
                 role: WindowRole::PrimaryShort,

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -26,15 +26,15 @@
 //! from an HTTP status to this module's error taxonomy — and [`cooldown`] is
 //! the retry-and-last-good-reading contract both sources are built on.
 //!
-//! # The ladder
+//! # Picking one reading
 //!
 //! Sources are ranked, not merged. When two of them describe the same
 //! provider account, the better one wins outright and the other is discarded
 //! — a snapshot is one coherent reading of one moment, and splicing a fresh
 //! five-hour window onto a stale weekly one produces a picture that was never
 //! true at any instant. In practice this build registers at most one source
-//! per provider, so the ladder's real job today is picking between a fresh
-//! reading and network the reader just turned off — see [`preferred`].
+//! per provider, so the rule's real job today is picking between a fresh
+//! reading and a cached one — see [`preferred`].
 
 pub mod anthropic_fetch;
 mod codex_app_server;
@@ -43,7 +43,7 @@ mod cooldown;
 mod http;
 
 use super::LiveUsageSource;
-use super::model::{Freshness, ProviderUsageSnapshot, SupportTier};
+use super::model::{Freshness, ProviderUsageSnapshot};
 
 /// The stable id both [`codex_fetch`] and [`codex_app_server`] stamp their
 /// snapshots with. One registered source, two ways of answering for it — the
@@ -112,26 +112,12 @@ impl Collected {
 
 /// Whether `candidate` is a better reading of the same account than `current`.
 ///
-/// The order is support tier, then freshness, then observation time. Tier
-/// leads because a stale figure the provider stated still beats a current
-/// figure we modelled: the first is old news about the truth, the second is
-/// fresh news about a guess.
+/// Freshness leads, then observation time. Every registered source reports
+/// provider-stated figures, so there is no second, speculative support tier
+/// to rank ahead of recency.
 fn preferred(candidate: &ProviderUsageSnapshot, current: &ProviderUsageSnapshot) -> bool {
-    let rank = |tier: SupportTier| match tier {
-        SupportTier::Live => 3,
-        SupportTier::Estimated => 2,
-        SupportTier::Observed => 1,
-        SupportTier::Detected => 0,
-    };
     let fresh = |freshness: Freshness| usize::from(freshness == Freshness::Fresh);
 
-    (
-        rank(candidate.support),
-        fresh(candidate.source.freshness),
-        candidate.observed_at,
-    ) > (
-        rank(current.support),
-        fresh(current.source.freshness),
-        current.observed_at,
-    )
+    (fresh(candidate.source.freshness), candidate.observed_at)
+        > (fresh(current.source.freshness), current.observed_at)
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -15,8 +15,8 @@ use time::OffsetDateTime;
 
 use super::anthropic;
 use super::model::{
-    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, SupportTier,
-    UsageScope, UsageSource, UsageWindowKind, WindowRole,
+    Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, UsageScope,
+    UsageSource, UsageWindowKind, WindowRole,
 };
 use super::{LiveUsageSource, SourceOutcome, sources, summarize};
 
@@ -261,12 +261,7 @@ impl LiveUsageSource for Broken {
     }
 }
 
-fn snapshot(
-    support: SupportTier,
-    freshness: Freshness,
-    observed: i64,
-    percent: f64,
-) -> ProviderUsageSnapshot {
+fn snapshot(freshness: Freshness, observed: i64, percent: f64) -> ProviderUsageSnapshot {
     ProviderUsageSnapshot {
         provider: crate::provider_usage::providers::ANTHROPIC,
         account: Some("account-a".into()),
@@ -278,7 +273,6 @@ fn snapshot(
             confidence: Confidence::High,
             freshness,
         },
-        support,
         windows: vec![super::UsageWindow {
             id: "five-hour".into(),
             role: WindowRole::PrimaryShort,
@@ -294,49 +288,13 @@ fn snapshot(
 }
 
 #[test]
-fn a_stated_figure_beats_a_fresher_modelled_one() {
-    // Old news about the truth beats fresh news about a guess.
-    let sources: Vec<Box<dyn LiveUsageSource>> = vec![
-        Box::new(Fixed(
-            "modelled",
-            vec![snapshot(
-                SupportTier::Estimated,
-                Freshness::Fresh,
-                NOW,
-                10.0,
-            )],
-        )),
-        Box::new(Fixed(
-            "stated",
-            vec![snapshot(
-                SupportTier::Live,
-                Freshness::Stale,
-                NOW - 7_200,
-                81.0,
-            )],
-        )),
-    ];
-    let summary = summarize(&sources, None, NOW, 0);
-    assert_eq!(summary.providers.len(), 1);
-    assert_eq!(summary.providers[0].windows[0].used_percent, Some(81.0));
-}
-
-#[test]
 fn between_two_stated_figures_the_fresher_one_wins() {
     let sources: Vec<Box<dyn LiveUsageSource>> = vec![
         Box::new(Fixed(
             "old",
-            vec![snapshot(
-                SupportTier::Live,
-                Freshness::Stale,
-                NOW - 7_200,
-                40.0,
-            )],
+            vec![snapshot(Freshness::Stale, NOW - 7_200, 40.0)],
         )),
-        Box::new(Fixed(
-            "new",
-            vec![snapshot(SupportTier::Live, Freshness::Fresh, NOW, 81.0)],
-        )),
+        Box::new(Fixed("new", vec![snapshot(Freshness::Fresh, NOW, 81.0)])),
     ];
     let summary = summarize(&sources, None, NOW, 0);
     assert_eq!(summary.providers[0].windows[0].used_percent, Some(81.0));
@@ -344,14 +302,11 @@ fn between_two_stated_figures_the_fresher_one_wins() {
 
 #[test]
 fn two_accounts_at_one_provider_never_merge() {
-    let mut other = snapshot(SupportTier::Live, Freshness::Fresh, NOW, 12.0);
+    let mut other = snapshot(Freshness::Fresh, NOW, 12.0);
     other.account = Some("account-b".into());
     let sources: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
         "both",
-        vec![
-            snapshot(SupportTier::Live, Freshness::Fresh, NOW, 81.0),
-            other,
-        ],
+        vec![snapshot(Freshness::Fresh, NOW, 81.0), other],
     ))];
     let collected = sources::collect(&sources, true);
     assert_eq!(collected.snapshots.len(), 2);
@@ -362,7 +317,7 @@ fn a_failed_source_reports_its_category_without_erasing_a_working_one() {
     let sources: Vec<Box<dyn LiveUsageSource>> = vec![
         Box::new(Fixed(
             "working",
-            vec![snapshot(SupportTier::Live, Freshness::Fresh, NOW, 81.0)],
+            vec![snapshot(Freshness::Fresh, NOW, 81.0)],
         )),
         Box::new(Broken("signed-out", ProviderUsageError::Authentication)),
     ];
@@ -392,7 +347,7 @@ fn the_live_payload_states_percentages_and_says_where_they_came_from() {
     // with the provenance that makes them readable.
     let sources: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
         "fixture",
-        vec![snapshot(SupportTier::Live, Freshness::Fresh, NOW, 81.0)],
+        vec![snapshot(Freshness::Fresh, NOW, 81.0)],
     ))];
     let json = serde_json::to_string(&summarize(&sources, None, NOW, 0)).unwrap();
 
@@ -433,12 +388,7 @@ impl LiveUsageSource for Counted {
     }
     fn fetch(&self) -> SourceOutcome {
         self.0.fetch_add(1, Ordering::SeqCst);
-        SourceOutcome::found(vec![snapshot(
-            SupportTier::Live,
-            Freshness::Fresh,
-            NOW,
-            99.0,
-        )])
+        SourceOutcome::found(vec![snapshot(Freshness::Fresh, NOW, 99.0)])
     }
 }
 
@@ -452,7 +402,7 @@ fn a_gated_source_is_never_called_while_the_opt_in_is_off() {
     let sources: Vec<Box<dyn LiveUsageSource>> = vec![
         Box::new(Fixed(
             "ungated",
-            vec![snapshot(SupportTier::Live, Freshness::Fresh, NOW, 40.0)],
+            vec![snapshot(Freshness::Fresh, NOW, 40.0)],
         )),
         Box::new(Counted(Arc::clone(&calls))),
     ];
@@ -548,7 +498,6 @@ fn weekly_scoped_snapshot(
             confidence: Confidence::High,
             freshness: Freshness::Fresh,
         },
-        support: SupportTier::Live,
         windows: vec![super::UsageWindow {
             id: "weekly-some-model".into(),
             role: WindowRole::Supplemental,

--- a/apps/desktop/src/components/providerUsage/ProviderUsageCluster.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageCluster.tsx
@@ -312,7 +312,6 @@ export function ProviderUsageCluster({
               // whose is a worse trade than the ring is worth.
               <UsageRing
                 percent={headline.usedPercent}
-                estimated={limits?.support === 'estimated'}
                 mark={providerMark(provider.provider)}
                 glyph={providerInitial(provider.displayName)}
                 size={22}

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -282,8 +282,8 @@ export interface ProviderUsageSummaryPayload {
  * `tests/no-exfiltration.test.ts`.
  * ---------------------------------------------------------------------- */
 
-/** How trustworthy a live reading is. Mirrors Rust `LiveUsageSupport`. */
-export type LiveUsageSupport = 'live' | 'estimated' | 'observed' | 'detected';
+/** Marks figures stated directly by a provider. Mirrors Rust `LiveUsageSupport`. */
+export type LiveUsageSupport = 'live';
 
 /** Whether a live reading still describes now. */
 export type LiveUsageFreshness = 'fresh' | 'stale';

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -18,8 +18,6 @@ import {
   liveResetLabel,
   liveSourceNote,
   liveStalenessNote,
-  liveSupportDescription,
-  liveSupportLabel,
   liveWindowElapsed,
   liveWindowLabel,
   liveMetricRows,
@@ -88,20 +86,6 @@ function provider(overrides: Partial<LiveProviderUsagePayload> = {}): LiveProvid
 function summary(overrides: Partial<LiveUsageSummaryPayload> = {}): LiveUsageSummaryPayload {
   return { providers: [provider()], errors: [], generatedAt: '', ...overrides };
 }
-
-describe('capability labels', () => {
-  it('names every support tier, including the ones no source produces yet', () => {
-    expect(liveSupportLabel('live')).toBe('Live');
-    expect(liveSupportLabel('estimated')).toBe('Estimated');
-    expect(liveSupportLabel('observed')).toBe('Activity only');
-    expect(liveSupportLabel('detected')).toBe('Unavailable');
-  });
-
-  it('describes a live figure as the provider’s own, never as ours', () => {
-    expect(liveSupportDescription('live')).toMatch(/your provider stated/i);
-    expect(liveSupportDescription('estimated')).toMatch(/rather than stated/i);
-  });
-});
 
 describe('window labels', () => {
   it('names a model-scoped weekly limit after its model', () => {

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -27,38 +27,9 @@ import type {
   LiveProviderUsagePayload,
   LiveUsageFreshness,
   LiveUsageSummaryPayload,
-  LiveUsageSupport,
   LiveUsageWindowPayload,
 } from '../ipc';
 import { relativeTime } from './relativeTime';
-
-/** The one-word capability label for a live reading. */
-export function liveSupportLabel(support: LiveUsageSupport): string {
-  switch (support) {
-    case 'live':
-      return 'Live';
-    case 'estimated':
-      return 'Estimated';
-    case 'observed':
-      return 'Activity only';
-    default:
-      return 'Unavailable';
-  }
-}
-
-/** What that label means, in a sentence. */
-export function liveSupportDescription(support: LiveUsageSupport): string {
-  switch (support) {
-    case 'live':
-      return 'Your provider stated these figures.';
-    case 'estimated':
-      return 'Modelled on this device rather than stated by your provider.';
-    case 'observed':
-      return 'Activity is known, but no trustworthy allowance is.';
-    default:
-      return 'An account was found without any usage figures.';
-  }
-}
 
 /**
  * The full name of one window.
@@ -155,16 +126,15 @@ export function liveResetLabel(window: LiveUsageWindowPayload, now: number): str
 }
 
 /**
- * The provenance line: what kind of reading this is, and how old.
+ * The provenance line: these are provider-stated figures, and this is how old
+ * the observation is.
  *
- * One line rather than two because they are one thought — a live figure from
- * four hours ago and a modelled figure from just now are both worth doubting,
- * for different reasons, and the reader should weigh them together.
+ * One line rather than two because provenance and age are one thought: even a
+ * figure stated directly by the provider can have moved since we observed it.
  */
 export function liveSourceNote(provider: LiveProviderUsagePayload): string {
-  const support = liveSupportLabel(provider.support);
-  if (!provider.observedAt) return support;
-  return `${support} · stated ${relativeTime(provider.observedAt)}`;
+  if (!provider.observedAt) return 'Live';
+  return `Live · stated ${relativeTime(provider.observedAt)}`;
 }
 
 /**

--- a/crates/antiburn-local/src/discovery/agents/cursor.rs
+++ b/crates/antiburn-local/src/discovery/agents/cursor.rs
@@ -61,22 +61,6 @@ struct CursorDiscoveredSession {
     log: SessionLog,
 }
 
-#[allow(dead_code)]
-/// Return all Cursor log directories for use by the post-commit hook.
-pub async fn log_dirs() -> Vec<PathBuf> {
-    let home = match home_dir() {
-        Some(h) => h,
-        None => return Vec::new(),
-    };
-    log_dirs_in(&home).await
-}
-
-#[allow(dead_code)]
-/// Return all Cursor log directories for backfill (not repo-scoped).
-pub async fn all_log_dirs() -> Vec<PathBuf> {
-    log_dirs().await
-}
-
 /// Cursor discovery over the vendor's own stores.
 pub struct CursorExplorer {
     /// How to decide that one desktop composer was duplicated from another.
@@ -214,7 +198,7 @@ async fn discover_recent_in(
     logs
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 async fn log_dirs_in(home: &Path) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 


### PR DESCRIPTION
## Summary

- Remove Cursor's unused public `log_dirs` and `all_log_dirs` APIs while retaining the directory collector only as a test helper.
- Remove the unused sound `WARNING` voice and its abandoned Triangle waveform path.
- Remove provider live-usage normalization helpers with no production callers, plus unconsumed unit and supplemental-kind scaffolding.
- Remove every `dead_code` allowance from the live-usage module and delete the speculative confidence, support-tier, calendar/billing-window, and provider-scope variants they hid.
- Remove the now-redundant `SupportTier` snapshot field and ranking dimension; registered sources all contain provider-stated facts, so source selection now ranks the real dimensions: freshness and observation time.
- Narrow the serialized and TypeScript live-support vocabulary to the only value actually produced, and remove future-only presentation branches and tests.
- Document in `AGENTS.md` that Rust `dead_code` and `deprecated` lint suppressions, including `allow` and `expect` forms, require explicit developer agreement.

## Verification

- Engine Clippy/tests: 652 unit tests plus 3 boundary tests passed; 1 ignored.
- Desktop Rust formatting and Clippy with warnings denied passed.
- Desktop Rust tests: 329 passed.
- Sound Clippy/tests: 15 passed; 1 ignored.
- Frontend ESLint and TypeScript passed.
- Frontend tests: 648 passed.
- Prettier and `git diff --check` passed.

The commit carries the DCO sign-off.
