### PR TITLE
Release antiburn 0.1.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,93 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.1.0-rc.6] - 2026-08-20
+
+This release candidate supersedes rc.5, which was not published after its
+embedded engine source was found not to have a matching component release tag.
+It contains the same tested application behavior with the engine correctly
+identified as the separately released `antiburn-local` 0.1.3.
+
+A release-candidate rehearsal build, not a supported release. The macOS and
+Windows binaries are **unsigned** — your operating system will warn you, and it
+is right to. Install it only if you are testing the release pipeline itself.
+
+On macOS, open the app for the first time with right-click → Open rather than a
+double-click. The build is sealed but has no Developer ID signature, so macOS
+shows its unidentified-developer warning.
+
+### Added
+
+- **Launch antiburn when you sign in.** New installs opt in by default from the
+  final setup step so the menu-bar or tray utility is available without being
+  opened by hand. The same switch is available later in Settings → General,
+  and can be turned off before setup finishes.
+
+- **What "local" means, spelled out.** antiburn needs no antiburn account,
+  server, or backend — everything runs on your machine, as you. The
+  connections it makes are yours: reading your provider's own current usage
+  figures with your own credentials, traffic between this machine and a
+  provider you already use. Its one call to a service of ours — checking
+  whether a newer version exists — is a convenience it never depends on, and
+  it hands your data to no one who doesn't already have it.
+
+### Changed
+
+- **Plan limits now live at the top of the main popover.** Expand the Limits
+  section for each provider's windows and reset times, or collapse it to a row
+  of compact percentage chips. Each chip's ring follows that provider's
+  fullest reported limit, so the most urgent allowance stays visible.
+
+- **A per-model weekly limit stays out of the way until you use that
+  model.** Your provider can report a supplemental weekly allowance scoped to
+  one model alongside your account-wide limits. Most readers never touch that
+  model, so its row used to sit at the bottom of the Usage screen reading 0%
+  forever. It is now hidden until you actually use the model it tracks, and
+  once it shows real usage it stays on screen for the rest of that week —
+  even past a reading that comes back without a percentage — so a limit you
+  are genuinely drawing on never looks like it disappeared.
+
+- **Plan limits are now fetched directly, not read from a file your agent
+  happened to cache — and that runs by default.** Settings → Usage's switch
+  asks each provider's own usage endpoint directly, with the credential your
+  coding tool already keeps on this machine — on macOS, that is usually the
+  same Keychain item the Claude CLI itself reads and writes, with its
+  credentials file as a fallback — instead of running your coding agent in the
+  background and reading the file it wrote. If Codex's endpoint can't be
+  reached directly, antiburn falls back to asking the local `codex app-server`
+  process the same question over its own protocol, rather than showing
+  nothing. This is your own connection, made as you, to a provider you already
+  use, with a credential you already hold — ordinary traffic, not something
+  antiburn asks permission for — so the switch is on by default once first-run
+  setup is complete, and no source runs a moment before that. One switch in
+  Settings → Usage turns all of it off, for anyone who wants no background
+  traffic at all; with it off, antiburn has no plan limits to show, since there
+  is no longer a cached file it reads on its own.
+
+- **Hidden utility windows no longer remain resident indefinitely.** The
+  popover, Settings, setup, and notification views are released when they are
+  no longer needed and recreated on demand, substantially reducing the app's
+  idle memory footprint.
+
+### Fixed
+
+- **Recent Activity follows real transcript activity.** Background file
+  touches, title changes, permission changes, and other agent housekeeping no
+  longer make an idle session look newly active. Subagent work still counts
+  toward its parent session.
+
+- **Native and WSL session analytics stay separate.** Sessions with the same
+  agent identifier can no longer reuse one another's cached analysis across
+  those environments.
+
+- Settings panes return to the top when you move between them, instead of
+  keeping the previous pane's scroll position.
+
+- **Session names in recent activity.** antiburn now reads authoritative names
+  from each agent's indexed session store when available, while keeping mounted
+  WSL sessions isolated from native stores. Renames appear on the next scan,
+  and a missing title can no longer leave mismatched title provenance behind.
+
 ## [0.1.0-rc.5] - 2026-08-20
 
 A release-candidate rehearsal build, not a supported release. The macOS and

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.5",
+  "version": "0.1.0-rc.6",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "antiburn-local",
  "antiburn-nudge",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/nudge", "crates/sound"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.5",
+  "version": "0.1.0-rc.6",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary

- bump all four desktop version sources to `0.1.0-rc.6`
- carry forward the reader-facing `rc.5` notes for the replacement candidate
- record that `rc.6` supersedes the unpublished `rc.5` after aligning the embedded engine with released `antiburn-local 0.1.3`

## Release invariant

The new provenance gate passes: the complete in-tree engine subtree exactly matches annotated, ancestral tag `antiburn-local-v0.1.3`, and the desktop lockfile records engine version 0.1.3.

This is intentionally a pure release-metadata change, so CI should select the narrow metadata gate. After merge, the exact `main` commit must pass CI before annotated tag `antiburn-v0.1.0-rc.6` is created and the four-platform draft build begins.

## Local validation

- `node scripts/verify-release-version.mjs app antiburn-v0.1.0-rc.6`
- `node scripts/verify-app-engine-release.mjs`
- locked desktop Cargo metadata
- release diff classifier: `release_app: true`, `full: false`
- `git diff --check`