### PR TITLE
chore(release): prepare antiburn-local 0.1.4

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,6 +21,12 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-08-21
+
+### Changed
+
+- The bundled SQLite integration now uses `rusqlite` 0.40.2.
+
 ## [0.1.3] - 2026-08-20
 
 ### Added

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MPL-2.0"


### PR DESCRIPTION
## Summary

- bump antiburn-local to 0.1.4
- record the rusqlite 0.40.2 integration update
- refresh both engine version lockfile entries

## Checks

- `node scripts/verify-release-version.mjs engine antiburn-local-v0.1.4`
- `cargo metadata --locked --no-deps --format-version 1` for both manifests
- `cargo test --locked --manifest-path crates/antiburn-local/Cargo.toml`
- `git diff --check`