### PR TITLE
fix(desktop): detect Codex session forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ CI changes, and documentation that no user acts on stay out — see
 
 ### Fixed
 
+- **Codex forks now show their relationship in Recent Activity.** antiburn
+  reads Codex's declared parent session during discovery, so both the fork and
+  its parent show the correct relationship without an extra navigation step.
+
 - **Codex sessions show their short task names again.** Recent Activity now
   prefers Codex's generated title instead of displaying the full opening
   request when both are present.

--- a/apps/desktop/src-tauri/src/analytics.rs
+++ b/apps/desktop/src-tauri/src/analytics.rs
@@ -581,9 +581,8 @@ pub fn analytics_supported(agent: AgentKind) -> bool {
     supports_analytics(agent)
 }
 
-/// How many leading transcript lines are searched for a fork observation.
-/// Vendors write it into the synthetic metadata header, which is the first
-/// record; a handful of lines is generous and keeps the read bounded.
+/// How many leading transcript lines are searched for fork evidence.
+/// The evidence is in a metadata header near the start of the transcript.
 const FORK_OBSERVATION_LINES: usize = 5;
 
 /// How deep the search descends into a header record. The observation sits at
@@ -601,20 +600,34 @@ pub async fn fork_parent(source: &SessionSource) -> Option<String> {
         SessionSource::File(path) => tokio::fs::read_to_string(path).await.ok()?,
         SessionSource::ProviderDb { .. } => session_source_content(source).await?,
     };
+    fork_parent_from_content(&content)
+}
+
+/// Read a declared fork parent from a bounded transcript preview.
+pub fn fork_parent_from_content(content: &str) -> Option<String> {
     content
         .lines()
         .take(FORK_OBSERVATION_LINES)
         .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-        .find_map(|value| find_fork_observation(&value, FORK_OBSERVATION_DEPTH))
+        .find_map(|value| find_fork_parent(&value, FORK_OBSERVATION_DEPTH))
 }
 
-/// Recursively look for the engine's fork-observation key and pull the parent
-/// session id out of it.
-fn find_fork_observation(value: &serde_json::Value, depth: usize) -> Option<String> {
+/// Read a fork parent from vendor metadata or a normalized observation.
+fn find_fork_parent(value: &serde_json::Value, depth: usize) -> Option<String> {
     if depth == 0 {
         return None;
     }
     let object = value.as_object()?;
+    if object.get("type").and_then(serde_json::Value::as_str) == Some("session_meta")
+        && let Some(parent_id) = object
+            .get("payload")
+            .and_then(|payload| payload.get("forked_from_id"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|parent_id| !parent_id.is_empty())
+    {
+        return Some(parent_id.to_string());
+    }
     if let Some(observation) = object.get(FORK_OBSERVATION_KEY)
         && let Ok(observation) = serde_json::from_value::<ForkObservation>(observation.clone())
         && !observation.parent_agent_session_id.is_empty()
@@ -623,7 +636,7 @@ fn find_fork_observation(value: &serde_json::Value, depth: usize) -> Option<Stri
     }
     object
         .values()
-        .find_map(|nested| find_fork_observation(nested, depth - 1))
+        .find_map(|nested| find_fork_parent(nested, depth - 1))
 }
 
 /// Every model that contributed billable tokens, in a stable order.
@@ -1028,18 +1041,50 @@ mod tests {
             }
         });
         assert_eq!(
-            find_fork_observation(&header, FORK_OBSERVATION_DEPTH).as_deref(),
+            find_fork_parent(&header, FORK_OBSERVATION_DEPTH).as_deref(),
             Some("parent-42")
         );
     }
 
     #[test]
+    fn a_codex_session_header_declares_its_fork_parent() {
+        let header = serde_json::json!({
+            "timestamp": "2026-08-22T04:05:01.756Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "child-42",
+                "forked_from_id": "parent-42",
+                "source": "cli",
+                "thread_source": "user",
+            }
+        });
+        assert_eq!(
+            find_fork_parent(&header, FORK_OBSERVATION_DEPTH).as_deref(),
+            Some("parent-42")
+        );
+    }
+
+    #[test]
+    fn a_codex_fork_parent_requires_a_session_header_and_a_nonempty_id() {
+        let message = serde_json::json!({
+            "type": "response_item",
+            "payload": { "forked_from_id": "not-a-parent" }
+        });
+        let empty = serde_json::json!({
+            "type": "session_meta",
+            "payload": { "forked_from_id": "  " }
+        });
+        assert_eq!(find_fork_parent(&message, FORK_OBSERVATION_DEPTH), None);
+        assert_eq!(find_fork_parent(&empty, FORK_OBSERVATION_DEPTH), None);
+    }
+
+    #[test]
     fn a_header_without_an_observation_yields_no_parent() {
         let header = serde_json::json!({ "type": "session_meta", "metadata": { "cwd": "/x" } });
-        assert_eq!(find_fork_observation(&header, FORK_OBSERVATION_DEPTH), None);
+        assert_eq!(find_fork_parent(&header, FORK_OBSERVATION_DEPTH), None);
         // A malformed observation is ignored rather than half-read.
         let broken = serde_json::json!({ FORK_OBSERVATION_KEY: { "parent_agent": "cursor" } });
-        assert_eq!(find_fork_observation(&broken, FORK_OBSERVATION_DEPTH), None);
+        assert_eq!(find_fork_parent(&broken, FORK_OBSERVATION_DEPTH), None);
     }
 
     #[test]
