### PR TITLE
Release antiburn-local 0.1.3 and enforce app engine provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Test the CI control plane
-        run: node --test scripts/classify-ci-changes.test.mjs scripts/wait-for-main-ci.test.mjs
+        run: node --test scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
 
       - name: Classify the diff
         id: changes
@@ -235,6 +235,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
 
       - name: Install Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -252,6 +254,7 @@ jobs:
           set -euo pipefail
           version=$(node -p "require('./apps/desktop/package.json').version")
           node scripts/verify-release-version.mjs app "antiburn-v${version}"
+          node scripts/verify-app-engine-release.mjs
           grep -q "^## \[${version}\] - " CHANGELOG.md
           cargo metadata --locked --no-deps --format-version 1 \
             --manifest-path apps/desktop/src-tauri/Cargo.toml > /dev/null

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -59,6 +59,8 @@ jobs:
       # Third-party actions are pinned by immutable commit SHA.
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
 
       - name: Install Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -70,6 +72,9 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
         run: node scripts/verify-release-version.mjs app "$TAG"
+
+      - name: Verify the embedded engine is a released source tree
+        run: node scripts/verify-app-engine-release.mjs
 
       # The updater is the one network-capable surface in the application, and
       # an update it cannot verify is worse than no update at all. Both halves

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,6 +21,8 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-20
+
 ### Added
 
 - `AgentExplorer::indexed_session_titles` and
@@ -28,6 +30,15 @@ version and refuses the release if there is none.
   vendor indexes without falling through to transcript content. Shared indexes
   are opened once per batch, so background discovery can reuse its bounded
   transcript metadata on misses.
+
+### Fixed
+
+- Claude and Codex discovery now derives session recency from meaningful
+  transcript events rather than filesystem modification times. Agent
+  housekeeping such as title, mode, permission, and token-count updates no
+  longer makes an idle session look active, while subagent transcript activity
+  still advances its parent session. Incremental aggregate cursors keep this
+  provider-aware scan bounded across unchanged parent and child transcripts.
 
 ## [0.1.2] - 2026-08-17
 

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MPL-2.0"

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -172,7 +172,15 @@ Check the whole set locally before pushing anything:
 
 ```bash
 node scripts/verify-release-version.mjs app antiburn-v<version>
+node scripts/verify-app-engine-release.mjs
 ```
+
+The second check proves that the complete in-tree `antiburn-local` crate is
+identical to the annotated `antiburn-local-v<version>` tag named by its own
+manifest, that the tag is an ancestor of the application commit, and that the
+desktop lockfile records the same engine version. If it fails, cut the engine
+release first. Application releases never ship an unreleased engine tree under
+an older component version.
 
 ### 2.3 Write the release notes
 
@@ -294,6 +302,12 @@ If anything here is wrong, **do not fix the assets**. Go to
 The engine is consumed as a Git dependency pinned to a tag; there is no
 crates.io publish. The release is a reviewable source snapshot with a checksum
 and a provenance record.
+
+The desktop path-depends on the in-tree engine while developing, but an
+application release is accepted only when that entire engine subtree exactly
+matches an annotated engine release tag. Any engine change since the last tag
+therefore makes an engine release the required first half of the next
+application release.
 
 1. Bump `version` in `crates/antiburn-local/Cargo.toml`, refresh its lockfile
    (`cargo update --manifest-path crates/antiburn-local/Cargo.toml --package antiburn-local`),

