### PR TITLE
Avoid the unreliable Azure Ubuntu package mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
+      - name: Use Canonical Ubuntu package archive
+        if: runner.os == 'Linux'
+        run: |
+          sudo find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+            -exec sed -i \
+              -e 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              -e 's|https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              {} +
+
       - name: Install Tauri system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -284,6 +293,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Use Canonical Ubuntu package archive
+        if: runner.os == 'Linux'
+        run: |
+          sudo find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+            -exec sed -i \
+              -e 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              -e 's|https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              {} +
 
       - name: Install Tauri system dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -286,6 +286,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
+      - name: Use Canonical Ubuntu package archive
+        if: runner.os == 'Linux'
+        run: |
+          sudo find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+            -exec sed -i \
+              -e 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              -e 's|https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              {} +
+
       # WebKitGTK, GTK and the AppIndicator tray are the shell's Linux
       # backend; desktop-file-utils, patchelf and file are what the AppImage
       # and .deb bundlers shell out to.


### PR DESCRIPTION
## Summary

- rewrite the Azure-hosted Ubuntu archive URL to the Canonical archive over HTTPS before installing Linux build dependencies
- apply the override to normal backend CI, release-cache warming, and the tagged Linux release build
- leave security and third-party APT sources unchanged

## Why

The Azure archive mirror is currently timing out. A main CI job has spent hours retrying package indexes, serializing the rc.5 release-metadata run behind it. The Canonical archive responds normally.

## Validation

- actionlint 1.7.12
- CI classifier and exact-main-run control-plane tests: 14 passed
- URL rewrite simulation for both HTTP and HTTPS Azure mirror forms
- whole-tree source-boundary check in a clean tracked-tree snapshot
- git diff --check

After this merges and its exact main CI succeeds, the rc.5 tag should be created at that merge commit.