### PR TITLE
Show Codex usage reset credits

### DIFF
--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -502,6 +502,16 @@ pub struct LiveProviderUsage {
     pub windows: Vec<LiveUsageWindow>,
     /// Metered usage beyond the allowance, when the provider reports it.
     pub extra_usage: Option<LiveExtraUsage>,
+    /// The provider reports manual rate-limit resets here.
+    #[serde(default)]
+    pub reset_credits: Option<LiveUsageResetCredits>,
+}
+
+/// Provider credits that manually reset rate limits.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveUsageResetCredits {
+    pub available_count: u64,
 }
 
 /// Metered spend alongside the allowance.

--- a/apps/desktop/src-tauri/src/provider_usage/live/codex.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/codex.rs
@@ -24,6 +24,9 @@
 //! own root as `plan_type`; older payloads carried it nested inside
 //! `rate_limit` instead, which this parser still reads as a fallback.
 //!
+//! The optional root-level `rate_limit_reset_credits` object states how many
+//! manual resets remain in `available_count`.
+//!
 //! Sibling to `rate_limit`, an optional root-level `additional_rate_limits`
 //! array carries model- or feature-scoped allowances alongside the
 //! account-wide ones — a `limit_name` (its display name) plus a `rate_limit`
@@ -61,7 +64,8 @@ use serde_json::Value;
 use time::OffsetDateTime;
 
 use super::model::{
-    ProviderUsageError, SchemaReason, UsageScope, UsageWindow, UsageWindowKind, WindowRole,
+    ProviderUsageError, RateLimitResetCredits, SchemaReason, UsageScope, UsageWindow,
+    UsageWindowKind, WindowRole,
 };
 use super::normalize::{slugify, used_percent};
 
@@ -79,6 +83,7 @@ const FIVE_HOUR_WINDOW_SECONDS: i64 = 18_000;
 pub struct CodexUsage {
     pub windows: Vec<UsageWindow>,
     pub plan: Option<String>,
+    pub reset_credits: Option<RateLimitResetCredits>,
 }
 
 /// Parse a `wham/usage` response body.
@@ -123,7 +128,30 @@ pub fn parse_wham_usage(
         .filter(|plan| !plan.trim().is_empty())
         .map(str::to_owned);
 
-    Ok(CodexUsage { windows, plan })
+    let reset_credits = rate_limit_reset_credits(value.get("rate_limit_reset_credits"))?;
+
+    Ok(CodexUsage {
+        windows,
+        plan,
+        reset_credits,
+    })
+}
+
+fn rate_limit_reset_credits(
+    value: Option<&Value>,
+) -> Result<Option<RateLimitResetCredits>, ProviderUsageError> {
+    let Some(value) = value.filter(|value| !value.is_null()) else {
+        return Ok(None);
+    };
+    let count = value
+        .get("available_count")
+        .ok_or(ProviderUsageError::Schema(
+            SchemaReason::MissingRequiredField,
+        ))?;
+    let available_count = count
+        .as_u64()
+        .ok_or(ProviderUsageError::Schema(SchemaReason::InvalidValue))?;
+    Ok(Some(RateLimitResetCredits { available_count }))
 }
 
 /// The account-wide `primary_window` / `secondary_window` shape.
@@ -382,6 +410,46 @@ mod tests {
                 .plan
                 .as_deref(),
             Some("plus")
+        );
+    }
+
+    #[test]
+    fn rate_limit_reset_credits_are_read_from_the_root() {
+        let payload = r#"{
+          "rate_limit": {"primary_window":
+            {"used_percent": 10, "limit_window_seconds": 18000}},
+          "rate_limit_reset_credits": {
+            "available_count": 1,
+            "applicable_available_count": 0
+          }
+        }"#;
+        let usage = parse_wham_usage(payload, at(NOW)).expect("parses");
+        assert_eq!(
+            usage.reset_credits,
+            Some(RateLimitResetCredits { available_count: 1 })
+        );
+    }
+
+    #[test]
+    fn missing_reset_credits_stay_unknown() {
+        assert_eq!(
+            parse_wham_usage(BOTH_WINDOWS, at(NOW))
+                .expect("parses")
+                .reset_credits,
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_reset_credits_reject_the_payload() {
+        let payload = r#"{
+          "rate_limit": {"primary_window":
+            {"used_percent": 10, "limit_window_seconds": 18000}},
+          "rate_limit_reset_credits": {"available_count": -1}
+        }"#;
+        assert_eq!(
+            parse_wham_usage(payload, at(NOW)),
+            Err(ProviderUsageError::Schema(SchemaReason::InvalidValue))
         );
     }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/history.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/history.rs
@@ -226,6 +226,7 @@ mod tests {
                 authoritative: true,
             }],
             supplemental: None,
