### PR TITLE
refactor(desktop): use cn for class composition

### DIFF
--- a/apps/desktop/src/components/activity/ActivityRowPrimitives.tsx
+++ b/apps/desktop/src/components/activity/ActivityRowPrimitives.tsx
@@ -4,6 +4,7 @@
 
 import { useCallback, useRef, useSyncExternalStore, type RefObject } from "react"
 
+import { cn } from "../../lib/cn"
 import { relativeTime } from "../../lib/presentation/relativeTime"
 import { Tooltip } from "../presentation/Tooltip"
 import {
@@ -92,7 +93,7 @@ export function TruncatedText({ className, text, shimmer = false }: TruncatedTex
   return (
     <div
       ref={ref}
-      className={`${className ?? ""}${shimmer ? ` ${ROW_TITLE_SHIMMER_CLASS}` : ""}`}
+      className={cn(className, shimmer && ROW_TITLE_SHIMMER_CLASS)}
       title={truncated ? text : undefined}
       data-text={shimmer ? text : undefined}
       aria-label={shimmer ? text : undefined}
@@ -142,7 +143,10 @@ export function RowTimeCorner({
       <div
         {...{ [ROW_CORNER_ATTR]: "" }}
         {...(pinned ? { [ROW_CORNER_PINNED_ATTR]: "" } : {})}
-        className={`absolute top-2 right-2 flex items-center gap-1 ${pinned ? "" : revealClassName}`}
+        className={cn(
+          "absolute top-2 right-2 flex items-center gap-1",
+          !pinned && revealClassName,
+        )}
       >
         <Tooltip
           side="bottom"
@@ -159,7 +163,10 @@ export function RowTimeCorner({
             // Muted by default — the time is supplementary next to the title,
             // and it is repeated in the tooltip and the copy above. A problem
             // outcome keeps its own tint, which must stay legible.
-            className={`flex items-center gap-1 text-sm font-normal ${tint || "text-label-tertiary"}`}
+            className={cn(
+              "flex items-center gap-1 text-sm font-normal",
+              tint || "text-label-tertiary",
+            )}
           >
             {Icon && <Icon size={11} className="shrink-0" aria-hidden="true" />}
             {relativeTime(timestamp, { compact: true })}

--- a/apps/desktop/src/components/activity/LocalActivityList.tsx
+++ b/apps/desktop/src/components/activity/LocalActivityList.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react"
 import type { ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
 import { agentDisplayName } from "../../lib/presentation/agents"
 import type { AgentSurface } from "../../lib/presentation/agents"
 import { localSessionKey } from "../../lib/presentation/localIdentity"
@@ -283,11 +284,14 @@ function SessionActivityRow({
 
   return (
     <div
-      className={`${ROW_CLASS}${entry.isActive ? ` ${ROW_ACTIVE_CLASS} isolate` : ""} ${ROW_LAYOUT_CLASS} transition-colors duration-[120ms] ${
-        clickable
-          ? "cursor-pointer hover:bg-surface-hover [&:has([data-state*=open])]:bg-surface-hover"
-          : ""
-      }`}
+      className={cn(
+        ROW_CLASS,
+        entry.isActive && `${ROW_ACTIVE_CLASS} isolate`,
+        ROW_LAYOUT_CLASS,
+        "transition-colors duration-[120ms]",
+        clickable &&
+          "cursor-pointer hover:bg-surface-hover [&:has([data-state*=open])]:bg-surface-hover",
+      )}
       {...(clickable
         ? {
             role: "button" as const,
@@ -310,9 +314,13 @@ function SessionActivityRow({
       {entry.isActive && <span className="sr-only">Active session</span>}
       <div className="mt-0.5 shrink-0">{renderAgentIcon?.(entry.agent, 18, entry.surface)}</div>
       <div className="min-w-0 flex-1 space-y-0.5">
-        <div className={`${ROW_CORNER_GUTTER_CLASS} flex min-w-0 items-center gap-1`}>
+        <div className={cn(ROW_CORNER_GUTTER_CLASS, "flex min-w-0 items-center gap-1")}>
           <TruncatedText
-            className={`${ROW_TITLE_CLASS} min-w-0 truncate type-callout ${entry.isActive ? "" : "text-label"}`}
+            className={cn(
+              ROW_TITLE_CLASS,
+              "min-w-0 truncate type-callout",
+              !entry.isActive && "text-label",
+            )}
             text={primary}
             shimmer={entry.isActive}
           />
@@ -373,7 +381,7 @@ function SessionActivityRow({
           <div className="flex min-h-[15px] min-w-0 items-center gap-1.5">
             {entry.cost && <SessionCostBadge {...entry.cost} />}
             {entry.activeTime && (
-              <span className={`flex ${SECONDARY_DETAIL_REVEAL_CLASS} shrink-0`}>
+              <span className={cn("flex", SECONDARY_DETAIL_REVEAL_CLASS, "shrink-0")}>
                 <SessionActiveTimeBadge
                   activeSecs={entry.activeTime.activeSecs}
                   {...(entry.activeTime.durationSecs != null
@@ -383,7 +391,7 @@ function SessionActivityRow({
               </span>
             )}
             {isOrchestrator && openRoster && (
-              <span className={`flex ${SECONDARY_DETAIL_REVEAL_CLASS} shrink-0`}>
+              <span className={cn("flex", SECONDARY_DETAIL_REVEAL_CLASS, "shrink-0")}>
                 <Tooltip
                   label={`Orchestrated ${subagentCount} sub-agents — view roster`}
                   delayMs={700}
@@ -501,7 +509,7 @@ export function LocalActivityList({
         <ScrollPane
           topEdgeFade
           viewportRef={assignViewportRef}
-          viewportClassName={`px-2${visibleCount === 0 ? " [&>div]:h-full" : ""}`}
+          viewportClassName={cn("px-2", visibleCount === 0 && "[&>div]:h-full")}
         >
           {visibleCount === 0 ? (
             <EmptyActivity title={resolvedEmptyTitle} description={emptyDescription} />

--- a/apps/desktop/src/components/providerUsage/LiveUsageDetail.tsx
+++ b/apps/desktop/src/components/providerUsage/LiveUsageDetail.tsx
@@ -80,7 +80,7 @@ export function LiveUsageDetail({
         {liveMetricRows(primary, now).map((row) => (
           <div key={row.key} className="flex items-baseline justify-between gap-3">
             <dt className="type-caption text-label-tertiary">{row.label}</dt>
-            <dd className={`type-caption tabular-nums ${row.toneClass}`}>{row.value}</dd>
+            <dd className={cn("type-caption tabular-nums", row.toneClass)}>{row.value}</dd>
           </div>
         ))}
       </dl>

--- a/apps/desktop/src/components/providerUsage/ProviderUsageCluster.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageCluster.tsx
@@ -6,6 +6,7 @@ import { Settings } from "lucide-react"
 import { useCallback, useId, useRef, useState } from "react"
 import { flushSync } from "react-dom"
 
+import { cn } from "../../lib/cn"
 import type { LiveUsageSummaryPayload, ProviderUsagePayload } from "../../lib/ipc"
 import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
 import {
@@ -259,9 +260,10 @@ export function ProviderUsageCluster({
                 panelRef.current?.querySelector<HTMLElement>(FOCUSABLE) ?? panelRef.current
               target?.focus()
             }}
-            className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-control px-1.5 type-caption tabular-nums leading-none text-label-secondary hover:bg-surface-hover ${
-              isOpen ? "bg-surface-hover" : ""
-            }`.trimEnd()}
+            className={cn(
+              "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-control px-1.5 type-caption tabular-nums leading-none text-label-secondary hover:bg-surface-hover",
+              isOpen && "bg-surface-hover",
+            )}
           >
             {headline ? (
               // The ring carries the provider's initial rather than replacing

--- a/apps/desktop/src/components/providerUsage/ProviderUsageDetail.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageDetail.tsx
@@ -4,6 +4,7 @@
 
 import { ChevronRight } from "lucide-react"
 
+import { cn } from "../../lib/cn"
 import type { LiveProviderUsagePayload, ProviderUsagePayload } from "../../lib/ipc"
 import {
   providerWindow,
@@ -73,7 +74,10 @@ export function ProviderUsageDetail({
           </h2>
           {(stale ?? updated) && (
             <p
-              className={`type-caption ${stale ? "text-system-orange" : "text-label-tertiary"}`}
+              className={cn(
+                "type-caption",
+                stale ? "text-system-orange" : "text-label-tertiary",
+              )}
             >
               {stale ?? updated}
             </p>

--- a/apps/desktop/src/components/providerUsage/ProviderUsagePrimitives.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsagePrimitives.tsx
@@ -14,6 +14,7 @@ import {
 } from "simple-icons"
 
 import { fromSimpleIcons, OPENAI_MARK, type BrandMark } from "../../lib/brandMarks"
+import { cn } from "../../lib/cn"
 import type { ProviderUsageState } from "../../lib/ipc"
 import {
   providerInitial,
@@ -97,7 +98,7 @@ export function ProviderGlyph({
         height={size}
         fill="currentColor"
         data-provider-icon={provider}
-        className={`shrink-0 text-label-secondary ${className}`.trimEnd()}
+        className={cn("shrink-0 text-label-secondary", className)}
       >
         <path d={mark.path} />
       </svg>
@@ -108,7 +109,10 @@ export function ProviderGlyph({
       aria-hidden="true"
       data-provider-icon="letter"
       style={{ width: size, height: size, fontSize: Math.round(size * 0.58) }}
-      className={`inline-flex shrink-0 items-center justify-center rounded-[4px] bg-surface-secondary font-medium leading-none text-label-secondary ${className}`.trimEnd()}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-[4px] bg-surface-secondary font-medium leading-none text-label-secondary",
+        className,
+      )}
     >
       {providerInitial(displayName)}
     </span>
@@ -135,9 +139,11 @@ interface UsageStateBadgeProps {
 export function UsageStateBadge({ state, className = "" }: UsageStateBadgeProps) {
   return (
     <span
-      className={`inline-flex shrink-0 items-center rounded-full px-1.5 py-px type-caption font-medium leading-[13px] ${usageStateToneClass(
-        state,
-      )} ${className}`.trimEnd()}
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full px-1.5 py-px type-caption font-medium leading-[13px]",
+        usageStateToneClass(state),
+        className,
+      )}
     >
       {usageStateLabel(state)}
     </span>

--- a/apps/desktop/src/components/providerUsage/UsageWindowRows.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageWindowRows.tsx
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { cn } from "../../lib/cn"
 import type { ProviderUsagePayload } from "../../lib/ipc"
 import {
   providerWindow,
@@ -30,7 +31,7 @@ export function UsageWindowRows({
   className?: string
 }) {
   return (
-    <dl className={`space-y-2 ${className}`.trim()}>
+    <dl className={cn("space-y-2", className)}>
       {USAGE_WINDOWS.map(({ value }) => {
         const window = providerWindow(provider, value)
         const share = windowShareOfMonth(provider, value)

--- a/apps/desktop/src/components/session/SessionAnalyticsPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionAnalyticsPresentation.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react"
 import { useCallback, useState, useSyncExternalStore, type ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
 import { agentDisplayName } from "../../lib/presentation/agents"
 import { sessionIdentityKey } from "../../lib/presentation/localIdentity"
 import {
@@ -320,9 +321,10 @@ function PhaseBreakdownRows({
       {phaseBreakdown(summary).map((row) => (
         <div
           key={row.key}
-          className={`-mx-2 flex items-center gap-2.5 rounded-lg px-2 py-1 transition-colors ${
-            activePhase === row.key ? "bg-surface-secondary" : ""
-          }`}
+          className={cn(
+            "-mx-2 flex items-center gap-2.5 rounded-lg px-2 py-1 transition-colors",
+            activePhase === row.key && "bg-surface-secondary",
+          )}
           onMouseEnter={() => onHoverPhase?.(row.key)}
           onMouseLeave={() => onHoverPhase?.(null)}
         >
@@ -836,11 +838,12 @@ export function SessionAnalyticsPresentation({
                             onClick={onPrev}
                             disabled={!onPrev}
                             aria-label="Newer session"
-                            className={`shrink-0 rounded-md p-1 transition-colors ${
+                            className={cn(
+                              "shrink-0 rounded-md p-1 transition-colors",
                               onPrev
                                 ? "text-label-tertiary hover:bg-surface-tertiary hover:text-label-secondary"
-                                : "cursor-default text-label-tertiary opacity-40"
-                            }`}
+                                : "cursor-default text-label-tertiary opacity-40",
+                            )}
                           >
                             <ChevronLeft size={16} aria-hidden="true" />
                           </button>
@@ -860,11 +863,12 @@ export function SessionAnalyticsPresentation({
                             onClick={onNext}
                             disabled={!onNext}
                             aria-label="Older session"
-                            className={`shrink-0 rounded-md p-1 transition-colors ${
+                            className={cn(
+                              "shrink-0 rounded-md p-1 transition-colors",
                               onNext
                                 ? "text-label-tertiary hover:bg-surface-tertiary hover:text-label-secondary"
-                                : "cursor-default text-label-tertiary opacity-40"
-                            }`}
+                                : "cursor-default text-label-tertiary opacity-40",
+                            )}
                           >
                             <ChevronRight size={16} aria-hidden="true" />
                           </button>

--- a/apps/desktop/src/components/session/metrics/SessionActiveTimeBadge.tsx
+++ b/apps/desktop/src/components/session/metrics/SessionActiveTimeBadge.tsx
@@ -4,6 +4,7 @@
 
 import { Clock } from "lucide-react"
 
+import { cn } from "../../../lib/cn"
 import { formatDuration } from "../../../lib/presentation/sessionAnalytics"
 import { Tooltip } from "../../presentation/Tooltip"
 
@@ -55,9 +56,10 @@ export function SessionActiveTimeBadge({
       }
     >
       <span
-        className={`flex shrink-0 items-center gap-0.5 rounded-full bg-label/[0.06] px-1.5 py-px type-caption font-medium leading-[13px] text-label-secondary tabular-nums${
-          className ? ` ${className}` : ""
-        }`}
+        className={cn(
+          "flex shrink-0 items-center gap-0.5 rounded-full bg-label/[0.06] px-1.5 py-px type-caption font-medium leading-[13px] text-label-secondary tabular-nums",
+          className,
+        )}
       >
         <Clock size={11} className="shrink-0" aria-hidden="true" />
         {formatDuration(activeSecs)}

--- a/apps/desktop/src/components/session/metrics/SessionCostBadge.tsx
+++ b/apps/desktop/src/components/session/metrics/SessionCostBadge.tsx
@@ -4,6 +4,7 @@
 
 import { Flame } from "lucide-react"
 
+import { cn } from "../../../lib/cn"
 import {
   formatCost,
   HIGH_COST_MEDIAN_MULTIPLE,
@@ -116,11 +117,13 @@ export function SessionCostBadge({
             ? `${figureLabel} ${formatCost(totalUsd)}, higher than usual`
             : `${figureLabel} ${formatCost(totalUsd)}`
         }
-        className={`${COST_PILL_CLASS} ${
+        className={cn(
+          COST_PILL_CLASS,
           isHighCost
             ? "bg-system-red/15 text-system-red-text"
-            : "bg-system-gold/15 text-system-gold-text"
-        }${className ? ` ${className}` : ""}`}
+            : "bg-system-gold/15 text-system-gold-text",
+          className,
+        )}
       >
         {isHighCost && <Flame size={11} className="shrink-0" aria-hidden="true" />}
         <TextRoll text={formatCost(totalUsd)} />
@@ -135,7 +138,7 @@ export function SessionCostBadge({
   // tooltip is open, and the trigger sets that attribute on the pill, which has
   // to be a *descendant* for `:has` to match.
   if (revealClassName && !isHighCost) {
-    return <span className={`flex shrink-0 ${revealClassName}`}>{badge}</span>
+    return <span className={cn("flex shrink-0", revealClassName)}>{badge}</span>
   }
   return badge
 }

--- a/apps/desktop/src/components/session/orchestration/CollapsibleOrchestrationCard.tsx
+++ b/apps/desktop/src/components/session/orchestration/CollapsibleOrchestrationCard.tsx
@@ -5,6 +5,8 @@
 import { ChevronDown, ChevronUp } from "lucide-react"
 import { useState, type ReactNode } from "react"
 
+import { cn } from "../../../lib/cn"
+
 export interface CollapsibleOrchestrationCardProps {
   /** Leading glyph in the header. */
   icon?: ReactNode
@@ -53,7 +55,7 @@ export function CollapsibleOrchestrationCard({
         />
       </button>
 
-      {expanded && <div className={`px-2 pt-0.5 pb-2 ${bodyClassName ?? ""}`}>{children}</div>}
+      {expanded && <div className={cn("px-2 pt-0.5 pb-2", bodyClassName)}>{children}</div>}
     </div>
   )
 }

--- a/apps/desktop/src/components/session/orchestration/SubagentRosterRow.tsx
+++ b/apps/desktop/src/components/session/orchestration/SubagentRosterRow.tsx
@@ -5,6 +5,8 @@
 import { ChevronRight } from "lucide-react"
 import type { ReactNode } from "react"
 
+import { cn } from "../../../lib/cn"
+
 /**
  * Renders the icon for an agent slug. Components take this as a slot rather
  * than reaching for artwork themselves, so the presentation layer ships no
@@ -48,12 +50,13 @@ export function SubagentRosterRow({
     <button
       type="button"
       onClick={onClick}
-      className={`group/srow flex w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-system-indigo/10 ${
-        dense ? "px-1 py-1" : "px-2 py-1.5"
-      }`}
+      className={cn(
+        "group/srow flex w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-system-indigo/10",
+        dense ? "px-1 py-1" : "px-2 py-1.5",
+      )}
     >
       {renderAgentIcon?.(agent, 14)}
-      <span className={`min-w-0 flex-1 truncate ${dense ? "" : "type-callout text-label"}`}>
+      <span className={cn("min-w-0 flex-1 truncate", !dense && "type-callout text-label")}>
         {label}
       </span>
       {trailing}

--- a/apps/desktop/src/components/ui/Banner.tsx
+++ b/apps/desktop/src/components/ui/Banner.tsx
@@ -4,6 +4,8 @@
 
 import { X, type LucideIcon } from "lucide-react"
 
+import { cn } from "../../lib/cn"
+
 /** How loudly a banner reads. */
 export type BannerTone = "warning" | "info"
 
@@ -62,7 +64,7 @@ export function Banner({
       data-testid="banner"
       // 8px horizontal padding, so a caller that lays banners out on the same
       // 8px gutter as a list gets text starting on the list's own left edge.
-      className={`flex items-start gap-2 rounded-control px-2 py-1.5 ${toneClass} ${className}`.trimEnd()}
+      className={cn("flex items-start gap-2 rounded-control px-2 py-1.5", toneClass, className)}
     >
       {Icon && (
         <Icon size={12} strokeWidth={2} aria-hidden="true" className="mt-0.5 shrink-0" />

--- a/apps/desktop/src/components/ui/Card.tsx
+++ b/apps/desktop/src/components/ui/Card.tsx
@@ -4,6 +4,8 @@
 
 import type { ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 /** Grouped, divided, bordered container. Children are laid out as edge-to-edge
  *  rows separated by hairlines — pair with `Row` / `ToggleRow`. */
 export function Card({
@@ -15,7 +17,10 @@ export function Card({
 }) {
   return (
     <div
-      className={`divide-y divide-separator overflow-hidden rounded-popover border border-separator bg-surface-card/60 ${className}`.trimEnd()}
+      className={cn(
+        "divide-y divide-separator overflow-hidden rounded-popover border border-separator bg-surface-card/60",
+        className,
+      )}
     >
       {children}
     </div>

--- a/apps/desktop/src/components/ui/Disclosure.tsx
+++ b/apps/desktop/src/components/ui/Disclosure.tsx
@@ -5,6 +5,8 @@
 import { ChevronDown } from "lucide-react"
 import { useId, useState, type ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 /**
  * A single collapsible disclosure: a full-width header button that reveals its
  * body. Hairline-separated and chrome-free by design — it sits directly on the
@@ -33,7 +35,7 @@ export function Disclosure({
   const bodyId = useId()
 
   return (
-    <div className={`border-b border-separator last:border-b-0 ${className}`.trimEnd()}>
+    <div className={cn("border-b border-separator last:border-b-0", className)}>
       <button
         type="button"
         aria-expanded={open}
@@ -53,9 +55,10 @@ export function Disclosure({
           size={14}
           strokeWidth={2}
           aria-hidden="true"
-          className={`shrink-0 text-label-secondary transition-transform duration-[120ms] ease-out ${
-            open ? "rotate-180" : ""
-          }`.trimEnd()}
+          className={cn(
+            "shrink-0 text-label-secondary transition-transform duration-[120ms] ease-out",
+            open && "rotate-180",
+          )}
         />
       </button>
       {/* Unmounted rather than hidden when collapsed, so collapsed prose stays
@@ -77,5 +80,5 @@ export function DisclosureGroup({
   children: ReactNode
   className?: string
 }) {
-  return <div className={`border-t border-separator ${className}`.trimEnd()}>{children}</div>
+  return <div className={cn("border-t border-separator", className)}>{children}</div>
 }

--- a/apps/desktop/src/components/ui/InlineLink.tsx
+++ b/apps/desktop/src/components/ui/InlineLink.tsx
@@ -4,6 +4,8 @@
 
 import type { ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 /**
  * A link rendered inline within a sentence.
  *
@@ -30,7 +32,10 @@ export function InlineLink({
     <button
       type="button"
       onClick={onClick}
-      className={`rounded-control text-label underline decoration-label-tertiary underline-offset-2 transition-colors duration-[120ms] ease-out hover:decoration-label ${className}`.trimEnd()}
+      className={cn(
+        "rounded-control text-label underline decoration-label-tertiary underline-offset-2 transition-colors duration-[120ms] ease-out hover:decoration-label",
+        className,
+      )}
     >
       {children}
     </button>

--- a/apps/desktop/src/components/ui/Pane.tsx
+++ b/apps/desktop/src/components/ui/Pane.tsx
@@ -4,6 +4,8 @@
 
 import type { ReactNode, Ref } from "react"
 
+import { cn } from "../../lib/cn"
+
 /** Title bar of a content pane: an optional leading control (a back arrow, say),
  *  the pane title, and an optional trailing action.
  *
@@ -34,7 +36,7 @@ export function PaneHeader({
   className?: string
 }) {
   return (
-    <div className={`mb-6 flex items-center gap-2 ${className}`.trimEnd()}>
+    <div className={cn("mb-6 flex items-center gap-2", className)}>
       {leading}
       <h1
         ref={headingRef}
@@ -70,7 +72,7 @@ export function Pane({
   return (
     <>
       <PaneHeader title={title} trailing={trailing} />
-      <div className={`space-y-6 ${className}`.trimEnd()}>{children}</div>
+      <div className={cn("space-y-6", className)}>{children}</div>
     </>
   )
 }

--- a/apps/desktop/src/components/ui/PushButton.tsx
+++ b/apps/desktop/src/components/ui/PushButton.tsx
@@ -5,6 +5,8 @@
 import type { LucideIcon } from "lucide-react"
 import type { ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 /** The two documented push-button treatments. `primary` is the accent-filled
  *  variant; everything else is the default secondary. */
 export type PushButtonVariant = "secondary" | "primary"
@@ -54,9 +56,11 @@ export function PushButton({
       disabled={disabled}
       onClick={onClick}
       autoFocus={autoFocus}
-      className={`ui-push-button gap-1 whitespace-nowrap disabled:opacity-50 ${variantClass} ${className}`
-        .replace(/\s+/g, " ")
-        .trimEnd()}
+      className={cn(
+        "ui-push-button gap-1 whitespace-nowrap disabled:opacity-50",
+        variantClass,
+        className,
+      )}
     >
       {children}
       {TrailingIcon && (

--- a/apps/desktop/src/components/ui/RangeSlider.tsx
+++ b/apps/desktop/src/components/ui/RangeSlider.tsx
@@ -4,6 +4,8 @@
 
 import { useRef } from "react"
 
+import { cn } from "../../lib/cn"
+
 /** A horizontal value slider.
  *
  *  A native `input[type=range]`, so the platform supplies the drag, the
@@ -67,7 +69,10 @@ export function RangeSlider({
       onBlur={(event) => endGesture(Number(event.currentTarget.value))}
       aria-label={ariaLabel}
       aria-valuetext={ariaValueText}
-      className={`h-1 w-full cursor-default appearance-none rounded-full bg-surface-secondary accent-[var(--color-accent-fill)] disabled:cursor-not-allowed ${className}`.trimEnd()}
+      className={cn(
+        "h-1 w-full cursor-default appearance-none rounded-full bg-surface-secondary accent-[var(--color-accent-fill)] disabled:cursor-not-allowed",
+        className,
+      )}
     />
   )
 }

--- a/apps/desktop/src/components/ui/Row.tsx
+++ b/apps/desktop/src/components/ui/Row.tsx
@@ -4,6 +4,8 @@
 
 import type { ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 /** A single row inside a `Card`: label on the left, an optional trailing
  *  control on the right, and a full-width description underneath.
  *
@@ -30,9 +32,10 @@ export function Row({
 }) {
   return (
     <div
-      className={`grid min-h-[58px] grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 px-4 py-3 ${
-        dimmed ? "opacity-50" : ""
-      }`}
+      className={cn(
+        "grid min-h-[58px] grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 px-4 py-3",
+        dimmed && "opacity-50",
+      )}
     >
       <p className="type-body min-w-0 truncate text-label">{label}</p>
       <div className="shrink-0">{trailing}</div>

--- a/apps/desktop/src/components/ui/ScrollPane.tsx
+++ b/apps/desktop/src/components/ui/ScrollPane.tsx
@@ -5,6 +5,8 @@
 import * as ScrollArea from "@radix-ui/react-scroll-area"
 import type { ReactNode, Ref } from "react"
 
+import { cn } from "../../lib/cn"
+
 function syncTopEdgeFade(viewport: HTMLDivElement) {
   const shouldFade = viewport.scrollTop > 1
   if (shouldFade === viewport.hasAttribute("data-scroll-edge-top")) return
@@ -48,11 +50,15 @@ export function ScrollPane({
   }
 
   return (
-    <ScrollArea.Root className={`flex-1 overflow-hidden ${className}`.trimEnd()}>
+    <ScrollArea.Root className={cn("flex-1 overflow-hidden", className)}>
       <ScrollArea.Viewport
         ref={assignViewportRef}
         onScroll={topEdgeFade ? (event) => syncTopEdgeFade(event.currentTarget) : undefined}
-        className={`ui-scroll-viewport h-full${topEdgeFade ? " scroll-edge-fade-top" : ""} ${viewportClassName}`.trimEnd()}
+        className={cn(
+          "ui-scroll-viewport h-full",
+          topEdgeFade && "scroll-edge-fade-top",
+          viewportClassName,
+        )}
       >
         {children}
       </ScrollArea.Viewport>

--- a/apps/desktop/src/components/ui/SectionGroup.tsx
+++ b/apps/desktop/src/components/ui/SectionGroup.tsx
@@ -4,6 +4,8 @@
 
 import type { ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 /** A labelled group of cards. The header sits a step above the row labels
  *  inside those cards (15px vs 13px, full-contrast vs secondary), so a pane
  *  scans as titled groups rather than one undifferentiated run of rows.
@@ -30,7 +32,7 @@ export function SectionGroup({
   className?: string
 }) {
   return (
-    <section className={`space-y-2 ${className}`.trimEnd()}>
+    <section className={cn("space-y-2", className)}>
       {title && (
         <div className="flex items-center justify-between gap-2 px-1">
           <h2 className="type-title-3 font-normal! text-label">{title}</h2>

--- a/apps/desktop/src/components/ui/SegmentedControl.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.tsx
@@ -4,6 +4,8 @@
 
 import { useRef } from "react"
 
+import { cn } from "../../lib/cn"
+
 export type SegmentedOption<T extends string> = {
   value: T
   label: string
@@ -64,8 +66,13 @@ export function SegmentedControl<T extends string>({
       data-variant={variant}
       className={
         textTabs
-          ? `inline-flex h-6 items-center gap-3 whitespace-nowrap ${className}`.trimEnd()
-          : `${showAnimatedIndicator ? "relative " : ""}${equalWidth ? "grid " : "inline-flex "}h-6 overflow-hidden rounded-control border border-separator bg-surface-secondary ${className}`.trimEnd()
+          ? cn("inline-flex h-6 items-center gap-3 whitespace-nowrap", className)
+          : cn(
+              showAnimatedIndicator && "relative",
+              equalWidth ? "grid" : "inline-flex",
+              "h-6 overflow-hidden rounded-control border border-separator bg-surface-secondary",
+              className,
+            )
       }
       style={
         equalWidth && !textTabs
@@ -119,8 +126,19 @@ export function SegmentedControl<T extends string>({
             }}
             className={
               textTabs
-                ? `type-footnote relative flex h-full items-center whitespace-nowrap px-0 transition-colors duration-100 ease-[cubic-bezier(0.23,1,0.32,1)] ${selected ? "font-medium text-label" : "text-label-tertiary hover:text-label-secondary"}`
-                : `${showAnimatedIndicator ? "relative " : ""}${equalWidth ? "min-w-0 " : ""}type-footnote px-2 ${selected ? `${showAnimatedIndicator ? "" : "bg-accent-fill "}text-white` : "text-label-secondary hover:bg-surface-hover"}`
+                ? cn(
+                    "type-footnote relative flex h-full items-center whitespace-nowrap px-0 transition-colors duration-100 ease-[cubic-bezier(0.23,1,0.32,1)]",
+                    selected
+                      ? "font-medium text-label"
+                      : "text-label-tertiary hover:text-label-secondary",
+                  )
+                : cn(
+                    showAnimatedIndicator && "relative",
+                    equalWidth && "min-w-0",
+                    "type-footnote px-2",
+                    selected && !showAnimatedIndicator && "bg-accent-fill",
+                    selected ? "text-white" : "text-label-secondary hover:bg-surface-hover",
+                  )
             }
           >
             {textTabs ? (
@@ -131,7 +149,10 @@ export function SegmentedControl<T extends string>({
               // the indicator, not a styling API.
               <span
                 aria-hidden="true"
-                className={`segmented-control-text-indicator pointer-events-none absolute inset-x-0 bottom-0 h-px rounded-full bg-label-secondary transition-opacity duration-100 ease-[cubic-bezier(0.23,1,0.32,1)] ${selected ? "opacity-100" : "opacity-0"}`}
+                className={cn(
+                  "segmented-control-text-indicator pointer-events-none absolute inset-x-0 bottom-0 h-px rounded-full bg-label-secondary transition-opacity duration-100 ease-[cubic-bezier(0.23,1,0.32,1)]",
+                  selected ? "opacity-100" : "opacity-0",
+                )}
               />
             ) : null}
             {showAnimatedIndicator ? (
@@ -141,7 +162,10 @@ export function SegmentedControl<T extends string>({
               // grants a short crossfade to, so the swap is not a hard flicker.
               <span
                 aria-hidden="true"
-                className={`ui-segmented-reduced-fill pointer-events-none absolute inset-0 hidden rounded-[4px] bg-accent-fill transition-opacity ease-out motion-reduce:block ${selected ? "opacity-100" : "opacity-0"}`}
+                className={cn(
+                  "ui-segmented-reduced-fill pointer-events-none absolute inset-0 hidden rounded-[4px] bg-accent-fill transition-opacity ease-out motion-reduce:block",
+                  selected ? "opacity-100" : "opacity-0",
+                )}
               />
             ) : null}
             <span className={showAnimatedIndicator ? "relative z-10" : undefined}>

--- a/apps/desktop/src/components/ui/SidebarNav.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.tsx
@@ -5,6 +5,8 @@
 import type { LucideIcon } from "lucide-react"
 import { Fragment, useRef, type KeyboardEvent, type ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 export type SidebarNavItem = {
   id: string
   label: string
@@ -74,7 +76,10 @@ export function SidebarNav({
   // group break reads as 25px of separation against the 8px plain row gap.
   return (
     <div
-      className={`flex w-[var(--sidebar-width)] shrink-0 flex-col border-r border-separator bg-surface-sidebar ${className}`.trimEnd()}
+      className={cn(
+        "flex w-[var(--sidebar-width)] shrink-0 flex-col border-r border-separator bg-surface-sidebar",
+        className,
+      )}
     >
       {header && <div className="px-5 pb-1 pt-4">{header}</div>}
       <div
@@ -104,11 +109,12 @@ export function SidebarNav({
                 aria-controls={`${item.id}-panel`}
                 tabIndex={selected ? 0 : -1}
                 onClick={() => onChange(item.id)}
-                className={`type-body flex h-9 items-center gap-3 rounded-control px-3 transition-colors duration-[120ms] ease-out ${
+                className={cn(
+                  "type-body flex h-9 items-center gap-3 rounded-control px-3 transition-colors duration-[120ms] ease-out",
                   selected
                     ? "bg-surface-selected text-label"
-                    : "text-label hover:bg-surface-hover"
-                }`}
+                    : "text-label hover:bg-surface-hover",
+                )}
               >
                 <Icon size={16} strokeWidth={2} className="shrink-0" aria-hidden="true" />
                 <span className="truncate">{item.label}</span>

--- a/apps/desktop/src/components/ui/Skeleton.tsx
+++ b/apps/desktop/src/components/ui/Skeleton.tsx
@@ -4,6 +4,8 @@
 
 import type { HTMLAttributes, ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 export interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
   /** When false the children render untouched, so a call site can wrap its
    *  real content once and flip a flag instead of branching in JSX. */
@@ -42,9 +44,11 @@ export function Skeleton({ loading = true, children, className = "", ...rest }: 
       aria-hidden="true"
       tabIndex={-1}
       data-placeholder=""
-      className={`pointer-events-none animate-pulse select-none rounded-small bg-surface-tertiary ${shape} ${className}`
-        .replace(/\s+/g, " ")
-        .trimEnd()}
+      className={cn(
+        "pointer-events-none animate-pulse select-none rounded-small bg-surface-tertiary",
+        shape,
+        className,
+      )}
     >
       {children}
     </span>
@@ -70,13 +74,16 @@ export function SkeletonCard({
 }: SkeletonCardProps) {
   return (
     <div
-      className={`overflow-hidden rounded-popover border border-separator bg-surface-card/60 px-4 py-3 ${className}`.trimEnd()}
+      className={cn(
+        "overflow-hidden rounded-popover border border-separator bg-surface-card/60 px-4 py-3",
+        className,
+      )}
     >
       <div className="flex items-start gap-2">
         {leading && <Skeleton className="mt-0.5 h-[15px] w-[15px] shrink-0" />}
         <div className="min-w-0 flex-1 space-y-1.5">
           {lines.map((width, index) => (
-            <Skeleton key={`${width}-${index}`} className={`h-3 ${width}`} />
+            <Skeleton key={`${width}-${index}`} className={cn("h-3", width)} />
           ))}
         </div>
       </div>

--- a/apps/desktop/src/components/ui/StatusText.tsx
+++ b/apps/desktop/src/components/ui/StatusText.tsx
@@ -5,6 +5,8 @@
 import type { LucideIcon } from "lucide-react"
 import type { ReactNode } from "react"
 
+import { cn } from "../../lib/cn"
+
 /** `primary` is the plain label color, `secondary` the quieter one used for a
  *  trailing status word next to a row label. */
 export type StatusTextTone = "primary" | "secondary"
@@ -33,16 +35,18 @@ export function StatusText({
 }) {
   return (
     <span
-      className={`type-footnote inline-flex items-center gap-1.5 ${
-        tone === "secondary" ? "text-label-secondary" : "text-label"
-      } ${className}`.trimEnd()}
+      className={cn(
+        "type-footnote inline-flex items-center gap-1.5",
+        tone === "secondary" ? "text-label-secondary" : "text-label",
+        className,
+      )}
     >
       {Icon && (
         <Icon
           size={12}
           strokeWidth={iconStrokeWidth}
           aria-hidden="true"
-          className={`shrink-0 ${iconClassName}`.trimEnd()}
+          className={cn("shrink-0", iconClassName)}
         />
       )}
       {children}

--- a/apps/desktop/src/components/ui/TextRoll.tsx
+++ b/apps/desktop/src/components/ui/TextRoll.tsx
@@ -4,6 +4,7 @@
 
 import { memo, useState, type CSSProperties } from "react"
 
+import { cn } from "../../lib/cn"
 import "./text-roll.css"
 
 /**
@@ -133,7 +134,7 @@ export const TextRoll = memo(function TextRoll({ text, className }: TextRollProp
   }
 
   return (
-    <span className={className ? `text-roll ${className}` : "text-roll"}>
+    <span className={cn("text-roll", className)}>
       {/* Assistive tech reads the plain string; the animated cells below are
           presentation-only (and excluded from text selection, so copying the
           element yields the string exactly once). */}

--- a/apps/desktop/src/views/NudgeView.tsx
+++ b/apps/desktop/src/views/NudgeView.tsx
@@ -6,6 +6,7 @@ import { X } from "lucide-react"
 import { useCallback, useState, useSyncExternalStore, type AnimationEvent } from "react"
 
 import appIcon from "../assets/app-icon.png"
+import { cn } from "../lib/cn"
 import { NudgeSession } from "./nudge/NudgeSession"
 
 /**
@@ -89,9 +90,10 @@ export function NudgeView() {
         // the hover state) rather than CSS `:hover`/`group-hover`: the pointer
         // events CSS hover depends on don't reach this window while another
         // antiburn window holds macOS key status — see `NudgeSession.applyHover`.
-        className={`relative overflow-hidden bg-surface text-label select-none ${
-          exiting ? "animate-nudge-out" : entering ? "animate-nudge-in" : ""
-        }`}
+        className={cn(
+          "relative overflow-hidden bg-surface text-label select-none",
+          exiting ? "animate-nudge-out" : entering && "animate-nudge-in",
+        )}
         onAnimationEnd={handleAnimationEnd}
       >
         {/* The clickable body. Bound here rather than on the card so the action
@@ -117,18 +119,20 @@ export function NudgeView() {
                 </p>
                 {/* Timestamp fades on hover as the card expands and the close appears. */}
                 <span
-                  className={`type-footnote shrink-0 text-label-tertiary transition-opacity ${
-                    expanded ? "opacity-0" : "opacity-100"
-                  }`}
+                  className={cn(
+                    "type-footnote shrink-0 text-label-tertiary transition-opacity",
+                    expanded ? "opacity-0" : "opacity-100",
+                  )}
                 >
                   {elapsedLabel}
                 </span>
               </div>
               {nudge.reason && (
                 <p
-                  className={`type-body mt-0.5 leading-snug text-label-secondary ${
-                    expanded ? "" : "line-clamp-2"
-                  }`}
+                  className={cn(
+                    "type-body mt-0.5 leading-snug text-label-secondary",
+                    !expanded && "line-clamp-2",
+                  )}
                 >
                   {nudge.reason}
                 </p>
@@ -162,9 +166,11 @@ export function NudgeView() {
               <button
                 key={action.id}
                 onClick={() => session.handleAction(action)}
-                className={`type-body flex-1 py-2.5 text-center transition-colors outline-none hover:bg-surface-hover focus-visible:outline-none ${
-                  i > 0 ? "border-l border-separator" : ""
-                } ${action.primary ? "font-medium text-accent" : "text-label"}`}
+                className={cn(
+                  "type-body flex-1 py-2.5 text-center transition-colors outline-none hover:bg-surface-hover focus-visible:outline-none",
+                  i > 0 && "border-l border-separator",
+                  action.primary ? "font-medium text-accent" : "text-label",
+                )}
               >
                 {action.label}
               </button>
@@ -177,9 +183,10 @@ export function NudgeView() {
         <button
           onClick={session.handleClose}
           aria-label="Close"
-          className={`absolute top-2 right-2 flex h-5 w-5 items-center justify-center rounded-full bg-surface-secondary text-label-secondary transition-opacity outline-none hover:text-label focus-visible:outline-none ${
-            expanded ? "opacity-100" : "opacity-0"
-          }`}
+          className={cn(
+            "absolute top-2 right-2 flex h-5 w-5 items-center justify-center rounded-full bg-surface-secondary text-label-secondary transition-opacity outline-none hover:text-label focus-visible:outline-none",
+            expanded ? "opacity-100" : "opacity-0",
+          )}
         >
           <X size={12} aria-hidden />
         </button>

--- a/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
+++ b/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
@@ -8,6 +8,7 @@ import appIcon from "../../assets/app-icon.png"
 import { useState } from "react"
 
 import { isMacOS } from "../../lib/platform"
+import { cn } from "../../lib/cn"
 
 import { FolderPermissionNotice } from "../../components/repositories/FolderPermissionNotice"
 import { LocalRepositoryList } from "../../components/repositories/LocalRepositoryList"
@@ -119,9 +120,10 @@ function StepDots({ step }: { step: Step }) {
       {STEPS.map((name, position) => (
         <span
           key={name}
-          className={`h-1.5 w-1.5 rounded-full transition-colors ${
-            position === index ? "bg-label-secondary" : "bg-label/20"
-          }`}
+          className={cn(
+            "h-1.5 w-1.5 rounded-full transition-colors",
+            position === index ? "bg-label-secondary" : "bg-label/20",
+          )}
         />
       ))}
     </div>
@@ -568,7 +570,7 @@ export function OnboardingFlow({
           title bar, by the app icon on the Welcome step, and by every step's
           own heading. Windows and Linux keep the native bar and show it. */}
       <header className="flex h-11 shrink-0 items-center px-4">
-        <h1 className={`type-headline text-label ${isMacOS() ? "sr-only" : ""}`}>antiburn</h1>
+        <h1 className={cn("type-headline text-label", isMacOS() && "sr-only")}>antiburn</h1>
         {/* The step is announced as text rather than left to the dots, which
             are decorative and hidden. */}
         <p className="sr-only" aria-live="polite">

--- a/apps/desktop/src/views/popover/UsageView.tsx
+++ b/apps/desktop/src/views/popover/UsageView.tsx
@@ -9,6 +9,7 @@ import { LiveUsageDetail } from "../../components/providerUsage/LiveUsageDetail"
 import { UsageMetricRows } from "../../components/providerUsage/UsageMetricRows"
 import { UsageWindowRows } from "../../components/providerUsage/UsageWindowRows"
 import { ScrollPane } from "../../components/ui/ScrollPane"
+import { cn } from "../../lib/cn"
 import type {
   LiveProviderUsagePayload,
   LiveUsageSummaryPayload,
@@ -208,7 +209,10 @@ function ProviderCard({
           </div>
           {(stale ?? updated) && (
             <p
-              className={`type-caption ${stale ? "text-system-orange" : "text-label-tertiary"}`}
+              className={cn(
+                "type-caption",
+                stale ? "text-system-orange" : "text-label-tertiary",
+              )}
             >
               {stale ?? updated}
             </p>

--- a/apps/desktop/src/views/settings/NotificationsPane.tsx
+++ b/apps/desktop/src/views/settings/NotificationsPane.tsx
@@ -10,6 +10,7 @@ import { Row } from "../../components/ui/Row"
 import { SectionGroup } from "../../components/ui/SectionGroup"
 import { SegmentedControl } from "../../components/ui/SegmentedControl"
 import { ToggleRow } from "../../components/ui/ToggleRow"
+import { cn } from "../../lib/cn"
 import {
   postTestNotification,
   type DiskSpaceDisplay,
@@ -91,11 +92,12 @@ function MilestonePills({
           aria-pressed={value[key]}
           disabled={disabled}
           onClick={() => onChange({ ...value, [key]: !value[key] })}
-          className={`type-footnote h-6 rounded-control px-2 tabular-nums transition-colors duration-[120ms] ease-out ${
+          className={cn(
+            "type-footnote h-6 rounded-control px-2 tabular-nums transition-colors duration-[120ms] ease-out",
             value[key]
               ? "bg-accent-fill text-white"
-              : "text-label-secondary hover:bg-surface-hover"
-          }`}
+              : "text-label-secondary hover:bg-surface-hover",
+          )}
         >
           {label}
         </button>


### PR DESCRIPTION
## Summary

- migrate shared UI primitives to the cn helper
- replace conditional and caller-supplied class string assembly across activity, session, usage, onboarding, and nudge surfaces
- leave simple mutually exclusive single-class selections as direct ternaries

## Validation

- pnpm --filter @antiburn/desktop format
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop knip
- pnpm --filter @antiburn/desktop test
- pnpm --filter @antiburn/desktop build