### PR TITLE
feat(desktop): Make the macOS popover touch the menu bar

### DIFF
--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -106,6 +106,12 @@ const RESIZE_DURATION: Duration = Duration::from_millis(140);
 const RESIZE_STEPS: u32 = 12;
 
 /// Gap in logical pixels between the menu-bar item and the popover edge.
+///
+/// The macOS popover touches the menu bar. Windows and Linux keep a small gap
+/// from their taskbar or panel.
+#[cfg(target_os = "macos")]
+const ANCHOR_GAP: f64 = 0.0;
+#[cfg(not(target_os = "macos"))]
 const ANCHOR_GAP: f64 = 6.0;
 
 /// Minimum logical gap between the popover and the edge of its display.
@@ -985,6 +991,11 @@ fn compute_position(
 
     if let Some(frame) = frame {
         let left = frame.left + SCREEN_MARGIN;
+        // The macOS tray rectangle can end one logical pixel above the monitor frame.
+        // Keep its anchor position so the clamp does not restore a gap.
+        #[cfg(target_os = "macos")]
+        let top = frame.top.min(y);
+        #[cfg(not(target_os = "macos"))]
         let top = frame.top + SCREEN_MARGIN;
         let right = frame.right - width - SCREEN_MARGIN;
         let bottom = frame.bottom - height - SCREEN_MARGIN;
@@ -1031,6 +1042,36 @@ mod tests {
     #[test]
     fn clamp_prefers_the_low_edge_on_undersized_displays() {
         assert_eq!(clamp(500.0, 8.0, -20.0), 8.0);
+    }
+
+    /// The macOS popover starts at the menu bar's bottom edge.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn the_macos_popover_touches_the_menu_bar() {
+        let frame = MonitorFrame {
+            left: 0.0,
+            top: -497.0,
+            right: 1728.0,
+            bottom: 620.0,
+            scale: 2.0,
+        };
+        let anchor = AnchorRect {
+            x: 3000.0,
+            y: -1044.0,
+            width: 60.0,
+            height: 48.0,
+        };
+        let (_, y) = compute_position(anchor, Some(&frame), WIDTH, DEFAULT_HEIGHT);
+        let menu_bar_bottom = (anchor.y + anchor.height) / frame.scale;
+
+        assert!((y - menu_bar_bottom).abs() < 0.5, "y was {y}");
+    }
+
+    /// Windows and Linux keep the existing gap from their taskbar or panel.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn other_platforms_keep_the_existing_anchor_gap() {
+        assert_eq!(ANCHOR_GAP, 6.0);
     }
 
     /// A 2x display: the anchor arrives in physical pixels, the window is
@@ -1365,6 +1406,7 @@ mod tests {
         assert!((y - (30.0 + ANCHOR_GAP)).abs() < 0.5, "y was {y}");
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn a_bottom_anchored_panel_flips_the_popover_above_its_item() {
         // The maths `place` runs, reproduced against a 1080px-tall display with


### PR DESCRIPTION
## Summary

- make the macOS tray popover touch the menu bar
- preserve the existing 6 px gap on Windows and Linux
- let the macOS tray anchor override the top screen-edge clamp on upper and Retina displays
- add platform-specific geometry regression coverage

## Screenshots
<img width="500" height="220" alt="image" src="https://github.com/user-attachments/assets/9474fcbc-1fd8-42cd-ab68-e28c72056ad7" />


## Test plan

- `cargo fmt --check`
- `cargo test --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- launch the macOS debug build and confirm the popover meets the menu bar with no background row between them