### PR TITLE
fix(desktop): serialize live-usage summarization, guard the blocking hop by type

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -431,25 +431,47 @@ const POPOVER_LIVE_USAGE_MAX_AGE: std::time::Duration = std::time::Duration::fro
 /// `utc_offset_minutes` travels for one reason only: "used today" is a claim
 /// about the reader's calendar day. The windows themselves are the provider's
 /// own boundaries, stated as absolute instants, and owe nothing to it.
+///
+/// `async`, and every byte of the work handed to a blocking thread, for one
+/// reason: a synchronous `#[tauri::command]` is run inline on the thread that
+/// delivered the IPC message, and the summary this returns reaches a provider
+/// over the network with `reqwest::blocking` — see
+/// `provider_usage::live::sources::http::client`. A provider that accepts a
+/// connection and then says nothing would hold that thread for the full
+/// fifteen-second timeout, once per source, and the popover polls this about
+/// once a minute while it is open. The reader would watch the whole app —
+/// tray, popover, every window — stop answering. Nothing here needs the main
+/// thread, so nothing here stays on it.
 #[tauri::command]
-pub fn get_live_usage(
+pub async fn get_live_usage(
     app: tauri::AppHandle,
     utc_offset_minutes: Option<i32>,
 ) -> CommandResult<LiveUsageSummary> {
-    let now = scan::unix_now();
-    let Some(live) = app.try_state::<crate::usage_alerts::LiveUsage>() else {
-        return Ok(LiveUsageSummary {
-            generated_at: crate::store::iso_from_epoch(Some(now)),
-            ..LiveUsageSummary::default()
-        });
-    };
-    Ok(provider_usage::live::summarize(
-        &live.sources,
-        app.try_state::<Store>().as_deref(),
-        now,
-        utc_offset_minutes.unwrap_or(0),
-        POPOVER_LIVE_USAGE_MAX_AGE,
-    ))
+    let utc_offset_minutes = utc_offset_minutes.unwrap_or(0);
+    tauri::async_runtime::spawn_blocking(move || {
+        // Read here rather than before the hop: this summary is stamped with
+        // the moment it was produced, and a caller queued behind another
+        // summarization can wait a while for its turn.
+        let now = scan::unix_now();
+        let Some(live) = app.try_state::<crate::usage_alerts::LiveUsage>() else {
+            return LiveUsageSummary {
+                generated_at: crate::store::iso_from_epoch(Some(now)),
+                ..LiveUsageSummary::default()
+            };
+        };
+        // Held for the whole pass: two of these can now genuinely overlap,
+        // and the reading history they append to is not written atomically.
+        let _summarizing = live.summarizing();
+        provider_usage::live::summarize(
+            &live.sources,
+            app.try_state::<Store>().as_deref(),
+            now,
+            utc_offset_minutes,
+            POPOVER_LIVE_USAGE_MAX_AGE,
+        )
+    })
+    .await
+    .map_err(fail)
 }
 
 /* -------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/http.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/http.rs
@@ -32,6 +32,21 @@ const MAX_RESPONSE_BYTES: u64 = 512 * 1024;
 /// hosts. The `rustls-no-provider` feature this crate builds `reqwest`
 /// against leaves the process-wide crypto provider unset, so the first call
 /// here installs it — see the `rustls` dependency comment in `Cargo.toml`.
+///
+/// Blocking, and only ever to be called where blocking is allowed. A caller
+/// holding a runtime has to hand the work to a blocking thread first, and
+/// both callers do: `crate::usage_alerts::blocking::run` for the background
+/// monitor, `crate::commands::get_live_usage` for the popover.
+///
+/// The cost of getting that wrong differs by profile, and both are worth
+/// knowing. In release, a blocking call parks the calling thread until the
+/// response or [`TIMEOUT`] — bad enough on a runtime worker, worse on the
+/// main thread. In debug, `reqwest` additionally builds and drops a `tokio`
+/// runtime on the calling thread purely to assert it is not inside one
+/// (`reqwest::blocking::wait::enter`, `#[cfg(debug_assertions)]`), and
+/// dropping a runtime inside an asynchronous context panics outright. So a
+/// debug build fails loudly where a release build only stalls: the rule is
+/// the same either way, and only the symptom of breaking it changes.
 pub fn client() -> &'static reqwest::blocking::Client {
     static CLIENT: std::sync::OnceLock<reqwest::blocking::Client> = std::sync::OnceLock::new();
     CLIENT.get_or_init(|| {

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -90,9 +90,49 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
-            run_pass(&app);
+            let app = app.clone();
+            blocking::run(move |blocking| run_pass(&app, blocking)).await;
         }
     })
+}
+
+/// The hop off the async runtime, and the proof that it happened.
+///
+/// A pass is blocking work end to end: it reads the store, and — through
+/// [`provider_usage::live::sources`] — it asks a provider's endpoint with
+/// `reqwest::blocking`. The second of those is not merely impolite on a
+/// runtime worker, it is a panic: a blocking `reqwest` call builds and drops
+/// a `tokio` runtime on the calling thread, and dropping a runtime from
+/// inside an asynchronous context aborts with "Cannot drop a runtime in a
+/// context where blocking is not allowed". Called inline, that panic unwound
+/// the spawned task itself, so one tick took the whole monitor — anomalies
+/// and milestones alike — down for the rest of the process while the app
+/// carried on looking healthy.
+///
+/// So the hop is what makes a pass *correct*, not just what keeps a
+/// fifteen-second request from stalling a worker — which is why it is a type
+/// and not a convention. [`blocking::Thread`] has a private field and this
+/// module is the only place that fills it, so [`run_pass`] cannot be reached
+/// from the scheduler's task without going through [`blocking::run`] first.
+/// A later refactor that drops the hop does not reintroduce the panic
+/// quietly; it stops the crate compiling.
+mod blocking {
+    /// Proof that the holder is running where blocking is allowed.
+    pub struct Thread(());
+
+    /// Run `pass` on a blocking thread, and survive it failing.
+    ///
+    /// Awaiting the handle keeps ticks serialized the way calling the pass
+    /// inline did, and folding the join error away means a pass that panics
+    /// anyway costs one pass rather than every pass after it.
+    pub async fn run<F: FnOnce(Thread) + Send + 'static>(pass: F) {
+        if tauri::async_runtime::spawn_blocking(move || pass(Thread(())))
+            .await
+            .is_err()
+        {
+            eprintln!("antiburn: a usage-alert pass failed; the monitor continues");
+        }
+    }
 }
 
 /// The registered live usage sources and the milestone engine's ledger.
@@ -103,6 +143,7 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
 pub struct LiveUsage {
     pub sources: Vec<Box<dyn provider_usage::live::LiveUsageSource>>,
     ledger: std::sync::Mutex<provider_usage::live::MilestoneLedger>,
+    summarizing: std::sync::Mutex<()>,
 }
 
 impl LiveUsage {
@@ -110,7 +151,27 @@ impl LiveUsage {
         LiveUsage {
             sources: provider_usage::live::sources::registered(),
             ledger: std::sync::Mutex::default(),
+            summarizing: std::sync::Mutex::default(),
         }
+    }
+
+    /// Hold this for one whole summarization, and no two can overlap.
+    ///
+    /// `provider_usage::live::history::record` appends a pass's readings by
+    /// loading the stored series, adding to it, and writing the whole thing
+    /// back. That is safe while only one caller is ever mid-pass, which used
+    /// to be guaranteed for free: [`crate::commands::get_live_usage`] was the
+    /// only caller that records, and a synchronous command runs inline on the
+    /// thread that delivered the IPC message, so two of them could not
+    /// interleave. Now that the command hands its work to a blocking thread,
+    /// they can — the popover and Settings → Usage each ask on their own
+    /// schedule — and an interleaved read-modify-write silently drops one
+    /// pass's samples. This restores the guarantee explicitly, and spares the
+    /// providers a second identical request while it is at it.
+    pub fn summarizing(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.summarizing
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -120,7 +181,7 @@ impl Default for LiveUsage {
     }
 }
 
-fn run_pass(app: &AppHandle) {
+fn run_pass(app: &AppHandle, _blocking: blocking::Thread) {
     let Some(store) = app.try_state::<Store>() else {
         return;
     };
@@ -267,6 +328,37 @@ fn anomaly(evidence: &[crate::store::UsageEvidenceRecord], now: i64) -> Option<(
 mod tests {
     use super::*;
     use crate::store::UsageEvidenceRecord;
+
+    /// A pass must land somewhere blocking is allowed.
+    ///
+    /// The type system already refuses a pass that skips [`blocking::run`] —
+    /// [`blocking::Thread`] cannot be built outside that module — so what is
+    /// left to prove is that the destination is real. The closure does
+    /// exactly what `reqwest::blocking` does on the calling thread before a
+    /// request: build a runtime, and drop it. That is the step that panics on
+    /// a runtime worker, so a pass that gets through it is a pass that can
+    /// reach a provider.
+    #[test]
+    fn a_pass_runs_where_blocking_is_allowed() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("a runtime with no driver enabled always builds");
+        let ran = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&ran);
+        runtime.block_on(blocking::run(move |_thread| {
+            drop(
+                tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .expect("a runtime with no driver enabled always builds"),
+            );
+            flag.store(true, Ordering::SeqCst);
+        }));
+
+        assert!(ran.load(Ordering::SeqCst));
+    }
 
     fn record(epoch: i64, output_tokens: u64) -> UsageEvidenceRecord {
         UsageEvidenceRecord {


### PR DESCRIPTION
Follow-up to #66, which fixed the same panic while this branch was in flight. That fix is now on `main` and this branch merges it rather than competing with it. What is left is the part #66 did not cover: a test, a guard that makes the fix unremovable, and a race it introduced.

## Background

Every debug run panicked on a `tokio-rt-worker` thread about two minutes after launch:

```
thread 'tokio-rt-worker' panicked at tokio-1.53.1/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed.
```

The app kept running, so it read as cosmetic. It wasn't — the panic unwound the spawned task, so one tick took the whole usage-alert monitor down for the rest of the process: spend anomalies and live milestones both, silently, while the app carried on looking healthy.

Call path, from the captured backtrace:

```
usage_alerts::spawn_scheduler → run_pass → milestone_pass
  → live::sources::collect → anthropic_fetch::fetch_live → http::client()
    → reqwest::blocking::wait::enter          (wait.rs:80)
```

`wait::enter` is a `#[cfg(debug_assertions)]` self-check inside reqwest: it builds a throwaway runtime, enters it, and drops it purely to assert the caller is not already inside one. It runs on **every** blocking reqwest call — building the client *and* each request — so building the client eagerly at startup would not have fixed this; the first request would have panicked instead.

Two corrections to the triage in #66, both worth recording:

- **It is not at wake, and not at startup.** It fires at `STARTUP_DELAY` (120s), on a plain launch, every time. It only looks immediate because nothing else writes to stderr.
- **Release builds never panicked.** `debug_assertions` is off, so `enter()` compiles to nothing. What they had instead was the same mistake with no guardrail: blocking network I/O parking a runtime worker for up to the 15s timeout.

`liveUsageEnabled` defaulting on (schema V3) is what turned a latent path into one every onboarded dev build walks.

## What this adds over #66

**A regression test.** `a_pass_runs_where_blocking_is_allowed` drops a `tokio` runtime inside a pass — the exact operation that panics on a worker — and proves the destination permits it.

**A guard that makes the hop unremovable.** `run_pass` now takes a `blocking::Thread`, a token whose field only its own module can fill. Reverting the scheduler to call `run_pass` directly no longer reintroduces the panic quietly; it fails to compile with `E0603: tuple struct constructor 'Thread' is private`. The hop is what makes a pass *correct*, not merely polite, so it is enforced by the type system rather than by a comment.

**The serialization #66 removed.** Its summary says background passes are awaited "so refreshes remain serialized", which holds for the scheduler loop but not for the IPC side:

- `history::record` loads the stored series, appends, and writes it back — three steps, not atomic.
- Its only caller is `live::summarize`, whose only production caller is `get_live_usage`. `milestone_pass` calls `sources::collect` directly and never records, so the serialized scheduler loop does not help here.
- The popover and Settings → Usage each poll `get_live_usage` on their own schedule. A synchronous command ran inline on the IPC thread and could not interleave with itself; an async one can.

`LiveUsage::summarizing` restores the guarantee explicitly. The cost of leaving it is bounded — one pass's samples dropped, so a forecast has less history — but it is a real regression and nothing else closes it.

**A timestamp that reflects when the work happened.** `now` is read after the hop, not before, so a summary queued behind another is not stamped with a time from before it waited.

**The rule, documented where it is broken.** `http::client()` states that it may only be called where blocking is allowed, names both callers, and separates the debug-build panic from the release-build stall — the two symptoms of the same mistake.

## Verification

- Pre-fix run panicked at T+120s with the full backtrace; post-fix run clean through T+176s with `reqwest-internal-sync-runtime` present in the process, i.e. the monitor's fetch ran, off the runtime.
- Reverting the scheduler to call `run_pass` directly fails to compile.
- clippy `--all-targets --locked -D warnings` clean · `cargo fmt --check` clean · 339/339 Rust tests · 684/684 frontend tests across 71 files · no new rustdoc broken links.
- All of the above re-run after merging `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
