### PR TITLE
chore(release): prepare antiburn 0.1.0-rc.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,29 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.1.0-rc.7] - 2026-08-21
+
+A release-candidate rehearsal build, not a supported release. The macOS and
+Windows binaries are **unsigned** — your operating system will warn you, and it
+is right to. Install it only if you are testing the release pipeline itself.
+
+On macOS, open the app for the first time with right-click → Open rather than a
+double-click. The build is sealed but has no Developer ID signature, so macOS
+shows its unidentified-developer warning.
+
 ### Changed
 
 - **The main popover stays ready after its first use.** Opening antiburn again
   reuses the existing hidden popover instead of rebuilding its webview, so the
   main surface returns immediately.
+
+- **Recent Activity is simpler to scan.** Session rows now focus on the agent,
+  repository, recency, and estimated cost, with less visual separation and no
+  duplicate duration measure.
+
+- **The macOS installer now has a branded, readable layout.** The disk image
+  shows the antiburn app and Applications folder on a light background with
+  clear labels.
 
 ### Fixed
 
@@ -36,6 +54,10 @@ CI changes, and documentation that no user acts on stay out — see
   shows its last successful provider reading while it refreshes that reading in
   the background. The activity list and saved limits now appear together,
   without a blank route or a second layout change before the limits arrive.
+
+- **Linux tray interactions now open in the right place.** The tray menu opens
+  the popover at the panel instead of the pointer, and notification cards size
+  themselves to their content.
 
 ## [0.1.0-rc.6] - 2026-08-20
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.6",
+  "version": "0.1.0-rc.7",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 dependencies = [
  "antiburn-local",
  "antiburn-nudge",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/nudge", "crates/sound"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.6",
+  "version": "0.1.0-rc.7",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary

- bump all desktop manifests to 0.1.0-rc.7
- publish reader-facing notes for the popover, activity list, Linux tray, and macOS installer changes
- retain the unsigned release-candidate warning

## Checks

- `node scripts/verify-release-version.mjs app antiburn-v0.1.0-rc.7`
- `node scripts/verify-app-engine-release.mjs`
- `git diff --check`