### PR TITLE
Make the running-session shimmer work in dark mode

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -98,6 +98,12 @@ colors:
   system-gold:
     light: "rgb(202 138 4)"
     dark: "rgb(255 204 0)"
+  shimmer: # the running-session title sweep. One value for both themes, sitting
+    # between the two text colors: it lights the near-black glyphs in light mode
+    # and dims the near-white ones in dark mode. Below 4.5:1 on a light row on
+    # purpose; the band is transient and the text under it is legible at rest.
+    light: "rgb(218 90 38)"
+    dark: "rgb(218 90 38)"
   system-gold-text:
     light: "rgb(146 100 0)"
     dark: "rgb(245 203 92)"

--- a/apps/desktop/src/styles/session-rows.css
+++ b/apps/desktop/src/styles/session-rows.css
@@ -13,7 +13,7 @@
    deliberately: a large surface pulsing at the title's rate is agitating. */
 .activity-row-active {
   --activity-row-pulse-cycle: 3200ms;
-  --activity-row-shimmer-cycle: 2000ms;
+  --activity-row-shimmer-cycle: 4000ms;
 }
 
 @keyframes activity-row-pulse {
@@ -60,8 +60,12 @@
 }
 
 .activity-row-title-shimmer {
+  /* A band of the brand orange sweeps across full-strength text. The band is
+     darker than the text in dark mode and lighter than it in light mode, so it
+     dims or lifts the glyphs it crosses. It never makes them brighter than the
+     text around them, which is what reads as a highlighter. */
   --activity-row-shimmer-base: var(--color-text-primary);
-  --activity-row-shimmer-highlight: var(--color-system-gold);
+  --activity-row-shimmer-highlight: var(--color-shimmer);
   position: relative;
   display: block;
   /* Contain the sweep's repaint to this box instead of invalidating the row. */
@@ -78,15 +82,21 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   pointer-events: none;
+  /* The band stays at the center of a background 300% as wide as the box, so
+     the box shows one third of the background at a time. Thus the visible
+     window is fully transparent at both ends of the sweep: the band goes off
+     the right edge before it comes in again from the left. The 35% and 65%
+     stops are the widest band that keeps this clearance. A wider band needs a
+     larger background-size, or it stays visible across the wrap and jumps. */
   background-image: linear-gradient(
     90deg,
     transparent 0%,
-    transparent 30%,
+    transparent 35%,
     var(--activity-row-shimmer-highlight) 50%,
-    transparent 70%,
+    transparent 65%,
     transparent 100%
   );
-  background-size: 200% 100%;
+  background-size: 300% 100%;
   background-repeat: no-repeat;
   background-clip: text;
   -webkit-background-clip: text;

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -71,6 +71,13 @@
   /* Legible gold for *text/glyphs* on the gold tint — same split again. */
   --color-system-gold-text: var(--color-system-gold-text-val);
 
+  /* The band that sweeps across a running session title. The same value in
+     every theme branch: it sits between the two text colors, so it moves away
+     from the glyphs in each. Light mode lights its near-black text, dark mode
+     dims its near-white text. Each branch restates it because the design
+     contract reads the explicit palettes. */
+  --color-shimmer: var(--color-shimmer-val);
+
   /* Ink for vendor brand marks on agent rows. Deliberately firmer than
      label-secondary: a mark is a shape, not text, so it needs near-full
      contrast to read at 18px, and the set has to look like one set. Marks
@@ -141,6 +148,7 @@
   --color-system-indigo-val: rgb(88 86 214);
   --color-system-indigo-text-val: rgb(88 86 214);
   --color-system-gold-val: rgb(202 138 4);
+  --color-shimmer-val: rgb(218 90 38);
   --color-system-gold-text-val: rgb(146 100 0);
 
   /* Brand-mark ink */
@@ -231,6 +239,7 @@
     --color-system-indigo-val: rgb(94 92 230);
     --color-system-indigo-text-val: rgb(150 148 255);
     --color-system-gold-val: rgb(255 204 0);
+    --color-shimmer-val: rgb(218 90 38);
     --color-system-gold-text-val: rgb(245 203 92);
     --color-agent-mark-val: rgb(247 247 244);
     /* The system tertiary label is ~25% opacity in dark mode; bump to 62%,
@@ -282,6 +291,7 @@
   --color-system-indigo-val: rgb(88 86 214);
   --color-system-indigo-text-val: rgb(88 86 214);
   --color-system-gold-val: rgb(202 138 4);
+  --color-shimmer-val: rgb(218 90 38);
   --color-system-gold-text-val: rgb(146 100 0);
   --color-agent-mark-val: rgb(38 37 30);
 }
@@ -333,6 +343,7 @@
   --color-system-indigo-val: rgb(94 92 230);
   --color-system-indigo-text-val: rgb(150 148 255);
   --color-system-gold-val: rgb(255 204 0);
+  --color-shimmer-val: rgb(218 90 38);
   --color-system-gold-text-val: rgb(245 203 92);
   --color-agent-mark-val: rgb(247 247 244);
 }


### PR DESCRIPTION
Fixes #101.

## The problem

#75 changed the title shimmer in two ways that combined badly:

- the highlight moved to `--color-system-gold`, a saturated yellow in dark mode and the colour the app uses for **warnings**
- the gradient background narrowed from `400%` to `200%` and the stops widened, so the lit band covers whole words at once

The result reads as a highlighter pen, and marks a healthy running session with the vocabulary of a problem.

## The fix

A new `--color-shimmer` token, valued so it sits *between* the two text colours. The band moves away from the glyphs in each theme — lifting the near-black text in light mode, dimming the near-white text in dark mode — and never paints them brighter than the text around them. That is what stops it reading as a highlighter, and it is why the band can be wide without the original problem returning.

Sweep geometry comes from the `proto/popover-overview` prototype: a background `300%` as wide as the box, so the band clears the right edge before re-entering from the left, plus a `4000ms` cycle.

| | main | this PR |
|---|---|---|
| highlight | `--color-system-gold` | `--color-shimmer` `rgb(218 90 38)` |
| background-size | `200%` | `300%` |
| stops | `30 / 50 / 70` | `35 / 50 / 65` |
| cycle | `2000ms` | `4000ms` |

The prototype hard-codes `#ff6a2c`, which `design.md` forbids, so the colour is promoted to a documented token instead.

## Screenshots

<!-- Keith: drag the two popover screenshots in here -->

## Verification

- `pnpm --filter @antiburn/desktop format` / `lint` / `type-check` / `knip`
- `pnpm --filter @antiburn/desktop test` — 682 tests, 72 files
- `node scripts/check-design-drift.mjs` — contract in sync
- Checked live in `tauri dev`, both themes, on a real ACTIVE row

## Note for reviewers

A session counts as active for only 180s after its last activity (`ACTIVE_SESSION_WINDOW_SECS`). A session you are not actively using drops out of the ACTIVE group and stops shimmering — keep it busy while you watch the row.