### PR TITLE
Enforce the desktop design contract, and fix what enforcing it exposed

### DIFF
--- a/.agents/skills/design-review/SKILL.md
+++ b/.agents/skills/design-review/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: design-review
+description: Review one antiburn desktop window against the antiburn design system. Captures the live window per surface and per theme, then reports ranked design findings (Blocker/High/Medium/Nitpick) tied to the tokens and rules in apps/desktop/design.md. Use when asked to design-review a window, pane, or surface, run a design pass, critique the UI, or check the desktop app against the design system.
+disable-model-invocation: true
+---
+
+# antiburn design review
+
+An AI design reviewer for the antiburn desktop app. It looks at a live window,
+checks it against the design system, and returns a ranked list of what to fix.
+The method comes from OneRedOak's design-review agent. The rules are antiburn's
+own.
+
+Scope: the Tauri desktop app in `apps/desktop`. The app has four windows, and
+each window is a fixed size. There is no responsive breakpoint pass, because
+there are no fluid widths to break at. The equivalent pass here walks every
+window, every surface inside it, and every theme.
+
+## Before you start: you need a running app
+
+This skill grades a live window, so the app must run.
+
+- Ask the user which instance to review. Do NOT start a second one on your own.
+- The app runs with `pnpm tauri dev` from `apps/desktop`.
+- Port 1420 is strict (`vite.config.ts` sets `strictPort: true`, and
+  `src-tauri/tauri.conf.json` points `devUrl` at `http://127.0.0.1:1420`). One
+  instance holds it at a time.
+- If another worktree holds 1420, do NOT kill the process. Ask the user. If the
+  user wants a second instance, start it with `tauri dev --config <override>`
+  and give the override its own port and `devUrl`.
+- The tray popover hides when it loses key status. Ask the user to select
+  **Pin Window** in the tray menu before you capture it. Unpinned, the popover
+  disappears the moment another window takes focus.
+
+Secondary path, with a limit: `pnpm dev:web` serves the same bundle in a
+browser, and the URL fragment picks the view (`#/settings`, `#/nudge`,
+`#/onboarding`; no fragment gives the popover). A browser has no shell, so
+`hasShell()` is false and every view falls back to `DEFAULT_SETTINGS` and empty
+data. Use this path for the accessibility tree, the console, the type ladder,
+and the themes. Do NOT grade data-dependent states from it, and never report
+"no data" as a finding when the shell is absent.
+
+## Step 1: load the rulebook
+
+Read `design-principles.md` in this skill folder. It numbers every rule. Each
+finding must cite a rule number plus the token, class, or file it breaks.
+
+## Step 2: capture the window, per surface and per theme
+
+Pick ONE window per invocation. Capture each surface of it, then repeat the
+worst surface in each theme.
+
+**The surface pass.** Capture every surface the chosen window can show:
+
+| Window | Size | Surfaces to capture |
+|---|---|---|
+| Tray popover | 380 wide; 700 tall, 780 on Usage | `activity`, `session`, `usage` (`lib/popoverHeight.ts`) |
+| Settings | 960 × 680, fixed | 7 panes: General, Privacy, Notifications, Usage, Sources, Appearance, About |
+| Onboarding | 680 × 480 | 5 steps: welcome, sources, repositories, scan, ready |
+| Notification | 344 wide, always on top | resting and expanded (the card expands on hover) |
+
+**The theme pass.** Repeat the surface that carries the most colour in each of
+these four conditions:
+
+1. Light.
+2. Dark.
+3. Reduced transparency. Every window and popover surface turns solid.
+4. Reduced motion. The global clamp stops animation.
+
+Switch light and dark from the app's own Appearance pane. Switch reduced
+transparency and reduced motion in the operating system's accessibility
+settings. In the browser path, emulate the media features from the developer
+tools instead.
+
+**How to capture.** The app is a native window, so use the computer-use
+screenshot tools. Bring the window forward first. Ask the user to take a shot
+for you if the capture path would steal focus from an unpinned popover. On the
+browser path, use the browser tools for a screenshot, the accessibility tree,
+and the console.
+
+## Step 3: grade it
+
+Walk these dimensions. Check each one against `design-principles.md`.
+
+1. First impression and hierarchy. Does the eye land on the one thing the
+   surface exists to say? Is anything inflated?
+2. Information architecture. Does the content sit in the right window? Is the
+   pane order right? Does every deep link land where it claims?
+3. Surfaces and geometry. All surfaces of the window. Clipping, overflow, a
+   surface that outgrows its fixed height, a scroll area with no edge treatment.
+4. Colour and tokens. Semantic utilities only. No raw hex, no ad-hoc `rgb()`.
+5. Typography. The `type-*` ladder, the settings type ladder, `tabular-nums` on
+   figures, no hardcoded sizes.
+6. Primitives. The real `ui/` components, and the `ui-*` classes under them.
+7. State taxonomy. Empty, loading, error, permission-blocked, first-run.
+8. Themes and materials. Light, dark, and reduced transparency.
+9. Motion. Token durations, the reduced-motion clamp, ambient loops.
+10. Accessibility (WCAG 2.1 AA). Contrast, keyboard-only focus, `role` and
+    `aria` wiring, never colour alone.
+11. Copy and voice. Plain, calm, present tense, sentence case.
+12. Console and robustness. Errors and warnings in the webview console.
+
+Grade the rendered window first. Then open the source to confirm a violation —
+a raw hex value, an arbitrary duration, a hand-rolled row. A guess from code
+alone is not a finding.
+
+## Step 4: write the report
+
+Use `report-template.md`. Give each finding a severity, a dimension, what is
+wrong, the rule and token it breaks, a suggested fix, and evidence. Evidence is
+a screenshot or a quoted class or value. Rank the most severe first.
+
+Save the report to `docs/design-reviews/<surface>-<date>.md`. Create the folder
+if it does not exist. `<surface>` names what you reviewed, such as
+`popover-activity` or `settings-privacy`. Give the user the top fixes in chat.
+
+Review only by default. Propose the fixes. Do not apply them unless the user
+asks.
+
+## The passes
+
+Run one window, or one surface of a window, per invocation. This keeps the
+context small and the findings specific. For a full sweep, work through this
+order:
+
+1. Popover, activity surface. The window most readers see most.
+2. Popover, session analytics.
+3. Popover, usage. The one surface that exceeds the default height.
+4. Settings, pane by pane.
+5. Onboarding, step by step.
+6. The notification window, resting and expanded.
+
+## Severity
+
+Blocker, High, Medium, and Nitpick. `design-principles.md` defines each one at
+the end.
+
+Accessibility ratchet: on an EXISTING screen an AA miss is **High**, not
+Blocker. New UI is held to AA from the start.
+
+## Principles
+
+- Live window first. Grade what the app draws, then confirm it in the code.
+- Be specific. Tie every finding to a rule number and to a token or a file.
+- Show evidence. Give a screenshot or a quoted class for each finding.
+- Assume competence. State the problem, its impact, and a fix. Do not lecture.

--- a/.agents/skills/design-review/design-principles.md
+++ b/.agents/skills/design-review/design-principles.md
@@ -289,10 +289,13 @@ without a comment that says what it means. **[Medium]**
 colour from a CSS variable, so both themes work with no branch in the chart
 code. **[High]**
 
-**RULE 8.3 — a figure is honest about its basis.** Estimated and measured
-figures must be distinguishable, and the label must say which one it is. A
-number the reader can mistake for a provider's own figure is a finding.
-**[High]**
+**RULE 8.3 — a figure is honest about its basis.** A reader must never take an
+estimate for a provider's own figure. Provenance has to be *reachable* — a
+tooltip, a disclosure, a detail row, or one statement covering a whole section
+— but it does not have to be a visible label on every number. On a dense
+surface, per-figure labels usually clutter more than they inform. The finding
+is a figure that reads as authoritative with no way to find out otherwise, not
+a figure without a label. **[High]**
 
 **RULE 8.4 — no chart junk.** One accent, quiet gridlines, a label on the chart
 in place of a busy legend. Thin strokes at chart scale
@@ -437,9 +440,10 @@ pressing it produces. **[Medium]**
 the dismiss control is named "Dismiss" and not the sentence again. A
 screen-reader user should not sit through it twice. **[Medium]**
 
-**RULE 12.7 — say what the app cannot see.** A gap, a blocked folder, a paused
-scan, and an estimated figure are all stated plainly. Never imply completeness
-the app does not have. **[High]**
+**RULE 12.7 — say what the app cannot see.** A gap, a blocked folder, and a
+paused scan are stated plainly. Never imply completeness the app does not have.
+Estimated figures follow Rule 8.3: the basis has to be reachable, not labelled
+on every number. **[High]**
 
 ## 13. Icons, marks, and emoji
 

