### PR TITLE
Prepare antiburn 0.1.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,22 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.1.0-rc.5] - 2026-08-20
+
+A release-candidate rehearsal build, not a supported release. The macOS and
+Windows binaries are **unsigned** — your operating system will warn you, and it
+is right to. Install it only if you are testing the release pipeline itself.
+
+On macOS, open the app for the first time with right-click → Open rather than a
+double-click. The build is sealed but has no Developer ID signature, so macOS
+shows its unidentified-developer warning.
+
 ### Added
+
+- **Launch antiburn when you sign in.** New installs opt in by default from the
+  final setup step so the menu-bar or tray utility is available without being
+  opened by hand. The same switch is available later in Settings → General,
+  and can be turned off before setup finishes.
 
 - **What "local" means, spelled out.** antiburn needs no antiburn account,
   server, or backend — everything runs on your machine, as you. The
@@ -35,6 +50,11 @@ CI changes, and documentation that no user acts on stay out — see
   it hands your data to no one who doesn't already have it.
 
 ### Changed
+
+- **Plan limits now live at the top of the main popover.** Expand the Limits
+  section for each provider's windows and reset times, or collapse it to a row
+  of compact percentage chips. Each chip's ring follows that provider's
+  fullest reported limit, so the most urgent allowance stays visible.
 
 - **A per-model weekly limit stays out of the way until you use that
   model.** Your provider can report a supplemental weekly allowance scoped to
@@ -62,7 +82,24 @@ CI changes, and documentation that no user acts on stay out — see
   traffic at all; with it off, antiburn has no plan limits to show, since there
   is no longer a cached file it reads on its own.
 
+- **Hidden utility windows no longer remain resident indefinitely.** The
+  popover, Settings, setup, and notification views are released when they are
+  no longer needed and recreated on demand, substantially reducing the app's
+  idle memory footprint.
+
 ### Fixed
+
+- **Recent Activity follows real transcript activity.** Background file
+  touches, title changes, permission changes, and other agent housekeeping no
+  longer make an idle session look newly active. Subagent work still counts
+  toward its parent session.
+
+- **Native and WSL session analytics stay separate.** Sessions with the same
+  agent identifier can no longer reuse one another's cached analysis across
+  those environments.
+
+- Settings panes return to the top when you move between them, instead of
+  keeping the previous pane's scroll position.
 
 - **Session names in recent activity.** antiburn now reads authoritative names
   from each agent's indexed session store when available, while keeping mounted

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.4",
+  "version": "0.1.0-rc.5",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "antiburn-local",
  "antiburn-nudge",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/nudge", "crates/sound"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.4",
+  "version": "0.1.0-rc.5",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary

- set all desktop version sources to 0.1.0-rc.5
- turn Unreleased into dated, reader-facing rc.5 release notes
- retain the explicit unsigned macOS and Windows rehearsal warning
- include the user-visible startup, usage, memory, and activity changes since rc.4

## Validation

- release-version verification for antiburn-v0.1.0-rc.5
- locked Cargo metadata verification
- exact changelog extraction
- release metadata classifier tests and release-app-only classification
- git diff --check

The release workflow will stop at a draft for human review; this PR does not tag or publish a release.