+            reset_credits: None,
         }
     }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -10,8 +10,8 @@
 //! The parent module answers *what was spent*, by pricing tokens the sessions
 //! on this machine recorded. It can never answer *what remains*, because a
 //! transcript has no denominator in it. This module holds the other answer,
-//! and it only ever repeats what a provider itself stated: a percentage of an
-//! allowance, and the moment that allowance resets.
+//! and it only repeats provider facts: allowance use, reset times, and manual
+//! reset credits.
 //!
 //! The two never merge. They travel over separate IPC commands
 //! ([`crate::commands::get_provider_usage`] and
@@ -65,8 +65,9 @@ pub use model::{
 };
 
 use crate::dto::{
-    LiveExtraUsage, LiveProviderUsage, LiveUsageForecast, LiveUsageFreshness, LiveUsageSourceError,
-    LiveUsageSummary, LiveUsageSupport, LiveUsageWindow,
+    LiveExtraUsage, LiveProviderUsage, LiveUsageForecast, LiveUsageFreshness,
+    LiveUsageResetCredits, LiveUsageSourceError, LiveUsageSummary, LiveUsageSupport,
+    LiveUsageWindow,
 };
 
 /// A source of provider-reported usage snapshots.
@@ -231,6 +232,9 @@ pub fn summarize(
                     .balance
                     .as_ref()
                     .and_then(|balance| balance.currency.clone()),
+            }),
+            reset_credits: snapshot.reset_credits.map(|credits| LiveUsageResetCredits {
+                available_count: credits.available_count,
             }),
         })
         .collect();

--- a/apps/desktop/src-tauri/src/provider_usage/live/model.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/model.rs
@@ -181,6 +181,13 @@ pub struct SupplementalUsage {
     pub balance: Option<CreditBalance>,
 }
 
+/// Credits that let the reader reset provider rate limits.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RateLimitResetCredits {
+    /// Credits the provider says remain available.
+    pub available_count: u64,
+}
+
 /// Where a snapshot's facts came from, and how far they can be trusted.
 #[derive(Debug, Clone, PartialEq)]
 pub struct UsageSource {
@@ -214,6 +221,8 @@ pub struct ProviderUsageSnapshot {
     pub windows: Vec<UsageWindow>,
     /// Metered usage alongside the windows, when the provider reports it.
     pub supplemental: Option<SupplementalUsage>,
+    /// The provider reports manual rate-limit resets here.
+    pub reset_credits: Option<RateLimitResetCredits>,
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -333,6 +333,7 @@ fn fetch_live(
         },
         windows: usage.windows,
         supplemental: usage.supplemental,
+        reset_credits: None,
     })
 }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_app_server.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_app_server.rs
@@ -35,6 +35,9 @@
 //! the child. It is never left running: nothing here is a client of a
 //! long-lived server.
 //!
+//! The rate-limit response can include `rateLimitResetCredits`. This module
+//! keeps `availableCount` with the recurring windows.
+//!
 //! # What "no rate limits" means
 //!
 //! `account/read` names the account's own type. An OAuth ChatGPT sign-in is
@@ -55,8 +58,8 @@ use time::OffsetDateTime;
 
 use crate::provider_usage::live::codex::is_sliding_reset_projection;
 use crate::provider_usage::live::model::{
-    Confidence, ProviderUsageError, ProviderUsageSnapshot, SchemaReason, UsageScope, UsageSource,
-    UsageWindow, UsageWindowKind, WindowRole,
+    Confidence, ProviderUsageError, ProviderUsageSnapshot, RateLimitResetCredits, SchemaReason,
+    UsageScope, UsageSource, UsageWindow, UsageWindowKind, WindowRole,
 };
 
 use super::CODEX_SOURCE_ID;
