### PR TITLE
feat(desktop): usage limits section on main popover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,9 @@ Only add a `useEffect` when it is strictly necessary to synchronize React with a
 Do not add or retain Rust lint suppressions for dead or deprecated code. This includes item-level forms such as `#[allow(dead_code)]` and `#[allow(deprecated)]`, crate- or module-level forms such as `#![allow(dead_code)]` and `#![allow(deprecated)]`, and the corresponding `#[expect(...)]` forms.
 
 Delete dead code and migrate away from deprecated APIs instead. A suppression is permitted only after explaining the concrete need and receiving explicit agreement from the developer. Existing suppressions are not precedent for adding or retaining more, and reviews should call them out.
+
+## Commits
+
+Every commit must carry a Developer Certificate of Origin sign-off: run `git commit -s` (or add `Signed-off-by: Name <email>` to the message by hand). The DCO check fails the whole PR on any commit that is missing one — it does not average out across the branch.
+
+Sign off from the first commit. Fixing a missing sign-off after the fact means amending or rebasing the offending commit and force-pushing the branch, which resets every check run and starts CI over from scratch.

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -887,6 +887,10 @@ fn read_settings(connection: &Connection) -> Result<AppSettings> {
             .get("liveUsageEnabled")
             .map(|value| value == "true")
             .unwrap_or(defaults.live_usage_enabled),
+        overview_limits_expanded: stored
+            .get("overviewLimitsExpanded")
+            .map(|value| value == "true")
+            .unwrap_or(defaults.overview_limits_expanded),
     }
     .normalized())
 }
@@ -960,6 +964,10 @@ fn write_settings(connection: &Connection, settings: &AppSettings) -> Result<()>
     put.execute(params![
         "liveUsageEnabled",
         bool_text(settings.live_usage_enabled)
+    ])?;
+    put.execute(params![
+        "overviewLimitsExpanded",
+        bool_text(settings.overview_limits_expanded)
     ])?;
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -449,6 +449,11 @@ pub struct AppSettings {
     /// [`AppSettings::live_usage_active`] for the second, unconditional gate
     /// that also has to hold before any of this runs.
     pub live_usage_enabled: bool,
+    /// Whether the popover's usage-limits section is expanded to its
+    /// per-provider rows, rather than collapsed to the chip row. Purely a
+    /// display preference — it never gates a fetch — so it defaults open and
+    /// stays wherever the reader last left it.
+    pub overview_limits_expanded: bool,
 }
 
 impl Default for AppSettings {
@@ -482,6 +487,9 @@ impl Default for AppSettings {
             // not sit behind a first-run choice. The switch is the opt-out
             // for a reader who wants no background traffic at all.
             live_usage_enabled: true,
+            // Open by default: a reader who has live limits at all should see
+            // them without an extra click the first time they notice this.
+            overview_limits_expanded: true,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -107,6 +107,9 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     // not something that needs a first-run choice. See `live_usage_active`
     // for the onboarding gate that still applies regardless of this default.
     assert!(defaults.live_usage_enabled);
+    // Open by default, same reasoning: a reader who has limits to see should
+    // see them without an extra click the first time they notice the section.
+    assert!(defaults.overview_limits_expanded);
 
     // Notifications default on, both kinds with them, so the two per-kind
     // preferences below are a real change rather than a re-statement.
@@ -143,6 +146,7 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
                 at90: false,
             },
             live_usage_enabled: true,
+            overview_limits_expanded: false,
         })
         .unwrap();
     assert_eq!(store.settings().unwrap(), saved);
@@ -157,6 +161,7 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     assert!(!saved.milestones_weekly.any());
     assert!(saved.milestones_5h.at75 && !saved.milestones_5h.at50);
     assert!(saved.live_usage_enabled);
+    assert!(!saved.overview_limits_expanded);
     assert!(saved.onboarding_completed);
     assert!(saved.discovery_paused);
     // Each notification preference is stored on its own key, so a reader who

--- a/apps/desktop/src/components/activity/LocalActivityList.test.tsx
+++ b/apps/desktop/src/components/activity/LocalActivityList.test.tsx
@@ -175,7 +175,7 @@ describe("LocalActivityList — navigation", () => {
   })
 })
 
