### PR TITLE
fix(desktop): isolate blocking live usage work

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -432,24 +432,31 @@ const POPOVER_LIVE_USAGE_MAX_AGE: std::time::Duration = std::time::Duration::fro
 /// about the reader's calendar day. The windows themselves are the provider's
 /// own boundaries, stated as absolute instants, and owe nothing to it.
 #[tauri::command]
-pub fn get_live_usage(
+pub async fn get_live_usage(
     app: tauri::AppHandle,
     utc_offset_minutes: Option<i32>,
 ) -> CommandResult<LiveUsageSummary> {
-    let now = scan::unix_now();
-    let Some(live) = app.try_state::<crate::usage_alerts::LiveUsage>() else {
-        return Ok(LiveUsageSummary {
-            generated_at: crate::store::iso_from_epoch(Some(now)),
-            ..LiveUsageSummary::default()
-        });
-    };
-    Ok(provider_usage::live::summarize(
-        &live.sources,
-        app.try_state::<Store>().as_deref(),
-        now,
-        utc_offset_minutes.unwrap_or(0),
-        POPOVER_LIVE_USAGE_MAX_AGE,
-    ))
+    // The sources deliberately expose a synchronous interface and include
+    // blocking HTTP, Keychain, and subprocess work. An async command keeps the
+    // IPC handler responsive; the blocking pool is the boundary for that work.
+    tauri::async_runtime::spawn_blocking(move || {
+        let now = scan::unix_now();
+        let Some(live) = app.try_state::<crate::usage_alerts::LiveUsage>() else {
+            return Ok(LiveUsageSummary {
+                generated_at: crate::store::iso_from_epoch(Some(now)),
+                ..LiveUsageSummary::default()
+            });
+        };
+        Ok(provider_usage::live::summarize(
+            &live.sources,
+            app.try_state::<Store>().as_deref(),
+            now,
+            utc_offset_minutes.unwrap_or(0),
+            POPOVER_LIVE_USAGE_MAX_AGE,
+        ))
+    })
+    .await
+    .map_err(fail)?
 }
 
 /* -------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -90,7 +90,15 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
-            run_pass(&app);
+            // A pass can read SQLite, call Keychain and child processes, and
+            // use reqwest's blocking client. Keep all of it off the runtime's
+            // worker threads, while awaiting each pass so two never overlap.
+            let pass_app = app.clone();
+            if let Err(error) =
+                tauri::async_runtime::spawn_blocking(move || run_pass(&pass_app)).await
+            {
+                eprintln!("antiburn: usage-alert pass failed ({error})");
+            }
         }
     })
 }


### PR DESCRIPTION
## Summary

- run background usage-alert passes on Tauri’s blocking pool
- make live-usage IPC refreshes async while keeping synchronous provider work off runtime workers
- await background passes so refreshes remain serialized and report task failures without killing the scheduler

This prevents `reqwest::blocking` from running inside Tokio’s async context, which produced the debug panic `Cannot drop a runtime in a context where blocking is not allowed` after a delayed pass (often immediately after wake).

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (338 passed)
- `cargo check --release --locked`
- `node scripts/check-boundary.mjs`
- `node --test scripts/classify-ci-changes.test.mjs scripts/wait-for-main-ci.test.mjs`