--- a/scripts/verify-app-engine-release.mjs
+++ b/scripts/verify-app-engine-release.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Prove that an application release embeds an actual antiburn-local release.
+//
+// The desktop path-depends on the in-tree engine, so Cargo correctly compiles
+// whatever source is present at the application tag. That convenience must not
+// let an app release label unreleased engine source with an older crate version
+// in its SBOM. The engine's declared version therefore names an annotated,
+// ancestral antiburn-local tag whose complete crate tree must be byte-for-byte
+// identical to the one the application is about to ship.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ENGINE_MANIFEST = "crates/antiburn-local/Cargo.toml";
+const APP_LOCKFILE = "apps/desktop/src-tauri/Cargo.lock";
+const ENGINE_TREE = "crates/antiburn-local";
+
+function git(root, ...arguments_) {
+  const result = spawnSync("git", arguments_, {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+  };
+}
+
+function cargoTomlVersion(contents) {
+  let inPackage = false;
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith("[")) {
+      inPackage = line === "[package]";
+      continue;
+    }
+    if (!inPackage) continue;
+    const match = /^version\s*=\s*"([^"]+)"/.exec(line);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function cargoLockVersion(contents, packageName) {
+  for (const block of contents.split("[[package]]")) {
+    const name = /^\s*name\s*=\s*"([^"]+)"/m.exec(block);
+    if (!name || name[1] !== packageName) continue;
+    return /^\s*version\s*=\s*"([^"]+)"/m.exec(block)?.[1] ?? null;
+  }
+  return null;
+}
+
+function show(root, ref, file) {
+  return git(root, "show", `${ref}:${file}`);
+}
+
+export function verifyAppEngineRelease(root = ROOT, ref = "HEAD") {
+  const errors = [];
+  const manifest = show(root, ref, ENGINE_MANIFEST);
+  if (manifest.status !== 0) {
+    return {
+      errors: [
+        `${ENGINE_MANIFEST} could not be read at ${ref}: ${manifest.stderr}`,
+      ],
+    };
+  }
+
+  const engineVersion = cargoTomlVersion(manifest.stdout);
+  if (!engineVersion) {
+    return {
+      errors: [`${ENGINE_MANIFEST} has no [package] version at ${ref}`],
+    };
+  }
+
+  const lockfile = show(root, ref, APP_LOCKFILE);
+  if (lockfile.status !== 0) {
+    errors.push(
+      `${APP_LOCKFILE} could not be read at ${ref}: ${lockfile.stderr}`,
+    );
+  } else {
+    const lockedVersion = cargoLockVersion(lockfile.stdout, "antiburn-local");
+    if (lockedVersion !== engineVersion) {
+      errors.push(
+        `${APP_LOCKFILE} records antiburn-local ${lockedVersion ?? "without a version"}, ` +
+          `but ${ENGINE_MANIFEST} declares ${engineVersion}`,
+      );
+    }
+  }
+
+  const tag = `antiburn-local-v${engineVersion}`;
+  const tagRef = `refs/tags/${tag}`;
+  const objectType = git(root, "cat-file", "-t", tagRef);
+  if (objectType.status !== 0) {
+    errors.push(
+      `${tag} does not exist. Release the changed engine before releasing the application.`,
+    );
+    return { engineVersion, tag, errors };
+  }
+  if (objectType.stdout !== "tag") {
+    errors.push(`${tag} is not an annotated tag`);
+  }
+
+  const tagCommit = git(root, "rev-parse", `${tagRef}^{commit}`);
+  if (tagCommit.status !== 0) {
+    errors.push(`${tag} does not resolve to a commit: ${tagCommit.stderr}`);
+    return { engineVersion, tag, errors };
+  }
+
+  const ancestry = git(
+    root,
+    "merge-base",
+    "--is-ancestor",
+    tagCommit.stdout,
+    ref,
+  );
+  if (ancestry.status !== 0) {
+    errors.push(`${tag} is not an ancestor of ${ref}`);
+  }
+
+  const currentTree = git(root, "rev-parse", `${ref}:${ENGINE_TREE}`);
+  const releasedTree = git(
+    root,
+    "rev-parse",
+    `${tagRef}^{commit}:${ENGINE_TREE}`,
+  );
+  if (currentTree.status !== 0 || releasedTree.status !== 0) {
+    errors.push(`Could not compare ${ENGINE_TREE} at ${ref} and ${tag}`);
+  } else if (currentTree.stdout !== releasedTree.stdout) {
+    const changed = git(
+      root,
+      "diff",
+      "--name-only",
+      tagCommit.stdout,
+      ref,
+      "--",
+      ENGINE_TREE,
+    );
+    const detail = changed.stdout ? ` Changed files:\n${changed.stdout}` : "";
+    errors.push(
+      `${ENGINE_TREE} at ${ref} does not match ${tag}. ` +
+        `Release the changed engine before releasing the application.${detail}`,
+    );
+  }
+
+  return {
+    engineVersion,
+    tag,
+    tagCommit: tagCommit.stdout,
+    currentTree: currentTree.stdout,
+    releasedTree: releasedTree.stdout,
+    errors,
+  };
+}
+
+function main() {
+  const ref = process.argv[2] ?? "HEAD";
+  const result = verifyAppEngineRelease(ROOT, ref);
+  if (result.errors.length > 0) {
+    for (const error of result.errors) console.error(`::error::${error}`);
+    process.exit(1);
+  }
+  console.log(
+    `ok  ${ENGINE_TREE} at ${ref} matches annotated ${result.tag} (${result.tagCommit})`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/verify-app-engine-release.test.mjs
+++ b/scripts/verify-app-engine-release.test.mjs
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { verifyAppEngineRelease } from "./verify-app-engine-release.mjs";
+
+function git(root, ...arguments_) {
+  return execFileSync("git", arguments_, {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+}
+
+function writeFixture(root, engineVersion, lockedVersion = engineVersion) {
+  mkdirSync(path.join(root, "crates/antiburn-local/src"), { recursive: true });
+  mkdirSync(path.join(root, "apps/desktop/src-tauri"), { recursive: true });
+  writeFileSync(
+    path.join(root, "crates/antiburn-local/Cargo.toml"),
+    `[package]\nname = "antiburn-local"\nversion = "${engineVersion}"\n`,
+  );
+  writeFileSync(
+    path.join(root, "crates/antiburn-local/src/lib.rs"),
+    "pub fn released() {}\n",
+  );
+  writeFileSync(
+    path.join(root, "apps/desktop/src-tauri/Cargo.lock"),
+    `version = 4\n\n[[package]]\nname = "antiburn-local"\nversion = "${lockedVersion}"\n`,
+  );
+}
+
+function repository(t, options = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "antiburn-engine-release-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "--quiet");
+  git(root, "config", "user.name", "Release Test");
+  git(root, "config", "user.email", "release-test@example.com");
+  writeFixture(root, "1.2.3", options.lockedVersion);
+  git(root, "add", ".");
+  git(root, "commit", "--quiet", "-m", "engine source");
+  if (options.tag === "annotated") {
+    git(root, "tag", "-a", "antiburn-local-v1.2.3", "-m", "engine 1.2.3");
+  } else if (options.tag === "lightweight") {
+    git(root, "tag", "antiburn-local-v1.2.3");
+  }
+  return root;
+}
+
+test("accepts an exact engine tree from an annotated ancestral tag", (t) => {
+  const root = repository(t, { tag: "annotated" });
+  const result = verifyAppEngineRelease(root);
+
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.engineVersion, "1.2.3");
+  assert.equal(result.tag, "antiburn-local-v1.2.3");
+  assert.equal(result.currentTree, result.releasedTree);
+});
+
+test("rejects engine changes made after the matching release tag", (t) => {
+  const root = repository(t, { tag: "annotated" });
+  writeFileSync(
+    path.join(root, "crates/antiburn-local/src/lib.rs"),
+    "pub fn unreleased() {}\n",
+  );
+  git(root, "add", ".");
+  git(root, "commit", "--quiet", "-m", "unreleased engine change");
+
+  const result = verifyAppEngineRelease(root);
+
+  assert.match(
+    result.errors.join("\n"),
+    /does not match antiburn-local-v1\.2\.3/,
+  );
+  assert.match(
+    result.errors.join("\n"),
+    /crates\/antiburn-local\/src\/lib\.rs/,
+  );
+});
+
+test("rejects a missing engine release tag", (t) => {
+  const root = repository(t);
+  const result = verifyAppEngineRelease(root);
+
+  assert.match(
+    result.errors.join("\n"),
+    /antiburn-local-v1\.2\.3 does not exist/,
+  );
+});
+
+test("rejects a lightweight engine tag", (t) => {
+  const root = repository(t, { tag: "lightweight" });
+  const result = verifyAppEngineRelease(root);
+
+  assert.match(result.errors.join("\n"), /is not an annotated tag/);
+});
+
+test("rejects a stale engine version in the desktop lockfile", (t) => {
+  const root = repository(t, { tag: "annotated", lockedVersion: "1.2.2" });
+  const result = verifyAppEngineRelease(root);
+
+  assert.match(
+    result.errors.join("\n"),
+    /Cargo\.lock records antiburn-local 1\.2\.2.*declares 1\.2\.3/,
+  );
+});


### PR DESCRIPTION
## Summary

- prepare `antiburn-local` 0.1.3 with indexed title APIs and semantic transcript recency
- require application releases to embed an engine subtree that exactly matches its annotated, ancestral engine tag
- verify the desktop lockfile names the same engine version in PR CI and the application tag workflow
- document the engine-first release invariant

## Why

The `rc.5` application source included engine changes made after `antiburn-local-v0.1.2`, while still reporting engine version 0.1.2. The app correctly built the latest path dependency, but its component release provenance was misleading. This gate turns that process convention into a hard check.

This PR intentionally runs full CI because it changes release workflows and their control-plane tests. After it merges and the exact main commit passes CI, the next steps are:

1. create annotated tag `antiburn-local-v0.1.3`
2. review the engine release draft
3. prepare application `0.1.0-rc.6`, which must pass the new engine provenance gate

## Validation

- `node --test scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs`
- `actionlint .github/workflows/ci.yml .github/workflows/release-app.yml`
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (654 unit tests, 3 boundary tests, 1 doctest; 1 ignored)
- locked Cargo metadata for engine and desktop
- clean source-boundary check