-describe("LocalActivityList — grouping and range", () => {
+describe("LocalActivityList — grouping", () => {
   it("buckets rows by calendar day and pins the newest label", () => {
     list({
       entries: [
@@ -212,51 +212,9 @@ describe("LocalActivityList — grouping and range", () => {
     expect(screen.getByText("Inside")).toBeTruthy()
     expect(screen.queryByText("Outside")).toBeNull()
   })
-
-  it("states the visible range and opens settings to change it", () => {
-    const onOpenSettings = vi.fn()
-    list({ onOpenSettings })
-    fireEvent.click(screen.getByLabelText(/Recent activity range: Last 7 days/))
-    expect(onOpenSettings).toHaveBeenCalledOnce()
-  })
-
-  it("renders the range as plain text when there is nowhere to change it", () => {
-    list({ days: 1 })
-    expect(screen.getByText("Last 1 day")).toBeTruthy()
-    expect(screen.queryByLabelText(/Recent activity range/)).toBeNull()
-  })
-
-  it("accepts a caller-supplied range label", () => {
-    list({ rangeLabel: "This week" })
-    expect(screen.getByText("This week")).toBeTruthy()
-  })
 })
 
-describe("LocalActivityList — filters and empty state", () => {
-  it("renders a plain title when there is nothing to filter by", () => {
-    list({ title: "Sessions" })
-    expect(screen.getByText("Sessions")).toBeTruthy()
-    expect(screen.queryByLabelText(/Activity filter/)).toBeNull()
-  })
-
-  it("offers the supplied filters and reports a selection", () => {
-    const onFilterChange = vi.fn()
-    list({
-      filters: [
-        { value: "all", label: "All sessions" },
-        { value: "active", label: "Running now" },
-      ],
-      selectedFilter: "all",
-      onFilterChange,
-    })
-    const trigger = screen.getByLabelText("Activity filter, current view: All sessions")
-    // The menu opens from the keyboard; jsdom has no pointer capture for the
-    // pointer path the trigger prefers.
-    fireEvent.keyDown(trigger, { key: "Enter" })
-    fireEvent.click(screen.getByText("Running now"))
-    expect(onFilterChange).toHaveBeenCalledWith("active")
-  })
-
+describe("LocalActivityList — empty state", () => {
   it("explains an empty range and announces it once", () => {
     list({ entries: [] })
     expect(screen.getAllByText("No sessions in the last 7 days").length).toBe(2)

--- a/apps/desktop/src/components/activity/LocalActivityList.tsx
+++ b/apps/desktop/src/components/activity/LocalActivityList.tsx
@@ -2,16 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
-import {
-  Bot,
-  Check,
-  ChevronDown,
-  GitBranchPlus,
-  GitFork,
-  Settings2,
-  SquareTerminal,
-} from "lucide-react"
+import { Bot, GitBranchPlus, GitFork, SquareTerminal } from "lucide-react"
 import type { ReactNode } from "react"
 
 import { cn } from "../../lib/cn"
@@ -84,27 +75,11 @@ export interface LocalActivityEntry {
   timeLabel?: string | undefined
 }
 
-/** One option in the list's filter control. */
-interface LocalActivityFilter {
-  value: string
-  label: string
-}
-
 export interface LocalActivityListProps {
   /** Sessions to show. Ordering and grouping are this component's job. */
   entries: LocalActivityEntry[]
-  /** Header title, used when no filter control is shown. */
-  title?: string
-  /** Visible calendar-day window. Also drives the range label and empty copy. */
+  /** Visible calendar-day window. Also drives the empty copy. */
   days: number
-  /** Override the default "Last N days" range label. */
-  rangeLabel?: string
-  /** Open wherever the day range is configured. Omitted makes it plain text. */
-  onOpenSettings?: () => void
-  /** Filter options. Fewer than two renders the plain title instead. */
-  filters?: readonly LocalActivityFilter[]
-  selectedFilter?: string
-  onFilterChange?: (value: string) => void
   /** Headline for the empty state; defaults to the range-aware wording. */
   emptyTitle?: string
   emptyDescription?: string
@@ -130,110 +105,6 @@ function primaryLine(entry: LocalActivityEntry): string {
   if (title) return title
   if (entry.sessionId) return `Session ${entry.sessionId.slice(0, 7)}`
   return agentDisplayName(entry.agent)
-}
-
-function rangeText(days: number): string {
-  return `Last ${days} ${days === 1 ? "day" : "days"}`
-}
-
-function ActivityHeader({
-  title,
-  days,
-  rangeLabel,
-  filters,
-  selectedFilter,
-  onFilterChange,
-  onOpenSettings,
-}: {
-  title: string
-  days: number
-  rangeLabel?: string
-  filters?: readonly LocalActivityFilter[]
-  selectedFilter?: string
-  onFilterChange?: (value: string) => void
-  onOpenSettings?: () => void
-}) {
-  const showFilter = !!filters && filters.length > 1 && !!onFilterChange
-  const currentLabel =
-    filters?.find((option) => option.value === selectedFilter)?.label ?? title
-  const range = rangeLabel ?? rangeText(days)
-
-  return (
-    <div className="flex h-6 items-center gap-3 px-4 whitespace-nowrap">
-      {showFilter ? (
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <button
-              type="button"
-              aria-label={`Activity filter, current view: ${currentLabel}`}
-              className="group -ml-1.5 inline-flex h-6 shrink-0 items-center gap-1 rounded-control px-1.5 type-body font-medium text-label hover:bg-surface-hover"
-            >
-              <span>{currentLabel}</span>
-              <ChevronDown
-                size={12}
-                strokeWidth={2.5}
-                aria-hidden="true"
-                className="shrink-0 text-label-tertiary transition-transform duration-[120ms] ease-out group-data-[state=open]:rotate-180"
-              />
-            </button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              className="ui-menu"
-              side="bottom"
-              align="start"
-              sideOffset={4}
-            >
-              <DropdownMenu.RadioGroup
-                value={selectedFilter ?? ""}
-                onValueChange={(value) => onFilterChange?.(value)}
-              >
-                {filters.map((option) => (
-                  <DropdownMenu.RadioItem
-                    key={option.value}
-                    value={option.value}
-                    className="ui-menu-item"
-                  >
-                    <span className="inline-flex w-3.5 shrink-0 justify-center">
-                      <DropdownMenu.ItemIndicator>
-                        <Check size={12} strokeWidth={2.5} aria-hidden="true" />
-                      </DropdownMenu.ItemIndicator>
-                    </span>
-                    <span>{option.label}</span>
-                  </DropdownMenu.RadioItem>
-                ))}
-              </DropdownMenu.RadioGroup>
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-      ) : (
-        <p className="shrink-0 type-body font-medium text-label">{currentLabel}</p>
-      )}
-
-      {onOpenSettings ? (
-        <button
-          type="button"
-          aria-label={`Recent activity range: ${range}. Change in settings`}
-          onClick={onOpenSettings}
-          className="group -mr-1.5 ml-auto inline-flex h-6 shrink-0 items-center gap-1 rounded-control px-1.5 type-footnote text-label-secondary hover:bg-surface-hover"
-        >
-          <span className="inline-flex w-3.5 shrink-0 justify-center">
-            <Settings2
-              size={12}
-              strokeWidth={2}
-              aria-hidden="true"
-              className="shrink-0 opacity-0 transition-opacity duration-[120ms] ease-out group-hover:opacity-100 group-focus-visible:opacity-100"
-            />
-          </span>
-          <span>{range}</span>
-        </button>
-      ) : (
-        <span className="-mr-1.5 ml-auto shrink-0 px-1.5 type-footnote text-label-secondary">
-          {range}
-        </span>
-      )}
-    </div>
-  )
 }
 
 function EmptyActivity({ title, description }: { title: string; description: string }) {
@@ -431,19 +302,13 @@ function SessionActivityRow({
 /**
  * A scrolling list of local coding sessions, bucketed by calendar day.
  *
- * Entirely prop-driven: entries, titles, the visible range, the filter set, and
- * every action arrive from the host. The list owns ordering, day grouping, the
- * sticky day label, and the row treatment — and nothing else.
+ * Entirely prop-driven: entries, the visible range, and every action arrive
+ * from the host. The list owns ordering, day grouping, the sticky day label,
+ * and the row treatment — and nothing else.
  */
 export function LocalActivityList({
   entries,
-  title = "Activity",
   days,
-  rangeLabel,
-  onOpenSettings,
-  filters,
-  selectedFilter,
-  onFilterChange,
   emptyTitle,
   emptyDescription = "Coding sessions appear here as they are discovered on this machine.",
   onOpenSession,
@@ -476,86 +341,70 @@ export function LocalActivityList({
     emptyTitle ?? (days === 1 ? "No sessions today" : `No sessions in the last ${days} days`)
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="pt-3 pb-2">
-        <ActivityHeader
-          title={title}
-          days={days}
-          {...(rangeLabel ? { rangeLabel } : {})}
-          {...(filters ? { filters } : {})}
-          {...(selectedFilter ? { selectedFilter } : {})}
-          {...(onFilterChange ? { onFilterChange } : {})}
-          {...(onOpenSettings ? { onOpenSettings } : {})}
-        />
-      </div>
+    <section aria-label="Activity feed" className="flex h-full min-h-0 flex-col pt-2">
+      {/* One live-region announcement for the whole list, rather than a
+          placeholder per row. */}
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {visibleCount === 0 ? resolvedEmptyTitle : ""}
+      </span>
 
-      <section aria-label="Activity feed" className="flex min-h-0 flex-1 flex-col">
-        {/* One live-region announcement for the whole list, rather than a
-            placeholder per row. */}
-        <span className="sr-only" aria-live="polite" aria-atomic="true">
-          {visibleCount === 0 ? resolvedEmptyTitle : ""}
-        </span>
+      {pinnedLabel && (
+        <div
+          data-testid="activity-pinned-group-label"
+          aria-hidden="true"
+          className="shrink-0 px-4 pb-1 type-caption font-medium tracking-wide uppercase text-label-tertiary"
+        >
+          {pinnedLabel}
+        </div>
+      )}
 
-        {pinnedLabel && (
-          <div
-            data-testid="activity-pinned-group-label"
-            aria-hidden="true"
-            className="shrink-0 px-4 pb-1 type-caption font-medium tracking-wide uppercase text-label-tertiary"
-          >
-            {pinnedLabel}
+      <ScrollPane
+        topEdgeFade
+        viewportRef={assignViewportRef}
+        viewportClassName={cn("px-2", visibleCount === 0 && "[&>div]:h-full")}
+      >
+        {visibleCount === 0 ? (
+          <EmptyActivity title={resolvedEmptyTitle} description={emptyDescription} />
+        ) : (
+          <div className="space-y-3 pb-3">
+            {groups.map((group, groupIndex) => {
+              const headingId = `activity-${group.label.replaceAll(" ", "-").toLowerCase()}`
+              return (
+                <section key={group.label} aria-labelledby={headingId}>
+                  <h3
+                    ref={registerHeading(group.label)}
+                    id={headingId}
+                    // The first day's heading is duplicated by the sticky
+                    // label above the viewport, so it is announced but not
+                    // painted twice.
+                    className={
+                      groupIndex === 0
+                        ? "sr-only"
+                        : "px-2 pb-1 type-caption font-medium tracking-wide uppercase text-label-tertiary"
+                    }
+                  >
+                    {group.label}
+                  </h3>
+                  <div className="space-y-1">
+                    {group.items.map((item) => (
+                      <SessionActivityRow
+                        key={item.key}
+                        entry={item.entry}
+                        {...(onOpenSession ? { onOpen: () => onOpenSession(item.entry) } : {})}
+                        {...(onOpenOrchestration
+                          ? { onOpenOrchestration: () => onOpenOrchestration(item.entry) }
+                          : {})}
+                        {...(renderAgentIcon ? { renderAgentIcon } : {})}
+                        {...(wslIcon ? { wslIcon } : {})}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )
+            })}
           </div>
         )}
-
-        <ScrollPane
-          topEdgeFade
-          viewportRef={assignViewportRef}
-          viewportClassName={cn("px-2", visibleCount === 0 && "[&>div]:h-full")}
-        >
-          {visibleCount === 0 ? (
-            <EmptyActivity title={resolvedEmptyTitle} description={emptyDescription} />
-          ) : (
-            <div className="space-y-3 pb-3">
-              {groups.map((group, groupIndex) => {
-                const headingId = `activity-${group.label.replaceAll(" ", "-").toLowerCase()}`
-                return (
-                  <section key={group.label} aria-labelledby={headingId}>
-                    <h3
-                      ref={registerHeading(group.label)}
-                      id={headingId}
-                      // The first day's heading is duplicated by the sticky
-                      // label above the viewport, so it is announced but not
-                      // painted twice.
-                      className={
-                        groupIndex === 0
-                          ? "sr-only"
-                          : "px-2 pb-1 type-caption font-medium tracking-wide uppercase text-label-tertiary"
-                      }
-                    >
-                      {group.label}
-                    </h3>
-                    <div className="space-y-1">
-                      {group.items.map((item) => (
-                        <SessionActivityRow
-                          key={item.key}
-                          entry={item.entry}
-                          {...(onOpenSession
-                            ? { onOpen: () => onOpenSession(item.entry) }
-                            : {})}
-                          {...(onOpenOrchestration
-                            ? { onOpenOrchestration: () => onOpenOrchestration(item.entry) }
-                            : {})}
-                          {...(renderAgentIcon ? { renderAgentIcon } : {})}
-                          {...(wslIcon ? { wslIcon } : {})}
-                        />
-                      ))}
-                    </div>
-                  </section>
-                )
-              })}
-            </div>
-          )}
-        </ScrollPane>
-      </section>
-    </div>
+      </ScrollPane>
+    </section>
   )
 }

--- a/apps/desktop/src/components/providerUsage/LiveUsageWindowRows.tsx
+++ b/apps/desktop/src/components/providerUsage/LiveUsageWindowRows.tsx
@@ -51,7 +51,7 @@ export function LiveUsageWindowRows({
             <div className="flex items-baseline justify-between gap-x-2">
               <span className="type-footnote text-label-secondary">
                 {liveWindowLabel(window)}
-                <span className="hidden group-hover:inline">
+                <span className="hidden group-hover:inline text-label-tertiary">
                   {" "}
                   ({liveResetLabel(window, now)})
                 </span>

--- a/apps/desktop/src/components/providerUsage/ProviderUsageChips.test.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageChips.test.tsx
@@ -51,17 +51,18 @@ function ranked(count: number): ProviderUsagePayload[] {
 }
 
 describe("ProviderUsageChips", () => {
-  it("shows a chip per provider used today, with the figure in its name", () => {
+  it("shows a chip per provider used today, glyph-only where the provider stated no live limit", () => {
     render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
 
-    // The chip renders a glyph and a number; everything a reader needs to know
-    // about what that number *is* has to be in the accessible name.
-    expect(
-      screen.getByRole("button", { name: "Anthropic, $1.25 today, estimated" }),
-    ).toBeInTheDocument()
+    // No live summary was given, so there is nothing to read a percentage
+    // from — and no dollar figure either, since that number has no
+    // denominator to sit beside a ring's percentage meaningfully.
+    const chip = screen.getByRole("button", { name: "Anthropic, estimated" })
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveTextContent("")
   })
 
-  it("shows a token count when the provider could not be priced", () => {
+  it("still shows the chip for a provider that could not be priced", () => {
     const window = usageWindow({ tokensIn: 12_000, sessionCount: 2 })
     render(
       <ProviderUsageChips
@@ -75,9 +76,7 @@ describe("ProviderUsageChips", () => {
       />,
     )
 
-    expect(
-      screen.getByRole("button", { name: "Anthropic, 12.0k today, observed" }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Anthropic, observed" })).toBeInTheDocument()
   })
 
   it("carries staleness into the chip name rather than only into a color", () => {
@@ -95,7 +94,7 @@ describe("ProviderUsageChips", () => {
 
     expect(
       screen.getByRole("button", {
-        name: /anthropic, \$1\.25 today, estimated, last used 2d ago/i,
+        name: /anthropic, estimated, last used 2d ago/i,
       }),
     ).toBeInTheDocument()
   })
@@ -223,7 +222,7 @@ describe("ProviderUsageChips", () => {
     // to an unknown branch the day a reviewed passive source does.
     render(<ProviderUsageChips providers={[provider({ state: "live" })]} onViewAll={vi.fn()} />)
 
-    fireEvent.click(screen.getByRole("button", { name: /anthropic, \$1\.25 today, live/i }))
+    fireEvent.click(screen.getByRole("button", { name: /anthropic, live/i }))
     expect(screen.getByText("Live")).toBeInTheDocument()
     expect(screen.getByText(/reported this usage directly/i)).toBeInTheDocument()
   })
@@ -348,6 +347,51 @@ describe("ProviderUsageChips — the limit ring", () => {
     expect(panel).toHaveTextContent("88%")
     // And the spend half is still there, below it.
     expect(panel).toHaveTextContent("Last 7 days")
+  })
+})
+
+describe("ProviderUsageChips — chip value", () => {
+  it("shows every live window's percentage, joined, in place of the dollar figure", () => {
+    render(
+      <ProviderUsageChips
+        providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
+        live={liveSummary(19)}
+        onViewAll={vi.fn()}
+      />,
+    )
+
+    // five-hour 12%, weekly (seven-day) 19% — in `liveWindows` order, not the
+    // dollar spend the provider prop carries.
+    expect(screen.getByRole("button", { name: /^Anthropic,/ })).toHaveTextContent("12% / 19%")
+  })
+
+  it("names each window's percentage in the accessible name, and drops the dollar clause", () => {
+    render(
+      <ProviderUsageChips
+        providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
+        live={liveSummary(19)}
+        onViewAll={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: "Anthropic, estimated, 5-hour limit 12%, weekly limit 19%",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows the glyph alone, with no value text, for a provider with no live windows", () => {
+    render(
+      <ProviderUsageChips
+        providers={[provider({ provider: "openai", displayName: "OpenAI" })]}
+        live={liveSummary(19)}
+        onViewAll={vi.fn()}
+      />,
+    )
+
+    const chip = screen.getByRole("button", { name: "OpenAI, estimated" })
+    expect(chip).toHaveTextContent("")
   })
 })
 

--- a/apps/desktop/src/components/providerUsage/ProviderUsageChips.test.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageChips.test.tsx
@@ -6,7 +6,9 @@ import { act, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type {
+  LiveProviderUsagePayload,
   LiveUsageSummaryPayload,
+  LiveUsageWindowPayload,
   ProviderUsagePayload,
   ProviderUsageWindowPayload,
 } from "../../lib/ipc"
@@ -38,31 +40,94 @@ function provider(overrides: Partial<ProviderUsagePayload> = {}): ProviderUsageP
   }
 }
 
-/** Providers ranked below the first, so the overflow affordance appears. */
-function ranked(count: number): ProviderUsagePayload[] {
-  return Array.from({ length: count }, (_, index) => {
-    const window = usageWindow({ estimatedUsd: count - index, sessionCount: 1 })
-    return provider({
+const FORECAST = {
+  unavailableReason: "sparseHistory",
+  confidence: null,
+  consumptionRate: null,
+  paceRatio: null,
+  paceTrend: null,
+  runwayAt: null,
+  usedToday: null,
+}
+
+function liveWindow(overrides: Partial<LiveUsageWindowPayload> = {}): LiveUsageWindowPayload {
+  return {
+    id: "seven-day",
+    role: "primaryLong",
+    kind: "weekly",
+    scopeModel: null,
+    usedPercent: 42,
+    startsAt: null,
+    resetsAt: null,
+    hasNonzeroUsageInCurrentPeriod: false,
+    forecast: FORECAST,
+    ...overrides,
+  }
+}
+
+function liveProvider(
+  overrides: Partial<LiveProviderUsagePayload> = {},
+): LiveProviderUsagePayload {
+  return {
+    provider: "anthropic",
+    displayName: "Anthropic",
+    support: "live",
+    freshness: "fresh",
+    sourceLabel: "Asked Claude directly",
+    observedAt: new Date().toISOString(),
+    windows: [liveWindow()],
+    extraUsage: null,
+    ...overrides,
+  }
+}
+
+function liveSummary(
+  providers: readonly LiveProviderUsagePayload[] = [liveProvider()],
+): LiveUsageSummaryPayload {
+  return { providers: [...providers], errors: [], generatedAt: new Date().toISOString() }
+}
+
+/** Live providers ranked below the first, so the overflow affordance appears. */
+function rankedLive(count: number): LiveProviderUsagePayload[] {
+  return Array.from({ length: count }, (_, index) =>
+    liveProvider({
       provider: `p${index}`,
       displayName: `Provider ${index}`,
-      windows: { today: window, week: window, month: window },
-    })
-  })
+      windows: [liveWindow({ usedPercent: count - index })],
+    }),
+  )
 }
 
 describe("ProviderUsageChips", () => {
-  it("shows a chip per provider used today, glyph-only where the provider stated no live limit", () => {
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
+  it("shows a chip from a live reading alone, even when nothing was spent today", () => {
+    // The bug this fixes: a fresh day with no local spend used to fall
+    // through to the empty-row fallback, even though the provider's own
+    // limits were sitting right there in `live`.
+    render(
+      <ProviderUsageChips
+        providers={[]}
+        live={liveSummary([liveProvider({ displayName: "Claude" })])}
+        onViewAll={vi.fn()}
+      />,
+    )
 
-    // No live summary was given, so there is nothing to read a percentage
-    // from — and no dollar figure either, since that number has no
-    // denominator to sit beside a ring's percentage meaningfully.
-    const chip = screen.getByRole("button", { name: "Anthropic, estimated" })
-    expect(chip).toBeInTheDocument()
-    expect(chip).toHaveTextContent("")
+    expect(screen.getByRole("button", { name: /^Claude,/ })).toBeInTheDocument()
+    expect(screen.queryByText("No live limits")).not.toBeInTheDocument()
   })
 
-  it("still shows the chip for a provider that could not be priced", () => {
+  it("drops the local-state clause when the provider has no local spend to describe", () => {
+    render(
+      <ProviderUsageChips
+        providers={[]}
+        live={liveSummary([liveProvider({ displayName: "Claude" })])}
+        onViewAll={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: "Claude, weekly limit 42%" })).toBeInTheDocument()
+  })
+
+  it("carries the local state into the chip name when local spend exists alongside the live reading", () => {
     const window = usageWindow({ tokensIn: 12_000, sessionCount: 2 })
     render(
       <ProviderUsageChips
@@ -72,11 +137,14 @@ describe("ProviderUsageChips", () => {
             windows: { today: window, week: window, month: window },
           }),
         ]}
+        live={liveSummary()}
         onViewAll={vi.fn()}
       />,
     )
 
-    expect(screen.getByRole("button", { name: "Anthropic, observed" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Anthropic, observed, weekly limit 42%" }),
+    ).toBeInTheDocument()
   })
 
   it("carries staleness into the chip name rather than only into a color", () => {
@@ -88,34 +156,36 @@ describe("ProviderUsageChips", () => {
             lastActivityAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
           }),
         ]}
+        live={liveSummary()}
         onViewAll={vi.fn()}
       />,
     )
 
     expect(
       screen.getByRole("button", {
-        name: /anthropic, estimated, last used 2d ago/i,
+        name: /anthropic, estimated, weekly limit 42%, last used 2d ago/i,
       }),
     ).toBeInTheDocument()
   })
 
-  it("says so honestly when nothing was used today", () => {
-    const idle = provider({
-      windows: {
-        today: usageWindow(),
-        week: usageWindow({ tokensIn: 5 }),
-        month: usageWindow(),
-      },
-    })
-    render(<ProviderUsageChips providers={[idle]} onViewAll={vi.fn()} />)
+  it("says so honestly when no provider has a live limit", () => {
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
 
-    expect(screen.getByText("No provider usage today")).toBeInTheDocument()
+    // Local spend alone no longer earns a chip — see the selection doc.
+    expect(screen.getByText("No live limits")).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /anthropic/i })).not.toBeInTheDocument()
   })
 
   it("collapses everything past the chip budget into one overflow affordance", () => {
     const onViewAll = vi.fn()
-    render(<ProviderUsageChips providers={ranked(5)} onViewAll={onViewAll} maxVisible={3} />)
+    render(
+      <ProviderUsageChips
+        providers={[]}
+        live={liveSummary(rankedLive(5))}
+        onViewAll={onViewAll}
+        maxVisible={3}
+      />,
+    )
 
     expect(screen.getAllByRole("button", { name: /^Provider \d/ })).toHaveLength(3)
     const overflow = screen.getByRole("button", { name: "Show 2 more providers" })
@@ -124,7 +194,9 @@ describe("ProviderUsageChips", () => {
   })
 
   it("opens a provider panel on click and closes it on a second click", () => {
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
+    render(
+      <ProviderUsageChips providers={[provider()]} live={liveSummary()} onViewAll={vi.fn()} />,
+    )
     const chip = screen.getByRole("button", { name: /anthropic/i })
 
     expect(chip).toHaveAttribute("aria-expanded", "false")
@@ -141,8 +213,28 @@ describe("ProviderUsageChips", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
+  it("opens a panel with only the live limits, and no spend section, for a live-only provider", () => {
+    render(
+      <ProviderUsageChips
+        providers={[]}
+        live={liveSummary([liveProvider({ displayName: "Claude" })])}
+        onViewAll={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /^Claude,/ }))
+    const panel = screen.getByRole("dialog")
+    expect(panel).toHaveTextContent("Plan limits")
+    // Nothing was ever run through this provider on this device, so the
+    // panel has no spend half to show — not even a zeroed one.
+    expect(panel).not.toHaveTextContent("Tokens · this month")
+    expect(panel).not.toHaveTextContent("Spend trend")
+  })
+
   it("closes the panel on Escape and on a press outside it", () => {
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
+    render(
+      <ProviderUsageChips providers={[provider()]} live={liveSummary()} onViewAll={vi.fn()} />,
+    )
     const chip = screen.getByRole("button", { name: /anthropic/i })
 
     fireEvent.click(chip)
@@ -157,7 +249,13 @@ describe("ProviderUsageChips", () => {
 
   it("leads to the full view from the panel", () => {
     const onViewAll = vi.fn()
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={onViewAll} />)
+    render(
+      <ProviderUsageChips
+        providers={[provider()]}
+        live={liveSummary()}
+        onViewAll={onViewAll}
+      />,
+    )
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
     fireEvent.click(screen.getByRole("button", { name: "All provider usage" }))
@@ -167,7 +265,9 @@ describe("ProviderUsageChips", () => {
   })
 
   it("moves focus into the panel it opens", () => {
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
+    render(
+      <ProviderUsageChips providers={[provider()]} live={liveSummary()} onViewAll={vi.fn()} />,
+    )
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
 
@@ -179,7 +279,9 @@ describe("ProviderUsageChips", () => {
   })
 
   it("holds Tab inside the panel while it is open", () => {
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
+    render(
+      <ProviderUsageChips providers={[provider()]} live={liveSummary()} onViewAll={vi.fn()} />,
+    )
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
     const panel = screen.getByRole("dialog")
@@ -196,7 +298,9 @@ describe("ProviderUsageChips", () => {
   })
 
   it("returns focus to the chip that opened the panel", () => {
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
+    render(
+      <ProviderUsageChips providers={[provider()]} live={liveSummary()} onViewAll={vi.fn()} />,
+    )
     const chip = screen.getByRole("button", { name: /anthropic/i })
 
     fireEvent.click(chip)
@@ -208,7 +312,9 @@ describe("ProviderUsageChips", () => {
   })
 
   it("claims Escape so a host does not also act on it", () => {
-    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
+    render(
+      <ProviderUsageChips providers={[provider()]} live={liveSummary()} onViewAll={vi.fn()} />,
+    )
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
     // `fireEvent` returns false when a handler called `preventDefault`, which
@@ -218,9 +324,16 @@ describe("ProviderUsageChips", () => {
   })
 
   it("renders a reserved state correctly if one ever arrives", () => {
-    // v1 never emits `live`, but the contract says a view must not fall through
-    // to an unknown branch the day a reviewed passive source does.
-    render(<ProviderUsageChips providers={[provider({ state: "live" })]} onViewAll={vi.fn()} />)
+    // v1 never emits `live` on the spend side, but the contract says a view
+    // must not fall through to an unknown branch the day a reviewed passive
+    // source does.
+    render(
+      <ProviderUsageChips
+        providers={[provider({ state: "live" })]}
+        live={liveSummary()}
+        onViewAll={vi.fn()}
+      />,
+    )
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic, live/i }))
     expect(screen.getByText("Live")).toBeInTheDocument()
@@ -229,114 +342,93 @@ describe("ProviderUsageChips", () => {
 
   it("anchors the panel above the row by default, and below it when asked", () => {
     const { container, rerender } = render(
-      <ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />,
+      <ProviderUsageChips providers={[provider()]} live={liveSummary()} onViewAll={vi.fn()} />,
     )
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
     expect(container.querySelector('[role="dialog"]')).toHaveClass("bottom-full")
 
     rerender(
-      <ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} panelAnchor="down" />,
+      <ProviderUsageChips
+        providers={[provider()]}
+        live={liveSummary()}
+        onViewAll={vi.fn()}
+        panelAnchor="down"
+      />,
     )
     expect(container.querySelector('[role="dialog"]')).toHaveClass("top-full")
   })
 })
 
 /* -------------------------------------------------------------------------
- * The ring: shown only where a provider stated a percentage
+ * The ring: shown only where a live window stated a percentage, and always
+ * the fullest one rather than the account-wide window.
  * ---------------------------------------------------------------------- */
 
-function liveSummary(usedPercent: number | null = 88): LiveUsageSummaryPayload {
-  const forecast = {
-    unavailableReason: "sparseHistory",
-    confidence: null,
-    consumptionRate: null,
-    paceRatio: null,
-    paceTrend: null,
-    runwayAt: null,
-    usedToday: null,
-  }
-  return {
-    providers: [
-      {
-        provider: "anthropic",
-        displayName: "Anthropic",
-        support: "live",
-        freshness: "fresh",
-        sourceLabel: "Asked Claude directly",
-        observedAt: new Date().toISOString(),
-        windows: [
-          {
-            id: "five-hour",
-            role: "primaryShort",
-            kind: "rolling",
-            scopeModel: null,
-            usedPercent: 12,
-            startsAt: null,
-            resetsAt: null,
-            hasNonzeroUsageInCurrentPeriod: false,
-            forecast,
-          },
-          {
-            id: "seven-day",
-            role: "primaryLong",
-            kind: "weekly",
-            scopeModel: null,
-            usedPercent,
-            startsAt: null,
-            resetsAt: null,
-            hasNonzeroUsageInCurrentPeriod: false,
-            forecast,
-          },
-        ],
-        extraUsage: null,
-      },
-    ],
-    errors: [],
-    generatedAt: new Date().toISOString(),
-  }
-}
-
 describe("ProviderUsageChips — the limit ring", () => {
-  it("replaces the glyph with a ring at the account-wide window", () => {
-    // Not the shortest and not the fullest: a single ring has to answer "how
-    // am I doing", which only the account-wide window answers.
+  it("shows the fullest live window's percentage, not the account-wide one", () => {
+    // The case that matters: a model-scoped weekly at 95% beside an account
+    // weekly at 69%. The ring answers "how worried should I be", and the
+    // per-model limit is exactly as worth a glance as the account-wide one.
     const { container } = render(
       <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
-        live={liveSummary(88)}
+        live={liveSummary([
+          liveProvider({
+            windows: [
+              liveWindow({ id: "five-hour", role: "primaryShort", usedPercent: 14 }),
+              liveWindow({
+                id: "seven-day",
+                role: "primaryLong",
+                kind: "weekly",
+                usedPercent: 69,
+              }),
+              liveWindow({
+                id: "weekly-fable",
+                role: "supplemental",
+                kind: "weekly",
+                scopeModel: "Fable",
+                usedPercent: 95,
+              }),
+            ],
+          }),
+        ])}
         onViewAll={vi.fn()}
       />,
     )
 
-    expect(container.querySelector('[data-testid="usage-ring-arc"]')).not.toBeNull()
-    // The ring carries the provider's identity rather than replacing it — the
-    // brand mark where one exists, so the chip still says whose limit it is.
+    const arc = container.querySelector('[data-testid="usage-ring-arc"]')
+    expect(arc).not.toBeNull()
     expect(container.querySelector('[data-testid="usage-ring-mark"]')).not.toBeNull()
+    const circumference = 2 * Math.PI * 13
+    expect(Number(arc?.getAttribute("stroke-dashoffset"))).toBeCloseTo(
+      circumference * (1 - 95 / 100),
+      5,
+    )
     // The ring is a shape with no text, so the figure has to reach the
     // accessible name or a screen-reader user simply does not get it.
     expect(
-      screen.getByRole("button", { name: /anthropic.*weekly limit 88%/i }),
+      screen.getByRole("button", { name: /anthropic.*fable weekly limit 95%/i }),
     ).toBeInTheDocument()
   })
 
-  it("keeps the glyph, and says nothing extra, where no limit was stated", () => {
+  it("keeps the glyph, with no ring, where a live window carries no percentage", () => {
     const { container } = render(
       <ProviderUsageChips
-        providers={[provider({ provider: "openai", displayName: "OpenAI" })]}
-        live={liveSummary(88)}
+        providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
+        live={liveSummary([liveProvider({ windows: [liveWindow({ usedPercent: null })] })])}
         onViewAll={vi.fn()}
       />,
     )
 
     expect(container.querySelector('[data-testid="usage-ring-arc"]')).toBeNull()
-    expect(screen.getByRole("button", { name: /^OpenAI,/ })).not.toHaveAccessibleName(/limit/i)
+    expect(screen.getByRole("button", { name: /^Anthropic,/ })).not.toHaveAccessibleName(/\d%/)
   })
 
   it("shows the plan limits inside the panel the chip opens", () => {
     render(
       <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
-        live={liveSummary(88)}
+        live={liveSummary([liveProvider({ windows: [liveWindow({ usedPercent: 88 })] })])}
         onViewAll={vi.fn()}
       />,
     )
@@ -345,7 +437,8 @@ describe("ProviderUsageChips — the limit ring", () => {
     const panel = screen.getByRole("dialog")
     expect(panel).toHaveTextContent("Plan limits")
     expect(panel).toHaveTextContent("88%")
-    // And the spend half is still there, below it.
+    // And the spend half is still there, below it, since this provider does
+    // have local spend to show.
     expect(panel).toHaveTextContent("Last 7 days")
   })
 })
@@ -355,7 +448,19 @@ describe("ProviderUsageChips — chip value", () => {
     render(
       <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
-        live={liveSummary(19)}
+        live={liveSummary([
+          liveProvider({
+            windows: [
+              liveWindow({ id: "five-hour", role: "primaryShort", usedPercent: 12 }),
+              liveWindow({
+                id: "seven-day",
+                role: "primaryLong",
+                kind: "weekly",
+                usedPercent: 19,
+              }),
+            ],
+          }),
+        ])}
         onViewAll={vi.fn()}
       />,
     )
@@ -369,7 +474,19 @@ describe("ProviderUsageChips — chip value", () => {
     render(
       <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
-        live={liveSummary(19)}
+        live={liveSummary([
+          liveProvider({
+            windows: [
+              liveWindow({ id: "five-hour", role: "primaryShort", usedPercent: 12 }),
+              liveWindow({
+                id: "seven-day",
+                role: "primaryLong",
+                kind: "weekly",
+                usedPercent: 19,
+              }),
+            ],
+          }),
+        ])}
         onViewAll={vi.fn()}
       />,
     )
@@ -380,19 +497,6 @@ describe("ProviderUsageChips — chip value", () => {
       }),
     ).toBeInTheDocument()
   })
-
-  it("shows the glyph alone, with no value text, for a provider with no live windows", () => {
-    render(
-      <ProviderUsageChips
-        providers={[provider({ provider: "openai", displayName: "OpenAI" })]}
-        live={liveSummary(19)}
-        onViewAll={vi.fn()}
-      />,
-    )
-
-    const chip = screen.getByRole("button", { name: "OpenAI, estimated" })
-    expect(chip).toHaveTextContent("")
-  })
 })
 
 describe("ProviderUsageChips — hover", () => {
@@ -402,7 +506,7 @@ describe("ProviderUsageChips — hover", () => {
     render(
       <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
-        live={liveSummary(88)}
+        live={liveSummary([liveProvider({ windows: [liveWindow({ usedPercent: 88 })] })])}
         onViewAll={vi.fn()}
       />,
     )

--- a/apps/desktop/src/components/providerUsage/ProviderUsageChips.test.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageChips.test.tsx
@@ -10,7 +10,7 @@ import type {
   ProviderUsagePayload,
   ProviderUsageWindowPayload,
 } from "../../lib/ipc"
-import { ProviderUsageCluster } from "./ProviderUsageCluster"
+import { ProviderUsageChips } from "./ProviderUsageChips"
 
 function usageWindow(
   overrides: Partial<ProviderUsageWindowPayload> = {},
@@ -50,15 +50,9 @@ function ranked(count: number): ProviderUsagePayload[] {
   })
 }
 
-describe("ProviderUsageCluster", () => {
+describe("ProviderUsageChips", () => {
   it("shows a chip per provider used today, with the figure in its name", () => {
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider()]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
 
     // The chip renders a glyph and a number; everything a reader needs to know
     // about what that number *is* has to be in the accessible name.
@@ -70,7 +64,7 @@ describe("ProviderUsageCluster", () => {
   it("shows a token count when the provider could not be priced", () => {
     const window = usageWindow({ tokensIn: 12_000, sessionCount: 2 })
     render(
-      <ProviderUsageCluster
+      <ProviderUsageChips
         providers={[
           provider({
             state: "observed",
@@ -78,7 +72,6 @@ describe("ProviderUsageCluster", () => {
           }),
         ]}
         onViewAll={vi.fn()}
-        onOpenSettings={vi.fn()}
       />,
     )
 
@@ -89,7 +82,7 @@ describe("ProviderUsageCluster", () => {
 
   it("carries staleness into the chip name rather than only into a color", () => {
     render(
-      <ProviderUsageCluster
+      <ProviderUsageChips
         providers={[
           provider({
             staleness: "stale",
@@ -97,7 +90,6 @@ describe("ProviderUsageCluster", () => {
           }),
         ]}
         onViewAll={vi.fn()}
-        onOpenSettings={vi.fn()}
       />,
     )
 
@@ -116,9 +108,7 @@ describe("ProviderUsageCluster", () => {
         month: usageWindow(),
       },
     })
-    render(
-      <ProviderUsageCluster onOpenSettings={vi.fn()} providers={[idle]} onViewAll={vi.fn()} />,
-    )
+    render(<ProviderUsageChips providers={[idle]} onViewAll={vi.fn()} />)
 
     expect(screen.getByText("No provider usage today")).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /anthropic/i })).not.toBeInTheDocument()
@@ -126,14 +116,7 @@ describe("ProviderUsageCluster", () => {
 
   it("collapses everything past the chip budget into one overflow affordance", () => {
     const onViewAll = vi.fn()
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={ranked(5)}
-        onViewAll={onViewAll}
-        maxVisible={3}
-      />,
-    )
+    render(<ProviderUsageChips providers={ranked(5)} onViewAll={onViewAll} maxVisible={3} />)
 
     expect(screen.getAllByRole("button", { name: /^Provider \d/ })).toHaveLength(3)
     const overflow = screen.getByRole("button", { name: "Show 2 more providers" })
@@ -142,13 +125,7 @@ describe("ProviderUsageCluster", () => {
   })
 
   it("opens a provider panel on click and closes it on a second click", () => {
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider()]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
     const chip = screen.getByRole("button", { name: /anthropic/i })
 
     expect(chip).toHaveAttribute("aria-expanded", "false")
@@ -166,13 +143,7 @@ describe("ProviderUsageCluster", () => {
   })
 
   it("closes the panel on Escape and on a press outside it", () => {
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider()]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
     const chip = screen.getByRole("button", { name: /anthropic/i })
 
     fireEvent.click(chip)
@@ -185,36 +156,19 @@ describe("ProviderUsageCluster", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
-  it("leads to the full view from the panel, and to settings from the gear", () => {
+  it("leads to the full view from the panel", () => {
     const onViewAll = vi.fn()
-    const onOpenSettings = vi.fn()
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={onOpenSettings}
-        providers={[provider()]}
-        onViewAll={onViewAll}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={onViewAll} />)
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
     fireEvent.click(screen.getByRole("button", { name: "All provider usage" }))
     expect(onViewAll).toHaveBeenCalledTimes(1)
     // Navigating away also dismisses the panel, so returning shows the list.
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole("button", { name: "Open settings" }))
-    expect(onOpenSettings).toHaveBeenCalledTimes(1)
-    expect(onViewAll).toHaveBeenCalledTimes(1)
   })
 
   it("moves focus into the panel it opens", () => {
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider()]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
 
@@ -226,20 +180,14 @@ describe("ProviderUsageCluster", () => {
   })
 
   it("holds Tab inside the panel while it is open", () => {
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider()]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
     const panel = screen.getByRole("dialog")
     const viewAll = screen.getByRole("button", { name: "All provider usage" })
 
     // Forwards from the last control wraps to the first rather than escaping
-    // into the footer behind the dialog.
+    // into the row behind the dialog.
     fireEvent.keyDown(document, { key: "Tab" })
     expect(panel.contains(document.activeElement)).toBe(true)
     expect(viewAll).toHaveFocus()
@@ -249,13 +197,7 @@ describe("ProviderUsageCluster", () => {
   })
 
   it("returns focus to the chip that opened the panel", () => {
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider()]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
     const chip = screen.getByRole("button", { name: /anthropic/i })
 
     fireEvent.click(chip)
@@ -267,13 +209,7 @@ describe("ProviderUsageCluster", () => {
   })
 
   it("claims Escape so a host does not also act on it", () => {
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider()]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />)
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
     // `fireEvent` returns false when a handler called `preventDefault`, which
@@ -285,17 +221,24 @@ describe("ProviderUsageCluster", () => {
   it("renders a reserved state correctly if one ever arrives", () => {
     // v1 never emits `live`, but the contract says a view must not fall through
     // to an unknown branch the day a reviewed passive source does.
-    render(
-      <ProviderUsageCluster
-        onOpenSettings={vi.fn()}
-        providers={[provider({ state: "live" })]}
-        onViewAll={vi.fn()}
-      />,
-    )
+    render(<ProviderUsageChips providers={[provider({ state: "live" })]} onViewAll={vi.fn()} />)
 
     fireEvent.click(screen.getByRole("button", { name: /anthropic, \$1\.25 today, live/i }))
     expect(screen.getByText("Live")).toBeInTheDocument()
     expect(screen.getByText(/reported this usage directly/i)).toBeInTheDocument()
+  })
+
+  it("anchors the panel above the row by default, and below it when asked", () => {
+    const { container, rerender } = render(
+      <ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /anthropic/i }))
+    expect(container.querySelector('[role="dialog"]')).toHaveClass("bottom-full")
+
+    rerender(
+      <ProviderUsageChips providers={[provider()]} onViewAll={vi.fn()} panelAnchor="down" />,
+    )
+    expect(container.querySelector('[role="dialog"]')).toHaveClass("top-full")
   })
 })
 
@@ -354,16 +297,15 @@ function liveSummary(usedPercent: number | null = 88): LiveUsageSummaryPayload {
   }
 }
 
-describe("ProviderUsageCluster — the limit ring", () => {
+describe("ProviderUsageChips — the limit ring", () => {
   it("replaces the glyph with a ring at the account-wide window", () => {
     // Not the shortest and not the fullest: a single ring has to answer "how
     // am I doing", which only the account-wide window answers.
     const { container } = render(
-      <ProviderUsageCluster
+      <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
         live={liveSummary(88)}
         onViewAll={vi.fn()}
-        onOpenSettings={vi.fn()}
       />,
     )
 
@@ -380,11 +322,10 @@ describe("ProviderUsageCluster — the limit ring", () => {
 
   it("keeps the glyph, and says nothing extra, where no limit was stated", () => {
     const { container } = render(
-      <ProviderUsageCluster
+      <ProviderUsageChips
         providers={[provider({ provider: "openai", displayName: "OpenAI" })]}
         live={liveSummary(88)}
         onViewAll={vi.fn()}
-        onOpenSettings={vi.fn()}
       />,
     )
 
@@ -394,11 +335,10 @@ describe("ProviderUsageCluster — the limit ring", () => {
 
   it("shows the plan limits inside the panel the chip opens", () => {
     render(
-      <ProviderUsageCluster
+      <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
         live={liveSummary(88)}
         onViewAll={vi.fn()}
-        onOpenSettings={vi.fn()}
       />,
     )
 
@@ -411,16 +351,15 @@ describe("ProviderUsageCluster — the limit ring", () => {
   })
 })
 
-describe("ProviderUsageCluster — hover", () => {
+describe("ProviderUsageChips — hover", () => {
   const chip = () => screen.getByRole("button", { name: /^Anthropic,/ })
 
-  function cluster() {
+  function chips() {
     render(
-      <ProviderUsageCluster
+      <ProviderUsageChips
         providers={[provider({ provider: "anthropic", displayName: "Anthropic" })]}
         live={liveSummary(88)}
         onViewAll={vi.fn()}
-        onOpenSettings={vi.fn()}
       />,
     )
   }
@@ -428,8 +367,8 @@ describe("ProviderUsageCluster — hover", () => {
   beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }))
   afterEach(() => vi.useRealTimers())
 
-  it("waits before opening, so a pointer crossing the footer lights nothing up", () => {
-    cluster()
+  it("waits before opening, so a pointer crossing the row lights nothing up", () => {
+    chips()
     fireEvent.pointerEnter(chip(), { pointerType: "mouse" })
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
 
@@ -440,7 +379,7 @@ describe("ProviderUsageCluster — hover", () => {
   it("does not claim to be modal, and does not steal focus, when hover opened it", () => {
     // Yanking focus out from under a pointer that merely passed over a chip is
     // hostile, and a modal nobody asked for is worse than a disclosure.
-    cluster()
+    chips()
     fireEvent.pointerEnter(chip(), { pointerType: "mouse" })
     act(() => void vi.advanceTimersByTime(200))
 
@@ -450,7 +389,7 @@ describe("ProviderUsageCluster — hover", () => {
   })
 
   it("survives the diagonal from the chip into the panel", () => {
-    cluster()
+    chips()
     fireEvent.pointerEnter(chip(), { pointerType: "mouse" })
     act(() => void vi.advanceTimersByTime(200))
 
@@ -463,7 +402,7 @@ describe("ProviderUsageCluster — hover", () => {
   })
 
   it("closes once the pointer leaves the panel too", () => {
-    cluster()
+    chips()
     fireEvent.pointerEnter(chip(), { pointerType: "mouse" })
     act(() => void vi.advanceTimersByTime(200))
 
@@ -474,7 +413,7 @@ describe("ProviderUsageCluster — hover", () => {
 
   it("keeps a deliberately opened panel open when the pointer wanders off", () => {
     // A click is a decision; a pointer moving away is not a retraction of it.
-    cluster()
+    chips()
     fireEvent.click(chip())
     expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true")
 
@@ -484,7 +423,7 @@ describe("ProviderUsageCluster — hover", () => {
   })
 
   it("ignores hover from a touch pointer, which fires one just before its tap", () => {
-    cluster()
+    chips()
     fireEvent.pointerEnter(chip(), { pointerType: "touch" })
     act(() => void vi.advanceTimersByTime(500))
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()

--- a/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
@@ -9,15 +9,13 @@ import { cn } from "../../lib/cn"
 import type { LiveUsageSummaryPayload, ProviderUsagePayload } from "../../lib/ipc"
 import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
 import {
-  headlineWindow,
-  liveForProvider,
   liveWindowLabel,
   liveWindows,
   liveWindowValueLabel,
+  maxLiveUsedPercent,
 } from "../../lib/presentation/liveUsage"
 import {
   providerInitial,
-  providersForWindow,
   stalenessNote,
   usageStateLabel,
 } from "../../lib/presentation/providerUsage"
@@ -32,6 +30,12 @@ import { UsageRing } from "./UsageRing"
 const DEFAULT_MAX_CHIPS = 3
 
 interface ProviderUsageChipsProps {
+  /**
+   * The reader's own local spend and sessions. No longer what selects which
+   * chips appear — see `live` below — but still what a chip's staleness note
+   * comes from, and what its panel shows beneath the provider's own limits,
+   * for a provider this device has actually run something through.
+   */
   providers: readonly ProviderUsagePayload[]
   /** The provider's own limit figures, when a source could prove any. */
   live?: LiveUsageSummaryPayload
@@ -58,13 +62,17 @@ interface ProviderUsageChipsProps {
 }
 
 /**
- * One compact chip per provider used today, an overflow count, and the way
- * through to the full Usage view.
+ * One compact chip per provider with a live limit reading, an overflow
+ * count, and the way through to the full Usage view.
  *
- * Chips are drawn from *today* only. A provider the reader has not touched
- * since yesterday is not shown a dash here — it is simply not in the row, and
- * the Usage view is where the wider windows live. That keeps the resting
- * state of the row a statement about right now.
+ * Chips are drawn from the *live* payload, not local spend: a chip shows a
+ * percentage now, so it is selected the same way the expanded section above
+ * it picks its subsections — any provider with at least one live window —
+ * and the two always agree on which providers appear. A provider with local
+ * spend but no live reading is not shown a dash here — it is simply not in
+ * the row, and the Usage view is where local-only providers live. A provider
+ * with a live reading but no local spend (nothing was ever run through it on
+ * this device) still gets a chip; its panel just has no spend half to show.
  *
  * Clicking a chip opens a panel anchored to this row. It is positioned by
  * this component rather than portalled, because the popover window is 380px of
@@ -164,10 +172,16 @@ export function ProviderUsageChips({
     }, HOVER_CLOSE_MS)
   }, [scheduleHover])
 
-  const today = providersForWindow(providers, "today")
-  const visible = today.slice(0, maxVisible)
-  const overflow = today.length - visible.length
+  // Same predicate the expanded section filters its subsections with, so
+  // collapsed and expanded never disagree about which providers are showing
+  // anything.
+  const limited = live.providers.filter((provider) => liveWindows(provider).length > 0)
+  const visible = limited.slice(0, maxVisible)
+  const overflow = limited.length - visible.length
   const open = visible.find((provider) => provider.provider === openProvider) ?? null
+  /** The reader's own local spend for one provider id, when there is any. */
+  const spendFor = (id: string) =>
+    providers.find((provider) => provider.provider === id) ?? null
 
   const close = useCallback(() => {
     cancelHover()
@@ -205,40 +219,40 @@ export function ProviderUsageChips({
       data-testid="provider-usage-chips"
       className={cn("relative flex min-w-0 items-center gap-1", className)}
     >
-      {visible.map((provider) => {
-        const stale = stalenessNote(provider)
-        const isOpen = open?.provider === provider.provider
-        // The ring is drawn only where the provider stated a percentage. The
-        // spend figure beside it has no denominator, so borrowing the shape
-        // for it would mean something here that it does not mean. Which window
-        // the ring shows is `headlineWindow`'s decision, and it is the
-        // account-wide one rather than the fullest — see its doc.
-        const limits = liveForProvider(live, provider.provider)
-        const windows = limits ? liveWindows(limits) : []
-        const headline = limits ? headlineWindow(limits) : null
+      {visible.map((limits) => {
+        // Every provider that reaches this row is selected *because* it has
+        // live windows — see `limited` above — but it may or may not have
+        // ever produced local spend on this device. Where it has, the
+        // staleness note and the panel's spend half both come from that.
+        const spend = spendFor(limits.provider)
+        const stale = spend ? stalenessNote(spend) : null
+        const isOpen = open?.provider === limits.provider
+        const windows = liveWindows(limits)
+        // The ring shows the fullest live window, not the account-wide one —
+        // see `maxLiveUsedPercent`'s doc for why a compact glance prefers the
+        // worst case over which window happens to be the account's own.
+        const maxPercent = maxLiveUsedPercent(limits)
         // A dollar figure here would be the local estimate, which has no
         // denominator to read against — showing it beside a ring drawn from
         // the provider's own percentage would imply a relationship that is
         // not there. So the chip shows only what the provider itself stated:
         // every live window's percentage, in the same order the panel lists
-        // them. A provider with no live windows shows no value text at all —
-        // the glyph alone, rather than falling back to a dollar figure the
-        // ring beside it does not agree with.
+        // them.
         const value = windows.map((window) => liveWindowValueLabel(window)).join(" / ")
         return (
           <button
-            key={provider.provider}
+            key={limits.provider}
             type="button"
             aria-haspopup="dialog"
             aria-expanded={isOpen}
             aria-controls={isOpen ? panelId : undefined}
-            // The chip shows a glyph and, where the provider stated any live
-            // windows, a number per window; the name, each window, and what
-            // kind of figure it is have to live in the accessible name or
-            // they are lost.
-            aria-label={`${provider.displayName}, ${usageStateLabel(
-              provider.state,
-            ).toLocaleLowerCase()}${windows
+            // The chip shows a glyph and a number per live window; the name,
+            // each window, and — where there is local spend to describe —
+            // what kind of figure it is, have to live in the accessible name
+            // or they are lost.
+            aria-label={`${limits.displayName}${
+              spend ? `, ${usageStateLabel(spend.state).toLocaleLowerCase()}` : ""
+            }${windows
               .map(
                 (window) =>
                   `, ${liveWindowLabel(window).toLocaleLowerCase()} ${liveWindowValueLabel(
@@ -251,7 +265,7 @@ export function ProviderUsageChips({
               // is about to fire; opening on it would make the tap a toggle
               // that opens and then closes.
               if (event.pointerType === "touch") return
-              hoverOpen(provider.provider)
+              hoverOpen(limits.provider)
             }}
             onPointerLeave={(event) => {
               if (event.pointerType === "touch") return
@@ -259,7 +273,7 @@ export function ProviderUsageChips({
             }}
             onClick={(event) => {
               cancelHover()
-              if (openProvider === provider.provider && openedBy === "pointer") {
+              if (openProvider === limits.provider && openedBy === "pointer") {
                 close()
                 return
               }
@@ -273,7 +287,7 @@ export function ProviderUsageChips({
               // an effect on it would re-steal focus each time.
               flushSync(() => {
                 setOpenedBy("pointer")
-                setOpenProvider(provider.provider)
+                setOpenProvider(limits.provider)
               })
               const target =
                 panelRef.current?.querySelector<HTMLElement>(FOCUSABLE) ?? panelRef.current
@@ -284,31 +298,31 @@ export function ProviderUsageChips({
               isOpen && "bg-surface-hover",
             )}
           >
-            {headline ? (
+            {maxPercent != null ? (
               // The ring carries the provider's initial rather than replacing
               // it: a chip that says how full something is without saying
               // whose is a worse trade than the ring is worth.
               <UsageRing
-                percent={headline.usedPercent}
-                mark={providerMark(provider.provider)}
-                glyph={providerInitial(provider.displayName)}
+                percent={maxPercent}
+                mark={providerMark(limits.provider)}
+                glyph={providerInitial(limits.displayName)}
                 size={22}
                 className="shrink-0 text-label-secondary"
               />
             ) : (
               <ProviderGlyph
-                displayName={provider.displayName}
-                provider={provider.provider}
+                displayName={limits.displayName}
+                provider={limits.provider}
                 size={18}
               />
             )}
-            {windows.length > 0 && <TextRoll text={value} />}
+            <TextRoll text={value} />
           </button>
         )
       })}
 
-      {today.length === 0 && (
-        <span className="type-caption text-label-tertiary">No provider usage today</span>
+      {limited.length === 0 && (
+        <span className="type-caption text-label-tertiary">No live limits</span>
       )}
 
       {overflow > 0 && (
@@ -349,8 +363,10 @@ export function ProviderUsageChips({
           )}
         >
           <ProviderUsageDetail
-            provider={open}
-            live={liveForProvider(live, open.provider)}
+            displayName={open.displayName}
+            providerId={open.provider}
+            provider={spendFor(open.provider)}
+            live={open}
             now={at}
             headingId={headingId}
             onViewAll={viewAll}

--- a/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
@@ -203,7 +203,7 @@ export function ProviderUsageChips({
   return (
     <div
       ref={rootRef}
-      data-testid="provider-usage-cluster"
+      data-testid="provider-usage-chips"
       className={cn("relative flex min-w-0 items-center gap-1", className)}
     >
       {visible.map((provider) => {

--- a/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
@@ -12,15 +12,14 @@ import {
   headlineWindow,
   liveForProvider,
   liveWindowLabel,
+  liveWindows,
   liveWindowValueLabel,
 } from "../../lib/presentation/liveUsage"
 import {
   providerInitial,
   providersForWindow,
-  providerWindow,
   stalenessNote,
   usageStateLabel,
-  usageValueLabel,
 } from "../../lib/presentation/providerUsage"
 import { useDialogDismissal } from "../../lib/useDialogDismissal"
 import { useHoverIntent } from "../../lib/useHoverIntent"
@@ -207,8 +206,6 @@ export function ProviderUsageChips({
       className={cn("relative flex min-w-0 items-center gap-1", className)}
     >
       {visible.map((provider) => {
-        const window = providerWindow(provider, "today")
-        const value = usageValueLabel(window)
         const stale = stalenessNote(provider)
         const isOpen = open?.provider === provider.provider
         // The ring is drawn only where the provider stated a percentage. The
@@ -217,7 +214,17 @@ export function ProviderUsageChips({
         // the ring shows is `headlineWindow`'s decision, and it is the
         // account-wide one rather than the fullest — see its doc.
         const limits = liveForProvider(live, provider.provider)
+        const windows = limits ? liveWindows(limits) : []
         const headline = limits ? headlineWindow(limits) : null
+        // A dollar figure here would be the local estimate, which has no
+        // denominator to read against — showing it beside a ring drawn from
+        // the provider's own percentage would imply a relationship that is
+        // not there. So the chip shows only what the provider itself stated:
+        // every live window's percentage, in the same order the panel lists
+        // them. A provider with no live windows shows no value text at all —
+        // the glyph alone, rather than falling back to a dollar figure the
+        // ring beside it does not agree with.
+        const value = windows.map((window) => liveWindowValueLabel(window)).join(" / ")
         return (
           <button
             key={provider.provider}
@@ -225,19 +232,20 @@ export function ProviderUsageChips({
             aria-haspopup="dialog"
             aria-expanded={isOpen}
             aria-controls={isOpen ? panelId : undefined}
-            // The chip shows a glyph and a number; the name, the window, and
-            // what kind of figure it is have to live in the accessible name or
-            // they are lost. The ring adds a second fact, so it adds a clause:
-            // a shape with no text is invisible to a screen reader.
-            aria-label={`${provider.displayName}, ${value} today, ${usageStateLabel(
+            // The chip shows a glyph and, where the provider stated any live
+            // windows, a number per window; the name, each window, and what
+            // kind of figure it is have to live in the accessible name or
+            // they are lost.
+            aria-label={`${provider.displayName}, ${usageStateLabel(
               provider.state,
-            ).toLocaleLowerCase()}${
-              headline
-                ? `, ${liveWindowLabel(headline).toLocaleLowerCase()} ${liveWindowValueLabel(
-                    headline,
-                  ).toLocaleLowerCase()}`
-                : ""
-            }${stale ? `, ${stale.toLocaleLowerCase()}` : ""}`}
+            ).toLocaleLowerCase()}${windows
+              .map(
+                (window) =>
+                  `, ${liveWindowLabel(window).toLocaleLowerCase()} ${liveWindowValueLabel(
+                    window,
+                  ).toLocaleLowerCase()}`,
+              )
+              .join("")}${stale ? `, ${stale.toLocaleLowerCase()}` : ""}`}
             onPointerEnter={(event) => {
               // Touch reports a pointer enter immediately before the click it
               // is about to fire; opening on it would make the tap a toggle
@@ -294,7 +302,7 @@ export function ProviderUsageChips({
                 size={18}
               />
             )}
-            <TextRoll text={value} />
+            {windows.length > 0 && <TextRoll text={value} />}
           </button>
         )
       })}

--- a/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageChips.tsx
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { Settings } from "lucide-react"
 import { useCallback, useId, useRef, useState } from "react"
 import { flushSync } from "react-dom"
 
@@ -33,7 +32,7 @@ import { UsageRing } from "./UsageRing"
 /** Chips shown before the rest collapse into a single overflow affordance. */
 const DEFAULT_MAX_CHIPS = 3
 
-interface ProviderUsageClusterProps {
+interface ProviderUsageChipsProps {
   providers: readonly ProviderUsagePayload[]
   /** The provider's own limit figures, when a source could prove any. */
   live?: LiveUsageSummaryPayload
@@ -45,30 +44,39 @@ interface ProviderUsageClusterProps {
   now?: number
   /** Open the full Usage view. */
   onViewAll: () => void
-  /** Open the standalone Settings window (the footer's right-hand gear). */
-  onOpenSettings: () => void
   maxVisible?: number
+  /**
+   * Which way the anchored detail panel opens. `"up"` sits the panel above
+   * the chip row — for a row that lives at the bottom of its container.
+   * `"down"` sits it below — for a row that lives at the top of one. There is
+   * no collision detection because there does not need to be one: the popover
+   * is a fixed 380px of chrome, so a caller near the bottom asks for `"up"`
+   * and a caller near the top asks for `"down"`, and that is the whole
+   * decision.
+   */
+  panelAnchor?: "up" | "down"
+  className?: string
 }
 
 /**
- * The popover's usage footer: one compact chip per provider used today, an
- * overflow count, and the way through to the full Usage view.
+ * One compact chip per provider used today, an overflow count, and the way
+ * through to the full Usage view.
  *
  * Chips are drawn from *today* only. A provider the reader has not touched
- * since yesterday is not shown a dash here — it is simply not in the footer,
- * and the Usage view is where the wider windows live. That keeps the resting
- * state of the popover a statement about right now.
+ * since yesterday is not shown a dash here — it is simply not in the row, and
+ * the Usage view is where the wider windows live. That keeps the resting
+ * state of the row a statement about right now.
  *
- * Clicking a chip opens a panel anchored above the footer. It is positioned by
+ * Clicking a chip opens a panel anchored to this row. It is positioned by
  * this component rather than portalled, because the popover window is 380px of
  * fixed chrome: a portalled surface would have nowhere to escape to, and a
- * collision-aware library would only be re-deriving "sit above the footer".
+ * collision-aware library would only be re-deriving "sit beside the row".
  *
  * There are two ways in, and they are not the same thing. **Hovering** a chip
  * opens the panel after a short delay and closes it a shorter one after the
- * pointer leaves — the delays exist so a pointer crossing the footer on its
- * way somewhere else does not strobe three panels, and so the diagonal from
- * chip to panel is forgiving. **Clicking or tabbing to** a chip opens the same
+ * pointer leaves — the delays exist so a pointer crossing the row on its way
+ * somewhere else does not strobe three panels, and so the diagonal from chip
+ * to panel is forgiving. **Clicking or tabbing to** a chip opens the same
  * panel deliberately, and it stays until dismissed.
  *
  * Only the deliberate path takes the obligations of a dialog: focus moves into
@@ -88,9 +96,10 @@ interface ProviderUsageClusterProps {
  * How long a pointer must rest on a chip before its panel opens, and how long
  * it may be away before the panel closes.
  *
- * Open is the longer of the two: a pointer crossing the footer on its way to
- * the gear should not light up three panels behind it. Close is shorter but
- * not zero, so the diagonal from a chip to the panel above it is forgiving.
+ * Open is the longer of the two: a pointer crossing the row on its way to
+ * somewhere else should not light up three panels behind it. Close is shorter
+ * but not zero, so the diagonal from a chip to the panel beside it is
+ * forgiving.
  */
 const HOVER_OPEN_MS = 200
 const HOVER_CLOSE_MS = 140
@@ -98,14 +107,16 @@ const HOVER_CLOSE_MS = 140
 /** Everything inside the panel a Tab can reach. */
 const FOCUSABLE =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-export function ProviderUsageCluster({
+
+export function ProviderUsageChips({
   providers,
   live = EMPTY_LIVE_USAGE,
   now,
   onViewAll,
-  onOpenSettings,
   maxVisible = DEFAULT_MAX_CHIPS,
-}: ProviderUsageClusterProps) {
+  panelAnchor = "up",
+  className = "",
+}: ProviderUsageChipsProps) {
   const at = now ?? (Date.parse(live.generatedAt) || 0)
   const [openProvider, setOpenProvider] = useState<string | null>(null)
   /**
@@ -172,8 +183,8 @@ export function ProviderUsageCluster({
   }, [cancelHover])
 
   // Dismissal is a genuine synchronization with the document: a pointer press
-  // anywhere outside the footer closes the panel, and Escape closes it from
-  // the keyboard. Both listeners exist only while a panel is open. Tab is
+  // anywhere outside the row closes the panel, and Escape closes it from the
+  // keyboard. Both listeners exist only while a panel is open. Tab is
   // additionally held inside the panel while it was opened on purpose.
   useDialogDismissal({
     active: !!open,
@@ -193,7 +204,7 @@ export function ProviderUsageCluster({
     <div
       ref={rootRef}
       data-testid="provider-usage-cluster"
-      className="relative flex h-11 shrink-0 items-center gap-1 border-t border-separator px-2"
+      className={cn("relative flex min-w-0 items-center gap-1", className)}
     >
       {visible.map((provider) => {
         const window = providerWindow(provider, "today")
@@ -303,15 +314,6 @@ export function ProviderUsageCluster({
         </button>
       )}
 
-      <button
-        type="button"
-        onClick={onOpenSettings}
-        aria-label="Open settings"
-        className="-mr-0.5 ml-auto inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-control text-label-secondary hover:bg-surface-hover"
-      >
-        <Settings size={14} strokeWidth={1.75} aria-hidden="true" />
-      </button>
-
       {open && (
         <div
           ref={panelRef}
@@ -333,7 +335,10 @@ export function ProviderUsageCluster({
           // Focusable so the dialog itself can hold focus when it contains no
           // control; never in the Tab order.
           tabIndex={-1}
-          className="ui-anchored-panel absolute bottom-full left-2 right-2 mb-1.5 p-3 outline-none"
+          className={cn(
+            "ui-anchored-panel absolute left-0 right-0 p-3 outline-none",
+            panelAnchor === "up" ? "bottom-full mb-1.5" : "top-full mt-1.5",
+          )}
         >
           <ProviderUsageDetail
             provider={open}

--- a/apps/desktop/src/components/providerUsage/ProviderUsageDetail.tsx
+++ b/apps/desktop/src/components/providerUsage/ProviderUsageDetail.tsx
@@ -19,7 +19,17 @@ import { UsageWindowRows } from "./UsageWindowRows"
 import { ProviderGlyph } from "./ProviderUsagePrimitives"
 
 interface ProviderUsageDetailProps {
-  provider: ProviderUsagePayload
+  /** The provider's own name and canonical id — always known, spend or not. */
+  displayName: string
+  providerId: string
+  /**
+   * The reader's own local spend and sessions, when this provider has ever
+   * produced any. A chip driven purely by a live limit reading — the
+   * provider stated a percentage, but nothing was ever run through it on
+   * this device — has none, and the panel below drops that half rather than
+   * fabricate figures for a provider it has never seen spend from.
+   */
+  provider?: ProviderUsagePayload | null
   /** The provider's own limits, when a source could prove any. */
   live?: LiveProviderUsagePayload | null
   /** Injected so the rendered output is a function of its inputs in tests. */
@@ -43,19 +53,26 @@ interface ProviderUsageDetailProps {
  * a loading state. The first half does have meters, because the provider
  * supplied the denominator. Keeping them visibly separate is the whole reason
  * the plan block carries its own heading in a panel this small.
+ *
+ * The second half is also entirely optional: a provider can reach this panel
+ * on a live limit reading alone, with no local session ever attributed to it,
+ * and the panel then shows only the header and the limits — never a zeroed
+ * spend section standing in for evidence that does not exist.
  */
 export function ProviderUsageDetail({
-  provider,
+  displayName,
+  providerId,
+  provider = null,
   live = null,
   now = 0,
   headingId,
   onViewAll,
 }: ProviderUsageDetailProps) {
-  const stale = stalenessNote(provider)
-  const updated = updatedNote(provider)
+  const stale = provider ? stalenessNote(provider) : null
+  const updated = provider ? updatedNote(provider) : null
   // The broadest window the app can see, so the token split describes as much
   // history as exists rather than only the current day.
-  const month = providerWindow(provider, "month")
+  const month = provider ? providerWindow(provider, "month") : null
 
   return (
     <div className="space-y-3">
@@ -63,14 +80,14 @@ export function ProviderUsageDetail({
         {/* The same glyph the chip carries, so the panel reads as that chip
             opened rather than as an unrelated card. */}
         <ProviderGlyph
-          displayName={provider.displayName}
-          provider={provider.provider}
+          displayName={displayName}
+          provider={providerId}
           size={18}
           className="mt-px"
         />
         <div className="min-w-0 flex-1">
           <h2 id={headingId} className="type-headline truncate text-label">
-            {provider.displayName}
+            {displayName}
           </h2>
           {(stale ?? updated) && (
             <p
@@ -87,23 +104,29 @@ export function ProviderUsageDetail({
 
       {live && <LiveUsageDetail live={live} now={now} />}
 
-      <UsageMetricRows provider={provider} />
+      {provider && month && (
+        <>
+          <UsageMetricRows provider={provider} />
 
-      <UsageWindowRows provider={provider} className="border-t border-separator pt-2.5" />
+          <UsageWindowRows provider={provider} className="border-t border-separator pt-2.5" />
 
-      <div className="space-y-1 border-t border-separator pt-2.5">
-        <p className="type-caption font-medium text-label-secondary">Tokens · this month</p>
-        {tokenRows(month).map((row) => (
-          <div key={row.label} className="flex items-baseline justify-between gap-3">
-            <span className="type-caption text-label-tertiary">{row.label}</span>
-            <span className="type-caption tabular-nums text-label-secondary">{row.value}</span>
+          <div className="space-y-1 border-t border-separator pt-2.5">
+            <p className="type-caption font-medium text-label-secondary">Tokens · this month</p>
+            {tokenRows(month).map((row) => (
+              <div key={row.label} className="flex items-baseline justify-between gap-3">
+                <span className="type-caption text-label-tertiary">{row.label}</span>
+                <span className="type-caption tabular-nums text-label-secondary">
+                  {row.value}
+                </span>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
 
-      <p className="type-caption text-label-tertiary">
-        {usageStateDescription(provider.state)}
-      </p>
+          <p className="type-caption text-label-tertiary">
+            {usageStateDescription(provider.state)}
+          </p>
+        </>
+      )}
 
       {onViewAll && (
         <button

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
@@ -176,6 +176,17 @@ describe("UsageLimitsSection — expanded", () => {
     expect(firstHeader).toHaveClass("pr-8")
     expect(secondHeader).not.toHaveClass("pr-8")
   })
+
+  it('labels the section by its vertical "Limits" heading rather than a redundant aria-label', () => {
+    const { container } = section()
+
+    const heading = screen.getByRole("heading", { name: "Limits", level: 2 })
+    expect(heading).toBeInTheDocument()
+
+    const region = screen.getByRole("region", { name: "Limits" })
+    expect(region).toBe(container.querySelector('[data-testid="usage-limits-section"]'))
+    expect(region).toHaveAttribute("aria-labelledby", heading.id)
+  })
 })
 
 describe("UsageLimitsSection — collapsed", () => {
@@ -190,6 +201,12 @@ describe("UsageLimitsSection — collapsed", () => {
   it("does not show the per-provider rows while collapsed", () => {
     section({ expanded: false })
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
+  })
+
+  it('shows no "Limits" heading or region — a single row of chips can\'t carry one', () => {
+    section({ expanded: false })
+    expect(screen.queryByText("Limits")).not.toBeInTheDocument()
+    expect(screen.queryByRole("region")).not.toBeInTheDocument()
   })
 })
 

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  LiveProviderUsagePayload,
+  LiveUsageSummaryPayload,
+  LiveUsageWindowPayload,
+  ProviderUsagePayload,
+  ProviderUsageWindowPayload,
+} from "../../lib/ipc"
+import { UsageLimitsSection } from "./UsageLimitsSection"
+
+const FORECAST = {
+  unavailableReason: "sparseHistory",
+  confidence: null,
+  consumptionRate: null,
+  paceRatio: null,
+  paceTrend: null,
+  runwayAt: null,
+  usedToday: null,
+}
+
+function liveWindow(overrides: Partial<LiveUsageWindowPayload> = {}): LiveUsageWindowPayload {
+  return {
+    id: "seven-day",
+    role: "primaryLong",
+    kind: "weekly",
+    scopeModel: null,
+    usedPercent: 42,
+    startsAt: null,
+    resetsAt: null,
+    hasNonzeroUsageInCurrentPeriod: false,
+    forecast: FORECAST,
+    ...overrides,
+  }
+}
+
+function liveProvider(
+  overrides: Partial<LiveProviderUsagePayload> = {},
+): LiveProviderUsagePayload {
+  return {
+    provider: "anthropic",
+    displayName: "Claude",
+    support: "live",
+    freshness: "fresh",
+    sourceLabel: "Asked Claude directly",
+    observedAt: new Date(Date.now() - 3 * 60_000).toISOString(),
+    windows: [liveWindow()],
+    extraUsage: null,
+    ...overrides,
+  }
+}
+
+function liveSummary(
+  providers: readonly LiveProviderUsagePayload[] = [liveProvider()],
+): LiveUsageSummaryPayload {
+  return { providers: [...providers], errors: [], generatedAt: new Date().toISOString() }
+}
+
+function spendWindow(
+  overrides: Partial<ProviderUsageWindowPayload> = {},
+): ProviderUsageWindowPayload {
+  return {
+    tokensIn: 0,
+    tokensOut: 0,
+    cacheRead: 0,
+    estimatedUsd: null,
+    sessionCount: 0,
+    ...overrides,
+  }
+}
+
+function spendProvider(overrides: Partial<ProviderUsagePayload> = {}): ProviderUsagePayload {
+  const today = spendWindow({ estimatedUsd: 1.25, tokensIn: 1_000, sessionCount: 1 })
+  return {
+    provider: "anthropic",
+    displayName: "Claude",
+    state: "estimated",
+    staleness: "fresh",
+    windows: { today, week: today, month: today },
+    lastActivityAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function section(over: Partial<Parameters<typeof UsageLimitsSection>[0]> = {}) {
+  return render(
+    <UsageLimitsSection
+      providers={[spendProvider()]}
+      live={liveSummary()}
+      expanded={true}
+      onToggleExpanded={vi.fn()}
+      refreshing={false}
+      onViewAll={vi.fn()}
+      {...over}
+    />,
+  )
+}
+
+describe("UsageLimitsSection — visibility", () => {
+  it("renders nothing when no provider has live limit data", () => {
+    const { container } = section({ live: liveSummary([]) })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders nothing when a provider reports but states no windows worth showing", () => {
+    const { container } = section({ live: liveSummary([liveProvider({ windows: [] })]) })
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe("UsageLimitsSection — expanded", () => {
+  it("shows one subsection per provider with limit data, each with its own rows", () => {
+    section({
+      live: liveSummary([
+        liveProvider({ provider: "anthropic", displayName: "Claude" }),
+        liveProvider({
+          provider: "openai",
+          displayName: "Codex",
+          windows: [liveWindow({ id: "five-hour", role: "primaryShort", usedPercent: 10 })],
+        }),
+      ]),
+    })
+
+    expect(screen.getByText("Claude")).toBeInTheDocument()
+    expect(screen.getByText("Codex")).toBeInTheDocument()
+    expect(screen.getAllByRole("progressbar").length).toBe(2)
+  })
+
+  it("carries a freshness note next to each provider's name", () => {
+    section()
+    expect(screen.getByText("Live 3m ago")).toBeInTheDocument()
+  })
+
+  it("does not show pace, trend, runway, or spend — only the limit rows", () => {
+    section()
+    expect(screen.queryByText(/pace/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/runway/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/trend/i)).not.toBeInTheDocument()
+  })
+
+  it("omits the chip row entirely while expanded", () => {
+    section()
+    expect(screen.queryByTestId("provider-usage-cluster")).not.toBeInTheDocument()
+  })
+})
+
+describe("UsageLimitsSection — collapsed", () => {
+  it("shows the same chip row the bottom bar used to carry", () => {
+    section({ expanded: false })
+    expect(screen.getByTestId("provider-usage-cluster")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Claude, $1.25 today, estimated, weekly limit 42%" }),
+    ).toBeInTheDocument()
+  })
+
+  it("does not show the per-provider rows while collapsed", () => {
+    section({ expanded: false })
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
+  })
+})
+
+describe("UsageLimitsSection — toggle and spinner", () => {
+  it("toggles through the chevron button, in either state", () => {
+    const onToggleExpanded = vi.fn()
+    const { rerender } = section({ expanded: true, onToggleExpanded })
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse usage limits" }))
+    expect(onToggleExpanded).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <UsageLimitsSection
+        providers={[spendProvider()]}
+        live={liveSummary()}
+        expanded={false}
+        onToggleExpanded={onToggleExpanded}
+        refreshing={false}
+        onViewAll={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Expand usage limits" }))
+    expect(onToggleExpanded).toHaveBeenCalledTimes(2)
+  })
+
+  it("shows a spinner while a refresh is in flight, and hides it once settled", () => {
+    const { rerender } = section({ refreshing: true })
+    expect(screen.getByRole("status")).toBeInTheDocument()
+
+    rerender(
+      <UsageLimitsSection
+        providers={[spendProvider()]}
+        live={liveSummary()}
+        expanded={true}
+        onToggleExpanded={vi.fn()}
+        refreshing={false}
+        onViewAll={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
@@ -148,33 +148,18 @@ describe("UsageLimitsSection — expanded", () => {
     expect(screen.queryByTestId("provider-usage-chips")).not.toBeInTheDocument()
   })
 
-  it("overlays the toggle on the corner rather than spending a row on it", () => {
+  it("sits the toggle in the left rail beside the vertical heading, not over the subsections", () => {
     const { container } = section()
     const toggle = screen.getByRole("button", { name: "Collapse usage limits" })
-    // Overlaid, not its own flow row: the toggle's row lives outside the
-    // document's normal layout, so it costs no vertical space of its own.
-    expect(toggle.parentElement).toHaveClass("absolute")
+    const heading = screen.getByRole("heading", { name: "Limits", level: 2 })
+    // The toggle shares the narrow left rail with the heading rather than
+    // floating over the subsection content, so it never needs to reserve
+    // space in any subsection's header.
+    expect(toggle.parentElement).toBe(heading.parentElement)
+    // Only the spinner is overlaid on the corner, costing no layout space.
     expect(container.querySelector('[data-testid="usage-limits-section"]')).toHaveClass(
       "relative",
     )
-  })
-
-  it("reserves right-hand space in only the first subsection's header, clear of the overlay", () => {
-    section({
-      live: liveSummary([
-        liveProvider({ provider: "anthropic", displayName: "Claude" }),
-        liveProvider({
-          provider: "openai",
-          displayName: "Codex",
-          windows: [liveWindow({ id: "five-hour", role: "primaryShort", usedPercent: 10 })],
-        }),
-      ]),
-    })
-
-    const firstHeader = screen.getByText("Claude").parentElement
-    const secondHeader = screen.getByText("Codex").parentElement
-    expect(firstHeader).toHaveClass("pr-8")
-    expect(secondHeader).not.toHaveClass("pr-8")
   })
 
   it('labels the section by its vertical "Limits" heading rather than a redundant aria-label', () => {
@@ -194,7 +179,7 @@ describe("UsageLimitsSection — collapsed", () => {
     section({ expanded: false })
     expect(screen.getByTestId("provider-usage-chips")).toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "Claude, $1.25 today, estimated, weekly limit 42%" }),
+      screen.getByRole("button", { name: "Claude, estimated, weekly limit 42%" }),
     ).toBeInTheDocument()
   })
 
@@ -234,7 +219,10 @@ describe("UsageLimitsSection — toggle and spinner", () => {
 
   it("shows a spinner while a refresh is in flight, and hides it once settled", () => {
     const { rerender } = section({ refreshing: true })
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    const status = screen.getByRole("status")
+    expect(status).toBeInTheDocument()
+    // The spinner alone is overlaid on the corner, costing no layout space.
+    expect(status.parentElement).toHaveClass("absolute")
 
     rerender(
       <UsageLimitsSection

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
@@ -145,14 +145,43 @@ describe("UsageLimitsSection — expanded", () => {
 
   it("omits the chip row entirely while expanded", () => {
     section()
-    expect(screen.queryByTestId("provider-usage-cluster")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("provider-usage-chips")).not.toBeInTheDocument()
+  })
+
+  it("overlays the toggle on the corner rather than spending a row on it", () => {
+    const { container } = section()
+    const toggle = screen.getByRole("button", { name: "Collapse usage limits" })
+    // Overlaid, not its own flow row: the toggle's row lives outside the
+    // document's normal layout, so it costs no vertical space of its own.
+    expect(toggle.parentElement).toHaveClass("absolute")
+    expect(container.querySelector('[data-testid="usage-limits-section"]')).toHaveClass(
+      "relative",
+    )
+  })
+
+  it("reserves right-hand space in only the first subsection's header, clear of the overlay", () => {
+    section({
+      live: liveSummary([
+        liveProvider({ provider: "anthropic", displayName: "Claude" }),
+        liveProvider({
+          provider: "openai",
+          displayName: "Codex",
+          windows: [liveWindow({ id: "five-hour", role: "primaryShort", usedPercent: 10 })],
+        }),
+      ]),
+    })
+
+    const firstHeader = screen.getByText("Claude").parentElement
+    const secondHeader = screen.getByText("Codex").parentElement
+    expect(firstHeader).toHaveClass("pr-8")
+    expect(secondHeader).not.toHaveClass("pr-8")
   })
 })
 
 describe("UsageLimitsSection — collapsed", () => {
   it("shows the same chip row the bottom bar used to carry", () => {
     section({ expanded: false })
-    expect(screen.getByTestId("provider-usage-cluster")).toBeInTheDocument()
+    expect(screen.getByTestId("provider-usage-chips")).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: "Claude, $1.25 today, estimated, weekly limit 42%" }),
     ).toBeInTheDocument()

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
@@ -1,0 +1,156 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { ChevronDown, Loader2 } from "lucide-react"
+
+import { cn } from "../../lib/cn"
+import type {
+  LiveProviderUsagePayload,
+  LiveUsageSummaryPayload,
+  ProviderUsagePayload,
+} from "../../lib/ipc"
+import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
+import {
+  liveFreshnessToneClass,
+  liveSourceNote,
+  liveWindows,
+} from "../../lib/presentation/liveUsage"
+import { LiveUsageWindowRows } from "./LiveUsageWindowRows"
+import { ProviderUsageChips } from "./ProviderUsageChips"
+
+export interface UsageLimitsSectionProps {
+  /** Local spend, for the collapsed row's chips — the same figures the chips
+   * always showed, independent of which providers stated a limit. */
+  providers: readonly ProviderUsagePayload[]
+  /** The provider's own limit figures, when a source could prove any. */
+  live?: LiveUsageSummaryPayload
+  /**
+   * The instant countdowns and elapsed markers are measured from. Defaults to
+   * when the shell collected the snapshot — a render must not read the clock.
+   */
+  now?: number
+  /** Whether the section shows its per-provider rows or the collapsed chips. */
+  expanded: boolean
+  onToggleExpanded: () => void
+  /** Whether a refresh is in flight, for the small spinner beside the toggle. */
+  refreshing: boolean
+  /** Open the full Usage view, from the collapsed row's overflow or panel. */
+  onViewAll: () => void
+}
+
+/**
+ * The popover's usage-limits section: what each provider itself says about
+ * the reader's standing against its own allowance, one subsection per
+ * provider that stated one.
+ *
+ * Nothing here is the local spend estimate — that stays where it always was,
+ * in the Usage view and, collapsed, as the chip row this section can shrink
+ * to. A subsection carries only the bars `LiveUsageWindowRows` already draws
+ * for the Usage view: no pace, no trend, no runway. Those are a full page's
+ * worth of derived reasoning, and this is a glance on the way past.
+ *
+ * The whole section is silent when no provider has anything to say — live
+ * usage off, or no reading has arrived yet — rather than rendering an empty
+ * shell. There is nothing to collapse *to* in that case, so the reader who
+ * has never turned the feature on sees nothing about it here at all.
+ */
+export function UsageLimitsSection({
+  providers,
+  live = EMPTY_LIVE_USAGE,
+  now,
+  expanded,
+  onToggleExpanded,
+  refreshing,
+  onViewAll,
+}: UsageLimitsSectionProps) {
+  const at = now ?? (Date.parse(live.generatedAt) || 0)
+  const limited = live.providers.filter((provider) => liveWindows(provider).length > 0)
+
+  if (limited.length === 0) return null
+
+  const toggle = (
+    <button
+      type="button"
+      onClick={onToggleExpanded}
+      aria-expanded={expanded}
+      aria-label={expanded ? "Collapse usage limits" : "Expand usage limits"}
+      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-control text-label-tertiary hover:bg-surface-hover"
+    >
+      <ChevronDown
+        size={13}
+        strokeWidth={2}
+        aria-hidden="true"
+        className={cn(
+          "transition-transform duration-[120ms] ease-out",
+          expanded && "rotate-180",
+        )}
+      />
+    </button>
+  )
+
+  const spinner = refreshing && (
+    <span role="status" className="inline-flex shrink-0 items-center text-label-tertiary">
+      <Loader2 size={12} strokeWidth={2} aria-hidden="true" className="animate-spin" />
+      <span className="sr-only">Refreshing usage limits</span>
+    </span>
+  )
+
+  return (
+    <div
+      data-testid="usage-limits-section"
+      className="shrink-0 space-y-2 border-b border-separator px-2 pt-2 pb-2.5"
+    >
+      {expanded ? (
+        <>
+          <div className="flex items-center justify-end gap-1">
+            {spinner}
+            {toggle}
+          </div>
+          <div className="space-y-2.5">
+            {limited.map((provider) => (
+              <ProviderLimitSubsection key={provider.provider} provider={provider} now={at} />
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="flex min-w-0 items-center gap-1">
+          <ProviderUsageChips
+            providers={providers}
+            live={live}
+            now={at}
+            onViewAll={onViewAll}
+            panelAnchor="down"
+            className="min-w-0 flex-1"
+          />
+          {spinner}
+          {toggle}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProviderLimitSubsection({
+  provider,
+  now,
+}: {
+  provider: LiveProviderUsagePayload
+  now: number
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-2 px-1 pb-1">
+        <h3 className="truncate type-caption font-medium text-label-secondary">
+          {provider.displayName}
+        </h3>
+        <span
+          className={cn("shrink-0 type-caption", liveFreshnessToneClass(provider.freshness))}
+        >
+          {liveSourceNote(provider)}
+        </span>
+      </div>
+      <LiveUsageWindowRows provider={provider} now={now} className="px-1" />
+    </div>
+  )
+}

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
@@ -77,7 +77,7 @@ export function UsageLimitsSection({
       onClick={onToggleExpanded}
       aria-expanded={expanded}
       aria-label={expanded ? "Collapse usage limits" : "Expand usage limits"}
-      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-control text-label-tertiary hover:bg-surface-hover"
+      className="flex items-center justify-center h-6 w-6 rounded-md text-label-tertiary hover:bg-surface-hover"
     >
       <ChevronDown
         size={13}
@@ -85,7 +85,7 @@ export function UsageLimitsSection({
         aria-hidden="true"
         className={cn(
           "transition-transform duration-[120ms] ease-out",
-          expanded && "rotate-180",
+          expanded && "rotate-270",
         )}
       />
     </button>
@@ -101,53 +101,40 @@ export function UsageLimitsSection({
   return (
     <div
       data-testid="usage-limits-section"
-      className="relative shrink-0 border-b border-separator px-2 pt-2 pb-2.5"
-      // The vertical "Limits" label is this section's visible name while
-      // expanded, so it doubles as the accessible one — a region labelled by
-      // a heading, rather than a redundant aria-label restating text already
-      // on screen. Collapsed, the chips already carry their own accessible
-      // names and there is no heading to point to.
+      className="relative shrink-0 border-b border-separator"
       {...(expanded ? { role: "region", "aria-labelledby": headingId } : {})}
     >
       {expanded ? (
         <>
-          {/* Overlaid on the corner rather than given its own row: the
-              product goal is minimal vertical footprint, and a toggle plus a
-              spinner is not worth a whole row of its own. The first
-              subsection reserves the horizontal space this needs — see
-              `reserveToggleSpace` below. */}
-          <div className="absolute top-2 right-2 flex items-center gap-1">
-            {spinner}
-            {toggle}
-          </div>
-          <div className="flex gap-2">
-            {/* A vertical label rather than a horizontal heading row: the
-                whole point is a header that costs no vertical space. Centred
-                by flexbox's default stretch — this column and the
-                subsections beside it share one cross-axis, so centring
-                within the column centres against the full stack of them. */}
-            <div className="flex w-4 shrink-0 items-center justify-center">
+          <div className="absolute top-2 right-2 flex items-center gap-1">{spinner}</div>
+
+          <div className="flex">
+            <div className="flex flex-col w-7 gap-y-2 py-2 shrink-0 items-center bg-surface-secondary">
+              {toggle}
+
               <h2
                 id={headingId}
-                className="[writing-mode:vertical-rl] rotate-180 type-caption font-medium tracking-wider text-label-tertiary uppercase"
+                className="[writing-mode:vertical-rl] [text-orientation:upright] type-caption font-medium tracking-wider text-label-tertiary uppercase"
               >
                 Limits
               </h2>
             </div>
-            <div className="min-w-0 flex-1 space-y-2.5">
+
+            <div className="min-w-0 flex-1 space-y-2.5 py-3 px-2">
               {limited.map((provider, index) => (
                 <ProviderLimitSubsection
                   key={provider.provider}
                   provider={provider}
                   now={at}
-                  reserveToggleSpace={index === 0}
                 />
               ))}
             </div>
           </div>
         </>
       ) : (
-        <div className="flex min-w-0 items-center gap-1">
+        <div className="flex min-w-0 items-center gap-1 px-1 py-1">
+          {toggle}
+
           <ProviderUsageChips
             providers={providers}
             live={live}
@@ -156,8 +143,8 @@ export function UsageLimitsSection({
             panelAnchor="down"
             className="min-w-0 flex-1"
           />
+
           {spinner}
-          {toggle}
         </div>
       )}
     </div>
@@ -171,28 +158,14 @@ function ProviderLimitSubsection({
 }: {
   provider: LiveProviderUsagePayload
   now: number
-  /**
-   * Leaves room on the right of the header row for the toggle (and spinner)
-   * overlaid on the section's top-right corner, so a "Live Xm ago" note never
-   * renders under it. Only the first subsection needs this — the toggle sits
-   * over the top of the section, not beside every subsection below it.
-   */
-  reserveToggleSpace?: boolean
 }) {
   return (
     <div>
-      <div
-        className={cn(
-          "flex items-baseline justify-between gap-2 px-1 pb-1",
-          reserveToggleSpace && "pr-8",
-        )}
-      >
-        <h3 className="truncate type-caption font-medium text-label-secondary">
+      <div className="flex items-baseline justify-between gap-2 px-1 pb-1 group">
+        <h3 className="truncate text-label-secondary">
           {provider.displayName}
         </h3>
-        <span
-          className={cn("shrink-0 type-caption", liveFreshnessToneClass(provider.freshness))}
-        >
+        <span className="shrink-0 type-caption text-label-tertiary hidden group-hover:inline">
           {liveSourceNote(provider)}
         </span>
       </div>

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
@@ -99,17 +99,27 @@ export function UsageLimitsSection({
   return (
     <div
       data-testid="usage-limits-section"
-      className="shrink-0 space-y-2 border-b border-separator px-2 pt-2 pb-2.5"
+      className="relative shrink-0 border-b border-separator px-2 pt-2 pb-2.5"
     >
       {expanded ? (
         <>
-          <div className="flex items-center justify-end gap-1">
+          {/* Overlaid on the corner rather than given its own row: the
+              product goal is minimal vertical footprint, and a toggle plus a
+              spinner is not worth a whole row of its own. The first
+              subsection reserves the horizontal space this needs — see
+              `reserveToggleSpace` below. */}
+          <div className="absolute top-2 right-2 flex items-center gap-1">
             {spinner}
             {toggle}
           </div>
           <div className="space-y-2.5">
-            {limited.map((provider) => (
-              <ProviderLimitSubsection key={provider.provider} provider={provider} now={at} />
+            {limited.map((provider, index) => (
+              <ProviderLimitSubsection
+                key={provider.provider}
+                provider={provider}
+                now={at}
+                reserveToggleSpace={index === 0}
+              />
             ))}
           </div>
         </>
@@ -134,13 +144,26 @@ export function UsageLimitsSection({
 function ProviderLimitSubsection({
   provider,
   now,
+  reserveToggleSpace = false,
 }: {
   provider: LiveProviderUsagePayload
   now: number
+  /**
+   * Leaves room on the right of the header row for the toggle (and spinner)
+   * overlaid on the section's top-right corner, so a "Live Xm ago" note never
+   * renders under it. Only the first subsection needs this — the toggle sits
+   * over the top of the section, not beside every subsection below it.
+   */
+  reserveToggleSpace?: boolean
 }) {
   return (
     <div>
-      <div className="flex items-baseline justify-between gap-2 px-1 pb-1">
+      <div
+        className={cn(
+          "flex items-baseline justify-between gap-2 px-1 pb-1",
+          reserveToggleSpace && "pr-8",
+        )}
+      >
         <h3 className="truncate type-caption font-medium text-label-secondary">
           {provider.displayName}
         </h3>

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
@@ -12,11 +12,7 @@ import type {
   ProviderUsagePayload,
 } from "../../lib/ipc"
 import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
-import {
-  liveFreshnessToneClass,
-  liveSourceNote,
-  liveWindows,
-} from "../../lib/presentation/liveUsage"
+import { liveSourceNote, liveWindows } from "../../lib/presentation/liveUsage"
 import { LiveUsageWindowRows } from "./LiveUsageWindowRows"
 import { ProviderUsageChips } from "./ProviderUsageChips"
 
@@ -121,12 +117,8 @@ export function UsageLimitsSection({
             </div>
 
             <div className="min-w-0 flex-1 space-y-2.5 py-3 px-2">
-              {limited.map((provider, index) => (
-                <ProviderLimitSubsection
-                  key={provider.provider}
-                  provider={provider}
-                  now={at}
-                />
+              {limited.map((provider) => (
+                <ProviderLimitSubsection key={provider.provider} provider={provider} now={at} />
               ))}
             </div>
           </div>
@@ -154,18 +146,15 @@ export function UsageLimitsSection({
 function ProviderLimitSubsection({
   provider,
   now,
-  reserveToggleSpace = false,
 }: {
   provider: LiveProviderUsagePayload
   now: number
 }) {
   return (
     <div>
-      <div className="flex items-baseline justify-between gap-2 px-1 pb-1 group">
-        <h3 className="truncate text-label-secondary">
-          {provider.displayName}
-        </h3>
-        <span className="shrink-0 type-caption text-label-tertiary hidden group-hover:inline">
+      <div className="group flex items-baseline justify-between gap-2 px-1 pb-1">
+        <h3 className="truncate text-label-secondary">{provider.displayName}</h3>
+        <span className="type-caption hidden shrink-0 text-label-tertiary group-hover:inline">
           {liveSourceNote(provider)}
         </span>
       </div>

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { ChevronDown, Loader2 } from "lucide-react"
+import { useId } from "react"
 
 import { cn } from "../../lib/cn"
 import type {
@@ -66,6 +67,7 @@ export function UsageLimitsSection({
 }: UsageLimitsSectionProps) {
   const at = now ?? (Date.parse(live.generatedAt) || 0)
   const limited = live.providers.filter((provider) => liveWindows(provider).length > 0)
+  const headingId = useId()
 
   if (limited.length === 0) return null
 
@@ -100,6 +102,12 @@ export function UsageLimitsSection({
     <div
       data-testid="usage-limits-section"
       className="relative shrink-0 border-b border-separator px-2 pt-2 pb-2.5"
+      // The vertical "Limits" label is this section's visible name while
+      // expanded, so it doubles as the accessible one — a region labelled by
+      // a heading, rather than a redundant aria-label restating text already
+      // on screen. Collapsed, the chips already carry their own accessible
+      // names and there is no heading to point to.
+      {...(expanded ? { role: "region", "aria-labelledby": headingId } : {})}
     >
       {expanded ? (
         <>
@@ -112,15 +120,30 @@ export function UsageLimitsSection({
             {spinner}
             {toggle}
           </div>
-          <div className="space-y-2.5">
-            {limited.map((provider, index) => (
-              <ProviderLimitSubsection
-                key={provider.provider}
-                provider={provider}
-                now={at}
-                reserveToggleSpace={index === 0}
-              />
-            ))}
+          <div className="flex gap-2">
+            {/* A vertical label rather than a horizontal heading row: the
+                whole point is a header that costs no vertical space. Centred
+                by flexbox's default stretch — this column and the
+                subsections beside it share one cross-axis, so centring
+                within the column centres against the full stack of them. */}
+            <div className="flex w-4 shrink-0 items-center justify-center">
+              <h2
+                id={headingId}
+                className="[writing-mode:vertical-rl] rotate-180 type-caption font-medium tracking-wider text-label-tertiary uppercase"
+              >
+                Limits
+              </h2>
+            </div>
+            <div className="min-w-0 flex-1 space-y-2.5">
+              {limited.map((provider, index) => (
+                <ProviderLimitSubsection
+                  key={provider.provider}
+                  provider={provider}
+                  now={at}
+                  reserveToggleSpace={index === 0}
+                />
+              ))}
+            </div>
           </div>
         </>
       ) : (

--- a/apps/desktop/src/components/providerUsage/index.ts
+++ b/apps/desktop/src/components/providerUsage/index.ts
@@ -2,5 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-export { ProviderUsageCluster } from "./ProviderUsageCluster"
 export { ProviderGlyph } from "./ProviderUsagePrimitives"
+export { UsageLimitsSection } from "./UsageLimitsSection"

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -105,6 +105,13 @@ export interface AppSettings {
    * setting for a reader who wants no background traffic at all.
    */
   liveUsageEnabled: boolean
+  /**
+   * Whether the popover's usage-limits section is expanded to its
+   * per-provider rows, rather than collapsed to the chip row. Purely a
+   * display preference — it never gates a fetch — so it defaults open and
+   * stays wherever the reader last left it.
+   */
+  overviewLimitsExpanded: boolean
 }
 
 /** Where the app came from. Mirrors Rust `AppInfo`. */
@@ -546,6 +553,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   milestones5h: { at50: true, at75: true, at90: true },
   milestonesWeekly: { at50: true, at75: true, at90: true },
   liveUsageEnabled: true,
+  overviewLimitsExpanded: true,
 }
 
 /* -------------------------------------------------------------------------

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -24,7 +24,6 @@ import {
   liveWindowValueLabel,
   liveWindows,
   forecastUnavailableNote,
-  headlineWindow,
   isConditionallyVisibleUsageWindow,
   isUsageWindowVisible,
   paceState,
@@ -559,76 +558,5 @@ describe("runway", () => {
 
   it("says nothing at all without a forecast", () => {
     expect(runwayLabel(window(), NOW)).toBeNull()
-  })
-})
-
-describe("the headline window", () => {
-  it("leads with the account-wide long window, not the shortest or the first", () => {
-    const provider_ = provider({
-      windows: [
-        window({ id: "five-hour", usedPercent: 10 }),
-        window({ id: "seven-day", role: "primaryLong", kind: "weekly", usedPercent: 88 }),
-      ],
-    })
-    expect(headlineWindow(provider_)?.id).toBe("seven-day")
-  })
-
-  it("does not let a fuller per-model limit take the ring from the account", () => {
-    // The case that made this rule: a model-scoped weekly at 95% beside an
-    // account weekly at 69%. Picking the fullest would have a reader glance at
-    // the footer and read 95% as their overall position, when it constrains
-    // one model. The per-model limit keeps its own row, one hover away.
-    const provider_ = provider({
-      windows: [
-        window({ id: "five-hour", usedPercent: 14 }),
-        window({ id: "seven-day", role: "primaryLong", kind: "weekly", usedPercent: 69 }),
-        window({
-          id: "weekly-fable",
-          role: "supplemental",
-          kind: "weekly",
-          scopeModel: "Fable",
-          usedPercent: 95,
-        }),
-      ],
-    })
-    expect(headlineWindow(provider_)?.id).toBe("seven-day")
-    expect(headlineWindow(provider_)?.usedPercent).toBe(69)
-  })
-
-  it("falls back through the roles rather than giving up", () => {
-    // A monthly account allowance with no weekly at all.
-    const monthly = provider({
-      windows: [
-        window({ id: "five-hour", usedPercent: 14 }),
-        window({ id: "billing", role: "other", kind: "billingCycle", usedPercent: 40 }),
-      ],
-    })
-    expect(headlineWindow(monthly)?.id).toBe("billing")
-
-    // Nothing but the short window: better than an empty footer.
-    const shortOnly = provider({ windows: [window({ id: "five-hour", usedPercent: 14 })] })
-    expect(headlineWindow(shortOnly)?.id).toBe("five-hour")
-  })
-
-  it("keeps the account window even when the provider stated no figure for it", () => {
-    // An indeterminate ring on the right window beats a determinate ring on
-    // the wrong one.
-    const provider_ = provider({
-      windows: [
-        window({ id: "seven-day", role: "primaryLong", kind: "weekly", usedPercent: null }),
-        window({ id: "five-hour", usedPercent: 14 }),
-      ],
-    })
-    expect(headlineWindow(provider_)?.id).toBe("seven-day")
-  })
-
-  it("has nothing to show when no window carries a figure or a role", () => {
-    expect(
-      headlineWindow(
-        provider({
-          windows: [window({ id: "five-hour", role: "primaryShort", usedPercent: null })],
-        }),
-      ),
-    ).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -225,6 +225,22 @@ export function liveWindows(provider: LiveProviderUsagePayload): LiveUsageWindow
   return provider.windows.filter(isUsageWindowVisible).sort((a, b) => rank(a) - rank(b))
 }
 
+/**
+ * The fullest of a provider's live windows, as a percentage, or null when
+ * none of them carries one.
+ *
+ * A compact ring can only show one number, and "how full is the fullest
+ * thing I'm watching" is the question a glance at a chip is asking — a
+ * per-model limit at 95% is exactly as worth a glance as an account-wide one
+ * at 95%. The full breakdown, with each window named, is one hover away.
+ */
+export function maxLiveUsedPercent(provider: LiveProviderUsagePayload): number | null {
+  return liveWindows(provider).reduce<number | null>((max, window) => {
+    if (window.usedPercent == null) return max
+    return max == null ? window.usedPercent : Math.max(max, window.usedPercent)
+  }, null)
+}
+
 /** The live reading for one provider id, or null when there is none. */
 export function liveForProvider(
   summary: LiveUsageSummaryPayload,
@@ -457,44 +473,4 @@ export function runwayLabel(window: LiveUsageWindowPayload, now: number): string
   const day = date.toLocaleDateString(undefined, { weekday: "short" })
   const time = date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
   return `Runs out ${day} ${time}`
-}
-
-/**
- * The window a compact surface should lead with.
- *
- * By *role*, not by how full it is. The account-wide long window — the weekly
- * limit — is the one that describes the account's overall standing, so it
- * leads whenever it exists.
- *
- * The tempting alternative is "whichever is nearest its ceiling", and it is
- * wrong. A per-model weekly limit at 95% next to an account weekly at 69%
- * would take the ring, and a reader glancing at the footer would read 95% as
- * their overall position when it constrains one model. A single ring has to
- * answer "how am I doing", and only the account-wide window answers that.
- *
- * The per-model limit is not hidden — it has its own row, with its own name,
- * one hover away.
- */
-export function headlineWindow(
-  provider: LiveProviderUsagePayload,
-): LiveUsageWindowPayload | null {
-  const windows = liveWindows(provider)
-  const find = (match: (window: LiveUsageWindowPayload) => boolean) => windows.find(match)
-
-  return (
-    find((window) => window.role === "primaryLong") ??
-    find((window) => window.kind === "weekly") ??
-    find((window) => window.kind === "billingCycle" && window.scopeModel == null) ??
-    // Anything account-wide that is neither the short window nor a secondary
-    // limit — a monthly allowance, say.
-    find(
-      (window) =>
-        window.role !== "primaryShort" &&
-        window.role !== "supplemental" &&
-        window.usedPercent != null,
-    ) ??
-    // Last resort: the short window, which is better than an empty footer.
-    find((window) => window.usedPercent != null) ??
-    null
-  )
 }

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -355,9 +355,7 @@ describe("PopoverView", () => {
     expect(invoke).toHaveBeenCalledWith("get_provider_usage", {
       utcOffsetMinutes: -new Date().getTimezoneOffset(),
     })
-    expect(
-      screen.getByRole("button", { name: "Anthropic, $1.25 today, estimated" }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Anthropic, estimated" })).toBeInTheDocument()
   })
 
   it("shows the plain title-and-gear footer, with none of the usage chips in it", async () => {
@@ -373,9 +371,7 @@ describe("PopoverView", () => {
   it("opens the full usage view through a provider panel and comes back", async () => {
     render(<PopoverView />)
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Anthropic, $1.25 today, estimated" }),
-    )
+    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
     fireEvent.click(await screen.findByRole("button", { name: "All provider usage" }))
 
     expect(await screen.findByRole("heading", { name: "Usage" })).toBeInTheDocument()
@@ -661,9 +657,7 @@ describe("PopoverView — window behaviour", () => {
       }),
     )
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Anthropic, $1.25 today, estimated" }),
-    )
+    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
     fireEvent.click(await screen.findByRole("button", { name: "All provider usage" }))
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("set_popover_height", {
@@ -704,9 +698,7 @@ describe("PopoverView — window behaviour", () => {
   it("lets an open provider panel claim Escape before the window does", async () => {
     render(<PopoverView />)
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Anthropic, $1.25 today, estimated" }),
-    )
+    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
     const panel = await screen.findByRole("dialog")
     expect(panel).toBeInTheDocument()
 
@@ -722,9 +714,7 @@ describe("PopoverView — window behaviour", () => {
     const activity = await screen.findByRole("heading", { name: "antiburn" })
     await waitFor(() => expect(activity).toHaveFocus())
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Anthropic, $1.25 today, estimated" }),
-    )
+    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
     fireEvent.click(await screen.findByRole("button", { name: "All provider usage" }))
 
     const usage = await screen.findByRole("heading", { name: "Usage" })

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -144,10 +144,12 @@ const LIVE_FORECAST = {
   usedToday: null,
 }
 
-// A different provider from `PROVIDER_USAGE`'s spend figures on purpose: this
-// is what puts the usage-limits section on screen (and so the chip row it
-// collapses to) without changing the accessible name the tests below assert
-// for the Anthropic chip, which carries no limit of its own here.
+// A different provider from `PROVIDER_USAGE`'s spend figures on purpose: the
+// usage-limits section — and the chip row it collapses to — is driven by
+// this payload, not by spend, so Codex is the only chip in these tests below
+// even though Anthropic is the only provider with any local spend. That
+// asymmetry is deliberate: it is what proves the chip row survives a day
+// with zero local spend, as long as a live reading exists.
 const LIVE_USAGE = {
   providers: [
     {
@@ -355,7 +357,7 @@ describe("PopoverView", () => {
     expect(invoke).toHaveBeenCalledWith("get_provider_usage", {
       utcOffsetMinutes: -new Date().getTimezoneOffset(),
     })
-    expect(screen.getByRole("button", { name: "Anthropic, estimated" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Codex, weekly limit 40%" })).toBeInTheDocument()
   })
 
   it("shows the plain title-and-gear footer, with none of the usage chips in it", async () => {
@@ -371,7 +373,7 @@ describe("PopoverView", () => {
   it("opens the full usage view through a provider panel and comes back", async () => {
     render(<PopoverView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Codex, weekly limit 40%" }))
     fireEvent.click(await screen.findByRole("button", { name: "All provider usage" }))
 
     expect(await screen.findByRole("heading", { name: "Usage" })).toBeInTheDocument()
@@ -381,16 +383,18 @@ describe("PopoverView", () => {
     expect(await screen.findByText("Wire the tray popover")).toBeInTheDocument()
   })
 
-  it("says so honestly in the chip row when nothing was spent today", async () => {
+  it("still shows a live-only chip on a fresh day with zero local spend anywhere", async () => {
+    // The bug this fixes: the chip row used to be driven by local spend, so
+    // a fresh day with none — even for a provider that never has any, like
+    // Codex here — fell through to an empty-row fallback despite Codex's own
+    // live reading sitting right there in `get_live_usage`.
     mockCommands({ get_provider_usage: { ...PROVIDER_USAGE, providers: [] } })
     render(<PopoverView />)
 
     await screen.findByText("Wire the tray popover")
-    // The usage-limits section still appears — Codex still has a limit to
-    // show — but its chip row says there was no spend today rather than
-    // showing an empty row.
     expect(screen.getByTestId("provider-usage-chips")).toBeInTheDocument()
-    expect(screen.getByText("No provider usage today")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Codex, weekly limit 40%" })).toBeInTheDocument()
+    expect(screen.queryByText("No live limits")).not.toBeInTheDocument()
   })
 
   it("withholds the usage-limits section entirely when no provider has a limit to show", async () => {
@@ -657,7 +661,7 @@ describe("PopoverView — window behaviour", () => {
       }),
     )
 
-    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Codex, weekly limit 40%" }))
     fireEvent.click(await screen.findByRole("button", { name: "All provider usage" }))
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("set_popover_height", {
@@ -698,7 +702,7 @@ describe("PopoverView — window behaviour", () => {
   it("lets an open provider panel claim Escape before the window does", async () => {
     render(<PopoverView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Codex, weekly limit 40%" }))
     const panel = await screen.findByRole("dialog")
     expect(panel).toBeInTheDocument()
 
@@ -714,7 +718,7 @@ describe("PopoverView — window behaviour", () => {
     const activity = await screen.findByRole("heading", { name: "antiburn" })
     await waitFor(() => expect(activity).toHaveFocus())
 
-    fireEvent.click(await screen.findByRole("button", { name: "Anthropic, estimated" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Codex, weekly limit 40%" }))
     fireEvent.click(await screen.findByRole("button", { name: "All provider usage" }))
 
     const usage = await screen.findByRole("heading", { name: "Usage" })

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -52,6 +52,10 @@ const SETTINGS = {
   launchAtLogin: false,
   autoUpdate: true,
   discoveryPaused: false,
+  // Collapsed, so the tests below that navigate through a provider chip do
+  // not each have to click the toggle open first. The expanded state itself
+  // is exercised in `UsageLimitsSection.test.tsx`.
+  overviewLimitsExpanded: false,
 }
 
 const SCAN_STATUS = {
@@ -130,6 +134,49 @@ const PROVIDER_USAGE = {
   generatedAt: "2027-01-15T08:00:00Z",
 }
 
+const LIVE_FORECAST = {
+  unavailableReason: "sparseHistory",
+  confidence: null,
+  consumptionRate: null,
+  paceRatio: null,
+  paceTrend: null,
+  runwayAt: null,
+  usedToday: null,
+}
+
+// A different provider from `PROVIDER_USAGE`'s spend figures on purpose: this
+// is what puts the usage-limits section on screen (and so the chip row it
+// collapses to) without changing the accessible name the tests below assert
+// for the Anthropic chip, which carries no limit of its own here.
+const LIVE_USAGE = {
+  providers: [
+    {
+      provider: "openai",
+      displayName: "Codex",
+      support: "live",
+      freshness: "fresh",
+      sourceLabel: "Asked Codex directly",
+      observedAt: "2027-01-15T07:58:00Z",
+      windows: [
+        {
+          id: "seven-day",
+          role: "primaryLong",
+          kind: "weekly",
+          scopeModel: null,
+          usedPercent: 40,
+          startsAt: null,
+          resetsAt: null,
+          hasNonzeroUsageInCurrentPeriod: false,
+          forecast: LIVE_FORECAST,
+        },
+      ],
+      extraUsage: null,
+    },
+  ],
+  errors: [],
+  generatedAt: "2027-01-15T08:00:00Z",
+}
+
 const HEALTHY_STORAGE = { failing: false, message: null }
 
 function repositoryPayload(overrides: Record<string, unknown> = {}) {
@@ -160,6 +207,8 @@ function mockCommands(overrides: Record<string, unknown> = {}) {
         return Promise.resolve(ANALYTICS)
       case "get_provider_usage":
         return Promise.resolve(PROVIDER_USAGE)
+      case "get_live_usage":
+        return Promise.resolve(LIVE_USAGE)
       case "get_scan_status":
       case "scan_now":
       case "cancel_scan":
@@ -297,7 +346,7 @@ describe("PopoverView", () => {
     )
   })
 
-  it("asks for provider usage with the reader own offset and shows the footer", async () => {
+  it("asks for provider usage with the reader own offset and shows the usage-limits chips", async () => {
     render(<PopoverView />)
 
     expect(await screen.findByTestId("provider-usage-cluster")).toBeInTheDocument()
@@ -309,6 +358,16 @@ describe("PopoverView", () => {
     expect(
       screen.getByRole("button", { name: "Anthropic, $1.25 today, estimated" }),
     ).toBeInTheDocument()
+  })
+
+  it("shows the plain title-and-gear footer, with none of the usage chips in it", async () => {
+    render(<PopoverView />)
+    await screen.findByTestId("provider-usage-cluster")
+
+    const footer = screen.getByRole("button", { name: "Open settings" }).parentElement
+    expect(footer).not.toBeNull()
+    expect(footer).toHaveTextContent("antiburn")
+    expect(footer?.querySelector('[data-testid="provider-usage-cluster"]')).toBeNull()
   })
 
   it("opens the full usage view through a provider panel and comes back", async () => {
@@ -326,15 +385,93 @@ describe("PopoverView", () => {
     expect(await screen.findByText("Wire the tray popover")).toBeInTheDocument()
   })
 
-  it("withholds the usage footer entirely when the shell reports nothing", async () => {
+  it("says so honestly in the chip row when nothing was spent today", async () => {
     mockCommands({ get_provider_usage: { ...PROVIDER_USAGE, providers: [] } })
     render(<PopoverView />)
 
     await screen.findByText("Wire the tray popover")
-    // The footer still appears — it is how the Usage view is reached — but it
-    // says there was no usage today rather than showing an empty chip row.
+    // The usage-limits section still appears — Codex still has a limit to
+    // show — but its chip row says there was no spend today rather than
+    // showing an empty row.
     expect(screen.getByTestId("provider-usage-cluster")).toBeInTheDocument()
     expect(screen.getByText("No provider usage today")).toBeInTheDocument()
+  })
+
+  it("withholds the usage-limits section entirely when no provider has a limit to show", async () => {
+    mockCommands({ get_live_usage: { providers: [], errors: [], generatedAt: "" } })
+    render(<PopoverView />)
+
+    await screen.findByText("Wire the tray popover")
+    expect(screen.queryByTestId("usage-limits-section")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("provider-usage-cluster")).not.toBeInTheDocument()
+    // The plain footer is unaffected — it never depended on usage at all.
+    expect(screen.getByRole("heading", { name: "antiburn" })).toBeInTheDocument()
+  })
+
+  it("persists the usage-limits toggle through set_settings, and switches the section's form", async () => {
+    render(<PopoverView />)
+    await screen.findByTestId("provider-usage-cluster")
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand usage limits" }))
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("set_settings", {
+        settings: expect.objectContaining({ overviewLimitsExpanded: true }),
+      }),
+    )
+    // The chips are gone, replaced by the provider's own limit rows.
+    expect(
+      await screen.findByRole("button", { name: "Collapse usage limits" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId("provider-usage-cluster")).not.toBeInTheDocument()
+    expect(screen.getByText("Codex")).toBeInTheDocument()
+  })
+
+  it("shows a spinner beside the toggle while a usage refresh is in flight", async () => {
+    let resolveSecondLoad: (() => void) | null = null
+    let liveCalls = 0
+    invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "get_live_usage") {
+        liveCalls += 1
+        // The first call is the initial load, which must settle so the view
+        // reaches its resting state; the second is the one this test holds
+        // open to observe the spinner.
+        if (liveCalls === 1) return Promise.resolve(LIVE_USAGE)
+        return new Promise((resolve) => {
+          resolveSecondLoad = () => resolve(LIVE_USAGE)
+        })
+      }
+      switch (command) {
+        case "get_settings":
+          return Promise.resolve(SETTINGS)
+        case "list_recent_sessions":
+          return Promise.resolve([activityEntry()])
+        case "get_provider_usage":
+          return Promise.resolve(PROVIDER_USAGE)
+        case "get_storage_health":
+          return Promise.resolve(HEALTHY_STORAGE)
+        case "list_repositories":
+          return Promise.resolve([])
+        case "set_settings":
+          return Promise.resolve((args as Record<string, unknown> | undefined)?.["settings"])
+        default:
+          return Promise.resolve(null)
+      }
+    })
+
+    render(<PopoverView />)
+    await screen.findByTestId("provider-usage-cluster")
+    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+
+    emit("popover:shown", undefined)
+    await waitFor(() => expect(resolveSecondLoad).not.toBeNull())
+    expect(screen.getByRole("status")).toBeInTheDocument()
+
+    await act(async () => {
+      resolveSecondLoad?.()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument())
   })
 
   it("refreshes usage on the shell’s popover-shown signal, independent of any scan", async () => {

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -349,7 +349,7 @@ describe("PopoverView", () => {
   it("asks for provider usage with the reader own offset and shows the usage-limits chips", async () => {
     render(<PopoverView />)
 
-    expect(await screen.findByTestId("provider-usage-cluster")).toBeInTheDocument()
+    expect(await screen.findByTestId("provider-usage-chips")).toBeInTheDocument()
     // "Today" and "this month" are the reader's calendar days, so the offset
     // travels with the request rather than being guessed shell-side.
     expect(invoke).toHaveBeenCalledWith("get_provider_usage", {
@@ -362,12 +362,12 @@ describe("PopoverView", () => {
 
   it("shows the plain title-and-gear footer, with none of the usage chips in it", async () => {
     render(<PopoverView />)
-    await screen.findByTestId("provider-usage-cluster")
+    await screen.findByTestId("provider-usage-chips")
 
     const footer = screen.getByRole("button", { name: "Open settings" }).parentElement
     expect(footer).not.toBeNull()
     expect(footer).toHaveTextContent("antiburn")
-    expect(footer?.querySelector('[data-testid="provider-usage-cluster"]')).toBeNull()
+    expect(footer?.querySelector('[data-testid="provider-usage-chips"]')).toBeNull()
   })
 
   it("opens the full usage view through a provider panel and comes back", async () => {
@@ -393,7 +393,7 @@ describe("PopoverView", () => {
     // The usage-limits section still appears — Codex still has a limit to
     // show — but its chip row says there was no spend today rather than
     // showing an empty row.
-    expect(screen.getByTestId("provider-usage-cluster")).toBeInTheDocument()
+    expect(screen.getByTestId("provider-usage-chips")).toBeInTheDocument()
     expect(screen.getByText("No provider usage today")).toBeInTheDocument()
   })
 
@@ -403,14 +403,14 @@ describe("PopoverView", () => {
 
     await screen.findByText("Wire the tray popover")
     expect(screen.queryByTestId("usage-limits-section")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("provider-usage-cluster")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("provider-usage-chips")).not.toBeInTheDocument()
     // The plain footer is unaffected — it never depended on usage at all.
     expect(screen.getByRole("heading", { name: "antiburn" })).toBeInTheDocument()
   })
 
   it("persists the usage-limits toggle through set_settings, and switches the section's form", async () => {
     render(<PopoverView />)
-    await screen.findByTestId("provider-usage-cluster")
+    await screen.findByTestId("provider-usage-chips")
 
     fireEvent.click(screen.getByRole("button", { name: "Expand usage limits" }))
 
@@ -423,7 +423,7 @@ describe("PopoverView", () => {
     expect(
       await screen.findByRole("button", { name: "Collapse usage limits" }),
     ).toBeInTheDocument()
-    expect(screen.queryByTestId("provider-usage-cluster")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("provider-usage-chips")).not.toBeInTheDocument()
     expect(screen.getByText("Codex")).toBeInTheDocument()
   })
 
@@ -460,7 +460,7 @@ describe("PopoverView", () => {
     })
 
     render(<PopoverView />)
-    await screen.findByTestId("provider-usage-cluster")
+    await screen.findByTestId("provider-usage-chips")
     expect(screen.queryByRole("status")).not.toBeInTheDocument()
 
     emit("popover:shown", undefined)
@@ -476,7 +476,7 @@ describe("PopoverView", () => {
 
   it("refreshes usage on the shell’s popover-shown signal, independent of any scan", async () => {
     render(<PopoverView />)
-    await screen.findByTestId("provider-usage-cluster")
+    await screen.findByTestId("provider-usage-chips")
 
     const callsBeforeShown = invoke.mock.calls.filter(
       ([command]) => command === "get_live_usage",

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -4,11 +4,11 @@
 
 import { lazy, Suspense, useCallback, useState, useSyncExternalStore } from "react"
 
-import { AlertTriangle } from "lucide-react"
+import { AlertTriangle, Settings } from "lucide-react"
 
 import { LocalActivityList } from "../components/activity/LocalActivityList"
 import type { LocalActivityEntry } from "../components/activity/LocalActivityList"
-import { ProviderUsageCluster } from "../components/providerUsage"
+import { UsageLimitsSection } from "../components/providerUsage"
 import { Banner } from "../components/ui/Banner"
 import { Skeleton } from "../components/ui/Skeleton"
 import { renderAgentIcon } from "../lib/agentIcon"
@@ -92,6 +92,36 @@ function SessionPaneLoading() {
       <div className="min-h-0 flex-1 px-4 pt-4">
         <Skeleton className="h-24 w-full" />
       </div>
+    </div>
+  )
+}
+
+/**
+ * The activity surface's bottom bar: the app's name, which also carries the
+ * surface's focus heading (see the class doc below), and the way to the
+ * standalone Settings window.
+ *
+ * This used to also hold a chip per provider used today. Those moved to the
+ * usage-limits section at the top of the surface, collapsed — the same
+ * chips, just relocated, so the footer here is name and gear and nothing
+ * else.
+ */
+function PopoverFooter({ onOpenSettings }: { onOpenSettings: () => void }) {
+  return (
+    <div className="flex h-11 shrink-0 items-center gap-2 border-t border-separator px-4">
+      {/* Focused by the popover when this surface takes over, so a keyboard
+          or screen-reader user lands in the view rather than on <body>. */}
+      <h1 data-view-heading tabIndex={-1} className="type-headline text-label outline-none">
+        antiburn
+      </h1>
+      <button
+        type="button"
+        onClick={onOpenSettings}
+        aria-label="Open settings"
+        className="-mr-0.5 ml-auto inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-control text-label-secondary hover:bg-surface-hover"
+      >
+        <Settings size={14} strokeWidth={1.75} aria-hidden="true" />
+      </button>
     </div>
   )
 }
@@ -204,16 +234,13 @@ export function PopoverView() {
       )
     }
 
+    const limitsExpanded =
+      state.settings?.overviewLimitsExpanded ?? DEFAULT_SETTINGS.overviewLimitsExpanded
+
     return (
       <div className="flex h-full flex-col">
-        <header className="flex h-11 shrink-0 items-center gap-2 px-4">
-          <h1 data-view-heading tabIndex={-1} className="type-headline text-label outline-none">
-            antiburn
-          </h1>
-        </header>
-
         {banners.length > 0 && (
-          <div className="shrink-0 space-y-1 px-2 pb-1.5">
+          <div className="shrink-0 space-y-1 px-2 pt-2 pb-1.5">
             {banners.map((banner) => (
               <Banner
                 key={banner.id}
@@ -234,6 +261,15 @@ export function PopoverView() {
           </div>
         )}
 
+        <UsageLimitsSection
+          providers={state.usage?.providers ?? []}
+          live={state.liveUsage}
+          expanded={limitsExpanded}
+          onToggleExpanded={() => session.setOverviewLimitsExpanded(!limitsExpanded)}
+          refreshing={state.usageRefreshing}
+          onViewAll={() => session.setShowUsage(true)}
+        />
+
         <div className="min-h-0 flex-1">
           {state.entries == null ? (
             <ActivitySkeleton />
@@ -241,9 +277,6 @@ export function PopoverView() {
             <LocalActivityList
               entries={state.entries}
               days={windowDays}
-              // The affordance sits on the day-range label, so it lands on the
-              // pane that owns "Show the last" rather than the last-open pane.
-              onOpenSettings={() => void openSettingsWindow("general")}
               onOpenSession={(entry) => {
                 if (!entry.sessionId) return
                 session.openSession(subjectFor(entry))
@@ -253,12 +286,7 @@ export function PopoverView() {
           )}
         </div>
 
-        <ProviderUsageCluster
-          providers={state.usage?.providers ?? []}
-          live={state.liveUsage}
-          onViewAll={() => session.setShowUsage(true)}
-          onOpenSettings={() => void openSettingsWindow()}
-        />
+        <PopoverFooter onOpenSettings={() => void openSettingsWindow()} />
       </div>
     )
   }

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -141,6 +141,15 @@ export class PopoverSession {
   private started = false
   private generation = 0
   private analyticsToken = 0
+  /**
+   * How many `refreshUsage` calls are currently in flight.
+   *
+   * A counter rather than a boolean: the popover-shown signal and a
+   * scan-finished event can each trigger a refresh close together, and the
+   * first one to settle must not clear the spinner out from under the one
+   * still running. The snapshot's `usageRefreshing` is `count > 0`.
+   */
+  private usageRefreshCount = 0
 
   private stopSettingsListening: (() => void) | null = null
   private stopSessionsInvalidatedListening: (() => void) | null = null
@@ -421,9 +430,11 @@ export class PopoverSession {
   }
 
   private refreshUsage = async (): Promise<void> => {
-    // Flagged for the limits section's spinner, set before the request and
-    // cleared once it settles either way — a source that throws must not
-    // leave the spinner stuck on.
+    // Counted rather than flagged directly, and flushed to the snapshot as
+    // `count > 0`: the popover-shown signal and a scan-finished event can
+    // each start a refresh close together, and the first call to settle must
+    // not clear the spinner while a second one is still in flight.
+    this.usageRefreshCount += 1
     this.update({ usageRefreshing: true })
     try {
       // Two commands, refreshed together and settled independently: the limit
@@ -440,7 +451,8 @@ export class PopoverSession {
       // too, not only the click-driven ones.
       this.syncHeight()
     } finally {
-      this.update({ usageRefreshing: false })
+      this.usageRefreshCount -= 1
+      this.update({ usageRefreshing: this.usageRefreshCount > 0 })
     }
   }
 

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -28,6 +28,7 @@ import {
   openSettingsWindow,
   scanNow,
   setPopoverHeight,
+  setSettings,
   type AppSettings,
   type LiveUsageSummaryPayload,
   type ProviderUsageSummaryPayload,
@@ -67,6 +68,8 @@ export interface PopoverSnapshot {
   /** Provider usage, or null while the first snapshot is in flight. */
   usage: ProviderUsageSummaryPayload | null
   liveUsage: LiveUsageSummaryPayload
+  /** Whether a `refreshUsage` call is in flight, for the limits section's spinner. */
+  usageRefreshing: boolean
   /** Whether the full Usage view is showing over the activity list. */
   showUsage: boolean
   storage: StorageHealthPayload
@@ -151,6 +154,7 @@ export class PopoverSession {
     repositories: [],
     usage: null,
     liveUsage: EMPTY_LIVE_USAGE,
+    usageRefreshing: false,
     showUsage: false,
     storage: HEALTHY_STORAGE,
     dismissed: [],
@@ -207,6 +211,24 @@ export class PopoverSession {
   dismissBanner = (id: AttentionKind): void => {
     if (this.snapshot.dismissed.includes(id)) return
     this.update({ dismissed: [...this.snapshot.dismissed, id] })
+  }
+
+  /**
+   * Open or close the popover's usage-limits section, and persist the choice
+   * so it never changes again on its own.
+   *
+   * Optimistic, the same way the settings window writes: the toggle must not
+   * lag behind the pointer, and the stored answer replaces this one a moment
+   * later — silently, since a boolean the store would reject does not exist.
+   */
+  setOverviewLimitsExpanded = (expanded: boolean): void => {
+    const current = this.snapshot.settings ?? DEFAULT_SETTINGS
+    if (current.overviewLimitsExpanded === expanded) return
+    const next = { ...current, overviewLimitsExpanded: expanded }
+    this.update({ settings: next })
+    void setSettings(next)
+      .then((saved) => this.update({ settings: saved }))
+      .catch(() => {})
   }
 
   /** Run a discovery pass. The source-access banner's only action. */
@@ -399,19 +421,27 @@ export class PopoverSession {
   }
 
   private refreshUsage = async (): Promise<void> => {
-    // Two commands, refreshed together and settled independently: the limit
-    // half is allowed to be missing without the spend half waiting on it, and
-    // a source that throws leaves the estimate surface untouched.
-    const [spend, limits] = await Promise.all([
-      getProviderUsage().catch(() => EMPTY_PROVIDER_USAGE),
-      getLiveUsage().catch(() => EMPTY_LIVE_USAGE),
-    ])
-    this.update({ usage: spend, liveUsage: limits })
-    // Usage arriving can flip the derived surface to 'usage' on its own — the
-    // reader may have already asked to see it before there was anything to
-    // show — so the height request has to follow this update too, not only
-    // the click-driven ones.
-    this.syncHeight()
+    // Flagged for the limits section's spinner, set before the request and
+    // cleared once it settles either way — a source that throws must not
+    // leave the spinner stuck on.
+    this.update({ usageRefreshing: true })
+    try {
+      // Two commands, refreshed together and settled independently: the limit
+      // half is allowed to be missing without the spend half waiting on it,
+      // and a source that throws leaves the estimate surface untouched.
+      const [spend, limits] = await Promise.all([
+        getProviderUsage().catch(() => EMPTY_PROVIDER_USAGE),
+        getLiveUsage().catch(() => EMPTY_LIVE_USAGE),
+      ])
+      this.update({ usage: spend, liveUsage: limits })
+      // Usage arriving can flip the derived surface to 'usage' on its own —
+      // the reader may have already asked to see it before there was
+      // anything to show — so the height request has to follow this update
+      // too, not only the click-driven ones.
+      this.syncHeight()
+    } finally {
+      this.update({ usageRefreshing: false })
+    }
   }
 
   private refreshRepositoryList = async (): Promise<void> => {


### PR DESCRIPTION
## Summary

Restructures the popover's activity surface per the agreed design:

- **Bottom bar simplified.** The "antiburn" title moved down to the bottom bar, which now shows only the title (left) and the settings gear (right) — the per-provider chips that used to live there are gone from this spot.
- **Activity header removed.** The "Activity / Last 7 days" header row (and the top `h-11` header that held the app title) is gone entirely; the list itself is unchanged. Dead filter/range machinery in `LocalActivityList` was removed along with it.
- **New collapsible usage-limits section** at the top of the activity surface:
  - One compact subsection per provider with live limit data (name + a "Live Xm ago" freshness note + `LiveUsageWindowRows` — no pace/trend/runway/spend).
  - A chevron toggle in the top-right corner; collapsed, the section shrinks to a single row showing the same provider radial chips that used to live in the bottom bar (extracted into a shared `ProviderUsageChips` component, reused here with the anchored detail panel opening downward instead of upward).
  - Renders nothing at all when no provider has limit data (live usage off, or no reading yet).
  - Expanded state overlays the toggle/spinner on the top-right corner rather than spending a row on them, to keep vertical footprint minimal.
- **Persistence.** Expand/collapse state is a new `overviewLimitsExpanded` `AppSettings` field (frontend `ipc.ts` + Rust `store/model.rs`/`store/mod.rs`, default `true`), written through the existing `setSettings` command and reflected back on the `settings:changed` broadcast.
- **Refresh spinner.** `PopoverSession` tracks in-flight `refreshUsage` calls with a counter (not a boolean), so overlapping triggers — e.g. popover-shown and scan-finished landing close together — don't have the first to settle clear the spinner while the second is still running. Exposed as `usageRefreshing` on the snapshot and shown as a small spinner beside the toggle.

## Review fixes

Applied after an initial lead review:

- `usageRefreshing` is now tracked with a private counter on `PopoverSession` rather than a boolean, so an overlapping refresh (popover-shown and scan-finished landing close together) no longer has the first call to settle clear the spinner while the second is still in flight.
- Renamed the `provider-usage-cluster` testid to `provider-usage-chips` to match the renamed component, updated across all tests.
- The expanded usage-limits section now overlays its spinner/toggle on the top-right corner instead of spending a full row on them, to minimize vertical footprint; the first provider subsection reserves right-hand padding (`pr-8`) so its freshness note never renders under the overlay.
- Added a short **Commits** section to `AGENTS.md` documenting the DCO sign-off requirement — this PR's own DCO check failed once because the initial commits weren't signed off, which needed a rebase and force-push to fix. The new section is there so that doesn't happen again.

## Visual experiment — vertical "Limits" label

In the expanded state, `UsageLimitsSection` carries a thin vertical "Limits" label down its left edge instead of no header at all, acting as the section's only header at no vertical cost. The heading also doubles as the section's accessible name (`role="region"` + `aria-labelledby`) rather than a redundant `aria-label`. Collapsed state has no header — a single row of chips has no room or need for one.

## Manual design tweaks, plus follow-up fixes

The label column and its surroundings were then hand-tweaked directly on the branch (`manual tweaks`, signed off in place — see below):

- The toggle moved into the left rail, above an upright-letter "LIMITS" heading (`[text-orientation:upright]` rather than the rotated `vertical-rl` text, on a `bg-surface-secondary` `w-7` column); its chevron now points `rotate-270` when expanded.
- Only the spinner is left overlaid on the top-right corner; the toggle no longer overlays anything, so the first subsection's `pr-8` reservation is gone.
- Each subsection's "Live Xm ago" freshness note is now `hidden group-hover:inline` and tertiary-toned always (it no longer changes color when stale), rather than always visible.
- `LiveUsageWindowRows`'s reset label is now tertiary-toned.
- The collapsed row now orders toggle first, chips in the middle, spinner last.

Follow-up fixes to keep those tweaks passing checks (own commit, not folded into the manual one):

- Dropped the now-unused `liveFreshnessToneClass` import from `UsageLimitsSection.tsx` (the function itself is still used elsewhere).
- Removed the leftover `reserveToggleSpace` parameter from `ProviderLimitSubsection`, which no longer has anywhere to reserve space for.
- **Collapsed-row chips now show live-limit percentages instead of dollars.** The chip text used to be today's spend (e.g. "$82.40"), which has no denominator to sit next to a percentage ring meaningfully. It's now each of that provider's live windows' percentages, in `liveWindows()` order, joined with " / " (e.g. "3% / 19%"). A provider with no live windows shows the glyph/ring alone — no dollar fallback. The chip's accessible name follows suit: a clause per live window, the dollar clause dropped. This only affects `ProviderUsageChips` as used here, since the bottom bar no longer carries chips of its own.
- Updated tests across `UsageLimitsSection.test.tsx`, `ProviderUsageChips.test.tsx`, and `PopoverView.test.tsx` for all of the above.
- The `manual tweaks` commit was missing a DCO sign-off; it was amended in place (author, message, and tree content untouched — verified the tree hash is identical before and after) rather than folded into the fix commit.

## Collapsed chips: follow live limits, ring shows the max

A second round of user feedback on the collapsed chip row, since screenshotted:

- **Chip selection now follows live limits, not local spend.** The row was still built from `providersForWindow(providers, "today")`, so a fresh day with no local spend fell through to the empty-row fallback even when a provider's live limit percentages existed. Chips are now selected exactly like the expanded section's subsections: any provider in `live` with at least one live window — so collapsed and expanded always agree on which providers show up. A provider with local spend but no live reading no longer gets a chip here (the Usage view is where it lives); a provider with a live reading but no local spend still does, with no dollar fallback and no local-state clause in its name.
  - `ProviderUsageDetail`'s spend payload is now optional (`displayName`/`providerId` are separate, always-known props). A live-only chip's panel simply omits the spend half — token split, spend trend, state line — rather than fabricating figures for a provider nothing was ever run through on this device. The live-limits half above it is unaffected either way.
  - The row's empty-state fallback is reworded from "No provider usage today" to "No live limits", since it's live-driven now.
- **The ring shows the fullest live window, not the account-wide one.** It used `headlineWindow` (deliberately the account-wide window). It now uses the maximum `usedPercent` across the provider's live windows — a new `maxLiveUsedPercent` in `liveUsage.ts`. `headlineWindow` had no other caller, so it and its dedicated test block are deleted rather than left unused.
- Updated tests in `ProviderUsageChips.test.tsx` (largely rewritten around the live-driven selection), `liveUsage.test.ts`, and `PopoverView.test.tsx`.

## Known product gap — flagging for a decision

When live usage is disabled or no provider has reported a limit yet, the whole usage-limits section — including its collapsed chip row — renders nothing, per spec. Since the bottom bar no longer carries chips either, this means **the popover overview currently has no entry point into the full Usage view** for a reader in that state. This matches the agreed spec literally, but is worth a follow-up decision: either an alternate way into the Usage view, or a decision that this is acceptable (e.g. because Settings still surfaces the switch, or the gap only affects the "live usage off" cohort).

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test` (684 tests)
- [x] `npm run format`
- [x] `npm run knip`
- [x] `cargo check`, `cargo clippy --all-targets`, `cargo fmt --check`
- [x] `cargo test` (334 tests, including `store::` settings round-trip/default coverage for the new field) — Rust untouched since the last run; no round-trip changes to re-verify this round

🤖 Generated with [Claude Code](https://claude.com/claude-code)