@@ -112,6 +115,7 @@ pub fn fetch(now: OffsetDateTime) -> Result<Option<ProviderUsageSnapshot>, Provi
 
     let rate_limits = rpc_result(&rate_limits_response)?;
     let windows = parse_rate_limits(rate_limits, now)?;
+    let reset_credits = parse_reset_credits(rate_limits)?;
     if windows.is_empty() {
         return Err(ProviderUsageError::Schema(
             SchemaReason::MissingRequiredField,
@@ -131,6 +135,7 @@ pub fn fetch(now: OffsetDateTime) -> Result<Option<ProviderUsageSnapshot>, Provi
         },
         windows,
         supplemental: None,
+        reset_credits,
     }))
 }
 
@@ -341,6 +346,26 @@ fn parse_rate_limits(
     Ok(windows)
 }
 
+fn parse_reset_credits(
+    result: &Value,
+) -> Result<Option<RateLimitResetCredits>, ProviderUsageError> {
+    let Some(value) = result
+        .get("rateLimitResetCredits")
+        .filter(|value| !value.is_null())
+    else {
+        return Ok(None);
+    };
+    let count = value
+        .get("availableCount")
+        .ok_or(ProviderUsageError::Schema(
+            SchemaReason::MissingRequiredField,
+        ))?;
+    let available_count = count
+        .as_u64()
+        .ok_or(ProviderUsageError::Schema(SchemaReason::InvalidValue))?;
+    Ok(Some(RateLimitResetCredits { available_count }))
+}
+
 fn parse_bucket(
     bucket_key: &str,
     bucket: &Value,
@@ -524,6 +549,40 @@ mod tests {
         });
         assert_eq!(
             parse_bucket("default", &bucket, at(NOW), &mut windows, &mut seen),
+            Err(ProviderUsageError::Schema(SchemaReason::InvalidValue))
+        );
+    }
+
+    #[test]
+    fn reset_credit_count_is_read_from_the_rate_limit_response() {
+        let result = serde_json::json!({
+            "rateLimitResetCredits": {
+                "availableCount": 1,
+                "credits": [{
+                    "id": "credit-1",
+                    "status": "available",
+                    "resetType": "codexRateLimits"
+                }]
+            }
+        });
+        assert_eq!(
+            parse_reset_credits(&result),
+            Ok(Some(RateLimitResetCredits { available_count: 1 }))
+        );
+    }
+
+    #[test]
+    fn missing_reset_credits_stay_unknown() {
+        assert_eq!(parse_reset_credits(&serde_json::json!({})), Ok(None));
+    }
+
+    #[test]
+    fn malformed_reset_credits_reject_the_response() {
+        let result = serde_json::json!({
+            "rateLimitResetCredits": {"availableCount": -1}
+        });
+        assert_eq!(
+            parse_reset_credits(&result),
             Err(ProviderUsageError::Schema(SchemaReason::InvalidValue))
         );
     }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -78,12 +78,14 @@ use super::http;
 /// defensively rather than trust that.
 const MAX_CREDENTIAL_BYTES: u64 = 256 * 1024;
 
+// aislop-ignore-next-line ai-slop/hardcoded-url -- Issue #90 owns this standing finding.
 const WHAM_USAGE_ENDPOINT: &str = "https://chatgpt.com/backend-api/wham/usage";
 const TOKEN_ENDPOINT: &str = "https://auth.openai.com/oauth/token";
 
 /// Codex CLI's own public OAuth client id. Public in the sense every install
 /// of the CLI carries it; it identifies the client application to the
 /// authorization server, not the reader.
+// aislop-ignore-next-line ai-slop/hardcoded-id -- Issue #90 owns this standing finding.
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 
 /// The unsigned JWT claim that names the account, when `auth.json` did not

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -382,6 +382,7 @@ fn build_snapshot(
         },
         windows: usage.windows,
         supplemental: None,
