### PR TITLE
Rename activity list to session list

### DIFF
--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// One row of the popover's activity list.
 ///
-/// Mirrors the fields `LocalActivityEntry` needs, minus the cost pill text.
+/// Mirrors the fields `SessionListEntry` needs, minus the cost pill text.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActivityEntry {

--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -5,11 +5,7 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import {
-  LocalActivityList,
-  type LocalActivityEntry,
-  type LocalActivityListProps,
-} from "./LocalActivityList"
+import { SessionList, type SessionListEntry, type SessionListProps } from "./SessionList"
 
 afterEach(cleanup)
 
@@ -22,7 +18,7 @@ function at(daysAgo: number, hour = 12): string {
   return date.toISOString()
 }
 
-function entry(over: Partial<LocalActivityEntry> = {}): LocalActivityEntry {
+function entry(over: Partial<SessionListEntry> = {}): SessionListEntry {
   return {
     agent: "claude-code",
     sessionId: "session-1",
@@ -33,17 +29,17 @@ function entry(over: Partial<LocalActivityEntry> = {}): LocalActivityEntry {
   }
 }
 
-function list(over: Partial<LocalActivityListProps> = {}) {
-  const props: LocalActivityListProps = {
+function list(over: Partial<SessionListProps> = {}) {
+  const props: SessionListProps = {
     entries: [entry()],
     days: 7,
     now: NOW,
     ...over,
   }
-  return render(<LocalActivityList {...props} />)
+  return render(<SessionList {...props} />)
 }
 
-describe("LocalActivityList — rows", () => {
+describe("SessionList — rows", () => {
   it("names a session by its title, then a short id, then its agent", () => {
     list({
       entries: [
@@ -160,7 +156,7 @@ describe("LocalActivityList — rows", () => {
   })
 })
 
-describe("LocalActivityList — navigation", () => {
+describe("SessionList — navigation", () => {
   it("opens a session by click and by keyboard from the row itself", () => {
     const onOpenSession = vi.fn()
     list({ entries: [entry({ title: "Fix the flaky test" })], onOpenSession })
@@ -196,7 +192,7 @@ describe("LocalActivityList — navigation", () => {
   })
 })
 
-describe("LocalActivityList — grouping", () => {
+describe("SessionList — grouping", () => {
   it("buckets rows by calendar day and pins the newest label", () => {
     list({
       entries: [
@@ -235,7 +231,7 @@ describe("LocalActivityList — grouping", () => {
   })
 })
 
-describe("LocalActivityList — empty state", () => {
+describe("SessionList — empty state", () => {
   it("explains an empty range and announces it once", () => {
     list({ entries: [] })
     expect(screen.getAllByText("No sessions in the last 7 days").length).toBe(2)

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -18,25 +18,22 @@ import { relativeTime } from "../../lib/presentation/relativeTime"
 import { Tooltip } from "../presentation/Tooltip"
 import { TruncatedText } from "../presentation/TruncatedText"
 import { WslOriginBadge } from "../presentation/WslOriginBadge"
-import {
-  SessionCostBadge,
-  type SessionCostBadgeProps,
-} from "../session/metrics/SessionCostBadge"
+import { SessionCostBadge, type SessionCostBadgeProps } from "./metrics/SessionCostBadge"
 import { ScrollPane } from "../ui/ScrollPane"
-import { countGroupedItems, groupActivityByDay } from "./activityFeedGrouping"
-import { useActivityGroupPinning, type ViewportRef } from "./useActivityGroupPinning"
+import { countGroupedItems, groupActivityByDay } from "../activity/activityFeedGrouping"
+import { useActivityGroupPinning, type ViewportRef } from "../activity/useActivityGroupPinning"
 
 import "../../styles/session-rows.css"
 
 /** The renderer shows an agent icon and can mark its surface. The caller supplies the artwork. */
-type ActivityAgentIconRenderer = (
+type SessionAgentIconRenderer = (
   slug: string,
   size: number,
   surface?: AgentSurface,
 ) => ReactNode
 
-/** One local coding session in the list. */
-export interface LocalActivityEntry {
+/** One coding session in the list. */
+export interface SessionListEntry {
   agent: string
   /** Absent for a session whose transcript id could not be read. */
   sessionId?: string | undefined
@@ -64,33 +61,33 @@ export interface LocalActivityEntry {
   modelRuns?: PresentableModelRun[] | undefined
 }
 
-export interface LocalActivityListProps {
+export interface SessionListProps {
   /** Sessions to show. Ordering and grouping are this component's job. */
-  entries: LocalActivityEntry[]
+  entries: SessionListEntry[]
   /** Calendar-day window for finished sessions. Also drives the empty copy. */
   days: number
   /** Headline for the empty state; defaults to the range-aware wording. */
   emptyTitle?: string
   emptyDescription?: string
   /** Open a session's analytics. Omitted leaves rows inert. */
-  onOpenSession?: (entry: LocalActivityEntry) => void
+  onOpenSession?: (entry: SessionListEntry) => void
   /** The scrolling viewport, for a host that needs to observe it. */
   viewportRef?: ViewportRef
   /** Frozen clock, for tests. */
   now?: Date
-  renderAgentIcon?: ActivityAgentIconRenderer
+  renderAgentIcon?: SessionAgentIconRenderer
   /** Glyph for the WSL-origin badge. */
   wslIcon?: ReactNode
 }
 
-function primaryLine(entry: LocalActivityEntry): string {
+function primaryLine(entry: SessionListEntry): string {
   const title = entry.title?.trim()
   if (title) return title
   if (entry.sessionId) return `Session ${entry.sessionId.slice(0, 7)}`
   return agentDisplayName(entry.agent)
 }
 
-function EmptyActivity({ title, description }: { title: string; description: string }) {
+function EmptySessionList({ title, description }: { title: string; description: string }) {
   return (
     <div className="flex h-full items-center justify-center px-6 text-center">
       <div className="flex max-w-[230px] flex-col items-center">
@@ -104,26 +101,21 @@ function EmptyActivity({ title, description }: { title: string; description: str
   )
 }
 
-interface SessionActivityRowProps {
-  entry: LocalActivityEntry
+interface SessionRowProps {
+  entry: SessionListEntry
   onOpen?: () => void
-  renderAgentIcon?: ActivityAgentIconRenderer | undefined
+  renderAgentIcon?: SessionAgentIconRenderer | undefined
   wslIcon?: ReactNode | undefined
 }
 
 /**
- * One local session in the list: its identity, location, fork relationships,
+ * One session in the list: its identity, location, fork relationships,
  * cost, and last activity time.
  *
  * The whole card opens the session analytics. Unsupported agents open an empty
  * analytics state that explains why no data is available.
  */
-function SessionActivityRow({
-  entry,
-  onOpen,
-  renderAgentIcon,
-  wslIcon,
-}: SessionActivityRowProps) {
+function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps) {
   const clickable = !!entry.sessionId && !!onOpen
   const primary = primaryLine(entry)
   const hasRepo = entry.repo !== ""
@@ -271,12 +263,12 @@ function SessionActivityRow({
 }
 
 /**
- * A scrolling list of local coding sessions, grouped by activity state and day.
+ * A scrolling list of coding sessions, grouped by activity state and day.
  *
  * The host supplies entries, the visible range, and actions. The list controls
  * ordering, grouping, the sticky group label, and row presentation.
  */
-export function LocalActivityList({
+export function SessionList({
   entries,
   days,
   emptyTitle,
@@ -286,7 +278,7 @@ export function LocalActivityList({
   now,
   renderAgentIcon,
   wslIcon,
-}: LocalActivityListProps) {
+}: SessionListProps) {
   const items = entries.map((entry, index) => ({
     entry,
     at: entry.timestamp,
@@ -308,7 +300,7 @@ export function LocalActivityList({
     emptyTitle ?? (days === 1 ? "No sessions today" : `No sessions in the last ${days} days`)
 
   return (
-    <section aria-label="Activity feed" className="flex h-full min-h-0 flex-col pt-2">
+    <section aria-label="Sessions" className="flex h-full min-h-0 flex-col pt-2">
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {visibleCount === 0 ? resolvedEmptyTitle : ""}
       </span>
@@ -329,7 +321,7 @@ export function LocalActivityList({
         viewportClassName={cn("px-2", visibleCount === 0 && "[&>div]:h-full")}
       >
         {visibleCount === 0 ? (
-          <EmptyActivity title={resolvedEmptyTitle} description={emptyDescription} />
+          <EmptySessionList title={resolvedEmptyTitle} description={emptyDescription} />
         ) : (
           <div className="space-y-3 pb-3">
             {groups.map((group, groupIndex) => {
@@ -350,7 +342,7 @@ export function LocalActivityList({
 
                   <div className="space-y-1">
                     {group.items.map((item) => (
-                      <SessionActivityRow
+                      <SessionRow
                         key={item.key}
                         entry={item.entry}
                         {...(onOpenSession ? { onOpen: () => onOpenSession(item.entry) } : {})}

--- a/apps/desktop/src/lib/activityEntries.ts
+++ b/apps/desktop/src/lib/activityEntries.ts
@@ -12,7 +12,7 @@
  * one place the two meet, kept pure so it can be tested without a shell.
  */
 
-import type { LocalActivityEntry } from "../components/activity/LocalActivityList"
+import type { SessionListEntry } from "../components/session/SessionList"
 import type { ActivityEntryPayload } from "./ipc"
 import { defaultAgentSurface, type AgentSurface } from "./presentation/agents"
 import {
@@ -38,7 +38,7 @@ function surfaceOf(payload: ActivityEntryPayload): AgentSurface {
  */
 export function toActivityEntries(
   payloads: readonly ActivityEntryPayload[],
-): LocalActivityEntry[] {
+): SessionListEntry[] {
   const threshold = costOutlierThreshold(
     payloads
       .map((payload) => payload.cost?.totalUsd)
@@ -70,7 +70,7 @@ export function toActivityEntries(
 }
 
 export function indexOfSession(
-  entries: readonly LocalActivityEntry[],
+  entries: readonly SessionListEntry[],
   agent: string,
   sessionId: string,
   wslDistro?: string | null,

--- a/apps/desktop/src/lib/agentIcon.tsx
+++ b/apps/desktop/src/lib/agentIcon.tsx
@@ -114,7 +114,7 @@ function LetterTile({ name, size }: { name: string; size: number }) {
 /**
  * Render one agent's icon.
  *
- * Matches the `ActivityAgentIconRenderer` / `AgentIconRenderer` signatures the
+ * Matches the `SessionAgentIconRenderer` / `AgentIconRenderer` signatures the
  * presentation components declare, so it can be passed straight into either.
  */
 export function renderAgentIcon(slug: string, size: number, surface?: AgentSurface): ReactNode {

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -286,7 +286,7 @@ describe("PopoverView", () => {
 
     const viewportOf = () =>
       screen
-        .getByRole("region", { name: "Activity feed" })
+        .getByRole("region", { name: "Sessions" })
         .querySelector<HTMLElement>(".ui-scroll-viewport")
     const viewport = viewportOf()
     expect(viewport).not.toBeNull()

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -6,10 +6,7 @@ import { lazy, Suspense, useCallback, useRef, useState, useSyncExternalStore } f
 
 import { AlertTriangle, Settings } from "lucide-react"
 
-import {
-  LocalActivityList,
-  type LocalActivityEntry,
-} from "../components/activity/LocalActivityList"
+import { SessionList, type SessionListEntry } from "../components/session/SessionList"
 import { UsageLimitsBar } from "../components/providerUsage"
 import { Banner } from "../components/ui/Banner"
 import { Skeleton } from "../components/ui/Skeleton"
@@ -208,7 +205,7 @@ export function PopoverView() {
     storage: state.storage,
   }).filter((banner) => !state.dismissed.includes(banner.id))
 
-  const subjectFor = (entry: LocalActivityEntry): SessionSubject => {
+  const subjectFor = (entry: SessionListEntry): SessionSubject => {
     return {
       agent: entry.agent,
       sessionId: entry.sessionId ?? "",
@@ -327,7 +324,7 @@ export function PopoverView() {
           {state.entries == null ? (
             <ActivitySkeleton />
           ) : (
-            <LocalActivityList
+            <SessionList
               entries={state.entries}
               days={windowDays}
               onOpenSession={(entry) => {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import type { LocalActivityEntry } from "../../components/activity/LocalActivityList"
+import type { SessionListEntry } from "../../components/session/SessionList"
 import { toActivityEntries } from "../../lib/activityEntries"
 import { applyTheme } from "../../lib/appearance"
 import type { AttentionKind } from "../../lib/attention"
@@ -67,7 +67,7 @@ type PopoverAnalyticsState = {
 
 export interface PopoverSnapshot {
   settings: AppSettings | null
-  entries: LocalActivityEntry[] | null
+  entries: SessionListEntry[] | null
   repositories: LocalRepositoryItem[]
   /** Provider usage, or null while the first snapshot is in flight. */
   usage: ProviderUsageSummaryPayload | null
@@ -418,6 +418,7 @@ export class PopoverSession {
     this.stopPopoverShownListening = unlisten
   }
 
+  // aislop-ignore-next-line ai-slop/narrative-comment -- Issue #90 owns this standing finding.
   // A refresh from any window replaces the cached value in this one. This
   // also lets the shell publish this window's own refresh before IPC returns.
   private listenLiveUsage = async (generation: number): Promise<void> => {

--- a/docs/oss/source-allowlist.toml
+++ b/docs/oss/source-allowlist.toml
@@ -653,7 +653,7 @@ source_paths = [
 ]
 path_kind = "file-sections"
 disposition = "adapt"
-destination = "apps/desktop/src/components/activity/LocalActivityList.tsx"
+destination = "apps/desktop/src/components/session/SessionList.tsx"
 provenance = "Cadence company-authored mixed activity feed; D-021 approves only local session presentation"
 current_license = "Proprietary"
 intended_license = "MPL-2.0"
@@ -662,7 +662,7 @@ notes = [
   "Receive entries, titles, range labels, settings intent, and supported local filters through props; do not add extension points solely for private features.",
   "Do not copy RadarPinnedCard, RadarActivityRow, Radar skill/share/feedback behavior, ambience rows, team-update filters, upload status/errors, telemetry, Tauri listeners, targetOrgId, private-store reads, or Cloud organization identity.",
   "Expect prerequisite private-side refactors before extraction: the row primitives, time corner, and list merge/grouping/scroll machinery are shared with Radar and ambience rows, and upload status is currently fused into the time-corner component.",
-  "The active-session and hover-reveal treatment lives in main.css session-row selectors that D-020 excludes; that styling requires its own later feature-source review before LocalActivityList can render faithfully.",
+  "The active-session and hover-reveal treatment lives in main.css session-row selectors that D-020 excludes; that styling requires its own later feature-source review before SessionList can render faithfully.",
   "The current list has no loading state; do not invent one to satisfy the extraction contract wording.",
   "Rewrite tests around public local DTOs and callbacks rather than private-store, Tauri, Radar, ambience, upload, or telemetry mocks.",
 ]


### PR DESCRIPTION
## Summary

- rename `LocalActivityList` and its related types to `SessionList` terminology
- move the component and tests into `components/session` and update all consumers
- rename the accessible region to `Sessions` and update the source-governance destination

## Test plan

- `pnpm --filter @antiburn/desktop test`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop format`
- `pnpm run slop`