### PR TITLE
fix(desktop): release transient webviews to reduce idle memory

### DIFF
--- a/apps/desktop/src-tauri/crates/nudge/src/commands.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/commands.rs
@@ -55,7 +55,7 @@ pub fn nudge_resize(manager: State<'_, NudgeManager>, height: f64) {
 
 /// Invoked by the notification webview once its `nudge:show` listener is
 /// attached, so a nudge emitted before the webview was ready (e.g. right after
-/// prewarm) is re-delivered instead of silently lost.
+/// creation) is re-delivered instead of silently lost.
 #[tauri::command]
 pub fn nudge_ready(manager: State<'_, NudgeManager>) {
     manager.on_nudge_ready();

--- a/apps/desktop/src-tauri/crates/nudge/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/lib.rs
@@ -36,7 +36,9 @@ pub mod model;
 mod win;
 mod window;
 
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, TryLockError};
+use std::time::Duration;
 
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -78,6 +80,27 @@ pub const NUDGE_HOVER_EVENT: &str = "nudge:hover";
 type ActionCallback = Arc<dyn Fn(NudgeActionEvent) + Send + Sync + 'static>;
 type PlacementProvider = Arc<dyn Fn() -> NudgePlacement + Send + Sync + 'static>;
 
+/// Leave enough time for a dismissing IPC command to return before destroying
+/// the webview that sent it. A replacement nudge cancels the task.
+const TEARDOWN_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Default)]
+struct TeardownGeneration(AtomicU64);
+
+impl TeardownGeneration {
+    fn advance(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    fn is_current(&self, generation: u64) -> bool {
+        self.0.load(Ordering::SeqCst) == generation
+    }
+
+    fn current(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
 /// Where the notification should appear when it is revealed.
 #[derive(Debug, Clone)]
 pub enum NudgePlacement {
@@ -99,12 +122,16 @@ pub struct NudgeManager {
     /// `listen()` may not have been attached when [`Self::show`] first emitted).
     /// Cleared on [`Self::dismiss`].
     pending: Mutex<Option<Nudge>>,
+    /// Serializes window creation/reuse with the final teardown check and
+    /// destruction. The generation remains the cheap stale-task filter; this
+    /// gate closes the check-then-destroy race with a replacement `show`.
+    lifecycle: Mutex<()>,
+    teardown_generation: TeardownGeneration,
 }
 
 impl NudgeManager {
     /// Capture the app handle and the on-action callback. The (hidden)
-    /// notification window itself is created lazily on first
-    /// [`Self::prewarm`]/[`Self::show`].
+    /// notification window itself is created lazily on first [`Self::show`].
     ///
     /// `on_action` is invoked with `{ kind, action_id }` when the user clicks a
     /// CTA; the notification is then dismissed automatically. The app implements
@@ -129,21 +156,21 @@ impl NudgeManager {
             on_action: Arc::new(on_action),
             placement: Arc::new(placement),
             pending: Mutex::new(None),
+            lifecycle: Mutex::new(()),
+            teardown_generation: TeardownGeneration::default(),
         })
-    }
-
-    /// Build the hidden notification window ahead of time so its webview is
-    /// mounted and listening before the first nudge fires. Call this once,
-    /// deferred a little after setup (like the popover) so the app has a valid
-    /// display context and avoids the WebKit "page has no displayID" warning.
-    pub fn prewarm(&self) {
-        let _ = window::get_or_create_nudge_window(&self.app);
     }
 
     /// Present `nudge`: position the notification at the OS-native corner,
     /// reveal it without taking focus, and push the payload to the webview.
     /// Policy-free — the caller has already decided this should be shown.
     pub fn show(&self, nudge: Nudge) {
+        let Ok(_lifecycle) = self.lifecycle.lock() else {
+            return;
+        };
+        // Invalidate a dismiss task before it can retire the window this show
+        // is about to reuse (or the new one it is about to create).
+        self.teardown_generation.advance();
         let Ok(window) = window::get_or_create_nudge_window(&self.app) else {
             return;
         };
@@ -182,6 +209,34 @@ impl NudgeManager {
     /// before it's shown, so it never resizes on screen. Called by the
     /// `nudge_reveal` command once the frontend has measured its content.
     pub fn reveal(&self, height: f64) {
+        let generation = self.teardown_generation.current();
+        let _lifecycle = match self.lifecycle.try_lock() {
+            Ok(lifecycle) => lifecycle,
+            Err(TryLockError::WouldBlock) => {
+                let app = self.app.clone();
+                tauri::async_runtime::spawn_blocking(move || {
+                    let Some(manager) = app.try_state::<NudgeManager>() else {
+                        return;
+                    };
+                    let Ok(_lifecycle) = manager.lifecycle.lock() else {
+                        return;
+                    };
+                    if !manager.teardown_generation.is_current(generation) {
+                        return;
+                    }
+                    manager.reveal_locked(height);
+                });
+                return;
+            }
+            Err(TryLockError::Poisoned(_)) => return,
+        };
+        self.reveal_locked(height);
+    }
+
+    fn reveal_locked(&self, height: f64) {
+        if !self.is_showing() {
+            return;
+        }
         if let Some(window) = self.app.get_webview_window(NUDGE_LABEL) {
             window::reveal(&window, height, (self.placement)());
         }
@@ -221,6 +276,31 @@ impl NudgeManager {
 
     /// Hide the notification without invoking any action.
     pub fn dismiss(&self) {
+        let generation = self.teardown_generation.current();
+        let _lifecycle = match self.lifecycle.try_lock() {
+            Ok(lifecycle) => lifecycle,
+            Err(TryLockError::WouldBlock) => {
+                let app = self.app.clone();
+                tauri::async_runtime::spawn_blocking(move || {
+                    let Some(manager) = app.try_state::<NudgeManager>() else {
+                        return;
+                    };
+                    let Ok(_lifecycle) = manager.lifecycle.lock() else {
+                        return;
+                    };
+                    if !manager.teardown_generation.is_current(generation) {
+                        return;
+                    }
+                    manager.dismiss_locked();
+                });
+                return;
+            }
+            Err(TryLockError::Poisoned(_)) => return,
+        };
+        self.dismiss_locked();
+    }
+
+    fn dismiss_locked(&self) {
         // Clear the retained payload so a later `nudge_ready` (e.g. a dev
         // webview reload) doesn't resurrect a nudge the user already dismissed.
         if let Ok(mut pending) = self.pending.lock() {
@@ -229,6 +309,42 @@ impl NudgeManager {
         if let Some(window) = self.app.get_webview_window(NUDGE_LABEL) {
             window::hide(&window);
         }
+        self.schedule_teardown();
+    }
+
+    fn schedule_teardown(&self) {
+        let generation = self.teardown_generation.advance();
+        Self::schedule_teardown_attempt(self.app.clone(), generation, TEARDOWN_DELAY);
+    }
+
+    fn schedule_teardown_attempt(app: AppHandle, generation: u64, delay: Duration) {
+        tauri::async_runtime::spawn_blocking(move || {
+            std::thread::sleep(delay);
+            let check_app = app.clone();
+            let _ = app.run_on_main_thread(move || {
+                let Some(manager) = check_app.try_state::<NudgeManager>() else {
+                    return;
+                };
+                let _lifecycle = match manager.lifecycle.try_lock() {
+                    Ok(lifecycle) => lifecycle,
+                    Err(TryLockError::WouldBlock) => {
+                        Self::schedule_teardown_attempt(
+                            check_app.clone(),
+                            generation,
+                            Duration::from_millis(25),
+                        );
+                        return;
+                    }
+                    Err(TryLockError::Poisoned(_)) => return,
+                };
+                if !manager.teardown_generation.is_current(generation) || manager.is_showing() {
+                    return;
+                }
+                if let Some(window) = check_app.get_webview_window(NUDGE_LABEL) {
+                    window::destroy(&window);
+                }
+            });
+        });
     }
 
     /// Whether a nudge is currently on screen or in flight to the webview — a
@@ -268,5 +384,21 @@ impl NudgeManager {
         {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TeardownGeneration;
+
+    #[test]
+    fn a_replacement_nudge_invalidates_the_pending_teardown() {
+        let generation = TeardownGeneration::default();
+        let dismissed = generation.advance();
+        assert!(generation.is_current(dismissed));
+
+        let shown = generation.advance();
+        assert!(generation.is_current(shown));
+        assert!(!generation.is_current(dismissed));
     }
 }

--- a/apps/desktop/src-tauri/crates/nudge/src/macos.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/macos.rs
@@ -75,6 +75,17 @@ pub(crate) fn to_nonactivating_panel(window: &WebviewWindow) {
     });
 }
 
+/// Convert the notification panel back to its original window class and remove
+/// the retained panel handle before Tauri destroys the webview. The pinned
+/// nspanel revision owns the class restoration in `Panel::to_window`.
+/// Returns `false` if a registered panel cannot be converted safely.
+pub(crate) fn prepare_for_destroy(window: &WebviewWindow) -> bool {
+    match window.get_webview_panel(crate::NUDGE_LABEL) {
+        Ok(panel) => panel.to_window().is_some(),
+        Err(_) => true,
+    }
+}
+
 /// Show the notification by ordering its panel front, **without** taking key
 /// window status. An unprompted nudge must never take key: even though the
 /// `NonactivatingPanel` style mask (see [`to_nonactivating_panel`]) keeps a

--- a/apps/desktop/src-tauri/crates/nudge/src/window.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/window.rs
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! The notification window mechanism: build it once, position it at the
-//! OS-native corner, show it **without stealing focus**. This module knows
+//! The notification window mechanism: build it on demand, position it at the
+//! OS-native corner, show it **without stealing focus**, and retire it after
+//! dismissal. This module knows
 //! nothing about *what* a nudge means — that is the app's policy.
 //!
 //! The notification loads the app's own frontend bundle (same SPA as the
@@ -59,11 +60,8 @@ pub(crate) fn get_or_create_nudge_window(app: &AppHandle) -> tauri::Result<Webvi
     }
     match build_nudge_window(app, crate::NUDGE_LABEL) {
         Ok(window) => Ok(window),
-        // `prewarm` and the first `show` can both observe `None` above and race
-        // into `build`; Tauri fails the loser with "a webview with label ...
-        // already exists". Recover by returning the window the winner created so
-        // the losing caller (e.g. `show`) still presents its nudge instead of
-        // silently dropping it.
+        // Concurrent policy events can both observe `None` above and race into
+        // `build`; return whichever build won instead of dropping a nudge.
         Err(err) => app.get_webview_window(crate::NUDGE_LABEL).ok_or(err),
     }
 }
@@ -288,6 +286,22 @@ pub(crate) fn hide(window: &WebviewWindow) {
     }
     #[cfg(not(target_os = "macos"))]
     let _ = window.hide();
+}
+
+/// Retire the hidden notification webview. The next delivery recreates it.
+pub(crate) fn destroy(window: &WebviewWindow) {
+    #[cfg(target_os = "macos")]
+    {
+        crate::macos::stop_hover_watch();
+        // `tauri-nspanel` mutates the native window class in place. Restore it
+        // and release the plugin's retained handle before Tauri removes the
+        // WKWebView, or AppKit terminates the process while unregistering
+        // WebKit's window-visibility observer.
+        if !crate::macos::prepare_for_destroy(window) {
+            return;
+        }
+    }
+    let _ = window.destroy();
 }
 
 /// The monitor currently containing the cursor, if it can be determined. Cursor

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -97,9 +97,10 @@ impl Schedulers {
 ///
 /// # Panics
 ///
-/// Panics if the webview runtime, the popover window, the tray item, or the
-/// local database cannot be created: none of the four has a meaningful degraded
-/// mode.
+/// Panics if the webview runtime, tray item, or local database cannot be
+/// created: none of the three has a meaningful degraded mode. Windows are
+/// created lazily and report their own failures at the interaction that asked
+/// for them.
 pub fn run() {
     // `register` installs the non-activating-panel support the notification
     // window needs on macOS; a no-op elsewhere.
@@ -193,11 +194,10 @@ pub fn run() {
             app.manage(settings::PendingPane::default());
             app.manage(nudges::AnchorOverride::default());
 
-            popover::create(app.handle())?;
             tray::create(app.handle())?;
-            // After both, and on the main thread: the monitor dismisses the
-            // popover and reaches the menu-bar item to unlight it, so neither
-            // may be missing by the time a click can arrive.
+            // After the tray, and on the main thread: the monitor reaches the
+            // menu-bar item to unlight it. The popover itself is lazy, and its
+            // dismissal path already treats a missing window as idle.
             global_click::install(app.handle());
 
             // The first run gets a window rather than silence. Everything above
@@ -223,25 +223,14 @@ pub fn run() {
             // automatic check can see whether there is anything to check with.
             install_updater(app.handle());
 
-            // The notification window's manager and the chime player. Prewarm
-            // is deferred a little so the app has a valid display context —
-            // the same reasoning as the popover's own deferred build.
+            // The notification window's manager and the chime player. The
+            // webview itself is created only when policy delivers a nudge.
             nudges::init(app.handle())?;
             // The live-usage registry: the sources that can prove a
             // provider's own limit figures, and the milestone ledger they
             // feed. Registered before the schedulers so the first pass sees
             // a populated registry rather than an empty one.
             app.manage(usage_alerts::LiveUsage::new());
-            {
-                let handle = app.handle().clone();
-                tauri::async_runtime::spawn(async move {
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                    if let Some(manager) = handle.try_state::<antiburn_nudge::NudgeManager>() {
-                        manager.prewarm();
-                    }
-                });
-            }
-
             if let Some(schedulers) = app.try_state::<Schedulers>() {
                 schedulers.push(scan::spawn_scheduler(app.handle()));
                 schedulers.push(updates::spawn_scheduler(app.handle()));
@@ -313,6 +302,26 @@ fn abort_schedulers(app: &tauri::AppHandle) {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClosePolicy {
+    Allow,
+    HidePopover,
+    HidePendingOnboarding,
+    HideNudge,
+}
+
+fn close_policy(label: &str, onboarding_pending: bool) -> ClosePolicy {
+    if label == popover::LABEL {
+        ClosePolicy::HidePopover
+    } else if label == antiburn_nudge::NUDGE_LABEL {
+        ClosePolicy::HideNudge
+    } else if label == onboarding::LABEL && onboarding_pending {
+        ClosePolicy::HidePendingOnboarding
+    } else {
+        ClosePolicy::Allow
+    }
+}
+
 /// Window policy shared by every window the shell creates.
 fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
     match event {
@@ -321,16 +330,30 @@ fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
         WindowEvent::Focused(false) if window.label() == popover::LABEL => {
             popover::hide_on_focus_loss(window);
         }
-        // Neither window is ever destroyed by the user: the popover hides and
-        // the settings window is reused on the next open.
         WindowEvent::CloseRequested { api, .. } => {
-            api.prevent_close();
-            if window.label() == popover::LABEL {
-                // Through `popover::hide` rather than `window.hide()`, so this
-                // path answers to the pin like every other dismissal does.
-                popover::hide(window.app_handle());
-            } else {
-                let _ = window.hide();
+            match close_policy(window.label(), onboarding::is_pending(window.app_handle())) {
+                ClosePolicy::Allow => {}
+                ClosePolicy::HidePopover => {
+                    api.prevent_close();
+                    // Through `popover::hide` rather than `window.hide()`, so
+                    // this path answers to the pin like every dismissal does.
+                    popover::hide(window.app_handle());
+                }
+                ClosePolicy::HidePendingOnboarding => {
+                    api.prevent_close();
+                    // Preserve first-run progress until it is completed. The
+                    // Dock and tray can both reopen this same window.
+                    let _ = window.hide();
+                }
+                ClosePolicy::HideNudge => {
+                    api.prevent_close();
+                    if let Some(manager) = window
+                        .app_handle()
+                        .try_state::<antiburn_nudge::NudgeManager>()
+                    {
+                        manager.dismiss();
+                    }
+                }
             }
         }
         _ => {}
@@ -372,7 +395,7 @@ fn install_updater(app: &tauri::AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::should_prevent_exit;
+    use super::{ClosePolicy, close_policy, should_prevent_exit};
 
     #[test]
     fn a_window_close_never_quits_the_finished_menu_bar_app() {
@@ -390,5 +413,29 @@ mod tests {
         // context menu both offer Quit and both arrive with no code; swallowing
         // them would ship a Quit item that does nothing.
         assert!(!should_prevent_exit(true, None));
+    }
+
+    #[test]
+    fn only_transient_or_incomplete_windows_intercept_close() {
+        assert_eq!(
+            close_policy(super::popover::LABEL, false),
+            ClosePolicy::HidePopover
+        );
+        assert_eq!(
+            close_policy(super::onboarding::LABEL, true),
+            ClosePolicy::HidePendingOnboarding
+        );
+        assert_eq!(
+            close_policy(super::onboarding::LABEL, false),
+            ClosePolicy::Allow
+        );
+        assert_eq!(
+            close_policy(super::settings::LABEL, false),
+            ClosePolicy::Allow
+        );
+        assert_eq!(
+            close_policy(antiburn_nudge::NUDGE_LABEL, false),
+            ClosePolicy::HideNudge
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/onboarding.rs
+++ b/apps/desktop/src-tauri/src/onboarding.rs
@@ -47,6 +47,10 @@ const URL: &str = "index.html#/onboarding";
 const WIDTH: f64 = 680.0;
 const HEIGHT: f64 = 480.0;
 
+/// Give the final settings command time to return before its caller's webview
+/// is destroyed. The window is hidden immediately, so this delay is invisible.
+const FINISH_TEARDOWN_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+
 // The reasons for those two numbers, as build errors rather than tests —
 // following `popover.rs`, and for the same reason: a geometry constant edited
 // without its rationale should fail to compile, not fail a suite somebody can
@@ -138,6 +142,23 @@ pub fn finish(app: &AppHandle) {
     // ordered out by it — hence this line before that one, not after.
     apply_activation_policy(app, false);
     crate::notifications::note_menu_bar_home(app);
+
+    // `finish` runs inside the onboarding webview's final `set_settings` IPC.
+    // Destroying that webview synchronously can cut off the command response;
+    // hide now, then retire it once the response and location nudge are away.
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(FINISH_TEARDOWN_DELAY).await;
+        let check_app = app.clone();
+        let _ = app.run_on_main_thread(move || {
+            if is_pending(&check_app) {
+                return;
+            }
+            if let Some(window) = check_app.get_webview_window(LABEL) {
+                let _ = window.destroy();
+            }
+        });
+    });
 }
 
 /// Which kind of application antiburn is while the first run is pending.

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -4,10 +4,10 @@
 
 //! The tray-anchored popover window.
 //!
-//! The popover is created once, hidden, at startup and then shown and hidden
-//! for the rest of the process lifetime. Creating it lazily would make the
-//! first open visibly slower (a webview has to boot and the bundle has to
-//! parse) and would lose any state the views accumulate.
+//! The popover is created lazily on the first tray click. After dismissal it
+//! stays warm briefly so a quick reopen is instant, then its webview is
+//! destroyed to release WebKit's resident memory. The next click rebuilds it
+//! from the durable shell state.
 //!
 //! # Geometry
 //!
@@ -98,6 +98,12 @@ const SCREEN_MARGIN: f64 = 8.0;
 /// and immediately reopen it. This window swallows that second half.
 const REOPEN_SUPPRESSION: Duration = Duration::from_millis(250);
 
+/// How long a hidden popover stays warm for a quick reopen.
+///
+/// Fifteen seconds covers the common "closed it, need one more look" gesture
+/// without leaving a background utility's largest webview resident at idle.
+pub const TEARDOWN_DELAY: Duration = Duration::from_secs(15);
+
 /// The menu-bar item's rectangle, in physical pixels on the display it lives
 /// on. Kept as plain numbers rather than a [`Rect`] so a height change can
 /// re-anchor without the tray handing the rectangle over a second time.
@@ -118,6 +124,9 @@ pub struct PopoverState {
     /// Bumped by every height request, so an animation still in flight can see
     /// that a newer one superseded it and stop rather than fight it.
     resize_generation: AtomicU64,
+    /// Bumped whenever visibility changes. A delayed teardown may destroy the
+    /// webview only while the generation it captured is still current.
+    teardown_generation: AtomicU64,
     /// While positive, losing focus does not hide the popover. Held around
     /// native dialogs (the folder picker) the popover itself opens: the dialog
     /// takes focus by design, and hiding would tear down the surface the
@@ -139,6 +148,7 @@ impl Default for PopoverState {
             anchor: Mutex::new(None),
             height: Mutex::new(DEFAULT_HEIGHT),
             resize_generation: AtomicU64::new(0),
+            teardown_generation: AtomicU64::new(0),
             focus_hold: AtomicU64::new(0),
             pinned: AtomicBool::new(false),
         }
@@ -235,6 +245,21 @@ impl PopoverState {
     fn resize_is_current(&self, generation: u64) -> bool {
         self.resize_generation.load(Ordering::SeqCst) == generation
     }
+
+    /// Start or cancel a delayed teardown. Both are the same operation: move
+    /// the generation forward so any older task loses ownership.
+    fn advance_teardown(&self) -> u64 {
+        self.teardown_generation.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    fn teardown_is_current(&self, generation: u64) -> bool {
+        self.teardown_generation.load(Ordering::SeqCst) == generation
+    }
+
+    fn reset_after_destroy(&self) {
+        self.set_height(DEFAULT_HEIGHT);
+        self.begin_resize();
+    }
 }
 
 /// A requested height, held inside the bounds the window can actually be.
@@ -252,11 +277,19 @@ fn ease_out(progress: f64) -> f64 {
     1.0 - remaining * remaining * remaining
 }
 
-/// Creates the popover window, hidden and off the taskbar.
-pub fn create(app: &AppHandle) -> tauri::Result<WebviewWindow> {
+/// Return the popover, creating it hidden and off the taskbar on first use.
+fn get_or_create(app: &AppHandle) -> tauri::Result<WebviewWindow> {
+    if let Some(window) = app.get_webview_window(LABEL) {
+        return Ok(window);
+    }
+
+    let height = app
+        .try_state::<PopoverState>()
+        .map(|state| state.height())
+        .unwrap_or(DEFAULT_HEIGHT);
     let builder = WebviewWindowBuilder::new(app, LABEL, WebviewUrl::App("index.html".into()))
         .title("antiburn")
-        .inner_size(WIDTH, DEFAULT_HEIGHT)
+        .inner_size(WIDTH, height)
         .resizable(false)
         .maximizable(false)
         .minimizable(false)
@@ -272,7 +305,12 @@ pub fn create(app: &AppHandle) -> tauri::Result<WebviewWindow> {
     #[cfg(target_os = "macos")]
     let builder = builder.accept_first_mouse(true);
 
-    builder.build()
+    match builder.build() {
+        Ok(window) => Ok(window),
+        // A tray click and a pin request can race into this function. Return
+        // whichever build won instead of dropping the user's request.
+        Err(error) => app.get_webview_window(LABEL).ok_or(error),
+    }
 }
 
 /// Handles a click on the menu-bar item.
@@ -291,11 +329,9 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
         return;
     }
 
-    let Some(window) = app.get_webview_window(LABEL) else {
-        return;
-    };
-
-    if window.is_visible().unwrap_or(false) {
+    if let Some(window) = app.get_webview_window(LABEL)
+        && window.is_visible().unwrap_or(false)
+    {
         // A pinned popover has no hide half to its toggle. Raise it instead of
         // doing nothing: a menu-bar item that swallows a click reads as broken,
         // and re-anchoring picks up a menu bar that has since moved display.
@@ -316,6 +352,14 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
     {
         return;
     }
+
+    let window = match get_or_create(app) {
+        Ok(window) => window,
+        Err(error) => {
+            eprintln!("antiburn: could not create the popover ({error})");
+            return;
+        }
+    };
 
     if let Err(error) = anchor_to(&window, anchor) {
         // Positioning is best-effort: a popover in the wrong place still beats
@@ -498,6 +542,11 @@ pub fn end_focus_hold(app: &AppHandle) {
         && window.is_visible().unwrap_or(false)
     {
         let _ = window.set_focus();
+    } else {
+        // A toggle can hide the window while a native dialog still owns the
+        // hold. Once the dialog returns, give that hidden window a fresh idle
+        // deadline instead of keeping it alive forever.
+        schedule_teardown(app);
     }
 }
 
@@ -534,10 +583,28 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
     let Some(state) = app.try_state::<PopoverState>() else {
         return;
     };
-    let Some(window) = app.get_webview_window(LABEL) else {
+    if !pinned {
+        state.set_pinned(false);
+        state.advance_teardown();
+        if let Some(window) = app.get_webview_window(LABEL)
+            && window.is_visible().unwrap_or(false)
+        {
+            let _ = window.set_focus();
+        } else {
+            schedule_teardown(app);
+        }
         return;
+    }
+
+    let window = match get_or_create(app) {
+        Ok(window) => window,
+        Err(error) => {
+            eprintln!("antiburn: could not create the pinned popover ({error})");
+            return;
+        }
     };
-    state.set_pinned(pinned);
+    state.set_pinned(true);
+    state.advance_teardown();
 
     // Only a pin re-opens, and only from hidden: re-anchoring a window already
     // on screen would move it for no reason the reader asked for.
@@ -590,6 +657,9 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
 /// highlight with visibility is structural rather than something each caller
 /// has to remember.
 fn note_shown(app: &AppHandle) {
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.advance_teardown();
+    }
     if let Some(controller) = app.try_state::<crate::scan::ScanController>() {
         controller.set_popover_visible(true);
         // Opening the popover is the one moment a reader is guaranteed to be
@@ -614,6 +684,43 @@ pub fn note_hidden(app: &AppHandle) {
         controller.set_popover_visible(false);
     }
     crate::tray::set_highlight(app, false);
+    schedule_teardown(app);
+}
+
+/// Destroy a popover that remains hidden after [`TEARDOWN_DELAY`].
+///
+/// Every show, pin, and later hide advances the generation. The task therefore
+/// needs no cancellation handle: stale tasks observe that they no longer own
+/// the lifecycle and exit.
+fn schedule_teardown(app: &AppHandle) {
+    if app.get_webview_window(LABEL).is_none() {
+        return;
+    }
+    let Some(state) = app.try_state::<PopoverState>() else {
+        return;
+    };
+    let generation = state.advance_teardown();
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(TEARDOWN_DELAY).await;
+        let check_app = app.clone();
+        let _ = app.run_on_main_thread(move || {
+            let Some(state) = check_app.try_state::<PopoverState>() else {
+                return;
+            };
+            if !state.teardown_is_current(generation) || state.is_pinned() || state.holds_focus() {
+                return;
+            }
+            let Some(window) = check_app.get_webview_window(LABEL) else {
+                return;
+            };
+            if window.is_visible().unwrap_or(false) {
+                return;
+            }
+            state.reset_after_destroy();
+            let _ = window.destroy();
+        });
+    });
 }
 
 /// Records the menu-bar item's rectangle and places the popover against it.
@@ -932,6 +1039,32 @@ mod tests {
             !state.resize_is_current(first),
             "the superseded animation must stop rather than fight the new one"
         );
+    }
+
+    #[test]
+    fn a_newer_visibility_transition_invalidates_a_scheduled_teardown() {
+        let state = PopoverState::default();
+        let hidden = state.advance_teardown();
+        assert!(state.teardown_is_current(hidden));
+
+        let shown = state.advance_teardown();
+        assert!(state.teardown_is_current(shown));
+        assert!(
+            !state.teardown_is_current(hidden),
+            "reopening must cancel the teardown scheduled by the prior hide"
+        );
+    }
+
+    #[test]
+    fn destroying_the_webview_resets_ephemeral_geometry() {
+        let state = PopoverState::default();
+        state.set_height(MAX_HEIGHT);
+        let resize = state.begin_resize();
+
+        state.reset_after_destroy();
+
+        assert_eq!(state.height(), DEFAULT_HEIGHT);
+        assert!(!state.resize_is_current(resize));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -6,8 +6,8 @@
 //!
 //! Unlike the popover this is an ordinary window with real decorations: a
 //! place to read and change configuration, not a transient surface. It is
-//! fixed at 960×680, created on first use, and then reused, because a
-//! menu-bar app can be asked to open settings many times per session.
+//! fixed at 960×680 and created on demand. Closing it destroys its webview;
+//! the next request rebuilds it from settings already persisted by the shell.
 //!
 //! On macOS the title bar is an overlay: decorations (traffic lights, system
 //! shadow, real close semantics) are kept, the bar itself is transparent, and
@@ -72,12 +72,9 @@ const HEIGHT: f64 = 680.0;
 /// about, instead of on whichever pane they last left open.
 pub fn open(app: &AppHandle, pane: Option<String>) -> tauri::Result<()> {
     if let Some(existing) = app.get_webview_window(LABEL) {
-        // Re-centered on every open, not just the first: this window hides on
-        // close rather than being destroyed, so without this a reader who
-        // moved desks (or just works across monitors) would have Settings
-        // reappear on whichever display it was last dismissed on. The private
-        // app gets the same behavior for free by destroying the window and
-        // letting the OS place the rebuild.
+        // Re-centered on every open, not just the first: this path covers a
+        // second request while Settings is already open, possibly after the
+        // reader moved the window to another display.
         center_on_active_monitor(&existing, WIDTH, HEIGHT);
         existing.show()?;
         existing.unminimize()?;


### PR DESCRIPTION
## Summary

Reduce antiburn's idle memory footprint by creating transient webviews only when needed and destroying them after use.

This addresses #51 and #52.

## Root cause

Hidden Tauri windows retain their WebKit processes. At startup, antiburn eagerly created the popover and notification windows, while other transient windows remained allocated after use, leaving WebContent processes resident while the app appeared idle.

During validation, destroying the macOS notification panel also exposed a `WKWindowVisibilityObserver` crash. Teardown now uses the pinned tauri-nspanel v2.1 `Panel::to_window` path to restore the original native window class and release the panel handle before Tauri destroys the webview.

## Changes

- Create the popover lazily.
- Destroy a hidden popover after a 15-second grace period.
- Cancel stale teardown when the popover is reopened or pinned.
- Reuse onboarding while incomplete, then destroy it after completion.
- Destroy Settings on close and recreate it on demand.
- Remove notification-window prewarming.
- Destroy notification webviews after dismissal and recreate them for later notifications.
- Serialize notification show/dismiss/destroy transitions.
- Reject stale deferred reveal and dismiss operations using lifecycle generations.
- Intercept nudge close requests so they cannot bypass crash-safe teardown.
- Restore the original macOS window class before destroying an `NSPanel`.

## Memory validation

Environment:

- macOS 26.4.1 (25E253)
- MacBook Pro, Apple M5 Pro, 24 GB RAM
- Unsigned release bundles
- Isolated bundle identifier: `ai.antiburn.desktop.memorytest`
- RSS is the sum of the antiburn host and WebKit helpers attributed by process creation time.
- The tabulated before/after samples used matched release bundles from the original implementation base. After porting the commit onto current `main`, the exact final bundle reran the notification crash/recreation checks described below.

| Scenario | Before | After |
| --- | ---: | ---: |
| First-run idle | 154.89 MiB, 3 WebContent | 126.55 MiB, 1 WebContent |
| Completed-install idle | 142.39 MiB, 2 WebContent | 65.08 MiB, 0 WebContent |
| Popover after teardown | No teardown | 102.03 MiB |
| Popover after recreate/final teardown | No teardown | 103.61 MiB |
| Settings + notification interaction, 30s idle | Not sampled | 120.38 MiB |

The completed-install host reported a 20 MB physical footprint before opening transient windows. After exercising Settings and three notification lifecycles, the host footprint was 46 MB and summed RSS remained below the 150 MiB target.

The first-run cold transient also dropped from approximately 326 MiB with three WebContent processes to 131.22 MiB with one WebContent process. These samples were taken at different elapsed times (~8s before and ~16s after), so they are directional rather than a strict like-for-like comparison.

### Lifecycle checks

- Popover WebContent exited after the 15-second grace period.
- Reopening during the grace period cancelled the pending teardown.
- Reopening after teardown created a fresh WebContent process.
- Closing Settings removed its WebContent process.
- Reopening Settings created a fresh WebContent process.
- The exact final release bundle completed two notification create/dismiss/destroy/recreate cycles.
- Each notification WebContent process exited after dismissal.
- The host remained alive with no `NSRangeException` or WebKit observer crash.

## Reproduction

Build the isolated release bundle:

```sh
cd apps/desktop
env RUSTC_WRAPPER= ./node_modules/.bin/tauri build \
  --bundles app \
  --no-sign \
  --config '{
    "identifier": "ai.antiburn.desktop.memorytest",
    "build": {
      "beforeBuildCommand": "./node_modules/.bin/vite build"
    },
    "bundle": {
      "createUpdaterArtifacts": false
    }
  }'
```

Record the host and WebKit helper processes after launch and after each lifecycle transition:

```sh
ps -axo pid=,ppid=,rss=,etime=,lstart=,command= |
  rg 'antiburn|WebKit\.(GPU|Networking|WebContent)'
```

Record the host footprint:

```sh
/usr/bin/footprint -p <antiburn-pid>
```

For each idle sample, wait at least 30 seconds after the final window closes and sum the attributed process RSS values.

## Automated validation

- Desktop Rust tests: 332 passed
- Nudge tests: 26 passed
- Desktop and nudge Clippy with `-D warnings`: passed
- Rust formatting: passed
- Frontend Vitest: 645 passed
- TypeScript build: passed
- ESLint: passed
- Prettier: passed
- Matched release build: passed
- Independent code and Rust safety reviews: no remaining blockers

## Interaction with #53

PR #53 has no file-level overlap with this change and is expected to merge cleanly. It does, however, rewrite the `NudgeView` and `PopoverView` subscription, timer, and measurement lifecycles.

If #53 lands first, this branch will be updated from `main` and the release memory and window-lifecycle tests will be rerun against the combined implementation. Particular attention will be given to lazy webview creation, nudge ready/reveal and rapid-replacement behavior, popover teardown/recreation, and first-open latency.

Destroying the popover resets frontend-only state, including dismissed attention banners; whether those banners should remain dismissed for the full app process is still to be confirmed.

## Limitations

- An eight-hour CPU soak was not performed.
- The macOS lifecycle checks were performed manually against a release bundle rather than through an automated UI harness.
- WebKit XPC helpers are reparented to PID 1, so attribution relies on creation time and observed lifecycle transitions.
- The cold-transient before/after samples were taken at different elapsed times.
- The full memory table was collected before the final port onto current `main`; the main-based release bundle refreshed automated validation and the notification teardown/recreation regression, not every memory scenario.

Closes #51
Closes #52
