### PR TITLE
feat: explain Context chart gaps and refresh the open session on reopen

### DIFF
--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -33,6 +33,8 @@ function bucket(over: Partial<SessionBucket> = {}): SessionBucket {
     isCacheRehydration: false,
     secsSincePriorTurn: null,
     subagentLaunches: 0,
+    userPrompts: 0,
+    lastTool: null,
     model: null,
     thinkingMode: null,
     speed: null,
@@ -197,6 +199,12 @@ describe("SessionDetailPresentation — chrome", () => {
     // The screen reader announces the view and the control correctly.
     expect(screen.getByRole("heading", { name: "Session Detail" })).toBeTruthy()
     expect(screen.getByRole("button", { name: "Back" })).toBeTruthy()
+  })
+
+  it("shows a header spinner while a newer analysis is on its way", () => {
+    view({ refreshing: true })
+    expect(screen.getByRole("status")).toHaveTextContent("Refreshing session analytics")
+    expect(screen.getByRole("heading", { name: "Session Detail" })).toBeTruthy()
   })
 
   it("navigates back through the callback", () => {

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -10,6 +10,7 @@ import {
   GitBranchPlus,
   GitFork,
   Info,
+  Loader2,
   Moon,
   Share,
   Trash2,
@@ -87,6 +88,8 @@ export interface SessionDetailPresentationProps {
   summary: ActiveSessionsSummary | null
   /** Whether the analysis is still being produced. */
   loading: boolean
+  /** Whether a newer analysis is on its way while `summary` stays on screen. */
+  refreshing?: boolean
   /** Whether producing it failed. */
   error: boolean
   /** The session this view describes. */
@@ -406,6 +409,7 @@ function useSkeletonVisible(loading: boolean): boolean {
 export function SessionDetailPresentation({
   summary,
   loading,
+  refreshing = false,
   error,
   session,
   supportsAnalytics,
@@ -515,6 +519,15 @@ export function SessionDetailPresentation({
           {subagent && (
             <span className="shrink-0 rounded bg-system-indigo/15 px-1.5 py-px type-caption font-medium text-system-indigo-text">
               Sub-agent
+            </span>
+          )}
+          {refreshing && (
+            <span
+              role="status"
+              className="inline-flex shrink-0 items-center text-label-tertiary"
+            >
+              <Loader2 size={12} strokeWidth={2} aria-hidden="true" className="animate-spin" />
+              <span className="sr-only">Refreshing session analytics</span>
             </span>
           )}
         </div>

--- a/apps/desktop/src/components/session/analytics/ContextTokensChart.test.tsx
+++ b/apps/desktop/src/components/session/analytics/ContextTokensChart.test.tsx
@@ -48,6 +48,8 @@ function bucket(over: Partial<SessionBucket> = {}): SessionBucket {
     isCacheRehydration: false,
     secsSincePriorTurn: null,
     subagentLaunches: 0,
+    userPrompts: 0,
+    lastTool: null,
     model: null,
     thinkingMode: null,
     speed: null,
@@ -155,6 +157,9 @@ function point(over: Partial<ContextTokenPoint> = {}): ContextTokenPoint {
     isCacheRehydration: false,
     secsSincePriorTurn: null,
     subagentLaunches: 0,
+    userPrompts: 0,
+    lastTool: null,
+    betweenCalls: null,
     model: null,
     thinkingMode: null,
     speed: null,
@@ -167,6 +172,108 @@ function point(over: Partial<ContextTokenPoint> = {}): ContextTokenPoint {
 }
 
 describe("ContextTokensTooltip", () => {
+  it("names the tool call and gap length for a bucket with no model call", () => {
+    render(
+      <ContextTokensTooltip
+        active
+        contextWindow={200_000}
+        payload={[
+          {
+            payload: point({
+              tokensIn: 0,
+              tokensOut: 0,
+              betweenCalls: { secs: 130, tool: "Bash", userPrompt: false },
+            }),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("During Bash call · 2m")).toBeInTheDocument()
+    expect(screen.queryByText("Tokens")).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Parent in/)).not.toBeInTheDocument()
+  })
+
+  it("names the drawn width of a long gap ended by a user prompt", () => {
+    render(
+      <ContextTokensTooltip
+        active
+        contextWindow={200_000}
+        payload={[
+          {
+            payload: point({
+              tokensIn: 0,
+              tokensOut: 0,
+              betweenCalls: { secs: 1_500, tool: null, userPrompt: true },
+            }),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("Waiting for user · 25m (5m shown)")).toBeInTheDocument()
+  })
+
+  it("keeps a long gap after a tool call attributed to the tool", () => {
+    render(
+      <ContextTokensTooltip
+        active
+        contextWindow={200_000}
+        payload={[
+          {
+            payload: point({
+              tokensIn: 0,
+              tokensOut: 0,
+              betweenCalls: { secs: 1_500, tool: "Task", userPrompt: false },
+            }),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("During Task call · 25m (5m shown)")).toBeInTheDocument()
+  })
+
+  it("says the model waited for the user when a prompt ends a short gap", () => {
+    render(
+      <ContextTokensTooltip
+        active
+        contextWindow={200_000}
+        payload={[
+          {
+            payload: point({
+              tokensIn: 0,
+              tokensOut: 0,
+              betweenCalls: { secs: 45, tool: "Bash", userPrompt: true },
+            }),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("Waiting for user · 45s")).toBeInTheDocument()
+  })
+
+  it("falls back to a plain gap line when no tool is recorded", () => {
+    render(
+      <ContextTokensTooltip
+        active
+        contextWindow={200_000}
+        payload={[
+          {
+            payload: point({
+              tokensIn: 0,
+              tokensOut: 0,
+              betweenCalls: { secs: null, tool: null, userPrompt: false },
+            }),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("Between model calls")).toBeInTheDocument()
+  })
+
   it("shows elapsed active time at the hovered bucket", () => {
     render(
       <ContextTokensTooltip
@@ -178,7 +285,7 @@ describe("ContextTokensTooltip", () => {
       />,
     )
 
-    expect(screen.getByText("30m")).toBeInTheDocument()
+    expect(screen.getByText("30m into session")).toBeInTheDocument()
     expect(screen.queryByText("25% through")).not.toBeInTheDocument()
   })
 
@@ -266,6 +373,36 @@ describe("ContextTokensTooltip", () => {
     expect(screen.getByText("Effort · high")).toBeInTheDocument()
     expect(screen.getByText("Speed · fast")).toBeInTheDocument()
     expect(screen.getByText("Thinking")).toBeInTheDocument()
+  })
+
+  it("omits mode lines that match the session baseline", () => {
+    render(
+      <ContextTokensTooltip
+        active
+        contextWindow={200_000}
+        baseline={{
+          model: "claude-opus-4-6",
+          thinkingMode: "high",
+          speed: "fast",
+          hasThinking: true,
+        }}
+        payload={[
+          {
+            payload: point({
+              model: "claude-opus-4-6",
+              thinkingMode: "max",
+              speed: "fast",
+              hasThinking: true,
+            }),
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.queryByText(/^Model/)).not.toBeInTheDocument()
+    expect(screen.getByText("Effort · max")).toBeInTheDocument()
+    expect(screen.queryByText(/^Speed/)).not.toBeInTheDocument()
+    expect(screen.queryByText("Thinking")).not.toBeInTheDocument()
   })
 
   it("omits model, effort, speed, and thinking lines when absent", () => {

--- a/apps/desktop/src/components/session/analytics/ContextTokensChart.test.tsx
+++ b/apps/desktop/src/components/session/analytics/ContextTokensChart.test.tsx
@@ -157,7 +157,6 @@ function point(over: Partial<ContextTokenPoint> = {}): ContextTokenPoint {
     isCacheRehydration: false,
     secsSincePriorTurn: null,
     subagentLaunches: 0,
-    userPrompts: 0,
     lastTool: null,
     betweenCalls: null,
     model: null,

--- a/apps/desktop/src/components/session/analytics/ContextTokensChart.tsx
+++ b/apps/desktop/src/components/session/analytics/ContextTokensChart.tsx
@@ -21,9 +21,12 @@ import {
   formatDuration,
   formatPct,
   formatTokenBand,
+  IDLE_GAP_SECS,
   timeAxisTicks,
   modeChangeMarkers,
+  sessionModeBaseline,
   type ContextTokenPoint,
+  type SessionModeBaseline,
 } from "../../../lib/presentation/sessionAnalytics"
 import type { SessionBucket } from "../../../lib/types/session"
 import { GLASS_TOOLTIP_STYLE } from "./tooltip"
@@ -51,7 +54,16 @@ export interface ContextTokensTooltipProps {
   contextWindow: number | null
   activeSecs?: number | null
   bucketCount?: number
+  /** The session's starting mode. A mode row that matches it is not shown. */
+  baseline?: SessionModeBaseline
   payload?: Array<{ payload?: ContextTokenPoint }>
+}
+
+const NO_BASELINE: SessionModeBaseline = {
+  model: null,
+  thinkingMode: null,
+  speed: null,
+  hasThinking: false,
 }
 
 /** Row swatches for the token-series lines, matching the chart's fill colors. */
@@ -66,6 +78,32 @@ const TOKEN_ROWS: Array<{
     key: "subagentTokens",
     label: "Subagents",
     colorVar: "var(--color-token-subagent)",
+  },
+]
+
+/**
+ * Cache rows are not drawn on the chart, so they get a hollow swatch in the
+ * input color: the same family as "Parent in", but not a plotted series.
+ * Vendors that report no cache writes (Codex) always show zero, so that row
+ * hides when it has nothing to say.
+ */
+const CACHE_ROWS: Array<{
+  key: "cacheReadTokens" | "cacheWriteTokens"
+  label: string
+  colorVar: string
+  hideWhenZero: boolean
+}> = [
+  {
+    key: "cacheReadTokens",
+    label: "Cache read",
+    colorVar: "var(--color-token-in)",
+    hideWhenZero: false,
+  },
+  {
+    key: "cacheWriteTokens",
+    label: "Cache write",
+    colorVar: "var(--color-token-in)",
+    hideWhenZero: true,
   },
 ]
 
@@ -88,6 +126,36 @@ function compactionLabel(point: ContextTokenPoint): string {
 }
 
 /**
+ * The line for a bucket with no model call: the slice sits inside a gap
+ * between two calls. The label names what the session waited on: a tool
+ * that ran during the gap, or the user when a prompt ended it. A gap at or
+ * past the idle cap also shows how much of it the axis draws.
+ */
+function betweenCallsLabel(gap: NonNullable<ContextTokenPoint["betweenCalls"]>): string {
+  let secs = ""
+  if (gap.secs != null) {
+    secs = ` · ${formatDuration(gap.secs)}`
+    if (gap.secs >= IDLE_GAP_SECS) secs += ` (${formatDuration(IDLE_GAP_SECS)} shown)`
+  }
+  if (gap.tool != null && !gap.userPrompt) return `During ${gap.tool} call${secs}`
+  if (gap.userPrompt) return `Waiting for user${secs}`
+  return `Between model calls${secs}`
+}
+
+/**
+ * The rehydration tooltip line. A vendor that reports cache writes (Claude)
+ * names the tokens written. A vendor that does not (Codex) always reports
+ * zero writes, so the line names the fresh input instead: that is the
+ * context the API had to re-read at full price after the cache expired.
+ */
+function rehydrationLabel(point: ContextTokenPoint): string {
+  if (point.cacheWriteTokens > 0) {
+    return `Cache rehydrated · ${formatCompact(point.cacheWriteTokens)} written`
+  }
+  return `Cache rehydrated · ${formatCompact(point.tokensIn)} re-sent uncached`
+}
+
+/**
  * The custom tooltip shows active time, context depth, token throughput,
  * compaction, and sub-agent launches. Tests can render it with a fixed payload.
  */
@@ -97,6 +165,7 @@ export function ContextTokensTooltip({
   contextWindow,
   activeSecs = null,
   bucketCount = 0,
+  baseline = NO_BASELINE,
 }: ContextTokensTooltipProps) {
   const point = payload?.[0]?.payload
   if (!active || !point) return null
@@ -119,40 +188,61 @@ export function ContextTokensTooltip({
         whiteSpace: "nowrap",
       }}
     >
-      <div className="mb-1">{elapsed}</div>
+      <div className="mb-1">{elapsed} into session</div>
       <div className="flex flex-col gap-1 text-label-secondary">
-        {point.secsSincePriorTurn != null && (
-          <span>Since prior turn · {formatDuration(point.secsSincePriorTurn)}</span>
-        )}
         {pct != null && (
           <span>
             Context · {formatCompact(point.contextTokens)} ({formatPct(pct)})
           </span>
         )}
-        {TOKEN_ROWS.map((row) => (
-          <span key={row.key} className="flex items-center gap-1.5">
-            <span
-              className="h-2 w-2 shrink-0 rounded-full"
-              style={{ backgroundColor: row.colorVar }}
-            />
-            {row.label} · {formatCompact(point[row.key])}
-          </span>
-        ))}
-        <span>Cache read · {formatCompact(point.cacheReadTokens)}</span>
-        <span>Cache write · {formatCompact(point.cacheWriteTokens)}</span>
+        {point.betweenCalls != null && (
+          <span className="mt-1">{betweenCallsLabel(point.betweenCalls)}</span>
+        )}
+        {point.betweenCalls == null && (
+          <span className="mt-1 type-caption text-label-tertiary">Tokens</span>
+        )}
+        {point.betweenCalls == null &&
+          TOKEN_ROWS.map((row) => (
+            <span key={row.key} className="flex items-center gap-1.5">
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: row.colorVar }}
+              />
+              {row.label} · {formatCompact(point[row.key])}
+            </span>
+          ))}
+        {point.betweenCalls == null &&
+          CACHE_ROWS.filter((row) => !row.hideWhenZero || point[row.key] > 0).map((row) => (
+            <span key={row.key} className="flex items-center gap-1.5">
+              <span
+                className="h-2 w-2 shrink-0 rounded-full border"
+                style={{ borderColor: row.colorVar }}
+              />
+              {row.label} · {formatCompact(point[row.key])}
+            </span>
+          ))}
         {point.isCacheRehydration && (
           <span style={{ color: "var(--color-context-critical)" }}>
-            Cache rehydrated · {formatCompact(point.cacheWriteTokens)} written
+            {rehydrationLabel(point)}
           </span>
+        )}
+        {point.secsSincePriorTurn != null && (
+          <span>Since prior turn · {formatDuration(point.secsSincePriorTurn)}</span>
         )}
         {point.isCompactionBoundary && <span>{compactionLabel(point)}</span>}
         {point.subagentLaunches > 0 && (
           <span>Subagents launched · {point.subagentLaunches}</span>
         )}
-        {point.model != null && <span>Model · {modelShortName(point.model)}</span>}
-        {point.thinkingMode != null && <span>Effort · {point.thinkingMode}</span>}
-        {point.speed != null && <span>Speed · {point.speed}</span>}
-        {point.hasThinking && <span>Thinking</span>}
+        {point.model != null && point.model !== baseline.model && (
+          <span>Model · {modelShortName(point.model)}</span>
+        )}
+        {point.thinkingMode != null && point.thinkingMode !== baseline.thinkingMode && (
+          <span>Effort · {point.thinkingMode}</span>
+        )}
+        {point.speed != null && point.speed !== baseline.speed && (
+          <span>Speed · {point.speed}</span>
+        )}
+        {point.hasThinking && !baseline.hasThinking && <span>Thinking</span>}
       </div>
     </div>
   )
@@ -308,39 +398,23 @@ export function ContextTokensChart({
               contextWindow={contextWindow}
               activeSecs={activeSecs}
               bucketCount={data.length}
+              baseline={sessionModeBaseline(data)}
             />
           }
         />
-        <Area
-          yAxisId="tokens"
-          type="monotone"
-          dataKey="tokensIn"
-          stackId="t"
-          stroke="none"
-          fill="var(--color-token-in)"
-          fillOpacity={0.22}
-          isAnimationActive={false}
-        />
-        <Area
-          yAxisId="tokens"
-          type="monotone"
-          dataKey="tokensOut"
-          stackId="t"
-          stroke="none"
-          fill="var(--color-token-out)"
-          fillOpacity={0.22}
-          isAnimationActive={false}
-        />
-        <Area
-          yAxisId="tokens"
-          type="monotone"
-          dataKey="subagentTokens"
-          stackId="t"
-          stroke="none"
-          fill="var(--color-token-subagent)"
-          fillOpacity={0.22}
-          isAnimationActive={false}
-        />
+        {TOKEN_ROWS.map((row) => (
+          <Area
+            key={row.key}
+            yAxisId="tokens"
+            type="monotone"
+            dataKey={row.key}
+            stackId="t"
+            stroke="none"
+            fill={row.colorVar}
+            fillOpacity={0.22}
+            isAnimationActive={false}
+          />
+        ))}
         {hasContext && (
           <Area
             yAxisId="context"

--- a/apps/desktop/src/lib/presentation/sessionAnalytics.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionAnalytics.test.ts
@@ -36,6 +36,8 @@ function bucket(over: Partial<SessionBucket> = {}): SessionBucket {
     isCacheRehydration: false,
     secsSincePriorTurn: null,
     subagentLaunches: 0,
+    userPrompts: 0,
+    lastTool: null,
     model: null,
     thinkingMode: null,
     speed: null,
@@ -122,6 +124,32 @@ describe("contextTokenSeries", () => {
     ])
 
     expect(series.map((point) => point.secsSincePriorTurn)).toEqual([null, 9_300, null])
+  })
+
+  it("describes the gap a call-less bucket sits in", () => {
+    const series = contextTokenSeries([
+      bucket({ contextTokens: 20_000, tokensIn: 100, lastTool: "Bash" }),
+      bucket({ contextTokens: 0 }),
+      bucket({ contextTokens: 0 }),
+      bucket({ contextTokens: 25_000, tokensIn: 100, secsSincePriorTurn: 130 }),
+    ])
+
+    expect(series.map((point) => point.betweenCalls)).toEqual([
+      null,
+      { secs: 130, tool: "Bash", userPrompt: false },
+      { secs: 130, tool: "Bash", userPrompt: false },
+      null,
+    ])
+  })
+
+  it("marks a gap that a user prompt ends", () => {
+    const series = contextTokenSeries([
+      bucket({ contextTokens: 20_000, tokensIn: 100, lastTool: "Bash" }),
+      bucket({ contextTokens: 0 }),
+      bucket({ contextTokens: 25_000, tokensIn: 100, secsSincePriorTurn: 600, userPrompts: 1 }),
+    ])
+
+    expect(series[1]!.betweenCalls).toEqual({ secs: 600, tool: "Bash", userPrompt: true })
   })
 
   it("forward-fills model, thinking mode, and speed across buckets with no value", () => {

--- a/apps/desktop/src/lib/presentation/sessionAnalytics.ts
+++ b/apps/desktop/src/lib/presentation/sessionAnalytics.ts
@@ -37,6 +37,16 @@ export interface ContextTokenPoint {
   isCacheRehydration: boolean
   secsSincePriorTurn: number | null
   subagentLaunches: number
+  /** The name of the last parent tool call in this bucket, when any. */
+  lastTool: string | null
+  /**
+   * Set when no model call landed in this bucket: the slice sits inside the
+   * gap between two calls. `tool` names the call the model made before the
+   * gap, when the transcript records one. `secs` is the length of the whole
+   * gap, when the next call recorded it. `userPrompt` is true when a user
+   * prompt ends the gap: the model waited for the user, not for a tool.
+   */
+  betweenCalls: { secs: number | null; tool: string | null; userPrompt: boolean } | null
   /** Model that produced this point, forward-filled from the last bucket that named one. */
   model: string | null
   /** Thinking-effort mode at this point, forward-filled the same way. */
@@ -101,6 +111,8 @@ export function contextTokenSeries(buckets: SessionBucket[]): ContextTokenPoint[
     isCacheRehydration: bucket.isCacheRehydration,
     secsSincePriorTurn: bucket.secsSincePriorTurn,
     subagentLaunches: bucket.subagentLaunches,
+    lastTool: bucket.lastTool,
+    betweenCalls: betweenCalls(buckets, index),
     model: models[index]!,
     thinkingMode: thinkingModes[index]!,
     speed: speeds[index]!,
@@ -109,6 +121,77 @@ export function contextTokenSeries(buckets: SessionBucket[]): ContextTokenPoint[
     compactionPreTokens: bucket.compactionPreTokens,
     compactionPostTokens: bucket.compactionPostTokens,
   }))
+}
+
+/**
+ * Mirrors `analysis::engine::IDLE_GAP_MS`. The engine counts each gap between
+ * events toward active time up to this cap, so the chart draws a longer gap
+ * as a shelf of this width.
+ */
+export const IDLE_GAP_SECS = 5 * 60
+
+/** True when a model call (parent or sub-agent) landed in the bucket. */
+function hasCall(bucket: SessionBucket): boolean {
+  return (
+    bucket.tokensIn > 0 ||
+    bucket.tokensOut > 0 ||
+    bucket.subagentTokens > 0 ||
+    bucket.secsSincePriorTurn != null
+  )
+}
+
+/**
+ * Describe the gap a call-less bucket sits in. The tool is the last one the
+ * parent called at or after the previous call bucket, so it names the call
+ * that ran during the gap. The length comes from the next call bucket, which
+ * records the seconds since the call before it. Null for a bucket with a call.
+ */
+function betweenCalls(
+  buckets: readonly SessionBucket[],
+  index: number,
+): ContextTokenPoint["betweenCalls"] {
+  const current = buckets[index]!
+  if (hasCall(current)) return null
+  let tool: string | null = null
+  for (let i = index; i >= 0; i--) {
+    const bucket = buckets[i]!
+    tool ??= bucket.lastTool
+    if (hasCall(bucket)) break
+  }
+  let secs: number | null = null
+  let userPrompt = current.userPrompts > 0
+  for (let i = index + 1; i < buckets.length; i++) {
+    const bucket = buckets[i]!
+    userPrompt ||= bucket.userPrompts > 0
+    if (hasCall(bucket)) {
+      secs = bucket.secsSincePriorTurn
+      break
+    }
+  }
+  return { secs, tool, userPrompt }
+}
+
+/** The mode the session starts in, as the detail header reports it. */
+export interface SessionModeBaseline {
+  model: string | null
+  thinkingMode: string | null
+  speed: string | null
+  hasThinking: boolean
+}
+
+/**
+ * The first observed model, effort, and speed, and whether the first bucket
+ * with a model signal carries a thinking block. The tooltip hides a mode row
+ * that matches this baseline, because the session header already names it.
+ */
+export function sessionModeBaseline(points: readonly ContextTokenPoint[]): SessionModeBaseline {
+  const first = points.find((point) => point.model != null)
+  return {
+    model: first?.model ?? null,
+    thinkingMode: points.find((point) => point.thinkingMode != null)?.thinkingMode ?? null,
+    speed: points.find((point) => point.speed != null)?.speed ?? null,
+    hasThinking: first?.hasThinking ?? false,
+  }
 }
 
 /**

--- a/apps/desktop/src/lib/types/session.ts
+++ b/apps/desktop/src/lib/types/session.ts
@@ -53,6 +53,10 @@ export interface SessionBucket {
   secsSincePriorTurn: number | null
   /** Count of `Task` tool calls in this bucket: how many sub-agents launched at this point. */
   subagentLaunches: number
+  /** Count of user prompts in this bucket. */
+  userPrompts: number
+  /** The name of the last parent tool call in this bucket, when any. */
+  lastTool: string | null
   /** The model that produced the last parent event in this bucket, when known. */
   model: string | null
   /** The thinking-effort mode of the last parent event in this bucket, when known. */

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -612,6 +612,44 @@ describe("PopoverView", () => {
     expect(invoke).not.toHaveBeenCalledWith("scan_now", expect.anything())
   })
 
+  it("re-loads the open session’s analytics on the popover-shown signal and shows a spinner meanwhile", async () => {
+    render(<PopoverView />)
+    fireEvent.click(await screen.findByText("Wire the tray popover"))
+    await screen.findByRole("button", { name: "Back" }, { timeout: 5_000 })
+    await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument())
+
+    const loadsBeforeShown = invoke.mock.calls.filter(
+      ([command]) => command === "get_session_analytics",
+    ).length
+
+    let finishLoad: (() => void) | null = null
+    const baseInvoke = invoke.getMockImplementation()!
+    invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command !== "get_session_analytics") return baseInvoke(command, args)
+      return new Promise((resolve) => {
+        finishLoad = () => resolve(ANALYTICS)
+      })
+    })
+
+    emit("popover:shown", undefined)
+
+    await waitFor(() =>
+      expect(
+        invoke.mock.calls.filter(([command]) => command === "get_session_analytics").length,
+      ).toBe(loadsBeforeShown + 1),
+    )
+    // The settled analysis stays on screen; only the header spinner says a
+    // newer one is on its way.
+    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.queryByTestId("session-analytics-skeleton")).not.toBeInTheDocument()
+
+    await act(async () => {
+      finishLoad?.()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument())
+  })
+
   it("never renders the first-run flow, whatever the flag says", async () => {
     // The flow has its own window now (D-25, `views/OnboardingView.tsx`), and
     // the shell sends the tray click there instead of here. A popover that

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -211,6 +211,9 @@ export function PopoverView() {
   const sessionPayload = settledAnalytics?.payload ?? null
   const sessionLoading = current != null && settledAnalytics == null
   const sessionError = settledAnalytics?.error ?? false
+  // Only a re-load over a settled result is "refreshing"; a first load shows
+  // the skeleton through `loading` instead.
+  const sessionRefreshing = state.analyticsRefreshing && settledAnalytics != null
 
   /* ---------------------------------------------------------------------
    * Attention banners
@@ -280,6 +283,7 @@ export function PopoverView() {
             subject={displaySubject}
             payload={sessionPayload}
             loading={sessionLoading}
+            refreshing={sessionRefreshing}
             error={sessionError}
             onBack={session.goBack}
             onPrev={neighbour(-1)}

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -94,6 +94,11 @@ export interface PopoverSnapshot {
    * way in — which is what keeps opening a session from cascading renders.
    */
   analytics: PopoverAnalyticsState
+  /**
+   * Whether a re-load of the open session's analytics is in flight while an
+   * earlier result is still on screen. Drives the detail header's spinner.
+   */
+  analyticsRefreshing: boolean
 }
 
 /**
@@ -157,6 +162,8 @@ export class PopoverSession {
    * still running. The snapshot's `usageRefreshing` is `count > 0`.
    */
   private usageRefreshCount = 0
+  /** How many `refreshAnalytics` calls are in flight; see `usageRefreshCount`. */
+  private analyticsRefreshCount = 0
   private liveUsageRevision = 0
 
   private stopSettingsListening: (() => void) | null = null
@@ -180,6 +187,7 @@ export class PopoverSession {
     dismissed: [],
     stack: [],
     analytics: null,
+    analyticsRefreshing: false,
   }
 
   getSnapshot = (): PopoverSnapshot => this.snapshot
@@ -415,12 +423,15 @@ export class PopoverSession {
   // paused or onboarding is unfinished, and even a scan that does run can
   // take a while to finish. Neither has any bearing on a provider's own
   // stated limits, so usage gets its own refresh here rather than waiting on
-  // — or being silenced by — the scan pipeline. Only usage: entries and the
-  // repository list are already covered by `listenScanEvent` above.
+  // — or being silenced by — the scan pipeline. Entries and the repository
+  // list are already covered by `listenScanEvent` above. The open session's
+  // analytics is not: its transcript can grow while the popover is hidden,
+  // and nothing else asks for it again until the reader navigates.
   private listenPopoverShown = async (generation: number): Promise<void> => {
     const unlisten = await onPopoverShown(() => {
       if (generation !== this.generation) return
       void this.refreshUsage()
+      void this.refreshAnalytics()
     })
     if (generation !== this.generation) {
       unlisten()
@@ -524,11 +535,11 @@ export class PopoverSession {
     })
   }
 
-  private loadAnalyticsFor = (subject: SessionSubject): void => {
+  private loadAnalyticsFor = (subject: SessionSubject): Promise<void> => {
     const key = sessionKey(subject)
     const generation = this.generation
     const token = ++this.analyticsToken
-    loadAnalytics(subject)
+    return loadAnalytics(subject)
       .then((payload) => {
         if (generation !== this.generation || token !== this.analyticsToken) return
         this.update({ analytics: { key, payload, error: false } })
@@ -537,6 +548,25 @@ export class PopoverSession {
         if (generation !== this.generation || token !== this.analyticsToken) return
         this.update({ analytics: { key, payload: null, error: true } })
       })
+  }
+
+  /**
+   * Re-load the analytics for the session on top of the stack. The settled
+   * result stays on screen until the new one lands: `loading` is derived from
+   * a key mismatch, and the key does not change here, so the reader sees the
+   * header spinner rather than the skeleton.
+   */
+  private refreshAnalytics = async (): Promise<void> => {
+    const top = this.snapshot.stack.at(-1)
+    if (!top) return
+    this.analyticsRefreshCount += 1
+    this.update({ analyticsRefreshing: true })
+    try {
+      await this.loadAnalyticsFor(top)
+    } finally {
+      this.analyticsRefreshCount -= 1
+      this.update({ analyticsRefreshing: this.analyticsRefreshCount > 0 })
+    }
   }
 
   /* -----------------------------------------------------------------------

--- a/apps/desktop/src/views/popover/SessionPane.tsx
+++ b/apps/desktop/src/views/popover/SessionPane.tsx
@@ -60,6 +60,8 @@ export interface SessionPaneProps {
   payload: SessionAnalyticsPayload | null
   /** Whether `payload` belongs to a load still in flight for this subject. */
   loading: boolean
+  /** Whether a re-load is in flight while `payload` is still on screen. */
+  refreshing: boolean
   /** Whether the load for this subject failed. */
   error: boolean
   onBack: () => void
@@ -197,6 +199,7 @@ export function SessionPane({
   subject,
   payload,
   loading,
+  refreshing,
   error,
   onBack,
   onPrev,
@@ -321,6 +324,7 @@ export function SessionPane({
     <SessionDetailPresentation
       summary={payload?.summary ?? null}
       loading={loading}
+      refreshing={refreshing}
       error={error}
       session={{
         agent: subject.agent,

--- a/crates/antiburn-local/src/analysis/engine.rs
+++ b/crates/antiburn-local/src/analysis/engine.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::analysis::initial_context::InitialContextBreakdown;
 use crate::analysis::model::{
-    CompactionTrigger, EventSource, ModelRun, NormalizedSession, ToolCategory,
+    CompactionTrigger, EventSource, ModelRun, NormalizedSession, Role, ToolCategory,
 };
 
 /// Number of progress buckets each session is resampled onto (0% → 100%).
@@ -278,6 +278,15 @@ pub struct Bucket {
     /// parent session launched at this point. Parent turns only — a
     /// sub-agent does not itself launch sub-agents in this count.
     pub subagent_launches: u32,
+    /// Count of user prompts in this bucket. A gap that ends at a prompt is
+    /// the user away, not a tool that runs.
+    #[serde(default)]
+    pub user_prompts: u32,
+    /// The name of the last parent tool call in this bucket, when any. The
+    /// tooltip names it for the slices that follow, while the tool runs and
+    /// no model call lands.
+    #[serde(default)]
+    pub last_tool: Option<String>,
     /// The model that produced the last parent event in this bucket. Parent
     /// turns only — a sub-agent runs its own model, which says nothing about
     /// the parent session's mode at this point.
@@ -563,8 +572,11 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
                     bucket.is_cache_rehydration = true;
                     cache_rehydration_count += 1;
                 }
-                // Keep the exact rehydration gap if another turn shares the bucket.
-                if is_cache_rehydration || !bucket.is_cache_rehydration {
+                // The bucket keeps the gap of its first turn: the gap that
+                // enters the bucket. A rehydration turn takes priority.
+                if is_cache_rehydration
+                    || (!bucket.is_cache_rehydration && bucket.secs_since_prior_turn.is_none())
+                {
                     bucket.secs_since_prior_turn = secs_since_prior_turn;
                 }
                 prev_turn_ts = ev.ts_ms;
@@ -577,6 +589,9 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
                 .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
                 .count() as u32;
             bucket.subagent_launches = bucket.subagent_launches.saturating_add(launches);
+            if ev.source == EventSource::Parent && ev.role == Role::User {
+                bucket.user_prompts = bucket.user_prompts.saturating_add(1);
+            }
 
             // Mode signals: the last parent event seen in this bucket wins.
             // Sub-agents run their own model/effort/speed, which says nothing
@@ -592,6 +607,9 @@ pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
                 bucket.speed = Some(speed.to_string());
             }
             bucket.has_thinking |= ev.has_thinking;
+            if let Some(tool) = ev.tools.last() {
+                bucket.last_tool = Some(tool.name.clone());
+            }
         }
 
         // Collect skill invocations for exports.
@@ -856,11 +874,13 @@ pub fn aggregate_metrics(metrics: Vec<SessionMetrics>) -> ActiveSessionsSummary 
         let mut is_compaction_boundary = false;
         let mut is_cache_rehydration = false;
         let mut subagent_launches = 0u32;
+        let mut user_prompts = 0u32;
         for m in &metrics {
             let b = &m.buckets[bi];
             is_compaction_boundary |= b.is_compaction_boundary;
             is_cache_rehydration |= b.is_cache_rehydration;
             subagent_launches = subagent_launches.saturating_add(b.subagent_launches);
+            user_prompts = user_prompts.saturating_add(b.user_prompts);
             tin = tin.saturating_add(b.tokens_in);
             tout = tout.saturating_add(b.tokens_out);
             subagent_tokens = subagent_tokens.saturating_add(b.subagent_tokens);
@@ -889,21 +909,26 @@ pub fn aggregate_metrics(metrics: Vec<SessionMetrics>) -> ActiveSessionsSummary 
         bucket.context_tokens = ctx_sum.checked_div(ctx_contributors).unwrap_or(0);
         bucket.is_compaction_boundary = is_compaction_boundary;
         bucket.is_cache_rehydration = is_cache_rehydration;
-        // A combined summary cannot name one prior-turn gap for several sessions.
-        if count == 1 {
-            bucket.secs_since_prior_turn = metrics[0].buckets[bi].secs_since_prior_turn;
-        }
         bucket.subagent_launches = subagent_launches;
-        // `model`, `thinking_mode`, `speed`, and `has_thinking` stay at their
-        // default (`None`/`false`) here. Each contributing session can be a
-        // different agent with its own model and mode, so one bucket cannot
-        // carry a single true value across a multi-session summary — the
-        // mode-change chart annotation is a single-session feature only.
-        //
-        // `compaction_trigger`, `compaction_pre_tokens`, and
-        // `compaction_post_tokens` stay `None` for the same reason: each
-        // contributing session's compaction is its own event, so one summary
-        // bucket cannot carry a single trigger or size across sessions.
+        bucket.user_prompts = user_prompts;
+        // The per-session signals below name one gap, one model, one mode, and
+        // one compaction. Each contributing session can run a different agent
+        // with its own mode and its own compactions, so a multi-session summary
+        // leaves them at their defaults (`None`/`false`). A single-session
+        // summary carries them through, so the session detail view can show
+        // them.
+        if count == 1 {
+            let own = &metrics[0].buckets[bi];
+            bucket.secs_since_prior_turn = own.secs_since_prior_turn;
+            bucket.model = own.model.clone();
+            bucket.thinking_mode = own.thinking_mode.clone();
+            bucket.speed = own.speed.clone();
+            bucket.has_thinking = own.has_thinking;
+            bucket.last_tool = own.last_tool.clone();
+            bucket.compaction_trigger = own.compaction_trigger;
+            bucket.compaction_pre_tokens = own.compaction_pre_tokens;
+            bucket.compaction_post_tokens = own.compaction_post_tokens;
+        }
     }
 
     ActiveSessionsSummary {

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -839,6 +839,42 @@ const CLAUDE_CACHE_REHYDRATION_WITH_CACHED_PREFIX_FIXTURE: &str = concat!(
 );
 
 #[test]
+fn bucket_keeps_the_gap_that_enters_it_and_counts_user_prompts() {
+    let assistant = |ts: &str| {
+        format!(
+            r#"{{"type":"assistant","timestamp":"{ts}","message":{{"role":"assistant","usage":{{"input_tokens":100,"output_tokens":10}},"content":[{{"type":"text","text":"x"}}]}}}}"#
+        )
+    };
+    let mut lines = vec![
+        assistant("2024-06-01T10:00:00Z"),
+        r#"{"type":"user","timestamp":"2024-06-01T10:10:02Z","message":{"role":"user","content":"go"}}"#.to_string(),
+        assistant("2024-06-01T10:10:05Z"),
+        assistant("2024-06-01T10:10:12Z"),
+    ];
+    // Pad the session so a bucket spans about 20 seconds and the two follow-up
+    // turns share one bucket.
+    for minute in (15..=70).step_by(5) {
+        lines.push(assistant(&format!("2024-06-01T10:{minute}:00Z")));
+    }
+    let session = normalize_source(&jsonl_input("claude", &lines.join("\n"))).unwrap();
+    let m = analyze_session(&session);
+
+    let bucket = m
+        .buckets
+        .iter()
+        .find(|bucket| bucket.user_prompts > 0)
+        .expect("the bucket with the prompt");
+    assert_eq!(bucket.user_prompts, 1);
+    assert!(
+        bucket.tokens_in >= 200,
+        "both follow-up turns share the bucket"
+    );
+    // The first turn in the bucket sets the gap: 10m 5s since the prior turn,
+    // not the 7s between the two follow-up turns.
+    assert_eq!(bucket.secs_since_prior_turn, Some(605));
+}
+
+#[test]
 fn cache_rehydration_is_detected_when_the_prefix_stays_cached() {
     let session = normalize_source(&jsonl_input(
         "claude",
@@ -1994,9 +2030,26 @@ fn buckets_with_no_mode_signal_stay_none() {
 }
 
 #[test]
-fn aggregate_metrics_leaves_mode_signals_at_default() {
+fn single_session_summary_keeps_mode_signals() {
     let fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":10,"speed":"fast"},"content":[{"type":"thinking","thinking":"x"}]},"effort":"high"}"#;
     let summary = analyze_sources(vec![jsonl_input("claude", fixture)]);
+
+    // The session detail view reads the summary buckets, so a one-session
+    // summary must carry the session's own mode signals through.
+    let first = &summary.buckets[0];
+    assert_eq!(first.model.as_deref(), Some("claude-opus-4-6"));
+    assert_eq!(first.thinking_mode.as_deref(), Some("high"));
+    assert_eq!(first.speed.as_deref(), Some("fast"));
+    assert!(first.has_thinking);
+}
+
+#[test]
+fn aggregate_metrics_leaves_mode_signals_at_default() {
+    let fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":10,"speed":"fast"},"content":[{"type":"thinking","thinking":"x"}]},"effort":"high"}"#;
+    let summary = analyze_sources(vec![
+        jsonl_input("claude", fixture),
+        jsonl_input("claude", fixture),
+    ]);
 
     // A multi-session summary cannot carry one session's mode signals, since
     // each contributing session can run a different agent/model.

--- a/crates/antiburn-local/src/analysis/vendors/jsonl.rs
+++ b/crates/antiburn-local/src/analysis/vendors/jsonl.rs
@@ -272,6 +272,11 @@ pub fn parse_record(value: &Value) -> Option<NormalizedEvent> {
         .and_then(|m| m.get("content"))
         .or_else(|| obj.get("content"));
     process_content(content, &mut ev);
+    // Claude Code writes a tool result as a `user` record whose content is a
+    // `tool_result` block. That is the tool's turn, not a user prompt.
+    if ev.role == Role::User && has_tool_result_block(content) {
+        ev.role = Role::Tool;
+    }
 
     // OpenAI-style tool calls.
     if let Some(calls) = msg
@@ -322,6 +327,15 @@ fn resolve_role(
         },
     };
     Some(role)
+}
+
+fn has_tool_result_block(content: Option<&Value>) -> bool {
+    let Some(Value::Array(items)) = content else {
+        return false;
+    };
+    items
+        .iter()
+        .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"))
 }
 
 fn process_content(content: Option<&Value>, ev: &mut NormalizedEvent) {
@@ -724,6 +738,23 @@ mod tests {
         let ev = parse_record(&record).expect("record should parse");
         assert_eq!(ev.tools.len(), 1);
         assert_eq!(ev.tools[0].category, ToolCategory::Test);
+    }
+
+    #[test]
+    fn claude_tool_result_user_record_is_a_tool_event() {
+        let result = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+            }
+        });
+        let prompt = json!({
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "go"}]}
+        });
+        assert_eq!(parse_record(&result).unwrap().role, Role::Tool);
+        assert_eq!(parse_record(&prompt).unwrap().role, Role::User);
     }
 
     #[test]

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
@@ -69,6 +69,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -76,7 +77,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 1
         },
         {
           "cacheReadTokens": 0,
@@ -88,6 +90,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -95,7 +98,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -107,6 +111,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -114,7 +119,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -126,6 +132,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -133,7 +140,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -145,6 +153,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -152,7 +161,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -164,6 +174,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -171,7 +182,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -183,6 +195,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -190,7 +203,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -202,6 +216,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -209,7 +224,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -221,6 +237,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -228,7 +245,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -240,6 +258,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -247,7 +266,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -259,6 +279,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -266,7 +287,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -278,6 +300,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -285,7 +308,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -297,6 +321,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -304,7 +329,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -316,6 +342,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -323,7 +350,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -335,6 +363,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -342,7 +371,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -354,6 +384,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -361,7 +392,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -373,6 +405,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -380,7 +413,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -392,6 +426,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -399,7 +434,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -411,6 +447,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -418,7 +455,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -430,6 +468,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -437,7 +476,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -449,6 +489,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -456,7 +497,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -468,6 +510,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -475,7 +518,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -487,6 +531,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -494,7 +539,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -506,6 +552,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -513,7 +560,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -525,6 +573,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -532,7 +581,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -544,6 +594,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -551,7 +602,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -563,6 +615,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -570,7 +623,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -582,6 +636,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -589,7 +644,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -601,6 +657,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -608,7 +665,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -620,6 +678,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -627,7 +686,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -639,6 +699,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -646,7 +707,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -658,6 +720,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -665,7 +728,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -677,6 +741,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -684,7 +749,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -696,6 +762,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -703,7 +770,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -715,6 +783,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -722,7 +791,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -734,6 +804,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -741,7 +812,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -753,6 +825,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -760,7 +833,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -772,6 +846,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -779,7 +854,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -791,6 +867,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -798,7 +875,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -810,6 +888,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -817,7 +896,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -829,6 +909,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -836,7 +917,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -848,6 +930,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -855,7 +938,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -867,6 +951,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -874,7 +959,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -886,6 +972,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -893,7 +980,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -905,6 +993,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -912,7 +1001,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -924,6 +1014,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -931,7 +1022,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -943,6 +1035,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -950,7 +1043,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -962,6 +1056,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -969,7 +1064,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -981,6 +1077,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -988,7 +1085,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1000,6 +1098,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1007,7 +1106,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1019,6 +1119,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1026,7 +1127,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1038,6 +1140,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1045,7 +1148,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1057,6 +1161,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1064,7 +1169,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1076,6 +1182,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1083,7 +1190,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1095,6 +1203,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1102,7 +1211,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1114,6 +1224,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1121,7 +1232,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1133,6 +1245,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1140,7 +1253,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1152,6 +1266,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1159,7 +1274,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1171,6 +1287,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1178,7 +1295,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1190,6 +1308,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1197,7 +1316,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1209,6 +1329,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1216,7 +1337,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1228,6 +1350,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1235,7 +1358,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1247,6 +1371,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1254,7 +1379,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1266,6 +1392,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1273,7 +1400,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1285,6 +1413,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1292,7 +1421,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1304,6 +1434,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1311,7 +1442,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1323,6 +1455,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1330,7 +1463,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1342,6 +1476,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1349,7 +1484,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1361,6 +1497,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1368,7 +1505,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1380,6 +1518,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1387,7 +1526,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1399,6 +1539,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1406,7 +1547,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1418,6 +1560,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1425,7 +1568,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1437,6 +1581,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1444,7 +1589,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1456,6 +1602,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1463,7 +1610,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1475,6 +1623,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1482,7 +1631,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1494,6 +1644,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1501,7 +1652,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1513,6 +1665,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1520,7 +1673,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1532,6 +1686,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1539,7 +1694,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1551,6 +1707,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1558,7 +1715,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1570,6 +1728,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1577,7 +1736,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1589,6 +1749,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1596,7 +1757,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1608,6 +1770,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1615,7 +1778,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1627,6 +1791,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1634,7 +1799,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1646,6 +1812,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1653,7 +1820,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1665,6 +1833,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1672,7 +1841,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1684,6 +1854,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1691,7 +1862,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1703,6 +1875,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1710,7 +1883,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1722,6 +1896,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1729,7 +1904,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1741,6 +1917,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1748,7 +1925,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1760,6 +1938,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1767,7 +1946,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1779,6 +1959,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1786,7 +1967,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1798,6 +1980,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1805,7 +1988,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1817,6 +2001,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1824,7 +2009,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1836,6 +2022,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1843,7 +2030,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1855,6 +2043,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1862,7 +2051,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1874,6 +2064,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1881,7 +2072,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1893,6 +2085,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1900,7 +2093,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1912,6 +2106,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1919,7 +2114,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1931,6 +2127,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1938,7 +2135,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1950,6 +2148,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1957,7 +2156,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1969,6 +2169,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1976,7 +2177,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1988,6 +2190,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1995,7 +2198,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2007,6 +2211,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2014,7 +2219,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2026,6 +2232,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2033,7 +2240,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2045,6 +2253,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2052,7 +2261,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2064,6 +2274,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2071,7 +2282,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2083,6 +2295,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2090,7 +2303,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2102,6 +2316,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2109,7 +2324,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2121,6 +2337,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2128,7 +2345,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2140,6 +2358,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2147,7 +2366,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2159,6 +2379,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2166,7 +2387,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2178,6 +2400,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2185,7 +2408,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2197,6 +2421,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2204,7 +2429,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2216,6 +2442,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2223,7 +2450,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2235,6 +2463,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2242,7 +2471,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2254,6 +2484,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2261,7 +2492,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2273,6 +2505,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2280,7 +2513,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2292,6 +2526,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2299,7 +2534,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2311,6 +2547,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2318,7 +2555,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2330,6 +2568,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2337,7 +2576,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2349,6 +2589,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2356,7 +2597,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2368,6 +2610,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2375,7 +2618,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2387,6 +2631,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2394,7 +2639,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2406,6 +2652,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2413,7 +2660,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2425,6 +2673,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2432,7 +2681,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2444,6 +2694,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2451,7 +2702,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2463,6 +2715,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2470,7 +2723,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2482,6 +2736,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2489,7 +2744,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2501,6 +2757,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2508,7 +2765,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2520,6 +2778,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2527,7 +2786,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2539,6 +2799,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2546,7 +2807,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2558,6 +2820,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2565,7 +2828,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2577,6 +2841,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2584,7 +2849,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2596,6 +2862,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2603,7 +2870,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2615,6 +2883,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2622,7 +2891,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2634,6 +2904,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2641,7 +2912,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2653,6 +2925,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2660,7 +2933,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2672,6 +2946,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2679,7 +2954,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2691,6 +2967,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2698,7 +2975,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2710,6 +2988,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2717,7 +2996,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2729,6 +3009,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2736,7 +3017,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2748,6 +3030,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2755,7 +3038,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2767,6 +3051,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2774,7 +3059,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2786,6 +3072,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2793,7 +3080,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2805,6 +3093,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2812,7 +3101,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2824,6 +3114,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2831,7 +3122,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2843,6 +3135,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2850,7 +3143,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2862,6 +3156,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2869,7 +3164,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2881,6 +3177,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2888,7 +3185,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2900,6 +3198,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2907,7 +3206,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2919,6 +3219,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2926,7 +3227,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2938,6 +3240,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2945,7 +3248,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2957,6 +3261,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2964,7 +3269,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2976,6 +3282,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2983,7 +3290,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2995,6 +3303,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3002,7 +3311,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3014,6 +3324,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3021,7 +3332,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3033,6 +3345,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3040,7 +3353,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3052,6 +3366,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3059,7 +3374,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3071,6 +3387,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3078,7 +3395,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3090,6 +3408,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3097,7 +3416,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3109,6 +3429,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3116,7 +3437,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3128,6 +3450,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3135,7 +3458,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3147,6 +3471,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3154,7 +3479,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3166,6 +3492,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3173,7 +3500,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3185,6 +3513,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3192,7 +3521,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3204,6 +3534,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3211,7 +3542,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3223,6 +3555,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3230,7 +3563,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3242,6 +3576,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3249,7 +3584,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3261,6 +3597,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3268,7 +3605,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3280,6 +3618,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3287,7 +3626,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3299,6 +3639,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3306,7 +3647,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3318,6 +3660,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3325,7 +3668,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3337,6 +3681,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3344,7 +3689,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3356,6 +3702,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3363,7 +3710,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3375,6 +3723,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3382,7 +3731,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3394,6 +3744,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3401,7 +3752,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3413,6 +3765,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3420,7 +3773,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3432,6 +3786,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3439,7 +3794,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3451,6 +3807,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3458,7 +3815,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3470,6 +3828,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3477,7 +3836,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 15,
-          "tokensOut": 8
+          "tokensOut": 8,
+          "userPrompts": 0
         }
       ],
       "cacheRehydrationCount": 0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
@@ -69,6 +69,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -76,7 +77,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 1
         },
         {
           "cacheReadTokens": 0,
@@ -88,6 +90,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -95,7 +98,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -107,6 +111,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -114,7 +119,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -126,6 +132,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -133,7 +140,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -145,6 +153,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -152,7 +161,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -164,6 +174,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -171,7 +182,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -183,6 +195,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -190,7 +203,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -202,6 +216,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -209,7 +224,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -221,6 +237,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -228,7 +245,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -240,6 +258,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -247,7 +266,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -259,6 +279,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -266,7 +287,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -278,6 +300,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -285,7 +308,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -297,6 +321,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -304,7 +329,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -316,6 +342,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -323,7 +350,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -335,6 +363,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -342,7 +371,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -354,6 +384,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -361,7 +392,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -373,6 +405,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -380,7 +413,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -392,6 +426,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -399,7 +434,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -411,6 +447,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -418,7 +455,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -430,6 +468,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -437,7 +476,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -449,6 +489,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -456,7 +497,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -468,6 +510,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -475,7 +518,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -487,6 +531,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -494,7 +539,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -506,6 +552,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -513,7 +560,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -525,6 +573,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -532,7 +581,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -544,6 +594,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -551,7 +602,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -563,6 +615,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -570,7 +623,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -582,6 +636,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -589,7 +644,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -601,6 +657,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -608,7 +665,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -620,6 +678,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -627,7 +686,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -639,6 +699,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -646,7 +707,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -658,6 +720,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -665,7 +728,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -677,6 +741,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -684,7 +749,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -696,6 +762,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -703,7 +770,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -715,6 +783,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -722,7 +791,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -734,6 +804,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -741,7 +812,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -753,6 +825,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -760,7 +833,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -772,6 +846,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -779,7 +854,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -791,6 +867,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -798,7 +875,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -810,6 +888,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -817,7 +896,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -829,6 +909,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -836,7 +917,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -848,6 +930,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -855,7 +938,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -867,6 +951,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -874,7 +959,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -886,6 +972,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -893,7 +980,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -905,6 +993,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -912,7 +1001,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -924,6 +1014,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -931,7 +1022,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -943,6 +1035,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -950,7 +1043,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -962,6 +1056,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -969,7 +1064,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -981,6 +1077,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -988,7 +1085,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1000,6 +1098,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1007,7 +1106,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1019,6 +1119,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1026,7 +1127,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1038,6 +1140,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1045,7 +1148,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1057,6 +1161,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1064,7 +1169,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1076,6 +1182,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1083,7 +1190,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1095,6 +1203,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1102,7 +1211,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1114,6 +1224,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1121,7 +1232,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1133,6 +1245,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1140,7 +1253,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1152,6 +1266,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1159,7 +1274,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1171,6 +1287,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1178,7 +1295,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1190,6 +1308,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1197,7 +1316,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1209,6 +1329,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1216,7 +1337,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1228,6 +1350,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1235,7 +1358,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1247,6 +1371,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1254,7 +1379,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1266,6 +1392,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1273,7 +1400,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1285,6 +1413,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1292,7 +1421,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1304,6 +1434,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1311,7 +1442,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1323,6 +1455,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1330,7 +1463,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1342,6 +1476,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1349,7 +1484,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1361,6 +1497,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1368,7 +1505,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1380,6 +1518,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1387,7 +1526,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1399,6 +1539,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1406,7 +1547,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1418,6 +1560,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1425,7 +1568,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1437,6 +1581,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1444,7 +1589,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1456,6 +1602,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1463,7 +1610,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1475,6 +1623,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1482,7 +1631,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1494,6 +1644,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1501,7 +1652,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1513,6 +1665,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1520,7 +1673,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1532,6 +1686,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1539,7 +1694,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1551,6 +1707,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1558,7 +1715,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1570,6 +1728,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1577,7 +1736,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1589,6 +1749,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1596,7 +1757,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1608,6 +1770,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1615,7 +1778,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1627,6 +1791,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1634,7 +1799,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1646,6 +1812,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1653,7 +1820,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1665,6 +1833,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1672,7 +1841,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1684,6 +1854,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1691,7 +1862,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1703,6 +1875,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1710,7 +1883,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1722,6 +1896,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1729,7 +1904,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1741,6 +1917,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1748,7 +1925,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1760,6 +1938,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1767,7 +1946,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1779,6 +1959,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1786,7 +1967,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1798,6 +1980,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1805,7 +1988,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1817,6 +2001,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1824,7 +2009,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1836,6 +2022,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1843,7 +2030,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1855,6 +2043,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1862,7 +2051,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1874,6 +2064,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1881,7 +2072,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1893,6 +2085,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1900,7 +2093,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1912,6 +2106,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1919,7 +2114,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1931,6 +2127,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1938,7 +2135,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1950,6 +2148,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1957,7 +2156,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1969,6 +2169,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1976,7 +2177,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1988,6 +2190,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1995,7 +2198,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2007,6 +2211,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2014,7 +2219,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2026,6 +2232,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2033,7 +2240,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2045,6 +2253,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2052,7 +2261,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2064,6 +2274,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2071,7 +2282,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2083,6 +2295,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2090,7 +2303,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2102,6 +2316,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2109,7 +2324,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2121,6 +2337,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2128,7 +2345,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2140,6 +2358,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2147,7 +2366,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2159,6 +2379,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2166,7 +2387,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2178,6 +2400,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2185,7 +2408,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2197,6 +2421,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2204,7 +2429,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2216,6 +2442,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2223,7 +2450,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2235,6 +2463,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2242,7 +2471,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2254,6 +2484,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2261,7 +2492,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2273,6 +2505,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2280,7 +2513,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2292,6 +2526,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2299,7 +2534,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2311,6 +2547,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2318,7 +2555,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2330,6 +2568,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2337,7 +2576,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2349,6 +2589,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2356,7 +2597,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2368,6 +2610,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2375,7 +2618,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2387,6 +2631,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2394,7 +2639,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2406,6 +2652,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2413,7 +2660,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2425,6 +2673,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2432,7 +2681,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2444,6 +2694,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2451,7 +2702,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2463,6 +2715,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2470,7 +2723,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2482,6 +2736,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2489,7 +2744,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2501,6 +2757,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2508,7 +2765,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2520,6 +2778,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2527,7 +2786,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2539,6 +2799,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2546,7 +2807,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2558,6 +2820,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2565,7 +2828,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2577,6 +2841,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2584,7 +2849,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2596,6 +2862,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2603,7 +2870,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2615,6 +2883,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2622,7 +2891,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2634,6 +2904,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2641,7 +2912,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2653,6 +2925,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2660,7 +2933,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2672,6 +2946,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2679,7 +2954,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2691,6 +2967,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2698,7 +2975,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2710,6 +2988,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2717,7 +2996,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2729,6 +3009,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2736,7 +3017,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2748,6 +3030,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2755,7 +3038,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2767,6 +3051,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2774,7 +3059,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2786,6 +3072,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2793,7 +3080,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2805,6 +3093,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2812,7 +3101,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2824,6 +3114,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2831,7 +3122,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2843,6 +3135,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2850,7 +3143,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2862,6 +3156,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2869,7 +3164,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2881,6 +3177,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2888,7 +3185,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2900,6 +3198,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2907,7 +3206,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2919,6 +3219,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2926,7 +3227,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2938,6 +3240,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2945,7 +3248,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2957,6 +3261,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2964,7 +3269,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2976,6 +3282,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2983,7 +3290,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2995,6 +3303,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3002,7 +3311,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3014,6 +3324,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3021,7 +3332,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3033,6 +3345,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3040,7 +3353,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3052,6 +3366,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3059,7 +3374,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3071,6 +3387,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3078,7 +3395,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3090,6 +3408,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3097,7 +3416,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3109,6 +3429,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3116,7 +3437,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3128,6 +3450,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3135,7 +3458,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3147,6 +3471,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3154,7 +3479,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3166,6 +3492,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3173,7 +3500,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3185,6 +3513,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3192,7 +3521,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3204,6 +3534,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3211,7 +3542,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3223,6 +3555,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3230,7 +3563,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3242,6 +3576,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3249,7 +3584,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3261,6 +3597,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3268,7 +3605,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3280,6 +3618,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3287,7 +3626,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3299,6 +3639,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3306,7 +3647,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3318,6 +3660,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3325,7 +3668,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3337,6 +3681,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3344,7 +3689,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3356,6 +3702,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3363,7 +3710,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3375,6 +3723,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3382,7 +3731,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3394,6 +3744,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3401,7 +3752,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3413,6 +3765,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3420,7 +3773,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3432,6 +3786,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3439,7 +3794,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3451,6 +3807,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3458,7 +3815,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3470,6 +3828,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3477,7 +3836,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 25,
-          "tokensOut": 12
+          "tokensOut": 12,
+          "userPrompts": 0
         }
       ],
       "cacheRehydrationCount": 0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
@@ -95,6 +95,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -102,7 +103,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 1
         },
         {
           "cacheReadTokens": 0,
@@ -114,6 +116,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -121,7 +124,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -133,6 +137,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -140,7 +145,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -152,6 +158,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -159,7 +166,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -171,6 +179,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -178,7 +187,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -190,6 +200,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -197,7 +208,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -209,6 +221,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -216,7 +229,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -228,6 +242,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -235,7 +250,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -247,6 +263,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -254,7 +271,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -266,6 +284,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -273,7 +292,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -285,6 +305,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -292,7 +313,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -304,6 +326,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -311,7 +334,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -323,6 +347,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -330,7 +355,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -342,6 +368,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -349,7 +376,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -361,6 +389,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -368,7 +397,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -380,6 +410,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -387,7 +418,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -399,6 +431,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -406,7 +439,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -418,6 +452,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -425,7 +460,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -437,6 +473,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -444,7 +481,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -456,6 +494,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -463,7 +502,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -475,6 +515,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -482,7 +523,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -494,6 +536,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -501,7 +544,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -513,6 +557,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -520,7 +565,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -532,6 +578,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -539,7 +586,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -551,6 +599,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -558,7 +607,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -570,6 +620,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -577,7 +628,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -589,6 +641,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -596,7 +649,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -608,6 +662,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -615,7 +670,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -627,6 +683,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -634,7 +691,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -646,6 +704,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -653,7 +712,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -665,6 +725,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -672,7 +733,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -684,6 +746,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -691,7 +754,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -703,6 +767,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -710,7 +775,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -722,6 +788,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -729,7 +796,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -741,6 +809,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -748,7 +817,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -760,6 +830,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -767,7 +838,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -779,6 +851,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -786,7 +859,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -798,6 +872,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -805,7 +880,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -817,6 +893,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -824,7 +901,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -836,6 +914,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -843,7 +922,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -855,6 +935,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -862,7 +943,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -874,6 +956,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -881,7 +964,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -893,6 +977,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -900,7 +985,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -912,6 +998,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -919,7 +1006,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -931,6 +1019,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -938,7 +1027,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -950,6 +1040,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -957,7 +1048,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -969,6 +1061,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -976,7 +1069,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -988,6 +1082,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -995,7 +1090,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1007,6 +1103,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1014,7 +1111,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1026,6 +1124,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1033,7 +1132,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1045,6 +1145,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1052,7 +1153,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1064,6 +1166,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1071,7 +1174,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1083,6 +1187,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1090,7 +1195,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1102,6 +1208,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1109,7 +1216,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1121,6 +1229,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1128,7 +1237,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1140,6 +1250,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1147,7 +1258,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1159,6 +1271,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1166,7 +1279,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1178,6 +1292,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1185,7 +1300,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1197,6 +1313,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1204,7 +1321,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1216,6 +1334,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1223,7 +1342,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1235,6 +1355,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": "Task",
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1242,7 +1363,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 50,
-          "tokensOut": 25
+          "tokensOut": 25,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1254,6 +1376,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1261,7 +1384,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1273,6 +1397,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1280,7 +1405,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1292,6 +1418,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1299,7 +1426,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1311,6 +1439,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1318,7 +1447,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1330,6 +1460,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1337,7 +1468,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1349,6 +1481,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1356,7 +1489,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1368,6 +1502,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1375,7 +1510,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1387,6 +1523,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1394,7 +1531,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1406,6 +1544,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1413,7 +1552,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1425,6 +1565,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1432,7 +1573,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1444,6 +1586,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1451,7 +1594,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1463,6 +1607,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1470,7 +1615,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1482,6 +1628,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1489,7 +1636,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1501,6 +1649,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1508,7 +1657,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1520,6 +1670,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1527,7 +1678,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1539,6 +1691,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1546,7 +1699,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1558,6 +1712,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1565,7 +1720,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1577,6 +1733,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1584,7 +1741,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1596,6 +1754,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1603,7 +1762,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1615,6 +1775,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1622,7 +1783,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1634,6 +1796,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1641,7 +1804,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1653,6 +1817,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1660,7 +1825,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1672,6 +1838,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1679,7 +1846,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1691,6 +1859,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1698,7 +1867,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1710,6 +1880,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1717,7 +1888,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1729,6 +1901,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1736,7 +1909,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1748,6 +1922,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1755,7 +1930,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1767,6 +1943,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1774,7 +1951,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1786,6 +1964,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1793,7 +1972,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1805,6 +1985,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1812,7 +1993,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1824,6 +2006,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1831,7 +2014,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1843,6 +2027,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1850,7 +2035,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1862,6 +2048,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1869,7 +2056,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1881,6 +2069,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1888,7 +2077,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1900,6 +2090,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1907,7 +2098,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1919,6 +2111,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1926,7 +2119,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1938,6 +2132,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1945,7 +2140,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1957,6 +2153,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1964,7 +2161,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1976,6 +2174,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1983,7 +2182,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1995,6 +2195,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2002,7 +2203,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2014,6 +2216,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2021,7 +2224,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2033,6 +2237,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2040,7 +2245,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2052,6 +2258,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2059,7 +2266,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2071,6 +2279,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2078,7 +2287,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2090,6 +2300,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2097,7 +2308,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2109,6 +2321,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2116,7 +2329,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2128,6 +2342,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2135,7 +2350,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2147,6 +2363,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2154,7 +2371,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2166,6 +2384,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2173,7 +2392,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2185,6 +2405,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2192,7 +2413,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2204,6 +2426,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2211,7 +2434,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2223,6 +2447,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2230,7 +2455,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2242,6 +2468,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2249,7 +2476,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2261,6 +2489,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2268,7 +2497,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2280,6 +2510,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2287,7 +2518,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2299,6 +2531,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2306,7 +2539,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2318,6 +2552,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2325,7 +2560,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2337,6 +2573,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2344,7 +2581,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2356,6 +2594,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2363,7 +2602,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2375,6 +2615,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2382,7 +2623,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2394,6 +2636,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2401,7 +2644,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2413,6 +2657,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2420,7 +2665,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2432,6 +2678,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2439,7 +2686,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2451,6 +2699,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2458,7 +2707,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2470,6 +2720,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2477,7 +2728,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2489,6 +2741,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2496,7 +2749,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2508,6 +2762,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2515,7 +2770,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2527,6 +2783,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2534,7 +2791,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2546,6 +2804,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2553,7 +2812,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2565,6 +2825,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2572,7 +2833,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2584,6 +2846,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2591,7 +2854,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2603,6 +2867,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2610,7 +2875,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2622,6 +2888,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2629,7 +2896,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2641,6 +2909,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2648,7 +2917,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2660,6 +2930,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2667,7 +2938,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2679,6 +2951,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2686,7 +2959,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2698,6 +2972,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2705,7 +2980,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2717,6 +2993,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2724,7 +3001,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2736,6 +3014,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2743,7 +3022,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2755,6 +3035,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2762,7 +3043,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2774,6 +3056,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2781,7 +3064,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2793,6 +3077,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2800,7 +3085,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2812,6 +3098,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2819,7 +3106,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2831,6 +3119,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2838,7 +3127,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2850,6 +3140,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2857,7 +3148,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2869,6 +3161,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2876,7 +3169,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2888,6 +3182,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2895,7 +3190,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2907,6 +3203,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2914,7 +3211,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2926,6 +3224,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2933,7 +3232,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2945,6 +3245,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2952,7 +3253,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2964,6 +3266,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2971,7 +3274,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2983,6 +3287,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2990,7 +3295,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3002,6 +3308,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3009,7 +3316,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3021,6 +3329,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3028,7 +3337,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3040,6 +3350,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3047,7 +3358,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3059,6 +3371,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3066,7 +3379,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3078,6 +3392,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3085,7 +3400,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3097,6 +3413,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3104,7 +3421,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3116,6 +3434,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3123,7 +3442,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3135,6 +3455,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3142,7 +3463,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3154,6 +3476,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3161,7 +3484,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3173,6 +3497,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3180,7 +3505,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3192,6 +3518,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3199,7 +3526,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3211,6 +3539,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3218,7 +3547,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3230,6 +3560,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3237,7 +3568,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3249,6 +3581,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3256,7 +3589,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3268,6 +3602,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3275,7 +3610,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3287,6 +3623,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3294,7 +3631,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3306,6 +3644,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3313,7 +3652,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3325,6 +3665,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3332,7 +3673,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3344,6 +3686,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3351,7 +3694,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3363,6 +3707,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3370,7 +3715,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3382,6 +3728,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3389,7 +3736,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3401,6 +3749,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3408,7 +3757,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3420,6 +3770,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3427,7 +3778,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3439,6 +3791,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3446,7 +3799,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3458,6 +3812,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3465,7 +3820,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3477,6 +3833,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3484,7 +3841,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3496,6 +3854,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": 10,
           "speed": null,
@@ -3503,7 +3862,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 30,
-          "tokensOut": 15
+          "tokensOut": 15,
+          "userPrompts": 0
         }
       ],
       "cacheRehydrationCount": 0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
@@ -86,7 +86,7 @@
         "isCompactionBoundary": false,
         "messageId": null,
         "model": null,
-        "role": "user",
+        "role": "tool",
         "source": "parent",
         "speed": null,
         "thinkingMode": null,
@@ -164,6 +164,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -171,7 +172,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 1
         },
         {
           "cacheReadTokens": 0,
@@ -183,6 +185,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -190,7 +193,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -202,6 +206,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -209,7 +214,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -221,6 +227,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -228,7 +235,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -240,6 +248,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -247,7 +256,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -259,6 +269,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -266,7 +277,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -278,6 +290,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -285,7 +298,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -297,6 +311,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -304,7 +319,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -316,6 +332,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -323,7 +340,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -335,6 +353,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -342,7 +361,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -354,6 +374,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -361,7 +382,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -373,6 +395,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -380,7 +403,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -392,6 +416,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -399,7 +424,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -411,6 +437,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -418,7 +445,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -430,6 +458,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -437,7 +466,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -449,6 +479,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -456,7 +487,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -468,6 +500,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -475,7 +508,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -487,6 +521,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -494,7 +529,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -506,6 +542,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -513,7 +550,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -525,6 +563,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -532,7 +571,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -544,6 +584,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -551,7 +592,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -563,6 +605,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -570,7 +613,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -582,6 +626,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -589,7 +634,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -601,6 +647,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -608,7 +655,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -620,6 +668,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -627,7 +676,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -639,6 +689,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -646,7 +697,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -658,6 +710,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -665,7 +718,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -677,6 +731,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -684,7 +739,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -696,6 +752,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -703,7 +760,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -715,6 +773,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -722,7 +781,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -734,6 +794,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -741,7 +802,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -753,6 +815,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -760,7 +823,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -772,6 +836,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -779,7 +844,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -791,6 +857,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -798,7 +865,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -810,6 +878,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -817,7 +886,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -829,6 +899,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -836,7 +907,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -848,6 +920,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -855,7 +928,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -867,6 +941,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -874,7 +949,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -886,6 +962,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -893,7 +970,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -905,6 +983,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -912,7 +991,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -924,6 +1004,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -931,7 +1012,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -943,6 +1025,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -950,7 +1033,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -962,6 +1046,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -969,7 +1054,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -981,6 +1067,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -988,7 +1075,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1000,6 +1088,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1007,7 +1096,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 3000,
@@ -1019,6 +1109,7 @@
           "hasThinking": true,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": "Read",
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1026,7 +1117,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 2000,
-          "tokensOut": 120
+          "tokensOut": 120,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1038,6 +1130,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1045,7 +1138,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1057,6 +1151,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1064,7 +1159,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1076,6 +1172,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1083,7 +1180,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1095,6 +1193,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1102,7 +1201,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1114,6 +1214,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1121,7 +1222,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1133,6 +1235,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1140,7 +1243,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1152,6 +1256,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1159,7 +1264,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1171,6 +1277,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1178,7 +1285,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1190,6 +1298,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1197,7 +1306,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1209,6 +1319,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1216,7 +1327,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1228,6 +1340,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1235,7 +1348,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1247,6 +1361,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1254,7 +1369,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1266,6 +1382,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1273,7 +1390,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1285,6 +1403,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1292,7 +1411,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1304,6 +1424,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1311,7 +1432,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1323,6 +1445,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1330,7 +1453,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1342,6 +1466,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1349,7 +1474,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1361,6 +1487,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1368,7 +1495,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1380,6 +1508,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1387,7 +1516,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1399,6 +1529,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1406,7 +1537,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1418,6 +1550,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1425,7 +1558,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1437,6 +1571,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1444,7 +1579,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1456,6 +1592,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1463,7 +1600,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1475,6 +1613,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1482,7 +1621,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1494,6 +1634,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1501,7 +1642,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1513,6 +1655,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1520,7 +1663,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1532,6 +1676,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1539,7 +1684,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1551,6 +1697,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1558,7 +1705,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1570,6 +1718,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1577,7 +1726,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1589,6 +1739,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1596,7 +1747,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1608,6 +1760,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1615,7 +1768,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1627,6 +1781,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1634,7 +1789,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1646,6 +1802,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1653,7 +1810,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1665,6 +1823,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1672,7 +1831,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1684,6 +1844,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1691,7 +1852,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1703,6 +1865,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1710,7 +1873,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1722,6 +1886,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1729,7 +1894,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1741,6 +1907,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1748,7 +1915,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1760,6 +1928,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1767,7 +1936,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1779,6 +1949,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1786,7 +1957,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1798,6 +1970,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1805,7 +1978,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1817,6 +1991,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1824,7 +1999,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1836,6 +2012,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1843,7 +2020,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1855,6 +2033,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1862,7 +2041,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 4200,
@@ -1874,6 +2054,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": "Skill",
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": 5,
           "speed": null,
@@ -1881,7 +2062,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 100,
-          "tokensOut": 40
+          "tokensOut": 40,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1893,6 +2075,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1900,7 +2083,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1912,6 +2096,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1919,7 +2104,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1931,6 +2117,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1938,7 +2125,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1950,6 +2138,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1957,7 +2146,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1969,6 +2159,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1976,7 +2167,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1988,6 +2180,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1995,7 +2188,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2007,6 +2201,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2014,7 +2209,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2026,6 +2222,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2033,7 +2230,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2045,6 +2243,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2052,7 +2251,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2064,6 +2264,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2071,7 +2272,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2083,6 +2285,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2090,7 +2293,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2102,6 +2306,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2109,7 +2314,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2121,6 +2327,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2128,7 +2335,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2140,6 +2348,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2147,7 +2356,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2159,6 +2369,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2166,7 +2377,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2178,6 +2390,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2185,7 +2398,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2197,6 +2411,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2204,7 +2419,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2216,6 +2432,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2223,7 +2440,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2235,6 +2453,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2242,7 +2461,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2254,6 +2474,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2261,7 +2482,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2273,6 +2495,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2280,7 +2503,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2292,6 +2516,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2299,7 +2524,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2311,6 +2537,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2318,7 +2545,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2330,6 +2558,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2337,7 +2566,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2349,6 +2579,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2356,7 +2587,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2368,6 +2600,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2375,7 +2608,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2387,6 +2621,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2394,7 +2629,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2406,6 +2642,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2413,7 +2650,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2425,6 +2663,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2432,7 +2671,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2444,6 +2684,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2451,7 +2692,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2463,6 +2705,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2470,7 +2713,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2482,6 +2726,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2489,7 +2734,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2501,6 +2747,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2508,7 +2755,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2520,6 +2768,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2527,7 +2776,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2539,6 +2789,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2546,7 +2797,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2558,6 +2810,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2565,7 +2818,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2577,6 +2831,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2584,7 +2839,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2596,6 +2852,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2603,7 +2860,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2615,6 +2873,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2622,7 +2881,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2634,6 +2894,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2641,7 +2902,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2653,6 +2915,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2660,7 +2923,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2672,6 +2936,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2679,7 +2944,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2691,6 +2957,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2698,7 +2965,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2710,6 +2978,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2717,7 +2986,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2729,6 +2999,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": true,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2736,7 +3007,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2748,6 +3020,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2755,7 +3028,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2767,6 +3041,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2774,7 +3049,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2786,6 +3062,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2793,7 +3070,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2805,6 +3083,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2812,7 +3091,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2824,6 +3104,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2831,7 +3112,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2843,6 +3125,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2850,7 +3133,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2862,6 +3146,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2869,7 +3154,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2881,6 +3167,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2888,7 +3175,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2900,6 +3188,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2907,7 +3196,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2919,6 +3209,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2926,7 +3217,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2938,6 +3230,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2945,7 +3238,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2957,6 +3251,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2964,7 +3259,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2976,6 +3272,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2983,7 +3280,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2995,6 +3293,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3002,7 +3301,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3014,6 +3314,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3021,7 +3322,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3033,6 +3335,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3040,7 +3343,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3052,6 +3356,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3059,7 +3364,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3071,6 +3377,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3078,7 +3385,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3090,6 +3398,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3097,7 +3406,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3109,6 +3419,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3116,7 +3427,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3128,6 +3440,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3135,7 +3448,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3147,6 +3461,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3154,7 +3469,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3166,6 +3482,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3173,7 +3490,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3185,6 +3503,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3192,7 +3511,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3204,6 +3524,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3211,7 +3532,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3223,6 +3545,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3230,7 +3553,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3242,6 +3566,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3249,7 +3574,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3261,6 +3587,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3268,7 +3595,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3280,6 +3608,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3287,7 +3616,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3299,6 +3629,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3306,7 +3637,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3318,6 +3650,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3325,7 +3658,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3337,6 +3671,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3344,7 +3679,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3356,6 +3692,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3363,7 +3700,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3375,6 +3713,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3382,7 +3721,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3394,6 +3734,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3401,7 +3742,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3413,6 +3755,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3420,7 +3763,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3432,6 +3776,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3439,7 +3784,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3451,6 +3797,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3458,7 +3805,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3470,6 +3818,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3477,7 +3826,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3489,6 +3839,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3496,7 +3847,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3508,6 +3860,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3515,7 +3868,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3527,6 +3881,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3534,7 +3889,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3546,6 +3902,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3553,7 +3910,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 800,
@@ -3565,6 +3923,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": 10,
           "speed": null,
@@ -3572,7 +3931,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 70,
-          "tokensOut": 30
+          "tokensOut": 30,
+          "userPrompts": 0
         }
       ],
       "cacheRehydrationCount": 0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
@@ -95,6 +95,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -102,7 +103,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 1
         },
         {
           "cacheReadTokens": 0,
@@ -114,6 +116,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -121,7 +124,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -133,6 +137,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -140,7 +145,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -152,6 +158,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -159,7 +166,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -171,6 +179,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -178,7 +187,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -190,6 +200,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -197,7 +208,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -209,6 +221,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -216,7 +229,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -228,6 +242,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -235,7 +250,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -247,6 +263,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -254,7 +271,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -266,6 +284,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -273,7 +292,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -285,6 +305,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -292,7 +313,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -304,6 +326,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -311,7 +334,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -323,6 +347,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -330,7 +355,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -342,6 +368,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -349,7 +376,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -361,6 +389,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -368,7 +397,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -380,6 +410,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -387,7 +418,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -399,6 +431,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -406,7 +439,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -418,6 +452,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -425,7 +460,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -437,6 +473,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -444,7 +481,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -456,6 +494,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -463,7 +502,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -475,6 +515,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -482,7 +523,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -494,6 +536,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -501,7 +544,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -513,6 +557,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -520,7 +565,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -532,6 +578,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -539,7 +586,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -551,6 +599,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -558,7 +607,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -570,6 +620,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -577,7 +628,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -589,6 +641,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -596,7 +649,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -608,6 +662,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -615,7 +670,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -627,6 +683,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -634,7 +691,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -646,6 +704,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -653,7 +712,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -665,6 +725,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -672,7 +733,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -684,6 +746,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -691,7 +754,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -703,6 +767,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -710,7 +775,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -722,6 +788,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -729,7 +796,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -741,6 +809,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -748,7 +817,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -760,6 +830,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -767,7 +838,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -779,6 +851,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -786,7 +859,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -798,6 +872,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -805,7 +880,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -817,6 +893,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -824,7 +901,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -836,6 +914,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -843,7 +922,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -855,6 +935,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -862,7 +943,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -874,6 +956,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -881,7 +964,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -893,6 +977,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -900,7 +985,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -912,6 +998,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -919,7 +1006,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -931,6 +1019,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -938,7 +1027,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -950,6 +1040,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -957,7 +1048,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -969,6 +1061,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -976,7 +1069,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -988,6 +1082,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -995,7 +1090,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1007,6 +1103,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1014,7 +1111,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1026,6 +1124,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1033,7 +1132,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1045,6 +1145,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1052,7 +1153,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1064,6 +1166,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1071,7 +1174,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1083,6 +1187,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1090,7 +1195,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1102,6 +1208,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1109,7 +1216,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1121,6 +1229,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1128,7 +1237,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1140,6 +1250,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1147,7 +1258,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1159,6 +1271,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1166,7 +1279,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1178,6 +1292,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1185,7 +1300,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1197,6 +1313,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1204,7 +1321,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1216,6 +1334,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1223,7 +1342,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1235,6 +1355,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1242,7 +1363,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1254,6 +1376,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1261,7 +1384,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1273,6 +1397,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1280,7 +1405,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1292,6 +1418,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1299,7 +1426,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1311,6 +1439,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1318,7 +1447,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1330,6 +1460,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1337,7 +1468,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1349,6 +1481,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1356,7 +1489,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1368,6 +1502,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1375,7 +1510,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1387,6 +1523,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1394,7 +1531,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1406,6 +1544,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1413,7 +1552,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1425,6 +1565,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1432,7 +1573,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1444,6 +1586,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1451,7 +1594,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1463,6 +1607,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1470,7 +1615,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1482,6 +1628,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1489,7 +1636,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1501,6 +1649,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1508,7 +1657,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1520,6 +1670,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1527,7 +1678,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1539,6 +1691,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1546,7 +1699,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1558,6 +1712,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1565,7 +1720,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1577,6 +1733,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1584,7 +1741,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1596,6 +1754,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1603,7 +1762,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1615,6 +1775,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1622,7 +1783,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1634,6 +1796,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1641,7 +1804,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1653,6 +1817,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1660,7 +1825,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1672,6 +1838,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1679,7 +1846,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1691,6 +1859,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1698,7 +1867,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1710,6 +1880,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1717,7 +1888,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1729,6 +1901,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1736,7 +1909,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1748,6 +1922,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1755,7 +1930,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1767,6 +1943,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1774,7 +1951,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1786,6 +1964,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1793,7 +1972,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1805,6 +1985,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": "Read",
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1812,7 +1993,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 35,
-          "tokensOut": 17
+          "tokensOut": 17,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1824,6 +2006,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1831,7 +2014,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1843,6 +2027,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1850,7 +2035,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1862,6 +2048,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1869,7 +2056,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1881,6 +2069,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1888,7 +2077,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1900,6 +2090,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1907,7 +2098,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1919,6 +2111,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1926,7 +2119,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1938,6 +2132,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1945,7 +2140,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1957,6 +2153,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1964,7 +2161,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1976,6 +2174,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1983,7 +2182,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1995,6 +2195,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2002,7 +2203,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2014,6 +2216,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2021,7 +2224,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2033,6 +2237,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2040,7 +2245,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2052,6 +2258,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2059,7 +2266,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2071,6 +2279,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2078,7 +2287,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2090,6 +2300,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2097,7 +2308,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2109,6 +2321,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2116,7 +2329,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2128,6 +2342,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2135,7 +2350,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2147,6 +2363,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2154,7 +2371,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2166,6 +2384,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2173,7 +2392,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2185,6 +2405,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2192,7 +2413,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2204,6 +2426,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2211,7 +2434,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2223,6 +2447,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2230,7 +2455,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2242,6 +2468,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2249,7 +2476,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2261,6 +2489,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2268,7 +2497,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2280,6 +2510,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2287,7 +2518,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2299,6 +2531,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2306,7 +2539,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2318,6 +2552,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2325,7 +2560,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2337,6 +2573,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2344,7 +2581,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2356,6 +2594,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2363,7 +2602,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2375,6 +2615,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2382,7 +2623,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2394,6 +2636,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2401,7 +2644,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2413,6 +2657,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2420,7 +2665,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2432,6 +2678,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2439,7 +2686,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2451,6 +2699,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2458,7 +2707,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2470,6 +2720,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2477,7 +2728,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2489,6 +2741,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2496,7 +2749,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2508,6 +2762,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2515,7 +2770,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2527,6 +2783,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2534,7 +2791,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2546,6 +2804,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2553,7 +2812,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2565,6 +2825,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2572,7 +2833,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2584,6 +2846,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2591,7 +2854,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2603,6 +2867,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2610,7 +2875,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2622,6 +2888,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2629,7 +2896,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2641,6 +2909,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2648,7 +2917,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2660,6 +2930,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2667,7 +2938,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2679,6 +2951,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2686,7 +2959,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2698,6 +2972,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2705,7 +2980,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2717,6 +2993,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2724,7 +3001,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2736,6 +3014,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2743,7 +3022,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2755,6 +3035,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2762,7 +3043,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2774,6 +3056,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2781,7 +3064,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2793,6 +3077,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2800,7 +3085,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2812,6 +3098,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2819,7 +3106,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2831,6 +3119,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2838,7 +3127,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2850,6 +3140,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2857,7 +3148,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2869,6 +3161,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2876,7 +3169,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2888,6 +3182,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2895,7 +3190,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2907,6 +3203,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2914,7 +3211,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2926,6 +3224,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2933,7 +3232,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2945,6 +3245,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2952,7 +3253,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2964,6 +3266,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2971,7 +3274,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2983,6 +3287,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2990,7 +3295,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3002,6 +3308,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3009,7 +3316,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3021,6 +3329,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3028,7 +3337,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3040,6 +3350,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3047,7 +3358,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3059,6 +3371,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3066,7 +3379,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3078,6 +3392,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3085,7 +3400,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3097,6 +3413,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3104,7 +3421,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3116,6 +3434,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3123,7 +3442,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3135,6 +3455,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3142,7 +3463,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3154,6 +3476,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3161,7 +3484,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3173,6 +3497,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3180,7 +3505,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3192,6 +3518,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3199,7 +3526,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3211,6 +3539,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3218,7 +3547,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3230,6 +3560,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3237,7 +3568,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3249,6 +3581,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3256,7 +3589,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3268,6 +3602,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3275,7 +3610,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3287,6 +3623,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3294,7 +3631,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3306,6 +3644,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3313,7 +3652,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3325,6 +3665,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3332,7 +3673,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3344,6 +3686,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3351,7 +3694,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3363,6 +3707,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3370,7 +3715,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3382,6 +3728,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3389,7 +3736,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3401,6 +3749,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3408,7 +3757,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3420,6 +3770,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3427,7 +3778,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3439,6 +3791,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3446,7 +3799,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3458,6 +3812,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3465,7 +3820,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3477,6 +3833,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3484,7 +3841,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3496,6 +3854,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": 3,
           "speed": null,
@@ -3503,7 +3862,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 20,
-          "tokensOut": 10
+          "tokensOut": 10,
+          "userPrompts": 0
         }
       ],
       "cacheRehydrationCount": 0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
@@ -116,6 +116,7 @@
           "hasThinking": true,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": "Grep",
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": 0,
           "speed": null,
@@ -123,7 +124,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 50,
-          "tokensOut": 25
+          "tokensOut": 25,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -135,6 +137,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -142,7 +145,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -154,6 +158,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -161,7 +166,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -173,6 +179,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -180,7 +187,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -192,6 +200,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -199,7 +208,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -211,6 +221,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -218,7 +229,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -230,6 +242,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -237,7 +250,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -249,6 +263,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -256,7 +271,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -268,6 +284,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -275,7 +292,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -287,6 +305,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -294,7 +313,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -306,6 +326,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -313,7 +334,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -325,6 +347,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -332,7 +355,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -344,6 +368,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -351,7 +376,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -363,6 +389,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -370,7 +397,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -382,6 +410,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -389,7 +418,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -401,6 +431,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -408,7 +439,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -420,6 +452,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -427,7 +460,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -439,6 +473,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -446,7 +481,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -458,6 +494,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -465,7 +502,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -477,6 +515,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -484,7 +523,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -496,6 +536,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -503,7 +544,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -515,6 +557,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -522,7 +565,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -534,6 +578,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -541,7 +586,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -553,6 +599,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -560,7 +607,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -572,6 +620,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -579,7 +628,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -591,6 +641,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -598,7 +649,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -610,6 +662,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -617,7 +670,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -629,6 +683,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -636,7 +691,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -648,6 +704,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -655,7 +712,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -667,6 +725,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -674,7 +733,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -686,6 +746,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -693,7 +754,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -705,6 +767,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -712,7 +775,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -724,6 +788,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -731,7 +796,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -743,6 +809,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -750,7 +817,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -762,6 +830,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -769,7 +838,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -781,6 +851,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -788,7 +859,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -800,6 +872,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -807,7 +880,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -819,6 +893,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -826,7 +901,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -838,6 +914,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -845,7 +922,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -857,6 +935,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -864,7 +943,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -876,6 +956,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -883,7 +964,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -895,6 +977,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -902,7 +985,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -914,6 +998,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -921,7 +1006,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -933,6 +1019,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -940,7 +1027,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -952,6 +1040,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -959,7 +1048,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -971,6 +1061,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -978,7 +1069,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -990,6 +1082,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -997,7 +1090,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1009,6 +1103,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1016,7 +1111,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1028,6 +1124,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1035,7 +1132,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1047,6 +1145,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1054,7 +1153,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1066,6 +1166,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1073,7 +1174,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1085,6 +1187,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1092,7 +1195,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1104,6 +1208,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1111,7 +1216,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1123,6 +1229,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1130,7 +1237,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1142,6 +1250,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1149,7 +1258,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1161,6 +1271,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1168,7 +1279,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1180,6 +1292,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1187,7 +1300,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1199,6 +1313,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1206,7 +1321,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1218,6 +1334,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1225,7 +1342,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1237,6 +1355,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1244,7 +1363,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1256,6 +1376,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1263,7 +1384,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 1
         },
         {
           "cacheReadTokens": 0,
@@ -1275,6 +1397,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1282,7 +1405,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1294,6 +1418,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1301,7 +1426,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1313,6 +1439,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1320,7 +1447,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1332,6 +1460,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1339,7 +1468,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1351,6 +1481,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1358,7 +1489,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1370,6 +1502,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1377,7 +1510,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1389,6 +1523,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1396,7 +1531,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1408,6 +1544,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1415,7 +1552,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1427,6 +1565,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1434,7 +1573,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1446,6 +1586,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1453,7 +1594,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1465,6 +1607,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1472,7 +1615,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1484,6 +1628,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1491,7 +1636,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1503,6 +1649,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1510,7 +1657,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1522,6 +1670,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1529,7 +1678,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1541,6 +1691,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1548,7 +1699,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1560,6 +1712,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1567,7 +1720,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1579,6 +1733,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1586,7 +1741,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1598,6 +1754,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1605,7 +1762,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1617,6 +1775,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1624,7 +1783,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1636,6 +1796,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1643,7 +1804,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1655,6 +1817,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1662,7 +1825,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1674,6 +1838,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1681,7 +1846,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1693,6 +1859,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1700,7 +1867,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1712,6 +1880,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1719,7 +1888,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1731,6 +1901,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1738,7 +1909,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1750,6 +1922,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1757,7 +1930,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1769,6 +1943,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1776,7 +1951,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1788,6 +1964,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1795,7 +1972,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1807,6 +1985,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1814,7 +1993,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1826,6 +2006,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1833,7 +2014,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1845,6 +2027,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1852,7 +2035,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1864,6 +2048,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1871,7 +2056,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1883,6 +2069,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1890,7 +2077,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1902,6 +2090,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1909,7 +2098,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1921,6 +2111,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1928,7 +2119,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1940,6 +2132,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1947,7 +2140,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1959,6 +2153,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1966,7 +2161,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1978,6 +2174,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1985,7 +2182,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1997,6 +2195,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2004,7 +2203,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2016,6 +2216,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2023,7 +2224,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2035,6 +2237,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2042,7 +2245,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2054,6 +2258,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2061,7 +2266,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2073,6 +2279,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2080,7 +2287,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2092,6 +2300,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2099,7 +2308,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2111,6 +2321,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2118,7 +2329,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2130,6 +2342,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2137,7 +2350,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2149,6 +2363,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2156,7 +2371,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2168,6 +2384,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2175,7 +2392,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2187,6 +2405,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2194,7 +2413,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2206,6 +2426,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2213,7 +2434,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2225,6 +2447,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2232,7 +2455,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2244,6 +2468,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2251,7 +2476,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2263,6 +2489,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2270,7 +2497,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2282,6 +2510,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2289,7 +2518,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2301,6 +2531,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2308,7 +2539,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2320,6 +2552,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2327,7 +2560,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2339,6 +2573,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2346,7 +2581,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2358,6 +2594,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2365,7 +2602,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2377,6 +2615,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2384,7 +2623,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2396,6 +2636,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2403,7 +2644,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2415,6 +2657,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2422,7 +2665,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2434,6 +2678,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2441,7 +2686,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2453,6 +2699,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2460,7 +2707,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2472,6 +2720,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2479,7 +2728,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2491,6 +2741,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2498,7 +2749,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2510,6 +2762,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2517,7 +2770,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2529,6 +2783,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2536,7 +2791,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2548,6 +2804,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2555,7 +2812,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2567,6 +2825,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2574,7 +2833,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2586,6 +2846,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2593,7 +2854,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2605,6 +2867,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2612,7 +2875,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2624,6 +2888,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2631,7 +2896,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2643,6 +2909,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2650,7 +2917,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2662,6 +2930,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2669,7 +2938,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2681,6 +2951,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2688,7 +2959,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2700,6 +2972,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2707,7 +2980,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2719,6 +2993,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2726,7 +3001,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2738,6 +3014,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2745,7 +3022,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2757,6 +3035,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2764,7 +3043,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2776,6 +3056,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2783,7 +3064,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2795,6 +3077,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2802,7 +3085,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2814,6 +3098,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2821,7 +3106,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2833,6 +3119,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2840,7 +3127,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2852,6 +3140,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2859,7 +3148,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2871,6 +3161,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2878,7 +3169,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2890,6 +3182,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2897,7 +3190,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2909,6 +3203,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2916,7 +3211,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2928,6 +3224,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2935,7 +3232,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2947,6 +3245,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2954,7 +3253,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2966,6 +3266,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2973,7 +3274,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2985,6 +3287,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2992,7 +3295,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3004,6 +3308,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3011,7 +3316,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3023,6 +3329,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3030,7 +3337,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3042,6 +3350,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3049,7 +3358,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3061,6 +3371,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3068,7 +3379,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3080,6 +3392,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3087,7 +3400,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3099,6 +3413,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3106,7 +3421,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3118,6 +3434,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3125,7 +3442,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3137,6 +3455,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3144,7 +3463,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3156,6 +3476,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3163,7 +3484,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3175,6 +3497,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3182,7 +3505,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3194,6 +3518,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3201,7 +3526,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3213,6 +3539,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3220,7 +3547,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3232,6 +3560,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3239,7 +3568,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3251,6 +3581,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3258,7 +3589,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3270,6 +3602,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3277,7 +3610,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3289,6 +3623,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3296,7 +3631,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3308,6 +3644,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3315,7 +3652,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3327,6 +3665,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3334,7 +3673,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3346,6 +3686,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3353,7 +3694,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3365,6 +3707,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3372,7 +3715,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3384,6 +3728,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3391,7 +3736,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3403,6 +3749,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3410,7 +3757,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3422,6 +3770,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3429,7 +3778,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3441,6 +3791,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3448,7 +3799,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3460,6 +3812,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3467,7 +3820,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3479,6 +3833,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3486,7 +3841,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3498,6 +3854,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3505,7 +3862,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3517,6 +3875,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": 15,
           "speed": null,
@@ -3524,7 +3883,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 40,
-          "tokensOut": 20
+          "tokensOut": 20,
+          "userPrompts": 0
         }
       ],
       "cacheRehydrationCount": 0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
@@ -90,6 +90,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -97,7 +98,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 1
         },
         {
           "cacheReadTokens": 0,
@@ -109,6 +111,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -116,7 +119,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -128,6 +132,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -135,7 +140,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -147,6 +153,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -154,7 +161,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -166,6 +174,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -173,7 +182,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -185,6 +195,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -192,7 +203,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -204,6 +216,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -211,7 +224,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -223,6 +237,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -230,7 +245,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -242,6 +258,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -249,7 +266,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -261,6 +279,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -268,7 +287,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -280,6 +300,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -287,7 +308,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -299,6 +321,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -306,7 +329,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -318,6 +342,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -325,7 +350,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -337,6 +363,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -344,7 +371,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -356,6 +384,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -363,7 +392,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -375,6 +405,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -382,7 +413,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -394,6 +426,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -401,7 +434,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -413,6 +447,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -420,7 +455,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -432,6 +468,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -439,7 +476,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -451,6 +489,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -458,7 +497,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -470,6 +510,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -477,7 +518,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -489,6 +531,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -496,7 +539,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -508,6 +552,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -515,7 +560,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -527,6 +573,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -534,7 +581,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -546,6 +594,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -553,7 +602,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -565,6 +615,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -572,7 +623,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -584,6 +636,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -591,7 +644,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -603,6 +657,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -610,7 +665,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -622,6 +678,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -629,7 +686,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -641,6 +699,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -648,7 +707,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -660,6 +720,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -667,7 +728,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -679,6 +741,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -686,7 +749,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -698,6 +762,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -705,7 +770,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -717,6 +783,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -724,7 +791,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -736,6 +804,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -743,7 +812,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -755,6 +825,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -762,7 +833,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -774,6 +846,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -781,7 +854,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -793,6 +867,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -800,7 +875,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -812,6 +888,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -819,7 +896,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -831,6 +909,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -838,7 +917,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -850,6 +930,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -857,7 +938,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -869,6 +951,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -876,7 +959,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -888,6 +972,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -895,7 +980,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -907,6 +993,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -914,7 +1001,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -926,6 +1014,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -933,7 +1022,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -945,6 +1035,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -952,7 +1043,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -964,6 +1056,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -971,7 +1064,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -983,6 +1077,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -990,7 +1085,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1002,6 +1098,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1009,7 +1106,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1021,6 +1119,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1028,7 +1127,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1040,6 +1140,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1047,7 +1148,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1059,6 +1161,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1066,7 +1169,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1078,6 +1182,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1085,7 +1190,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1097,6 +1203,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1104,7 +1211,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1116,6 +1224,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1123,7 +1232,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1135,6 +1245,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1142,7 +1253,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1154,6 +1266,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1161,7 +1274,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1173,6 +1287,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1180,7 +1295,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1192,6 +1308,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1199,7 +1316,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1211,6 +1329,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1218,7 +1337,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1230,6 +1350,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1237,7 +1358,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1249,6 +1371,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1256,7 +1379,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1268,6 +1392,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1275,7 +1400,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1287,6 +1413,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1294,7 +1421,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1306,6 +1434,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1313,7 +1442,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1325,6 +1455,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1332,7 +1463,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1344,6 +1476,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1351,7 +1484,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1363,6 +1497,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1370,7 +1505,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1382,6 +1518,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1389,7 +1526,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1401,6 +1539,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1408,7 +1547,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1420,6 +1560,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1427,7 +1568,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1439,6 +1581,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1446,7 +1589,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1458,6 +1602,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1465,7 +1610,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1477,6 +1623,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1484,7 +1631,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1496,6 +1644,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1503,7 +1652,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1515,6 +1665,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1522,7 +1673,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1534,6 +1686,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1541,7 +1694,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1553,6 +1707,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1560,7 +1715,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1572,6 +1728,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1579,7 +1736,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1591,6 +1749,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1598,7 +1757,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1610,6 +1770,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1617,7 +1778,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1629,6 +1791,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1636,7 +1799,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1648,6 +1812,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1655,7 +1820,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1667,6 +1833,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1674,7 +1841,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1686,6 +1854,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1693,7 +1862,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1705,6 +1875,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1712,7 +1883,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1724,6 +1896,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1731,7 +1904,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1743,6 +1917,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1750,7 +1925,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1762,6 +1938,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1769,7 +1946,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1781,6 +1959,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1788,7 +1967,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1800,6 +1980,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1807,7 +1988,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1819,6 +2001,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1826,7 +2009,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1838,6 +2022,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1845,7 +2030,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1857,6 +2043,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1864,7 +2051,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1876,6 +2064,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1883,7 +2072,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1895,6 +2085,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1902,7 +2093,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1914,6 +2106,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1921,7 +2114,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1933,6 +2127,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1940,7 +2135,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1952,6 +2148,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1959,7 +2156,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1971,6 +2169,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1978,7 +2177,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -1990,6 +2190,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -1997,7 +2198,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2009,6 +2211,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2016,7 +2219,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2028,6 +2232,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2035,7 +2240,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2047,6 +2253,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2054,7 +2261,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2066,6 +2274,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2073,7 +2282,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2085,6 +2295,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2092,7 +2303,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2104,6 +2316,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2111,7 +2324,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2123,6 +2337,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2130,7 +2345,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2142,6 +2358,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2149,7 +2366,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2161,6 +2379,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2168,7 +2387,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2180,6 +2400,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2187,7 +2408,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2199,6 +2421,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2206,7 +2429,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2218,6 +2442,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2225,7 +2450,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2237,6 +2463,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2244,7 +2471,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2256,6 +2484,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2263,7 +2492,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2275,6 +2505,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2282,7 +2513,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2294,6 +2526,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2301,7 +2534,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2313,6 +2547,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2320,7 +2555,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2332,6 +2568,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2339,7 +2576,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2351,6 +2589,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2358,7 +2597,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2370,6 +2610,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2377,7 +2618,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2389,6 +2631,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2396,7 +2639,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2408,6 +2652,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2415,7 +2660,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2427,6 +2673,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2434,7 +2681,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2446,6 +2694,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2453,7 +2702,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2465,6 +2715,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2472,7 +2723,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2484,6 +2736,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2491,7 +2744,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2503,6 +2757,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2510,7 +2765,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2522,6 +2778,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2529,7 +2786,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2541,6 +2799,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2548,7 +2807,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2560,6 +2820,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2567,7 +2828,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2579,6 +2841,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2586,7 +2849,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2598,6 +2862,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2605,7 +2870,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2617,6 +2883,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2624,7 +2891,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2636,6 +2904,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2643,7 +2912,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2655,6 +2925,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2662,7 +2933,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2674,6 +2946,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2681,7 +2954,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2693,6 +2967,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2700,7 +2975,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2712,6 +2988,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2719,7 +2996,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2731,6 +3009,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2738,7 +3017,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2750,6 +3030,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2757,7 +3038,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2769,6 +3051,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2776,7 +3059,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2788,6 +3072,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2795,7 +3080,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2807,6 +3093,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2814,7 +3101,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2826,6 +3114,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2833,7 +3122,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2845,6 +3135,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2852,7 +3143,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2864,6 +3156,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2871,7 +3164,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2883,6 +3177,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2890,7 +3185,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2902,6 +3198,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2909,7 +3206,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2921,6 +3219,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2928,7 +3227,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2940,6 +3240,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2947,7 +3248,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2959,6 +3261,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2966,7 +3269,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2978,6 +3282,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -2985,7 +3290,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -2997,6 +3303,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3004,7 +3311,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3016,6 +3324,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3023,7 +3332,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3035,6 +3345,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3042,7 +3353,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3054,6 +3366,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3061,7 +3374,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3073,6 +3387,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3080,7 +3395,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3092,6 +3408,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3099,7 +3416,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3111,6 +3429,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3118,7 +3437,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3130,6 +3450,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3137,7 +3458,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3149,6 +3471,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3156,7 +3479,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3168,6 +3492,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3175,7 +3500,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3187,6 +3513,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3194,7 +3521,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3206,6 +3534,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3213,7 +3542,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3225,6 +3555,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3232,7 +3563,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3244,6 +3576,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3251,7 +3584,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3263,6 +3597,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3270,7 +3605,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3282,6 +3618,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3289,7 +3626,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3301,6 +3639,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3308,7 +3647,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3320,6 +3660,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3327,7 +3668,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3339,6 +3681,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3346,7 +3689,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3358,6 +3702,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3365,7 +3710,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3377,6 +3723,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3384,7 +3731,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3396,6 +3744,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3403,7 +3752,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3415,6 +3765,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3422,7 +3773,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3434,6 +3786,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3441,7 +3794,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3453,6 +3807,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3460,7 +3815,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3472,6 +3828,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": null,
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3479,7 +3836,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 0,
-          "tokensOut": 0
+          "tokensOut": 0,
+          "userPrompts": 0
         },
         {
           "cacheReadTokens": 0,
@@ -3491,6 +3849,7 @@
           "hasThinking": false,
           "isCacheRehydration": false,
           "isCompactionBoundary": false,
+          "lastTool": null,
           "model": "claude-3-5-haiku-20241022",
           "secsSincePriorTurn": null,
           "speed": null,
@@ -3498,7 +3857,8 @@
           "subagentTokens": 0,
           "thinkingMode": null,
           "tokensIn": 18,
-          "tokensOut": 9
+          "tokensOut": 9,
+          "userPrompts": 0
         }
       ],
       "cacheRehydrationCount": 0,


### PR DESCRIPTION
## Summary

Two related fixes to the session detail view.

**Context chart tooltip**
- Buckets with no model call now describe the gap they sit in from the calls around them: `During Bash call · 7s`, `Waiting for user · 25m (5m shown)`, or `Between model calls · 7s`. The `(5m shown)` suffix marks a gap the idle cap truncates on the axis.
- Cache rows sit under a `Tokens` subhead with a hollow swatch; zero cache-write rows are hidden, and a vendor with no cache-write data (Codex) reads `re-sent uncached` instead of `0 written`.
- Model / Effort / Speed / Thinking rows appear only when a turn differs from the session's baseline.

**Engine**
- A bucket keeps the gap of the *first* turn that enters it (was last-wins, which mislabelled long idle stretches with the 7s follow-up gap).
- Buckets count parent user prompts and record their last tool.
- Claude Code `tool_result` records carry `role: user` in the transcript; the adapter now classifies them as `Role::Tool`.
- `aggregate_metrics` keeps per-bucket mode signals and compaction detail for a single session — the detail view never rendered them before.
- Goldens regenerated for the two additive fields and the one role change.

**Popover reopen**
- The shell already emits `popover:shown`; the store now re-loads the open session's analytics on it (previously only usage). The settled result stays on screen with a spinner in the detail header until the fresh one lands.

## Test plan
- [x] `cargo test -p antiburn-local` (722), clippy `-D warnings`, `cargo fmt --check`
- [x] `pnpm exec vitest run` (718), `tsc`, eslint, prettier, `pnpm run slop`
- [x] Verified tooltip labels manually against a real Claude Code session with a 10-minute idle stretch and a Codex session
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