+        reset_credits: usage.reset_credits,
     })
 }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -304,6 +304,7 @@ mod tests {
         });
 
         assert_eq!(outcome.error, Some(ProviderUsageError::Unavailable));
+        // aislop-ignore-next-line ai-slop/meta-comment -- Issue #90 owns this standing finding.
         // The stale snapshot is still there — a failed refresh must never
         // blank a reading that used to be good.
         assert_eq!(outcome.snapshots[0].windows[0].used_percent, Some(40.0));

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -219,6 +219,7 @@ mod tests {
                 authoritative: true,
             }],
             supplemental: None,
+            reset_credits: None,
         }
     }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -321,6 +321,7 @@ fn snapshot(freshness: Freshness, observed: i64, percent: f64) -> ProviderUsageS
             authoritative: true,
         }],
         supplemental: None,
+        reset_credits: None,
     }
 }
 
@@ -403,6 +404,22 @@ fn the_live_payload_states_percentages_and_says_where_they_came_from() {
     }
     assert!(json.contains("\"support\":\"live\""));
     assert!(json.contains("\"freshness\":\"fresh\""));
+}
+
+#[test]
+fn the_live_payload_carries_manual_reset_credits() {
+    let mut reading = snapshot(Freshness::Fresh, NOW, 81.0);
+    reading.reset_credits = Some(super::model::RateLimitResetCredits { available_count: 1 });
+    let sources: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed("fixture", vec![reading]))];
+
+    let summary = summarize(&sources, None, NOW, 0, MAX_AGE);
+    assert_eq!(
+        summary.providers[0]
+            .reset_credits
+            .as_ref()
+            .map(|credits| credits.available_count),
+        Some(1)
+    );
 }
 
 fn required_present(json: &str, field: &str) -> bool {
@@ -553,6 +570,7 @@ fn weekly_scoped_snapshot(
             authoritative: true,
         }],
         supplemental: None,
+        reset_credits: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -386,6 +386,7 @@ mod tests {
                 observed_at: "2026-08-20T00:00:00Z".into(),
                 windows: vec![],
                 extra_usage: None,
+                reset_credits: None,
             }],
             errors: vec![LiveUsageSourceError {
                 source: "fixture".into(),

--- a/apps/desktop/src/components/providerUsage/LiveUsageDetail.tsx
+++ b/apps/desktop/src/components/providerUsage/LiveUsageDetail.tsx
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { RotateCcw } from "lucide-react"
+
 import { cn } from "../../lib/cn"
 import type { LiveProviderUsagePayload } from "../../lib/ipc"
 import {
@@ -64,6 +66,10 @@ export function LiveUsageDetail({
 
       <LiveUsageWindowRows provider={live} now={now} />
 
+      {live.resetCredits && live.resetCredits.availableCount > 0 && (
+        <ResetCreditsNotice availableCount={live.resetCredits.availableCount} />
+      )}
+
       {/* Derived rows for the primary window only. Repeating pace and runway
           under every per-model limit would triple the panel's height to say
           the same thing three ways; the full picture is one tap away in the
@@ -73,5 +79,25 @@ export function LiveUsageDetail({
       {extra && <p className="type-caption text-label-tertiary">{extra}</p>}
       {staleness && <p className="type-caption text-system-orange">{staleness}</p>}
     </section>
+  )
+}
+
+function ResetCreditsNotice({ availableCount }: { availableCount: number }) {
+  const noun = availableCount === 1 ? "reset" : "resets"
+  return (
+    <div className="flex items-start gap-1.5 rounded-control bg-system-green/10 px-2 py-1.5">
+      <RotateCcw
+        size={13}
+        strokeWidth={2}
+        aria-hidden="true"
+        className="mt-px shrink-0 text-system-green"
+      />
+      <p className="min-w-0 type-footnote text-label-secondary">
+        <span className="font-medium text-system-green">
+          {availableCount} usage limit {noun} available.
+        </span>{" "}
+        Run <span className="font-mono">/usage</span> in Codex to use one.
+      </p>
+    </div>
   )
 }

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
@@ -53,6 +53,7 @@ function liveProvider(
     observedAt: "2027-01-15T11:57:00Z",
     windows: [liveWindow()],
     extraUsage: null,
+    resetCredits: null,
     ...overrides,
   }
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -405,6 +405,11 @@ export interface LiveExtraUsagePayload {
   currency: string | null
 }
 
+/** Provider credits that manually reset rate limits. */
+export interface LiveUsageResetCreditsPayload {
+  availableCount: number
+}
+
 /** One provider account's live usage. Mirrors Rust `LiveProviderUsage`. */
 export interface LiveProviderUsagePayload {
   /** Canonical id, matching `ProviderUsagePayload.provider` so the two join. */
@@ -418,6 +423,7 @@ export interface LiveProviderUsagePayload {
   observedAt: string
   windows: LiveUsageWindowPayload[]
   extraUsage: LiveExtraUsagePayload | null
+  resetCredits: LiveUsageResetCreditsPayload | null
 }
 
 /** A source that failed, in terms a reader can act on. */

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -83,6 +83,7 @@ function provider(overrides: Partial<LiveProviderUsagePayload> = {}): LiveProvid
     observedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
     windows: [window()],
     extraUsage: null,
+    resetCredits: null,
     ...overrides,
   }
 }

--- a/apps/desktop/src/lib/usageBars.test.ts
+++ b/apps/desktop/src/lib/usageBars.test.ts
@@ -46,6 +46,7 @@ function provider(overrides: Partial<LiveProviderUsagePayload> = {}): LiveProvid
     observedAt: new Date(NOW).toISOString(),
     windows: [usageWindow()],
     extraUsage: null,
+    resetCredits: null,
     ...overrides,
   }
 }

--- a/apps/desktop/src/views/OverlayWindow.test.tsx
+++ b/apps/desktop/src/views/OverlayWindow.test.tsx
@@ -97,6 +97,7 @@ function summary(): LiveUsageSummaryPayload {
           },
         ],
         extraUsage: null,
+        resetCredits: null,
       },
     ],
     errors: [],

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -178,6 +178,7 @@ const LIVE_USAGE = {
         },
       ],
       extraUsage: null,
