### PR TITLE
refactor(desktop): compact live usage details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/target/
 node_modules/
 .DS_Store
+.*.sw?
 
 # Local agent worktrees and metadata are not repository content.
 /.claude/

--- a/apps/desktop/src/components/providerUsage/LiveUsageDetail.tsx
+++ b/apps/desktop/src/components/providerUsage/LiveUsageDetail.tsx
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { cn } from "../../lib/cn"
 import type { LiveProviderUsagePayload } from "../../lib/ipc"
 import {
   liveExtraUsageLabel,
@@ -46,13 +47,18 @@ export function LiveUsageDetail({
   return (
     <section
       aria-label={`${live.displayName} plan limits`}
-      className={`space-y-1.5 ${className}`.trim()}
+      className={cn("space-y-2", className)}
     >
-      <div className="flex items-baseline justify-between gap-2">
+      <div className="flex items-baseline justify-between gap-2 group">
         <h4 className="type-caption font-medium tracking-wide uppercase text-label-tertiary">
           Plan limits
         </h4>
-        <span className={`type-caption ${liveFreshnessToneClass(live.freshness)}`}>
+        <span
+          className={cn(
+            "type-caption hidden group-hover:inline",
+            liveFreshnessToneClass(live.freshness),
+          )}
+        >
           {liveSourceNote(live)}
         </span>
       </div>

--- a/apps/desktop/src/components/providerUsage/LiveUsageWindowRows.tsx
+++ b/apps/desktop/src/components/providerUsage/LiveUsageWindowRows.tsx
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { cn } from "../../lib/cn"
 import type { LiveProviderUsagePayload } from "../../lib/ipc"
 import {
   liveResetLabel,
@@ -41,67 +42,69 @@ export function LiveUsageWindowRows({
   if (windows.length === 0) return null
 
   return (
-    <dl className={`space-y-2 ${className}`.trim()}>
+    <div className={cn("space-y-1.5", className)}>
       {windows.map((window) => {
         const used = window.usedPercent
         const elapsed = liveWindowElapsed(window, now)
         return (
-          <div key={window.id}>
-            <div className="flex items-baseline justify-between gap-3">
-              <dt className="type-footnote text-label-secondary">{liveWindowLabel(window)}</dt>
-              <dd className="type-footnote tabular-nums text-label">
+          <div key={window.id} className="group">
+            <div className="flex items-baseline justify-between gap-x-2">
+              <span className="type-footnote text-label-secondary">
+                {liveWindowLabel(window)}
+                <span className="hidden group-hover:inline">
+                  {" "}
+                  ({liveResetLabel(window, now)})
+                </span>
+              </span>
+              <span className="type-footnote tabular-nums text-label text-right">
                 {liveWindowValueLabel(window)}
-              </dd>
+              </span>
             </div>
-            <div
-              role="progressbar"
-              aria-label={liveWindowLabel(window)}
-              aria-valuemin={0}
-              aria-valuemax={100}
-              // Absent rather than zero when unknown: a progressbar with no
-              // value is announced as indeterminate, which is the truth.
-              aria-valuenow={used ?? undefined}
-              aria-valuetext={
-                used == null
-                  ? "Usage unknown"
-                  : elapsed == null
-                    ? `${Math.round(used)}% used`
-                    : `${Math.round(used)}% used; ${Math.round(elapsed * 100)}% of the period elapsed`
-              }
-              className="relative mt-1 w-full overflow-hidden rounded-full"
-              style={{ height: 3, backgroundColor: "var(--color-separator)" }}
-            >
-              {used != null && (
-                <div
-                  className="h-full rounded-full"
-                  data-testid={`live-usage-fill-${window.id}`}
-                  style={{
-                    width: `${Math.min(100, Math.max(0, used))}%`,
-                    // accent-fill, not accent: the live macOS system-accent
-                    // token breaks as a background-color (see tokens.css).
-                    backgroundColor: "var(--color-accent-fill, var(--color-accent-fill-val))",
-                  }}
-                />
-              )}
+
+            <div className="mt-0.5 h-[6px] py-[1.5px] relative">
+              <div
+                role="progressbar"
+                aria-label={liveWindowLabel(window)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                // Absent rather than zero when unknown: a progressbar with no
+                // value is announced as indeterminate, which is the truth.
+                aria-valuenow={used ?? undefined}
+                aria-valuetext={
+                  used == null
+                    ? "Usage unknown"
+                    : elapsed == null
+                      ? `${Math.round(used)}% used`
+                      : `${Math.round(used)}% used; ${Math.round(elapsed * 100)}% of the period elapsed`
+                }
+                className="h-full w-full bg-(--color-separator) rounded-full overflow-hidden"
+              >
+                {used != null && (
+                  <div
+                    className="h-full"
+                    data-testid={`live-usage-fill-${window.id}`}
+                    style={{
+                      width: `${Math.min(100, Math.max(0, used))}%`,
+                      // accent-fill, not accent: the live macOS system-accent
+                      // token breaks as a background-color (see tokens.css).
+                      backgroundColor: "var(--color-accent-fill, var(--color-accent-fill-val))",
+                    }}
+                  />
+                )}
+              </div>
+
               {elapsed != null && (
                 <div
                   aria-hidden="true"
                   data-testid={`live-usage-elapsed-${window.id}`}
-                  className="absolute inset-y-0"
-                  style={{
-                    left: `${Math.min(100, Math.max(0, elapsed * 100))}%`,
-                    width: 1,
-                    backgroundColor: "var(--color-label)",
-                  }}
+                  className="absolute inset-y-0 w-[1.5px] z-1 bg-(--color-label)"
+                  style={{ left: `${Math.min(100, Math.max(0, elapsed * 100))}%` }}
                 />
               )}
             </div>
-            <p className="mt-0.5 type-caption text-label-tertiary">
-              {liveResetLabel(window, now)}
-            </p>
           </div>
         )
       })}
-    </dl>
+    </div>
   )
 }

--- a/apps/desktop/src/components/providerUsage/ProviderUsageCluster.test.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageCluster.test.tsx
@@ -374,7 +374,7 @@ describe("ProviderUsageCluster — the limit ring", () => {
     // The ring is a shape with no text, so the figure has to reach the
     // accessible name or a screen-reader user simply does not get it.
     expect(
-      screen.getByRole("button", { name: /anthropic.*weekly limit 88% used/i }),
+      screen.getByRole("button", { name: /anthropic.*weekly limit 88%/i }),
     ).toBeInTheDocument()
   })
 
@@ -405,7 +405,7 @@ describe("ProviderUsageCluster — the limit ring", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Anthropic,/ }))
     const panel = screen.getByRole("dialog")
     expect(panel).toHaveTextContent("Plan limits")
-    expect(panel).toHaveTextContent("88% used")
+    expect(panel).toHaveTextContent("88%")
     // And the spend half is still there, below it.
     expect(panel).toHaveTextContent("Last 7 days")
   })

--- a/apps/desktop/src/lib/cn.ts
+++ b/apps/desktop/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ")
+}

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -109,8 +109,8 @@ describe("window labels", () => {
   it("reads an absent percentage as unknown, never as zero", () => {
     // An empty meter is a claim, and this one would be a claim nobody made.
     expect(liveWindowValueLabel(window({ usedPercent: null }))).toBe("Unknown")
-    expect(liveWindowValueLabel(window({ usedPercent: 0 }))).toBe("0% used")
-    expect(liveWindowValueLabel(window({ usedPercent: 80.6 }))).toBe("81% used")
+    expect(liveWindowValueLabel(window({ usedPercent: 0 }))).toBe("0%")
+    expect(liveWindowValueLabel(window({ usedPercent: 80.6 }))).toBe("81%")
   })
 })
 
@@ -233,30 +233,30 @@ describe("the elapsed marker", () => {
 describe("reset labels", () => {
   it("counts down within the day and names the day beyond it", () => {
     expect(liveResetLabel(window({ resetsAt: "2027-01-15T14:30:00Z" }), NOW)).toBe(
-      "Resets in 2h 30m",
+      "resets in 2h 30m",
     )
     expect(liveResetLabel(window({ resetsAt: "2027-01-15T12:45:00Z" }), NOW)).toBe(
-      "Resets in 45m",
+      "resets in 45m",
     )
     // Beyond a day, "resets in 76h" is not a sentence anyone reads as a time.
     expect(liveResetLabel(window({ resetsAt: "2027-01-19T18:00:00Z" }), NOW)).toMatch(
-      /^Resets \w{3} /,
+      /^resets \w{3} /,
     )
   })
 
   it("says so when the provider gave no reset, and distinguishes that from a passed one", () => {
-    expect(liveResetLabel(window({ resetsAt: null }), NOW)).toBe("Reset unavailable")
-    expect(liveResetLabel(window({ resetsAt: "not a date" }), NOW)).toBe("Reset unavailable")
+    expect(liveResetLabel(window({ resetsAt: null }), NOW)).toBe("reset unavailable")
+    expect(liveResetLabel(window({ resetsAt: "not a date" }), NOW)).toBe("reset unavailable")
     // Past, because the window rolls on the provider's clock and not ours.
     expect(liveResetLabel(window({ resetsAt: "2027-01-15T11:00:00Z" }), NOW)).toBe(
-      "Reset pending",
+      "reset pending",
     )
   })
 })
 
 describe("provenance", () => {
   it("says what kind of reading it is and when it was stated", () => {
-    expect(liveSourceNote(provider())).toBe("Live · stated 5m ago")
+    expect(liveSourceNote(provider())).toBe("Live 5m ago")
   })
 
   it("marks a stale reading and leaves a fresh one alone", () => {

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -48,14 +48,14 @@ export function liveWindowLabel(window: LiveUsageWindowPayload): string {
 }
 
 /**
- * `"81% used"`, or that we do not know.
+ * `"81%"`, or that we do not know.
  *
  * Deliberately not `"0% used"` when the figure is missing: an empty meter is a
  * claim, and this one would be a claim nobody made.
  */
 export function liveWindowValueLabel(window: LiveUsageWindowPayload): string {
   if (window.usedPercent == null) return "Unknown"
-  return `${Math.round(window.usedPercent)}% used`
+  return `${Math.round(window.usedPercent)}%`
 }
 
 /**
@@ -127,29 +127,29 @@ export function liveWindowElapsed(window: LiveUsageWindowPayload, now: number): 
 }
 
 /**
- * `"Resets in 3h 12m"` for something imminent, `"Resets Tue 15:00"` further
+ * `"resets in 3h 12m"` for something imminent, `"resets Tue 15:00"` further
  * out, and an honest admission when the provider did not say.
  *
  * The switch is at a day because "resets in 76h" is not a sentence anyone
  * reads as a time, and a weekday and clock time is.
  */
 export function liveResetLabel(window: LiveUsageWindowPayload, now: number): string {
-  if (!window.resetsAt) return "Reset unavailable"
+  if (!window.resetsAt) return "reset unavailable"
   const at = new Date(window.resetsAt).getTime()
-  if (Number.isNaN(at)) return "Reset unavailable"
+  if (Number.isNaN(at)) return "reset unavailable"
   const remaining = at - now
   // Already past, and the provider has not published the next one yet. Not an
   // error: a rolling window resets on the provider's clock, not ours.
-  if (remaining <= 0) return "Reset pending"
+  if (remaining <= 0) return "reset pending"
   if (remaining < 86_400_000) {
     const hours = Math.floor(remaining / 3_600_000)
     const minutes = Math.floor((remaining % 3_600_000) / 60_000)
-    return hours > 0 ? `Resets in ${hours}h ${minutes}m` : `Resets in ${minutes}m`
+    return hours > 0 ? `resets in ${hours}h ${minutes}m` : `resets in ${minutes}m`
   }
   const date = new Date(at)
   const day = date.toLocaleDateString(undefined, { weekday: "short" })
   const time = date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
-  return `Resets ${day} ${time}`
+  return `resets ${day} ${time}`
 }
 
 /**
@@ -161,7 +161,7 @@ export function liveResetLabel(window: LiveUsageWindowPayload, now: number): str
  */
 export function liveSourceNote(provider: LiveProviderUsagePayload): string {
   if (!provider.observedAt) return "Live"
-  return `Live · stated ${relativeTime(provider.observedAt)}`
+  return `Live ${relativeTime(provider.observedAt)}`
 }
 
 /**

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -30,7 +30,8 @@ button,
 }
 
 input:not([type="range"]),
-textarea {
+textarea,
+[contenteditable] {
   cursor: text;
 }
 
@@ -47,6 +48,7 @@ textarea {
 
 /* UI chrome is not selectable text; inputs and editable regions still are. */
 body {
+  cursor: default;
   user-select: none;
   -webkit-user-select: none;
 }

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -223,9 +223,9 @@ describe("UsageView — plan limits layered over local estimates", () => {
     const card = screen.getByText("Anthropic").closest("li")!
     const limits = within(card).getByRole("region", { name: "Anthropic plan limits" })
     expect(within(limits).getByText("5-hour limit")).toBeInTheDocument()
-    expect(within(limits).getByText("81% used")).toBeInTheDocument()
+    expect(within(limits).getByText("81%")).toBeInTheDocument()
     expect(within(limits).getByText("Weekly limit")).toBeInTheDocument()
-    expect(within(limits).getByText("Resets in 2h 30m")).toBeInTheDocument()
+    expect(within(limits).getByText(/resets in 2h 30m/)).toBeInTheDocument()
 
     // The estimate half is still there and unchanged: a reader who connects a
     // source gains the limits, they do not trade one surface for the other.
@@ -247,7 +247,7 @@ describe("UsageView — plan limits layered over local estimates", () => {
     const bar = screen.getByRole("progressbar", { name: "5-hour limit" })
     expect(bar).toHaveAttribute("aria-valuenow", "81")
     expect(bar).toHaveAttribute("aria-valuetext", "81% used; 50% of the period elapsed")
-    expect(within(bar).getByTestId("live-usage-elapsed-five-hour")).toHaveStyle({
+    expect(screen.getByTestId("live-usage-elapsed-five-hour")).toHaveStyle({
       left: "50%",
     })
   })
@@ -336,7 +336,7 @@ describe("UsageView — plan limits layered over local estimates", () => {
 
     expect(screen.getByText(/may have moved since/)).toBeInTheDocument()
     // Still the best figures anyone has, so they stay on screen.
-    expect(screen.getByText("81% used")).toBeInTheDocument()
+    expect(screen.getByText("81%")).toBeInTheDocument()
   })
 
   it("shows nothing at all where no source could prove a limit", () => {

--- a/apps/desktop/src/views/settings/UsagePane.test.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.test.tsx
@@ -99,7 +99,7 @@ describe("UsagePane", () => {
     pane()
     await waitFor(() => expect(screen.getByText("Anthropic")).toBeInTheDocument())
     expect(screen.getByText(/Asked Claude directly/)).toBeInTheDocument()
-    expect(screen.getByText("Live · stated 5m ago")).toBeInTheDocument()
+    expect(screen.getByText("Live 5m ago")).toBeInTheDocument()
   })
 
   it("degrades to an empty list rather than throwing when the shell answers with nothing", async () => {


### PR DESCRIPTION
## Summary

- compact live usage rows and reveal reset timing on hover
- show source freshness on heading hover and tighten progress-bar presentation
- use desktop-style cursors globally while preserving text cursors for editable controls
- update presentation tests for the compact labels and marker structure

## Verification

- pnpm --filter @antiburn/desktop test
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop format
- pnpm --filter @antiburn/desktop knip
- pnpm --filter @antiburn/desktop build