--- a/.agents/skills/design-review/design-principles.md
+++ b/.agents/skills/design-review/design-principles.md
@@ -1,0 +1,473 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+# antiburn design principles — the design-review rulebook
+
+This is the rulebook the design-review skill grades a window against.
+
+`apps/desktop/design.md` is the token contract, and it wins on every value it
+states. This file adds what a token cannot state: which window owns what, which
+state a surface must have, how the copy sounds, and where the accessibility line
+sits. Every rule below carries a number so a finding can cite it.
+
+Paths in this file are relative to `apps/desktop/`.
+
+## 0. Source of truth and how to cite a finding
+
+- `design.md` is the contract. Its YAML front matter lists every colour, type
+  role, spacing step, radius, shadow, and motion value.
+- The CSS under `src/styles/` is where those values live: `tokens.css`,
+  `base.css`, `typography.css`, `focus.css`, `controls.css`, `motion.css`,
+  `platform-controls.css`, `session-analytics-colors.css`, `session-rows.css`.
+  A component-scoped stylesheet is imported by the component that owns it, not
+  from `src/styles.css`.
+- The shared primitives live in `src/components/ui/`. Each one carries a doc
+  comment that states what it is for. Read that comment before you claim a
+  component is wrong.
+- `scripts/check-design-drift.mjs` keeps the contract and those stylesheets
+  equal. So a value in `design.md` that disagrees with the CSS is a CI failure,
+  not a design finding. Report it, and stop there.
+- `docs/deviations.md` records every knowing difference from the ratified
+  feature matrix. Check it before you report something as a mistake. A recorded
+  deviation is a decision, not a finding.
+- Cite a rule number from this file, plus the token, class, or file it breaks.
+  A finding with no citation is an opinion.
+
+## 1. North star (what an antiburn window should feel like)
+
+- Native, not web. Each window should read like part of the operating system.
+  It borrows the system's palette, its type sizes, and its control geometry.
+- Quiet. The app watches work that is already happening. It reports; it does not
+  perform. Nothing pulses for attention without a real signal behind it.
+- One glance per surface. A surface answers one question. If a reader has to
+  scroll a fixed-height window to get the answer, the surface is doing too much.
+- Local and honest. The app says what it knows, when it last looked, and what it
+  cannot see. A gap is stated, never hidden.
+
+## 2. Windows and surfaces (information architecture)
+
+There is no router. Each window opens with a URL fragment and keeps one route
+for its whole life (`src/lib/route.ts`).
+
+| Route | Window | Size | What it owns |
+|---|---|---|---|
+| default | Tray popover | 380 wide; 700 tall, 780 on Usage | The reading surfaces: what happened, and what it cost |
+| `#/settings` | Settings | 960 × 680 | Every choice the reader makes, and every explanation |
+| `#/onboarding` | Onboarding | 680 × 480 | First run only |
+| `#/nudge` | Notification | 344 wide | One alert, always on top |
+
+**RULE 2.1 — put content in the window that owns it.** The popover reads. The
+settings window decides and explains. The notification alerts. A control that
+changes stored settings does not belong in the popover, and a paragraph of
+explanation does not belong in the notification. **[High]**
+
+**RULE 2.2 — the popover has three surfaces, and only three.** They are
+`activity`, `session`, and `usage` (`src/lib/popoverHeight.ts`). `activity` is
+the list. `session` is one session's analytics, reached from the list. `usage`
+sits over the list rather than in the session stack, because it is a second way
+to read the same activity. Do not add a fourth surface without a decision
+record. **[High]**
+
+**RULE 2.3 — respect the popover height contract.** 700 is the height the
+window is created at and rests at. 780 is a ceiling that exactly one surface
+uses, and that use is a recorded deviation (D-22). A new surface that asks for
+780 is a finding until a deviation records it. **[High]**
+
+**RULE 2.4 — the settings pane order is deliberate.** General, Privacy,
+Notifications, Usage, Sources, Appearance, About (`src/views/SettingsView.tsx`).
+Everyday panes come first and provenance comes last. About closes the list and
+carries software update. The pane ids live in `src/lib/settingsPanes.ts`, so a
+renamed pane is a type error at every call site. **[Medium]**
+
+**RULE 2.5 — a deep link must land somewhere real.** The popover's attention
+banners open the settings window at the pane that can fix what they report
+(`src/lib/attention.ts` → `openSettingsWindow(pane)`). The About pane links to
+sibling panes the same way. Every link states where it goes. A link that opens
+the window at the wrong pane, or at no pane, is a finding. **[High]**
+
+**RULE 2.6 — the notification never becomes a third reading surface.** It
+carries a title, one reason line, optional recommendations, and at most a short
+action bar. Anything that needs a paragraph belongs in a pane. **[Medium]**
+
+**RULE 2.7 — window chrome belongs to the window.** A window that hides its
+native title bar owns the drag strip and the matching top clearance. A window
+that keeps native decorations must not reserve that space. Keep that decision in
+the window's own layout, never in a shared primitive. **[Medium]**
+
+## 3. Colour and tokens
+
+Every `colors` key in `design.md` is a Tailwind utility through
+`bg-<name>`, `text-<name>`, and `border-<name>`.
+
+**RULE 3.1 — no raw colour in feature code.** No raw hex. No ad-hoc `rgb()`. No
+stock Tailwind colours such as `bg-blue-500` or `text-slate-400`. Use the
+semantic utilities: `bg-surface`, `bg-surface-card`, `text-label`,
+`text-label-secondary`, `border-separator`, `text-system-green`. **[High]**
+
+- Do NOT flag the token layer itself. `src/styles/tokens.css` and the other
+  files under `src/styles/` are where the raw values legitimately live.
+- Do NOT flag a documented one-off visualization or geometry value. `design.md`
+  allows those, and asks that they stay local and carry a comment.
+
+**RULE 3.2 — use `bg-accent-fill` for an accent background.** The live system
+accent token resolves incorrectly as a `background-color`, so `bg-accent` is
+wrong for a fill. `text-accent` and `border-accent` are fine. **[High]**
+
+**RULE 3.3 — status colour carries meaning, never decoration.** `system-red`,
+`system-orange`, `system-yellow`, and `system-green` state a condition. They are
+not brand colour and not a way to add interest. **[Medium]**
+
+**RULE 3.4 — use the `-text` variant when a status colour is text.** Some fill
+colours drop below AA as text. `tokens.css` says so: the red fill reads about
+4.04:1 on a tinted pill in light mode. So `system-red-text`,
+`system-indigo-text`, and `system-gold-text` exist. Coloured text that uses the
+fill variant instead of the `-text` variant is a contrast finding. **[High]**
+
+**RULE 3.5 — no manual `dark:` colour override.** Every semantic token already
+carries both values. `bg-white dark:bg-neutral-900` is a finding; `bg-surface`
+is the fix. **[Medium]**
+
+**RULE 3.6 — a tinted fill, not a saturated band.** The popover surfaces are
+translucent. A solid status colour across one reads as a separate window. Follow
+`Banner`, which tints (`bg-system-orange-tint/12 text-system-orange`).
+**[Medium]**
+
+## 4. Typography
+
+- The type ladder is the `.type-*` classes in `src/styles/typography.css`:
+  `type-large-title`, `type-title-1`, `type-title-2`, `type-title-3`,
+  `type-headline`, `type-body`, `type-callout`, `type-footnote`,
+  `type-caption`.
+- Those classes sit outside any `@layer`, so unlayered CSS outranks Tailwind's
+  `utilities` layer. To override a baked-in weight you need the important
+  modifier, as `SectionGroup` does with `font-normal!`.
+
+**RULE 4.1 — no hardcoded type size.** `text-[13px]`, `text-sm`, and a raw
+`font-size` are all findings. Use a `type-*` class. **[High]**
+
+**RULE 4.2 — follow the settings type ladder.** One descending step per level,
+set by the `ui/` primitives rather than per pane: pane title `type-title-2`
+(`Pane`) → group header `type-title-3 font-normal!` (`SectionGroup`) → row label
+`type-body` (`Row`) → row description `type-footnote text-label-secondary`. Only
+the pane title is semibold. Below it, size and contrast carry the hierarchy. A
+hand-rolled row must match `Row`. **[Medium]**
+
+**RULE 4.3 — figures line up.** A number that changes in place, a column of
+numbers, and a timer all take `tabular-nums`. Without it the digits jitter.
+**[Medium]**
+
+**RULE 4.4 — `font-mono` is for machine text.** Paths, identifiers, and raw
+values. Not for product copy and not for figures the reader is meant to compare
+at a glance. **[Nitpick]**
+
+## 5. Spacing, geometry, and layout
+
+- Spacing is a 4px rhythm. `design.md` lists both the Tailwind steps (1–6) and
+  the `--space-*` variables.
+- Geometry variables are raw CSS custom properties in `tokens.css` and are not
+  registered with `@theme`. Consume them as arbitrary values, such as
+  `w-[var(--sidebar-width)]`.
+- Radii: `rounded-small` (4px), `rounded-control` (5px), `rounded-popover`
+  (10px), `rounded-full`.
+
+**RULE 5.1 — no ad-hoc radius.** `rounded-md`, `rounded-lg`, and
+`rounded-[7px]` are findings. Use a named radius. **[Medium]**
+
+**RULE 5.2 — control height comes from the token.** 22px regular
+(`--control-height-regular`), 17px small (`--control-height-small`). The
+`ui-push-button` class already supplies it. **[Medium]**
+
+**RULE 5.3 — `gap-*` between children.** Not `space-x-*` or `space-y-*`.
+**[Medium]**
+
+**RULE 5.4 — a fixed window must not overflow.** Every window here has a fixed
+size. Check that no surface clips its content, that the scroll area scrolls, and
+that nothing hides under the drag strip. **[High]**
+
+**RULE 5.5 — use `ScrollPane` for a scroll area.** Its `ui-scroll-viewport`
+class is load-bearing, not cosmetic. When scrolling content must dissolve into a
+fixed top boundary, use the `topEdgeFade` prop and keep fixed labels outside
+`ScrollPane`. Do not rebuild that effect with an overlay, a fill, a backdrop
+blur, or a feature-specific gradient. **[High]**
+
+## 6. Primitives — use the real ones
+
+Accessibility, keyboard behaviour, and the type ladder all ride on these. A
+hand-rolled copy loses all three. The set in `src/components/ui/` is:
+
+`Banner`, `Card`, `Disclosure`, `InlineLink`, `Pane`, `PushButton`,
+`RangeSlider`, `Row`, `ScrollPane`, `SectionGroup`, `SegmentedControl`,
+`SidebarNav`, `Skeleton`, `StatusText`, `TextRoll`, `ToggleRow`, `ToggleSwitch`.
+
+**RULE 6.1 — reach for the primitive first.** A pane is a `Pane` with
+`SectionGroup` groups and `Card` rows. A setting with a switch is a `ToggleRow`.
+A label with a control on the right is a `Row`. A one-line alert is a `Banner`.
+A placeholder is a `Skeleton`. A live status line is a `StatusText`. An outbound
+link inside a sentence is an `InlineLink`, which is a `button` rather than an
+`<a>` because a real `href` in a desktop window is a navigation hazard.
+**[High]**
+
+**RULE 6.2 — use the `ui-*` classes for control chrome.** `ui-push-button`,
+`ui-menu`, `ui-tooltip`, `ui-switch` with `ui-switch-thumb`,
+`ui-radio-indicator` with `ui-radio-dot`, `ui-progress` with
+`ui-progress-indicator`, `ui-scrollbar` with `ui-scrollbar-thumb`. They live in
+`src/styles/controls.css` and `src/styles/platform-controls.css`. A restyled
+`<button>` that re-derives that geometry is a finding. **[High]**
+
+**RULE 6.3 — style headless state with `[data-state]` and `[data-highlighted]`,
+not `:hover`.** The headless primitives already report their state. In the
+notification window this is not a preference but a requirement: pointer events
+do not reach that window while another window holds key status, so CSS `:hover`
+never fires there. **[High]**
+
+**RULE 6.4 — a banner is always dismissible, has at most one action, and is one
+line.** That shape is what keeps it from becoming noise. It renders as
+`role="status"` with a polite live region. **[Medium]**
+
+**RULE 6.5 — the platform attribute stays in the foundation.**
+`<html data-platform>` is set once at startup (`src/lib/platform.ts`). Only the
+design foundation reads it. A component never asks what platform it is on.
+**[Medium]**
+
+## 7. State taxonomy
+
+The token contract says nothing about states, so this section carries the whole
+rule. Every surface that loads anything needs all of the states that apply to
+it. A missing state is a real finding, not a polish item.
+
+**RULE 7.1 — empty.** A title and one describing line, never a blank box. The
+copy names why the surface is empty and what would fill it.
+`LocalActivityList` does this: the title is range-aware ("No sessions today", or
+"No sessions in the last N days") and the description says that sessions appear
+as they are discovered. The usage surface says "No local evidence yet". **[High]**
+
+**RULE 7.2 — loading.** A `Skeleton` in the shape of the content it hides, never
+a spinner over a blank surface, and never a layout that jumps when data lands.
+Mark the region `aria-busy` and hide decorative placeholders with `aria-hidden`.
+The popover's activity skeleton and its lazy session-analytics placeholder both
+show the pattern. **[High]**
+
+**RULE 7.3 — error.** Say what failed, in plain words, and offer the way
+forward. The onboarding window's failure state is the model: a title, the error
+text, and a "Try again" button. The scan status line says "Last scan did not
+finish" beside a warning glyph, and keeps the rescan control next to it. An
+error with no next step is a finding. **[High]**
+
+**RULE 7.4 — permission-blocked is its own state, and it is not an error.** The
+operating system refusing a folder is a normal condition with a known remedy.
+`FolderPermissionNotice` explains what the app wants and why BEFORE the system's
+consent dialog appears, and that dialog only ever follows a button on the
+notice. The notice is not dismissible, because it explains a visible gap in a
+list rather than interrupting. A blocked folder must never read as a crash, and
+must never silently vanish from the list. **[High]**
+
+**RULE 7.5 — first run.** The onboarding window owns first run: five linear
+steps (welcome, sources, repositories, scan, ready), a "Step N of M" text label
+beside the step dots, and no step that cannot be reached by keyboard. First run
+is not a popover surface, and it must not be rebuilt as one (D-25). **[High]**
+
+**RULE 7.6 — freshness is a state.** A local-first app has to say when it last
+looked. `ScanStatusBar` answers two questions on sight: is it looking, and how
+old is what I am reading. A surface that reads indexed data and shows no
+freshness or scan state is a finding. **[Medium]**
+
+**RULE 7.7 — a state change is announced.** Use a polite live region for
+progress and status (`aria-live="polite"`), never assertive. A scan finishing is
+worth knowing. It is not worth interrupting what the reader is reading.
+**[Medium]**
+
+## 8. Data display and session analytics
+
+**RULE 8.1 — the session-analytics palette stays in its own surface.** The
+mode, context, token, and pattern colours in
+`src/styles/session-analytics-colors.css` are a sub-palette for that one
+surface. Do not borrow them as general product colour, and do not add a new one
+without a comment that says what it means. **[Medium]**
+
+**RULE 8.2 — a chart colour resolves through a token.** Chart series read their
+colour from a CSS variable, so both themes work with no branch in the chart
+code. **[High]**
+
+**RULE 8.3 — a figure is honest about its basis.** Estimated and measured
+figures must be distinguishable, and the label must say which one it is. A
+number the reader can mistake for a provider's own figure is a finding.
+**[High]**
+
+**RULE 8.4 — no chart junk.** One accent, quiet gridlines, a label on the chart
+in place of a busy legend. Thin strokes at chart scale
+(`strokeWidth` 1.5 for large marks). **[Medium]**
+
+## 9. Themes and materials (the theme pass)
+
+Three theme sources, in cascade order (`design.md`, "Themes"):
+
+1. The system light/dark preference is the default.
+2. A webview that exposes live system label, separator, and accent tokens picks
+   those up through `@supports`, so text and chrome track the operating system.
+3. A platform without them takes an explicit `<html data-theme="light|dark">`
+   palette. That palette is deliberately more opaque, because no window material
+   sits behind it.
+
+`prefers-reduced-transparency` makes the window and popover surfaces solid in
+every branch.
+
+**RULE 9.1 — both themes must work.** Toggle to dark and look. Flag anything
+that only reads in one theme: a near-white or near-black value, text that
+disappears, a border that vanishes. **[High]**
+
+**RULE 9.2 — reduced transparency must stay legible.** With the material gone,
+the surfaces are solid. Check that text on a translucent tint still reads, and
+that a hairline is still visible. **[High]**
+
+**RULE 9.3 — do not fight the material.** A surface that stacks its own backdrop
+blur or its own opaque fill over the window material defeats the point. Use the
+`surface-*` tokens. **[Medium]**
+
+## 10. Motion
+
+`src/styles/motion.css` holds one global reduced-motion clamp. Under
+`prefers-reduced-motion: reduce`, every animation and transition collapses to
+about 0ms and every loop is cut to a single iteration. A surface that still
+needs a hint of movement re-states a short duration there, with the reason.
+Today there is exactly one such exception: the segmented control's reduced-motion
+fill crossfades over 60ms, because an instant swap between two filled segments
+reads as a flicker.
+
+**RULE 10.1 — use a motion token, not a literal value.** The durations are
+`--duration-quick` (100ms), `--duration-fast` (120ms), and `--duration-slow`
+(300ms), declared in `src/styles/tokens.css`. Tailwind has no `--duration-*`
+theme namespace, so a call site writes `duration-[var(--duration-fast)]`. The
+easing `--ease-out-quart` is `@theme`-registered, so it is the `ease-out-quart`
+utility. A literal such as `duration-[120ms]`, a bare `transition-colors` that
+inherits the framework default, or an inline `cubic-bezier(...)` is a finding.
+An animation timing stays with the keyframes that own it. **[Medium]**
+
+**RULE 10.2 — an ambient loop stops, it does not shorten.** No duration makes a
+loop acceptable, so an ambient loop sets `animation: none` under reduced motion
+and keeps its resting meaning. The activity-row pulse settles at a fixed tint
+that still marks the row; the title shimmer drops its overlay and paints as
+plain primary text. Both are in `src/styles/session-rows.css`. A loop that
+merely runs faster, or one whose resting state loses the meaning the movement
+carried, is a finding. **[High]**
+
+**RULE 10.3 — a new reduced-motion exception needs a written reason.** Put it in
+`motion.css` beside the rule, and say why the movement is load-bearing.
+**[High]**
+
+**RULE 10.4 — motion never carries meaning on its own.** If an animation stops,
+the reader must still learn the same fact from text or from a glyph. **[High]**
+
+**RULE 10.5 — an exit animation that gates an action must exist.** The
+notification defers its dismiss to `animationend`, so the keyframes are
+load-bearing. The clamp collapses them to about 0ms, and the event still fires.
+Do not "simplify" such an animation away. **[Blocker]**
+
+## 11. Accessibility (WCAG 2.1 AA)
+
+**RULE 11.1 — contrast.** At least 4.5:1 for text, and at least 3:1 for large
+text and for a meaningful UI or graphic element. Check the tertiary label
+tokens, which are the closest to the line, and check every coloured status
+string (see rule 3.4). **[High]**
+
+**RULE 11.2 — the focus ring is keyboard-only, on purpose.** It paints under
+`html[data-keyboard]`, which `src/lib/focusModality.ts` sets on Tab and clears
+on any pointer press (`src/styles/focus.css`). This is deliberate: webviews
+paint `:focus-visible` for programmatic focus and for window activation too,
+which would put a ring on a window that simply reopened. So:
+
+- Do NOT report "no focus ring on click" as a finding. That is the design.
+- DO report a control that shows no ring after Tab.
+- DO report a control that suppresses the ring with `outline-none` and puts
+  nothing gated on `data-keyboard` back.
+- DO check that every interactive element is reachable by Tab at all. **[High]**
+
+**RULE 11.3 — focus lands somewhere on a surface change.** Swapping a surface
+leaves focus on `<body>`, which tells a screen-reader user nothing. Every
+popover surface marks its heading with `data-view-heading` and `tabIndex={-1}`,
+and the heading takes focus when the surface changes. A new surface with no
+focus target is a finding. **[High]**
+
+**RULE 11.4 — tab and panel wiring.** `SidebarNav` is a vertical tablist with a
+roving tabindex: only the selected row is tabbable, and Up, Down, Home, and End
+move both selection and focus. Each row's `aria-controls` points at
+`<id>-panel`, so the pane it drives must carry `role="tabpanel"`,
+`id="<id>-panel"`, and `aria-labelledby="<id>-tab"`. A broken pair is a finding.
+**[High]**
+
+**RULE 11.5 — never colour alone.** Pair a status colour with a glyph, a word,
+or a shape. Follow `StatusText`, where the glyph is decorative and the message
+carries the meaning. **[High]**
+
+**RULE 11.6 — a decorative glyph is hidden.** `aria-hidden` on every Lucide icon
+that repeats what the text says. An icon-only control gets an `aria-label` that
+names the action. **[High]**
+
+**RULE 11.7 — a keyboard escape exists, and it is the right one.** Escape
+dismisses the popover, because a tray popover is transient. Escape must NOT
+close the settings window, because that window is not a modal. Command-W or
+Control-W closes a decorated window, because an accessory app has no application
+menu to own the shortcut. **[High]**
+
+**RULE 11.8 — the ratchet.** On an EXISTING screen, an AA miss reports as
+**High**, not Blocker, so the app improves steadily instead of stalling. NEW UI
+is held to AA from the start, and an AA miss there is a **Blocker**.
+
+## 12. Copy and voice
+
+**RULE 12.1 — plain and calm.** Short words. Present tense. Active voice. Say
+what happened and what to do. "Last scan did not finish" beside a rescan
+control, not "Oops! Something went wrong." **[Medium]**
+
+**RULE 12.2 — sentence case everywhere.** Buttons, labels, headings, and
+titles. Title Case belongs to a platform menu item, not to product chrome.
+**[Medium]**
+
+**RULE 12.3 — no marketing voice.** No superlative, no exclamation mark, no
+promise the app cannot keep. The app reports what it found on this machine.
+**[Medium]**
+
+**RULE 12.4 — a label names the action, not the condition.** A pinned window
+offers "Unpin Window". A control that pauses says which of the two states
+pressing it produces. **[Medium]**
+
+**RULE 12.5 — the product name is `antiburn`, lower case, always.** **[Medium]**
+
+**RULE 12.6 — an accessible name is short.** The message is a whole sentence, so
+the dismiss control is named "Dismiss" and not the sentence again. A
+screen-reader user should not sit through it twice. **[Medium]**
+
+**RULE 12.7 — say what the app cannot see.** A gap, a blocked folder, a paused
+scan, and an estimated figure are all stated plainly. Never imply completeness
+the app does not have. **[High]**
+
+## 13. Icons, marks, and emoji
+
+**RULE 13.1 — icons come from `lucide-react`.** They inherit `currentColor`.
+Sizes: 12 for footnote scale, 14 to 16 by default, 24 for a feature. Colour with
+`text-*`. `strokeWidth` 2, or 2.5 to 3 for a tiny mark, or 1.5 for a large or
+chart mark. Add `shrink-0` inside a flex row. **[Medium]**
+
+**RULE 13.2 — a vendor brand mark is the one exception, and it is not
+interchangeable with an icon.** A mark is a trademark, so its shape and colour
+belong to the vendor. Marks are filled paths, not stroked glyphs, and take
+`--color-agent-mark` rather than a `text-*` label colour. A mark whose identity
+is its colour keeps that colour in both themes. Marks are never drawn inline;
+they come from the `renderAgentIcon` slot. Do NOT report a mark's colour as a
+raw-colour violation. **[High]**
+
+**RULE 13.3 — no emoji in product chrome.** Not in a list, a button, a label, a
+pane, or a notification. Use a Lucide icon. **[Medium]**
+
+## Severity ladder
+
+- **Blocker** — broken or unusable as shipped. Unreadable text, a surface that
+  clips its own content, a control that cannot be reached, a removed animation
+  that a dismiss depends on, or an AA miss in new UI.
+- **High** — a clear rule or token violation a reader would notice. A raw colour
+  in feature code, a missing empty or error state, a broken tab and panel pair,
+  an ambient loop that survives reduced motion, an AA miss on an existing
+  screen.
+- **Medium** — real but contained. A hand-rolled row, an ad-hoc radius, a
+  missing `tabular-nums`, Title Case in a button, an emoji in chrome.
+- **Nitpick** — polish. A few pixels of alignment, a slightly loose gap.

--- a/.agents/skills/design-review/design-principles.md
+++ b/.agents/skills/design-review/design-principles.md
@@ -289,15 +289,7 @@ without a comment that says what it means. **[Medium]**
 colour from a CSS variable, so both themes work with no branch in the chart
 code. **[High]**
 
-**RULE 8.3 — a figure is honest about its basis.** A reader must never take an
-estimate for a provider's own figure. Provenance has to be *reachable* — a
-tooltip, a disclosure, a detail row, or one statement covering a whole section
-— but it does not have to be a visible label on every number. On a dense
-surface, per-figure labels usually clutter more than they inform. The finding
-is a figure that reads as authoritative with no way to find out otherwise, not
-a figure without a label. **[High]**
-
-**RULE 8.4 — no chart junk.** One accent, quiet gridlines, a label on the chart
+**RULE 8.3 — no chart junk.** One accent, quiet gridlines, a label on the chart
 in place of a busy legend. Thin strokes at chart scale
 (`strokeWidth` 1.5 for large marks). **[Medium]**
 
@@ -441,9 +433,13 @@ the dismiss control is named "Dismiss" and not the sentence again. A
 screen-reader user should not sit through it twice. **[Medium]**
 
 **RULE 12.7 — say what the app cannot see.** A gap, a blocked folder, and a
-paused scan are stated plainly. Never imply completeness the app does not have.
-Estimated figures follow Rule 8.3: the basis has to be reachable, not labelled
-on every number. **[High]**
+paused scan are stated plainly; never imply completeness the app does not have.
+The same holds for a figure the app worked out itself: where an estimate stands
+in for a provider's own number, the reader needs *some* way to tell. A tooltip
+is usually the right amount — `SessionCostBadge` leads with the number and
+explains it on hover. Raise this only when there is no way to find out at all;
+a figure without a visible label is not a finding, and labelling every one of
+them clutters a dense surface. **[High]**
 
 ## 13. Icons, marks, and emoji
 

--- a/.agents/skills/design-review/report-template.md
+++ b/.agents/skills/design-review/report-template.md
@@ -1,0 +1,56 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+# Design review: {window} — {surface}
+
+- **Window:** {popover | settings | onboarding | notification} ({width} × {height})
+- **Surface:** {activity | session | usage | pane name | step name | resting | expanded}
+- **Build:** {dev instance, branch, or commit}
+- **Date:** {YYYY-MM-DD}
+- **Reviewer:** antiburn design-review skill
+
+## Captures
+
+Surface pass:
+
+- {surface}: {path}
+- {surface}: {path}
+
+Theme pass:
+
+- Light: {path}
+- Dark: {path}
+- Reduced transparency: {path}
+- Reduced motion: {path, or "checked live, no capture"}
+
+## Summary
+
+{2 to 3 sentences. The overall read, the biggest win, and the biggest risk.}
+
+## Top fixes
+
+1. {highest-impact fix}
+2. {next}
+3. {next}
+
+## Findings
+
+Ranked most severe first.
+
+| # | Severity | Dimension | Finding | Rule / token | Suggested fix | Evidence |
+|---|----------|-----------|---------|--------------|---------------|----------|
+| 1 | High | Colour | {what is wrong} | 3.1 no raw colour, `tokens.css` | {fix} | dark capture, card X |
+| 2 | High | State | {what is wrong} | 7.1 empty state | {fix} | `LocalActivityList.tsx:265` |
+| 3 | Medium | Motion | {what is wrong} | 10.1 token durations | {fix} | `duration-[120ms]` |
+
+## Checked and clean
+
+{The dimensions that passed. This keeps the next review from re-testing them
+blind, and it stops a short findings table from reading as a shallow pass.}
+
+## Notes
+
+{Anything you could not confirm, or that needs the user. A recorded deviation
+that explains a difference. A state you could not reach. A capture taken from
+the browser path, where no shell is present.}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Test the CI control plane
         run: node --test scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/verify-workflow-portability.test.mjs scripts/wait-for-main-ci.test.mjs
 
+      # The drift guard runs here, not in a classified job. It reads the
+      # contract, the stylesheets, and the popover window's own corner
+      # constant, so a change to any one of them has to reach it — and a
+      # change under src-tauri classifies as backend, which never starts the
+      # frontend job. It needs no dependencies, so the cost is a few
+      # milliseconds on every run.
+      - name: Check design-contract drift
+        run: node scripts/check-design-drift.mjs
+
       - name: Classify the diff
         id: changes
         env:
@@ -123,12 +132,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      # The drift guard needs no dependencies, so it runs before the install
-      # and fails fast when the design contract and the stylesheets disagree.
-      - name: Check design-contract drift
-        if: runner.os == 'Linux'
-        run: node scripts/check-design-drift.mjs
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Test the CI control plane
-        run: node --test scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/verify-workflow-portability.test.mjs scripts/wait-for-main-ci.test.mjs
+        run: node --test scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/verify-workflow-portability.test.mjs scripts/wait-for-main-ci.test.mjs
 
       - name: Classify the diff
         id: changes
@@ -123,6 +123,12 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      # The drift guard needs no dependencies, so it runs before the install
+      # and fails fast when the design contract and the stylesheets disagree.
+      - name: Check design-contract drift
+        if: runner.os == 'Linux'
+        run: node scripts/check-design-drift.mjs
 
       - name: Enable Corepack
         run: corepack enable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,16 @@ There should be no Rust lint suppressions for dead or deprecated code.
 
 Only add a suppression when it is _strictly_ necessary. Before adding it, explain why and get explicit agreement from the dev.
 
