### PR TITLE
ci: parallelize desktop backend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,27 +165,71 @@ jobs:
         if: runner.os == 'Linux'
         run: pnpm --filter @antiburn/desktop build
 
-  desktop-backend:
-    name: desktop app (backend, ${{ matrix.name }})
+  desktop-backend-format:
+    name: desktop app (backend formatting)
+    needs: classify
+    if: needs.classify.outputs.desktop_backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt
+
+      - name: Check formatting
+        working-directory: apps/desktop/src-tauri
+        run: cargo fmt --check
+
+      - name: Check diagnostic crate formatting
+        working-directory: apps/desktop/src-tauri/crates/trace
+        run: cargo fmt --check
+
+      - name: Check HUD crate formatting
+        working-directory: apps/desktop/src-tauri/crates/hud
+        run: cargo fmt --check
+
+  desktop-backend-checks:
+    name: desktop app (backend, ${{ matrix.check.name }}, ${{ matrix.workspace.name }}, ${{ matrix.platform.name }})
     needs: classify
     if: needs.classify.outputs.desktop_backend == 'true'
     strategy:
       fail-fast: false
       matrix:
-        include:
+        platform:
           - name: linux
             os: ubuntu-latest
           - name: windows
             os: windows-latest
           - name: macos
             os: macos-latest
-    runs-on: ${{ matrix.os }}
+        check:
+          - name: Clippy
+            command: clippy --all-targets --locked -- -D warnings
+            save_cache: false
+          - name: Tests
+            command: test --locked
+            save_cache: true
+        workspace:
+          - name: shell
+            directory: apps/desktop/src-tauri
+            tauri: true
+          - name: diagnostic
+            directory: apps/desktop/src-tauri/crates/trace
+            tauri: false
+          - name: HUD
+            directory: apps/desktop/src-tauri/crates/hud
+            tauri: true
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Use Canonical Ubuntu package archive
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.workspace.tauri
         run: |
           sudo find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
             -exec sed -i \
@@ -194,7 +238,7 @@ jobs:
               {} +
 
       - name: Install Tauri system dependencies
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.workspace.tauri
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends --yes \
@@ -212,58 +256,52 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Restore Rust dependency cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          workspaces: |
-            apps/desktop/src-tauri -> target
-            apps/desktop/src-tauri/crates/hud -> target
-            apps/desktop/src-tauri/crates/trace -> target
+          workspaces: ${{ matrix.workspace.directory }} -> target
           shared-key: desktop-backend-ci
