### PR TITLE
fix(desktop): load settings modules in new webviews

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -12,7 +12,22 @@ import { defineConfig } from "vitest/config"
 const DEV_SERVER_PORT = 1420
 
 export default defineConfig(({ command, mode }) => ({
-  plugins: [react(), babel({ presets: [reactCompilerPreset()] }), tailwindcss()],
+  plugins: [
+    {
+      name: "tauri-webview-module-cache",
+      configureServer(server) {
+        server.middlewares.use((request, _response, next) => {
+          // A new Tauri webview can lack the cached body for a conditional Vite response. Send every module body.
+          delete request.headers["if-none-match"]
+          delete request.headers["if-modified-since"]
+          next()
+        })
+      },
+    },
+    react(),
+    babel({ presets: [reactCompilerPreset()] }),
+    tailwindcss(),
+  ],
 
   // Tauri reads the shell's stderr, so Vite must not clear it, and the dev
   // server has to stay on the exact port `devUrl` points at.
@@ -21,6 +36,8 @@ export default defineConfig(({ command, mode }) => ({
     host: "127.0.0.1",
     port: DEV_SERVER_PORT,
     strictPort: true,
+    // Do not store a partial module graph for a later webview.
+    headers: { "Cache-Control": "no-store" },
   },
 
   // Only variables with these prefixes reach the renderer.


### PR DESCRIPTION
## Summary

- prevent conditional Vite module responses from reaching newly created Tauri webviews
- mark development responses as non-cacheable so WebKit receives a complete lazy module graph
- keep React Compiler enabled for every desktop route

## Verification

- opened Settings repeatedly in the live macOS Tauri development app
- confirmed every module request returned a complete 200 response
- confirmed React Compiler output remains in the production Settings chunk
- pnpm --filter @antiburn/desktop build
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop test
- pnpm --filter @antiburn/desktop format