### PR TITLE
feat(desktop): show session model runs and hygiene checks

### DIFF
--- a/apps/desktop/src-tauri/src/analytics.rs
+++ b/apps/desktop/src-tauri/src/analytics.rs
@@ -13,11 +13,11 @@
 //! never on a runtime worker, where a multi-megabyte transcript would stall
 //! every other command.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use antiburn_local::analysis::{
-    ActiveSessionsSummary, RawSource, SessionCost, SessionInput, SessionMetrics, SkillUse,
-    active_time_fraction, aggregate_metrics, analyze_sources_with, normalize_source,
+    ActiveSessionsSummary, ModelRun, RawSource, SessionCost, SessionInput, SessionMetrics,
+    SkillUse, active_time_fraction, aggregate_metrics, analyze_sources_with, normalize_source,
     price_breakdown, pricing_generation,
 };
 use antiburn_local::discovery::{
@@ -105,9 +105,10 @@ pub struct SessionAnalysis {
     /// sums every sub-agent. The value is `None` when the session has no
     /// sub-agent.
     pub subagents_tokens: Option<BillableTokens>,
-    /// Every model that contributed billable tokens. The list covers the
-    /// parent transcript and every sub-agent. It matches [`Self::cost`].
+    /// Every model that contributed billable tokens.
     pub models: Vec<String>,
+    /// Parent model runs followed by runs used only by sub-agents.
+    pub model_runs: Vec<ModelRun>,
     /// Billable tokens per model. The map merges the parent transcript and
     /// every sub-agent. The cache stores this map, so a later pass can
     /// re-price the session without reading any transcript again.
@@ -134,6 +135,7 @@ impl SessionAnalysis {
             inclusive_tokens: None,
             subagents_tokens: None,
             models: Vec::new(),
+            model_runs: Vec::new(),
             inclusive_model_breakdown: HashMap::new(),
             skills: Vec::new(),
             orchestration: None,
@@ -154,6 +156,8 @@ impl SessionAnalysis {
                 .and_then(|cost| serde_json::to_string(cost).ok()),
             model_breakdown_json: serde_json::to_string(&self.inclusive_model_breakdown)
                 .unwrap_or_else(|_| "{}".to_string()),
+            inclusive_models_json: serde_json::to_string(&self.model_runs)
+                .unwrap_or_else(|_| "[]".to_string()),
             active_secs: metrics.active_secs as i64,
             duration_secs: metrics.duration_secs as i64,
             pattern_score: i64::from(metrics.pattern_score),
@@ -205,6 +209,9 @@ fn sum_billable_tokens(breakdown: &HashMap<String, ModelTokens>) -> BillableToke
 /// pass, because there is no cheap way to tell whether it changed.
 pub const MISSING_FINGERPRINT: &str = "-";
 
+/// This version invalidates cached values when the analysis cache contract changes.
+const ANALYSIS_FINGERPRINT_VERSION: u8 = 1;
+
 /// `mtime:size` of a transcript file, or [`MISSING_FINGERPRINT`].
 pub fn fingerprint_of(source: &SessionSource) -> String {
     let SessionSource::File(path) = source else {
@@ -220,6 +227,40 @@ pub fn fingerprint_of(source: &SessionSource) -> String {
         .map(|since| since.as_secs())
         .unwrap_or(0);
     format!("{mtime}:{}", metadata.len())
+}
+
+/// Fingerprint the parent transcript and all current sub-agent transcripts.
+pub async fn fingerprint_with_subagents(
+    agent: AgentKind,
+    session_id: &str,
+    wsl_distro: Option<&str>,
+    source: &SessionSource,
+) -> String {
+    let mut subagent_paths = Explorers::DISK
+        .list_subagents_in_environment(&agent, session_id, wsl_distro)
+        .await;
+    subagent_paths.sort();
+    combined_fingerprint(source, &subagent_paths)
+}
+
+/// Build one stable fingerprint from a parent and its sorted child paths.
+fn combined_fingerprint(source: &SessionSource, subagent_paths: &[std::path::PathBuf]) -> String {
+    let parent_fingerprint = fingerprint_of(source);
+    if parent_fingerprint == MISSING_FINGERPRINT {
+        return parent_fingerprint;
+    }
+
+    let parts = std::iter::once(("parent".to_string(), parent_fingerprint)).chain(
+        subagent_paths.iter().map(|path| {
+            (
+                path.to_string_lossy().into_owned(),
+                fingerprint_of(&SessionSource::File(path.clone())),
+            )
+        }),
+    );
+    serde_json::to_string(&parts.collect::<Vec<_>>())
+        .map(|fingerprint| format!("v{ANALYSIS_FINGERPRINT_VERSION}:{fingerprint}"))
+        .unwrap_or_else(|_| MISSING_FINGERPRINT.to_string())
 }
 
 /// Whether a cached analysis is still good for `source`.
@@ -294,11 +335,13 @@ pub async fn analyze(
     // Sub-agent transcripts, resolved before the analysis so all of them ride
     // the same batch. The engine short-circuits for vendors that record no
     // orchestration, so this needs no per-agent gate of its own.
-    let mut subagents: Vec<(String, String, SessionInput)> = Vec::new();
-    for path in Explorers::DISK
+    let mut subagent_paths = Explorers::DISK
         .list_subagents_in_environment(&agent, session_id, wsl_distro)
-        .await
-    {
+        .await;
+    subagent_paths.sort();
+    let fingerprint = combined_fingerprint(&source, &subagent_paths);
+    let mut subagents: Vec<(String, String, SessionInput)> = Vec::new();
+    for path in subagent_paths {
         let Some(subagent_id) = Explorers::DISK.subagent_id(&agent, &path) else {
             continue;
         };
@@ -314,7 +357,6 @@ pub async fn analyze(
         ));
     }
 
-    let fingerprint = fingerprint_of(&source);
     let source_path = source_path(&source);
     let parent_session_id = session_id.to_string();
     let agent_slug = agent.slug().to_string();
@@ -405,6 +447,7 @@ pub async fn analyze(
     let subagents_cost = price_breakdown(&subagents_model_breakdown);
     let cost = price_breakdown(&inclusive_model_breakdown);
     let models = sorted_models(&inclusive_model_breakdown);
+    let model_runs = model_runs_parent_first(&metrics, by_id.values());
     let inclusive_tokens = Some(sum_billable_tokens(&inclusive_model_breakdown));
     let subagents_tokens = has_subagents.then(|| sum_billable_tokens(&subagents_model_breakdown));
     let skills = metrics.skill_uses.clone();
@@ -419,6 +462,7 @@ pub async fn analyze(
         inclusive_tokens,
         subagents_tokens,
         models,
+        model_runs,
         inclusive_model_breakdown,
         skills,
         orchestration,
@@ -479,6 +523,7 @@ pub async fn analyze_subagent(
     // here.
     let cost = price_breakdown(&metrics.model_breakdown);
     let models = sorted_models(&metrics.model_breakdown);
+    let model_runs = model_runs_for_metrics(&metrics);
     let inclusive_model_breakdown = metrics.model_breakdown.clone();
     let inclusive_tokens = Some(sum_billable_tokens(&inclusive_model_breakdown));
     let skills = metrics.skill_uses.clone();
@@ -493,6 +538,7 @@ pub async fn analyze_subagent(
         inclusive_tokens,
         subagents_tokens: None,
         models,
+        model_runs,
         inclusive_model_breakdown,
         skills,
         orchestration: None,
@@ -562,6 +608,74 @@ pub fn sorted_models(breakdown: &HashMap<String, ModelTokens>) -> Vec<String> {
     models
 }
 
+/// Return sorted parent model runs, followed by sorted child-only model runs.
+fn model_runs_parent_first<'a>(
+    parent: &SessionMetrics,
+    children: impl Iterator<Item = &'a SessionMetrics>,
+) -> Vec<ModelRun> {
+    model_runs_parent_first_lists(
+        model_runs_for_metrics(parent),
+        children.map(model_runs_for_metrics),
+    )
+}
+
+fn model_runs_parent_first_lists(
+    mut runs: Vec<ModelRun>,
+    child_runs: impl Iterator<Item = Vec<ModelRun>>,
+) -> Vec<ModelRun> {
+    let mut seen: HashSet<ModelRun> = runs.iter().cloned().collect();
+    let child_runs = child_runs.flatten().collect::<BTreeSet<_>>().into_iter();
+    runs.extend(child_runs.filter(|run| seen.insert(run.clone())));
+    runs
+}
+
+/// Return the distinct model runs for one session.
+fn model_runs_for_metrics(metrics: &SessionMetrics) -> Vec<ModelRun> {
+    if metrics.model_runs.is_empty() {
+        return sorted_models(&metrics.model_breakdown)
+            .into_iter()
+            .map(|model| ModelRun {
+                model,
+                thinking_mode: None,
+            })
+            .collect();
+    }
+    metrics
+        .model_runs
+        .iter()
+        .filter_map(normalize_model_run)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn normalize_model_run(run: &ModelRun) -> Option<ModelRun> {
+    let model = run.model.trim();
+    if model.is_empty() {
+        return None;
+    }
+    let mode = run
+        .thinking_mode
+        .as_deref()
+        .map(str::trim)
+        .filter(|mode| !mode.is_empty());
+    Some(ModelRun {
+        model: model.to_string(),
+        thinking_mode: mode.map(str::to_string),
+    })
+}
+
+/// Read the inclusive model runs from a cached analysis.
+pub fn cached_inclusive_model_runs(inclusive_models_json: &str) -> Vec<ModelRun> {
+    let mut seen = HashSet::new();
+    serde_json::from_str::<Vec<ModelRun>>(inclusive_models_json)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|run| normalize_model_run(&run))
+        .filter(|run| seen.insert(run.clone()))
+        .collect()
+}
+
 /// Whether meaningful session activity fell inside the active window. The
 /// timestamp is semantic when the transcript provides one, rather than a
 /// filesystem-touch heartbeat.
@@ -598,6 +712,7 @@ mod tests {
             metrics_json: "{}".into(),
             cost_json: None,
             model_breakdown_json: "{}".into(),
+            inclusive_models_json: "[]".into(),
             active_secs: 0,
             duration_secs: 0,
             pattern_score: 0,
@@ -621,6 +736,7 @@ mod tests {
             metrics_json: "{}".into(),
             cost_json: None,
             model_breakdown_json: "{}".into(),
+            inclusive_models_json: "[]".into(),
             active_secs: 0,
             duration_secs: 0,
             pattern_score: 0,
@@ -628,6 +744,72 @@ mod tests {
             pricing_generation: pricing_generation() as i64 - 1,
         };
         assert!(!cache_is_fresh(&cached, "123:456"));
+    }
+
+    #[test]
+    fn inclusive_model_runs_put_parent_modes_before_subagent_modes() {
+        let parent = vec![
+            ModelRun {
+                model: "claude-opus-4-6".to_string(),
+                thinking_mode: Some("high".to_string()),
+            },
+            ModelRun {
+                model: "gpt-5.6-sol".to_string(),
+                thinking_mode: Some("xhigh".to_string()),
+            },
+        ];
+        let child = vec![
+            ModelRun {
+                model: "claude-fable-5".to_string(),
+                thinking_mode: Some("high".to_string()),
+            },
+            ModelRun {
+                model: "claude-haiku-4-5".to_string(),
+                thinking_mode: Some("low".to_string()),
+            },
+            ModelRun {
+                model: "gpt-5.6-sol".to_string(),
+                thinking_mode: Some("xhigh".to_string()),
+            },
+        ];
+
+        assert_eq!(
+            model_runs_parent_first_lists(parent.clone(), [child.clone()].into_iter()),
+            vec![
+                parent[0].clone(),
+                parent[1].clone(),
+                child[0].clone(),
+                child[1].clone(),
+            ]
+        );
+    }
+
+    #[test]
+    fn model_runs_are_trimmed_without_losing_the_thinking_mode() {
+        assert_eq!(
+            normalize_model_run(&ModelRun {
+                model: " gpt-5.6-sol ".to_string(),
+                thinking_mode: Some(" xhigh ".to_string()),
+            }),
+            Some(ModelRun {
+                model: "gpt-5.6-sol".to_string(),
+                thinking_mode: Some("xhigh".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn cached_inclusive_model_runs_reject_invalid_json_and_normalize_values() {
+        assert!(cached_inclusive_model_runs("not json").is_empty());
+        assert_eq!(
+            cached_inclusive_model_runs(
+                r#"[{"model":" model-b ","thinkingMode":" high "},{"model":"model-b","thinkingMode":"high"},{"model":""}]"#,
+            ),
+            vec![ModelRun {
+                model: "model-b".to_string(),
+                thinking_mode: Some("high".to_string()),
+            }]
+        );
     }
 
     #[test]
@@ -645,6 +827,25 @@ mod tests {
         };
         assert_eq!(fingerprint_of(&inline), MISSING_FINGERPRINT);
         assert_eq!(source_path(&inline), None);
+    }
+
+    #[test]
+    fn a_child_transcript_change_updates_the_combined_fingerprint() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let parent = directory.path().join("parent.jsonl");
+        let child = directory.path().join("child.jsonl");
+        std::fs::write(&parent, "parent").unwrap();
+        std::fs::write(&child, "child").unwrap();
+        let source = SessionSource::File(parent);
+
+        let before = combined_fingerprint(&source, std::slice::from_ref(&child));
+        assert!(before.starts_with(&format!("v{ANALYSIS_FINGERPRINT_VERSION}:")));
+        std::fs::write(&child, "child has more model events").unwrap();
+
+        assert_ne!(
+            before,
+            combined_fingerprint(&source, std::slice::from_ref(&child))
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -411,6 +411,10 @@ fn activity_entry(
         .as_ref()
         .map(|record| analytics::price_cached_breakdown(&record.model_breakdown_json))
         .unwrap_or((None, Vec::new()));
+    let model_runs = analysis
+        .as_ref()
+        .map(|record| analytics::cached_inclusive_model_runs(&record.inclusive_models_json))
+        .unwrap_or_default();
 
     Ok(ActivityEntry {
         agent: session.key.agent.clone(),
@@ -425,6 +429,7 @@ fn activity_entry(
         fork_child_count: store.fork_children(&session.key)?.len() as u32,
         cost,
         models,
+        model_runs,
     })
 }
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -14,7 +14,7 @@
 //! around them belongs to the views — so these payloads carry values and facts,
 //! never labels.
 
-use antiburn_local::analysis::{ActiveSessionsSummary, SessionCost, SkillUse};
+use antiburn_local::analysis::{ActiveSessionsSummary, ModelRun, SessionCost, SkillUse};
 use serde::{Deserialize, Serialize};
 
 /// One row of the popover's activity list.
@@ -45,9 +45,10 @@ pub struct ActivityEntry {
     /// session launched. The value is absent when no model in the combined
     /// breakdown has a price. This field never holds a partial total.
     pub cost: Option<SessionCost>,
-    /// Every model that contributed billable tokens. The list covers the
-    /// parent and every sub-agent. The cost tooltip shows this list.
+    /// Every model that contributed billable tokens.
     pub models: Vec<String>,
+    /// Parent model runs come before runs used only by sub-agents.
+    pub model_runs: Vec<ModelRun>,
 }
 
 /// Identity of one local session, as the views key on it.

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -877,7 +877,13 @@ async fn top_up_analysis(app: &AppHandle, now: i64, activity_days: i64) -> anyho
         else {
             continue;
         };
-        let fingerprint = analytics::fingerprint_of(&source);
+        let fingerprint = analytics::fingerprint_with_subagents(
+            agent,
+            &record.key.session_id,
+            record.wsl_distro.as_deref(),
+            &source,
+        )
+        .await;
         if let Some(cached) = store.analysis(&record.key)?
             && analytics::cache_is_fresh(&cached, &fingerprint)
         {

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -616,13 +616,14 @@ impl Store {
         self.lock().execute(
             "INSERT INTO session_analysis (
                  environment_key, agent, session_id, metrics_json, cost_json,
-                 model_breakdown_json, active_secs, duration_secs, pattern_score,
-                 source_fingerprint, pricing_generation, analyzed_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                 model_breakdown_json, inclusive_models_json, active_secs, duration_secs,
+                 pattern_score, source_fingerprint, pricing_generation, analyzed_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
              ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
                  metrics_json = excluded.metrics_json,
                  cost_json = excluded.cost_json,
                  model_breakdown_json = excluded.model_breakdown_json,
+                 inclusive_models_json = excluded.inclusive_models_json,
                  active_secs = excluded.active_secs,
                  duration_secs = excluded.duration_secs,
                  pattern_score = excluded.pattern_score,
@@ -636,6 +637,7 @@ impl Store {
                 record.metrics_json,
                 record.cost_json,
                 record.model_breakdown_json,
+                record.inclusive_models_json,
                 record.active_secs,
                 record.duration_secs,
                 record.pattern_score,
@@ -652,8 +654,8 @@ impl Store {
         let connection = self.lock();
         let mut statement = connection.prepare(
             "SELECT environment_key, agent, session_id, metrics_json, cost_json,
-                    model_breakdown_json, active_secs, duration_secs, pattern_score,
-                    source_fingerprint, pricing_generation
+                    model_breakdown_json, inclusive_models_json, active_secs, duration_secs,
+                    pattern_score, source_fingerprint, pricing_generation
                FROM session_analysis
               WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         )?;
@@ -670,11 +672,12 @@ impl Store {
                         metrics_json: row.get(3)?,
                         cost_json: row.get(4)?,
                         model_breakdown_json: row.get(5)?,
-                        active_secs: row.get(6)?,
-                        duration_secs: row.get(7)?,
-                        pattern_score: row.get(8)?,
-                        source_fingerprint: row.get(9)?,
-                        pricing_generation: row.get(10)?,
+                        inclusive_models_json: row.get(6)?,
+                        active_secs: row.get(7)?,
+                        duration_secs: row.get(8)?,
+                        pattern_score: row.get(9)?,
+                        source_fingerprint: row.get(10)?,
+                        pricing_generation: row.get(11)?,
                     })
                 },
             )

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -133,10 +133,12 @@ pub struct AnalysisRecord {
     pub cost_json: Option<String>,
     /// Billable tokens per normalized model key, as camelCase JSON.
     pub model_breakdown_json: String,
+    /// This JSON array puts parent model runs before sub-agent-only runs.
+    pub inclusive_models_json: String,
     pub active_secs: i64,
     pub duration_secs: i64,
     pub pattern_score: i64,
-    /// `mtime:size` of the transcript the analysis was computed from.
+    /// This fingerprint covers the parent transcript and its sub-agent transcripts.
     pub source_fingerprint: String,
     /// `antiburn_local::analysis::pricing_generation()` at the time of writing.
     pub pricing_generation: i64,

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -14,7 +14,7 @@
 
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
-pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4, V5, V6];
+pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4, V5, V6, V7];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
 ///
@@ -242,5 +242,14 @@ CREATE TABLE usage_analytics_identity (
 /// this kind of change. Dropping every row forces the next scan to
 /// recompute each one under the new merge rule.
 const V6: &str = r#"
+DELETE FROM session_analysis;
+"#;
+
+/// v7 — ordered model runs used by a session and its sub-agents.
+///
+/// The cost breakdown has no thinking modes or display order. The new list
+/// puts parent runs before runs used only by sub-agents.
+const V7: &str = r#"
+ALTER TABLE session_analysis ADD COLUMN inclusive_models_json TEXT NOT NULL DEFAULT '[]';
 DELETE FROM session_analysis;
 "#;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -308,6 +308,7 @@ fn clearing_local_data_forgets_session_records_and_keeps_the_readers_choices() {
             metrics_json: "{}".into(),
             cost_json: None,
             model_breakdown_json: "{}".into(),
+            inclusive_models_json: "[]".into(),
             active_secs: 1,
             duration_secs: 1,
             pattern_score: 0,
@@ -615,6 +616,9 @@ fn analysis_round_trips_and_is_replaced_rather_than_duplicated() {
         metrics_json: r#"{"agent":"claude-code","sessionId":"abc"}"#.into(),
         cost_json: Some(r#"{"totalUsd":1.5}"#.into()),
         model_breakdown_json: r#"{"claude-opus-4-6":{"inputTokens":10}}"#.into(),
+        inclusive_models_json:
+            r#"[{"model":"claude-haiku-4-5"},{"model":"claude-opus-4-6","thinkingMode":"high"}]"#
+                .into(),
         active_secs: 120,
         duration_secs: 300,
         pattern_score: 81,
@@ -689,6 +693,7 @@ fn deleting_a_session_takes_its_derived_records_with_it() {
             metrics_json: "{}".into(),
             cost_json: None,
             model_breakdown_json: "{}".into(),
+            inclusive_models_json: "[]".into(),
             active_secs: 1,
             duration_secs: 1,
             pattern_score: 50,
@@ -825,6 +830,7 @@ fn usage_evidence_joins_the_analysis_and_keeps_sessions_that_have_none() {
             metrics_json: "{}".into(),
             cost_json: None,
             model_breakdown_json: r#"{"claude-opus-4-6":{"input_tokens":10}}"#.into(),
+            inclusive_models_json: r#"[{"model":"claude-opus-4-6","thinkingMode":"high"}]"#.into(),
             active_secs: 1,
             duration_secs: 1,
             pattern_score: 0,

--- a/apps/desktop/src/components/activity/LocalActivityList.test.tsx
+++ b/apps/desktop/src/components/activity/LocalActivityList.test.tsx
@@ -113,6 +113,47 @@ describe("LocalActivityList — rows", () => {
     expect(screen.getByLabelText("Estimated cost $2.40")).toBeTruthy()
   })
 
+  it("shows short model names in the supplied parent-first order", () => {
+    list({
+      entries: [
+        entry({
+          modelRuns: [
+            { model: "gpt-5.6-sol", thinkingMode: "xhigh" },
+            { model: "claude-fable-5", thinkingMode: "high" },
+          ],
+        }),
+      ],
+    })
+    const models = screen.getByText("5.6-sol/xhigh · fable-5/high")
+    expect(models.parentElement?.title).toBe("gpt-5.6-sol/xhigh\nclaude-fable-5/high")
+  })
+
+  it("includes the relative-time suffix", () => {
+    list({ entries: [entry({ timestamp: at(0, 9) })] })
+    expect(screen.getByText(/ ago$/)).toBeTruthy()
+  })
+
+  it("shows six deterministic mock hygiene checks", () => {
+    const first = list({ entries: [entry({ sessionId: "mock-0" })] })
+    const labels = [
+      /session overdepth/i,
+      /model overthinking/i,
+      /overpowered subagents/i,
+      /obsolete model/i,
+      /fast mode overuse/i,
+      /excess cache rehydration/i,
+    ]
+    const firstResults = labels.map((label) => screen.getByLabelText(label).textContent)
+    expect(firstResults).toContain("✓")
+    expect(firstResults).toContain("×")
+
+    first.unmount()
+    list({ entries: [entry({ sessionId: "mock-0" })] })
+    expect(labels.map((label) => screen.getByLabelText(label).textContent)).toEqual(
+      firstResults,
+    )
+  })
+
   it("states the last-activity time", () => {
     list({ entries: [entry({ timestamp: at(0, 9) })] })
     expect(screen.getByLabelText(/^Last activity /)).toBeTruthy()

--- a/apps/desktop/src/components/activity/LocalActivityList.tsx
+++ b/apps/desktop/src/components/activity/LocalActivityList.tsx
@@ -8,6 +8,11 @@ import type { ReactNode } from "react"
 import { cn } from "../../lib/cn"
 import { agentDisplayName, type AgentSurface } from "../../lib/presentation/agents"
 import { localSessionKey } from "../../lib/presentation/localIdentity"
+import {
+  modelRunNames,
+  modelRunShortNames,
+  type PresentableModelRun,
+} from "../../lib/presentation/models"
 import { relativeTime } from "../../lib/presentation/relativeTime"
 import { Tooltip } from "../presentation/Tooltip"
 import { WslOriginBadge } from "../presentation/WslOriginBadge"
@@ -18,6 +23,7 @@ import {
 import { ScrollPane } from "../ui/ScrollPane"
 import { TruncatedText } from "./TruncatedText"
 import { countGroupedItems, groupActivityByDay } from "./activityFeedGrouping"
+import { mockSessionHygiene } from "./mockSessionHygiene"
 import { useActivityGroupPinning } from "./useActivityGroupPinning"
 
 import "../../styles/session-rows.css"
@@ -54,6 +60,8 @@ export interface LocalActivityEntry {
   forkChildCount?: number | undefined
   /** Display values for the cost pill; omit when nothing priced the session. */
   cost?: SessionCostBadgeProps | null | undefined
+  /** Parent model runs followed by runs used only by sub-agents. */
+  modelRuns?: PresentableModelRun[] | undefined
 }
 
 export interface LocalActivityListProps {
@@ -119,6 +127,12 @@ function SessionActivityRow({
   const clickable = !!entry.sessionId && !!onOpen
   const primary = primaryLine(entry)
   const hasRepo = entry.repo !== ""
+  const modelRuns = entry.modelRuns ?? []
+  const modelNames = modelRunShortNames(modelRuns)
+  const hygieneSeed = entry.sessionId
+    ? localSessionKey(entry.agent, entry.sessionId, entry.wslDistro)
+    : `${entry.agent}|${entry.repo}|${entry.timestamp}`
+  const hygieneChecks = mockSessionHygiene(hygieneSeed)
 
   return (
     <div
@@ -219,8 +233,37 @@ function SessionActivityRow({
             aria-label={`Last activity ${relativeTime(entry.timestamp)}`}
             className="shrink-0 text-sm text-label-secondary"
           >
-            {relativeTime(entry.timestamp, { compact: true })}
+            {relativeTime(entry.timestamp)}
           </time>
+        </div>
+
+        <div className="flex w-full items-center justify-between gap-1.5">
+          {modelNames.length > 0 && (
+            <div className="min-w-0" title={modelRunNames(modelRuns).join("\n")}>
+              <TruncatedText
+                className="type-footnote text-label-tertiary"
+                text={modelNames.join(" · ")}
+              />
+            </div>
+          )}
+
+          <div className="ml-auto flex items-center gap-1.5">
+            {hygieneChecks.map((check) => (
+              <span
+                key={check.id}
+                className={cn(
+                  "inline-flex h-3 w-3 items-center justify-center rounded-full text-[0.55rem] leading-none text-white",
+                  check.passed
+                    ? "bg-(--color-system-green) opacity-30 hover:opacity-80"
+                    : "bg-(--color-system-red) opacity-50 hover:opacity-80",
+                )}
+                title={check.title}
+                aria-label={check.title}
+              >
+                {check.passed ? "✓" : "×"}
+              </span>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/components/activity/mockSessionHygiene.test.ts
+++ b/apps/desktop/src/components/activity/mockSessionHygiene.test.ts
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { describe, expect, it } from "vitest"
+
+import { mockSessionHygiene } from "./mockSessionHygiene"
+
+describe("mockSessionHygiene", () => {
+  it("returns the six checks in display order", () => {
+    expect(mockSessionHygiene("session-1").map((check) => check.id)).toEqual([
+      "sessionOverdepth",
+      "modelOverthinking",
+      "overpoweredSubagents",
+      "obsoleteModel",
+      "fastModeOveruse",
+      "excessCacheRehydration",
+    ])
+  })
+
+  it("returns the same mock results for the same session", () => {
+    expect(mockSessionHygiene("session-1")).toEqual(mockSessionHygiene("session-1"))
+  })
+
+  it("gives the prototype a mix of passing and failing sessions", () => {
+    const results = ["session-1", "session-2", "session-3"].flatMap(mockSessionHygiene)
+    expect(results.some((check) => check.passed)).toBe(true)
+    expect(results.some((check) => !check.passed)).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/activity/mockSessionHygiene.ts
+++ b/apps/desktop/src/components/activity/mockSessionHygiene.ts
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+export interface MockSessionHygieneCheck {
+  id:
+    | "sessionOverdepth"
+    | "modelOverthinking"
+    | "overpoweredSubagents"
+    | "obsoleteModel"
+    | "fastModeOveruse"
+    | "excessCacheRehydration"
+  passed: boolean
+  title: string
+}
+
+interface HygieneCheckDefinition {
+  id: MockSessionHygieneCheck["id"]
+  passedTitle: string
+  failedTitle: string
+}
+
+const CHECKS: readonly HygieneCheckDefinition[] = [
+  {
+    id: "sessionOverdepth",
+    passedTitle: "No session overdepth detected",
+    failedTitle: "Session overdepth detected",
+  },
+  {
+    id: "modelOverthinking",
+    passedTitle: "No model overthinking detected",
+    failedTitle: "Model overthinking detected",
+  },
+  {
+    id: "overpoweredSubagents",
+    passedTitle: "No overpowered subagents detected",
+    failedTitle: "Overpowered subagents detected",
+  },
+  {
+    id: "obsoleteModel",
+    passedTitle: "No obsolete model detected",
+    failedTitle: "Obsolete model detected",
+  },
+  {
+    id: "fastModeOveruse",
+    passedTitle: "No fast mode overuse detected",
+    failedTitle: "Fast mode overuse detected",
+  },
+  {
+    id: "excessCacheRehydration",
+    passedTitle: "No excess cache rehydration detected",
+    failedTitle: "Excess cache rehydration detected",
+  },
+]
+
+/** Return a stable unsigned hash for prototype data. */
+function stableHash(value: string): number {
+  let hash = 2_166_136_261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16_777_619)
+  }
+  return hash >>> 0
+}
+
+/** Build deterministic mock hygiene results for one session. */
+export function mockSessionHygiene(seed: string): MockSessionHygieneCheck[] {
+  return CHECKS.map((check) => {
+    const passed = stableHash(`${seed}:${check.id}`) % 6 !== 0
+    return {
+      id: check.id,
+      passed,
+      title: passed ? check.passedTitle : check.failedTitle,
+    }
+  })
+}

--- a/apps/desktop/src/lib/activityEntries.test.ts
+++ b/apps/desktop/src/lib/activityEntries.test.ts
@@ -22,6 +22,7 @@ function payload(over: Partial<ActivityEntryPayload> = {}): ActivityEntryPayload
     forkChildCount: 0,
     cost: null,
     models: [],
+    modelRuns: [],
     ...over,
   }
 }
@@ -38,14 +39,27 @@ function cost(totalUsd: number) {
 
 describe("toActivityEntries", () => {
   it("carries the identity, repository, and title straight through", () => {
-    const [entry] = toActivityEntries([payload()])
+    const [entry] = toActivityEntries([
+      payload({
+        models: ["claude-haiku-4-5"],
+        modelRuns: [{ model: "claude-haiku-4-5", thinkingMode: "low" }],
+      }),
+    ])
     expect(entry).toMatchObject({
       agent: "claude-code",
       sessionId: "session-1",
       repo: "widgets",
       title: "Wire the tray popover",
       surface: "cli",
+      modelRuns: [{ model: "claude-haiku-4-5", thinkingMode: "low" }],
     })
+  })
+
+  it("keeps raw models in the cost tooltip data", () => {
+    const [entry] = toActivityEntries([
+      payload({ cost: cost(1), models: ["claude-haiku-4-5"] }),
+    ])
+    expect(entry?.cost?.models).toEqual(["claude-haiku-4-5"])
   })
 
   it("labels a live session as a projection and a finished one as an estimate", () => {

--- a/apps/desktop/src/lib/activityEntries.ts
+++ b/apps/desktop/src/lib/activityEntries.ts
@@ -56,6 +56,7 @@ export function toActivityEntries(
     ...(payload.title ? { title: payload.title } : {}),
     hasForkParent: payload.hasForkParent,
     forkChildCount: payload.forkChildCount,
+    modelRuns: payload.modelRuns,
     cost: payload.cost
       ? {
           totalUsd: payload.cost.totalUsd,

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -165,6 +165,11 @@ export interface AppInfo {
 }
 
 /** One row of the activity list, before it is shaped for presentation. */
+export interface ModelRunPayload {
+  model: string
+  thinkingMode?: string
+}
+
 export interface ActivityEntryPayload {
   agent: string
   sessionId: string
@@ -178,9 +183,10 @@ export interface ActivityEntryPayload {
   forkChildCount: number
   /** Cost of the parent transcript plus every sub-agent the session launched. */
   cost: SessionCostComponents | null
-  /** Every model that contributed billable tokens. The list covers the
-   * parent transcript and every sub-agent. */
+  /** Every model that contributed billable tokens. */
   models: string[]
+  /** Parent model runs followed by runs used only by sub-agents. */
+  modelRuns: ModelRunPayload[]
 }
 
 /** Identity of one local session, as the analytics view carries it. */

--- a/apps/desktop/src/lib/presentation/models.test.ts
+++ b/apps/desktop/src/lib/presentation/models.test.ts
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { describe, expect, it } from "vitest"
+
+import { modelRunName, modelRunNames, modelRunShortNames, modelShortName } from "./models"
+
+describe("modelShortName", () => {
+  it("removes the Claude and GPT family prefixes", () => {
+    expect(modelShortName("claude-fable-5")).toBe("fable-5")
+    expect(modelShortName("claude-opus-4-6")).toBe("opus-4-6")
+    expect(modelShortName("gpt-5.6-sol")).toBe("5.6-sol")
+  })
+
+  it("removes known provider wrappers", () => {
+    expect(modelShortName("anthropic/claude-opus-4.8")).toBe("opus-4.8")
+    expect(modelShortName("openai.gpt-5.6-terra")).toBe("5.6-terra")
+    expect(modelShortName("antigravity-claude-opus-4-6-thinking")).toBe("opus-4-6-thinking")
+  })
+
+  it("keeps an unknown model ID unchanged", () => {
+    expect(modelShortName("composer-2.5-fast")).toBe("composer-2.5-fast")
+  })
+})
+
+describe("modelRunNames", () => {
+  it("formats the thinking mode and removes duplicate labels", () => {
+    expect(
+      modelRunNames([
+        { model: "gpt-5.6-sol", thinkingMode: "xhigh" },
+        { model: "gpt-5.6-sol", thinkingMode: "xhigh" },
+        { model: "claude-fable-5" },
+      ]),
+    ).toEqual(["gpt-5.6-sol/xhigh", "claude-fable-5"])
+    expect(modelRunName({ model: "gpt-5.6-sol", thinkingMode: " " })).toBe("gpt-5.6-sol")
+  })
+
+  it("shortens model IDs without changing run order", () => {
+    expect(
+      modelRunShortNames([
+        { model: "gpt-5.6-sol", thinkingMode: "xhigh" },
+        { model: "claude-fable-5", thinkingMode: "high" },
+      ]),
+    ).toEqual(["5.6-sol/xhigh", "fable-5/high"])
+  })
+})

--- a/apps/desktop/src/lib/presentation/models.ts
+++ b/apps/desktop/src/lib/presentation/models.ts
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/** The compact label omits these known provider wrappers. */
+const MODEL_PREFIXES = [
+  "antigravity-claude-",
+  "anthropic/claude-",
+  "anthropic.claude-",
+  "openai/gpt-",
+  "openai.gpt-",
+  "claude-",
+  "gpt-",
+] as const
+
+export interface PresentableModelRun {
+  model: string
+  thinkingMode?: string | undefined
+}
+
+/** Return a compact label for a model ID. Keep unknown IDs unchanged. */
+export function modelShortName(model: string): string {
+  const trimmed = model.trim()
+  const prefix = MODEL_PREFIXES.find((candidate) => trimmed.startsWith(candidate))
+  return prefix ? trimmed.slice(prefix.length) : trimmed
+}
+
+/** Format one model run. */
+export function modelRunName(run: PresentableModelRun): string {
+  const model = run.model.trim()
+  const mode = run.thinkingMode?.trim()
+  return model && mode ? `${model}/${mode}` : model
+}
+
+/** Format model runs without changing their order. Remove duplicate labels. */
+export function modelRunNames(runs: readonly PresentableModelRun[]): string[] {
+  const seen = new Set<string>()
+  const names: string[] = []
+  for (const run of runs) {
+    const name = modelRunName(run)
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    names.push(name)
+  }
+  return names
+}
+
+/** Shorten the model IDs in formatted model runs. */
+export function modelRunShortNames(runs: readonly PresentableModelRun[]): string[] {
+  return modelRunNames(runs.map((run) => ({ ...run, model: modelShortName(run.model) })))
+}

--- a/crates/antiburn-local/src/analysis/engine.rs
+++ b/crates/antiburn-local/src/analysis/engine.rs
@@ -10,7 +10,7 @@
 //! averaged, and derives the token / tool / context / pattern-score metrics the
 //! sleep-style UI renders.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::pricing::ModelTokens;
 // Re-exported through `engine` (and in turn the `analysis` module) so consumers
@@ -21,7 +21,7 @@ pub use crate::model::skill::SkillUse;
 use serde::{Deserialize, Serialize};
 
 use crate::analysis::initial_context::InitialContextBreakdown;
-use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role, ToolCategory};
+use crate::analysis::model::{ModelRun, NormalizedEvent, NormalizedSession, Role, ToolCategory};
 
 /// Number of progress buckets each session is resampled onto (0% → 100%).
 /// Higher = finer time resolution, so fewer turns land in the same bucket and
@@ -247,6 +247,9 @@ pub struct SessionMetrics {
     /// mixed). `None` when no adapter could extract it.
     #[serde(default)]
     pub model: Option<String>,
+    /// Distinct model and thinking-mode pairs that produced billable tokens.
+    #[serde(default)]
+    pub model_runs: Vec<ModelRun>,
     /// Billable token components used for the cost estimate: fresh input, generated
     /// output, cache reads, and cache writes — each prices at a different rate.
     /// `tokens_out` mirrors generated output; `tokens_in` is displayed effective input
@@ -508,6 +511,8 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
     // Opus + Haiku is no longer billed entirely at Opus). The aggregate `bill_*`
     // totals above are unchanged and the breakdown sums to them.
     let mut cost_breakdown: HashMap<String, ModelTokens> = HashMap::new();
+    let mut model_runs = Vec::new();
+    let mut seen_model_runs = HashSet::new();
     for ev in &session.events {
         tokens_in = tokens_in.saturating_add(ev.usage.effective_input_tokens());
         tokens_out = tokens_out.saturating_add(ev.usage.output_tokens);
@@ -524,15 +529,31 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
         // Resolve the owning model: the event's own model, else the session
         // headline. Tokens with no resolvable model are unpriceable, so skip them.
         if has_tokens && let Some(model) = ev.model.as_deref().or(session.model.as_deref()) {
-            let entry = cost_breakdown
-                .entry(crate::analysis::pricing::strip_window_tag(model).to_string())
-                .or_default();
-            entry.input_tokens = entry.input_tokens.saturating_add(u.input_tokens);
-            entry.output_tokens = entry.output_tokens.saturating_add(u.output_tokens);
-            entry.cache_read_tokens = entry.cache_read_tokens.saturating_add(u.cache_read_tokens);
-            entry.cache_creation_tokens = entry
-                .cache_creation_tokens
-                .saturating_add(u.cache_creation_tokens);
+            let model = crate::analysis::pricing::strip_window_tag(model)
+                .trim()
+                .to_string();
+            if !model.is_empty() {
+                let run = ModelRun {
+                    model: model.clone(),
+                    thinking_mode: ev
+                        .thinking_mode
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|mode| !mode.is_empty())
+                        .map(str::to_string),
+                };
+                if seen_model_runs.insert(run.clone()) {
+                    model_runs.push(run);
+                }
+                let entry = cost_breakdown.entry(model).or_default();
+                entry.input_tokens = entry.input_tokens.saturating_add(u.input_tokens);
+                entry.output_tokens = entry.output_tokens.saturating_add(u.output_tokens);
+                entry.cache_read_tokens =
+                    entry.cache_read_tokens.saturating_add(u.cache_read_tokens);
+                entry.cache_creation_tokens = entry
+                    .cache_creation_tokens
+                    .saturating_add(u.cache_creation_tokens);
+            }
         }
         for tool in &ev.tools {
             tool_mix.add(tool.category);
@@ -707,6 +728,7 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
         segments,
         initial_context: None,
         model: session.model.clone(),
+        model_runs,
         billable_input_tokens: bill_in,
         billable_output_tokens: bill_out,
         billable_cache_read_tokens: bill_cr,

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -44,7 +44,9 @@ pub use engine::{
 };
 pub use initial_context::{InitialContextBreakdown, InitialContextSourceCount, TrackingStatus};
 pub use interface::{RawSource, SessionInput, VendorAdapter};
-pub use model::{NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage};
+pub use model::{
+    ModelRun, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
+};
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
 pub use vendors::{adapter_for, has_dedicated_adapter};
 

--- a/crates/antiburn-local/src/analysis/model.rs
+++ b/crates/antiburn-local/src/analysis/model.rs
@@ -255,6 +255,9 @@ pub struct NormalizedEvent {
     /// falls back to the session's headline model.
     #[serde(default)]
     pub model: Option<String>,
+    /// The model's thinking mode for this turn, when the transcript records it.
+    #[serde(default)]
+    pub thinking_mode: Option<String>,
     /// The provider's message id (Anthropic `message.id`), when present. Claude
     /// transcripts re-log the same assistant message more than once, each copy
     /// carrying the full `usage`; this id lets the Claude adapter de-duplicate
@@ -282,10 +285,20 @@ impl NormalizedEvent {
             thinking: false,
             text_len: 0,
             model: None,
+            thinking_mode: None,
             message_id: None,
             is_compaction_boundary: false,
         }
     }
+}
+
+/// One model and thinking-mode pair that produced billable tokens.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelRun {
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_mode: Option<String>,
 }
 
 /// A full session after normalization, ready for the engine.

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::analysis::engine::{Phase, analyze_session};
-use crate::analysis::model::{NormalizedSession, Role, ToolCategory};
+use crate::analysis::model::{ModelRun, NormalizedSession, Role, ToolCategory};
 use crate::analysis::{RawSource, SessionInput, analyze_sources, normalize_source};
 
 fn jsonl_input(agent: &str, jsonl: &str) -> SessionInput {
@@ -1043,6 +1043,50 @@ fn mixed_model_session_prices_each_model_at_its_own_rate() {
     // Pricing both buckets at Opus (the old behavior) would have been 2M @ $25/1M
     // = $50; per-model must be strictly cheaper.
     assert!(cost.total_usd < 50.0);
+}
+
+#[test]
+fn claude_records_distinct_model_thinking_modes() {
+    let fixture = concat!(
+        r#"{"type":"assistant","effort":"high","message":{"role":"assistant","model":"claude-fable-5","usage":{"input_tokens":10,"output_tokens":2},"content":[{"type":"text","text":"one"}]}}"#,
+        "\n",
+        r#"{"type":"assistant","effort":"low","message":{"role":"assistant","model":"claude-fable-5","usage":{"input_tokens":20,"output_tokens":3},"content":[{"type":"text","text":"two"}]}}"#,
+    );
+    let metrics = analyze_session(&normalize_source(&jsonl_input("claude", fixture)).unwrap());
+
+    assert_eq!(
+        metrics.model_runs,
+        vec![
+            ModelRun {
+                model: "claude-fable-5".to_string(),
+                thinking_mode: Some("high".to_string()),
+            },
+            ModelRun {
+                model: "claude-fable-5".to_string(),
+                thinking_mode: Some("low".to_string()),
+            },
+        ]
+    );
+}
+
+#[test]
+fn codex_applies_turn_effort_to_the_following_usage() {
+    let fixture = concat!(
+        r#"{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"xhigh"}}"#,
+        "\n",
+        r#"{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10}}}}"#,
+    );
+    let session = normalize_source(&jsonl_input("codex", fixture)).unwrap();
+    assert_eq!(session.events[0].thinking_mode.as_deref(), Some("xhigh"));
+
+    let metrics = analyze_session(&session);
+    assert_eq!(
+        metrics.model_runs,
+        vec![ModelRun {
+            model: "gpt-5.6-sol".to_string(),
+            thinking_mode: Some("xhigh".to_string()),
+        }]
+    );
 }
 
 /// A model id carrying a context-window tag (`claude-opus-4-7[1m]`) still prices —

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -70,6 +70,8 @@ fn parse_codex(content: &str) -> (Vec<NormalizedEvent>, Option<u64>, Option<Stri
     // Best-effort across the pointers Codex has used; first non-empty wins. `None`
     // is fine — cost then has no local estimate for the session.
     let mut model: Option<String> = None;
+    let mut current_model: Option<String> = None;
+    let mut current_thinking_mode: Option<String> = None;
     let mut offset = 0;
     for line_with_ending in content.split_inclusive('\n') {
         let line_offset = offset;
@@ -86,21 +88,46 @@ fn parse_codex(content: &str) -> (Vec<NormalizedEvent>, Option<u64>, Option<Stri
                     .and_then(Value::as_u64)
                     .filter(|&w| w > 0);
             }
-            if usage_is_owned && model.is_none() {
-                model = [
+            if usage_is_owned {
+                if let Some(next_model) = [
                     "/payload/model",
                     "/payload/info/model",
                     "/payload/turn_context/model",
                 ]
                 .iter()
                 .find_map(|p| value.pointer(p).and_then(Value::as_str))
-                .filter(|m| !m.is_empty())
-                .map(str::to_string);
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+                {
+                    current_model = Some(next_model.to_string());
+                    if model.is_none() {
+                        model = current_model.clone();
+                    }
+                }
+                if let Some(next_mode) = [
+                    "/payload/effort",
+                    "/payload/reasoning_effort",
+                    "/payload/turn_context/effort",
+                    "/payload/turn_context/reasoning_effort",
+                    "/payload/thread_settings/reasoning_effort",
+                    "/payload/collaboration_mode/settings/reasoning_effort",
+                ]
+                .iter()
+                .find_map(|p| value.pointer(p).and_then(Value::as_str))
+                .map(str::trim)
+                .filter(|mode| !mode.is_empty())
+                {
+                    current_thinking_mode = Some(next_mode.to_string());
+                }
             }
             let inherited_token_count = !usage_is_owned
                 && value.get("type").and_then(Value::as_str) == Some("event_msg")
                 && value.pointer("/payload/type").and_then(Value::as_str) == Some("token_count");
-            if !inherited_token_count && let Some(ev) = record_to_event(&value) {
+            if !inherited_token_count && let Some(mut ev) = record_to_event(&value) {
+                if usage_is_owned {
+                    ev.model = ev.model.or_else(|| current_model.clone());
+                    ev.thinking_mode = current_thinking_mode.clone();
+                }
                 events.push(ev);
             }
         }

--- a/crates/antiburn-local/src/analysis/vendors/jsonl.rs
+++ b/crates/antiburn-local/src/analysis/vendors/jsonl.rs
@@ -202,6 +202,16 @@ pub fn parse_record(value: &Value) -> Option<NormalizedEvent> {
         .filter(|m| !m.is_empty() && *m != "<synthetic>")
         .map(str::to_string);
 
+    ev.thinking_mode = obj
+        .get("effort")
+        .or_else(|| obj.get("reasoning_effort"))
+        .or_else(|| msg.and_then(|m| m.get("effort")))
+        .or_else(|| msg.and_then(|m| m.get("reasoning_effort")))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|mode| !mode.is_empty())
+        .map(str::to_string);
+
     // Provider message id (Anthropic `message.id`), used by the Claude adapter to
     // de-duplicate re-logged copies of the same assistant message.
     ev.message_id = msg


### PR DESCRIPTION
## Summary

- collect structured model and thinking-mode runs from parent and sub-agent transcripts, with parent runs first
- invalidate cached inclusive analysis when a sub-agent transcript changes and persist ordered model runs for the activity list
- show compact model labels, suffixed relative times, and deterministic mocked hygiene checks in each activity row
- preserve raw model IDs in cost tooltips and exported/session analytics data

The six hygiene checks are deliberately deterministic prototype data. They do not make real hygiene judgements yet.

## Testing

- `cargo test --manifest-path crates/antiburn-local/Cargo.toml`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `cargo clippy --manifest-path crates/antiburn-local/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `pnpm --filter @antiburn/desktop test`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop knip`
- `pnpm --filter @antiburn/desktop build`