+## Desktop design system
+
+Read `apps/desktop/design.md` before you do styling work in `apps/desktop`. Its YAML front matter is the token reference, and the stylesheets it names are the source of truth.
+
+Use the semantic utilities the contract documents (`bg-/text-/border-<token>`, the `type-*` scale, `rounded-control`, `duration-*`). Do not hard-code a color, a type size, a radius, or a duration.
+
+CI runs `scripts/check-design-drift.mjs`. When you change a token or a stylesheet, update `design.md` in the same change, and add a new stylesheet to its `sources:` list.
+
+For a review of a surface against the wider interface rules, use the `design-review` skill.
+
 ## Comments
 
 Write all code comments in ASD-STE100 (Simplified Technical English). The rules that matter most for comments:

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -113,7 +113,7 @@ colors:
     dark: "rgb(242 113 34)"
   bg-hud:
     light: "rgb(246 246 246)"
-    dark: "rgb(32 32 32)" # @media dark: rgb(40 40 40)
+    dark: "rgb(32 32 32)"
   # Session-analytics sub-palette only (src/styles/session-analytics-colors.css)
   mode-implementing:
     light: "rgb(29 78 216)"

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -22,7 +22,7 @@ colors:
   # for is a failure, and so is a note that no longer differs.
   surface: # the menu-bar popover, which sits on the window material
     light: "rgb(255 255 255 / 0.85)" # reduced-transparency: rgb(255 255 255)
-    dark: "rgb(30 30 30 / 0.92)" # @media dark: rgb(30 30 30 / 0.40)
+    dark: "rgb(30 30 30 / 0.92)"
   surface-secondary:
     light: "rgb(0 0 0 / 0.08)"
     dark: "rgb(255 255 255 / 0.12)"
@@ -55,7 +55,7 @@ colors:
     dark: "rgb(235 235 245 / 0.72)"
   label-tertiary: # 4.5:1 on a card on the popover, over any desktop behind it
     light: "rgb(60 60 67 / 0.79)"
-    dark: "rgb(235 235 245 / 0.55)"
+    dark: "rgb(235 235 245 / 0.62)"
   separator: # live system separator token where available
     light: "rgb(0 0 0 / 0.15)"
     dark: "rgb(255 255 255 / 0.18)"

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -10,11 +10,13 @@ sources:
   - src/styles/controls.css
   - src/styles/motion.css
   - src/styles/platform-controls.css
+  - src/styles/hud.css
   - src/styles/session-analytics-colors.css
+  - src/styles/session-rows.css
   - src/components/ui/text-roll.css
 colors:
   # name → Tailwind utility via bg-/text-/border-<name>
-  # light = the default :root palette · dark = the explicit [data-theme="dark"] palette
+  # Both values are the explicit [data-theme="light"|"dark"] palettes.
   # System-preference (@media) values are noted where they differ from the explicit ones.
   surface:
     light: "rgb(255 255 255 / 0.58)" # reduced-transparency: rgb(255 255 255)
@@ -100,6 +102,16 @@ colors:
   agent-mark: # vendor brand-mark ink; see the Vendor brand marks note below
     light: "rgb(38 37 30)"
     dark: "rgb(247 247 244)"
+  # Floating-HUD sub-palette only (src/styles/hud.css)
+  burn:
+    light: "rgb(255 77 0)"
+    dark: "rgb(255 106 0)"
+  burn-muted:
+    light: "rgb(240 88 22)"
+    dark: "rgb(242 113 34)"
+  bg-hud:
+    light: "rgb(246 246 246)"
+    dark: "rgb(32 32 32)" # @media dark: rgb(40 40 40)
   # Session-analytics sub-palette only (src/styles/session-analytics-colors.css)
   mode-implementing:
     light: "rgb(29 78 216)"
@@ -293,7 +305,10 @@ Notes for what isn't expressible as a token:
 - **Motion** — `prefers-reduced-motion: reduce` clamps every animation and transition globally
   (`src/styles/motion.css`). A surface that still needs a hint of movement re-states a short
   duration there, with the reason; today the only such exception is the segmented control's
-  reduced-motion fill, which crossfades over 60ms instead of swapping instantly.
+  reduced-motion fill, which crossfades over 60ms instead of swapping instantly. An ambient loop
+  stops instead of shortening: the activity-row pulse and title shimmer in
+  `src/styles/session-rows.css` set `animation: none` under reduced motion and keep their resting
+  state, because a loop clamped to ~0ms still repeats forever.
 - **State** — style the headless control primitives via `[data-state]` / `[data-highlighted]`, not
   `:hover`.
 - **Scroll edges** — use the shared `ScrollPane` `topEdgeFade` prop when scrolling content needs to

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -53,8 +53,8 @@ colors:
   label-secondary:
     light: "rgb(60 60 67 / 0.85)"
     dark: "rgb(235 235 245 / 0.72)"
-  label-tertiary: # 4.5:1 on a card, the lightest surface it sits on
-    light: "rgb(60 60 67 / 0.75)"
+  label-tertiary: # 4.5:1 on a card on the popover, over any desktop behind it
+    light: "rgb(60 60 67 / 0.79)"
     dark: "rgb(235 235 245 / 0.55)"
   separator: # live system separator token where available
     light: "rgb(0 0 0 / 0.15)"

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -32,8 +32,8 @@ colors:
   surface-card:
     light: "rgb(0 0 0 / 0.04)"
     dark: "rgb(255 255 255 / 0.08)"
-  surface-hover:
-    light: "rgb(0 0 0 / 0.08)" # @media light: rgb(0 0 0 / 0.04)
+  surface-hover: # stays clear of surface-selected, so a hover never reads as a selection
+    light: "rgb(0 0 0 / 0.04)"
     dark: "rgb(255 255 255 / 0.04)" # @media dark: rgb(255 255 255 / 0.07)
   surface-window: # standard decorated window
     light: "rgb(246 246 246)" # @media light: rgb(246 246 246 / 0.80)

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -194,6 +194,16 @@ shadow:
   tooltip: "0 2px 8px rgb(0 0 0 / 0.12), 0 0.5px 2px rgb(0 0 0 / 0.06)"
   raised: "0 1px 2px rgb(0 0 0 / 0.15), 0 0 0 0.5px rgb(0 0 0 / 0.04)"
 motion:
+  # Transition tokens. Durations are plain :root vars in src/styles/tokens.css,
+  # because Tailwind has no --duration-* theme namespace; consume one as
+  # duration-[var(--duration-fast)]. The easing is @theme-registered, so it is
+  # the `ease-out-quart` utility. Plain `ease-out` is the default elsewhere.
+  --duration-quick: 100ms # a crossfade that leads the movement it accompanies
+  --duration-fast: 120ms # the default control, hover, and disclosure transition
+  --duration-slow: 300ms # a meter or bar that fills
+  --ease-out-quart: cubic-bezier(0.23, 1, 0.32, 1)
+  # Recipes, for the timings the tokens above do not carry. Animation timings
+  # stay with the keyframes that own them.
   button: "transform 80ms / opacity 120ms ease-out; :active scale(0.98) opacity 0.85"
   menu-in: "120ms ease-out from trigger origin"
   tooltip-in: "100ms"
@@ -306,9 +316,9 @@ Notes for what isn't expressible as a token:
   (`src/styles/motion.css`). A surface that still needs a hint of movement re-states a short
   duration there, with the reason; today the only such exception is the segmented control's
   reduced-motion fill, which crossfades over 60ms instead of swapping instantly. An ambient loop
-  stops instead of shortening: the activity-row pulse and title shimmer in
-  `src/styles/session-rows.css` set `animation: none` under reduced motion and keep their resting
-  state, because a loop clamped to ~0ms still repeats forever.
+  stops instead of shortening: no duration makes a loop acceptable, so the activity-row pulse and
+  title shimmer in `src/styles/session-rows.css` set `animation: none` and each keeps its resting
+  meaning — the pulse settles at a fixed tint, and the title paints as plain primary text.
 - **State** — style the headless control primitives via `[data-state]` / `[data-highlighted]`, not
   `:hover`.
 - **Scroll edges** — use the shared `ScrollPane` `topEdgeFade` prop when scrolling content needs to

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -17,7 +17,9 @@ sources:
 colors:
   # name → Tailwind utility via bg-/text-/border-<name>
   # Both values are the explicit [data-theme="light"|"dark"] palettes.
-  # System-preference (@media) values are noted where they differ from the explicit ones.
+  # A `# @media <theme>: <value>` note states the system-preference value where it
+  # differs. The drift check reads those notes: a difference it cannot find a note
+  # for is a failure, and so is a note that no longer differs.
   surface:
     light: "rgb(255 255 255 / 0.58)" # reduced-transparency: rgb(255 255 255)
     dark: "rgb(30 30 30 / 0.92)" # @media dark: rgb(30 30 30 / 0.40)

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -20,8 +20,8 @@ colors:
   # A `# @media <theme>: <value>` note states the system-preference value where it
   # differs. The drift check reads those notes: a difference it cannot find a note
   # for is a failure, and so is a note that no longer differs.
-  surface:
-    light: "rgb(255 255 255 / 0.58)" # reduced-transparency: rgb(255 255 255)
+  surface: # the menu-bar popover, which sits on the window material
+    light: "rgb(255 255 255 / 0.85)" # reduced-transparency: rgb(255 255 255)
     dark: "rgb(30 30 30 / 0.92)" # @media dark: rgb(30 30 30 / 0.40)
   surface-secondary:
     light: "rgb(0 0 0 / 0.08)"

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -51,21 +51,21 @@ colors:
   label-secondary:
     light: "rgb(60 60 67 / 0.85)"
     dark: "rgb(235 235 245 / 0.72)"
-  label-tertiary:
-    light: "rgb(60 60 67 / 0.5)"
-    dark: "rgb(235 235 245 / 0.45)" # @media dark: rgb(235 235 245 / 0.35)
+  label-tertiary: # 4.5:1 on a card, the lightest surface it sits on
+    light: "rgb(60 60 67 / 0.75)"
+    dark: "rgb(235 235 245 / 0.55)"
   separator: # live system separator token where available
     light: "rgb(0 0 0 / 0.15)"
     dark: "rgb(255 255 255 / 0.18)"
   accent: # live system accent token where available
     light: "rgb(0 122 255)"
     dark: "rgb(10 132 255)"
-  accent-hover:
-    light: "rgb(0 122 255 / 0.85)"
-    dark: "rgb(10 132 255 / 0.85)"
+  accent-hover: # darker than accent-fill, because white text sits on it
+    light: "rgb(0 98 199)"
+    dark: "rgb(10 96 205)"
   accent-fill: # concrete fill; use bg-accent-fill for backgrounds
-    light: "rgb(0 122 255)"
-    dark: "rgb(10 132 255)"
+    light: "rgb(0 113 227)"
+    dark: "rgb(10 110 235)"
   system-green:
     light: "rgb(36 138 61)"
     dark: "rgb(48 219 91)"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -88,8 +88,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # `tray-icon` gives the menu-bar item; `image-png` lets the tray glyph be
 # decoded from the generated PNG.
