### PR TITLE
fix(desktop): keep a provider visible when its live usage source fails

### DIFF
--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -485,6 +485,18 @@ pub struct LiveExtraUsage {
 pub struct LiveUsageSourceError {
     /// The source's stable id.
     pub source: String,
+    /// The canonical id of the provider the source answers for.
+    ///
+    /// A failed source contributes no entry to `providers`, so this field is
+    /// the only place the views can learn whose usage is missing. Defaulted
+    /// on deserialize: a snapshot cached before this field existed must
+    /// still load.
+    #[serde(default)]
+    pub provider: String,
+    /// The provider's display name, for example "Claude". Defaulted like
+    /// `provider`.
+    #[serde(default)]
+    pub display_name: String,
     /// `authentication`, `rateLimited`, `schema`, or `unavailable`.
     pub category: String,
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -88,6 +88,15 @@ pub trait LiveUsageSource: Send + Sync {
     /// A stable id for this source, used in the error surface and in logs.
     fn id(&self) -> &'static str;
 
+    /// The canonical id of the provider this source answers for — one of the
+    /// [`crate::provider_usage::providers`] constants.
+    ///
+    /// A failed source produces no snapshot, and without this the error would
+    /// be the only trace of the provider: the views could not say *whose*
+    /// usage they cannot show. Required rather than defaulted, so a new
+    /// source cannot forget to say.
+    fn provider(&self) -> &'static str;
+
     /// Whether this source may only run behind the online opt-in.
     ///
     /// Declared by the source rather than known by the caller, so adding one
@@ -232,9 +241,11 @@ pub fn summarize(
         errors: collected
             .errors
             .into_iter()
-            .map(|(source, error)| LiveUsageSourceError {
-                source: source.to_string(),
-                category: error.category().to_string(),
+            .map(|failure| LiveUsageSourceError {
+                source: failure.source.to_string(),
+                provider: failure.provider.to_string(),
+                display_name: super::providers::display_name(failure.provider).to_string(),
+                category: failure.error.category().to_string(),
             })
             .collect(),
         generated_at: crate::store::iso_from_epoch(Some(now)),

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -265,6 +265,10 @@ impl LiveUsageSource for ClaudeDirectFetch {
         SOURCE_ID
     }
 
+    fn provider(&self) -> &'static str {
+        crate::provider_usage::providers::ANTHROPIC
+    }
+
     /// This source makes a request of its own, on the reader's own account —
     /// exactly the traffic the online opt-in exists to gate.
     fn requires_online_opt_in(&self) -> bool {

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -271,6 +271,10 @@ impl LiveUsageSource for CodexDirectFetch {
         super::CODEX_SOURCE_ID
     }
 
+    fn provider(&self) -> &'static str {
+        crate::provider_usage::providers::OPENAI
+    }
+
     fn requires_online_opt_in(&self) -> bool {
         true
     }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -82,7 +82,11 @@ pub fn collect(sources: &[Box<dyn LiveUsageSource>], online: bool, max_age: Dura
         }
         let outcome = source.fetch(max_age);
         if let Some(error) = outcome.error {
-            collected.errors.push((source.id(), error));
+            collected.errors.push(SourceFailure {
+                source: source.id(),
+                provider: source.provider(),
+                error,
+            });
         }
         for snapshot in outcome.snapshots {
             collected.push(snapshot);
@@ -96,8 +100,22 @@ pub fn collect(sources: &[Box<dyn LiveUsageSource>], online: bool, max_age: Dura
 pub struct Collected {
     /// One snapshot per provider account, best reading kept.
     pub snapshots: Vec<ProviderUsageSnapshot>,
-    /// Failures worth telling the reader about, by source id.
-    pub errors: Vec<(&'static str, super::model::ProviderUsageError)>,
+    /// Failures worth telling the reader about.
+    pub errors: Vec<SourceFailure>,
+}
+
+/// One source's failure, with the provider it answers for.
+///
+/// The provider travels with the error because a failed source produces no
+/// snapshot: this is the only place the views can learn whose usage is
+/// missing.
+#[derive(Debug)]
+pub struct SourceFailure {
+    /// The failed source's stable id.
+    pub source: &'static str,
+    /// The canonical provider id the source answers for.
+    pub provider: &'static str,
+    pub error: super::model::ProviderUsageError,
 }
 
 impl Collected {

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -250,6 +250,9 @@ impl LiveUsageSource for Fixed {
     fn id(&self) -> &'static str {
         self.0
     }
+    fn provider(&self) -> &'static str {
+        crate::provider_usage::providers::ANTHROPIC
+    }
     fn fetch(&self, _max_age: std::time::Duration) -> SourceOutcome {
         SourceOutcome::found(self.1.clone())
     }
@@ -260,6 +263,9 @@ struct Broken(&'static str, ProviderUsageError);
 impl LiveUsageSource for Broken {
     fn id(&self) -> &'static str {
         self.0
+    }
+    fn provider(&self) -> &'static str {
+        crate::provider_usage::providers::ANTHROPIC
     }
     fn fetch(&self, _max_age: std::time::Duration) -> SourceOutcome {
         SourceOutcome::failed(self.1)
@@ -331,6 +337,10 @@ fn a_failed_source_reports_its_category_without_erasing_a_working_one() {
     assert_eq!(summary.errors.len(), 1);
     assert_eq!(summary.errors[0].source, "signed-out");
     assert_eq!(summary.errors[0].category, "authentication");
+    // The error names its provider, so the views can keep a section for a
+    // provider the failure left without a snapshot.
+    assert_eq!(summary.errors[0].provider, "anthropic");
+    assert_eq!(summary.errors[0].display_name, "Claude");
 }
 
 #[test]
@@ -387,6 +397,9 @@ struct Counted(Arc<AtomicUsize>);
 impl LiveUsageSource for Counted {
     fn id(&self) -> &'static str {
         "counted"
+    }
+    fn provider(&self) -> &'static str {
+        crate::provider_usage::providers::ANTHROPIC
     }
     fn requires_online_opt_in(&self) -> bool {
         true

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -392,6 +392,8 @@ mod tests {
             }],
             errors: vec![LiveUsageSourceError {
                 source: "fixture".into(),
+                provider: "openai".into(),
+                display_name: "Codex".into(),
                 category: "unavailable".into(),
             }],
             generated_at: "2026-08-20T00:00:00Z".into(),

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.test.tsx
@@ -111,6 +111,29 @@ describe("UsageLimitsSection — visibility", () => {
     const { container } = section({ live: liveSummary([liveProvider({ windows: [] })]) })
     expect(container).toBeEmptyDOMElement()
   })
+
+  it("keeps a subsection for a provider whose source failed with nothing cached", () => {
+    // The error is the provider's only trace; a section that silently
+    // vanishes reads as data loss rather than as a passing failure.
+    section({
+      live: {
+        providers: [],
+        errors: [
+          {
+            source: "claude-usage-fetch",
+            provider: "anthropic",
+            displayName: "Claude",
+            category: "rateLimited",
+          },
+        ],
+        generatedAt: new Date().toISOString(),
+      },
+    })
+    const subsection = screen.getByTestId("usage-limits-unavailable")
+    expect(subsection).toHaveTextContent("Claude")
+    expect(subsection).toHaveTextContent("rate limited")
+    expect(subsection).toHaveTextContent(/asked antiburn to slow down/i)
+  })
 })
 
 describe("UsageLimitsSection — expanded", () => {

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
@@ -12,7 +12,14 @@ import type {
   ProviderUsagePayload,
 } from "../../lib/ipc"
 import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
-import { liveSourceNote, liveWindows } from "../../lib/presentation/liveUsage"
+import type { UnavailableLiveProvider } from "../../lib/presentation/liveUsage"
+import {
+  liveErrorNote,
+  liveSourceNote,
+  liveUnavailableProviders,
+  liveUnavailableReason,
+  liveWindows,
+} from "../../lib/presentation/liveUsage"
 import { LiveUsageWindowRows } from "./LiveUsageWindowRows"
 import { ProviderUsageChips } from "./ProviderUsageChips"
 
@@ -50,7 +57,10 @@ export interface UsageLimitsSectionProps {
  * The whole section is silent when no provider has anything to say — live
  * usage off, or no reading has arrived yet — rather than rendering an empty
  * shell. There is nothing to collapse *to* in that case, so the reader who
- * has never turned the feature on sees nothing about it here at all.
+ * has never turned the feature on sees nothing about it here at all. A
+ * provider whose source *failed* is different: it keeps a subsection that
+ * names the failure, because a section that silently vanishes reads as data
+ * loss.
  */
 export function UsageLimitsSection({
   providers,
@@ -63,9 +73,12 @@ export function UsageLimitsSection({
 }: UsageLimitsSectionProps) {
   const at = now ?? (Date.parse(live.generatedAt) || 0)
   const limited = live.providers.filter((provider) => liveWindows(provider).length > 0)
+  // Providers whose only trace is a source error — a failed fetch with no
+  // cached reading. They keep a degraded subsection rather than vanishing.
+  const unavailable = liveUnavailableProviders(live)
   const headingId = useId()
 
-  if (limited.length === 0) return null
+  if (limited.length === 0 && unavailable.length === 0) return null
 
   const toggle = (
     <button
@@ -120,6 +133,9 @@ export function UsageLimitsSection({
               {limited.map((provider) => (
                 <ProviderLimitSubsection key={provider.provider} provider={provider} now={at} />
               ))}
+              {unavailable.map((entry) => (
+                <UnavailableLimitSubsection key={entry.provider} entry={entry} />
+              ))}
             </div>
           </div>
         </>
@@ -139,6 +155,25 @@ export function UsageLimitsSection({
           {spinner}
         </div>
       )}
+    </div>
+  )
+}
+
+/**
+ * One provider's subsection while its live reading is unavailable — a failed
+ * source with nothing cached to fall back on. The provider keeps its place
+ * with the failure named, instead of vanishing without a word.
+ */
+function UnavailableLimitSubsection({ entry }: { entry: UnavailableLiveProvider }) {
+  return (
+    <div data-testid="usage-limits-unavailable">
+      <div className="flex items-baseline justify-between gap-2 px-1 pb-1">
+        <h3 className="truncate text-label-secondary">{entry.displayName}</h3>
+        <span className="shrink-0 type-caption text-label-tertiary">
+          {liveUnavailableReason(entry.category)}
+        </span>
+      </div>
+      <p className="px-1 type-caption text-label-tertiary">{liveErrorNote(entry.category)}</p>
     </div>
   )
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -399,6 +399,15 @@ export interface LiveProviderUsagePayload {
 /** A source that failed, in terms a reader can act on. */
 export interface LiveUsageSourceErrorPayload {
   source: string
+  /**
+   * The canonical id of the provider the source answers for. A failed source
+   * contributes no entry to `providers`, so this is how the views keep a
+   * section for the provider the failure left without a reading. Empty on a
+   * snapshot cached before the field existed.
+   */
+  provider: string
+  /** The provider's display name, for example "Claude". Empty like `provider`. */
+  displayName: string
   /** `authentication` | `rateLimited` | `schema` | `unavailable`. */
   category: string
 }

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest"
 import type {
   LiveProviderUsagePayload,
   LiveUsageForecastPayload,
+  LiveUsageSourceErrorPayload,
   LiveUsageSummaryPayload,
   LiveUsageWindowPayload,
 } from "../ipc"
@@ -18,6 +19,8 @@ import {
   liveResetLabel,
   liveSourceNote,
   liveStalenessNote,
+  liveUnavailableProviders,
+  liveUnavailableReason,
   liveWindowElapsed,
   liveWindowLabel,
   liveMetricRows,
@@ -383,20 +386,78 @@ describe("hiding unused model quota limits", () => {
   })
 })
 
+function sourceError(
+  overrides: Partial<LiveUsageSourceErrorPayload> = {},
+): LiveUsageSourceErrorPayload {
+  return {
+    source: "claude-usage-fetch",
+    provider: "anthropic",
+    displayName: "Claude",
+    category: "rateLimited",
+    ...overrides,
+  }
+}
+
 describe("the failure surface", () => {
   it("banners only the failure a reader can act on", () => {
     expect(liveAuthNote(summary())).toBeNull()
     // A rate limit passes on its own and an unreadable file is usually a
     // missing agent; neither is worth interrupting someone over.
     expect(
-      liveAuthNote(summary({ errors: [{ source: "s", category: "rateLimited" }] })),
+      liveAuthNote(summary({ errors: [sourceError({ category: "rateLimited" })] })),
     ).toBeNull()
     expect(
-      liveAuthNote(summary({ errors: [{ source: "s", category: "unavailable" }] })),
+      liveAuthNote(summary({ errors: [sourceError({ category: "unavailable" })] })),
     ).toBeNull()
     expect(
-      liveAuthNote(summary({ errors: [{ source: "s", category: "authentication" }] })),
+      liveAuthNote(summary({ errors: [sourceError({ category: "authentication" })] })),
     ).toMatch(/sign in again/i)
+  })
+
+  it("lists a provider whose failure left nothing to show", () => {
+    // The cold-start failure: first fetch rejected, nothing cached. The error
+    // is the only trace of the provider, so the views need it as a row.
+    const vanished = summary({ providers: [], errors: [sourceError()] })
+    expect(liveUnavailableProviders(vanished)).toEqual([
+      { provider: "anthropic", displayName: "Claude", category: "rateLimited" },
+    ])
+  })
+
+  it("does not list a provider that still shows windows beside its error", () => {
+    // A failed refresh after an earlier success: the cooldown keeps the
+    // last-good reading, so the provider is on screen and the staleness
+    // treatment covers it. A second, degraded row would say it twice.
+    const cached = summary({ errors: [sourceError()] })
+    expect(liveUnavailableProviders(cached)).toEqual([])
+  })
+
+  it("lists a provider whose reading is present but has no windows worth showing", () => {
+    const windowless = summary({
+      providers: [provider({ windows: [] })],
+      errors: [sourceError()],
+    })
+    expect(liveUnavailableProviders(windowless)).toHaveLength(1)
+  })
+
+  it("dedupes two failures for one provider and skips an error with no provider id", () => {
+    const noisy = summary({
+      providers: [],
+      errors: [
+        sourceError(),
+        sourceError({ source: "another-source" }),
+        // A snapshot cached before the provider field existed cannot name a
+        // section.
+        sourceError({ source: "legacy", provider: "", displayName: "" }),
+      ],
+    })
+    expect(liveUnavailableProviders(noisy)).toHaveLength(1)
+  })
+
+  it("phrases each failure category in a couple of words", () => {
+    expect(liveUnavailableReason("rateLimited")).toBe("rate limited")
+    expect(liveUnavailableReason("authentication")).toBe("sign-in needed")
+    expect(liveUnavailableReason("schema")).toBe("unreadable reply")
+    expect(liveUnavailableReason("somethingNew")).toBe("unreachable")
   })
 })
 

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -29,6 +29,15 @@ import type {
   LiveUsageSummaryPayload,
   LiveUsageWindowPayload,
 } from "../ipc"
+
+/** A provider whose live reading failed and left nothing to show. */
+export interface UnavailableLiveProvider {
+  /** Canonical provider id, from the failed source. */
+  provider: string
+  displayName: string
+  /** `authentication` | `rateLimited` | `schema` | `unavailable`. */
+  category: string
+}
 import { relativeTime } from "./relativeTime"
 
 /**
@@ -260,6 +269,67 @@ export function liveAuthNote(summary: LiveUsageSummaryPayload): string | null {
   const failed = summary.errors.some((error) => error.category === "authentication")
   if (!failed) return null
   return "antiburn could not sign in to read your plan usage. Sign in again with your coding tool, then reopen this view."
+}
+
+/**
+ * The providers whose live reading failed and left no windows to draw —
+ * exactly the ones the limits surfaces would otherwise drop without a word.
+ *
+ * A failed source with a cached last-good reading still appears in
+ * `providers`, carrying its stale figures; the staleness treatment covers
+ * that case and no entry appears here. This list is for the cold-start
+ * failure — first fetch rejected, nothing cached — where the error is the
+ * only trace of the provider. An error without a provider id (a snapshot
+ * cached before the field existed) cannot name a section and is skipped.
+ */
+export function liveUnavailableProviders(
+  summary: LiveUsageSummaryPayload,
+): UnavailableLiveProvider[] {
+  const showing = new Set(
+    summary.providers
+      .filter((provider) => liveWindows(provider).length > 0)
+      .map((provider) => provider.provider),
+  )
+  const seen = new Set<string>()
+  const unavailable: UnavailableLiveProvider[] = []
+  for (const error of summary.errors) {
+    if (!error.provider || showing.has(error.provider) || seen.has(error.provider)) continue
+    seen.add(error.provider)
+    unavailable.push({
+      provider: error.provider,
+      displayName: error.displayName || error.provider,
+      category: error.category,
+    })
+  }
+  return unavailable
+}
+
+/** A failure category as two or three words, for a row with no room. */
+export function liveUnavailableReason(category: string): string {
+  switch (category) {
+    case "authentication":
+      return "sign-in needed"
+    case "rateLimited":
+      return "rate limited"
+    case "schema":
+      return "unreadable reply"
+    default:
+      return "unreachable"
+  }
+}
+
+/** What a failed source means, phrased as something a reader could act on. */
+export function liveErrorNote(category: string): string {
+  switch (category) {
+    case "authentication":
+      return "antiburn could not sign in to read your plan usage. Sign in again with your coding tool, then reopen this view."
+    case "rateLimited":
+      return "Your provider asked antiburn to slow down. It will try again later."
+    case "schema":
+      return "Your provider reported usage in a shape antiburn does not recognise."
+    default:
+      return "antiburn could not reach your provider for usage. It will try again later."
+  }
 }
 
 /**

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -392,7 +392,16 @@ describe("UsageView — plan limits layered over local estimates", () => {
     render(
       <UsageView
         summary={summary()}
-        live={live({ errors: [{ source: "claude-usage-fetch", category: "authentication" }] })}
+        live={live({
+          errors: [
+            {
+              source: "claude-usage-fetch",
+              provider: "anthropic",
+              displayName: "Claude",
+              category: "authentication",
+            },
+          ],
+        })}
         now={NOW}
         onBack={vi.fn()}
       />,

--- a/apps/desktop/src/views/settings/UsagePane.test.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.test.tsx
@@ -97,7 +97,16 @@ describe("UsagePane", () => {
 
   it("turns each failure into something a reader could act on", async () => {
     getLiveUsage.mockResolvedValue(
-      summary({ errors: [{ source: "claude-usage-fetch", category: "authentication" }] }),
+      summary({
+        errors: [
+          {
+            source: "claude-usage-fetch",
+            provider: "anthropic",
+            displayName: "Claude",
+            category: "authentication",
+          },
+        ],
+      }),
     )
     pane()
     await waitFor(() =>

--- a/apps/desktop/src/views/settings/UsagePane.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.tsx
@@ -23,7 +23,7 @@ import {
   setFloatingHudEnabled,
 } from "../../lib/overlayWindow"
 import { isMacOS } from "../../lib/platform"
-import { liveSourceNote } from "../../lib/presentation/liveUsage"
+import { liveErrorNote, liveSourceNote } from "../../lib/presentation/liveUsage"
 import type { AppSettingsController } from "./useAppSettings"
 
 /**
@@ -46,20 +46,6 @@ import type { AppSettingsController } from "./useAppSettings"
  */
 
 export type UsagePaneProps = AppSettingsController
-
-/** What a failed source means, phrased as something a reader could act on. */
-function errorNote(category: string): string {
-  switch (category) {
-    case "authentication":
-      return "antiburn could not sign in to read your plan usage. Sign in again with your coding tool, then reopen this view."
-    case "rateLimited":
-      return "Your provider asked antiburn to slow down. It will try again later."
-    case "schema":
-      return "Your provider reported usage in a shape antiburn does not recognise."
-    default:
-      return "antiburn could not reach your provider for usage. It will try again later."
-  }
-}
 
 export function UsagePane({ settings, update }: UsagePaneProps) {
   const [hudShown, setHudShown] = useState(() => isFloatingHudEnabled())
@@ -149,8 +135,12 @@ export function UsagePane({ settings, update }: UsagePaneProps) {
           {live.errors.map((error) => (
             <Row
               key={error.source}
-              label="Could not read usage"
-              description={errorNote(error.category)}
+              label={
+                error.displayName
+                  ? `Could not read ${error.displayName} usage`
+                  : "Could not read usage"
+              }
+              description={liveErrorNote(error.category)}
             />
           ))}
         </Card>

--- a/docs/plans/live-usage-degraded-state.md
+++ b/docs/plans/live-usage-degraded-state.md
@@ -1,0 +1,78 @@
+# Live usage degraded state
+
+## The problem
+
+When a live-usage source fails with no cached last-good reading (observed:
+Anthropic's `https://api.anthropic.com/api/oauth/usage` returning HTTP 429 on a
+cold start), the summary arrives with an empty `providers` list and one entry
+in `errors`. `UsageLimitsSection`'s `limited` filter and its expanded listing
+both key off `providers`, so the provider's section vanishes with no
+explanation. A reader sees that as data loss, not as a passing failure.
+
+The in-session case is already covered: `sources/cooldown.rs` keeps the last
+good snapshot across a failed retry, so a 429 mid-session shows stale figures
+plus an error. The gap is the cold start, where no last-good exists yet
+because that cache is in memory only.
+
+## The design
+
+Keep the provider visible with an explicit unavailable row instead of
+vanishing. Two layers:
+
+### Rust: name the provider on the error
+
+`LiveUsageSourceError` carried only `source` ("claude-usage-fetch") and
+`category`. The frontend cannot map a source id to a provider without
+duplicating registry knowledge. So:
+
+1. `LiveUsageSource` gains `fn provider(&self) -> &'static str` — the
+   canonical provider id a source answers for. Required method, so a new
+   source cannot forget it.
+2. `sources::collect` records failures as a `SourceFailure` carrying the
+   source id, the provider, and the error.
+3. DTO `LiveUsageSourceError` gains `provider` and `displayName` (via
+   `providers::display_name`). Both are `#[serde(default)]` so a snapshot
+   cached before the fields existed still loads.
+
+Sources: `anthropic_fetch` → `ANTHROPIC`, `codex_fetch` → `OPENAI`.
+
+### Frontend: derive and render the degraded rows
+
+New helpers in `lib/presentation/liveUsage.ts`:
+
+- `liveUnavailableProviders(summary)`: the errors whose provider shows no
+  visible windows in `summary.providers`, deduped by provider — exactly the
+  providers that would otherwise vanish. When the provider *is* visible
+  (cooldown-cached reading), the existing staleness treatment already covers
+  it and no extra row appears, so one failure is never reported twice.
+- `liveUnavailableReason(category)`: short label — "rate limited",
+  "sign-in needed", "unreadable reply", "unreachable".
+- `liveErrorNote(category)`: the full sentence, moved from `UsagePane` so the
+  wording lives in one place.
+
+`UsageLimitsSection`:
+
+- The render gate becomes `limited.length === 0 && unavailable.length === 0`.
+- The expanded listing gains a subsection per unavailable provider: the
+  provider name, the short reason, and the full sentence beneath.
+
+`UsagePane` labels its error rows with the provider's display name and imports
+the shared `liveErrorNote`.
+
+## Scope
+
+The popover prototype's `UsageLimitsBar` — the horizontal replacement for
+`UsageLimitsSection` — carries the same treatment on
+`proto/popover-overview`, where that component lives. It is not part of this
+change, which targets only what is on `main`.
+
+## Tests
+
+- Rust `live/tests.rs`: a failed source's error carries its provider id and
+  display name.
+- `liveUsage.test.ts`: `liveUnavailableProviders` returns the vanished
+  provider, dedupes two failures for one provider, skips an error with no
+  provider id, and stays empty while the provider has visible windows.
+- `UsageLimitsSection.test.tsx`: the section keeps a subsection for a
+  provider whose source failed with nothing cached, and still renders nothing
+  when there are no providers and no errors.


### PR DESCRIPTION
## The bug

Open the popover on a cold start while a provider's usage endpoint is rate limiting you, and that provider's whole limits section disappears — no row, no message, nothing. It reads as "what happened to my Claude usage?" rather than as a passing failure.

Observed with Anthropic's `https://api.anthropic.com/api/oauth/usage` returning HTTP 429 at launch.

## Why

A failed source contributes no entry to `providers`, only an entry in `errors`. `UsageLimitsSection` filters on `providers`, so the section is filtered away entirely.

The mid-session case was already handled — `sources/cooldown.rs` keeps the last-good snapshot across a failed retry, so a 429 while the app is running shows stale figures plus the error. The gap is the cold start, where that in-memory cache is still empty.

## The fix

**The error now names its provider.** `LiveUsageSource` gains a required `provider()` method returning the canonical provider id it answers for, and `LiveUsageSourceError` carries that id plus the display name to the frontend. Previously the payload had only a source id (`"claude-usage-fetch"`), which the views can't map to a provider without duplicating registry knowledge. Both new DTO fields are `#[serde(default)]`, so a snapshot cached before they existed still loads.

**The views keep a degraded row.** A new `liveUnavailableProviders(summary)` helper returns exactly the providers that would otherwise vanish — errors whose provider shows no visible windows. `UsageLimitsSection` renders a subsection for each: the provider name, the failure in two words ("rate limited", "sign-in needed", "unreadable reply", "unreachable"), and the full sentence beneath. Settings → Usage now names the provider on its error rows too, and the wording moved into `liveUsage.ts` so it lives in one place.

When a cached reading exists alongside the error, no degraded row appears — the staleness treatment already covers that, and one failure shouldn't be reported twice.

## Checks

All run locally against this branch:

- `cargo test` — 368 passed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean
- `vitest run` — 719 passed, 73 files
- `tsc --build` — clean
- `eslint .` — clean
- `prettier --check` — clean
- `node scripts/check-boundary.mjs` — source boundary clean

New coverage: the cold-start case, dedupe of two failures for one provider, an error with no provider id, and the cached-reading suppression.

## Scope

The popover prototype's `UsageLimitsBar` (the horizontal replacement for `UsageLimitsSection`) carries the same treatment on `proto/popover-overview`, where that component lives. It's kept out of this PR so this stays reviewable and independently shippable against `main`.

Design notes: `docs/plans/live-usage-degraded-state.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)