-          key: ${{ matrix.name }}
+          key: ${{ matrix.platform.name }}-${{ matrix.workspace.name }}
           cache-bin: false
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          save-if: ${{ matrix.check.save_cache && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-      - name: Check formatting
-        if: runner.os == 'Linux'
-        working-directory: apps/desktop/src-tauri
-        run: cargo fmt --check
+      - name: Run ${{ matrix.check.name }}
+        working-directory: ${{ matrix.workspace.directory }}
+        run: cargo ${{ matrix.check.command }}
 
-      - name: Check diagnostic crate formatting
-        if: runner.os == 'Linux'
-        working-directory: apps/desktop/src-tauri/crates/trace
-        run: cargo fmt --check
-
-      - name: Check HUD crate formatting
-        if: runner.os == 'Linux'
-        working-directory: apps/desktop/src-tauri/crates/hud
-        run: cargo fmt --check
-
-      - name: Clippy
-        working-directory: apps/desktop/src-tauri
-        run: cargo clippy --all-targets --locked -- -D warnings
-
-      - name: Clippy diagnostic crate
-        working-directory: apps/desktop/src-tauri/crates/trace
-        run: cargo clippy --all-targets --locked -- -D warnings
-
-      - name: Clippy HUD crate
-        working-directory: apps/desktop/src-tauri/crates/hud
-        run: cargo clippy --all-targets --locked -- -D warnings
-
-      - name: Tests
-        working-directory: apps/desktop/src-tauri
-        run: cargo test --locked
-
-      - name: Test diagnostic crate
-        working-directory: apps/desktop/src-tauri/crates/trace
-        run: cargo test --locked
-
-      - name: Test HUD crate
-        working-directory: apps/desktop/src-tauri/crates/hud
-        run: cargo test --locked
+  desktop-backend:
+    name: desktop app (backend)
+    needs:
+      - classify
+      - desktop-backend-format
+      - desktop-backend-checks
+    if: always()
+    runs-on: ubuntu-24.04
+    env:
+      BACKEND_SELECTED: ${{ needs.classify.outputs.desktop_backend }}
+      FORMAT_RESULT: ${{ needs.desktop-backend-format.result }}
+      CHECKS_RESULT: ${{ needs.desktop-backend-checks.result }}
+    steps:
+      - name: Require every selected backend check
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$BACKEND_SELECTED" != "true" ]]; then
+            exit 0
+          fi
+          failed=0
+          require_success() {
+            local name="$1" result="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::${name} finished with ${result}, expected success."
+              failed=1
+            fi
+          }
+          require_success desktop-backend-format "$FORMAT_RESULT"
+          require_success desktop-backend-checks "$CHECKS_RESULT"
+          exit "$failed"
 
   release-metadata:
     name: release metadata

--- a/scripts/verify-workflow-portability.test.mjs
+++ b/scripts/verify-workflow-portability.test.mjs
@@ -244,19 +244,69 @@ fi`;
   assert.ok(script.indexOf(aislopBranch) < script.indexOf('exit "$failed"'));
 });
 
-test("the standalone HUD crate has dedicated backend checks", () => {
-  assert.match(workflow, /apps\/desktop\/src-tauri\/crates\/hud -> target/);
+test("desktop backend checks use parallel jobs with one aggregate result", () => {
+  const format = jobBlock("desktop-backend-format");
+  const checks = jobBlock("desktop-backend-checks");
+  const aggregate = jobBlock("desktop-backend");
 
-  for (const [name, command] of [
-    ["Check HUD crate formatting", "cargo fmt --check"],
-    ["Clippy HUD crate", "cargo clippy --all-targets --locked -- -D warnings"],
-    ["Test HUD crate", "cargo test --locked"],
+  assert.match(format, /^ {4}runs-on: ubuntu-latest$/m);
+  assert.equal(count(format, /run: cargo fmt --check/g), 3);
+  assert.doesNotMatch(format, /runner\.os/);
+
+  assert.equal(
+    count(checks, /^ {10}- name: (linux|windows|macos)$/gm),
+    3,
+  );
+  assert.match(
+    checks,
+    /^ {4}if: needs\.classify\.outputs\.desktop_backend == 'true'$/m,
+  );
+  assert.match(
+    checks,
+    /^ {12}command: clippy --all-targets --locked -- -D warnings$/m,
+  );
+  assert.match(checks, /^ {12}command: test --locked$/m);
+  assert.equal(count(checks, /^ {10}- name: (shell|diagnostic|HUD)$/gm), 3);
+  assert.match(
+    checks,
+    /^ {8}working-directory: \$\{\{ matrix\.workspace\.directory \}\}$/m,
+  );
+  assert.match(
+    checks,
+    /^ {8}run: cargo \$\{\{ matrix\.check\.command \}\}$/m,
+  );
+  assert.match(
+    checks,
+    /^ {10}save-if: \$\{\{ matrix\.check\.save_cache && github\.event_name == 'push' && github\.ref == 'refs\/heads\/main' \}\}$/m,
+  );
+
+  for (const dependency of [
+    "classify",
+    "desktop-backend-format",
+    "desktop-backend-checks",
   ]) {
-    const step = namedStep(name);
-    assert.match(
-      step,
-      /working-directory: apps\/desktop\/src-tauri\/crates\/hud/,
-    );
-    assert.ok(step.includes(`run: ${command}`));
+    assert.equal(count(aggregate, new RegExp(`^ {6}- ${dependency}$`, "gm")), 1);
   }
+  assert.match(aggregate, /^ {4}if: always\(\)$/m);
+  assert.match(
+    aggregate,
+    /^ {6}BACKEND_SELECTED: \$\{\{ needs\.classify\.outputs\.desktop_backend \}\}$/m,
+  );
+});
+
+test("the standalone HUD crate has dedicated backend checks", () => {
+  const checks = jobBlock("desktop-backend-checks");
+  assert.match(
+    checks,
+    /^ {10}- name: HUD\n {12}directory: apps\/desktop\/src-tauri\/crates\/hud$/m,
+  );
+  assert.match(
+    checks,
+    /^ {12}command: clippy --all-targets --locked -- -D warnings$/m,
+  );
+  assert.match(checks, /^ {12}command: test --locked$/m);
+
+  const format = namedStep("Check HUD crate formatting");
+  assert.match(format, /working-directory: apps\/desktop\/src-tauri\/crates\/hud/);
+  assert.ok(format.includes("run: cargo fmt --check"));
 });


### PR DESCRIPTION
## Summary

- run desktop backend formatting once on Linux
- expand Clippy and tests into an OS × command × workspace matrix
- preserve a fail-closed aggregate backend result for the required CI gate
- let only test entries save the shared Rust cache

## Verification

- `node --test scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/verify-app-engine-release.test.mjs scripts/verify-workflow-portability.test.mjs scripts/wait-for-main-ci.test.mjs`
- `actionlint .github/workflows/ci.yml`
- `cargo fmt --check` for the shell, diagnostic, and HUD workspaces
- `git diff --check`