-# The HUD crate builds a transparent macOS window. Tauri's configuration check
-# requires the shell manifest to declare the matching private API feature.
+# Two windows need `macos-private-api`. The HUD crate builds a transparent macOS
+# window, and the popover uses the window-effect builder for its rounded
+# material. Tauri's configuration check requires the shell manifest to declare
+# the feature.
 tauri = { version = "2", features = ["image-png", "tray-icon", "macos-private-api"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"

--- a/apps/desktop/src-tauri/crates/nudge/src/window.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/window.rs
@@ -86,10 +86,9 @@ fn build_nudge_window(app: &AppHandle, label: &str) -> tauri::Result<WebviewWind
     {
         // Undecorated with a real window shadow, and first-click-through so a CTA
         // responds to the click that would otherwise only have activated the
-        // window. The app's own popover chrome — the card paints its surface and
-        // its 16pt corner itself, so the window needs no vibrancy material (and
-        // this build does not enable tauri's `macos-private-api`, which is what
-        // the transparent/effects builder methods require).
+        // window. The card paints its surface and its 16pt corner itself, so
+        // this window needs no vibrancy material. The popover takes the other
+        // route and lets a material draw its corner; see `popover.rs`.
         builder = builder
             .decorations(false)
             .shadow(true)

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -67,8 +67,9 @@ const WIDTH: f64 = 380.0;
 /// Corner radius of the popover window, in logical pixels.
 ///
 /// This is `rounded.popover` from `apps/desktop/design.md`. The window corner
-/// and the card corners inside it must agree, so change both together. The
-/// design-drift check reads the stylesheets only, and cannot see this copy.
+/// and the card corners inside it must agree, so change both together.
+/// `scripts/check-design-drift.mjs` reads this constant and fails if the two
+/// numbers differ.
 #[cfg(target_os = "macos")]
 const CORNER_RADIUS: f64 = 10.0;
 

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -45,6 +45,8 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "macos")]
+use tauri::window::{Effect, EffectState, EffectsBuilder};
 use tauri::{
     AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Rect, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder, Window,
@@ -61,6 +63,14 @@ pub const EVENT_SHOWN: &str = "popover:shown";
 
 /// Popover width in logical pixels. Fixed: the views size themselves to it.
 const WIDTH: f64 = 380.0;
+
+/// Corner radius of the popover window, in logical pixels.
+///
+/// This is `rounded.popover` from `apps/desktop/design.md`. The window corner
+/// and the card corners inside it must agree, so change both together. The
+/// design-drift check reads the stylesheets only, and cannot see this copy.
+#[cfg(target_os = "macos")]
+const CORNER_RADIUS: f64 = 10.0;
 
 /// Tallest the popover may ever get, in logical pixels.
 ///
@@ -453,8 +463,20 @@ fn get_or_create(app: &AppHandle) -> tauri::Result<WebviewWindow> {
 
     // Let the first click both focus the popover and act on the control under
     // the cursor; a menu-bar surface that eats the first click feels broken.
+    //
+    // The popover material also gives the window its rounded corner. Without it
+    // the window is an opaque square, which is wrong for a menu-bar surface, and
+    // the translucent palette in the stylesheets has nothing to sit on. The
+    // stylesheets already paint html, body, and #root transparent, so the
+    // material is what the reader sees behind the content.
     #[cfg(target_os = "macos")]
-    let builder = builder.accept_first_mouse(true);
+    let builder = builder.accept_first_mouse(true).transparent(true).effects(
+        EffectsBuilder::new()
+            .effect(Effect::Popover)
+            .state(EffectState::Active)
+            .radius(CORNER_RADIUS)
+            .build(),
+    );
 
     match builder.build() {
         Ok(window) => Ok(window),

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -13,6 +13,7 @@
   "app": {
     "macOSPrivateApi": true,
     "windows": [],
+    "macOSPrivateApi": true,
     "security": {
       "csp": "default-src 'self'; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost"
     }

--- a/apps/desktop/src/components/activity/LocalActivityList.tsx
+++ b/apps/desktop/src/components/activity/LocalActivityList.tsx
@@ -138,7 +138,7 @@ function SessionActivityRow({
     <div
       className={cn(
         "relative flex items-start gap-3 py-3 px-2 w-full text-left rounded-md",
-        "transition-colors duration-[var(--duration-fast)]",
+        "transition-colors duration-[var(--duration-fast)] ease-out",
         entry.isActive && "activity-row-active isolate",
         clickable &&
           "cursor-pointer hover:bg-surface-hover [&:has([data-state*=open])]:bg-surface-hover",

--- a/apps/desktop/src/components/activity/LocalActivityList.tsx
+++ b/apps/desktop/src/components/activity/LocalActivityList.tsx
@@ -138,7 +138,7 @@ function SessionActivityRow({
     <div
       className={cn(
         "relative flex items-start gap-3 py-3 px-2 w-full text-left rounded-md",
-        "transition-colors duration-[120ms]",
+        "transition-colors duration-[var(--duration-fast)]",
         entry.isActive && "activity-row-active isolate",
         clickable &&
           "cursor-pointer hover:bg-surface-hover [&:has([data-state*=open])]:bg-surface-hover",

--- a/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsSection.tsx
@@ -93,7 +93,7 @@ export function UsageLimitsSection({
         strokeWidth={2}
         aria-hidden="true"
         className={cn(
-          "transition-transform duration-[120ms] ease-out",
+          "transition-transform duration-[var(--duration-fast)] ease-out",
           expanded && "rotate-270",
         )}
       />

--- a/apps/desktop/src/components/repositories/LocalRepositoryList.tsx
+++ b/apps/desktop/src/components/repositories/LocalRepositoryList.tsx
@@ -76,7 +76,7 @@ function RepositoryRow({
   }
 
   return (
-    <div className="flex items-start gap-3 rounded-md px-2 py-2 transition-colors hover:bg-surface-hover">
+    <div className="flex items-start gap-3 rounded-md px-2 py-2 transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover">
       <div className="min-w-0 flex-1 space-y-0.5">
         <div className="flex min-w-0 items-center gap-1.5">
           <span className="truncate type-callout text-label">{item.fullName}</span>

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -261,7 +261,7 @@ function Card({
               <button
                 type="button"
                 aria-label={`About ${title}`}
-                className="leading-none text-label-tertiary transition-colors hover:text-label-secondary"
+                className="leading-none text-label-tertiary transition-colors duration-[var(--duration-fast)] ease-out hover:text-label-secondary"
               >
                 <Info size={13} aria-hidden="true" />
               </button>
@@ -308,7 +308,7 @@ function PhaseBreakdownRows({
         <div
           key={row.key}
           className={cn(
-            "-mx-2 flex items-center gap-2.5 rounded-lg px-2 py-1 transition-colors",
+            "-mx-2 flex items-center gap-2.5 rounded-lg px-2 py-1 transition-colors duration-[var(--duration-fast)] ease-out",
             activePhase === row.key && "bg-surface-secondary",
           )}
           onMouseEnter={() => onHoverPhase?.(row.key)}
@@ -325,7 +325,7 @@ function PhaseBreakdownRows({
                 <button
                   type="button"
                   aria-label={`About ${row.label}`}
-                  className="leading-none text-label-tertiary transition-colors hover:text-label-secondary"
+                  className="leading-none text-label-tertiary transition-colors duration-[var(--duration-fast)] ease-out hover:text-label-secondary"
                 >
                   <Info size={11} aria-hidden="true" />
                 </button>
@@ -808,7 +808,7 @@ export function SessionDetailPresentation({
                         disabled={!onPrev}
                         aria-label="Newer session"
                         className={cn(
-                          "shrink-0 rounded-md p-1 transition-colors",
+                          "shrink-0 rounded-md p-1 transition-colors duration-[var(--duration-fast)] ease-out",
                           onPrev
                             ? "text-label-tertiary hover:bg-surface-tertiary hover:text-label-secondary"
                             : "cursor-default text-label-tertiary opacity-40",
@@ -833,7 +833,7 @@ export function SessionDetailPresentation({
                         disabled={!onNext}
                         aria-label="Older session"
                         className={cn(
-                          "shrink-0 rounded-md p-1 transition-colors",
+                          "shrink-0 rounded-md p-1 transition-colors duration-[var(--duration-fast)] ease-out",
                           onNext
                             ? "text-label-tertiary hover:bg-surface-tertiary hover:text-label-secondary"
                             : "cursor-default text-label-tertiary opacity-40",

--- a/apps/desktop/src/components/session/analytics/HypnogramMarkers.tsx
+++ b/apps/desktop/src/components/session/analytics/HypnogramMarkers.tsx
@@ -147,7 +147,7 @@ export function HypnogramMarkers<T>({
           translate-based centering instead of overriding it. */}
       <style>{`
         @media (prefers-reduced-motion: no-preference) {
-          .ui-marker-dot { transition: scale 0.15s ease; }
+          .ui-marker-dot { transition: scale var(--duration-fast) ease-out; }
           .ui-marker-dot:hover { scale: 1.15; }
         }
       `}</style>

--- a/apps/desktop/src/components/session/analytics/InitialContextChart.tsx
+++ b/apps/desktop/src/components/session/analytics/InitialContextChart.tsx
@@ -76,7 +76,7 @@ export function InitialContextChart({ breakdown }: InitialContextChartProps) {
                 <button
                   type="button"
                   aria-label={`About ${slice.label}`}
-                  className="shrink-0 leading-none text-label-tertiary transition-colors hover:text-label-secondary"
+                  className="shrink-0 leading-none text-label-tertiary transition-colors duration-[var(--duration-fast)] ease-out hover:text-label-secondary"
                 >
                   <Info size={11} aria-hidden="true" />
                 </button>

--- a/apps/desktop/src/components/session/analytics/PatternScore.tsx
+++ b/apps/desktop/src/components/session/analytics/PatternScore.tsx
@@ -37,7 +37,7 @@ export function PatternScore({ score, signals }: PatternScoreProps) {
 
       <div className="ui-progress mt-2 h-1.5">
         <div
-          className="h-full rounded-full transition-[width] duration-300 ease-out"
+          className="h-full rounded-full transition-[width] duration-[var(--duration-slow)] ease-out"
           style={{ width: `${score}%`, backgroundColor: color }}
         />
       </div>

--- a/apps/desktop/src/components/session/analytics/PhaseDonut.tsx
+++ b/apps/desktop/src/components/session/analytics/PhaseDonut.tsx
@@ -41,7 +41,7 @@ export function PhaseDonut({ summary, activePhase, onHoverPhase }: PhaseDonutPro
                 key={row.key}
                 fill={row.colorVar}
                 opacity={activePhase && activePhase !== row.key ? 0.75 : 1}
-                style={{ transition: "opacity 120ms" }}
+                style={{ transition: "opacity var(--duration-fast)" }}
               />
             ))}
           </Pie>

--- a/apps/desktop/src/components/session/orchestration/CollapsibleOrchestrationCard.tsx
+++ b/apps/desktop/src/components/session/orchestration/CollapsibleOrchestrationCard.tsx
@@ -44,7 +44,7 @@ export function CollapsibleOrchestrationCard({
         type="button"
         onClick={() => setExpanded((e) => !e)}
         aria-expanded={expanded}
-        className="group flex w-full items-center gap-1.5 px-3 py-2 text-left transition-colors hover:bg-system-indigo/15"
+        className="group flex w-full items-center gap-1.5 px-3 py-2 text-left transition-colors duration-[var(--duration-fast)] ease-out hover:bg-system-indigo/15"
       >
         {icon}
         <span className="type-callout text-system-indigo-text">{title}</span>

--- a/apps/desktop/src/components/session/orchestration/SubagentRosterRow.tsx
+++ b/apps/desktop/src/components/session/orchestration/SubagentRosterRow.tsx
@@ -51,7 +51,7 @@ export function SubagentRosterRow({
       type="button"
       onClick={onClick}
       className={cn(
-        "group/srow flex w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-system-indigo/10",
+        "group/srow flex w-full items-center gap-2 rounded-md text-left transition-colors duration-[var(--duration-fast)] ease-out hover:bg-system-indigo/10",
         dense ? "px-1 py-1" : "px-2 py-1.5",
       )}
     >

--- a/apps/desktop/src/components/ui/Disclosure.tsx
+++ b/apps/desktop/src/components/ui/Disclosure.tsx
@@ -56,7 +56,7 @@ export function Disclosure({
           strokeWidth={2}
           aria-hidden="true"
           className={cn(
-            "shrink-0 text-label-secondary transition-transform duration-[120ms] ease-out",
+            "shrink-0 text-label-secondary transition-transform duration-[var(--duration-fast)] ease-out",
             open && "rotate-180",
           )}
         />

--- a/apps/desktop/src/components/ui/InlineLink.tsx
+++ b/apps/desktop/src/components/ui/InlineLink.tsx
@@ -33,7 +33,7 @@ export function InlineLink({
       type="button"
       onClick={onClick}
       className={cn(
-        "rounded-control text-label underline decoration-label-tertiary underline-offset-2 transition-colors duration-[120ms] ease-out hover:decoration-label",
+        "rounded-control text-label underline decoration-label-tertiary underline-offset-2 transition-colors duration-[var(--duration-fast)] ease-out hover:decoration-label",
         className,
       )}
     >

--- a/apps/desktop/src/components/ui/SegmentedControl.test.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.test.tsx
@@ -90,7 +90,7 @@ describe("SegmentedControl", () => {
     expect(screen.getByRole("tab", { name: "C" }).getAttribute("aria-controls")).toBe(
       "sessions-panel",
     )
-    expect(document.querySelector(".duration-\\[120ms\\]")).toBeTruthy()
+    expect(document.querySelector(".duration-\\[var\\(--duration-fast\\)\\]")).toBeTruthy()
     // The reduced-motion fallback fill is always in the DOM; CSS decides which
     // of the two indicators paints.
     expect(document.querySelector(".ui-segmented-reduced-fill")).toBeTruthy()
@@ -119,7 +119,7 @@ describe("SegmentedControl", () => {
     }
     expect(tablist.getAttribute("style")).toBeNull()
     expect(document.querySelector(".bg-accent-fill")).toBeNull()
-    expect(document.querySelector(".duration-\\[120ms\\]")).toBeNull()
+    expect(document.querySelector(".duration-\\[var\\(--duration-fast\\)\\]")).toBeNull()
 
     const selected = screen.getByRole("tab", { name: "B" })
     expect(selected.className).toContain("font-medium")

--- a/apps/desktop/src/components/ui/SegmentedControl.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.tsx
@@ -85,7 +85,7 @@ export function SegmentedControl<T extends string>({
       {showAnimatedIndicator ? (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 left-0 rounded-[4px] bg-accent-fill transition-transform duration-[120ms] ease-out motion-reduce:hidden"
+          className="pointer-events-none absolute inset-y-0 left-0 rounded-[4px] bg-accent-fill transition-transform duration-[var(--duration-fast)] ease-out motion-reduce:hidden"
           style={{
             width: `${100 / options.length}%`,
             transform: `translateX(${selectedIndex * 100}%)`,
@@ -127,7 +127,7 @@ export function SegmentedControl<T extends string>({
             className={
               textTabs
                 ? cn(
-                    "type-footnote relative flex h-full items-center whitespace-nowrap px-0 transition-colors duration-100 ease-[cubic-bezier(0.23,1,0.32,1)]",
+                    "type-footnote relative flex h-full items-center whitespace-nowrap px-0 transition-colors duration-[var(--duration-quick)] ease-out-quart",
                     selected
                       ? "font-medium text-label"
                       : "text-label-tertiary hover:text-label-secondary",
@@ -150,7 +150,7 @@ export function SegmentedControl<T extends string>({
               <span
                 aria-hidden="true"
                 className={cn(
-                  "segmented-control-text-indicator pointer-events-none absolute inset-x-0 bottom-0 h-px rounded-full bg-label-secondary transition-opacity duration-100 ease-[cubic-bezier(0.23,1,0.32,1)]",
+                  "segmented-control-text-indicator pointer-events-none absolute inset-x-0 bottom-0 h-px rounded-full bg-label-secondary transition-opacity duration-[var(--duration-quick)] ease-out-quart",
                   selected ? "opacity-100" : "opacity-0",
                 )}
               />

--- a/apps/desktop/src/components/ui/SidebarNav.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.tsx
@@ -110,7 +110,7 @@ export function SidebarNav({
                 tabIndex={selected ? 0 : -1}
                 onClick={() => onChange(item.id)}
                 className={cn(
-                  "type-body flex h-9 items-center gap-3 rounded-control px-3 transition-colors duration-[120ms] ease-out",
+                  "type-body flex h-9 items-center gap-3 rounded-control px-3 transition-colors duration-[var(--duration-fast)] ease-out",
                   selected
                     ? "bg-surface-selected text-label"
                     : "text-label hover:bg-surface-hover",

--- a/apps/desktop/src/lib/route.test.ts
+++ b/apps/desktop/src/lib/route.test.ts
@@ -4,7 +4,13 @@
 
 import { describe, expect, it } from "vitest"
 
-import { NUDGE_FRAGMENT, OVERLAY_FRAGMENT, routeFromHash, SETTINGS_FRAGMENT } from "./route"
+import {
+  applyRouteAttribute,
+  NUDGE_FRAGMENT,
+  OVERLAY_FRAGMENT,
+  routeFromHash,
+  SETTINGS_FRAGMENT,
+} from "./route"
 
 /**
  * The fragment is the only thing that distinguishes one window from another,
@@ -40,5 +46,24 @@ describe("routeFromHash", () => {
     // it is an inherited object property rather than a known route.
     expect(routeFromHash("#/constructor")).toBe("popover")
     expect(routeFromHash("#/toString")).toBe("popover")
+  })
+})
+
+describe("applyRouteAttribute", () => {
+  it("publishes the route so CSS can branch on the window", () => {
+    const root = document.createElement("html")
+
+    applyRouteAttribute(root, "popover")
+
+    expect(root.getAttribute("data-route")).toBe("popover")
+  })
+
+  it("overwrites a stale value instead of appending", () => {
+    const root = document.createElement("html")
+
+    applyRouteAttribute(root, "popover")
+    applyRouteAttribute(root, "settings")
+
+    expect(root.getAttribute("data-route")).toBe("settings")
   })
 })

--- a/apps/desktop/src/lib/route.ts
+++ b/apps/desktop/src/lib/route.ts
@@ -40,6 +40,18 @@ export function routeFromHash(hash: string): Route {
   return ROUTES.get(hash.replace(/^#\/?/, "")) ?? "popover"
 }
 
+/**
+ * Publishes the route to `<html data-route>` so CSS can branch on the window.
+ * Call once, before the first render: a window keeps its route for its whole
+ * lifetime, so this attribute never has to change.
+ */
+export function applyRouteAttribute(
+  root: HTMLElement = document.documentElement,
+  route: Route = routeFromHash(window.location.hash),
+): void {
+  root.setAttribute("data-route", route)
+}
+
 function subscribe(onChange: () => void): () => void {
   window.addEventListener("hashchange", onChange)
   return () => window.removeEventListener("hashchange", onChange)

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -8,6 +8,7 @@ import { createRoot } from "react-dom/client"
 import { App } from "./App"
 import { installFocusModality } from "./lib/focusModality"
 import { applyPlatformAttribute } from "./lib/platform"
+import { applyRouteAttribute } from "./lib/route"
 import "./styles.css"
 
 const container = document.getElementById("root")
@@ -15,10 +16,12 @@ if (!container) {
   throw new Error("index.html is missing the #root mount point")
 }
 
-// Both write attributes the stylesheet keys off, so they run before the first
-// paint: `data-platform` guards the platform-specific control rules, and
-// `data-keyboard` gates the focus ring.
+// All three write attributes the stylesheet keys off, so they run before the
+// first paint: `data-platform` guards the platform-specific control rules,
+// `data-route` gives the popover window its corner, and `data-keyboard` gates
+// the focus ring.
 applyPlatformAttribute()
+applyRouteAttribute()
 installFocusModality()
 
 createRoot(container).render(

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -51,11 +51,45 @@ body,
  * opaque. Either way the shell paints the window surface here, over whatever
  * the window itself gives it.
  *
+ * The surface goes on `#root`, not on `body`. A background on `body` is
+ * propagated to the canvas while `html` is transparent, and the canvas fills
+ * the whole window and takes no corner. `#root` is an ordinary element, so it
+ * keeps its own geometry and the rule below can round it.
+ *
  * These read the raw palette variables rather than the `@theme` aliases:
  * Tailwind only emits an alias that a generated utility uses, and no utility
  * references these two.
  */
 body {
-  background-color: var(--color-bg-window);
   color: var(--color-text-primary);
+}
+
+#root {
+  background-color: var(--color-bg-window);
+}
+
+/*
+ * The macOS popover window is the exception: it carries the Popover material
+ * (src-tauri/src/popover.rs), and the material *is* its surface. It already
+ * gives the translucency this palette asks for, and macOS makes it solid on
+ * its own when the reader turns Reduce transparency on.
+ *
+ * So that window paints no surface of its own. A surface on top of the
+ * material is not opaque, so the window shadow shows through it at the edges
+ * and reads as a heavy border, which no system window has.
+ *
+ * The corner belongs here too. The material draws the window corner at
+ * `CORNER_RADIUS` in popover.rs — keep the two radii equal — and
+ * `overflow: hidden` stops a child painting square over it. Nothing scrolls
+ * at this level, and floating layers portal to `body`, outside `#root`, so
+ * they stay unclipped.
+ *
+ * `data-platform` guards both. popover.rs applies the material on macOS only,
+ * so on every other platform the popover is an ordinary opaque square window
+ * that still needs its surface painted and must not be rounded.
+ */
+:root[data-platform="macos"][data-route="popover"] #root {
+  background-color: transparent;
+  border-radius: var(--radius-popover);
+  overflow: hidden;
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -18,8 +18,8 @@
  *   hud                         floating usage HUD presentation
  *   motion                      reduced-motion clamp, last so it wins
  *
- * Other component-scoped stylesheets (text-roll.css) are imported by the
- * component that owns them, not from here.
+ * Other component-scoped stylesheets (text-roll.css, session-rows.css) are
+ * imported by the component that owns them, not from here.
  */
 
 @import "tailwindcss";

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -69,14 +69,17 @@ body {
 }
 
 /*
- * The macOS popover window is the exception: it carries the Popover material
- * (src-tauri/src/popover.rs), and the material *is* its surface. It already
- * gives the translucency this palette asks for, and macOS makes it solid on
- * its own when the reader turns Reduce transparency on.
+ * The macOS popover window is the exception. It carries the Popover material
+ * (src-tauri/src/popover.rs), and the material shows the desktop through it.
+ * A window surface does not belong on top of that: `bg-window` is a flat grey,
+ * and over the material it reads as a slab with a hard edge.
  *
- * So that window paints no surface of its own. A surface on top of the
- * material is not opaque, so the window shadow shows through it at the edges
- * and reads as a heavy border, which no system window has.
+ * `bg-primary` is the surface the palette gives a translucent window. It is
+ * white at 0.58 in light and near-black in dark, so it lifts the material
+ * toward the theme instead of covering it, and the desktop behind the window
+ * can no longer drag the contrast down. It is also the one surface token with
+ * a `prefers-reduced-transparency` value, which is what makes it solid for a
+ * reader who asks for that.
  *
  * The corner belongs here too. The material draws the window corner at
  * `CORNER_RADIUS` in popover.rs — keep the two radii equal — and
@@ -89,7 +92,7 @@ body {
  * that still needs its surface painted and must not be rounded.
  */
 :root[data-platform="macos"][data-route="popover"] #root {
-  background-color: transparent;
+  background-color: var(--color-bg-primary);
   border-radius: var(--radius-popover);
   overflow: hidden;
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -75,7 +75,7 @@ body {
  * and over the material it reads as a slab with a hard edge.
  *
  * `bg-primary` is the surface the palette gives a translucent window. It is
- * white at 0.58 in light and near-black in dark, so it lifts the material
+ * mostly white in light and near-black in dark, so it lifts the material
  * toward the theme instead of covering it, and the desktop behind the window
  * can no longer drag the contrast down. It is also the one surface token with
  * a `prefers-reduced-transparency` value, which is what makes it solid for a

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -46,8 +46,10 @@ body,
 
 /*
  * The foundation leaves the document transparent so a window can opt into
- * translucent material. Neither of this app's windows does yet, so the shell
- * paints the standard window surface itself.
+ * translucent material. The popover window does: it carries the Popover
+ * material, which also draws its corner. The nudge window does not and stays
+ * opaque. Either way the shell paints the window surface here, over whatever
+ * the window itself gives it.
  *
  * These read the raw palette variables rather than the `@theme` aliases:
  * Tailwind only emits an alias that a generated utility uses, and no utility

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -41,7 +41,14 @@
   --color-bg-hud-val: rgb(32 32 32);
 }
 
-body[data-transparent-window] {
+/*
+ * The HUD window shows the desktop behind it, so it paints no surface. The
+ * shell paints the window surface on `#root`, so this must clear both: `body`
+ * keeps the canvas transparent, and `#root` drops the surface the shell gives
+ * every other window.
+ */
+body[data-transparent-window],
+body[data-transparent-window] #root {
   background-color: transparent;
 }
 

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -25,7 +25,7 @@
   :root {
     --color-burn-val: rgb(255 106 0);
     --color-burn-muted-val: rgb(242 113 34);
-    --color-bg-hud-val: rgb(40 40 40);
+    --color-bg-hud-val: rgb(32 32 32);
   }
 }
 

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -117,15 +117,17 @@
   /* Text — explicit fallbacks, replaced by live system tokens when available */
   --color-text-primary: rgb(0 0 0 / 0.85);
   --color-text-secondary: rgb(60 60 67 / 0.85);
-  --color-text-tertiary: rgb(60 60 67 / 0.55);
+  --color-text-tertiary: rgb(60 60 67 / 0.75);
 
   /* Borders */
   --color-border: rgb(0 0 0 / 0.15);
 
-  /* Accent */
+  /* Accent. accent-val keeps the system blue, because it carries text and
+     icons on a surface. accent-fill and accent-hover are darker: they sit
+     behind white text, and the system blue gives it only 4.02:1. */
   --color-accent-val: rgb(0 122 255);
-  --color-accent-fill-val: rgb(0 122 255);
-  --color-accent-hover-val: rgb(0 122 255 / 0.85);
+  --color-accent-fill-val: rgb(0 113 227);
+  --color-accent-hover-val: rgb(0 98 199);
 
   /* Status — accessible variants, tuned for contrast on a light surface */
   --color-system-green-val: rgb(36 138 61);
@@ -186,13 +188,13 @@
   }
 }
 
-/* The system tertiary label is ~30% opacity in light mode, which reads as too
-   faint on a translucent surface. Bump it to ~50% so the hierarchy stays
-   (still below secondary's ~60%) but tertiary actually registers. Dark mode
-   keeps the system token, which already has appropriate contrast. */
+/* The system tertiary label is ~30% opacity in light mode, which gives small
+   text about 2.6:1. Bump it to 75%, the point where 11px text reaches the
+   WCAG AA ratio of 4.5:1 on a card, which is the lightest surface it sits on.
+   Secondary stays above it at 85%, so the hierarchy holds. */
 @media (prefers-color-scheme: light) {
   :root {
-    --color-text-tertiary: rgb(60 60 67 / 0.5);
+    --color-text-tertiary: rgb(60 60 67 / 0.75);
   }
 }
 
@@ -212,8 +214,8 @@
     --color-text-secondary: rgb(235 235 245 / 0.72);
     --color-border: rgb(255 255 255 / 0.18);
     --color-accent-val: rgb(10 132 255);
-    --color-accent-fill-val: rgb(10 132 255);
-    --color-accent-hover-val: rgb(10 132 255 / 0.85);
+    --color-accent-fill-val: rgb(10 110 235);
+    --color-accent-hover-val: rgb(10 96 205);
     --color-system-green-val: rgb(48 219 91);
     --color-system-orange-val: rgb(255 179 64);
     --color-system-orange-tint-val: rgb(255 159 10);
@@ -226,9 +228,10 @@
     --color-system-gold-val: rgb(255 204 0);
     --color-system-gold-text-val: rgb(245 203 92);
     --color-agent-mark-val: rgb(247 247 244);
-    /* The system tertiary label is ~25% opacity in dark mode; bump to ~35% so
-       it reads on a translucent surface (same rationale as light mode). */
-    --color-text-tertiary: rgb(235 235 245 / 0.35);
+    /* The system tertiary label is ~25% opacity in dark mode; bump to 55%,
+       where small text reaches 4.5:1 on a card (same rationale as light
+       mode). 50% is enough on the window, but not on the lighter card. */
+    --color-text-tertiary: rgb(235 235 245 / 0.55);
     /* The live label, separator, and accent tokens auto-adapt in dark mode —
        no overrides needed for those three. */
   }
@@ -256,11 +259,11 @@
   --color-bg-selected: rgb(0 0 0 / 0.09);
   --color-text-primary: rgb(0 0 0 / 0.85);
   --color-text-secondary: rgb(60 60 67 / 0.85);
-  --color-text-tertiary: rgb(60 60 67 / 0.5);
+  --color-text-tertiary: rgb(60 60 67 / 0.75);
   --color-border: rgb(0 0 0 / 0.15);
   --color-accent-val: rgb(0 122 255);
-  --color-accent-fill-val: rgb(0 122 255);
-  --color-accent-hover-val: rgb(0 122 255 / 0.85);
+  --color-accent-fill-val: rgb(0 113 227);
+  --color-accent-hover-val: rgb(0 98 199);
   --color-system-green-val: rgb(36 138 61);
   --color-system-orange-val: rgb(179 81 0);
   --color-system-orange-tint-val: rgb(255 149 0);
@@ -307,11 +310,11 @@
   --color-bg-selected: rgb(255 255 255 / 0.14);
   --color-text-primary: rgb(255 255 255 / 0.92);
   --color-text-secondary: rgb(235 235 245 / 0.72);
-  --color-text-tertiary: rgb(235 235 245 / 0.45);
+  --color-text-tertiary: rgb(235 235 245 / 0.55);
   --color-border: rgb(255 255 255 / 0.18);
   --color-accent-val: rgb(10 132 255);
-  --color-accent-fill-val: rgb(10 132 255);
-  --color-accent-hover-val: rgb(10 132 255 / 0.85);
+  --color-accent-fill-val: rgb(10 110 235);
+  --color-accent-hover-val: rgb(10 96 205);
   --color-system-green-val: rgb(48 219 91);
   --color-system-orange-val: rgb(255 179 64);
   --color-system-orange-tint-val: rgb(255 159 10);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -203,7 +203,10 @@
 /* --- Dark --- */
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg-primary: rgb(30 30 30 / 0.4);
+    /* Matches the explicit dark theme. At 0.40 the popover surface let a light
+       desktop behind the window through, and the secondary label fell to
+       1.93:1 on it. The surface has to set the tone, not the desktop. */
+    --color-bg-primary: rgb(30 30 30 / 0.92);
     --color-bg-secondary: rgb(255 255 255 / 0.12);
     --color-bg-tertiary: rgb(255 255 255 / 0.18);
     --color-bg-row-hover: rgb(255 255 255 / 0.07);
@@ -230,10 +233,11 @@
     --color-system-gold-val: rgb(255 204 0);
     --color-system-gold-text-val: rgb(245 203 92);
     --color-agent-mark-val: rgb(247 247 244);
-    /* The system tertiary label is ~25% opacity in dark mode; bump to 55%,
+    /* The system tertiary label is ~25% opacity in dark mode; bump to 62%,
        where small text reaches 4.5:1 on a card (same rationale as light
-       mode). 50% is enough on the window, but not on the lighter card. */
-    --color-text-tertiary: rgb(235 235 245 / 0.55);
+       mode). The hard case is again the popover: the surface is translucent,
+       so a light desktop behind the window lifts the card the text sits on. */
+    --color-text-tertiary: rgb(235 235 245 / 0.62);
     /* The live label, separator, and accent tokens auto-adapt in dark mode —
        no overrides needed for those three. */
   }
@@ -314,7 +318,7 @@
   --color-bg-selected: rgb(255 255 255 / 0.14);
   --color-text-primary: rgb(255 255 255 / 0.92);
   --color-text-secondary: rgb(235 235 245 / 0.72);
-  --color-text-tertiary: rgb(235 235 245 / 0.55);
+  --color-text-tertiary: rgb(235 235 245 / 0.62);
   --color-border: rgb(255 255 255 / 0.18);
   --color-accent-val: rgb(10 132 255);
   --color-accent-fill-val: rgb(10 110 235);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -97,7 +97,7 @@
   color-scheme: light dark;
 
   /* Backgrounds */
-  --color-bg-primary: rgb(255 255 255 / 0.58);
+  --color-bg-primary: rgb(255 255 255 / 0.85);
   --color-bg-secondary: rgb(0 0 0 / 0.08);
   --color-bg-tertiary: rgb(0 0 0 / 0.12);
   --color-bg-row-hover: rgb(0 0 0 / 0.04);
@@ -248,7 +248,7 @@
 
 /* --- Explicit theme override, for platforms with no live system tokens --- */
 :root[data-theme="light"] {
-  --color-bg-primary: rgb(255 255 255 / 0.58);
+  --color-bg-primary: rgb(255 255 255 / 0.85);
   --color-bg-secondary: rgb(0 0 0 / 0.08);
   --color-bg-tertiary: rgb(0 0 0 / 0.12);
   /* Matches the system branch. At 0.08 a hovered row sat one percent below

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -85,6 +85,11 @@
   --radius-control: 5px;
   --radius-popover: 10px;
   --radius-small: 4px;
+
+  /* A strong ease-out for a control that must feel like it settles rather than
+     stops. Tailwind registers `--ease-*`, so this becomes `ease-out-quart`.
+     Plain `ease-out` stays the default for everything else. */
+  --ease-out-quart: cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 /* --- Light (default) --- */
@@ -152,6 +157,15 @@
   /* Control geometry */
   --control-height-regular: 22px;
   --control-height-small: 17px;
+
+  /* Transition durations. Tailwind has no `--duration-*` theme namespace, so
+     these are plain vars and a call site consumes one as
+     duration-[var(--duration-fast)] — the same shape as the geometry vars.
+     Keeping them here is what stops 120ms from being retyped at each site.
+     Animation timings stay with the keyframes that own them in motion.css. */
+  --duration-quick: 100ms;
+  --duration-fast: 120ms;
+  --duration-slow: 300ms;
 
   /* Source-list / sidebar width for multi-pane windows. Geometry vars are not
      @theme-registered; consume as w-[var(--sidebar-width)]. Sized for the 36px

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -117,7 +117,7 @@
   /* Text — explicit fallbacks, replaced by live system tokens when available */
   --color-text-primary: rgb(0 0 0 / 0.85);
   --color-text-secondary: rgb(60 60 67 / 0.85);
-  --color-text-tertiary: rgb(60 60 67 / 0.75);
+  --color-text-tertiary: rgb(60 60 67 / 0.79);
 
   /* Borders */
   --color-border: rgb(0 0 0 / 0.15);
@@ -189,12 +189,14 @@
 }
 
 /* The system tertiary label is ~30% opacity in light mode, which gives small
-   text about 2.6:1. Bump it to 75%, the point where 11px text reaches the
-   WCAG AA ratio of 4.5:1 on a card, which is the lightest surface it sits on.
-   Secondary stays above it at 85%, so the hierarchy holds. */
+   text about 2.6:1. Bump it to 79%, the point where 11px text reaches the
+   WCAG AA ratio of 4.5:1 on a card on the popover. That is the hardest case:
+   the popover surface is translucent, so a dark desktop behind the window
+   darkens the card the text sits on. Secondary stays above it at 85%, so the
+   hierarchy holds. */
 @media (prefers-color-scheme: light) {
   :root {
-    --color-text-tertiary: rgb(60 60 67 / 0.75);
+    --color-text-tertiary: rgb(60 60 67 / 0.79);
   }
 }
 
@@ -261,7 +263,7 @@
   --color-bg-selected: rgb(0 0 0 / 0.09);
   --color-text-primary: rgb(0 0 0 / 0.85);
   --color-text-secondary: rgb(60 60 67 / 0.85);
-  --color-text-tertiary: rgb(60 60 67 / 0.75);
+  --color-text-tertiary: rgb(60 60 67 / 0.79);
   --color-border: rgb(0 0 0 / 0.15);
   --color-accent-val: rgb(0 122 255);
   --color-accent-fill-val: rgb(0 113 227);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -251,7 +251,9 @@
   --color-bg-primary: rgb(255 255 255 / 0.58);
   --color-bg-secondary: rgb(0 0 0 / 0.08);
   --color-bg-tertiary: rgb(0 0 0 / 0.12);
-  --color-bg-row-hover: rgb(0 0 0 / 0.08);
+  /* Matches the system branch. At 0.08 a hovered row sat one percent below
+     bg-selected at 0.09, so the two states looked the same. */
+  --color-bg-row-hover: rgb(0 0 0 / 0.04);
   --color-bg-card: rgb(0 0 0 / 0.04);
   --color-bg-input: rgb(255 255 255);
   --color-bg-window: rgb(246 246 246);

--- a/apps/desktop/src/views/NudgeView.tsx
+++ b/apps/desktop/src/views/NudgeView.tsx
@@ -167,7 +167,7 @@ export function NudgeView() {
                 key={action.id}
                 onClick={() => session.handleAction(action)}
                 className={cn(
-                  "type-body flex-1 py-2.5 text-center transition-colors outline-none hover:bg-surface-hover focus-visible:outline-none",
+                  "type-body flex-1 py-2.5 text-center transition-colors duration-[var(--duration-fast)] ease-out outline-none hover:bg-surface-hover focus-visible:outline-none",
                   i > 0 && "border-l border-separator",
                   action.primary ? "font-medium text-accent" : "text-label",
                 )}

--- a/apps/desktop/src/views/OverlayWindow.tsx
+++ b/apps/desktop/src/views/OverlayWindow.tsx
@@ -57,7 +57,7 @@ export function OverlayWindow() {
             type="button"
             aria-label="Open antiburn settings"
             onClick={() => session.openSettings()}
-            className="font-bitcount text-[11px] text-label-tertiary lowercase hover:text-label-secondary transition-colors"
+            className="font-bitcount text-[11px] text-label-tertiary lowercase hover:text-label-secondary transition-colors duration-[var(--duration-fast)] ease-out"
           >
             antiburn
           </button>
@@ -65,7 +65,7 @@ export function OverlayWindow() {
             type="button"
             aria-label="Close overlay"
             onClick={() => session.close()}
-            className="p-1 -m-1 rounded-md text-label-tertiary hover:text-label-secondary hover:bg-surface-tertiary transition-colors"
+            className="p-1 -m-1 rounded-md text-label-tertiary hover:text-label-secondary hover:bg-surface-tertiary transition-colors duration-[var(--duration-fast)] ease-out"
           >
             <X size={13} />
           </button>

--- a/apps/desktop/src/views/SettingsView.tsx
+++ b/apps/desktop/src/views/SettingsView.tsx
@@ -127,7 +127,7 @@ export function SettingsView() {
           <button
             type="button"
             onClick={() => void quitApp()}
-            className="type-body flex h-9 w-full items-center gap-3 rounded-control px-3 text-label transition-colors duration-[120ms] ease-out hover:bg-surface-hover"
+            className="type-body flex h-9 w-full items-center gap-3 rounded-control px-3 text-label transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover"
           >
             <LogOut size={16} strokeWidth={2} className="shrink-0" aria-hidden="true" />
             <span className="truncate">Quit antiburn</span>

--- a/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
+++ b/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
@@ -132,7 +132,7 @@ function StepDots({ step }: { step: Step }) {
         <span
           key={name}
           className={cn(
-            "h-1.5 w-1.5 rounded-full transition-colors",
+            "h-1.5 w-1.5 rounded-full transition-colors duration-[var(--duration-fast)] ease-out",
             position === index ? "bg-label-secondary" : "bg-label/20",
           )}
         />

--- a/apps/desktop/src/views/settings/AboutDocumentView.tsx
+++ b/apps/desktop/src/views/settings/AboutDocumentView.tsx
@@ -87,7 +87,7 @@ export function AboutDocumentView({ id, onBack }: { id: AboutDocumentId; onBack:
             type="button"
             onClick={onBack}
             aria-label="Back to About"
-            className="-ml-1 inline-flex h-7 shrink-0 items-center rounded-control px-1 text-label-secondary transition-colors duration-[120ms] ease-out hover:bg-surface-hover hover:text-label"
+            className="-ml-1 inline-flex h-7 shrink-0 items-center rounded-control px-1 text-label-secondary transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover hover:text-label"
           >
             <ChevronLeft size={18} strokeWidth={2} aria-hidden="true" className="shrink-0" />
           </button>

--- a/apps/desktop/src/views/settings/NotificationsPane.tsx
+++ b/apps/desktop/src/views/settings/NotificationsPane.tsx
@@ -93,7 +93,7 @@ function MilestonePills({
           disabled={disabled}
           onClick={() => onChange({ ...value, [key]: !value[key] })}
           className={cn(
-            "type-footnote h-6 rounded-control px-2 tabular-nums transition-colors duration-[120ms] ease-out",
+            "type-footnote h-6 rounded-control px-2 tabular-nums transition-colors duration-[var(--duration-fast)] ease-out",
             value[key]
               ? "bg-accent-fill text-white"
               : "text-label-secondary hover:bg-surface-hover",

--- a/crates/antiburn-local/src/discovery/agents/antigravity_subagents.rs
+++ b/crates/antiburn-local/src/discovery/agents/antigravity_subagents.rs
@@ -148,6 +148,13 @@ pub async fn save_spawn_edges(path: &Path, edges: &SpawnEdges) -> anyhow::Result
         match opts.open(&tmp).await {
             Ok(mut file) => {
                 tokio::io::AsyncWriteExt::write_all(&mut file, &data).await?;
+                // A tokio File buffers the write and finishes it on the
+                // blocking pool. A drop does not wait for that work, so the
+                // rename below can move an empty file into place. Flush the
+                // buffer, then sync, so the data is on disk before the file
+                // becomes visible under its real name.
+                tokio::io::AsyncWriteExt::flush(&mut file).await?;
+                file.sync_all().await?;
                 drop(file);
                 tokio::fs::rename(&tmp, &path).await?;
                 return Ok(());

--- a/docs/oss/source-allowlist.toml
+++ b/docs/oss/source-allowlist.toml
@@ -21,7 +21,7 @@ source_commit = "54c4a3bceda80558760a9ff6fc8bf7d04873b43f"
 # later authorized platform migration makes it canonical, version this manifest at the next source
 # review to record its exact reviewed commit while retaining Cadence provenance.
 intended_future_private_repository = "antiburn/antiburn-cloud"
-governance_decisions = ["D-001", "D-002", "D-003", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-014", "D-020", "D-021", "D-022", "D-023", "D-024", "D-026", "D-028"]
+governance_decisions = ["D-001", "D-002", "D-003", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-014", "D-020", "D-021", "D-022", "D-023", "D-024", "D-026", "D-028", "D-029"]
 default_action = "deny"
 publication_authorization = "authorized MPL-2.0 repository commit or merge; unresolved rights remain denied"
 third_party_resolution = "deferred until the public local-crate manifest and lockfile exist"
@@ -963,4 +963,20 @@ notes = [
   "Add the information-architecture, state-taxonomy, and copy guidance the token contract deliberately omits; these are authored for the public surfaces, not extracted.",
   "Remove Cadence, Radar, Tune-up, account, publication, telemetry, private routes, private fonts, and private component names.",
   "Do not port the private web component inventory, chart wrappers, or the design-system gallery route.",
+]
+
+[[rule]]
+id = "popover-window-corner"
+source_paths = ["desktop/src-tauri/src/platform_window.rs"]
+path_kind = "file"
+disposition = "adapt"
+destination = "apps/desktop/src-tauri/src/popover.rs"
+provenance = "Cadence company-authored macOS popover window setup; D-029 maintainer decision authorizes the adapted port"
+current_license = "Proprietary"
+intended_license = "MPL-2.0"
+notes = [
+  "Extract the window treatment only: on macOS build the popover with a rounded popover material, and keep an opaque borderless window on every other platform.",
+  "Take the corner radius from the public contract's rounded.popover token, not from the private source; the two agree at 10px today.",
+  "Do not port the private window's position, size, state, or close behaviour; the public popover already owns those.",
+  "Declare the macos-private-api feature in the public manifest. The build already resolves it through tauri-nspanel, but the popover must not depend on another crate's feature by accident.",
 ]

--- a/docs/oss/source-allowlist.toml
+++ b/docs/oss/source-allowlist.toml
@@ -21,7 +21,7 @@ source_commit = "54c4a3bceda80558760a9ff6fc8bf7d04873b43f"
 # later authorized platform migration makes it canonical, version this manifest at the next source
 # review to record its exact reviewed commit while retaining Cadence provenance.
 intended_future_private_repository = "antiburn/antiburn-cloud"
-governance_decisions = ["D-001", "D-002", "D-003", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-014", "D-020", "D-021", "D-022", "D-023", "D-024", "D-026"]
+governance_decisions = ["D-001", "D-002", "D-003", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-014", "D-020", "D-021", "D-022", "D-023", "D-024", "D-026", "D-028"]
 default_action = "deny"
 publication_authorization = "authorized MPL-2.0 repository commit or merge; unresolved rights remain denied"
 third_party_resolution = "deferred until the public local-crate manifest and lockfile exist"
@@ -928,4 +928,39 @@ notes = [
   "Register the HUD on macOS only for v1. Keep the native platform gate in the antiburn-hud crate.",
   "Write tests in the public repository under Git and DCO provenance.",
   "Remove Cadence names from product source. Add MPL-2.0 headers.",
+]
+
+[[rule]]
+id = "design-drift-check"
+source_paths = ["scripts/check-design-system-drift.mjs"]
+path_kind = "file"
+disposition = "adapt"
+destination = "scripts/check-design-drift.mjs"
+provenance = "Cadence company-authored CI drift guard; D-028 maintainer decision authorizes the adapted port; reviewed at private commit 508b7e1a98a61a46f251bc587f746978a1650d2b"
+current_license = "Proprietary"
+intended_license = "MPL-2.0"
+notes = [
+  "Extract the checking method only: derive the token-to-variable mapping from the @theme blocks at run time, parse the contract's own YAML front matter, accumulate failures, and exit non-zero.",
+  "Adapt every extractor to the public shapes: one consolidated contract whose colors carry a light and a dark value, the .type-* scale, the ui-* control selectors, and the explicit [data-theme] palettes.",
+  "Read the stylesheet set from the contract's own sources list and verify that list against the tree; the source hard-codes its file paths.",
+  "Add the line-height, geometry, and source-completeness checks, which the source does not make.",
+  "Do not copy the private monorepo change-classifier gating; the public classifier already routes this job.",
+  "Strip Cadence names; add MPL-2.0 headers and public unit tests.",
+]
+
+[[rule]]
+id = "design-review-skill"
+source_paths = ["web/.agents/skills/design-review/**"]
+path_kind = "directory"
+disposition = "adapt"
+destination = ".agents/skills/design-review/"
+provenance = "Cadence company-authored design-review rulebook; D-028 maintainer decision authorizes the adapted port"
+current_license = "Proprietary"
+intended_license = "MPL-2.0"
+notes = [
+  "Extract the review method only: load the rulebook, capture the running surface, grade against numbered dimensions, and rank findings on the Blocker/High/Medium/Nitpick ladder with the accessibility ratchet.",
+  "Rewrite the rulebook for the desktop app: per-window and per-surface passes replace the responsive-width passes, and every rule cites a public token or primitive.",
+  "Add the information-architecture, state-taxonomy, and copy guidance the token contract deliberately omits; these are authored for the public surfaces, not extracted.",
+  "Remove Cadence, Radar, Tune-up, account, publication, telemetry, private routes, private fonts, and private component names.",
+  "Do not port the private web component inventory, chart wrappers, or the design-system gallery route.",
 ]

--- a/docs/oss/source-denylist.toml
+++ b/docs/oss/source-denylist.toml
@@ -23,7 +23,7 @@ source_commit = "54c4a3bceda80558760a9ff6fc8bf7d04873b43f"
 # later authorized platform migration makes it canonical, version this manifest at the next source
 # review to record its exact reviewed commit while retaining Cadence provenance.
 intended_future_private_repository = "antiburn/antiburn-cloud"
-governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-015", "D-016", "D-017", "D-018", "D-019", "D-020", "D-021", "D-022", "D-023", "D-024", "D-025", "D-026", "D-027"]
+governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-015", "D-016", "D-017", "D-018", "D-019", "D-020", "D-021", "D-022", "D-023", "D-024", "D-025", "D-026", "D-027", "D-028"]
 # D-025 (maintainer decision, 2026-08-18; definition of "local" in docs/deviations.md D-27):
 # fixes the boundary this manifest draws around what the installed app may DO.
 # antiburn is local in that it needs no service of antiburn's; as the reader's
@@ -66,6 +66,26 @@ governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D
 # has no account to stitch to, and a stable identifier would defeat the
 # rotation D-28 relies on. The device-telemetry snapshot is a separate
 # private system and is not ported, permitted, or planned.
+# D-028 (maintainer decision, 2026-08-21): authorizes the adapt ports named by
+# allowlist rules design-drift-check and design-review-skill — the CI guard that
+# keeps apps/desktop/design.md equal to the stylesheets it names, and the
+# design-review rulebook that carries the interface guidance the token contract
+# deliberately leaves out.
+# The design contract itself came across earlier under desktop-design-contract,
+# but its enforcement did not, so the contract was prose that could rot in
+# silence — and had already started to: its source list had lost a stylesheet.
+# That is the gap this decision closes.
+# Neither port adds a runtime surface. The guard reads files already published
+# in this tree, runs in CI, and writes nothing; the rulebook is documentation
+# that reviews the app a reader already builds. No new source leaves the private
+# repository beyond the checking method itself, and both ports are rewritten
+# against the public token names.
+# The private script name and repository appear only in these manifests, which
+# the concept scan exempts, so the public tree names neither.
+# The rulebook's information-architecture, state, and copy sections are authored
+# for the public surfaces rather than extracted; they carry ordinary Git/DCO
+# provenance, the same footing as the store-backed ConsentGrants implementation
+# under D-024.
 # D-023 (maintainer decision): authorizes the adapt ports named by allowlist rules
 # startup-registration, disk-space-monitor, tray-title-attributed-string,
 # notification-sound-crate, nudge-window-mechanics, and usage-milestone-engine.

--- a/docs/oss/source-denylist.toml
+++ b/docs/oss/source-denylist.toml
@@ -23,7 +23,7 @@ source_commit = "54c4a3bceda80558760a9ff6fc8bf7d04873b43f"
 # later authorized platform migration makes it canonical, version this manifest at the next source
 # review to record its exact reviewed commit while retaining Cadence provenance.
 intended_future_private_repository = "antiburn/antiburn-cloud"
-governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-015", "D-016", "D-017", "D-018", "D-019", "D-020", "D-021", "D-022", "D-023", "D-024", "D-025", "D-026", "D-027", "D-028"]
+governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-015", "D-016", "D-017", "D-018", "D-019", "D-020", "D-021", "D-022", "D-023", "D-024", "D-025", "D-026", "D-027", "D-028", "D-029"]
 # D-025 (maintainer decision, 2026-08-18; definition of "local" in docs/deviations.md D-27):
 # fixes the boundary this manifest draws around what the installed app may DO.
 # antiburn is local in that it needs no service of antiburn's; as the reader's
@@ -86,6 +86,24 @@ governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D
 # for the public surfaces rather than extracted; they carry ordinary Git/DCO
 # provenance, the same footing as the store-backed ConsentGrants implementation
 # under D-024.
+# D-029 (maintainer decision, 2026-08-21): authorizes the adapt port named by
+# allowlist rule popover-window-corner — the macOS window treatment that gives
+# the popover a rounded corner instead of a square one.
+# The popover is a menu-bar surface, and it renders today as a square rectangle
+# because the window is opaque and carries no material. The stylesheets already
+# expect the opposite: the palette is built from translucent backgrounds, the
+# base rule paints html, body, and #root transparent for "a window that opts
+# into translucent material", and there is a whole reduced-transparency branch
+# that only means something once a material exists. This decision closes that
+# gap between the stylesheets and the window.
+# The radius is not private information. It comes from rounded.popover in
+# apps/desktop/design.md, which is already published; the private source happens
+# to use the same number.
+# The port adds no data flow. It changes how one window is built, and every
+# other platform keeps the opaque borderless window it has today.
+# The macos-private-api feature this needs is already in the build, resolved
+# through tauri-nspanel. The manifest now asks for it directly so the popover
+# does not depend on another crate's feature by accident.
 # D-023 (maintainer decision): authorizes the adapt ports named by allowlist rules
 # startup-registration, disk-space-monitor, tray-title-attributed-string,
 # notification-sound-crate, nudge-window-mechanics, and usage-milestone-engine.

--- a/scripts/check-design-drift.mjs
+++ b/scripts/check-design-drift.mjs
@@ -52,6 +52,15 @@ const GENERIC_FONT_FAMILIES = new Set([
 
 const norm = (s) => s.replace(/\s+/g, ' ').trim();
 
+// Compare colors by number, not by text: the contract writes an alpha as
+// `0.40` where the CSS writes `0.4`, and both mean the same channel.
+const normColor = (s) => norm(s).replace(/\d*\.?\d+/g, (n) => String(parseFloat(n)));
+
+// A comment can hold a selector this file scans for. `tokens.css` names
+// `:root[data-theme="dark"]` in prose, next to the rule it explains. Strip
+// comments so a sentence about a rule is never read as the rule.
+const stripComments = (css) => css.replace(/\/\*[\s\S]*?\*\//g, ' ');
+
 // --- file access ------------------------------------------------------------
 
 /** Read the desktop app from disk. Tests pass an in-memory object instead. */
@@ -117,6 +126,33 @@ function docColors(fm) {
   return out;
 }
 
+/**
+ * The `# @media <theme>: <value>` note a color may carry.
+ *
+ * A reader who leaves the app on "System" gets the system-preference branch,
+ * not the `[data-theme]` one. Where the two differ, the contract states the
+ * system value in this note. Anything the note does not name must agree.
+ */
+function docColorMedia(fm) {
+  const out = {};
+  let current = null;
+  for (const line of section(fm, 'colors').split('\n')) {
+    const name = /^ {2}([a-z0-9-]+):/.exec(line);
+    if (name) {
+      current = name[1];
+      out[current] = {};
+      continue;
+    }
+    const note = /^ {4}(light|dark):.*#\s*@media\s+(light|dark):\s*(.+?)\s*$/.exec(line);
+    if (note && current) {
+      // The note sits on the value it qualifies; a note for the other theme is
+      // a copy-paste slip, so keep both keys and let the check compare them.
+      out[current][note[1]] = { theme: note[2], value: note[3] };
+    }
+  }
+  return out;
+}
+
 function docTypography(fm) {
   const out = {};
   for (const m of section(fm, 'typography').matchAll(/^\s+([a-z0-9-]+):\s*\{(.+)\}/gm)) {
@@ -176,6 +212,73 @@ function themeVars(css, theme) {
     }
   }
   return out;
+}
+
+/**
+ * The palette a reader gets while the app follows the system.
+ *
+ * Light is the bare `:root`. Dark is the bare `:root` with the
+ * `prefers-color-scheme: dark` block on top, which states only what it
+ * changes. The reduced-transparency blocks are a separate axis and stay out.
+ *
+ * A live system token has no static value, so it is skipped here exactly as
+ * it is in [`themeVars`]. That is what keeps the four `-apple-system-*` tokens
+ * out of the comparison: they are the point of following the system.
+ */
+function systemVars(css, theme) {
+  const out = {};
+  const add = (blocks) => {
+    for (const block of blocks) {
+      for (const v of block.matchAll(/--color-([\w-]+):\s*([^;]+);/g)) {
+        if (v[2].trim().startsWith('-apple-system')) continue;
+        out[v[1]] = v[2].trim();
+      }
+    }
+  };
+  add(bareRootBodies(css));
+  if (theme === 'dark') {
+    for (const body of preferenceBlocks(css, 'dark')) add(bareRootBodies(body));
+  }
+  return out;
+}
+
+/**
+ * Bodies of every top-level rule whose selector list holds a bare `:root`.
+ *
+ * `:root, :root[data-theme="light"]` counts: the bare half applies while the
+ * app follows the system. `:root[data-theme="light"]` alone does not, so the
+ * character after the selector has to be one that ends it.
+ */
+function bareRootBodies(css) {
+  const bodies = [];
+  let depth = 0;
+  for (let index = 0; index < css.length; index += 1) {
+    if (depth === 0 && css.startsWith(':root', index) && /^[\s,{]$/.test(css[index + 5] ?? '')) {
+      const open = css.indexOf('{', index + 5);
+      if (open === -1) break;
+      const close = matchingBrace(css, open);
+      bodies.push(css.slice(open + 1, close));
+      index = close;
+      continue;
+    }
+    const ch = css[index];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth = Math.max(0, depth - 1);
+  }
+  return bodies;
+}
+
+/** Bodies of the top-level `prefers-color-scheme` blocks for one theme. */
+function preferenceBlocks(css, theme) {
+  const bodies = [];
+  const pattern = new RegExp(`@media[^{]*prefers-color-scheme:\\s*${theme}[^{]*\\{`, 'g');
+  for (const m of css.matchAll(pattern)) {
+    // The reduced-transparency overrides answer a different setting.
+    if (m[0].includes('reduced-transparency')) continue;
+    const open = m.index + m[0].length - 1;
+    bodies.push(css.slice(open + 1, matchingBrace(css, open)));
+  }
+  return bodies;
 }
 
 /** Bodies of every rule that names the selector at the top level of the file. */
@@ -258,10 +361,12 @@ export function checkDesignDrift(io = fileSystemIo()) {
     if (!io.exists(file)) fail(`sources names \`${file}\`, which does not exist`);
   }
 
-  const cssAll = sources
-    .filter((file) => io.exists(file))
-    .map((file) => io.read(file))
-    .join('\n');
+  const cssAll = stripComments(
+    sources
+      .filter((file) => io.exists(file))
+      .map((file) => io.read(file))
+      .join('\n'),
+  );
 
   // Colors: coverage first, then the value in each theme.
   const map = themeMap(cssAll);
@@ -289,6 +394,50 @@ export function checkDesignDrift(io = fileSystemIo()) {
       }
       if (norm(documented) !== norm(actual)) {
         fail(`color \`${name}\` ${theme} = ${documented}, expected ${actual} (--color-${ref})`);
+      }
+    }
+  }
+
+  // The system-preference palette against the explicit one.
+  //
+  // The contract states the `[data-theme]` values, which a reader gets only
+  // after forcing a theme. On "System" the bare `:root` and the
+  // `prefers-color-scheme` block apply instead. The two are one palette
+  // written twice, so every token must agree unless the contract states the
+  // system value in a `# @media <theme>: <value>` note.
+  const media = docColorMedia(fm);
+  for (const theme of ['light', 'dark']) {
+    const explicit = themeVars(cssAll, theme);
+    const system = systemVars(cssAll, theme);
+    for (const [name, values] of Object.entries(colors)) {
+      const ref = map[name];
+      if (!ref || values[theme] === undefined) continue;
+      const note = media[name]?.[theme];
+      const forced = explicit[ref];
+      const followed = system[ref];
+      // A missing explicit value is already reported by the check above.
+      if (forced === undefined) continue;
+      if (followed === undefined) {
+        fail(`color \`${name}\`: --color-${ref} is unset in the ${theme} system palette`);
+        continue;
+      }
+      if (normColor(forced) === normColor(followed)) {
+        if (note) fail(`color \`${name}\` ${theme}: the @media note repeats the value; drop it`);
+        continue;
+      }
+      if (!note) {
+        fail(
+          `color \`${name}\` ${theme} = ${forced}, but the system palette sets ` +
+            `${followed}; state it as a \`# @media ${theme}: ${followed}\` note`,
+        );
+        continue;
+      }
+      if (note.theme !== theme) {
+        fail(`color \`${name}\` ${theme}: the note names @media ${note.theme}`);
+        continue;
+      }
+      if (normColor(note.value) !== normColor(followed)) {
+        fail(`color \`${name}\` @media ${theme} note = ${note.value}, expected ${followed}`);
       }
     }
   }

--- a/scripts/check-design-drift.mjs
+++ b/scripts/check-design-drift.mjs
@@ -351,15 +351,18 @@ export function checkDesignDrift(io = fileSystemIo()) {
     }
   }
 
-  // Geometry vars listed under `sizes`.
-  for (const [key, value] of Object.entries(docPairs(fm, 'sizes'))) {
-    if (!key.startsWith('--')) continue;
-    const css = new RegExp(`${key}:\\s*([^;]+);`).exec(cssAll)?.[1];
-    if (css === undefined) {
-      fail(`sizes ${key}: not found in the CSS`);
-      continue;
+  // Custom properties documented under `sizes` and `motion`. A group may also
+  // hold prose recipes, which carry no var name and so have nothing to compare.
+  for (const group of ['sizes', 'motion']) {
+    for (const [key, value] of Object.entries(docPairs(fm, group))) {
+      if (!key.startsWith('--')) continue;
+      const css = new RegExp(`${key}:\\s*([^;]+);`).exec(cssAll)?.[1];
+      if (css === undefined) {
+        fail(`${group} ${key}: not found in the CSS`);
+        continue;
+      }
+      if (norm(value) !== norm(css)) fail(`${group} ${key} = ${value}, expected ${norm(css)}`);
     }
-    if (norm(value) !== norm(css)) fail(`sizes ${key} = ${value}, expected ${norm(css)}`);
   }
 
   // Shadows against the selectors that carry them.

--- a/scripts/check-design-drift.mjs
+++ b/scripts/check-design-drift.mjs
@@ -217,9 +217,10 @@ function themeVars(css, theme) {
 /**
  * The palette a reader gets while the app follows the system.
  *
- * Light is the bare `:root`. Dark is the bare `:root` with the
- * `prefers-color-scheme: dark` block on top, which states only what it
- * changes. The reduced-transparency blocks are a separate axis and stay out.
+ * The bare `:root` holds the whole palette, and a `prefers-color-scheme`
+ * block states only what that theme changes. Both themes have one: light
+ * restates the tertiary label the `@supports` block just made live. The
+ * reduced-transparency blocks are a separate axis and stay out.
  *
  * A live system token has no static value, so it is skipped here exactly as
  * it is in [`themeVars`]. That is what keeps the four `-apple-system-*` tokens
@@ -236,9 +237,7 @@ function systemVars(css, theme) {
     }
   };
   add(bareRootBodies(css));
-  if (theme === 'dark') {
-    for (const body of preferenceBlocks(css, 'dark')) add(bareRootBodies(body));
-  }
+  for (const body of preferenceBlocks(css, theme)) add(bareRootBodies(body));
   return out;
 }
 

--- a/scripts/check-design-drift.mjs
+++ b/scripts/check-design-drift.mjs
@@ -34,6 +34,11 @@ const CONTRACT = 'design.md';
 // It declares no tokens, so the contract does not list it as a source.
 const ENTRY_STYLESHEET = 'src/styles.css';
 
+// The window that draws its own corner from `rounded.popover`. The value is a
+// Rust constant there, because the corner comes from the window material and
+// not from a stylesheet.
+const WINDOW_CORNER_SOURCE = 'src-tauri/src/popover.rs';
+
 // Each shadow token names one selector that must carry that exact box-shadow.
 const SHADOW_SELECTORS = {
   popover: 'ui-menu',
@@ -503,6 +508,25 @@ export function checkDesignDrift(io = fileSystemIo()) {
     }
     if (parseInt(rounded[key], 10) !== parseInt(css, 10)) {
       fail(`rounded.${key} ${rounded[key]} != --radius-${key} ${css}px`);
+    }
+  }
+
+  // The macOS popover corner. The window material draws it, so the radius is
+  // a Rust constant as well as a token, and the two must agree — a window
+  // corner that differs from the surface corner inside it is visible. Rust is
+  // the one place a token value is copied rather than referenced, so it is the
+  // one place this check has to leave the stylesheets.
+  if (!io.exists(WINDOW_CORNER_SOURCE)) {
+    fail(`rounded.popover: ${WINDOW_CORNER_SOURCE} not found`);
+  } else {
+    const rust = /const\s+CORNER_RADIUS:\s*f64\s*=\s*([\d.]+)\s*;/.exec(io.read(WINDOW_CORNER_SOURCE));
+    if (!rust) {
+      fail(`rounded.popover: ${WINDOW_CORNER_SOURCE} declares no CORNER_RADIUS`);
+    } else if (parseFloat(rust[1]) !== parseFloat(rounded.popover)) {
+      fail(
+        `rounded.popover ${rounded.popover} != CORNER_RADIUS ${rust[1]} ` +
+          `in ${WINDOW_CORNER_SOURCE}`,
+      );
     }
   }
 

--- a/scripts/check-design-drift.mjs
+++ b/scripts/check-design-drift.mjs
@@ -295,6 +295,13 @@ export function checkDesignDrift(io = fileSystemIo()) {
 
   // Typography: the `.type-*` classes set size, weight, and tracking. The
   // line-height comes from the base element rules, so compare it to those.
+  // A step that sets its own line-height breaks that one-value assumption, and
+  // the contract could no longer state the leading once. Report it instead.
+  for (const m of cssAll.matchAll(/\.type-([\w-]+)\s*\{([\s\S]*?)\}/g)) {
+    if (/line-height:/.test(m[2])) {
+      fail(`typography \`${m[1]}\`: .type-${m[1]} sets its own line-height`);
+    }
+  }
   const baseLeading = /line-height:\s*([\d.]+)\s*;/.exec(cssAll)?.[1];
   for (const [name, t] of Object.entries(docTypography(fm))) {
     if (t.missing.length) {
@@ -365,8 +372,12 @@ export function checkDesignDrift(io = fileSystemIo()) {
     }
   }
 
-  // Shadows against the selectors that carry them.
+  // Shadows against the selectors that carry them. Every documented shadow
+  // needs a selector, or it is a value nothing compares.
   const shadow = docPairs(fm, 'shadow');
+  for (const key of Object.keys(shadow)) {
+    if (!(key in SHADOW_SELECTORS)) fail(`shadow.${key} has no selector to check it against`);
+  }
   for (const [key, selector] of Object.entries(SHADOW_SELECTORS)) {
     const css = cssBoxShadow(cssAll, selector);
     if (css.error) {

--- a/scripts/check-design-drift.mjs
+++ b/scripts/check-design-drift.mjs
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Design-contract drift guard (dependency-free; no install required).
+//
+// `apps/desktop/design.md` is the design contract an agent reads before it
+// does UI work. Its YAML front matter is a token reference, and the
+// stylesheets it names are the source of truth. This script keeps the two
+// equal. Without it the contract is prose that can rot in silence.
+//
+// The token -> CSS-var mapping comes from the `@theme` blocks at run time, so
+// this check has no hand-maintained color table to drift. It also reads the
+// stylesheet set from the contract's own `sources:` list, and fails when that
+// list and the tree disagree.
+//
+// The check is direction-agnostic. It shows that a value differs. It does not
+// say which side is correct.
+//
+// Run locally: `node scripts/check-design-drift.mjs`
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const APP_ROOT = resolve(REPO_ROOT, 'apps/desktop');
+
+/** The design contract, relative to the desktop app. */
+const CONTRACT = 'design.md';
+
+// The entry stylesheet only imports the others and holds the app shell rules.
+// It declares no tokens, so the contract does not list it as a source.
+const ENTRY_STYLESHEET = 'src/styles.css';
+
+// Each shadow token names one selector that must carry that exact box-shadow.
+const SHADOW_SELECTORS = {
+  popover: 'ui-menu',
+  tooltip: 'ui-tooltip',
+  raised: 'ui-switch-thumb',
+};
+
+// CSS generic font families share the `ui-` prefix with the control classes.
+// They belong to a font stack, so the class scan must pass over them.
+const GENERIC_FONT_FAMILIES = new Set([
+  'ui-monospace',
+  'ui-sans-serif',
+  'ui-serif',
+  'ui-rounded',
+]);
+
+const norm = (s) => s.replace(/\s+/g, ' ').trim();
+
+// --- file access ------------------------------------------------------------
+
+/** Read the desktop app from disk. Tests pass an in-memory object instead. */
+export function fileSystemIo(root = APP_ROOT) {
+  return {
+    read: (rel) => readFileSync(resolve(root, rel), 'utf8'),
+    exists: (rel) => existsSync(resolve(root, rel)),
+    listStylesheets: () => listCss(resolve(root, 'src'), root),
+  };
+}
+
+function listCss(dir, root, found = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    const stats = statSync(full, { throwIfNoEntry: false });
+    if (!stats) continue;
+    if (stats.isDirectory()) listCss(full, root, found);
+    else if (entry.endsWith('.css')) found.push(relative(root, full).split(sep).join('/'));
+  }
+  return found;
+}
+
+// --- front-matter parsing ---------------------------------------------------
+
+function frontMatter(text) {
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) throw new Error(`${CONTRACT}: no YAML front matter`);
+  return m[1];
+}
+
+/** Body of a top-level front-matter section. Top-level keys sit at column 0. */
+function section(fm, name) {
+  const lines = fm.split('\n');
+  const start = lines.findIndex((l) => l.startsWith(`${name}:`));
+  if (start === -1) return '';
+  const out = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^[A-Za-z]/.test(lines[i])) break;
+    out.push(lines[i]);
+  }
+  return out.join('\n');
+}
+
+function docSources(fm) {
+  return [...section(fm, 'sources').matchAll(/^\s+-\s+(\S+)/gm)].map((m) => m[1]);
+}
+
+/** Colors nest one level: a name, then a `light` and a `dark` value. */
+function docColors(fm) {
+  const out = {};
+  let current = null;
+  for (const line of section(fm, 'colors').split('\n')) {
+    if (/^\s*#/.test(line)) continue;
+    const name = /^ {2}([a-z0-9-]+):\s*(?:#.*)?$/.exec(line);
+    if (name) {
+      current = name[1];
+      out[current] = {};
+      continue;
+    }
+    const value = /^ {4}(light|dark):\s*"([^"]+)"/.exec(line);
+    if (value && current) out[current][value[1]] = value[2];
+  }
+  return out;
+}
+
+function docTypography(fm) {
+  const out = {};
+  for (const m of section(fm, 'typography').matchAll(/^\s+([a-z0-9-]+):\s*\{(.+)\}/gm)) {
+    const body = m[2];
+    const size = /fontSize:\s*([\d.]+)px/.exec(body)?.[1];
+    const weight = /fontWeight:\s*(\d+)/.exec(body)?.[1];
+    const leading = /lineHeight:\s*"?([\d.]+)/.exec(body)?.[1];
+    const tracking = /letterSpacing:\s*"?(-?[\d.]+)/.exec(body)?.[1];
+    out[m[1]] = {
+      missing: [
+        ...(size === undefined ? ['fontSize'] : []),
+        ...(weight === undefined ? ['fontWeight'] : []),
+        ...(leading === undefined ? ['lineHeight'] : []),
+        ...(tracking === undefined ? ['letterSpacing'] : []),
+      ],
+      size: size === undefined ? null : parseFloat(size),
+      weight: weight === undefined ? null : parseInt(weight, 10),
+      leading: leading === undefined ? null : parseFloat(leading),
+      tracking: tracking === undefined ? null : parseFloat(tracking),
+    };
+  }
+  return out;
+}
+
+/** Flat `key: value` pairs. Keys are names, numbers, or CSS custom properties. */
+function docPairs(fm, name) {
+  const out = {};
+  const pattern = /^\s+(--[a-z0-9-]+|[a-z0-9]+):\s*"?([^"\n#]+?)"?\s*(?:#.*)?$/gm;
+  for (const m of section(fm, name).matchAll(pattern)) out[m[1]] = m[2].trim();
+  return out;
+}
+
+// --- CSS parsing ------------------------------------------------------------
+
+/** `--color-surface: var(--color-bg-primary)` becomes `{ surface: 'bg-primary' }`. */
+function themeMap(css) {
+  const out = {};
+  for (const m of css.matchAll(/--color-([\w-]+):\s*var\(--color-([\w-]+)\)/g)) out[m[1]] = m[2];
+  return out;
+}
+
+/**
+ * The palette a theme sets on its explicit `[data-theme]` selector.
+ *
+ * The contract documents the explicit palettes, not the system-preference
+ * branches: a platform without live system tokens gets these values, and they
+ * are the only branch stated in full. Nested rules sit below the top level, so
+ * the `@media` and `@supports` overrides do not reach this scan.
+ */
+function themeVars(css, theme) {
+  const out = {};
+  for (const block of topLevelRuleBodies(css, `:root[data-theme="${theme}"]`)) {
+    for (const v of block.matchAll(/--color-([\w-]+):\s*([^;]+);/g)) {
+      // A live system token has no static value to compare.
+      if (v[2].trim().startsWith('-apple-system')) continue;
+      out[v[1]] = v[2].trim();
+    }
+  }
+  return out;
+}
+
+/** Bodies of every rule that names the selector at the top level of the file. */
+function topLevelRuleBodies(css, selector) {
+  const bodies = [];
+  let depth = 0;
+  for (let index = 0; index < css.length; index += 1) {
+    if (depth === 0 && css.startsWith(selector, index)) {
+      const open = css.indexOf('{', index + selector.length);
+      if (open === -1) break;
+      const close = matchingBrace(css, open);
+      bodies.push(css.slice(open + 1, close));
+      index = close;
+      continue;
+    }
+    const ch = css[index];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth = Math.max(0, depth - 1);
+  }
+  return bodies;
+}
+
+function matchingBrace(css, open) {
+  let depth = 1;
+  for (let index = open + 1; index < css.length; index += 1) {
+    const ch = css[index];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  throw new Error('Unclosed CSS block while the theme palette was read');
+}
+
+function cssTypography(css, name) {
+  const body = new RegExp(`\\.type-${name}\\s*\\{([\\s\\S]*?)\\}`).exec(css)?.[1];
+  if (!body) return null;
+  const size = /font-size:\s*([\d.]+)px/.exec(body)?.[1];
+  const weight = /font-weight:\s*(\d+)/.exec(body)?.[1];
+  const tracking = /letter-spacing:\s*(-?[\d.]+)/.exec(body)?.[1];
+  return {
+    missing: [
+      ...(size === undefined ? ['font-size'] : []),
+      ...(weight === undefined ? ['font-weight'] : []),
+      ...(tracking === undefined ? ['letter-spacing'] : []),
+    ],
+    size: size === undefined ? null : parseFloat(size),
+    weight: weight === undefined ? null : parseInt(weight, 10),
+    tracking: tracking === undefined ? null : parseFloat(tracking),
+  };
+}
+
+function cssBoxShadow(css, selector) {
+  const body = new RegExp(`\\.${selector}\\s*\\{([\\s\\S]*?)\\}`).exec(css)?.[1];
+  if (!body) return { value: null, error: `.${selector} not found in the CSS` };
+  const shadow = /box-shadow:\s*([\s\S]*?);/.exec(body)?.[1];
+  if (!shadow) return { value: null, error: `.${selector} sets no box-shadow` };
+  return { value: norm(shadow), error: null };
+}
+
+// --- checks -----------------------------------------------------------------
+
+export function checkDesignDrift(io = fileSystemIo()) {
+  const failures = [];
+  const fail = (msg) => failures.push(msg);
+
+  const docText = io.read(CONTRACT);
+  const fm = frontMatter(docText);
+  const sources = docSources(fm);
+
+  // The source list must name every stylesheet the app has. A stylesheet the
+  // contract does not know about is a token set nothing checks.
+  const listed = new Set(sources);
+  const present = io.listStylesheets().filter((p) => p !== ENTRY_STYLESHEET);
+  for (const file of present) {
+    if (!listed.has(file)) fail(`stylesheet \`${file}\` is missing from sources`);
+  }
+  for (const file of sources) {
+    if (!io.exists(file)) fail(`sources names \`${file}\`, which does not exist`);
+  }
+
+  const cssAll = sources
+    .filter((file) => io.exists(file))
+    .map((file) => io.read(file))
+    .join('\n');
+
+  // Colors: coverage first, then the value in each theme.
+  const map = themeMap(cssAll);
+  const colors = docColors(fm);
+  for (const name of Object.keys(map)) {
+    if (!(name in colors)) fail(`@theme token \`${name}\` is not documented in colors`);
+  }
+  for (const name of Object.keys(colors)) {
+    if (!map[name]) fail(`color \`${name}\` is not registered in any @theme block`);
+  }
+  for (const theme of ['light', 'dark']) {
+    const vars = themeVars(cssAll, theme);
+    for (const [name, values] of Object.entries(colors)) {
+      const ref = map[name];
+      if (!ref) continue;
+      const documented = values[theme];
+      if (documented === undefined) {
+        fail(`color \`${name}\` has no ${theme} value`);
+        continue;
+      }
+      const actual = vars[ref];
+      if (actual === undefined) {
+        fail(`color \`${name}\`: --color-${ref} is not set in the ${theme} palette`);
+        continue;
+      }
+      if (norm(documented) !== norm(actual)) {
+        fail(`color \`${name}\` ${theme} = ${documented}, expected ${actual} (--color-${ref})`);
+      }
+    }
+  }
+
+  // Typography: the `.type-*` classes set size, weight, and tracking. The
+  // line-height comes from the base element rules, so compare it to those.
+  const baseLeading = /line-height:\s*([\d.]+)\s*;/.exec(cssAll)?.[1];
+  for (const [name, t] of Object.entries(docTypography(fm))) {
+    if (t.missing.length) {
+      fail(`typography \`${name}\`: front matter is missing ${t.missing.join(', ')}`);
+      continue;
+    }
+    const css = cssTypography(cssAll, name);
+    if (!css) {
+      fail(`typography \`${name}\`: .type-${name} not found in the CSS`);
+      continue;
+    }
+    if (css.missing.length) {
+      fail(`typography \`${name}\`: .type-${name} is missing ${css.missing.join(', ')}`);
+      continue;
+    }
+    if (t.size !== css.size) fail(`type \`${name}\` fontSize ${t.size} != ${css.size}`);
+    if (t.weight !== css.weight) fail(`type \`${name}\` fontWeight ${t.weight} != ${css.weight}`);
+    if (Math.abs(t.tracking - css.tracking) > 1e-6) {
+      fail(`type \`${name}\` letterSpacing ${t.tracking} != ${css.tracking}`);
+    }
+    if (baseLeading === undefined) {
+      fail(`type \`${name}\` lineHeight: no base line-height found in the CSS`);
+    } else if (Math.abs(t.leading - parseFloat(baseLeading)) > 1e-6) {
+      fail(`type \`${name}\` lineHeight ${t.leading} != the base ${baseLeading}`);
+    }
+  }
+
+  // Spacing rhythm against the --space-* vars.
+  const cssSpace = [...cssAll.matchAll(/--space-[a-z\d]+:\s*(\d+)px/g)]
+    .map((m) => Number(m[1]))
+    .sort((a, b) => a - b);
+  const sp = docPairs(fm, 'spacing');
+  const steps = Object.entries(sp)
+    .filter(([k]) => /^\d+$/.test(k))
+    .map(([, v]) => parseInt(v, 10))
+    .sort((a, b) => a - b);
+  if (JSON.stringify(steps) !== JSON.stringify(cssSpace)) {
+    fail(`spacing ${JSON.stringify(steps)} != --space-* ${JSON.stringify(cssSpace)}`);
+  }
+  if (parseInt(sp.base, 10) !== cssSpace[0]) {
+    fail(`spacing.base ${sp.base} != ${cssSpace[0]}px`);
+  }
+
+  // Radii. `full` is a plain CSS value with no var, so it has nothing to match.
+  const rounded = docPairs(fm, 'rounded');
+  for (const key of ['small', 'control', 'popover']) {
+    const css = new RegExp(`--radius-${key}:\\s*(\\d+)px`).exec(cssAll)?.[1];
+    if (css === undefined) {
+      fail(`rounded.${key}: --radius-${key} not found in the CSS`);
+      continue;
+    }
+    if (parseInt(rounded[key], 10) !== parseInt(css, 10)) {
+      fail(`rounded.${key} ${rounded[key]} != --radius-${key} ${css}px`);
+    }
+  }
+
+  // Geometry vars listed under `sizes`.
+  for (const [key, value] of Object.entries(docPairs(fm, 'sizes'))) {
+    if (!key.startsWith('--')) continue;
+    const css = new RegExp(`${key}:\\s*([^;]+);`).exec(cssAll)?.[1];
+    if (css === undefined) {
+      fail(`sizes ${key}: not found in the CSS`);
+      continue;
+    }
+    if (norm(value) !== norm(css)) fail(`sizes ${key} = ${value}, expected ${norm(css)}`);
+  }
+
+  // Shadows against the selectors that carry them.
+  const shadow = docPairs(fm, 'shadow');
+  for (const [key, selector] of Object.entries(SHADOW_SELECTORS)) {
+    const css = cssBoxShadow(cssAll, selector);
+    if (css.error) {
+      fail(`shadow.${key}: ${css.error}`);
+      continue;
+    }
+    if (norm(shadow[key] ?? '') !== css.value) {
+      fail(`shadow.${key} does not match the .${selector} box-shadow`);
+    }
+  }
+
+  // Reference integrity: the prose names real files and real classes.
+  for (const m of docText.matchAll(/\bsrc\/[\w./-]+\.(?:ts|tsx|css)\b/g)) {
+    if (!io.exists(m[0])) fail(`referenced path does not exist: ${m[0]}`);
+  }
+  for (const m of docText.matchAll(/\b(?:ui|type)-[a-z][\w-]*/g)) {
+    if (GENERIC_FONT_FAMILIES.has(m[0])) continue;
+    if (!cssAll.includes(m[0])) fail(`referenced class not found in the CSS: ${m[0]}`);
+  }
+
+  // Every {group.key} resolves inside the front matter.
+  const groups = ['colors', 'typography', 'spacing', 'rounded', 'shadow', 'fonts'];
+  const keys = {};
+  for (const g of groups) {
+    keys[g] = new Set([...section(fm, g).matchAll(/^\s+([a-z0-9-]+):/gm)].map((m) => m[1]));
+  }
+  for (const m of fm.matchAll(/\{([a-z]+)\.([a-z0-9-]+)\}/g)) {
+    if (!keys[m[1]]?.has(m[2])) fail(`unresolved interpolation {${m[1]}.${m[2]}}`);
+  }
+
+  return failures;
+}
+
+// --- CLI --------------------------------------------------------------------
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const failures = checkDesignDrift();
+  if (failures.length) {
+    console.error(`design-contract drift detected (${failures.length}):\n`);
+    for (const f of failures) console.error(`  - ${f}`);
+    console.error('\nUpdate apps/desktop/design.md to match the CSS, or the CSS to match it.');
+    process.exit(1);
+  }
+  console.log('design contract is in sync with the stylesheets');
+}

--- a/scripts/check-design-drift.test.mjs
+++ b/scripts/check-design-drift.test.mjs
@@ -36,6 +36,10 @@ shadow:
   popover: "0 4px 12px rgb(0 0 0 / 0.15)"
   tooltip: "0 2px 8px rgb(0 0 0 / 0.12)"
   raised: "0 1px 2px rgb(0 0 0 / 0.15)"
+motion:
+  --duration-fast: 120ms
+  --ease-out-quart: cubic-bezier(0.23, 1, 0.32, 1)
+  button: "transform 80ms ease-out"
 components:
   button:
     className: ui-push-button
@@ -58,6 +62,8 @@ const CSS = `@theme {
   --space-xs: 4px;
   --space-sm: 8px;
   --sidebar-width: 220px;
+  --duration-fast: 120ms;
+  --ease-out-quart: cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 :root[data-theme="light"] {
@@ -199,6 +205,24 @@ test('reports a radius that differs', () => {
 test('reports a geometry var that differs', () => {
   const css = CSS.replace('--sidebar-width: 220px;', '--sidebar-width: 240px;');
   assertFails(checkDesignDrift(fixture({ css })), 'sizes --sidebar-width = 220px, expected 240px');
+});
+
+test('reports a motion duration that differs', () => {
+  const css = CSS.replace('--duration-fast: 120ms;', '--duration-fast: 150ms;');
+  assertFails(checkDesignDrift(fixture({ css })), 'motion --duration-fast = 120ms, expected 150ms');
+});
+
+test('reports a motion easing that differs', () => {
+  const css = CSS.replace(
+    '--ease-out-quart: cubic-bezier(0.23, 1, 0.32, 1);',
+    '--ease-out-quart: cubic-bezier(0.4, 0, 0.2, 1);',
+  );
+  assertFails(checkDesignDrift(fixture({ css })), 'motion --ease-out-quart');
+});
+
+test('ignores a motion recipe that names no custom property', () => {
+  assert.ok(CONTRACT.includes('button: "transform 80ms ease-out"'), 'fixture must hold a recipe');
+  assert.deepEqual(checkDesignDrift(fixture()), []);
 });
 
 test('reports a shadow that differs from the selector that carries it', () => {

--- a/scripts/check-design-drift.test.mjs
+++ b/scripts/check-design-drift.test.mjs
@@ -59,11 +59,18 @@ const CSS = `@theme {
 }
 
 :root {
+  --color-bg-primary: rgb(255 255 255);
   --space-xs: 4px;
   --space-sm: 8px;
   --sidebar-width: 220px;
   --duration-fast: 120ms;
   --ease-out-quart: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg-primary: rgb(30 30 30);
+  }
 }
 
 :root[data-theme="light"] {
@@ -148,10 +155,18 @@ test('reports a documented color that no @theme block registers', () => {
 });
 
 test('compares each theme against its own palette', () => {
-  const css = CSS.replace('--color-bg-primary: rgb(30 30 30);', '--color-bg-primary: rgb(9 9 9);');
+  // Name the selector too: the dark value appears in the system branch as
+  // well, and only the explicit one is under test here.
+  const css = CSS.replace(
+    ':root[data-theme="dark"] {\n  --color-bg-primary: rgb(30 30 30);',
+    ':root[data-theme="dark"] {\n  --color-bg-primary: rgb(9 9 9);',
+  );
   const failures = checkDesignDrift(fixture({ css }));
   assertFails(failures, 'color `surface` dark = rgb(30 30 30), expected rgb(9 9 9)');
-  assert.equal(failures.length, 1, 'the light theme must stay green');
+  assert.ok(
+    !failures.some((f) => f.includes('light')),
+    'the light theme must stay green',
+  );
 });
 
 test('reads a palette that shares its selector list with a plain :root', () => {
@@ -290,4 +305,71 @@ test('reports a source that does not exist', () => {
 test('does not expect the entry stylesheet in the source list', () => {
   const extra = { 'src/styles.css': '@import "./styles/tokens.css";\n' };
   assert.deepEqual(checkDesignDrift(fixture({ extra })), []);
+});
+
+// --- the system-preference palette ------------------------------------------
+
+/** Bare `:root` light value, and the note that would document it. */
+const SYSTEM_LIGHT = '--color-bg-primary: rgb(255 255 255);';
+const NOTE_LIGHT = '    light: "rgb(255 255 255)" # @media light: rgb(250 250 250)';
+
+test('accepts a system value the contract states in an @media note', () => {
+  const css = CSS.replace(SYSTEM_LIGHT, '--color-bg-primary: rgb(250 250 250);');
+  const contract = CONTRACT.replace('    light: "rgb(255 255 255)"', NOTE_LIGHT);
+  assert.deepEqual(checkDesignDrift(fixture({ contract, css })), []);
+});
+
+test('reports a system value that no @media note states', () => {
+  const css = CSS.replace(SYSTEM_LIGHT, '--color-bg-primary: rgb(250 250 250);');
+  assertFails(checkDesignDrift(fixture({ css })), 'the system palette sets rgb(250 250 250)');
+});
+
+test('reports an @media note whose value is wrong', () => {
+  const css = CSS.replace(SYSTEM_LIGHT, '--color-bg-primary: rgb(250 250 250);');
+  const contract = CONTRACT.replace(
+    '    light: "rgb(255 255 255)"',
+    '    light: "rgb(255 255 255)" # @media light: rgb(200 200 200)',
+  );
+  assertFails(checkDesignDrift(fixture({ contract, css })), '@media light note = rgb(200 200 200)');
+});
+
+test('reports an @media note that only repeats the value', () => {
+  const contract = CONTRACT.replace(
+    '    light: "rgb(255 255 255)"',
+    '    light: "rgb(255 255 255)" # @media light: rgb(255 255 255)',
+  );
+  assertFails(checkDesignDrift(fixture({ contract })), 'the @media note repeats the value');
+});
+
+test('reports an @media note that names the other theme', () => {
+  const css = CSS.replace(SYSTEM_LIGHT, '--color-bg-primary: rgb(250 250 250);');
+  const contract = CONTRACT.replace(
+    '    light: "rgb(255 255 255)"',
+    '    light: "rgb(255 255 255)" # @media dark: rgb(250 250 250)',
+  );
+  assertFails(checkDesignDrift(fixture({ contract, css })), 'the note names @media dark');
+});
+
+test('compares an alpha by number, not by the digits written', () => {
+  const css = CSS.replace(SYSTEM_LIGHT, '--color-bg-primary: rgb(255 255 255 / 0.5);');
+  const contract = CONTRACT.replace(
+    '    light: "rgb(255 255 255)"',
+    '    light: "rgb(255 255 255)" # @media light: rgb(255 255 255 / 0.50)',
+  );
+  assert.deepEqual(checkDesignDrift(fixture({ contract, css })), []);
+});
+
+test('reports a token the system palette never sets', () => {
+  const css = CSS.replace(`:root {\n  ${SYSTEM_LIGHT}`, ':root {');
+  assertFails(checkDesignDrift(fixture({ css })), 'unset in the light system palette');
+});
+
+test('does not read a selector named inside a comment as a rule', () => {
+  // The real tokens.css explains one rule in a comment above another. A
+  // comment that names `:root` must not be scanned as a `:root` block.
+  const css = CSS.replace(
+    ':root {',
+    '/* :root and :root[data-theme="dark"] both set the surface. */\n:root {',
+  );
+  assert.deepEqual(checkDesignDrift(fixture({ css })), []);
 });

--- a/scripts/check-design-drift.test.mjs
+++ b/scripts/check-design-drift.test.mjs
@@ -187,6 +187,22 @@ test('reports a line height that differs from the base element rule', () => {
   assertFails(checkDesignDrift(fixture({ css })), 'type `body` lineHeight 1.4 != the base 1.6');
 });
 
+test('reports a type class that sets its own line height', () => {
+  const css = CSS.replace(
+    '.type-body {\n  font-size: 13px;',
+    '.type-body {\n  line-height: 1.2;\n  font-size: 13px;',
+  );
+  assertFails(checkDesignDrift(fixture({ css })), '.type-body sets its own line-height');
+});
+
+test('reports a documented shadow that no selector covers', () => {
+  const contract = CONTRACT.replace(
+    '  raised: "0 1px 2px rgb(0 0 0 / 0.15)"',
+    '  raised: "0 1px 2px rgb(0 0 0 / 0.15)"\n  sunken: "inset 0 1px 2px rgb(0 0 0 / 0.2)"',
+  );
+  assertFails(checkDesignDrift(fixture({ contract })), 'shadow.sunken has no selector');
+});
+
 test('reports a typography step with no class in the CSS', () => {
   const css = CSS.replace('.type-body {', '.type-other {');
   assertFails(checkDesignDrift(fixture({ css })), '.type-body not found');

--- a/scripts/check-design-drift.test.mjs
+++ b/scripts/check-design-drift.test.mjs
@@ -1,0 +1,253 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { checkDesignDrift } from './check-design-drift.mjs';
+
+const CONTRACT = `---
+version: alpha
+name: test
+sources:
+  - src/styles/tokens.css
+colors:
+  surface:
+    light: "rgb(255 255 255)"
+    dark: "rgb(30 30 30)"
+fonts:
+  sans: "system-ui, sans-serif"
+  mono: "ui-monospace, Menlo, monospace"
+typography:
+  body: { fontSize: 13px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "-0.08px" }
+spacing:
+  1: 4px
+  2: 8px
+  base: 4px
+sizes:
+  --sidebar-width: 220px
+rounded:
+  small: 4px
+  control: 5px
+  popover: 10px
+  full: 9999px
+shadow:
+  popover: "0 4px 12px rgb(0 0 0 / 0.15)"
+  tooltip: "0 2px 8px rgb(0 0 0 / 0.12)"
+  raised: "0 1px 2px rgb(0 0 0 / 0.15)"
+components:
+  button:
+    className: ui-push-button
+    textColor: "{colors.surface}"
+---
+
+# Test contract
+
+The type scale lives in src/styles/tokens.css.
+`;
+
+const CSS = `@theme {
+  --color-surface: var(--color-bg-primary);
+  --radius-control: 5px;
+  --radius-popover: 10px;
+  --radius-small: 4px;
+}
+
+:root {
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --sidebar-width: 220px;
+}
+
+:root[data-theme="light"] {
+  --color-bg-primary: rgb(255 255 255);
+}
+
+:root[data-theme="dark"] {
+  --color-bg-primary: rgb(30 30 30);
+}
+
+html,
+body {
+  line-height: 1.4;
+}
+
+.type-body {
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: -0.08px;
+}
+
+.ui-push-button {
+  height: 22px;
+}
+
+.ui-menu {
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
+}
+
+.ui-tooltip {
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+}
+
+.ui-switch-thumb {
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.15);
+}
+`;
+
+/** An in-memory desktop app. Keys are paths relative to apps/desktop. */
+function io(files) {
+  return {
+    read: (rel) => {
+      if (!(rel in files)) throw new Error(`missing ${rel}`);
+      return files[rel];
+    },
+    exists: (rel) => rel in files,
+    listStylesheets: () => Object.keys(files).filter((f) => f.endsWith('.css')),
+  };
+}
+
+/** The green fixture, with optional edits to either side of the contract. */
+function fixture({ contract = CONTRACT, css = CSS, extra = {} } = {}) {
+  return io({ 'design.md': contract, 'src/styles/tokens.css': css, ...extra });
+}
+
+function assertFails(failures, fragment) {
+  assert.equal(
+    failures.filter((f) => f.includes(fragment)).length,
+    1,
+    `expected one failure containing ${JSON.stringify(fragment)}, got ${JSON.stringify(failures)}`,
+  );
+}
+
+test('a contract that matches the CSS reports no drift', () => {
+  assert.deepEqual(checkDesignDrift(fixture()), []);
+});
+
+test('reports an @theme token that the contract does not document', () => {
+  const css = CSS.replace(
+    '--color-surface: var(--color-bg-primary);',
+    '--color-surface: var(--color-bg-primary);\n  --color-label: var(--color-text-primary);',
+  );
+  assertFails(checkDesignDrift(fixture({ css })), '`label` is not documented in colors');
+});
+
+test('reports a documented color that no @theme block registers', () => {
+  const contract = CONTRACT.replace(
+    '  surface:\n',
+    '  ghost:\n    light: "rgb(1 1 1)"\n    dark: "rgb(2 2 2)"\n  surface:\n',
+  );
+  assertFails(checkDesignDrift(fixture({ contract })), '`ghost` is not registered');
+});
+
+test('compares each theme against its own palette', () => {
+  const css = CSS.replace('--color-bg-primary: rgb(30 30 30);', '--color-bg-primary: rgb(9 9 9);');
+  const failures = checkDesignDrift(fixture({ css }));
+  assertFails(failures, 'color `surface` dark = rgb(30 30 30), expected rgb(9 9 9)');
+  assert.equal(failures.length, 1, 'the light theme must stay green');
+});
+
+test('reads a palette that shares its selector list with a plain :root', () => {
+  const css = CSS.replace(':root[data-theme="light"] {', ':root,\n:root[data-theme="light"] {');
+  assert.deepEqual(checkDesignDrift(fixture({ css })), []);
+});
+
+test('ignores a [data-theme] rule nested inside a media query', () => {
+  const css = `${CSS}\n@media (prefers-reduced-transparency: reduce) {\n  :root[data-theme="dark"] {\n    --color-bg-primary: rgb(77 77 77);\n  }\n}\n`;
+  assert.deepEqual(checkDesignDrift(fixture({ css })), []);
+});
+
+test('ignores a live system token nested inside @supports', () => {
+  const css = `${CSS}\n@supports (color: -apple-system-label) {\n  :root[data-theme="light"] {\n    --color-bg-primary: -apple-system-label;\n  }\n}\n`;
+  assert.deepEqual(checkDesignDrift(fixture({ css })), []);
+});
+
+test('skips a live system token declared at the top level', () => {
+  const css = CSS.replace(
+    ':root[data-theme="light"] {\n  --color-bg-primary: rgb(255 255 255);',
+    ':root[data-theme="light"] {\n  --color-bg-primary: -apple-system-label;',
+  );
+  assertFails(checkDesignDrift(fixture({ css })), 'is not set in the light palette');
+});
+
+test('reports a typography step whose size differs', () => {
+  const css = CSS.replace('font-size: 13px;', 'font-size: 15px;');
+  assertFails(checkDesignDrift(fixture({ css })), 'type `body` fontSize 13 != 15');
+});
+
+test('reports a line height that differs from the base element rule', () => {
+  const css = CSS.replace('line-height: 1.4;', 'line-height: 1.6;');
+  assertFails(checkDesignDrift(fixture({ css })), 'type `body` lineHeight 1.4 != the base 1.6');
+});
+
+test('reports a typography step with no class in the CSS', () => {
+  const css = CSS.replace('.type-body {', '.type-other {');
+  assertFails(checkDesignDrift(fixture({ css })), '.type-body not found');
+});
+
+test('reports a spacing scale that differs from the --space-* vars', () => {
+  const css = CSS.replace('--space-sm: 8px;', '--space-sm: 10px;');
+  assertFails(checkDesignDrift(fixture({ css })), 'spacing [4,8] != --space-* [4,10]');
+});
+
+test('reports a radius that differs', () => {
+  const css = CSS.replace('--radius-control: 5px;', '--radius-control: 6px;');
+  assertFails(checkDesignDrift(fixture({ css })), 'rounded.control 5px != --radius-control 6px');
+});
+
+test('reports a geometry var that differs', () => {
+  const css = CSS.replace('--sidebar-width: 220px;', '--sidebar-width: 240px;');
+  assertFails(checkDesignDrift(fixture({ css })), 'sizes --sidebar-width = 220px, expected 240px');
+});
+
+test('reports a shadow that differs from the selector that carries it', () => {
+  const css = CSS.replace('box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);', 'box-shadow: none;');
+  assertFails(checkDesignDrift(fixture({ css })), 'shadow.tooltip does not match');
+});
+
+test('reports a shadow selector that the CSS does not define', () => {
+  const css = CSS.replace('.ui-switch-thumb {', '.ui-switch-knob {');
+  assertFails(checkDesignDrift(fixture({ css })), '.ui-switch-thumb not found');
+});
+
+test('reports a prose path that does not exist', () => {
+  const contract = CONTRACT.replace('src/styles/tokens.css.\n', 'src/styles/gone.css.\n');
+  assertFails(checkDesignDrift(fixture({ contract })), 'referenced path does not exist');
+});
+
+test('reports a prose class that the CSS does not define', () => {
+  const contract = CONTRACT.replace('className: ui-push-button', 'className: ui-ghost-button');
+  assertFails(checkDesignDrift(fixture({ contract })), 'ui-ghost-button');
+});
+
+test('accepts a generic font family that shares the ui- prefix', () => {
+  assert.ok(CONTRACT.includes('ui-monospace'), 'the fixture must exercise the font stack');
+  assert.deepEqual(checkDesignDrift(fixture()), []);
+});
+
+test('reports an interpolation that does not resolve', () => {
+  const contract = CONTRACT.replace('{colors.surface}', '{colors.nowhere}');
+  assertFails(checkDesignDrift(fixture({ contract })), 'unresolved interpolation {colors.nowhere}');
+});
+
+test('reports a stylesheet that the source list omits', () => {
+  const extra = { 'src/styles/extra.css': '.thing { color: red; }\n' };
+  assertFails(
+    checkDesignDrift(fixture({ extra })),
+    'stylesheet `src/styles/extra.css` is missing from sources',
+  );
+});
+
+test('reports a source that does not exist', () => {
+  const contract = CONTRACT.replace(
+    '  - src/styles/tokens.css',
+    '  - src/styles/tokens.css\n  - src/styles/gone.css',
+  );
+  assertFails(checkDesignDrift(fixture({ contract })), 'sources names `src/styles/gone.css`');
+});
+
+test('does not expect the entry stylesheet in the source list', () => {
+  const extra = { 'src/styles.css': '@import "./styles/tokens.css";\n' };
+  assert.deepEqual(checkDesignDrift(fixture({ extra })), []);
+});

--- a/scripts/check-design-drift.test.mjs
+++ b/scripts/check-design-drift.test.mjs
@@ -109,6 +109,11 @@ body {
 }
 `;
 
+/** The popover window copies `rounded.popover` into a Rust constant. */
+const RUST = `#[cfg(target_os = "macos")]
+const CORNER_RADIUS: f64 = 10.0;
+`;
+
 /** An in-memory desktop app. Keys are paths relative to apps/desktop. */
 function io(files) {
   return {
@@ -122,8 +127,13 @@ function io(files) {
 }
 
 /** The green fixture, with optional edits to either side of the contract. */
-function fixture({ contract = CONTRACT, css = CSS, extra = {} } = {}) {
-  return io({ 'design.md': contract, 'src/styles/tokens.css': css, ...extra });
+function fixture({ contract = CONTRACT, css = CSS, rust = RUST, extra = {} } = {}) {
+  return io({
+    'design.md': contract,
+    'src/styles/tokens.css': css,
+    'src-tauri/src/popover.rs': rust,
+    ...extra,
+  });
 }
 
 function assertFails(failures, fragment) {
@@ -380,4 +390,29 @@ test('keeps the reduced-transparency dark block out of the system palette', () =
   // system value — which would hide a real difference from the contract.
   const css = `${CSS}\n@media (prefers-reduced-transparency: reduce) and (prefers-color-scheme: dark) {\n  :root {\n    --color-bg-primary: rgb(255 255 255);\n  }\n}\n`;
   assert.deepEqual(checkDesignDrift(fixture({ css })), []);
+});
+
+// --- the popover window corner ----------------------------------------------
+
+test('reports a window corner constant that differs from the token', () => {
+  const rust = RUST.replace('10.0', '12.0');
+  assertFails(checkDesignDrift(fixture({ rust })), 'rounded.popover 10px != CORNER_RADIUS 12.0');
+});
+
+test('reports a token change the window corner constant did not follow', () => {
+  const contract = CONTRACT.replace('  popover: 10px', '  popover: 12px');
+  const css = CSS.replace('--radius-popover: 10px;', '--radius-popover: 12px;');
+  assertFails(
+    checkDesignDrift(fixture({ contract, css })),
+    'rounded.popover 12px != CORNER_RADIUS 10.0',
+  );
+});
+
+test('reports a window source that declares no corner constant', () => {
+  assertFails(checkDesignDrift(fixture({ rust: '// nothing here\n' })), 'declares no CORNER_RADIUS');
+});
+
+test('reports a window source that is missing', () => {
+  const files = io({ 'design.md': CONTRACT, 'src/styles/tokens.css': CSS });
+  assertFails(checkDesignDrift(files), 'src-tauri/src/popover.rs not found');
 });

--- a/scripts/check-design-drift.test.mjs
+++ b/scripts/check-design-drift.test.mjs
@@ -373,3 +373,11 @@ test('does not read a selector named inside a comment as a rule', () => {
   );
   assert.deepEqual(checkDesignDrift(fixture({ css })), []);
 });
+
+test('keeps the reduced-transparency dark block out of the system palette', () => {
+  // tokens.css makes the window solid under `prefers-reduced-transparency`.
+  // That answers a different setting, so it must not stand in for the dark
+  // system value — which would hide a real difference from the contract.
+  const css = `${CSS}\n@media (prefers-reduced-transparency: reduce) and (prefers-color-scheme: dark) {\n  :root {\n    --color-bg-primary: rgb(255 255 255);\n  }\n}\n`;
+  assert.deepEqual(checkDesignDrift(fixture({ css })), []);
+});


### PR DESCRIPTION
## Summary

Add automated checks for the desktop design contract and fix the drift those checks found.

- Verify stylesheet registration, color tokens, theme values, typography, spacing, radii, motion, shadows, window corners, and documented references.
- Add shared motion tokens and a desktop design-review guide.
- Apply the macOS popover material and preserve transparent window surfaces.
- Fix contrast problems across light and dark themes.
- Run the design check for every change that can affect desktop styling.

## Validation

- Design checks and their mutation-tested suite passed.
- Frontend tests, formatting, lint, type checks, build, Rust checks, and accessibility measurements passed.
- The checker detected new stylesheet and palette drift during integration.