### PR TITLE
fix(desktop): use registered color tokens in FolderPermissionNotice

### DIFF
--- a/apps/desktop/src/components/repositories/FolderPermissionNotice.tsx
+++ b/apps/desktop/src/components/repositories/FolderPermissionNotice.tsx
@@ -56,10 +56,7 @@ export function FolderPermissionNotice({
   const busy = phase === "asking" || phase === "settling"
 
   return (
-    <div
-      role="status"
-      className="rounded-lg border border-separator bg-surface-card px-4 py-3"
-    >
+    <div role="status" className="rounded-lg border border-separator bg-surface-card px-4 py-3">
       <div className="flex items-start gap-3">
         <FolderLock aria-hidden className="mt-0.5 size-4 shrink-0 text-label-secondary" />
         <div className="min-w-0 flex-1 space-y-2">

--- a/apps/desktop/src/components/repositories/FolderPermissionNotice.tsx
+++ b/apps/desktop/src/components/repositories/FolderPermissionNotice.tsx
@@ -58,12 +58,12 @@ export function FolderPermissionNotice({
   return (
     <div
       role="status"
-      className="rounded-lg border border-separator bg-fill-quaternary px-4 py-3"
+      className="rounded-lg border border-separator bg-surface-card px-4 py-3"
     >
       <div className="flex items-start gap-3">
         <FolderLock aria-hidden className="mt-0.5 size-4 shrink-0 text-label-secondary" />
         <div className="min-w-0 flex-1 space-y-2">
-          <p className="type-footnote text-label-primary">
+          <p className="type-footnote text-label">
             {allStuck ? headlineForStuck(deferred) : headlineForPending(deferred)}
           </p>
           <p className="type-caption text-label-secondary">


### PR DESCRIPTION
`FolderPermissionNotice` used two Tailwind color utilities whose tokens were never registered in any `@theme` block: `bg-fill-quaternary` and `text-label-primary`. Tailwind v4 emits no CSS for an unknown color name and raises no error, so the notice rendered with no background fill and its headline fell back to an inherited color. Both classes were invented when the component was written in `aa68db2`; no commit ever defined the tokens, so this is a naming mistake rather than token drift.

The design contract in `apps/desktop/design.md` names the correct tokens: `surface-card` for a soft card fill (light `rgb(0 0 0 / 0.04)`, dark `rgb(255 255 255 / 0.08)`) and `label` for the primary label color. There is no "quaternary" step in the token system — the surface scale stops at tertiary — so registering a new token is not warranted.

## Verification

- `rg "fill-quaternary|label-primary" apps/desktop/src` returns nothing.
- Type-check, ESLint, and the full desktop suite pass (686 tests, 71 files).
- Ran the app's dev server and read the compiled stylesheet: `bg-surface-card` resolves to `rgba(255, 255, 255, 0.08)` in dark and `rgba(0, 0, 0, 0.04)` in light, matching the contract. The old `bg-fill-quaternary` resolves to `rgba(0, 0, 0, 0)`, confirming the missing fill.

A repo-wide cross-check of every color utility against both `@theme` blocks found no other unregistered classes.

Relates to #104, which enforces this contract — no overlap, that PR does not touch this file and keeps both token names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
