### PR TITLE
Fix the Windows release-cache target argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Test the CI control plane
-        run: node --test scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
+        run: node --test scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/verify-workflow-portability.test.mjs scripts/wait-for-main-ci.test.mjs
 
       - name: Classify the diff
         id: changes
@@ -354,9 +354,9 @@ jobs:
         run: echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
 
       - name: Compile the release target without bundling or signing
-        env:
-          TARGET: ${{ matrix.target }}
-        run: pnpm --filter @antiburn/desktop exec tauri build --features distribution --target "$TARGET" --no-bundle
+        # This matrix includes PowerShell on Windows and POSIX shells elsewhere.
+        # Let Actions substitute the value before either shell sees the command.
+        run: pnpm --filter @antiburn/desktop exec tauri build --features distribution --target "${{ matrix.target }}" --no-bundle
 
   boundary:
     name: whole-tree source boundary

--- a/scripts/verify-workflow-portability.test.mjs
+++ b/scripts/verify-workflow-portability.test.mjs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/ci.yml", import.meta.url),
+  "utf8",
+);
+
+function namedStep(name) {
+  const marker = `      - name: ${name}`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `${name} step must exist`);
+  const next = workflow.indexOf("\n      - name:", start + marker.length);
+  return workflow.slice(start, next === -1 ? undefined : next);
+}
+
+test("the cross-platform release cache target is shell-neutral", () => {
+  const step = namedStep(
+    "Compile the release target without bundling or signing",
+  );
+
+  assert.match(step, /--target "\$\{\{ matrix\.target \}\}" --no-bundle/);
+  assert.doesNotMatch(step, /\$TARGET/);
+});


### PR DESCRIPTION
## Summary

- interpolate the release target through the Actions matrix before the runner shell sees the command
- remove the POSIX-only `$TARGET` expansion from the cross-platform cache-warming step
- add a control-plane regression test that requires the target invocation to remain shell-neutral

## Failure

The `rc.6` release-metadata merge reached the Windows cache-warming path and PowerShell interpreted `$TARGET` as an unset local variable. The environment value was available as `$env:TARGET`, but the command therefore passed `--target ""` to Tauri.

The actual tagged release build already runs under Bash and is unaffected. No `rc.6` tag was created, so after this PR merges and exact-main CI succeeds, the existing `0.1.0-rc.6` metadata can be tagged without cutting `rc.7`.

## Validation

- 20 CI control-plane tests pass
- `actionlint .github/workflows/ci.yml`
- Prettier check
- `git diff --check`