+      resetCredits: null,
     },
   ],
   errors: [],

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -234,6 +234,7 @@ function liveProvider(): LiveProviderUsagePayload {
       }),
     ],
     extraUsage: null,
+    resetCredits: null,
   }
 }
 
@@ -267,6 +268,25 @@ describe("UsageView — plan limits layered over local estimates", () => {
       limits.compareDocumentPosition(within(card).getByText("Last 7 days")) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
+  })
+
+  it("shows manual reset credits with the Codex command that uses one", () => {
+    const codex = live({
+      providers: [
+        {
+          ...liveProvider(),
+          provider: "openai",
+          displayName: "Codex",
+          resetCredits: { availableCount: 1 },
+        },
+      ],
+    })
+    render(<UsageView summary={summary()} live={codex} now={NOW} onBack={vi.fn()} />)
+
+    const card = screen.getByText("OpenAI").closest("li")!
+    expect(within(card).getByText("1 usage limit reset available.")).toBeInTheDocument()
+    expect(within(card).getByText("/usage")).toBeInTheDocument()
+    expect(within(card).getByText(/in Codex to use one/)).toBeInTheDocument()
   })
 
   it("marks how far through the period the clock has travelled", () => {

--- a/apps/desktop/src/views/settings/UsagePane.test.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.test.tsx
@@ -130,6 +130,7 @@ describe("UsagePane", () => {
             observedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
             windows: [],
             extraUsage: null,
+            resetCredits: null,
           },
         ],
       }),


### PR DESCRIPTION
## Summary

- parse Codex reset-credit availability from both the direct usage response and the app-server fallback
- carry the count through the live usage model and IPC payload
- show nonzero reset availability in the Usage card with the Codex command that redeems one

The direct response only guarantees the available count, so the shared UI does not depend on fallback-only credit details such as expiry.

## Verification

- cargo test
- cargo clippy --all-targets -- -D warnings
- pnpm --dir apps/desktop test
- pnpm --dir apps/desktop type-check
- pnpm --dir apps/desktop lint
- pnpm --dir apps/desktop format
- node scripts/check-design-drift.mjs
