### PR TITLE
fix(activity): use semantic transcript recency

### DIFF
--- a/apps/desktop/src-tauri/src/analytics.rs
+++ b/apps/desktop/src-tauri/src/analytics.rs
@@ -463,7 +463,9 @@ pub fn sorted_models(breakdown: &HashMap<String, ModelTokens>) -> Vec<String> {
     models
 }
 
-/// Whether a transcript heartbeat means the session is still being written.
+/// Whether meaningful session activity fell inside the active window. The
+/// timestamp is semantic when the transcript provides one, rather than a
+/// filesystem-touch heartbeat.
 pub fn is_active(updated_at_epoch: Option<i64>, now: i64) -> bool {
     updated_at_epoch.is_some_and(|updated| now.saturating_sub(updated) < ACTIVE_SESSION_WINDOW_SECS)
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1183,7 +1183,7 @@ mod tests {
     fn epochs_render_as_the_iso_stamps_the_activity_list_parses() {
         assert_eq!(iso_from_epoch(Some(0)), "1970-01-01T00:00:00Z");
         assert_eq!(iso_from_epoch(Some(1_800_000_000)), "2027-01-15T08:00:00Z");
-        // A session with no heartbeat still yields a parseable stamp rather
+        // A session with no activity still yields a parseable stamp rather
         // than an empty string the list would drop.
         assert_eq!(iso_from_epoch(None), "1970-01-01T00:00:00Z");
     }

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -31,8 +31,8 @@ pub struct ActivityEntry {
     pub repo: String,
     /// ISO-8601 stamp of the session's most recent transcript activity.
     pub timestamp: String,
-    /// Whether the transcript is still being written (heartbeat inside the
-    /// engine's active-session window).
+    /// Whether meaningful session activity fell inside the engine's
+    /// active-session window.
     pub is_active: bool,
     /// `cli`, `ide_desktop`, or `unknown`.
     pub surface: String,

--- a/apps/desktop/src-tauri/src/provider_usage/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/mod.rs
@@ -25,7 +25,7 @@
 //! # An honest limitation, surfaced rather than hidden
 //!
 //! 1. **A session lands in one window: the one its last activity falls in.**
-//!    The store keeps a per-session heartbeat, not a per-turn timeline, so a
+//!    The store keeps a per-session activity timestamp, not a per-turn timeline, so a
 //!    session that ran across midnight counts entirely in the day it last
 //!    touched. The views say so.
 
@@ -115,7 +115,7 @@ pub fn window_bounds(now: i64, utc_offset_minutes: i32) -> WindowBounds {
     }
 }
 
-/// The earliest heartbeat the aggregation needs to read.
+/// The earliest activity timestamp the aggregation needs to read.
 ///
 /// Exposed so the caller can bound its query instead of loading every retained
 /// session and discarding most of them.
@@ -147,7 +147,7 @@ impl Membership {
     }
 
     /// True when the row falls outside every window, which makes it irrelevant
-    /// — a session whose heartbeat is older than the widest bound, or missing
+    /// — a session whose activity is older than the widest bound, or missing
     /// entirely (stored as zero).
     fn is_empty(self) -> bool {
         !self.today && !self.week && !self.month
@@ -329,7 +329,7 @@ fn provider_without_models(agent: &str) -> &'static str {
 /// bounded by [`lookback_start`], which is a lower bound, not an exact filter —
 /// and those are skipped here.
 /// Estimated spend, in USD, across every provider for sessions whose
-/// heartbeat falls in `[start, end)`.
+/// activity timestamp falls in `[start, end)`.
 ///
 /// The anomaly monitor's arithmetic, kept next to `summarize` because it
 /// reuses the same attribution and per-model pricing. Same floor semantics as

--- a/apps/desktop/src-tauri/src/repositories.rs
+++ b/apps/desktop/src-tauri/src/repositories.rs
@@ -745,6 +745,8 @@ mod tests {
             cwd: Some(cwd.to_string()),
             surface: "cli".to_string(),
             updated_at_epoch: Some(1_800_000_000),
+            activity_cursor: String::new(),
+            activity_source: "mtime".to_string(),
             subagent_count: 0,
             fork_parent_session_id: None,
         };
@@ -829,6 +831,8 @@ mod tests {
             cwd: Some(cwd.to_string()),
             surface: "cli".into(),
             updated_at_epoch: Some(1),
+            activity_cursor: String::new(),
+            activity_source: "mtime".into(),
             subagent_count: 0,
             fork_parent_session_id: None,
         };

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -69,10 +69,10 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use antiburn_local::discovery::scanner::TitleSource;
+use antiburn_local::discovery::scanner::{self, TitleSource};
 use antiburn_local::discovery::{
     Explorers, ResolvedTitle, SessionLog, SessionSource, TitleLookupKind, session_log_metadata,
-    session_source_preview,
+    session_source_preview, session_source_tail,
 };
 use antiburn_local::model::AgentKind;
 use antiburn_local::paths::{home_dir, ignored_paths};
@@ -84,7 +84,7 @@ use crate::analytics;
 use crate::dto::ScanStatus;
 use crate::repositories;
 use crate::storage_health::{self, checked};
-use crate::store::{SessionKey, SessionRecord, Store};
+use crate::store::{SessionActivityKey, SessionActivityState, SessionKey, SessionRecord, Store};
 
 /// How often the scheduler wakes up.
 pub const TICK: Duration = Duration::from_secs(60);
@@ -292,7 +292,9 @@ async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Res
         )
         .await;
 
-    let Described { records, rejected } = describe(logs, &home, &ignored).await;
+    let activity_states = store.session_activity_states()?;
+    let Described { records, rejected } =
+        describe_with_states(logs, &home, &ignored, &activity_states).await;
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
@@ -351,10 +353,20 @@ struct Described {
 
 /// Read metadata for every discovered log, at a bounded concurrency, and drop
 /// the ones the reader opted out of.
+#[cfg(test)]
 async fn describe(
     logs: Vec<SessionLog>,
     home: &std::path::Path,
     ignored: &std::collections::HashSet<String>,
+) -> Described {
+    describe_with_states(logs, home, ignored, &std::collections::HashMap::new()).await
+}
+
+async fn describe_with_states(
+    logs: Vec<SessionLog>,
+    home: &std::path::Path,
+    ignored: &std::collections::HashSet<String>,
+    activity_states: &std::collections::HashMap<SessionActivityKey, SessionActivityState>,
 ) -> Described {
     let indexed_titles = indexed_titles_for_logs(&logs).await;
     let mut records = Vec::with_capacity(logs.len());
@@ -364,9 +376,17 @@ async fn describe(
         for log in chunk {
             let log = log.clone();
             let home = home.to_path_buf();
+            let activity_key = SessionActivityKey::new(
+                log.environment.key(),
+                log.agent_type.slug(),
+                log.source_label(),
+            );
+            let activity_state = activity_states.get(&activity_key).cloned();
             let indexed_title = recovered_id(&log)
                 .and_then(|session_id| indexed_titles.get(&(log.agent_type, session_id)).cloned());
-            set.spawn(async move { describe_one(log, &home, indexed_title).await });
+            set.spawn(async move {
+                describe_one_with_activity(log, &home, indexed_title, activity_state).await
+            });
         }
         while let Some(joined) = set.join_next().await {
             match joined {
@@ -423,10 +443,113 @@ enum DescribeOutcome {
     Skip,
 }
 
+/// Resolve the display timestamp from transcript events while using the
+/// persisted aggregate cursor as a cheap unchanged-source gate.
+async fn semantic_activity_for_log(
+    log: &SessionLog,
+    previous: Option<&SessionActivityState>,
+    children: &[std::path::PathBuf],
+    preview: Option<&str>,
+) -> (Option<i64>, String, String) {
+    let SessionSource::File(path) = &log.source else {
+        return (log.updated_at, "unknown".to_string(), String::new());
+    };
+
+    let Some(size) = tokio::fs::metadata(path).await.ok().map(|meta| meta.len()) else {
+        return (log.updated_at, "mtime".to_string(), String::new());
+    };
+
+    // Include the complete source set in the cursor. Parent + child sizes and
+    // identities make an unchanged orchestrator as cheap as a leaf while a
+    // child append naturally invalidates the gate.
+    let mut cursor_parts = vec![[
+        "parent".to_string(),
+        path.to_string_lossy().into_owned(),
+        size.to_string(),
+    ]];
+    for child in children {
+        let child_size = tokio::fs::metadata(child)
+            .await
+            .ok()
+            .map(|meta| meta.len())
+            .map_or_else(|| "missing".to_string(), |size| size.to_string());
+        cursor_parts.push([
+            "child".to_string(),
+            child.to_string_lossy().into_owned(),
+            child_size,
+        ]);
+    }
+    cursor_parts.sort_unstable();
+    let cursor = serde_json::to_string(&cursor_parts).expect("activity cursor is serializable");
+
+    let unchanged_event = previous
+        .is_some_and(|state| state.activity_source == "event" && state.activity_cursor == cursor);
+    if unchanged_event {
+        let state = previous.expect("checked above");
+        return (
+            state.updated_at_epoch,
+            state.activity_source.clone(),
+            cursor,
+        );
+    }
+
+    // Preserve a known event timestamp before looking at changed content. A
+    // size-growing append containing only housekeeping must never fall back to
+    // its new mtime or promote an otherwise idle session.
+    let mut latest = previous
+        .filter(|state| state.activity_source == "event")
+        .and_then(|state| state.updated_at_epoch);
+    let mut consider = |content: &str| {
+        if let Some(epoch) = scanner::max_activity_event_epoch(content, log.agent_type) {
+            latest = Some(latest.map_or(epoch, |current| current.max(epoch)));
+        }
+    };
+
+    // `describe_one_with_activity` already fetched the bounded preview for
+    // metadata/title work. Reuse it for normal-sized files; larger files use
+    // both the preview and a line-aligned tail so old activity can heal a
+    // migrated mtime row even when the tail is housekeeping-only.
+    if let Some(preview) = preview {
+        consider(preview);
+    }
+    let preview_is_complete = preview.is_some_and(|content| size <= content.len() as u64);
+    if !preview_is_complete && let Some(tail) = session_source_tail(&log.source).await {
+        consider(&tail);
+    }
+
+    // Child transcripts are separate append-only files. Their semantic work
+    // belongs to the orchestrator's activity row; child mtimes are discovery
+    // hints only.
+    for child in children {
+        let child_source = SessionSource::File(child.clone());
+        if let Some(epoch) = session_source_tail(&child_source)
+            .await
+            .and_then(|tail| scanner::max_activity_event_epoch(&tail, log.agent_type))
+        {
+            latest = Some(latest.map_or(epoch, |current| current.max(epoch)));
+        }
+    }
+
+    match latest {
+        Some(epoch) => (Some(epoch), "event".to_string(), cursor),
+        None => (log.updated_at, "mtime".to_string(), cursor),
+    }
+}
+
+#[cfg(test)]
 async fn describe_one(
     log: SessionLog,
     home: &std::path::Path,
     indexed_title: Option<ResolvedTitle>,
+) -> DescribeOutcome {
+    describe_one_with_activity(log, home, indexed_title, None).await
+}
+
+async fn describe_one_with_activity(
+    log: SessionLog,
+    home: &std::path::Path,
+    indexed_title: Option<ResolvedTitle>,
+    activity_state: Option<SessionActivityState>,
 ) -> DescribeOutcome {
     let metadata = session_log_metadata(&log).await;
     let Some(session_id) = metadata
@@ -471,13 +594,21 @@ async fn describe_one(
 
     // A dir listing per orchestrator-capable session; vendors that record no
     // orchestration return empty without touching the disk.
-    let subagent_count = match &log.source {
-        SessionSource::File(path) => Explorers::DISK
-            .list_subagents_for_transcript(&log.agent_type, path)
-            .await
-            .len() as u32,
-        _ => 0,
+    let children = match &log.source {
+        SessionSource::File(path)
+            if matches!(log.agent_type, AgentKind::Claude | AgentKind::Codex) =>
+        {
+            Explorers::DISK
+                .list_subagents_for_transcript(&log.agent_type, path)
+                .await
+        }
+        _ => Vec::new(),
     };
+    let subagent_count = children.len() as u32;
+
+    let (updated_at_epoch, activity_source, activity_cursor) =
+        semantic_activity_for_log(&log, activity_state.as_ref(), &children, preview.as_deref())
+            .await;
 
     DescribeOutcome::Session(Box::new(SessionRecord {
         key,
@@ -488,7 +619,9 @@ async fn describe_one(
         title_source,
         cwd: metadata.and_then(|metadata| metadata.cwd),
         surface: log.surface_label(home).to_string(),
-        updated_at_epoch: log.updated_at,
+        updated_at_epoch,
+        activity_cursor,
+        activity_source,
         subagent_count,
         // Lineage is resolved when a session is opened: the observation lives
         // inside the transcript, and reading every transcript on every pass
@@ -696,7 +829,7 @@ fn source_kind(source: &SessionSource) -> &'static str {
     }
 }
 
-/// Per-agent `(slug, sessions seen, newest heartbeat)` for the scan-state table.
+/// Per-agent `(slug, sessions seen, newest activity)` for the scan-state table.
 fn per_agent_totals(records: &[SessionRecord]) -> Vec<(String, i64, Option<i64>)> {
     let mut totals: std::collections::BTreeMap<String, (i64, Option<i64>)> =
         std::collections::BTreeMap::new();
@@ -784,6 +917,7 @@ mod tests {
     use super::*;
     use antiburn_local::platform::environment::DiscoveryEnvironment;
     use std::collections::HashSet;
+    use std::io::Write;
 
     /// A synthetic Claude store: `<home>/.claude/projects/<encoded>/<id>.jsonl`.
     /// Every value is fictional; the shapes are what the engine's scanner reads.
@@ -1112,7 +1246,7 @@ mod tests {
         assert_eq!(stored.len(), 2);
         assert_eq!(
             stored[0].key.session_id, "codex-abc",
-            "newest heartbeat first"
+            "newest activity first"
         );
 
         let state = store.scan_state().unwrap();
@@ -1122,6 +1256,194 @@ mod tests {
                 .iter()
                 .all(|(_, completed, seen)| { completed.is_some() && *seen == 1 })
         );
+    }
+
+    #[tokio::test]
+    async fn an_idle_touched_transcript_heals_mtime_recency_and_then_uses_size_gate() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = home
+            .path()
+            .join(".claude/projects/-home-avery-code-widgets/old.jsonl");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"type":"user","sessionId":"old","cwd":"/home/avery/code/widgets","timestamp":"2026-06-26T21:20:00Z"}"#,
+                "\n",
+                r#"{"type":"custom-title","customTitle":"Renamed","timestamp":"2026-08-19T17:07:32Z"}"#,
+                "\n",
+                r#"{"type":"permission-mode","mode":"default","timestamp":"2026-08-19T17:07:33Z"}"#,
+                "\n",
+                r#"{"type":"assistant","timestamp":"2026-06-26T21:30:15Z"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+
+        // Append a housekeeping record larger than the bounded tail. The
+        // preview still contains the old activity and should heal this
+        // migrated mtime row on its first semantic scan.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(
+                format!(
+                    r#"{{"type":"permission-mode","mode":"default","timestamp":"2026-08-19T17:08:00Z","padding":"{}"}}
+"#,
+                    "x".repeat(300_000)
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+
+        // Simulate a row written by the old mtime-based scanner. The semantic
+        // pass must replace it with the old meaningful transcript activity.
+        let mut stale = record("claude-code", "old", Some(1_787_155_652));
+        stale.source_label = path.to_string_lossy().into_owned();
+        stale.activity_cursor = "legacy".into();
+        stale.activity_source = "mtime".into();
+        store.upsert_sessions(&[stale]).unwrap();
+
+        let states = store.session_activity_states().unwrap();
+        let described = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_787_155_652)],
+            home.path(),
+            &HashSet::new(),
+            &states,
+        )
+        .await;
+        let expected = time::OffsetDateTime::parse(
+            "2026-06-26T21:30:15Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap()
+        .unix_timestamp();
+        assert_eq!(described.records[0].updated_at_epoch, Some(expected));
+        assert_eq!(described.records[0].activity_source, "event");
+        store.upsert_sessions(&described.records).unwrap();
+        let stored = store
+            .session_activity_states()
+            .unwrap()
+            .remove(&SessionActivityKey::new(
+                "native",
+                AgentKind::Claude.slug(),
+                path.to_string_lossy().into_owned(),
+            ))
+            .expect("healed activity cursor");
+        assert_eq!(stored.updated_at_epoch, Some(expected));
+        assert_eq!(stored.activity_source, "event");
+
+        // A harness appends housekeeping only. The changed size invalidates
+        // the cursor, but the previous event seed survives the suffix parse
+        // and prevents the new mtime from promoting the session.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(
+                format!(
+                    r#"{{"type":"permission-mode","mode":"default","timestamp":"2026-08-19T17:08:00Z","padding":"{}"}}
+"#,
+                    "x".repeat(300_000)
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        let states = store.session_activity_states().unwrap();
+        let touched = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_800_000_000)],
+            home.path(),
+            &HashSet::new(),
+            &states,
+        )
+        .await;
+        assert_eq!(touched.records[0].updated_at_epoch, Some(expected));
+        assert_eq!(touched.records[0].activity_source, "event");
+
+        // A later mtime-only touch now hits the unchanged-size cursor gate.
+        let states = {
+            store.upsert_sessions(&touched.records).unwrap();
+            store.session_activity_states().unwrap()
+        };
+        let gated = describe_with_states(
+            vec![log(AgentKind::Claude, path, 1_800_000_001)],
+            home.path(),
+            &HashSet::new(),
+            &states,
+        )
+        .await;
+        assert_eq!(gated.records[0].updated_at_epoch, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn an_orchestrator_cursor_gates_unchanged_children_and_advances_on_child_growth() {
+        let home = tempfile::TempDir::new().unwrap();
+        let parent = write_claude_session(home.path(), "orchestrator");
+        let child_dir = parent
+            .parent()
+            .unwrap()
+            .join("orchestrator")
+            .join("subagents");
+        std::fs::create_dir_all(&child_dir).unwrap();
+        let child = child_dir.join("agent-child.jsonl");
+        std::fs::write(
+            &child,
+            r#"{"type":"assistant","timestamp":"2026-08-01T10:02:00Z"}
+"#,
+        )
+        .unwrap();
+        let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+
+        let first = describe_with_states(
+            vec![log(AgentKind::Claude, parent.clone(), 1_800_000_000)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_activity_states().unwrap(),
+        )
+        .await;
+        assert_eq!(first.records[0].subagent_count, 1);
+        let first_epoch = first.records[0].updated_at_epoch.unwrap();
+        store.upsert_sessions(&first.records).unwrap();
+
+        // An mtime-only parent touch with an unchanged parent+child cursor is
+        // served from the cached semantic event without reading either tail.
+        let gated = describe_with_states(
+            vec![log(AgentKind::Claude, parent.clone(), 1_900_000_000)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_activity_states().unwrap(),
+        )
+        .await;
+        assert_eq!(gated.records[0].updated_at_epoch, Some(first_epoch));
+
+        // Appending genuine child work changes the aggregate cursor and
+        // promotes the parent to the child's semantic event time.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&child)
+            .unwrap()
+            .write_all(
+                br#"{"type":"assistant","timestamp":"2026-08-01T10:03:00Z"}
+"#,
+            )
+            .unwrap();
+        let advanced = describe_with_states(
+            vec![log(AgentKind::Claude, parent, 1_900_000_001)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_activity_states().unwrap(),
+        )
+        .await;
+        let expected = time::OffsetDateTime::parse(
+            "2026-08-01T10:03:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap()
+        .unix_timestamp();
+        assert_eq!(advanced.records[0].updated_at_epoch, Some(expected));
+        assert!(advanced.records[0].updated_at_epoch.unwrap() > first_epoch);
     }
 
     /// A synthetic Claude sidechain transcript: `agentId` on every record and
@@ -1348,13 +1670,15 @@ mod tests {
             cwd: None,
             surface: "cli".into(),
             updated_at_epoch: updated_at,
+            activity_cursor: String::new(),
+            activity_source: "mtime".into(),
             subagent_count: 0,
             fork_parent_session_id: None,
         }
     }
 
     #[test]
-    fn per_agent_totals_count_sessions_and_keep_the_newest_heartbeat() {
+    fn per_agent_totals_count_sessions_and_keep_the_newest_activity() {
         let records = vec![
             record("claude-code", "a", Some(1_000)),
             record("claude-code", "b", Some(3_000)),

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -42,8 +42,8 @@ use crate::dto::DeferredPermissionDir;
 
 pub use model::{
     AnalysisRecord, AppSettings, DiskSpaceDisplay, MAX_ACTIVITY_DAYS, MIN_ACTIVITY_DAYS,
-    Milestones, NudgePlacement, RelationKind, RelationRecord, RepositoryRecord, SessionKey,
-    SessionRecord, ThemePreference, UsageEvidenceRecord,
+    Milestones, NudgePlacement, RelationKind, RelationRecord, RepositoryRecord, SessionActivityKey,
+    SessionActivityState, SessionKey, SessionRecord, ThemePreference, UsageEvidenceRecord,
 };
 
 /// Internal-scalar key holding the protected directories the last pass declined
@@ -358,12 +358,13 @@ impl Store {
         Ok(())
     }
 
-    /// Sessions whose heartbeat falls at or after `since_epoch`, newest first.
+    /// Sessions whose activity falls at or after `since_epoch`, newest first.
     pub fn recent_sessions(&self, since_epoch: i64, limit: usize) -> Result<Vec<SessionRecord>> {
         let connection = self.lock();
         let mut statement = connection.prepare(
             "SELECT environment_key, agent, session_id, source_kind, source_label, wsl_distro,
-                    title, title_source, cwd, surface, updated_at_epoch, subagent_count,
+                    title, title_source, cwd, surface, updated_at_epoch,
+                    activity_cursor, activity_source, subagent_count,
                     (SELECT related_id FROM session_relation r
                        WHERE r.environment_key = s.environment_key
                          AND r.agent = s.agent
@@ -379,12 +380,47 @@ impl Store {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
+    /// Return the persisted activity cursor keyed by environment,
+    /// agent, and source label. A single map keeps the scan's cheap size gate
+    /// outside the SQLite lock without allowing native/WSL rows to collide.
+    pub fn session_activity_states(
+        &self,
+    ) -> Result<HashMap<SessionActivityKey, SessionActivityState>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(
+            "SELECT environment_key, agent, source_label, activity_cursor,
+                    updated_at_epoch, activity_source
+               FROM session",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((
+                SessionActivityKey::new(
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ),
+                SessionActivityState {
+                    activity_cursor: row.get(3)?,
+                    updated_at_epoch: row.get(4)?,
+                    activity_source: row.get(5)?,
+                },
+            ))
+        })?;
+        let mut states = HashMap::new();
+        for row in rows {
+            let (key, state) = row?;
+            states.insert(key, state);
+        }
+        Ok(states)
+    }
+
     /// One session's cached metadata, when it has been seen.
     pub fn session(&self, key: &SessionKey) -> Result<Option<SessionRecord>> {
         let connection = self.lock();
         let mut statement = connection.prepare(
             "SELECT environment_key, agent, session_id, source_kind, source_label, wsl_distro,
-                    title, title_source, cwd, surface, updated_at_epoch, subagent_count,
+                    title, title_source, cwd, surface, updated_at_epoch,
+                    activity_cursor, activity_source, subagent_count,
                     (SELECT related_id FROM session_relation r
                        WHERE r.environment_key = s.environment_key
                          AND r.agent = s.agent
@@ -517,7 +553,7 @@ impl Store {
             .optional()?)
     }
 
-    /// Agent, heartbeat, and token breakdown for every session at or after
+    /// Agent, activity timestamp, and token breakdown for every session at or after
     /// `since_epoch`.
     ///
     /// One join rather than a listing plus a lookup per row: provider usage
@@ -962,11 +998,12 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
     connection.execute(
         "INSERT INTO session (
              environment_key, agent, session_id, source_kind, source_label, wsl_distro,
-             title, title_source, cwd, surface, updated_at_epoch, subagent_count,
+             title, title_source, cwd, surface, updated_at_epoch,
+             activity_cursor, activity_source, subagent_count,
              first_seen_at, last_seen_at)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7,
                  CASE WHEN ?7 IS NOT NULL THEN ?8 ELSE NULL END,
-                 ?9, ?10, ?11, ?12, ?13, ?13)
+                 ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)
          ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
              source_kind = excluded.source_kind,
              source_label = excluded.source_label,
@@ -979,8 +1016,27 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
              END,
              cwd = COALESCE(excluded.cwd, session.cwd),
              surface = excluded.surface,
-             updated_at_epoch = MAX(COALESCE(excluded.updated_at_epoch, 0),
-                                    COALESCE(session.updated_at_epoch, 0)),
+             updated_at_epoch = CASE
+                 WHEN session.activity_source = 'event'
+                      AND excluded.activity_source <> 'event'
+                     THEN session.updated_at_epoch
+                 WHEN excluded.activity_source = 'event'
+                      AND session.activity_source = 'event'
+                     THEN MAX(COALESCE(excluded.updated_at_epoch, 0),
+                              COALESCE(session.updated_at_epoch, 0))
+                 WHEN excluded.activity_source = 'event'
+                     THEN excluded.updated_at_epoch
+                 ELSE MAX(COALESCE(excluded.updated_at_epoch, 0),
+                          COALESCE(session.updated_at_epoch, 0))
+             END,
+             activity_cursor = excluded.activity_cursor,
+             activity_source = CASE
+                 WHEN excluded.activity_source = 'event'
+                     THEN 'event'
+                 WHEN session.activity_source = 'event'
+                     THEN 'event'
+                 ELSE excluded.activity_source
+             END,
              subagent_count = excluded.subagent_count,
              last_seen_at = excluded.last_seen_at",
         params![
@@ -995,6 +1051,8 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
             record.cwd,
             record.surface,
             record.updated_at_epoch,
+            record.activity_cursor,
+            record.activity_source,
             record.subagent_count,
             now,
         ],
@@ -1058,7 +1116,9 @@ fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> 
         cwd: row.get(8)?,
         surface: row.get(9)?,
         updated_at_epoch: row.get(10)?,
-        subagent_count: row.get(11)?,
-        fork_parent_session_id: row.get(12)?,
+        activity_cursor: row.get(11)?,
+        activity_source: row.get(12)?,
+        subagent_count: row.get(13)?,
+        fork_parent_session_id: row.get(14)?,
     })
 }

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -73,11 +73,54 @@ pub struct SessionRecord {
     pub cwd: Option<String>,
     /// `cli`, `ide_desktop`, or `unknown`.
     pub surface: String,
-    /// Transcript heartbeat, in unix seconds.
+    /// Most recent meaningful transcript activity, in unix seconds. A
+    /// filesystem mtime is retained only when the source has no usable event
+    /// timestamp; see [`Self::activity_source`].
     pub updated_at_epoch: Option<i64>,
+    /// Fingerprint of the complete activity source set: parent size plus the
+    /// identities and sizes of any child transcripts. Used as the cheap gate
+    /// before re-reading transcript suffixes for semantic activity.
+    pub activity_cursor: String,
+    /// Provenance of `updated_at_epoch`: `event` for a meaningful transcript
+    /// event, `mtime` for the filesystem fallback, or `unknown` for sources
+    /// without a file heartbeat.
+    pub activity_source: String,
     pub subagent_count: u32,
     /// The session this one was branched from, when the vendor records it.
     pub fork_parent_session_id: Option<String>,
+}
+
+/// Identity of one persisted activity cursor. The source label alone is not
+/// enough: native and WSL environments can expose the same provider path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionActivityKey {
+    pub environment_key: String,
+    pub agent: String,
+    pub source_label: String,
+}
+
+impl SessionActivityKey {
+    pub fn new(
+        environment_key: impl Into<String>,
+        agent: impl Into<String>,
+        source_label: impl Into<String>,
+    ) -> Self {
+        Self {
+            environment_key: environment_key.into(),
+            agent: agent.into(),
+            source_label: source_label.into(),
+        }
+    }
+}
+
+/// Small persisted cursor used by the scanner before it reads transcript
+/// suffixes. Kept separate from [`SessionRecord`] so callers that only need
+/// the activity gate do not materialize titles, CWDs, or relationships.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionActivityState {
+    pub activity_cursor: String,
+    pub updated_at_epoch: Option<i64>,
+    pub activity_source: String,
 }
 
 /// Engine-derived analysis for one session, as cached.
@@ -109,8 +152,8 @@ pub struct AnalysisRecord {
 pub struct UsageEvidenceRecord {
     /// The agent's discovery slug.
     pub agent: String,
-    /// Transcript heartbeat, in unix seconds. Zero when the session never
-    /// carried one, which puts it outside every window.
+    /// Most recent meaningful session activity, in unix seconds. Zero when
+    /// the session never carried one, which puts it outside every window.
     pub updated_at_epoch: i64,
     /// Billable tokens per normalized model key, or `None` when the session has
     /// not been analyzed. Absence is "we do not know yet", never "zero".

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -14,7 +14,7 @@
 
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
-pub const MIGRATIONS: &[&str] = &[V1, V2, V3];
+pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
 ///
@@ -65,7 +65,8 @@ CREATE TABLE session (
     title_source     TEXT,
     cwd              TEXT,
     surface          TEXT NOT NULL DEFAULT 'unknown',
-    -- Transcript heartbeat (unix seconds), as discovery reported it.
+    -- Most recent meaningful transcript activity (unix seconds), as the scan
+    -- reported it. File mtime is only a fallback for sources without events.
     updated_at_epoch INTEGER,
     subagent_count   INTEGER NOT NULL DEFAULT 0,
     first_seen_at    TEXT NOT NULL,
@@ -179,4 +180,13 @@ CREATE TABLE consent_grant (
 /// strategy instead of this one.
 const V3: &str = r#"
 DELETE FROM setting WHERE key = 'liveUsageEnabled';
+"#;
+
+/// v4 — activity cursor and timestamp provenance.
+///
+/// Existing rows are marked as mtime-derived so the next scan gets one chance
+/// to replace a stale mtime-derived timestamp with one from transcript content.
+const V4: &str = r#"
+ALTER TABLE session ADD COLUMN activity_source TEXT NOT NULL DEFAULT 'mtime';
+ALTER TABLE session ADD COLUMN activity_cursor TEXT NOT NULL DEFAULT '';
 "#;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -21,6 +21,8 @@ fn session(session_id: &str, updated_at: i64) -> SessionRecord {
         cwd: Some("/home/avery/code/widgets".into()),
         surface: "cli".into(),
         updated_at_epoch: Some(updated_at),
+        activity_cursor: String::new(),
+        activity_source: "mtime".into(),
         subagent_count: 0,
         fork_parent_session_id: None,
     }
@@ -208,10 +210,10 @@ fn updating_settings_merges_against_the_latest_stored_value() {
     assert_eq!(store.settings().unwrap(), saved);
 }
 
-/// Pin the shipped v1 shape so migrations remain deliberate. This is not a
-/// restriction on what a future local visibility feature may store.
+/// Pin the current session shape so migrations remain deliberate. This is not
+/// a restriction on what a future local visibility feature may store.
 #[test]
-fn the_v1_session_table_shape_is_stable() {
+fn the_session_table_shape_is_stable() {
     let store = store();
     let connection = store.lock();
     let mut statement = connection
@@ -240,6 +242,8 @@ fn the_v1_session_table_shape_is_stable() {
             "subagent_count",
             "first_seen_at",
             "last_seen_at",
+            "activity_source",
+            "activity_cursor",
         ]
     );
 }
@@ -371,7 +375,7 @@ fn a_session_round_trips_and_a_rescan_updates_it_in_place() {
     store.upsert_sessions(std::slice::from_ref(&later)).unwrap();
 
     // Idempotent: a rescan that sees the same session again must not duplicate
-    // it, and must not rewind the heartbeat.
+    // it, and must not rewind the activity timestamp.
     store.upsert_sessions(&[session("abc", 1_500)]).unwrap();
 
     assert_eq!(store.recent_sessions(0, 100).unwrap().len(), 1);
@@ -382,6 +386,50 @@ fn a_session_round_trips_and_a_rescan_updates_it_in_place() {
     assert_eq!(stored.updated_at_epoch, Some(2_000));
     assert_eq!(stored.subagent_count, 0, "the last scan saw no sub-agents");
     assert_eq!(stored.title.as_deref(), Some("Wire the popover"));
+}
+
+#[test]
+fn an_event_timestamp_survives_a_newer_mtime_only_upsert() {
+    let store = store();
+    let mut event = session("semantic", 1_000);
+    event.activity_cursor = "[\"parent\",10]".into();
+    event.activity_source = "event".into();
+    store.upsert_sessions(&[event]).unwrap();
+
+    let mut mtime = session("semantic", 2_000);
+    mtime.activity_cursor = "[\"parent\",20]".into();
+    mtime.activity_source = "mtime".into();
+    store.upsert_sessions(&[mtime]).unwrap();
+
+    let stored = store
+        .session(&SessionKey::new("native", "claude-code", "semantic"))
+        .unwrap()
+        .expect("session");
+    assert_eq!(stored.updated_at_epoch, Some(1_000));
+    assert_eq!(stored.activity_source, "event");
+    assert_eq!(stored.activity_cursor, "[\"parent\",20]");
+}
+
+#[test]
+fn activity_cursors_do_not_collide_across_environments() {
+    let store = store();
+    let native = session("shared", 1_000);
+    let mut wsl = native.clone();
+    wsl.key = SessionKey::new("wsl:ubuntu", "claude-code", "shared");
+    store.upsert_sessions(&[native, wsl]).unwrap();
+
+    let states = store.session_activity_states().unwrap();
+    assert_eq!(states.len(), 2);
+    assert!(states.contains_key(&SessionActivityKey::new(
+        "native",
+        "claude-code",
+        "/home/avery/.claude/projects/demo/shared.jsonl",
+    )));
+    assert!(states.contains_key(&SessionActivityKey::new(
+        "wsl:ubuntu",
+        "claude-code",
+        "/home/avery/.claude/projects/demo/shared.jsonl",
+    )));
 }
 
 #[test]

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -54,6 +54,12 @@ const LOG_METADATA_CONCURRENCY: usize = 16;
 /// a multi-gigabyte log never needs to be materialized in full to be described.
 const SOURCE_PREVIEW_BYTES: u64 = 16 * 1024 * 1024;
 
+/// Maximum transcript suffix read to recover semantic activity. Activity
+/// records are append-oriented in the JSONL formats we support; a suffix is
+/// enough to find the latest meaningful event without materialising a large
+/// historical transcript on every scan.
+pub const ACTIVITY_TAIL_BYTES: u64 = 256 * 1024;
+
 /// A session whose transcript was written within this window is treated as
 /// "live" — the mtime heartbeat, since no agent writes an explicit
 /// in-progress flag. Shared by every surface that reports live sessions
@@ -1016,6 +1022,42 @@ pub async fn session_source_preview(source: &SessionSource) -> Option<String> {
         .read_to_end(&mut bytes)
         .await
         .ok()?;
+    match String::from_utf8(bytes) {
+        Ok(content) => Some(content),
+        Err(error) if error.utf8_error().error_len().is_none() => {
+            let valid = error.utf8_error().valid_up_to();
+            String::from_utf8(error.into_bytes()[..valid].to_vec()).ok()
+        }
+        Err(_) => None,
+    }
+}
+
+/// Read a bounded, line-aligned suffix of a source file.
+///
+/// The first bytes are discarded when the bound starts in the middle of a
+/// JSONL record. Inline and provider-db sources retain their normal whole
+/// content behavior because they are already bounded by their source adapter.
+/// A single final JSONL record larger than [`ACTIVITY_TAIL_BYTES`] is therefore
+/// intentionally omitted. The scan preserves a previously cached semantic
+/// timestamp in that case; first discovery falls back to the source mtime.
+pub async fn session_source_tail(source: &SessionSource) -> Option<String> {
+    let SessionSource::File(path) = source else {
+        return session_source_content(source).await;
+    };
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    let mut file = tokio::fs::File::open(path).await.ok()?;
+    let len = file.metadata().await.ok()?.len();
+    let start = len.saturating_sub(ACTIVITY_TAIL_BYTES);
+    if start > 0 {
+        file.seek(std::io::SeekFrom::Start(start)).await.ok()?;
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).await.ok()?;
+    if start > 0
+        && let Some(newline) = bytes.iter().position(|byte| *byte == b'\n')
+    {
+        bytes.drain(..=newline);
+    }
     match String::from_utf8(bytes) {
         Ok(content) => Some(content),
         Err(error) if error.utf8_error().error_len().is_none() => {

--- a/crates/antiburn-local/src/discovery/scanner.rs
+++ b/crates/antiburn-local/src/discovery/scanner.rs
@@ -1267,6 +1267,87 @@ pub fn max_event_epoch(content: &str) -> Option<i64> {
     max_ts
 }
 
+/// Return the latest timestamp on a record that represents actual agent work.
+///
+/// Transcript files also contain records for titles, mode changes, token
+/// accounting, permissions, and other bookkeeping. Those records may be
+/// written by a harness while an otherwise idle TUI is open, so their
+/// timestamps must not move the Recent Activity row. This deliberately keeps
+/// the provider-specific allowlist small and fail-closed: callers can fall
+/// back to the source heartbeat when a format has no recognised event time.
+pub fn max_activity_event_epoch(content: &str, agent: AgentKind) -> Option<i64> {
+    fn timestamp(value: &serde_json::Value) -> Option<i64> {
+        [
+            value.get("timestamp"),
+            value.get("time"),
+            value.get("created_at"),
+            value.get("createdAt"),
+            value.get("creationDate"),
+            value.pointer("/payload/timestamp"),
+        ]
+        .into_iter()
+        .flatten()
+        .find_map(|candidate| {
+            parse_timestamp(candidate).or_else(|| parse_numeric_timestamp(candidate))
+        })
+    }
+
+    fn claude_activity(value: &serde_json::Value) -> bool {
+        matches!(
+            value.get("type").and_then(serde_json::Value::as_str),
+            Some("user")
+                | Some("assistant")
+                | Some("tool_use")
+                | Some("tool_result")
+                | Some("function_call")
+                | Some("function_call_output")
+        )
+    }
+
+    fn codex_activity(value: &serde_json::Value) -> bool {
+        let top_type = value.get("type").and_then(serde_json::Value::as_str);
+        match top_type {
+            Some("function_call") | Some("function_call_output") => true,
+            Some("response_item") => {
+                let payload_type = value
+                    .pointer("/payload/type")
+                    .and_then(serde_json::Value::as_str);
+                matches!(
+                    payload_type,
+                    Some("message")
+                        | Some("reasoning")
+                        | Some("function_call")
+                        | Some("function_call_output")
+                        | Some("custom_tool_call")
+                        | Some("custom_tool_call_output")
+                        | Some("local_shell_call")
+                        | Some("local_shell_call_output")
+                )
+            }
+            Some("event_msg") => matches!(
+                value
+                    .pointer("/payload/type")
+                    .and_then(serde_json::Value::as_str),
+                Some("agent_message") | Some("task_started") | Some("task_complete")
+            ),
+            _ => false,
+        }
+    }
+
+    let is_activity = |value: &serde_json::Value| match agent {
+        AgentKind::Claude => claude_activity(value),
+        AgentKind::Codex => codex_activity(value),
+        _ => false,
+    };
+
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line.trim()).ok())
+        .filter(is_activity)
+        .filter_map(|value| timestamp(&value))
+        .max()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1302,6 +1383,44 @@ mod tests {
         // No parseable timestamp anywhere → None so callers fall back to mtime.
         assert_eq!(max_event_epoch(r#"{"type":"user","text":"hi"}"#), None);
         assert_eq!(max_event_epoch(""), None);
+    }
+
+    #[test]
+    fn max_activity_event_epoch_ignores_claude_housekeeping_records() {
+        let content = concat!(
+            r#"{"type":"user","timestamp":"2026-06-26T21:20:00Z"}"#,
+            "\n",
+            r#"{"type":"custom-title","timestamp":"2026-08-19T17:07:32Z"}"#,
+            "\n",
+            r#"{"type":"permission-mode","timestamp":"2026-08-19T17:07:33Z"}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-06-26T21:30:15Z"}"#,
+        );
+        let expected = OffsetDateTime::parse("2026-06-26T21:30:15Z", &Rfc3339)
+            .unwrap()
+            .unix_timestamp();
+        assert_eq!(
+            max_activity_event_epoch(content, AgentKind::Claude),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn max_activity_event_epoch_ignores_codex_metadata_and_token_counts() {
+        let content = concat!(
+            r#"{"timestamp":"2026-06-26T21:20:00Z","type":"session_meta","payload":{"id":"x"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-26T21:30:15Z","type":"response_item","payload":{"type":"function_call","name":"exec_command"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-19T17:07:32Z","type":"event_msg","payload":{"type":"token_count"}}"#,
+        );
+        let expected = OffsetDateTime::parse("2026-06-26T21:30:15Z", &Rfc3339)
+            .unwrap()
+            .unix_timestamp();
+        assert_eq!(
+            max_activity_event_epoch(content, AgentKind::Codex),
+            Some(expected)
+        );
     }
 
     async fn write_temp_file(dir: &Path, name: &str, content: &str) -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

Filesystem mtime touches from an idle Claude/Codex TUI or harness housekeeping could falsely promote a session in Recent Activity. This changes displayed recency to meaningful transcript activity.

- Use provider-aware Claude/Codex event allowlists for activity timestamps; ignore titles, modes, permissions, token counts, and other housekeeping.
- Persist a sorted JSON aggregate cursor containing parent/child transcript paths and sizes, so unchanged sources avoid content reads while subagent growth invalidates the cursor and contributes semantic activity to the parent.
- Reuse the existing bounded preview for normal files; combine preview and a line-aligned 256 KiB tail for larger files. Preserve cached semantic activity when a huge housekeeping record crosses the tail boundary.
- Heal existing mtime-derived rows during migration/first semantic scan and prevent weaker mtime/unknown upserts from overwriting event provenance or timestamps.
- Key scan state by environment, agent, and source label to keep native and WSL sources isolated.

## Verification

- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo fmt --manifest-path crates/antiburn-local/Cargo.toml --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib` (338 passed)
- `cargo test --manifest-path crates/antiburn-local/Cargo.toml` (654 passed, 1 ignored; boundary/doctests passed)
- `git diff --check`
