### PR TITLE
fix: infer Codex cache rehydration

### DIFF
--- a/apps/desktop/src-tauri/src/analytics.rs
+++ b/apps/desktop/src-tauri/src/analytics.rs
@@ -200,7 +200,7 @@ fn sum_billable_tokens(breakdown: &HashMap<String, ModelTokens>) -> BillableToke
 pub const MISSING_FINGERPRINT: &str = "-";
 
 /// This version invalidates cached values when the analysis cache contract changes.
-const ANALYSIS_FINGERPRINT_VERSION: u8 = 1;
+const ANALYSIS_FINGERPRINT_VERSION: u8 = 2;
 
 /// `mtime:size` of a transcript file, or [`MISSING_FINGERPRINT`].
 pub fn fingerprint_of(source: &SessionSource) -> String {

--- a/crates/antiburn-local/src/analysis/engine.rs
+++ b/crates/antiburn-local/src/analysis/engine.rs
@@ -50,6 +50,9 @@ pub const IDLE_GAP_MS: i64 = 5 * 60 * 1000;
 ///   compaction always rewrites the (now smaller) context and that is not a
 ///   TTL lapse.
 ///
+/// Some providers do not report cache writes. For them, the engine finds a
+/// large replay after a cache-read collapse. The next cached turn confirms it.
+///
 /// Ignore contexts under this size; a full rewrite of a small context is
 /// cheap and not worth flagging as a rehydration event.
 const CACHE_REHYDRATION_MIN_CONTEXT_TOKENS: u64 = 20_000;
@@ -62,6 +65,14 @@ const CACHE_REHYDRATION_WRITE_RATIO: f64 = 0.5;
 /// The previous turn's cache read must reach this share of its context so the
 /// rehydration is a real TTL lapse, not the first turn after a fresh session.
 const CACHE_REHYDRATION_PRIOR_READ_RATIO: f64 = 0.5;
+/// An inferred miss reads at most this share from the old cache.
+const CACHE_REHYDRATION_MISS_READ_RATIO: f64 = 0.2;
+/// An inferred miss keeps at least this share of the previous context.
+const CACHE_REHYDRATION_CONTEXT_RETENTION_RATIO: f64 = 0.8;
+/// Replayed input must reach this share of the current context.
+const CACHE_REHYDRATION_REPLAY_RATIO: f64 = 0.5;
+/// The next turn must read at least this share from the rebuilt cache.
+const CACHE_REHYDRATION_RECOVERY_READ_RATIO: f64 = 0.5;
 
 /// Pure decision function for [`CACHE_REHYDRATION_*`] rehydration detection,
 /// factored out so the rule is unit-testable without a full event fixture.
@@ -82,6 +93,123 @@ fn is_cache_rehydration_turn(
     let prev_read_ratio = prev_cache_read_tokens as f64 / prev_context_tokens as f64;
     write_ratio >= CACHE_REHYDRATION_WRITE_RATIO
         && prev_read_ratio >= CACHE_REHYDRATION_PRIOR_READ_RATIO
+}
+
+#[derive(Clone, Copy)]
+struct CacheTurn<'a> {
+    event_index: usize,
+    context_tokens: u64,
+    fresh_input_tokens: u64,
+    cache_read_tokens: u64,
+    first_turn_after_compaction: bool,
+    model: Option<&'a str>,
+}
+
+fn cache_ratio(tokens: u64, context_tokens: u64) -> f64 {
+    if context_tokens == 0 {
+        return 0.0;
+    }
+    tokens as f64 / context_tokens as f64
+}
+
+fn same_known_model(left: Option<&str>, right: Option<&str>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => left == right,
+        _ => true,
+    }
+}
+
+fn inferred_cache_rehydration_turn(previous: CacheTurn<'_>, current: CacheTurn<'_>) -> bool {
+    if current.first_turn_after_compaction
+        || current.context_tokens < CACHE_REHYDRATION_MIN_CONTEXT_TOKENS
+        || cache_ratio(previous.cache_read_tokens, previous.context_tokens)
+            < CACHE_REHYDRATION_PRIOR_READ_RATIO
+        || cache_ratio(current.cache_read_tokens, current.context_tokens)
+            > CACHE_REHYDRATION_MISS_READ_RATIO
+        || !same_known_model(previous.model, current.model)
+    {
+        return false;
+    }
+
+    let retained_context_ratio = current.context_tokens as f64 / previous.context_tokens as f64;
+    if retained_context_ratio < CACHE_REHYDRATION_CONTEXT_RETENTION_RATIO {
+        return false;
+    }
+
+    let context_growth = current
+        .context_tokens
+        .saturating_sub(previous.context_tokens);
+    let replayed_input = current.fresh_input_tokens.saturating_sub(context_growth);
+    cache_ratio(replayed_input, current.context_tokens) >= CACHE_REHYDRATION_REPLAY_RATIO
+}
+
+fn cache_rehydration_event_indices(session: &NormalizedSession) -> HashSet<usize> {
+    let mut indices = HashSet::new();
+    let mut turns = Vec::new();
+    let mut previous_context = 0u64;
+    let mut previous_cache_read = 0u64;
+    let mut first_turn_after_compaction = false;
+    let mut active_model = session.model.as_deref();
+
+    for (event_index, event) in session.events.iter().enumerate() {
+        if event.source != EventSource::Parent {
+            continue;
+        }
+        if let Some(model) = event.model.as_deref().filter(|model| !model.is_empty()) {
+            active_model = Some(model);
+        }
+        if event.is_compaction_boundary {
+            first_turn_after_compaction = true;
+        }
+        let context_tokens = event.usage.context_tokens();
+        if context_tokens == 0 {
+            continue;
+        }
+
+        if session.cache_write_tokens_available
+            && is_cache_rehydration_turn(
+                context_tokens,
+                event.usage.cache_creation_tokens,
+                previous_context,
+                previous_cache_read,
+                first_turn_after_compaction,
+            )
+        {
+            indices.insert(event_index);
+        }
+        turns.push(CacheTurn {
+            event_index,
+            context_tokens,
+            fresh_input_tokens: event.usage.input_tokens,
+            cache_read_tokens: event.usage.cache_read_tokens,
+            first_turn_after_compaction,
+            model: active_model,
+        });
+        previous_context = context_tokens;
+        previous_cache_read = event.usage.cache_read_tokens;
+        first_turn_after_compaction = false;
+    }
+
+    if session.cache_write_tokens_available {
+        return indices;
+    }
+
+    for window in turns.windows(3) {
+        let [previous, current, next] = window else {
+            continue;
+        };
+        let recovery_ratio = cache_ratio(next.cache_read_tokens, next.context_tokens);
+        let recovery_retention = next.context_tokens as f64 / current.context_tokens as f64;
+        if inferred_cache_rehydration_turn(*previous, *current)
+            && !next.first_turn_after_compaction
+            && recovery_ratio >= CACHE_REHYDRATION_RECOVERY_READ_RATIO
+            && recovery_retention >= CACHE_REHYDRATION_CONTEXT_RETENTION_RATIO
+            && same_known_model(current.model, next.model)
+        {
+            indices.insert(current.event_index);
+        }
+    }
+    indices
 }
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -140,7 +268,7 @@ pub struct Bucket {
     /// already includes cache writes as effective input.
     pub cache_write_tokens: u64,
     /// True when a turn landing in this bucket is a detected cache
-    /// rehydration (see `CACHE_REHYDRATION_WRITE_RATIO`).
+    /// rehydration (see `cache_rehydration_event_indices`).
     pub is_cache_rehydration: bool,
     /// Count of `Task` tool calls in this bucket: how many sub-agents the
     /// parent session launched at this point. Parent turns only — a
@@ -205,7 +333,7 @@ pub struct SessionMetrics {
     /// Compaction boundaries in the parent transcript.
     #[serde(default)]
     pub compaction_count: u64,
-    /// Turns the engine flags as a cache rehydration (see `is_cache_rehydration_turn`).
+    /// Turns the engine flags as a cache rehydration.
     #[serde(default)]
     pub cache_rehydration_count: u64,
     /// Whether the model context window is known well enough to present
@@ -366,14 +494,9 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
     let mut skill_event_idx: Vec<usize> = Vec::new();
     let mut buckets = vec![Bucket::default(); BUCKETS];
     let n = session.events.len();
+    let cache_rehydration_events = cache_rehydration_event_indices(session);
     // Timestamp-less events use the position of the preceding timestamped event.
     let mut last_progress = 0.0f32;
-    // Cache-rehydration detection state, carried turn to turn (a "turn" is an
-    // event with non-zero context occupancy; events with no usage, like tool
-    // results, don't move this state).
-    let mut prev_turn_context = 0u64;
-    let mut prev_turn_cache_read = 0u64;
-    let mut awaiting_first_turn_after_compaction = false;
     let mut compaction_count = 0u64;
     let mut cache_rehydration_count = 0u64;
     for (idx, ev) in session.events.iter().enumerate() {
@@ -419,28 +542,15 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
             bucket.is_compaction_boundary |= ev.is_compaction_boundary;
             if ev.is_compaction_boundary {
                 compaction_count += 1;
-                awaiting_first_turn_after_compaction = true;
                 // Keep the last compaction's trigger/sizes when two land in
                 // one bucket.
                 bucket.compaction_trigger = ev.compaction_trigger;
                 bucket.compaction_pre_tokens = ev.compaction_pre_tokens;
                 bucket.compaction_post_tokens = ev.compaction_post_tokens;
             }
-            let context_tokens = ev.usage.context_tokens();
-            if context_tokens > 0 {
-                if is_cache_rehydration_turn(
-                    context_tokens,
-                    ev.usage.cache_creation_tokens,
-                    prev_turn_context,
-                    prev_turn_cache_read,
-                    awaiting_first_turn_after_compaction,
-                ) {
-                    bucket.is_cache_rehydration = true;
-                    cache_rehydration_count += 1;
-                }
-                prev_turn_context = context_tokens;
-                prev_turn_cache_read = ev.usage.cache_read_tokens;
-                awaiting_first_turn_after_compaction = false;
+            if cache_rehydration_events.contains(&idx) {
+                bucket.is_cache_rehydration = true;
+                cache_rehydration_count += 1;
             }
             // A `Task` tool call launches a sub-agent. Mark the bucket so a
             // reader can see it in the tooltip; this never draws a chart line.

--- a/crates/antiburn-local/src/analysis/merge.rs
+++ b/crates/antiburn-local/src/analysis/merge.rs
@@ -47,6 +47,7 @@ pub fn merge_subagent_events(
         agent,
         session_id,
         events: parent_events,
+        cache_write_tokens_available,
         context_window,
         model,
     } = parent;
@@ -63,6 +64,7 @@ pub fn merge_subagent_events(
         agent,
         session_id,
         events: combined.into_iter().map(|(_, event)| event).collect(),
+        cache_write_tokens_available,
         context_window,
         model,
     }
@@ -97,6 +99,7 @@ mod tests {
             agent: "claude".into(),
             session_id: id.into(),
             events,
+            cache_write_tokens_available: true,
             context_window: None,
             model: None,
         }

--- a/crates/antiburn-local/src/analysis/model.rs
+++ b/crates/antiburn-local/src/analysis/model.rs
@@ -358,6 +358,10 @@ pub struct NormalizedSession {
     pub agent: String,
     pub session_id: String,
     pub events: Vec<NormalizedEvent>,
+    /// True when the adapter can observe cache-write tokens. A false value
+    /// means zero cache writes are unknown, not that no cache write occurred.
+    #[serde(default)]
+    pub cache_write_tokens_available: bool,
     /// The model's context-window size for this session, when the vendor reports
     /// it (e.g. Codex `model_context_window`). Claude leaves this as `None` for
     /// unknown model ids so context occupancy can be presented as unavailable.

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -951,6 +951,40 @@ fn codex_cache_read_tokens_are_carried_into_buckets() {
     );
 }
 
+/// Codex writes the last `token_count` row again on resume. The third row here
+/// repeats the second exactly. The fourth row repeats `last_token_usage` but
+/// moves `total_token_usage`, so it is a real turn and must stay.
+const CODEX_RESUME_GHOST_FIXTURE: &str = concat!(
+    r#"{"timestamp":"2026-08-22T07:55:39Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":30000,"cached_input_tokens":25000,"output_tokens":100},"last_token_usage":{"input_tokens":30000,"cached_input_tokens":25000,"output_tokens":100},"model_context_window":258400}}}"#,
+    "\n",
+    r#"{"timestamp":"2026-08-22T07:56:39Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":61000,"cached_input_tokens":55000,"output_tokens":200},"last_token_usage":{"input_tokens":31000,"cached_input_tokens":30000,"output_tokens":100},"model_context_window":258400}}}"#,
+    "\n",
+    r#"{"timestamp":"2026-08-22T11:24:21Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":61000,"cached_input_tokens":55000,"output_tokens":200},"last_token_usage":{"input_tokens":31000,"cached_input_tokens":30000,"output_tokens":100},"model_context_window":258400}}}"#,
+    "\n",
+    r#"{"timestamp":"2026-08-22T11:24:29Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":92000,"cached_input_tokens":85000,"output_tokens":300},"last_token_usage":{"input_tokens":31000,"cached_input_tokens":30000,"output_tokens":100},"model_context_window":258400}}}"#,
+);
+
+#[test]
+fn codex_resume_does_not_repeat_the_last_token_count_as_a_turn() {
+    let session = normalize_source(&jsonl_input("codex", CODEX_RESUME_GHOST_FIXTURE)).unwrap();
+    let turns: Vec<i64> = session
+        .events
+        .iter()
+        .filter(|event| event.usage.context_tokens() > 0)
+        .filter_map(|event| event.ts_ms)
+        .collect();
+
+    assert_eq!(
+        turns.len(),
+        3,
+        "the resume copy is dropped, the real repeat stays"
+    );
+    assert!(
+        !turns.contains(&1_787_397_861_000),
+        "the 11:24:21Z ghost row is absent"
+    );
+}
+
 /// These values come from a Codex session after a long idle gap. The miss
 /// replays the old context, and the next turn confirms that the cache returns.
 const CODEX_INFERRED_CACHE_REHYDRATION_FIXTURE: &str = concat!(

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -932,6 +932,7 @@ const CODEX_CACHE_FIXTURE: &str = concat!(
 #[test]
 fn codex_cache_read_tokens_are_carried_into_buckets() {
     let session = normalize_source(&jsonl_input("codex", CODEX_CACHE_FIXTURE)).unwrap();
+    assert!(!session.cache_write_tokens_available);
     let m = analyze_session(&session);
 
     assert_eq!(
@@ -948,6 +949,95 @@ fn codex_cache_read_tokens_are_carried_into_buckets() {
             .sum::<u64>(),
         0
     );
+}
+
+/// These values come from a Codex session after a long idle gap. The miss
+/// replays the old context, and the next turn confirms that the cache returns.
+const CODEX_INFERRED_CACHE_REHYDRATION_FIXTURE: &str = concat!(
+    r#"{"timestamp":"2026-08-22T07:55:39.907Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":151715,"cached_input_tokens":150400,"cache_write_input_tokens":0,"output_tokens":194},"model_context_window":258400}}}"#,
+    "\n",
+    r#"{"timestamp":"2026-08-22T11:24:21.967Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":151941,"cached_input_tokens":6912,"cache_write_input_tokens":0,"output_tokens":577},"model_context_window":258400}}}"#,
+    "\n",
+    r#"{"timestamp":"2026-08-22T11:24:29.777Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":153079,"cached_input_tokens":151424,"cache_write_input_tokens":0,"output_tokens":271},"model_context_window":258400}}}"#,
+);
+
+#[test]
+fn codex_cache_rehydration_is_inferred_from_replay_and_recovery() {
+    let session = normalize_source(&jsonl_input(
+        "codex",
+        CODEX_INFERRED_CACHE_REHYDRATION_FIXTURE,
+    ))
+    .unwrap();
+    let m = analyze_session(&session);
+
+    assert_eq!(m.cache_rehydration_count, 1);
+    assert_eq!(
+        m.buckets
+            .iter()
+            .filter(|bucket| bucket.is_cache_rehydration)
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn known_zero_cache_writes_do_not_use_rehydration_inference() {
+    let mut session = normalize_source(&jsonl_input(
+        "codex",
+        CODEX_INFERRED_CACHE_REHYDRATION_FIXTURE,
+    ))
+    .unwrap();
+    session.cache_write_tokens_available = true;
+    let m = analyze_session(&session);
+
+    assert_eq!(m.cache_rehydration_count, 0);
+}
+
+#[test]
+fn codex_large_new_input_is_not_inferred_as_cache_rehydration() {
+    let fixture = concat!(
+        r#"{"timestamp":"2026-08-22T07:55:39Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":30000,"cached_input_tokens":25000,"output_tokens":100},"model_context_window":258400}}}"#,
+        "\n",
+        r#"{"timestamp":"2026-08-22T11:24:21Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100000,"cached_input_tokens":5000,"output_tokens":100},"model_context_window":258400}}}"#,
+        "\n",
+        r#"{"timestamp":"2026-08-22T11:24:29Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":102000,"cached_input_tokens":100000,"output_tokens":100},"model_context_window":258400}}}"#,
+    );
+    let session = normalize_source(&jsonl_input("codex", fixture)).unwrap();
+    let m = analyze_session(&session);
+
+    assert_eq!(m.cache_rehydration_count, 0);
+}
+
+#[test]
+fn codex_cache_miss_without_recovery_is_not_a_confirmed_rehydration() {
+    let fixture = concat!(
+        r#"{"timestamp":"2026-08-22T07:55:39Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":151715,"cached_input_tokens":150400,"output_tokens":100},"model_context_window":258400}}}"#,
+        "\n",
+        r#"{"timestamp":"2026-08-22T11:24:21Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":151941,"cached_input_tokens":6912,"output_tokens":100},"model_context_window":258400}}}"#,
+        "\n",
+        r#"{"timestamp":"2026-08-22T11:24:29Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":153079,"cached_input_tokens":6912,"output_tokens":100},"model_context_window":258400}}}"#,
+    );
+    let session = normalize_source(&jsonl_input("codex", fixture)).unwrap();
+    let m = analyze_session(&session);
+
+    assert_eq!(m.cache_rehydration_count, 0);
+}
+
+#[test]
+fn codex_first_turn_after_compaction_is_not_an_inferred_rehydration() {
+    let fixture = concat!(
+        r#"{"timestamp":"2026-08-22T07:55:39Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":151715,"cached_input_tokens":150400,"output_tokens":100},"model_context_window":258400}}}"#,
+        "\n",
+        r#"{"timestamp":"2026-08-22T11:24:20Z","type":"compacted","payload":{}}"#,
+        "\n",
+        r#"{"timestamp":"2026-08-22T11:24:21Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":151941,"cached_input_tokens":6912,"output_tokens":100},"model_context_window":258400}}}"#,
+        "\n",
+        r#"{"timestamp":"2026-08-22T11:24:29Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":153079,"cached_input_tokens":151424,"output_tokens":100},"model_context_window":258400}}}"#,
+    );
+    let session = normalize_source(&jsonl_input("codex", fixture)).unwrap();
+    let m = analyze_session(&session);
+
+    assert_eq!(m.cache_rehydration_count, 0);
 }
 
 /// An OpenCode session as the discovery layer emits it: `message` rows (role +

--- a/crates/antiburn-local/src/analysis/vendors/antigravity.rs
+++ b/crates/antiburn-local/src/analysis/vendors/antigravity.rs
@@ -46,6 +46,7 @@ impl VendorAdapter for AntigravityAdapter {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events: parse_antigravity(&content),
+            cache_write_tokens_available: true,
             context_window: None,
             model: None,
         })

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -39,6 +39,7 @@ impl VendorAdapter for ClaudeAdapter {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events,
+            cache_write_tokens_available: true,
             context_window,
             model,
         })

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -83,6 +83,8 @@ fn parse_codex(content: &str) -> (Vec<NormalizedEvent>, Option<u64>, Option<Stri
     // back-to-back for the same compaction (see `compaction_event`).
     let mut previous_event_was_boundary = false;
     let mut previous_boundary_ts: Option<i64> = None;
+    // Dedupe state for `token_count` rows (see `token_count_key`).
+    let mut previous_token_count_key: Option<TokenCountKey> = None;
     let mut offset = 0;
     for line_with_ending in content.split_inclusive('\n') {
         let line_offset = offset;
@@ -136,6 +138,13 @@ fn parse_codex(content: &str) -> (Vec<NormalizedEvent>, Option<u64>, Option<Stri
             let inherited_token_count = !usage_is_owned
                 && value.get("type").and_then(Value::as_str) == Some("event_msg")
                 && value.pointer("/payload/type").and_then(Value::as_str) == Some("token_count");
+            if let Some(key) = token_count_key(&value) {
+                let duplicate_token_count = previous_token_count_key.as_ref() == Some(&key);
+                previous_token_count_key = Some(key);
+                if duplicate_token_count {
+                    continue;
+                }
+            }
             if !inherited_token_count && let Some(mut ev) = record_to_event(&value) {
                 if usage_is_owned {
                     ev.model = ev.model.or_else(|| current_model.clone());
@@ -567,6 +576,29 @@ fn token_count_event(payload: &Map<String, Value>, ts: Option<i64>) -> Option<No
     ev.ts_ms = ts;
     ev.usage = usage;
     Some(ev)
+}
+
+/// The usage pair that identifies one `token_count` row.
+type TokenCountKey = (Value, Value);
+
+/// Codex writes the last `token_count` row again when it resumes a rollout.
+/// The copy repeats both `last_token_usage` and `total_token_usage` exactly.
+/// A real turn always moves `total_token_usage`, so `parse_codex` drops a row
+/// whose pair equals the previous `token_count` row. This keeps a resume from
+/// adding a ghost turn with a second copy of the same context occupancy.
+fn token_count_key(value: &Value) -> Option<TokenCountKey> {
+    if value.get("type").and_then(Value::as_str) != Some("event_msg")
+        || value.pointer("/payload/type").and_then(Value::as_str) != Some("token_count")
+    {
+        return None;
+    }
+    let info = value.pointer("/payload/info")?;
+    Some((
+        info.get("last_token_usage").cloned().unwrap_or(Value::Null),
+        info.get("total_token_usage")
+            .cloned()
+            .unwrap_or(Value::Null),
+    ))
 }
 
 /// The largest gap between two compaction records that `parse_codex` still

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -55,6 +55,7 @@ impl VendorAdapter for CodexAdapter {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events,
+            cache_write_tokens_available: false,
             context_window,
             model,
         })

--- a/crates/antiburn-local/src/analysis/vendors/cursor.rs
+++ b/crates/antiburn-local/src/analysis/vendors/cursor.rs
@@ -28,6 +28,7 @@ impl VendorAdapter for CursorAdapter {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events,
+            cache_write_tokens_available: true,
             context_window: None,
             model,
         })

--- a/crates/antiburn-local/src/analysis/vendors/generic_jsonl.rs
+++ b/crates/antiburn-local/src/analysis/vendors/generic_jsonl.rs
@@ -31,6 +31,7 @@ impl VendorAdapter for GenericJsonlAdapter {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events: parse_jsonl(&content),
+            cache_write_tokens_available: true,
             context_window: None,
             model: None,
         })

--- a/crates/antiburn-local/src/analysis/vendors/opencode.rs
+++ b/crates/antiburn-local/src/analysis/vendors/opencode.rs
@@ -52,6 +52,7 @@ impl VendorAdapter for OpenCodeAdapter {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events: parse_opencode(&content),
+            cache_write_tokens_available: true,
             context_window: None,
             model: None,
         })

--- a/crates/antiburn-local/src/analysis/vendors/sqlite.rs
+++ b/crates/antiburn-local/src/analysis/vendors/sqlite.rs
@@ -49,6 +49,7 @@ impl VendorAdapter for SqliteAdapter {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events,
+            cache_write_tokens_available: true,
             context_window: None,
             model: None,
         })

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
@@ -1,6 +1,7 @@
 {
   "normalizedSession": {
     "agent": "claude",
+    "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
     "events": [
       {

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
@@ -1,6 +1,7 @@
 {
   "normalizedSession": {
     "agent": "claude",
+    "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
     "events": [
       {

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
@@ -1,6 +1,7 @@
 {
   "normalizedSession": {
     "agent": "claude",
+    "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
     "events": [
       {

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
@@ -1,6 +1,7 @@
 {
   "normalizedSession": {
     "agent": "claude",
+    "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
     "events": [
       {

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
@@ -1,6 +1,7 @@
 {
   "normalizedSession": {
     "agent": "claude",
+    "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
     "events": [
       {

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
@@ -1,6 +1,7 @@
 {
   "normalizedSession": {
     "agent": "claude",
+    "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
     "events": [
       {

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
@@ -1,6 +1,7 @@
 {
   "normalizedSession": {
     "agent": "claude",
+    "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
     "events": [
       {


### PR DESCRIPTION
## Summary

- distinguish unavailable cache-write telemetry from a reported zero
- infer confirmed Codex cache rehydration from cache collapse, replayed context, and next-turn recovery
- invalidate cached analyses so existing sessions are recalculated
- cover the audited session pattern and false-positive cases

## Verification

- cargo test --manifest-path crates/antiburn-local/Cargo.toml --lib --no-fail-fast
- cargo clippy --manifest-path crates/antiburn-local/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml analytics::tests --no-fail-fast
- cargo fmt checks for both Rust manifests
- git diff --check