@@ -1047,7 +1092,7 @@ mod tests {
         let deep = serde_json::json!({ "a": { "b": { "c": { "d": {
             FORK_OBSERVATION_KEY: { "parent_agent_session_id": "too-deep" }
         }}}}});
-        assert_eq!(find_fork_observation(&deep, FORK_OBSERVATION_DEPTH), None);
+        assert_eq!(find_fork_parent(&deep, FORK_OBSERVATION_DEPTH), None);
     }
 
     fn skill(description: Option<&str>) -> SkillUse {

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -610,6 +610,9 @@ async fn describe_one_with_activity(
         _ => Vec::new(),
     };
     let subagent_count = children.len() as u32;
+    let fork_parent_session_id = preview
+        .as_deref()
+        .and_then(analytics::fork_parent_from_content);
 
     let (updated_at_epoch, activity_source, activity_cursor) =
         semantic_activity_for_log(&log, activity_state.as_ref(), &children, preview.as_deref())
@@ -628,10 +631,7 @@ async fn describe_one_with_activity(
         activity_cursor,
         activity_source,
         subagent_count,
-        // Lineage is resolved when a session is opened: the observation lives
-        // inside the transcript, and reading every transcript on every pass
-        // would cost far more than the relationship is worth here.
-        fork_parent_session_id: None,
+        fork_parent_session_id,
     }))
 }
 
@@ -987,6 +987,27 @@ mod tests {
         path
     }
 
+    fn write_codex_fork_session(
+        home: &std::path::Path,
+        session_id: &str,
+        parent_session_id: &str,
+    ) -> std::path::PathBuf {
+        let path = write_codex_session(home, session_id);
+        let header = serde_json::json!({
+            "timestamp": "2026-08-01T10:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "forked_from_id": parent_session_id,
+                "cwd": "/home/avery/code/gadgets",
+                "source": "cli",
+                "thread_source": "user",
+            }
+        });
+        std::fs::write(&path, format!("{header}\n")).unwrap();
+        path
+    }
+
     fn log(agent: AgentKind, path: std::path::PathBuf, updated_at: i64) -> SessionLog {
         SessionLog {
             agent_type: agent,
@@ -1162,6 +1183,41 @@ mod tests {
         assert_eq!(wsl.key.environment_key, "wsl:syntheticlinux");
         assert_eq!(wsl.title.as_deref(), Some("Fallback transcript request"));
         assert_eq!(wsl.title_source.as_deref(), Some("firstMessage"));
+    }
+
+    #[tokio::test]
+    async fn a_codex_fork_records_its_parent_during_the_scan() {
+        let home = tempfile::TempDir::new().unwrap();
+        let parent_session_id = "parent-session";
+        let child_session_id = "child-session";
+        let path = write_codex_fork_session(home.path(), child_session_id, parent_session_id);
+
+        let DescribeOutcome::Session(child) = describe_one(
+            log(AgentKind::Codex, path, 1_800_000_000),
+            home.path(),
+            None,
+        )
+        .await
+        else {
+            panic!("Codex fork should be described");
+        };
+        assert_eq!(
+            child.fork_parent_session_id.as_deref(),
+            Some(parent_session_id)
+        );
+
+        let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+        store
+            .upsert_sessions(&[record("codex", parent_session_id, Some(1_799_999_000))])
+            .unwrap();
+        store.upsert_sessions(std::slice::from_ref(&child)).unwrap();
+
+        assert_eq!(
+            store
+                .fork_children(&SessionKey::new("native", "codex", parent_session_id))
+                .unwrap(),
+            vec![child_session_id.to_string()]
+        );
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -1199,11 +1199,8 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
 
     // A fork parent is written only when the caller actually observed one.
     //
-    // Absence is *not* evidence: the scan never reads transcripts deep enough
-    // to see a lineage header, so it always passes `None`, and treating that as
-    // "no parent" would erase a relation resolved when the session was opened
-    // on every subsequent pass. Lineage is a property of a transcript, and a
-    // transcript's lineage does not change.
+    // Absence is not evidence. Some adapters resolve lineage only when a
+    // session opens. A later scan must not erase that relation.
     if let Some(parent) = &record.fork_parent_session_id {
         connection.execute(
             "INSERT INTO session_relation

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -615,9 +615,7 @@ fn a_fork_parent_rides_with_the_session_and_resolves_children_back() {
         .unwrap();
     assert_eq!(children, vec!["child".to_string()]);
 
-    // A later scan carries no observation — it never reads transcripts deeply
-    // enough to see one — and must therefore leave the recorded lineage alone
-    // rather than reading absence as "no parent".
+    // A later scan can carry no observation. It must keep the recorded lineage.
     store.upsert_sessions(&[session("child", 2_100)]).unwrap();
     assert_eq!(
         store


### PR DESCRIPTION
## Summary

- recognize Codex `session_meta.payload.forked_from_id` as declared fork lineage
- persist the relationship during the existing bounded discovery preview
- preserve detail-time lineage resolution and add scan-to-store coverage

## Why

Codex writes an explicit parent ID for user-created forks, but antiburn only read normalized `local_fork_observation` metadata. Both sessions appeared in Recent Activity without either fork indicator.

## Verification

- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` (384 passed)
- `cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check`
- `git diff --check`