### PR TITLE
feat(desktop): notify when a session rehydrates its cache

### DIFF
--- a/apps/desktop/src-tauri/crates/nudge/src/model.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/model.rs
@@ -37,6 +37,8 @@ pub enum NudgeKind {
     UsageAnomaly,
     /// A provider quota window crossed a configured usage milestone.
     UsageMilestone,
+    /// A session re-sent a context the prompt cache already held.
+    CacheRehydration,
     /// The first run just finished, and the app is about to become a glyph in
     /// the menu bar the reader has never had reason to look at.
     MenuBarLocation,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -65,6 +65,7 @@ mod nudges;
 mod onboarding;
 mod popover;
 mod provider_usage;
+mod rehydration_alert;
 mod repositories;
 mod scan;
 mod settings;

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -575,7 +575,10 @@ mod tests {
         assert!(body.contains("times"), "body was {body}");
 
         // The reader is told why it costs, since that is the whole point.
-        for message in [cache_rehydration_message(1).1, cache_rehydration_message(9).1] {
+        for message in [
+            cache_rehydration_message(1).1,
+            cache_rehydration_message(9).1,
+        ] {
             assert!(message.contains("charged again"), "body was {message}");
         }
     }

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -62,6 +62,9 @@ pub enum Kind {
     UsageAnomaly,
     /// A live usage window crossed a milestone the reader asked about.
     UsageMilestone,
+    /// A session re-sent a context the prompt cache had already stored, so
+    /// the same content is billed a second time at the cache-write rate.
+    CacheRehydration,
     /// The first run finished and its window went away. Says where the app is
     /// now, once, in the reader's whole time with it.
     MenuBarHome,
@@ -94,6 +97,7 @@ pub fn allowed(settings: &AppSettings, kind: Kind) -> bool {
             Kind::ScanFailure => settings.notify_scan_failure,
             Kind::DiskSpaceLow => settings.notify_disk_space_low,
             Kind::UsageAnomaly => settings.notify_usage_anomalies,
+            Kind::CacheRehydration => settings.notify_cache_rehydration,
             // Milestones have no single switch: the two per-window rows are
             // the preference, and an empty selection is "off".
             Kind::UsageMilestone => {
@@ -165,6 +169,7 @@ fn deliver(
         Kind::DiskSpaceLow => (NudgeKind::DiskSpaceLow, NudgeTone::Warning),
         Kind::UsageAnomaly => (NudgeKind::UsageAnomaly, NudgeTone::Warning),
         Kind::UsageMilestone => (NudgeKind::UsageMilestone, NudgeTone::Info),
+        Kind::CacheRehydration => (NudgeKind::CacheRehydration, NudgeTone::Warning),
         Kind::MenuBarHome => (NudgeKind::MenuBarLocation, NudgeTone::Success),
         Kind::Test => (NudgeKind::Test, NudgeTone::Info),
     };
@@ -230,6 +235,26 @@ pub fn usage_anomaly_message(hour_usd: f64, week_usd: f64) -> (String, String) {
             "An estimated ${hour_usd:.2} in the last hour, against roughly \
              ${week_usd:.2} across the whole past week. Estimated locally \
              from your sessions — nothing was fetched."
+        ),
+    )
+}
+
+/// The title and body of a cache-rehydration notification.
+///
+/// The body carries a count and nothing else. A session title comes from
+/// transcript text, so naming the session would put session content in a
+/// notification.
+pub fn cache_rehydration_message(count: u64) -> (String, String) {
+    let detail = if count <= 1 {
+        "A session re-sent its whole context to the prompt cache.".to_string()
+    } else {
+        format!("A session re-sent its whole context to the prompt cache {count} times.")
+    };
+    (
+        "Ouch \u{2014} cache rehydration".to_string(),
+        format!(
+            "{detail} That content was already cached, so it is charged again \
+             at the cache-write rate."
         ),
     )
 }
@@ -371,6 +396,17 @@ pub fn note_usage_anomaly(app: &AppHandle, hour_usd: f64, week_usd: f64) -> bool
     true
 }
 
+/// Report a cache rehydration. Deciding that one is *new* is the caller's job
+/// ([`crate::rehydration_alert`]); this only applies the preference gate.
+pub fn note_cache_rehydration(app: &AppHandle, count: u64) -> bool {
+    if !enabled(app, Kind::CacheRehydration) {
+        return false;
+    }
+    let (title, body) = cache_rehydration_message(count);
+    deliver(app, Kind::CacheRehydration, title, body, None);
+    true
+}
+
 /// Report crossed milestones. Selection and dedup happen in the engine
 /// ([`crate::provider_usage::live`]); this only applies the preference gate.
 pub fn note_usage_milestone(
@@ -504,6 +540,44 @@ mod tests {
         assert_eq!(HOME_NOUN, "menu bar");
         #[cfg(not(target_os = "macos"))]
         assert_eq!(HOME_NOUN, "system tray");
+    }
+
+    #[test]
+    fn cache_rehydration_honors_its_own_switch_and_the_master() {
+        let settings = AppSettings {
+            notify_cache_rehydration: false,
+            ..settings()
+        };
+        assert!(!allowed(&settings, Kind::CacheRehydration));
+        assert!(
+            allowed(&settings, Kind::UsageAnomaly),
+            "one kind off must leave the others alone"
+        );
+
+        let master_off = AppSettings {
+            notifications_enabled: false,
+            ..AppSettings::default()
+        };
+        assert!(!allowed(&master_off, Kind::CacheRehydration));
+        assert!(allowed(&AppSettings::default(), Kind::CacheRehydration));
+    }
+
+    #[test]
+    fn the_rehydration_message_counts_without_naming_a_session() {
+        let (title, body) = cache_rehydration_message(1);
+        assert!(title.starts_with("Ouch"), "title was {title}");
+        assert!(title.contains("cache rehydration"), "title was {title}");
+        // One event reads as one event, not "1 times".
+        assert!(!body.contains('1'), "body was {body}");
+
+        let (_, body) = cache_rehydration_message(4);
+        assert!(body.contains('4'), "body was {body}");
+        assert!(body.contains("times"), "body was {body}");
+
+        // The reader is told why it costs, since that is the whole point.
+        for message in [cache_rehydration_message(1).1, cache_rehydration_message(9).1] {
+            assert!(message.contains("charged again"), "body was {message}");
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/rehydration_alert.rs
+++ b/apps/desktop/src-tauri/src/rehydration_alert.rs
@@ -1,0 +1,177 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The cache-rehydration alert: say when a session pays a second time for
+//! context the prompt cache had already stored.
+//!
+//! # What counts as new
+//!
+//! The engine reports how many turns of a session rewrote a context the cache
+//! already held ([`SessionMetrics::cache_rehydration_count`]). This module
+//! keeps the count each session last reported, and announces only an
+//! *increase*.
+//!
+//! A session this module has never seen records its count and says nothing.
+//! That one rule is what keeps the first scan of a machine quiet: months of
+//! finished sessions each establish a baseline instead of each announcing
+//! their history. The reader hears about what happens while antiburn watches.
+//!
+//! # Why a key/value blob, and not a column
+//!
+//! "Have I mentioned this yet" is bookkeeping, not session evidence, so it
+//! does not belong in the analysis tables the views and the export read. It
+//! lives under `internal:` beside the other alert state, and the map is
+//! pruned every pass to the sessions that pass looked at, so it stays the
+//! size of the activity window rather than the size of the archive.
+//!
+//! # What a notification carries
+//!
+//! A count, and nothing else. A session title comes from transcript text, so
+//! naming the session here would put session content in a notification — see
+//! the rules in [`crate::notifications`].
+
+use std::collections::{BTreeMap, HashSet};
+
+use tauri::AppHandle;
+
+use crate::store::{SessionKey, Store};
+
+/// Where the per-session counts survive a relaunch.
+const SEEN_KEY: &str = "internal:cacheRehydrationSeen";
+
+/// Whether `current` is worth announcing, given what the last pass recorded.
+///
+/// `seen` of `None` means no pass has looked at this session before. The
+/// count becomes a baseline and nothing is announced.
+pub fn is_new_rehydration(seen: Option<u64>, current: u64) -> bool {
+    matches!(seen, Some(previous) if current > previous)
+}
+
+/// The identity a count is filed under. Includes the environment so the same
+/// session id under two roots cannot share one baseline.
+fn map_key(key: &SessionKey) -> String {
+    format!(
+        "{}\u{1f}{}\u{1f}{}",
+        key.environment_key, key.agent, key.session_id
+    )
+}
+
+/// The per-session counts the last pass recorded.
+///
+/// A malformed or missing value reads as empty. The consequence is one quiet
+/// pass while every session re-baselines, where the alternative — failing the
+/// pass — would take scanning down over an alert's bookkeeping.
+#[derive(Debug, Default)]
+pub struct SeenCounts {
+    counts: BTreeMap<String, u64>,
+}
+
+impl SeenCounts {
+    pub fn load(store: &Store) -> Self {
+        let counts = store
+            .internal_value(SEEN_KEY)
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default();
+        Self { counts }
+    }
+
+    /// Record `current` for this session, and report whether it is a rise on
+    /// what the last pass saw.
+    pub fn observe(&mut self, key: &SessionKey, current: u64) -> bool {
+        let key = map_key(key);
+        let announce = is_new_rehydration(self.counts.get(&key).copied(), current);
+        self.counts.insert(key, current);
+        announce
+    }
+
+    /// Drop every session outside `keep`, so the map tracks the activity
+    /// window rather than growing for the life of the install.
+    pub fn retain(&mut self, keep: &HashSet<String>) {
+        self.counts.retain(|key, _| keep.contains(key));
+    }
+
+    /// The key `retain` expects for a session this pass considered.
+    pub fn retained_key(key: &SessionKey) -> String {
+        map_key(key)
+    }
+
+    pub fn save(&self, store: &Store) {
+        if let Ok(raw) = serde_json::to_string(&self.counts) {
+            store.set_internal_value(SEEN_KEY, &raw);
+        }
+    }
+}
+
+/// Announce a rise in one session's rehydration count.
+///
+/// Split from [`SeenCounts::observe`] so a pass can decide and record without
+/// a running application — the tests, and any caller with no `AppHandle`.
+pub fn announce(app: &AppHandle, count: u64) {
+    crate::notifications::note_cache_rehydration(app, count);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_session_never_seen_before_only_baselines() {
+        assert!(!is_new_rehydration(None, 0));
+        assert!(
+            !is_new_rehydration(None, 12),
+            "a first sight of an old session must not announce its history"
+        );
+    }
+
+    #[test]
+    fn a_rise_announces_and_a_repeat_does_not() {
+        assert!(is_new_rehydration(Some(0), 1));
+        assert!(is_new_rehydration(Some(3), 9));
+        assert!(!is_new_rehydration(Some(3), 3));
+    }
+
+    #[test]
+    fn a_fall_does_not_announce() {
+        // A re-analysis can report fewer turns than the last one — a shorter
+        // window, or a transcript that was rewritten. That is not an event.
+        assert!(!is_new_rehydration(Some(5), 2));
+    }
+
+    #[test]
+    fn the_key_separates_environments() {
+        let one = SessionKey::new("root-a", "claude", "s1");
+        let two = SessionKey::new("root-b", "claude", "s1");
+        assert_ne!(map_key(&one), map_key(&two));
+    }
+
+    #[test]
+    fn observe_baselines_then_announces() {
+        let mut seen = SeenCounts::default();
+        let key = SessionKey::new("root", "claude", "s1");
+        assert!(!seen.observe(&key, 2), "the first look is a baseline");
+        assert!(!seen.observe(&key, 2), "an unchanged count says nothing");
+        assert!(seen.observe(&key, 3), "one more rehydration is an event");
+        assert!(!seen.observe(&key, 3));
+    }
+
+    #[test]
+    fn retain_drops_sessions_outside_the_window() {
+        let mut seen = SeenCounts::default();
+        let kept = SessionKey::new("root", "claude", "kept");
+        let dropped = SessionKey::new("root", "claude", "dropped");
+        seen.observe(&kept, 1);
+        seen.observe(&dropped, 1);
+
+        let keep = HashSet::from([SeenCounts::retained_key(&kept)]);
+        seen.retain(&keep);
+
+        assert_eq!(seen.counts.len(), 1);
+        assert!(seen.counts.contains_key(&map_key(&kept)));
+    }
+
+    #[test]
+    fn the_state_key_is_internal() {
+        assert!(SEEN_KEY.starts_with("internal:"));
+    }
+}

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -858,6 +858,15 @@ async fn top_up_analysis(app: &AppHandle, now: i64, activity_days: i64) -> anyho
     let since = now - activity_days.max(1) * 86_400;
     let candidates = store.recent_sessions(since, MAX_ANALYSES_PER_PASS)?;
 
+    // Rehydration counts for every session this pass considers, so the map is
+    // pruned to the activity window rather than growing for the life of the
+    // install. Sessions whose analysis is still fresh keep their baseline.
+    let mut seen = crate::rehydration_alert::SeenCounts::load(&store);
+    let considered: std::collections::HashSet<String> = candidates
+        .iter()
+        .map(|record| crate::rehydration_alert::SeenCounts::retained_key(&record.key))
+        .collect();
+
     for record in candidates {
         // Analysis is the long tail of a pass — one whole transcript read per
         // session — so this is where a cancel is felt.
@@ -892,6 +901,16 @@ async fn top_up_analysis(app: &AppHandle, now: i64, activity_days: i64) -> anyho
 
         let analysis =
             analytics::analyze(agent, &record.key.session_id, record.wsl_distro.as_deref()).await;
+        if let Some(metrics) = analysis.metrics.as_ref() {
+            let count = metrics.cache_rehydration_count;
+            if seen.observe(&record.key, count) {
+                // Record before saying anything. A pass can still be cancelled
+                // or fail after this point, and a count that only lived in
+                // memory would announce the same rehydration again next pass.
+                seen.save(&store);
+                crate::rehydration_alert::announce(app, count);
+            }
+        }
         if let Some(cache) = analysis.record(&record.key) {
             store.save_analysis(&cache)?;
         }
@@ -912,6 +931,8 @@ async fn top_up_analysis(app: &AppHandle, now: i64, activity_days: i64) -> anyho
             )?;
         }
     }
+    seen.retain(&considered);
+    seen.save(&store);
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -987,6 +987,10 @@ fn read_settings(connection: &Connection) -> Result<AppSettings> {
             .get("notifyUsageAnomalies")
             .map(|value| value == "true")
             .unwrap_or(defaults.notify_usage_anomalies),
+        notify_cache_rehydration: stored
+            .get("notifyCacheRehydration")
+            .map(|value| value == "true")
+            .unwrap_or(defaults.notify_cache_rehydration),
         milestones_5h: stored
             .get("milestones5h")
             .map(|value| Milestones::parse(value))
@@ -1082,6 +1086,10 @@ fn write_settings(connection: &Connection, settings: &AppSettings) -> Result<()>
     put.execute(params![
         "notifyUsageAnomalies",
         bool_text(settings.notify_usage_anomalies)
+    ])?;
+    put.execute(params![
+        "notifyCacheRehydration",
+        bool_text(settings.notify_cache_rehydration)
     ])?;
     put.execute(params!["milestones5h", settings.milestones_5h.as_str()])?;
     put.execute(params![

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -429,6 +429,8 @@ pub struct AppSettings {
     pub notify_disk_space_low: bool,
     /// Notify when sustained spend is unusually fast for this machine.
     pub notify_usage_anomalies: bool,
+    /// Notify when a session re-sends a context the prompt cache already held.
+    pub notify_cache_rehydration: bool,
     /// Five-hour-window usage milestones that notify. Only meaningful while
     /// the live usage source is enabled — milestones need a real limit.
     pub milestones_5h: Milestones,
@@ -479,6 +481,7 @@ impl Default for AppSettings {
             disk_space_threshold_gb: DEFAULT_DISK_THRESHOLD_GB,
             notify_disk_space_low: true,
             notify_usage_anomalies: true,
+            notify_cache_rehydration: true,
             milestones_5h: Milestones::default(),
             milestones_weekly: Milestones::default(),
             // On by default. This is antiburn's own agent asking a provider

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -206,6 +206,7 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
             disk_space_threshold_gb: 100,
             notify_disk_space_low: false,
             notify_usage_anomalies: false,
+            notify_cache_rehydration: false,
             milestones_5h: Milestones {
                 at50: false,
                 at75: true,

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -92,6 +92,8 @@ export interface AppSettings {
   notifyDiskSpaceLow: boolean
   /** Notify when sustained spend is unusually fast for this machine. */
   notifyUsageAnomalies: boolean
+  /** Notify when a session re-sends a context the prompt cache already held. */
+  notifyCacheRehydration: boolean
   /** Five-hour-window milestones. Only fire while live usage is enabled. */
   milestones5h: Milestones
   /** Weekly-window milestones. */
@@ -531,6 +533,7 @@ export type NudgeKind =
   | "diskSpaceLow"
   | "usageAnomaly"
   | "usageMilestone"
+  | "cacheRehydration"
   | "test"
 
 /** Visual tone — informational, positive, or attention. Mirrors Rust `NudgeTone`. */
@@ -603,6 +606,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   diskSpaceThresholdGb: 50,
   notifyDiskSpaceLow: true,
   notifyUsageAnomalies: true,
+  notifyCacheRehydration: true,
   milestones5h: { at50: true, at75: true, at90: true },
   milestonesWeekly: { at50: true, at75: true, at90: true },
   liveUsageEnabled: true,

--- a/apps/desktop/src/views/settings/NotificationsPane.tsx
+++ b/apps/desktop/src/views/settings/NotificationsPane.tsx
@@ -184,6 +184,14 @@ export function NotificationsPane({ settings, update }: NotificationsPaneProps) 
             dimmed={!on}
             disabled={!on}
           />
+          <ToggleRow
+            label="Cache rehydrations"
+            description="Alerts when a session re-sends a context the prompt cache had already stored — content you have paid to cache, charged again at the write rate. Read from your own transcripts; nothing is fetched."
+            checked={settings.notifyCacheRehydration}
+            onChange={(next) => void update({ notifyCacheRehydration: next })}
+            dimmed={!on}
+            disabled={!on}
+          />
           <Row
             label="5-hour milestones"
             description="Notify once as each selected level of a provider's 5-hour limit is crossed. These need readings that keep moving, so they fire only while Settings → Usage is set to refresh. With that off you still see your limits; antiburn just never interrupts you about them."


### PR DESCRIPTION
## What

A new notification: when a session re-sends a context the prompt cache had already stored, antiburn says so.

> **Ouch — cache rehydration**
> A session re-sent its whole context to the prompt cache. That content was already cached, so it is charged again at the cache-write rate.

The engine has counted these turns per session since the Context chart started drawing them (`SessionMetrics::cache_rehydration_count`), but nothing told the reader while it was happening. This wires that existing count to the existing notification path — no engine or detection change.

## How

`rehydration_alert.rs` keeps the count each session last reported, under `internal:` with the other alert bookkeeping, and announces only an **increase**.

Three properties that shape the design:

- **A first scan stays silent.** A session no pass has seen records its count and says nothing. Without that rule, installing antiburn on a machine with months of history would fire a notification per historical session.
- **The count is saved before the notification goes out.** A pass can be cancelled or fail after the decision; a count that only lived in memory would announce the same rehydration again next pass.
- **The map is pruned each pass** to the sessions that pass considered, so it stays the size of the activity window rather than growing for the life of the install.

Gated like every other kind — the master switch plus its own row in Settings → Notifications, defaulting on.

## Notes

The body carries a count and nothing else. A session title comes from transcript text, and per the rules in `notifications.rs` no notification carries session content — so the copy names no session and no path.

The user deferred the token figure (`… — 123k tokens`) for now. Worth knowing for when it comes back: there is no token quantity to put there today. The current detector emits only a bool and a count, and its write-ratio rule (`engine.rs:68`) both misses partial rehydrations and cannot express magnitude. That would need the engine change, not this one.

## Testing

- `cargo test` — 388 pass (13 new: 7 in `rehydration_alert`, 2 notification gate/copy, plus the settings round-trip)
- `cargo clippy --all-targets` — clean
- `pnpm test` — 693 pass; `pnpm type-check`, `pnpm lint`, `pnpm format` — clean
- `scripts/check-design-drift.mjs` — in sync

Not verified: the notification rendering on a real desktop. This container has no display, so the nudge window itself was never shown — only its payload and gating are covered by tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fz7L1niQHF1mJW28niVBgu)_