### PR TITLE
feat(desktop): Show app version and debug status in popover footer

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -173,6 +173,7 @@ pub fn app_info(app: tauri::AppHandle) -> CommandResult<AppInfo> {
     let store = app.state::<Store>();
     Ok(AppInfo {
         app_version: app.package_info().version.to_string(),
+        debug_build: cfg!(debug_assertions),
         arch: std::env::consts::ARCH.to_string(),
         pricing_catalog_version: antiburn_local::pricing::PRICING_CATALOG_VERSION.to_string(),
         schema_version: store.schema_version().map_err(fail)?,

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -362,6 +362,8 @@ pub struct ProviderUsageSummary {
 #[serde(rename_all = "camelCase")]
 pub struct AppInfo {
     pub app_version: String,
+    /// True when Rust enables debug assertions for this binary.
+    pub debug_build: bool,
     /// CPU architecture this binary was compiled for, e.g. `aarch64`.
     pub arch: String,
     /// Review date of the engine's bundled pricing catalog.

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -49,6 +49,7 @@ describe("App", () => {
         case "app_info":
           return Promise.resolve({
             appVersion: "0.1.0",
+            debugBuild: false,
             pricingCatalogVersion: "2026-01-01",
             schemaVersion: 1,
             dataDir: "/home/avery/.antiburn",

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -130,6 +130,8 @@ export interface AppSettings {
 /** Where the app came from. Mirrors Rust `AppInfo`. */
 export interface AppInfo {
   appVersion: string
+  /** True when the binary enables Rust debug assertions. */
+  debugBuild: boolean
   /** CPU architecture this binary was compiled for, e.g. `aarch64`. */
   arch: string
   pricingCatalogVersion: string

--- a/apps/desktop/src/views/OnboardingView.test.tsx
+++ b/apps/desktop/src/views/OnboardingView.test.tsx
@@ -50,6 +50,7 @@ const SETTINGS = {
 /// injected" is the state every clean checkout is in.
 const APP_INFO = {
   appVersion: "0.1.0",
+  debugBuild: false,
   arch: "aarch64",
   updatesSupported: false,
   usageAnalyticsSupported: true,

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -205,8 +205,13 @@ function repositoryPayload(overrides: Record<string, unknown> = {}) {
 
 function mockCommands(overrides: Record<string, unknown> = {}) {
   invoke.mockImplementation((command: string, args?: unknown) => {
-    if (command in overrides) return Promise.resolve(overrides[command])
+    if (command in overrides) {
+      const result = overrides[command]
+      return result instanceof Error ? Promise.reject(result) : Promise.resolve(result)
+    }
     switch (command) {
+      case "app_info":
+        return Promise.resolve({ appVersion: "0.1.0", debugBuild: true })
       case "get_settings":
         return Promise.resolve(SETTINGS)
       case "list_recent_sessions":
@@ -451,7 +456,7 @@ describe("PopoverView", () => {
     })
   })
 
-  it("shows the plain title-and-gear footer, with none of the usage surface in it", async () => {
+  it("shows the app version beside the title without putting usage in the footer", async () => {
     render(<PopoverView />)
     await screen.findByTestId("usage-limits-bar")
 
@@ -459,6 +464,26 @@ describe("PopoverView", () => {
     expect(footer).not.toBeNull()
     expect(footer).toHaveTextContent("antiburn")
     expect(footer?.querySelector('[data-testid="usage-limits-bar"]')).toBeNull()
+    expect(screen.getByRole("heading", { name: "antiburn" })).toBeInTheDocument()
+    const version = screen.getByText("v0.1.0 debug")
+    expect(version).toHaveClass("type-caption", "text-label-secondary")
+    expect(version.parentElement).toHaveClass("gap-2")
+  })
+
+  it("omits the debug label from a release build", async () => {
+    mockCommands({ app_info: { appVersion: "0.1.0", debugBuild: false } })
+    render(<PopoverView />)
+
+    expect(await screen.findByText("v0.1.0")).toBeInTheDocument()
+    expect(screen.queryByText("v0.1.0 debug")).toBeNull()
+  })
+
+  it("omits the version when app info cannot load", async () => {
+    mockCommands({ app_info: new Error("unavailable") })
+    render(<PopoverView />)
+
+    await screen.findByTestId("usage-limits-bar")
+    expect(screen.queryByText(/^v\d/)).toBeNull()
   })
 
   it("opens the full usage view from a provider pill and comes back", async () => {

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -456,7 +456,7 @@ describe("PopoverView", () => {
     })
   })
 
-  it("shows the app version beside the title without putting usage in the footer", async () => {
+  it("shows the app version beside the title", async () => {
     render(<PopoverView />)
     await screen.findByTestId("usage-limits-bar")
 

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -118,18 +118,34 @@ function usageEvidence(
 }
 
 /**
- * The activity surface's bottom bar: the app's name, which also carries the
- * surface's focus heading (see the class doc below), and the way to the
- * standalone Settings window.
+ * The activity surface's bottom bar shows the app name and version.
+ * The name also carries the surface's focus heading.
+ * The settings control opens the standalone Settings window.
  */
-function PopoverFooter({ onOpenSettings }: { onOpenSettings: () => void }) {
+function PopoverFooter({
+  appVersion,
+  debugBuild,
+  onOpenSettings,
+}: {
+  appVersion: string | null
+  debugBuild: boolean
+  onOpenSettings: () => void
+}) {
   return (
     <div className="flex h-11 shrink-0 items-center gap-2 border-t border-separator px-4">
-      {/* Focused by the popover when this surface takes over, so a keyboard
-          or screen-reader user lands in the view rather than on <body>. */}
-      <h1 data-view-heading tabIndex={-1} className="type-headline text-label outline-none">
-        antiburn
-      </h1>
+      <div className="flex items-baseline gap-2">
+        {/* Focused by the popover when this surface takes over, so a keyboard
+            or screen-reader user lands in the view rather than on <body>. */}
+        <h1 data-view-heading tabIndex={-1} className="type-headline text-label outline-none">
+          antiburn
+        </h1>
+        {appVersion && (
+          <span className="type-caption whitespace-nowrap text-label-secondary">
+            v{appVersion}
+            {debugBuild ? " debug" : ""}
+          </span>
+        )}
+      </div>
       <button
         type="button"
         onClick={onOpenSettings}
@@ -349,7 +365,11 @@ export function PopoverView() {
           )}
         </div>
 
-        <PopoverFooter onOpenSettings={() => void openSettingsWindow()} />
+        <PopoverFooter
+          appVersion={state.appVersion}
+          debugBuild={state.debugBuild}
+          onOpenSettings={() => void openSettingsWindow()}
+        />
       </div>
     )
   }

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -75,6 +75,7 @@ const SETTINGS = {
 
 const INFO = {
   appVersion: "0.1.0",
+  debugBuild: false,
   arch: "aarch64",
   pricingCatalogVersion: "2026-08-12",
   schemaVersion: 1,

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_SETTINGS,
   EMPTY_LIVE_USAGE,
   EMPTY_PROVIDER_USAGE,
+  appInfo,
   getLiveUsage,
   getProviderUsage,
   getSessionAnalytics,
@@ -66,6 +67,8 @@ type PopoverAnalyticsState = {
 } | null
 
 export interface PopoverSnapshot {
+  appVersion: string | null
+  debugBuild: boolean
   settings: AppSettings | null
   entries: SessionListEntry[] | null
   repositories: LocalRepositoryItem[]
@@ -164,6 +167,8 @@ export class PopoverSession {
   private stopLiveUsageListening: (() => void) | null = null
 
   private snapshot: PopoverSnapshot = {
+    appVersion: null,
+    debugBuild: false,
     settings: null,
     entries: null,
     repositories: [],
@@ -299,13 +304,19 @@ export class PopoverSession {
   // the stored time window. The cached limits do not wait for either read.
   private loadInitial = async (generation: number): Promise<void> => {
     const usage = this.loadCachedUsage()
-    const [stored, health] = await Promise.all([
+    const [stored, health, info] = await Promise.all([
       getSettings().catch(() => DEFAULT_SETTINGS),
       getStorageHealth().catch(() => HEALTHY_STORAGE),
+      appInfo().catch(() => null),
     ])
     if (generation !== this.generation) return
     applyTheme(stored.theme)
-    this.update({ settings: stored, storage: health })
+    this.update({
+      appVersion: info?.appVersion ?? null,
+      debugBuild: info?.debugBuild ?? false,
+      settings: stored,
+      storage: health,
+    })
     // The repository list is read on first paint rather than waiting for a
     // scan to finish, because the source-access banner needs it — a blocked
     // repository is exactly the case where no scan will ever complete to


### PR DESCRIPTION
## Summary

- show the running app version beside `antiburn` in the popover footer
- label debug builds with `debug` while release builds show only the version
- keep the version always visible in the secondary text color and omit it if app metadata cannot load
- full time at the moment - in the future we can hide and reveal with modifier again if desired.

## Screenshots
<img width="380" height="700" alt="image" src="https://github.com/user-attachments/assets/64a71faf-ab5d-4b42-83e0-61ce006a6569" />


## Validation

- `vitest run src/views/PopoverView.test.tsx` — 35 passed
- desktop type-check — passed
- desktop lint — passed
- `cargo test --lib --quiet` — 391 passed
- Rust formatting — passed
- design-contract check — passed
- native Tauri popover inspected under the current system theme
