### PR TITLE
fix(desktop): preserve one-percent Claude usage

### DIFF
--- a/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
@@ -25,12 +25,10 @@
 //! present; the flat keys are the fallback, never a supplement, so one
 //! payload never yields the same window twice.
 //!
-//! Two more shape inconsistencies are absorbed rather than treated as errors,
-//! because the provider is not consistent about either across its own
-//! payload family: a usage figure may be a `0..=1` fraction or an
-//! already-multiplied percent (see
-//! [`normalize::used_percent_or_fraction`](super::normalize::used_percent_or_fraction)),
-//! and `resets_at` may be epoch seconds or an RFC 3339 string.
+//! Two more shape inconsistencies are absorbed rather than treated as errors.
+//! A `utilization` figure in the limits array may be a fraction or a percent.
+//! The explicit `percent` and legacy flat `utilization` fields are percentages.
+//! Also, `resets_at` may be epoch seconds or an RFC 3339 string.
 
 use serde_json::Value;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
@@ -169,16 +167,24 @@ fn window(
         role,
         kind,
         scope,
-        used_percent: used_percent_or_fraction(
-            value
-                .get("percent")
-                .or_else(|| value.get("utilization"))
-                .and_then(Value::as_f64),
-        )?,
+        used_percent: window_used_percent(name, value)?,
         starts_at: None,
         resets_at: reset_at(value.get("resets_at"))?,
         authoritative: true,
     })
+}
+
+/// Read the unit from the field and payload shape instead of the value.
+fn window_used_percent(name: &str, value: &Value) -> Result<Option<f64>, ProviderUsageError> {
+    if let Some(percent) = value.get("percent") {
+        return used_percent(percent.as_f64());
+    }
+
+    let utilization = value.get("utilization").and_then(Value::as_f64);
+    if matches!(name, "five_hour" | "seven_day") {
+        return used_percent(utilization);
+    }
+    used_percent_or_fraction(utilization)
 }
 
 /// Metered usage beyond the subscription allowance.

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -226,6 +226,32 @@ fn a_fraction_shaped_utilization_is_scaled_the_same_as_an_already_stated_percent
 }
 
 #[test]
+fn an_explicit_one_percent_reading_stays_one_percent() {
+    let current = r#"{
+      "limits": [
+        {"kind": "session", "percent": 1, "resets_at": null, "scope": null},
+        {"kind": "weekly_all", "percent": 37, "resets_at": null, "scope": null}
+      ],
+      "five_hour": {"utilization": 1.0, "resets_at": null},
+      "seven_day": {"utilization": 37.0, "resets_at": null}
+    }"#;
+    let usage = anthropic::parse_usage(current).expect("parses");
+    assert_eq!(usage.windows[0].used_percent, Some(1.0));
+    assert_eq!(usage.windows[1].used_percent, Some(37.0));
+}
+
+#[test]
+fn a_legacy_one_percent_reading_stays_one_percent() {
+    let legacy = r#"{
+      "five_hour": {"utilization": 1.0, "resets_at": null},
+      "seven_day": {"utilization": 37.0, "resets_at": null}
+    }"#;
+    let usage = anthropic::parse_usage(legacy).expect("parses");
+    assert_eq!(usage.windows[0].used_percent, Some(1.0));
+    assert_eq!(usage.windows[1].used_percent, Some(37.0));
+}
+
+#[test]
 fn resets_at_is_read_whether_it_is_epoch_seconds_or_rfc_3339() {
     let mixed = r#"{"limits": [
       {"kind": "session", "percent": 10, "resets_at": 1800003600, "scope": null},


### PR DESCRIPTION
## Summary

- parse Anthropic percentage fields according to their field and payload semantics
- keep an explicit 1 percent reading as 1 percent instead of scaling it to 100 percent
- cover both the current limits array and the legacy flat payload

## Verification

- cargo fmt --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked
- provider usage focused suite (136 tests)
- CI control-plane tests and design drift check
- pnpm slop gate (100, Healthy)
- live debug snapshot refreshed from 100 percent to 1 percent