### PR TITLE
Stack GH-70: 0003 Source generations and projection revisions

### DIFF
--- a/apps/desktop/src-tauri/src/repositories.rs
+++ b/apps/desktop/src-tauri/src/repositories.rs
@@ -749,6 +749,7 @@ mod tests {
             activity_source: "mtime".to_string(),
             subagent_count: 0,
             fork_parent_session_id: None,
+            source_fingerprint: None,
         };
         store
             .upsert_sessions(&[
@@ -835,6 +836,7 @@ mod tests {
             activity_source: "mtime".into(),
             subagent_count: 0,
             fork_parent_session_id: None,
+            source_fingerprint: None,
         };
         let sessions = vec![
             session("/home/avery/code/widgets"),

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -632,6 +632,7 @@ async fn describe_one_with_activity(
         activity_source,
         subagent_count,
         fork_parent_session_id,
+        source_fingerprint: None,
     }))
 }
 
@@ -1741,6 +1742,7 @@ mod tests {
             activity_source: "mtime".into(),
             subagent_count: 0,
             fork_parent_session_id: None,
+            source_fingerprint: None,
         }
     }
 

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -71,8 +71,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use antiburn_local::discovery::scanner::{self, TitleSource};
 use antiburn_local::discovery::{
-    Explorers, ResolvedTitle, SessionLog, SessionSource, TitleLookupKind, session_log_metadata,
-    session_source_preview, session_source_tail,
+    Explorers, ResolvedTitle, SessionLog, SessionSource, SourceDescriptor, TitleLookupKind,
+    session_log_read, session_source_tail,
 };
 use antiburn_local::model::AgentKind;
 use antiburn_local::paths::{home_dir, ignored_paths};
@@ -326,7 +326,8 @@ async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Res
 
     // Everything discovered so far is already persisted, so a cancel here keeps
     // the reader's results and only skips the work still ahead.
-    if app.state::<ScanController>().cancelled() {
+    let controller = app.state::<ScanController>();
+    if controller.cancelled() {
         return Ok(records.len());
     }
 
@@ -338,9 +339,21 @@ async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Res
             crate::store::MIN_ACTIVITY_DAYS,
             crate::store::MAX_ACTIVITY_DAYS,
         );
-    top_up_analysis(app, now, i64::from(activity_window_days)).await?;
+    top_up_analysis(
+        &store,
+        &controller,
+        now,
+        i64::from(activity_window_days),
+        |agent, session_id, wsl_distro| async move {
+            analytics::locate(agent, &session_id, wsl_distro.as_deref()).await
+        },
+        |agent, session_id, wsl_distro| async move {
+            analytics::analyze(agent, &session_id, wsl_distro.as_deref()).await
+        },
+    )
+    .await?;
 
-    if app.state::<ScanController>().cancelled() {
+    if controller.cancelled() {
         return Ok(records.len());
     }
 
@@ -556,9 +569,9 @@ async fn describe_one_with_activity(
     indexed_title: Option<ResolvedTitle>,
     activity_state: Option<SessionActivityState>,
 ) -> DescribeOutcome {
-    let metadata = session_log_metadata(&log).await;
+    let read = session_log_read(&log).await;
+    let metadata = read.as_ref().map(|read| &read.metadata);
     let Some(session_id) = metadata
-        .as_ref()
         .and_then(|metadata| metadata.session_id.clone())
         .or_else(|| recovered_id(&log))
     else {
@@ -573,12 +586,13 @@ async fn describe_one_with_activity(
         log.agent_type.slug(),
         session_id.clone(),
     );
-    // One bounded content read serves both content checks below.
     let preview = match log.agent_type {
-        AgentKind::Claude | AgentKind::Codex => session_source_preview(&log.source).await,
+        AgentKind::Claude | AgentKind::Codex => {
+            read.as_ref().and_then(|read| read.content.as_deref())
+        }
         _ => None,
     };
-    if is_subagent_transcript(&log, preview.as_deref()) {
+    if is_subagent_transcript(&log, preview) {
         return DescribeOutcome::Subagent(key);
     }
 
@@ -589,12 +603,10 @@ async fn describe_one_with_activity(
     };
     let (title, title_source) = select_title_pair(
         resolved_title,
-        metadata
-            .as_ref()
-            .and_then(|metadata| metadata.title.clone()),
-        metadata.as_ref().and_then(|metadata| metadata.title_source),
+        metadata.and_then(|metadata| metadata.title.clone()),
+        metadata.and_then(|metadata| metadata.title_source),
         &log.agent_type,
-        preview.as_deref(),
+        preview,
     );
 
     // A dir listing per orchestrator-capable session; vendors that record no
@@ -610,13 +622,21 @@ async fn describe_one_with_activity(
         _ => Vec::new(),
     };
     let subagent_count = children.len() as u32;
-    let fork_parent_session_id = preview
-        .as_deref()
-        .and_then(analytics::fork_parent_from_content);
+    let fork_parent_session_id = preview.and_then(analytics::fork_parent_from_content);
 
     let (updated_at_epoch, activity_source, activity_cursor) =
-        semantic_activity_for_log(&log, activity_state.as_ref(), &children, preview.as_deref())
-            .await;
+        semantic_activity_for_log(&log, activity_state.as_ref(), &children, preview).await;
+    let descriptor = SourceDescriptor {
+        agent: log.agent_type,
+        session_id: session_id.clone(),
+        environment: log.environment.clone(),
+        source: log.source.clone(),
+        updated_at_epoch: log.updated_at,
+    };
+    let source_fingerprint = Explorers::DISK
+        .source_version(&descriptor, read.as_ref())
+        .await
+        .map(|version| version.fingerprint);
 
     DescribeOutcome::Session(Box::new(SessionRecord {
         key,
@@ -625,14 +645,14 @@ async fn describe_one_with_activity(
         wsl_distro: log.environment.wsl_distro().map(str::to_string),
         title,
         title_source,
-        cwd: metadata.and_then(|metadata| metadata.cwd),
+        cwd: metadata.and_then(|metadata| metadata.cwd.clone()),
         surface: log.surface_label(home).to_string(),
         updated_at_epoch,
         activity_cursor,
         activity_source,
         subagent_count,
         fork_parent_session_id,
-        source_fingerprint: None,
+        source_fingerprint,
     }))
 }
 
@@ -854,15 +874,27 @@ fn per_agent_totals(records: &[SessionRecord]) -> Vec<(String, i64, Option<i64>)
 }
 
 /// Analyze the newest sessions whose cached analysis is missing or stale.
-async fn top_up_analysis(app: &AppHandle, now: i64, activity_days: i64) -> anyhow::Result<()> {
-    let store = app.state::<Store>();
+async fn top_up_analysis<F, Fut, A, AFut>(
+    store: &Store,
+    controller: &ScanController,
+    now: i64,
+    activity_days: i64,
+    mut locate: F,
+    mut analyze: A,
+) -> anyhow::Result<()>
+where
+    F: FnMut(AgentKind, String, Option<String>) -> Fut,
+    Fut: std::future::Future<Output = Option<SessionSource>>,
+    A: FnMut(AgentKind, String, Option<String>) -> AFut,
+    AFut: std::future::Future<Output = analytics::SessionAnalysis>,
+{
     let since = now - activity_days.max(1) * 86_400;
     let candidates = store.recent_sessions(since, MAX_ANALYSES_PER_PASS)?;
 
     for record in candidates {
         // Analysis is the long tail of a pass — one whole transcript read per
         // session — so this is where a cancel is felt.
-        if app.state::<ScanController>().cancelled() {
+        if controller.cancelled() {
             return Ok(());
         }
         let Some(agent) = crate::agents::kind_from_slug(&record.key.agent) else {
@@ -873,8 +905,12 @@ async fn top_up_analysis(app: &AppHandle, now: i64, activity_days: i64) -> anyho
             // metric; the view says so instead of showing one.
             continue;
         }
-        let Some(source) =
-            analytics::locate(agent, &record.key.session_id, record.wsl_distro.as_deref()).await
+        let Some(source) = locate(
+            agent,
+            record.key.session_id.clone(),
+            record.wsl_distro.clone(),
+        )
+        .await
         else {
             continue;
         };
@@ -891,8 +927,12 @@ async fn top_up_analysis(app: &AppHandle, now: i64, activity_days: i64) -> anyho
             continue;
         }
 
-        let analysis =
-            analytics::analyze(agent, &record.key.session_id, record.wsl_distro.as_deref()).await;
+        let analysis = analyze(
+            agent,
+            record.key.session_id.clone(),
+            record.wsl_distro.clone(),
+        )
+        .await;
         if let Some(cache) = analysis.record(&record.key) {
             store.save_analysis(&cache)?;
         }
@@ -958,6 +998,36 @@ mod tests {
             ),
         )
         .unwrap();
+        path
+    }
+
+    fn write_opencode_provider_db(home: &std::path::Path, session_id: &str) -> std::path::PathBuf {
+        let path = home.join("opencode.db");
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE session (
+                     id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT,
+                     directory TEXT NOT NULL, title TEXT NOT NULL, version TEXT NOT NULL,
+                     time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL
+                 );
+                 CREATE TABLE message (
+                     id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+                     time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL
+                 );
+                 CREATE TABLE part (
+                     id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL,
+                     time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO session VALUES (?1, 'synthetic-project', NULL, '/repo',
+                                              'Synthetic session', '1', 100, 120, '{}')",
+                [session_id],
+            )
+            .unwrap();
         path
     }
 
@@ -1254,6 +1324,12 @@ mod tests {
         assert_eq!(claude.title.as_deref(), Some("Wire the tray popover"));
         assert_eq!(claude.source_kind, "file");
         assert_eq!(claude.subagent_count, 0);
+        assert!(
+            claude
+                .source_fingerprint
+                .as_deref()
+                .is_some_and(|value| value.starts_with("sv1:"))
+        );
 
         let codex = records
             .records
@@ -1266,6 +1342,307 @@ mod tests {
             codex.surface.as_str(),
             "cli" | "ide_desktop" | "unknown"
         ));
+    }
+
+    #[tokio::test]
+    async fn describing_a_claude_session_reads_the_head_once() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = write_claude_session(home.path(), "one-head-read");
+        antiburn_local::discovery::track_head_reads(&path);
+
+        let outcome = describe_one(
+            log(AgentKind::Claude, path.clone(), 1_800_000_000),
+            home.path(),
+            None,
+        )
+        .await;
+
+        assert!(matches!(outcome, DescribeOutcome::Session(_)));
+        assert_eq!(antiburn_local::discovery::take_tracked_head_reads(&path), 1);
+    }
+
+    #[tokio::test]
+    async fn describing_an_opencode_provider_db_does_not_render_the_transcript() {
+        let home = tempfile::TempDir::new().unwrap();
+        let session_id = "opencode-provider-db";
+        let db_path = write_opencode_provider_db(home.path(), session_id);
+        let log = SessionLog {
+            agent_type: AgentKind::OpenCode,
+            source: SessionSource::ProviderDb {
+                agent: AgentKind::OpenCode,
+                db_path: db_path.clone(),
+                session_id: session_id.to_string(),
+            },
+            updated_at: Some(120),
+            environment: DiscoveryEnvironment::Native,
+        };
+        antiburn_local::discovery::track_provider_db_renders(&db_path);
+
+        let outcome = describe_one(log, home.path(), None).await;
+
+        assert!(matches!(outcome, DescribeOutcome::Session(_)));
+        assert_eq!(
+            antiburn_local::discovery::take_tracked_provider_db_renders(&db_path),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn a_consumed_provider_db_preview_is_rendered() {
+        let home = tempfile::TempDir::new().unwrap();
+        let session_id = "consumed-provider-db";
+        let db_path = write_opencode_provider_db(home.path(), session_id);
+        let log = SessionLog {
+            agent_type: AgentKind::Claude,
+            source: SessionSource::ProviderDb {
+                agent: AgentKind::OpenCode,
+                db_path: db_path.clone(),
+                session_id: session_id.to_string(),
+            },
+            updated_at: Some(120),
+            environment: DiscoveryEnvironment::Native,
+        };
+        antiburn_local::discovery::track_provider_db_renders(&db_path);
+
+        let read = session_log_read(&log).await.expect("source read");
+
+        assert!(read.content.is_some());
+        assert_eq!(
+            antiburn_local::discovery::take_tracked_provider_db_renders(&db_path),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn an_inline_claude_subagent_is_rejected_on_the_scan_path() {
+        let content = concat!(
+            r#"{"type":"user","sessionId":"inline-subagent","isSidechain":true,"agentId":"agent-child","message":{"role":"user","content":"Investigate the failed deployment"}}"#,
+            "\n",
+        );
+        let log = SessionLog {
+            agent_type: AgentKind::Claude,
+            source: SessionSource::Inline {
+                label: "inline-subagent".to_string(),
+                content: content.to_string(),
+            },
+            updated_at: Some(1_800_000_000),
+            environment: DiscoveryEnvironment::Native,
+        };
+
+        assert!(matches!(
+            describe_one(log, std::path::Path::new("/tmp"), None).await,
+            DescribeOutcome::Subagent(key)
+                if key == SessionKey::new("native", "claude-code", "inline-subagent")
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_descriptor_takes_the_metadata_session_id() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = home.path().join("recovered-file-name.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"user","sessionId":"metadata-id","cwd":"/repo"}
+"#,
+        )
+        .unwrap();
+
+        let DescribeOutcome::Session(record) =
+            describe_one(log(AgentKind::Claude, path, 100), home.path(), None).await
+        else {
+            panic!("session should be described");
+        };
+
+        assert_eq!(record.key.session_id, "metadata-id");
+        assert!(record.source_fingerprint.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_descriptor_falls_back_to_the_recovered_id() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = home.path().join("recovered-id.jsonl");
+        std::fs::write(&path, "not json\n").unwrap();
+
+        let DescribeOutcome::Session(record) =
+            describe_one(log(AgentKind::Pi, path, 100), home.path(), None).await
+        else {
+            panic!("session should be described");
+        };
+
+        assert_eq!(record.key.session_id, "recovered-id");
+        assert!(record.source_fingerprint.is_some());
+    }
+
+    #[tokio::test]
+    async fn an_empty_session_id_is_still_skipped() {
+        let log = SessionLog {
+            agent_type: AgentKind::Claude,
+            source: SessionSource::Inline {
+                label: String::new(),
+                content: "{}".to_string(),
+            },
+            updated_at: None,
+            environment: DiscoveryEnvironment::Native,
+        };
+
+        assert!(matches!(
+            describe_one(log, std::path::Path::new("/tmp"), None).await,
+            DescribeOutcome::Skip
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_appended_transcript_produces_a_different_fingerprint() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = write_claude_session(home.path(), "changing-session");
+        let DescribeOutcome::Session(first) =
+            describe_one(log(AgentKind::Claude, path.clone(), 100), home.path(), None).await
+        else {
+            panic!("session should be described");
+        };
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{\"type\":\"assistant\"}\n")
+            .unwrap();
+        let DescribeOutcome::Session(second) =
+            describe_one(log(AgentKind::Claude, path, 101), home.path(), None).await
+        else {
+            panic!("session should be described");
+        };
+
+        assert_ne!(first.source_fingerprint, second.source_fingerprint);
+    }
+
+    #[tokio::test]
+    async fn a_non_native_codex_title_survives_the_scan_path() {
+        let home = tempfile::TempDir::new().unwrap();
+        let session_id = "wsl-indexed-title";
+        let path = write_codex_session(home.path(), session_id);
+        std::fs::write(
+            home.path().join(".codex/session_index.jsonl"),
+            format!(
+                r#"{{"id":"{session_id}","thread_name":"Indexed WSL title"}}
+"#
+            ),
+        )
+        .unwrap();
+        let log = SessionLog {
+            environment: DiscoveryEnvironment::Wsl {
+                distribution: "SyntheticLinux".into(),
+                user: "avery".into(),
+            },
+            ..log(AgentKind::Codex, path, 100)
+        };
+
+        let DescribeOutcome::Session(record) = describe_one(log, home.path(), None).await else {
+            panic!("session should be described");
+        };
+
+        assert_eq!(record.title.as_deref(), Some("Indexed WSL title"));
+        assert_eq!(record.title_source.as_deref(), Some("aiGenerated"));
+    }
+
+    #[tokio::test]
+    async fn a_wsl_cwd_is_mapped_to_a_windows_path_in_the_scan_path() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = write_codex_session(home.path(), "wsl-cwd");
+        let log = SessionLog {
+            environment: DiscoveryEnvironment::Wsl {
+                distribution: "SyntheticLinux".into(),
+                user: "avery".into(),
+            },
+            ..log(AgentKind::Codex, path, 100)
+        };
+
+        let DescribeOutcome::Session(record) = describe_one(log, home.path(), None).await else {
+            panic!("session should be described");
+        };
+
+        assert_eq!(
+            record.cwd.as_deref(),
+            Some(r"\\wsl.localhost\SyntheticLinux\home\avery\code\gadgets")
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_freshness_ignores_the_session_source_fingerprint() {
+        let home = tempfile::TempDir::new().unwrap();
+        let session_id = "cache-contract-session";
+        let source = SessionSource::File(write_claude_session(home.path(), session_id));
+        let mut session = record("claude-code", session_id, Some(100));
+        session.source_fingerprint = Some("sv1:session-source".to_string());
+        let SessionSource::File(source_path) = &source else {
+            unreachable!("the fixture uses a file source");
+        };
+        session.source_label = source_path.to_string_lossy().into_owned();
+        let store = Store::open_in_memory(home.path()).unwrap();
+        store
+            .upsert_sessions(std::slice::from_ref(&session))
+            .unwrap();
+
+        let legacy_fingerprint =
+            analytics::fingerprint_with_subagents(AgentKind::Claude, session_id, None, &source)
+                .await;
+        let cached = crate::store::AnalysisRecord {
+            key: session.key.clone(),
+            model_breakdown_json: r#"{"cached":true}"#.to_string(),
+            inclusive_models_json: "[]".to_string(),
+            source_fingerprint: legacy_fingerprint.clone(),
+            pricing_generation: antiburn_local::analysis::pricing_generation() as i64,
+        };
+        store.save_analysis(&cached).unwrap();
+
+        let persisted_session = store
+            .session(&session.key)
+            .unwrap()
+            .expect("persisted session");
+        assert_eq!(
+            persisted_session.source_fingerprint.as_deref(),
+            Some("sv1:session-source")
+        );
+        assert!(analytics::cache_is_fresh(
+            &store
+                .analysis(&session.key)
+                .unwrap()
+                .expect("persisted analysis"),
+            &legacy_fingerprint
+        ));
+
+        let locate_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed_locates = locate_calls.clone();
+        let analysis_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed_analyses = analysis_calls.clone();
+        let located_source = source.clone();
+        let expected_id = session_id.to_string();
+        top_up_analysis(
+            &store,
+            &ScanController::default(),
+            200,
+            1,
+            move |agent, candidate_id, wsl_distro| {
+                observed_locates.fetch_add(1, Ordering::SeqCst);
+                let source = located_source.clone();
+                let matches = agent == AgentKind::Claude
+                    && candidate_id == expected_id
+                    && wsl_distro.is_none();
+                async move { matches.then_some(source) }
+            },
+            move |_, _, _| {
+                observed_analyses.fetch_add(1, Ordering::SeqCst);
+                async { analytics::SessionAnalysis::unavailable() }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(locate_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(analysis_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            store.analysis(&session.key).unwrap().as_ref(),
+            Some(&cached)
+        );
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -40,6 +40,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::dto::DeferredPermissionDir;
 
+#[cfg(test)]
+pub use model::SourceVersionState;
 pub use model::{
     AnalysisRecord, AppSettings, DiskSpaceDisplay, MAX_ACTIVITY_DAYS, MIN_ACTIVITY_DAYS,
     Milestones, NudgePlacement, RelationKind, RelationRecord, RepositoryRecord, SessionActivityKey,
@@ -498,7 +500,8 @@ impl Store {
                          AND r.agent = s.agent
                          AND r.session_id = s.session_id
                          AND r.kind = 'forkParent'
-                       LIMIT 1)
+                       LIMIT 1),
+                    s.source_fingerprint
                FROM session s
               WHERE COALESCE(updated_at_epoch, 0) >= ?1
               ORDER BY COALESCE(updated_at_epoch, 0) DESC, session_id DESC
@@ -554,7 +557,8 @@ impl Store {
                          AND r.agent = s.agent
                          AND r.session_id = s.session_id
                          AND r.kind = 'forkParent'
-                       LIMIT 1)
+                       LIMIT 1),
+                    s.source_fingerprint
                FROM session s
               WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         )?;
@@ -562,6 +566,28 @@ impl Store {
             .query_row(
                 params![key.environment_key, key.agent, key.session_id],
                 session_from_row,
+            )
+            .optional()?)
+    }
+
+    /// One session's persisted source version and optional start time.
+    // CH-005 and CH-007 add production consumers before this test-only accessor enters runtime code.
+    #[cfg(test)]
+    pub fn session_source_state(&self, key: &SessionKey) -> Result<Option<SourceVersionState>> {
+        let connection = self.lock();
+        Ok(connection
+            .query_row(
+                "SELECT source_fingerprint, source_generation, started_at_epoch
+                   FROM session
+                  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+                params![key.environment_key, key.agent, key.session_id],
+                |row| {
+                    Ok(SourceVersionState {
+                        source_fingerprint: row.get(0)?,
+                        source_generation: row.get(1)?,
+                        started_at_epoch: row.get(2)?,
+                    })
+                },
             )
             .optional()?)
     }
@@ -1139,10 +1165,11 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
              environment_key, agent, session_id, source_kind, source_label, wsl_distro,
              title, title_source, cwd, surface, updated_at_epoch,
              activity_cursor, activity_source, subagent_count,
-             first_seen_at, last_seen_at)
+             first_seen_at, last_seen_at, source_fingerprint, source_generation)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7,
                  CASE WHEN ?7 IS NOT NULL THEN ?8 ELSE NULL END,
-                 ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)
+                 ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15, ?16,
+                 CASE WHEN ?16 IS NOT NULL THEN 1 ELSE 0 END)
          ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
              source_kind = excluded.source_kind,
              source_label = excluded.source_label,
@@ -1177,6 +1204,13 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
                  ELSE excluded.activity_source
              END,
              subagent_count = excluded.subagent_count,
+             source_fingerprint = COALESCE(excluded.source_fingerprint, session.source_fingerprint),
+             source_generation = CASE
+                 WHEN excluded.source_fingerprint IS NULL THEN session.source_generation
+                 WHEN session.source_fingerprint = excluded.source_fingerprint
+                     THEN session.source_generation
+                 ELSE session.source_generation + 1
+             END,
              last_seen_at = excluded.last_seen_at",
         params![
             record.key.environment_key,
@@ -1194,6 +1228,7 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
             record.activity_source,
             record.subagent_count,
             now,
+            record.source_fingerprint,
         ],
     )?;
 
@@ -1256,5 +1291,6 @@ fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> 
         activity_source: row.get(12)?,
         subagent_count: row.get(13)?,
         fork_parent_session_id: row.get(14)?,
+        source_fingerprint: row.get(15)?,
     })
 }

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -88,6 +88,16 @@ pub struct SessionRecord {
     pub subagent_count: u32,
     /// The session this one was branched from, when the vendor records it.
     pub fork_parent_session_id: Option<String>,
+    pub source_fingerprint: Option<String>,
+}
+
+// CH-005 and CH-007 add production consumers before this test-only type enters runtime code.
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceVersionState {
+    pub source_fingerprint: Option<String>,
+    pub source_generation: i64,
+    pub started_at_epoch: Option<i64>,
 }
 
 /// Identity of one persisted activity cursor. The source label alone is not

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -14,7 +14,7 @@
 
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
-pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4, V5, V6, V7, V8];
+pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4, V5, V6, V7, V8, V9];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
 ///
@@ -277,4 +277,19 @@ FROM session_analysis;
 
 DROP TABLE session_analysis;
 ALTER TABLE session_analysis_v8 RENAME TO session_analysis;
+"#;
+
+/// v9 — source generations and analysis projection revisions.
+///
+/// The source fingerprint is a derived identity value. It contains no
+/// transcript content. The head hash contributes to it and is never stored
+/// separately.
+const V9: &str = r#"
+ALTER TABLE session ADD COLUMN source_fingerprint TEXT;
+ALTER TABLE session ADD COLUMN source_generation INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session ADD COLUMN started_at_epoch INTEGER;
+ALTER TABLE session_analysis ADD COLUMN analyzed_generation INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session_analysis ADD COLUMN parser_revision INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE session_analysis ADD COLUMN analyzer_revision INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE session_analysis ADD COLUMN metrics_schema_revision INTEGER NOT NULL DEFAULT 1;
 "#;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -25,6 +25,7 @@ fn session(session_id: &str, updated_at: i64) -> SessionRecord {
         activity_source: "mtime".into(),
         subagent_count: 0,
         fork_parent_session_id: None,
+        source_fingerprint: None,
     }
 }
 
@@ -38,7 +39,7 @@ fn a_fresh_database_is_migrated_to_the_latest_version() {
 }
 
 #[test]
-fn session_analysis_keeps_only_the_cache_values_the_app_reads() {
+fn session_analysis_holds_the_cache_values_and_the_projection_revisions() {
     let store = store();
     let connection = store.lock();
     let mut statement = connection
@@ -60,6 +61,10 @@ fn session_analysis_keeps_only_the_cache_values_the_app_reads() {
             "inclusive_models_json",
             "source_fingerprint",
             "pricing_generation",
+            "analyzed_generation",
+            "parser_revision",
+            "analyzer_revision",
+            "metrics_schema_revision",
         ]
     );
 }
@@ -321,6 +326,9 @@ fn the_session_table_shape_is_stable() {
             "last_seen_at",
             "activity_source",
             "activity_cursor",
+            "source_fingerprint",
+            "source_generation",
+            "started_at_epoch",
         ]
     );
 }
@@ -928,6 +936,194 @@ fn migrating_forward_drops_a_legacy_live_usage_off_row_so_the_new_default_applie
         store.settings().unwrap().live_usage_enabled,
         "with the legacy row gone, the read path falls through to the new default"
     );
+}
+
+#[test]
+fn migrating_from_every_prior_schema_version_reaches_the_current_head() {
+    for start in 0..super::schema::MIGRATIONS.len() {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        for &sql in &super::schema::MIGRATIONS[..start] {
+            connection.execute_batch(sql).unwrap();
+        }
+        connection
+            .pragma_update(None, "user_version", start as i64)
+            .unwrap();
+
+        let store = Store::from_connection(
+            connection,
+            Path::new("/tmp/antiburn-all-migrations-test").to_path_buf(),
+        )
+        .expect("migration reaches the head");
+        assert_eq!(
+            store.schema_version().unwrap(),
+            super::schema::MIGRATIONS.len() as i64
+        );
+        let connection = store.lock();
+        let added_columns: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('session')
+                   WHERE name IN ('source_fingerprint', 'source_generation', 'started_at_epoch')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let projection_columns: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('session_analysis')
+                   WHERE name IN ('analyzed_generation', 'parser_revision',
+                                  'analyzer_revision', 'metrics_schema_revision')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(added_columns, 3, "start version {start}");
+        assert_eq!(projection_columns, 4, "start version {start}");
+    }
+}
+
+#[test]
+fn existing_analysis_rows_take_the_revision_defaults() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    for &sql in &super::schema::MIGRATIONS[..8] {
+        connection.execute_batch(sql).unwrap();
+    }
+    connection
+        .execute(
+            "INSERT INTO session_analysis (
+                 environment_key, agent, session_id, model_breakdown_json,
+                 inclusive_models_json, source_fingerprint, pricing_generation)
+             VALUES ('native', 'claude-code', 'legacy', '{}', '[]', '1:1', 1)",
+            [],
+        )
+        .unwrap();
+    connection
+        .pragma_update(None, "user_version", 8i64)
+        .unwrap();
+
+    let store = Store::from_connection(
+        connection,
+        Path::new("/tmp/antiburn-analysis-migration-test").to_path_buf(),
+    )
+    .expect("migration reaches the head");
+    let revisions: (i64, i64, i64, i64) = store
+        .lock()
+        .query_row(
+            "SELECT analyzed_generation, parser_revision, analyzer_revision,
+                    metrics_schema_revision
+               FROM session_analysis
+              WHERE session_id = 'legacy'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+
+    assert_eq!(revisions, (0, 1, 1, 1));
+}
+
+#[test]
+fn a_session_keeps_its_key_across_the_migration() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    for &sql in &super::schema::MIGRATIONS[..8] {
+        connection.execute_batch(sql).unwrap();
+    }
+    connection
+        .execute(
+            "INSERT INTO session (
+                 environment_key, agent, session_id, source_kind, source_label,
+                 surface, subagent_count, first_seen_at, last_seen_at,
+                 activity_source, activity_cursor)
+             VALUES ('native', 'claude-code', 'stable', 'file', '/tmp/stable.jsonl',
+                     'cli', 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                     'mtime', '')",
+            [],
+        )
+        .unwrap();
+    connection
+        .pragma_update(None, "user_version", 8i64)
+        .unwrap();
+
+    let store = Store::from_connection(
+        connection,
+        Path::new("/tmp/antiburn-session-migration-test").to_path_buf(),
+    )
+    .expect("migration reaches the head");
+    let key = SessionKey::new("native", "claude-code", "stable");
+    let before = store
+        .session_source_state(&key)
+        .unwrap()
+        .expect("source state");
+    assert_eq!(before.source_generation, 0);
+    assert_eq!(before.source_fingerprint, None);
+    assert_eq!(store.session(&key).unwrap().expect("session").key, key);
+
+    let mut rescanned = session("stable", 1_000);
+    rescanned.source_fingerprint = Some("sv1:stable".to_string());
+    store.upsert_sessions(&[rescanned]).unwrap();
+
+    assert_eq!(store.session_count().unwrap(), 1);
+    let after = store
+        .session_source_state(&key)
+        .unwrap()
+        .expect("source state");
+    assert_eq!(after.source_generation, 1);
+    assert_eq!(after.source_fingerprint.as_deref(), Some("sv1:stable"));
+}
+
+#[test]
+fn the_generation_increments_only_when_the_fingerprint_changes() {
+    let store = store();
+    let key = SessionKey::new("native", "claude-code", "generation");
+    let mut record = session("generation", 1_000);
+    record.source_fingerprint = Some("sv1:first".to_string());
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+    let first = store
+        .session_source_state(&key)
+        .unwrap()
+        .expect("source state");
+    assert_eq!(first.source_generation, 1);
+
+    record.source_fingerprint = Some("sv1:second".to_string());
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+    let second = store
+        .session_source_state(&key)
+        .unwrap()
+        .expect("source state");
+    assert_eq!(second.source_generation, 2);
+    assert_eq!(second.source_fingerprint.as_deref(), Some("sv1:second"));
+
+    record.source_fingerprint = None;
+    store.upsert_sessions(&[record]).unwrap();
+    let unreadable = store
+        .session_source_state(&key)
+        .unwrap()
+        .expect("source state");
+    assert_eq!(unreadable, second);
+}
+
+#[test]
+fn started_at_epoch_stays_null_through_scan_upserts() {
+    let store = store();
+    let key = SessionKey::new("native", "claude-code", "no-start");
+    let mut record = session("no-start", 1_000);
+    record.source_fingerprint = Some("sv1:first".to_string());
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+    record.source_fingerprint = Some("sv1:second".to_string());
+    store.upsert_sessions(&[record]).unwrap();
+
+    let state = store
+        .session_source_state(&key)
+        .unwrap()
+        .expect("source state");
+    assert_eq!(state.started_at_epoch, None);
 }
 
 #[test]

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -1005,7 +1005,11 @@ pub async fn session_source_content(source: &SessionSource) -> Option<String> {
             agent: AgentKind::OpenCode,
             db_path,
             session_id,
-        } => agents::opencode::render_db_session(db_path.clone(), session_id.clone()).await,
+        } => {
+            #[cfg(any(test, debug_assertions))]
+            record_tracked_provider_db_render(db_path);
+            agents::opencode::render_db_session(db_path.clone(), session_id.clone()).await
+        }
         SessionSource::ProviderDb {
             agent,
             db_path,
@@ -1030,7 +1034,7 @@ pub async fn session_source_preview(source: &SessionSource) -> Option<String> {
         return session_source_content(source).await;
     };
     use tokio::io::AsyncReadExt;
-    let file = tokio::fs::File::open(path).await.ok()?;
+    let file = open_file_for_head_read(path).await?;
     let mut bytes = Vec::new();
     file.take(SOURCE_PREVIEW_BYTES)
         .read_to_end(&mut bytes)
@@ -1162,24 +1166,37 @@ async fn session_source_read(
         SessionSource::Inline { content, .. } => {
             let mut metadata = scanner::parse_session_metadata_str(content);
             metadata.agent_type = agent_type;
+            let content = if matches!(agent_type, Some(AgentKind::Claude | AgentKind::Codex)) {
+                Some(content.clone())
+            } else {
+                None
+            };
             Some(SourceRead {
                 metadata,
                 stat: None,
                 head_hash: None,
-                content: None,
+                content,
             })
         }
         SessionSource::ProviderDb {
             agent: AgentKind::OpenCode,
             db_path,
             session_id,
-        } => Some(SourceRead {
-            metadata: agents::opencode::db_session_metadata(db_path.clone(), session_id.clone())
-                .await?,
-            stat: None,
-            head_hash: None,
-            content: None,
-        }),
+        } => {
+            let metadata =
+                agents::opencode::db_session_metadata(db_path.clone(), session_id.clone()).await?;
+            let content = if matches!(agent_type, Some(AgentKind::Claude | AgentKind::Codex)) {
+                session_source_content(source).await
+            } else {
+                None
+            };
+            Some(SourceRead {
+                metadata,
+                stat: None,
+                head_hash: None,
+                content,
+            })
+        }
         SessionSource::ProviderDb {
             agent,
             db_path,
@@ -1199,7 +1216,7 @@ async fn session_source_read(
 async fn read_file_source(path: &Path) -> Option<(Option<SourceStat>, u64, Option<String>)> {
     use tokio::io::AsyncReadExt;
 
-    let file = tokio::fs::File::open(path).await.ok()?;
+    let file = open_file_for_head_read(path).await?;
     let stat = SourceStat::from_open_file(&file).await;
     let mut bytes = Vec::new();
     file.take(SOURCE_PREVIEW_BYTES)
@@ -1209,6 +1226,80 @@ async fn read_file_source(path: &Path) -> Option<(Option<SourceStat>, u64, Optio
     let head_hash = source_version::head_hash_of(&bytes);
     let content = preview_from_owned(bytes);
     Some((stat, head_hash, content))
+}
+
+async fn open_file_for_head_read(path: &Path) -> Option<tokio::fs::File> {
+    #[cfg(any(test, debug_assertions))]
+    record_tracked_head_read(path);
+    tokio::fs::File::open(path).await.ok()
+}
+
+#[cfg(any(test, debug_assertions))]
+static TRACKED_PROVIDER_DB_RENDERS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<PathBuf, usize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[doc(hidden)]
+#[cfg(any(test, debug_assertions))]
+pub fn track_provider_db_renders(path: &Path) {
+    TRACKED_PROVIDER_DB_RENDERS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(path.to_path_buf(), 0);
+}
+
+#[cfg(any(test, debug_assertions))]
+fn record_tracked_provider_db_render(path: &Path) {
+    let mut renders = TRACKED_PROVIDER_DB_RENDERS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(count) = renders.get_mut(path) {
+        *count += 1;
+    }
+}
+
+#[doc(hidden)]
+#[cfg(any(test, debug_assertions))]
+pub fn take_tracked_provider_db_renders(path: &Path) -> usize {
+    TRACKED_PROVIDER_DB_RENDERS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(path)
+        .unwrap_or(0)
+}
+
+#[cfg(any(test, debug_assertions))]
+static TRACKED_HEAD_READS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<PathBuf, usize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[doc(hidden)]
+#[cfg(any(test, debug_assertions))]
+pub fn track_head_reads(path: &Path) {
+    TRACKED_HEAD_READS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(path.to_path_buf(), 0);
+}
+
+#[cfg(any(test, debug_assertions))]
+fn record_tracked_head_read(path: &Path) {
+    let mut reads = TRACKED_HEAD_READS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(count) = reads.get_mut(path) {
+        *count += 1;
+    }
+}
+
+#[doc(hidden)]
+#[cfg(any(test, debug_assertions))]
+pub fn take_tracked_head_reads(path: &Path) -> usize {
+    TRACKED_HEAD_READS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(path)
+        .unwrap_or(0)
 }
 
 /// Extract a JSON string value (`"field":"value"`) from a single line, as a

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -33,6 +33,7 @@
 pub mod agents;
 pub mod fork;
 pub mod scanner;
+pub mod source_version;
 
 use crate::model::AgentKind;
 use crate::platform::environment::{DiscoveryEnvironment, WslEnvironmentInfo};
@@ -43,6 +44,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, UNIX_EPOCH};
 
 pub use fork::{DuplicateForkDetector, FORK_OBSERVATION_KEY, ForkObservation};
+pub use source_version::{
+    FingerprintInputs, SourceDescriptor, SourceStat, SourceVersion, Streamability,
+};
 
 /// How many session logs may have their metadata read concurrently. Bounds the
 /// open-file and blocking-pool pressure of a whole-machine scan.
@@ -1032,6 +1036,10 @@ pub async fn session_source_preview(source: &SessionSource) -> Option<String> {
         .read_to_end(&mut bytes)
         .await
         .ok()?;
+    preview_from_owned(bytes)
+}
+
+fn preview_from_owned(bytes: Vec<u8>) -> Option<String> {
     match String::from_utf8(bytes) {
         Ok(content) => Some(content),
         Err(error) if error.utf8_error().error_len().is_none() => {
@@ -1078,49 +1086,100 @@ pub async fn session_source_tail(source: &SessionSource) -> Option<String> {
     }
 }
 
-pub async fn session_log_metadata(log: &SessionLog) -> Option<scanner::SessionMetadata> {
-    let mut metadata = session_source_metadata(&log.source, Some(log.agent_type)).await?;
+#[derive(Debug, Clone)]
+pub struct SourceRead {
+    pub metadata: scanner::SessionMetadata,
+    pub stat: Option<SourceStat>,
+    pub head_hash: Option<u64>,
+    pub content: Option<String>,
+}
+
+pub async fn session_log_read(log: &SessionLog) -> Option<SourceRead> {
+    let mut read = session_source_read(&log.source, Some(log.agent_type)).await?;
     if log.agent_type == AgentKind::Codex
         && !log.environment().is_native()
         && let SessionSource::File(path) = &log.source
-        && let Some(session_id) = metadata.session_id.as_deref()
+        && let Some(session_id) = read.metadata.session_id.as_deref()
         && let Some(title) = agents::codex::index_title_for_rollout(path, session_id).await
     {
-        metadata.title = Some(title);
-        metadata.title_source = Some(TitleSource::AiGenerated);
+        read.metadata.title = Some(title);
+        read.metadata.title_source = Some(TitleSource::AiGenerated);
     }
     if let DiscoveryEnvironment::Wsl { distribution, .. } = log.environment()
-        && let Some(cwd) = metadata.cwd.as_deref().filter(|cwd| cwd.starts_with('/'))
+        && let Some(cwd) = read
+            .metadata
+            .cwd
+            .as_deref()
+            .filter(|cwd| cwd.starts_with('/'))
     {
-        metadata.cwd = Some(
+        read.metadata.cwd = Some(
             crate::platform::environment::wsl_to_windows_path(&distribution, cwd)
                 .ok()?
                 .to_string_lossy()
                 .to_string(),
         );
     }
-    Some(metadata)
+    Some(read)
+}
+
+pub async fn session_log_metadata(log: &SessionLog) -> Option<scanner::SessionMetadata> {
+    session_log_read(log).await.map(|read| read.metadata)
 }
 
 async fn session_source_metadata(
     source: &SessionSource,
     agent_type: Option<AgentKind>,
 ) -> Option<scanner::SessionMetadata> {
+    session_source_read(source, agent_type)
+        .await
+        .map(|read| read.metadata)
+}
+
+async fn session_source_read(
+    source: &SessionSource,
+    agent_type: Option<AgentKind>,
+) -> Option<SourceRead> {
     match source {
         SessionSource::File(path) => {
-            let content = session_source_preview(source).await.unwrap_or_default();
-            Some(scanner::parse_session_metadata_with_agent(path, &content, agent_type).await)
+            let (stat, head_hash, content) = read_file_source(path)
+                .await
+                .map_or((None, None, None), |(stat, head_hash, content)| {
+                    (stat, Some(head_hash), content)
+                });
+            let metadata = scanner::parse_session_metadata_with_agent(
+                path,
+                content.as_deref().unwrap_or_default(),
+                agent_type,
+            )
+            .await;
+            Some(SourceRead {
+                metadata,
+                stat,
+                head_hash,
+                content,
+            })
         }
         SessionSource::Inline { content, .. } => {
             let mut metadata = scanner::parse_session_metadata_str(content);
             metadata.agent_type = agent_type;
-            Some(metadata)
+            Some(SourceRead {
+                metadata,
+                stat: None,
+                head_hash: None,
+                content: None,
+            })
         }
         SessionSource::ProviderDb {
             agent: AgentKind::OpenCode,
             db_path,
             session_id,
-        } => agents::opencode::db_session_metadata(db_path.clone(), session_id.clone()).await,
+        } => Some(SourceRead {
+            metadata: agents::opencode::db_session_metadata(db_path.clone(), session_id.clone())
+                .await?,
+            stat: None,
+            head_hash: None,
+            content: None,
+        }),
         SessionSource::ProviderDb {
             agent,
             db_path,
@@ -1135,6 +1194,21 @@ async fn session_source_metadata(
             None
         }
     }
+}
+
+async fn read_file_source(path: &Path) -> Option<(Option<SourceStat>, u64, Option<String>)> {
+    use tokio::io::AsyncReadExt;
+
+    let file = tokio::fs::File::open(path).await.ok()?;
+    let stat = SourceStat::from_open_file(&file).await;
+    let mut bytes = Vec::new();
+    file.take(SOURCE_PREVIEW_BYTES)
+        .read_to_end(&mut bytes)
+        .await
+        .ok()?;
+    let head_hash = source_version::head_hash_of(&bytes);
+    let content = preview_from_owned(bytes);
+    Some((stat, head_hash, content))
 }
 
 /// Extract a JSON string value (`"field":"value"`) from a single line, as a

--- a/crates/antiburn-local/src/discovery/source_version.rs
+++ b/crates/antiburn-local/src/discovery/source_version.rs
@@ -36,6 +36,68 @@ pub enum Streamability {
     InlineMaterialized,
 }
 
+impl super::Explorers {
+    pub async fn source_version(
+        &self,
+        descriptor: &SourceDescriptor,
+        read: Option<&super::SourceRead>,
+    ) -> Option<SourceVersion> {
+        match &descriptor.source {
+            SessionSource::File(_) => {
+                let read = read?;
+                let stat = read.stat.clone()?;
+                let estimated_bytes = Some(stat.size);
+                let fingerprint = FingerprintInputs {
+                    stat,
+                    head_hash: read.head_hash,
+                }
+                .fingerprint();
+                let streamability = if descriptor.agent == AgentKind::Claude {
+                    Streamability::RecordStream
+                } else {
+                    Streamability::WholeDocumentFallback
+                };
+                Some(SourceVersion {
+                    fingerprint,
+                    estimated_bytes,
+                    streamability,
+                })
+            }
+            SessionSource::ProviderDb {
+                agent,
+                db_path,
+                session_id,
+            } => {
+                let (latest, rows) = self
+                    .provider_db_fingerprint(agent, db_path, session_id)
+                    .await?;
+                Some(SourceVersion {
+                    fingerprint: format!("sv1:db:{latest}:{rows}"),
+                    estimated_bytes: None,
+                    streamability: Streamability::DatabaseRows,
+                })
+            }
+            SessionSource::Inline { content, .. } => {
+                let stat = SourceStat {
+                    identity: None,
+                    size: content.len() as u64,
+                    modified_nanos: None,
+                    changed_nanos: None,
+                };
+                Some(SourceVersion {
+                    fingerprint: FingerprintInputs {
+                        stat,
+                        head_hash: Some(head_hash_of(content.as_bytes())),
+                    }
+                    .fingerprint(),
+                    estimated_bytes: Some(content.len() as u64),
+                    streamability: Streamability::InlineMaterialized,
+                })
+            }
+        }
+    }
+}
+
 /// Identity and time inputs from an open handle or a path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceStat {
@@ -297,9 +359,189 @@ mod tests {
         assert_ne!(first.identity, second.identity);
     }
 
+    fn descriptor(agent: AgentKind, source: SessionSource) -> SourceDescriptor {
+        SourceDescriptor {
+            agent,
+            session_id: "session-1".to_string(),
+            environment: DiscoveryEnvironment::default(),
+            source,
+            updated_at_epoch: Some(100),
+        }
+    }
+
+    #[tokio::test]
+    async fn source_version_for_a_file_reports_size_and_record_stream() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let content = b"{\"session_id\":\"session-1\"}\n";
+        tokio::fs::write(&path, content)
+            .await
+            .expect("write source");
+        let log = super::super::SessionLog {
+            agent_type: AgentKind::Claude,
+            source: SessionSource::File(path),
+            updated_at: Some(100),
+            environment: DiscoveryEnvironment::default(),
+        };
+        let read = super::super::session_log_read(&log)
+            .await
+            .expect("source read");
+        let descriptor = descriptor(log.agent_type, log.source);
+
+        let version = super::super::Explorers::DISK
+            .source_version(&descriptor, Some(&read))
+            .await
+            .expect("source version");
+
+        assert_eq!(version.estimated_bytes, Some(content.len() as u64));
+        assert_eq!(version.streamability, Streamability::RecordStream);
+        assert!(version.fingerprint.starts_with("sv1:"));
+    }
+
+    #[tokio::test]
+    async fn source_version_is_none_when_the_source_cannot_be_read() {
+        let descriptor = descriptor(
+            AgentKind::Claude,
+            SessionSource::File(std::path::PathBuf::from("/missing/session.jsonl")),
+        );
+
+        assert!(
+            super::super::Explorers::DISK
+                .source_version(&descriptor, None)
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_inline_source_is_fingerprinted_from_its_content() {
+        let content = "synthetic inline session";
+        let descriptor = descriptor(
+            AgentKind::Claude,
+            SessionSource::Inline {
+                label: "inline-1".to_string(),
+                content: content.to_string(),
+            },
+        );
+
+        let version = super::super::Explorers::DISK
+            .source_version(&descriptor, None)
+            .await
+            .expect("source version");
+
+        assert_eq!(version.estimated_bytes, Some(content.len() as u64));
+        assert_eq!(version.streamability, Streamability::InlineMaterialized);
+        assert_eq!(
+            version.fingerprint,
+            format!(
+                "sv1:-:{}:-:-:{:016x}",
+                content.len(),
+                head_hash_of(content.as_bytes())
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn a_provider_db_source_reuses_the_provider_fingerprint() {
+        let dir = TempDir::new().expect("tempdir");
+        let db_path = dir.path().join("opencode.db");
+        let connection = rusqlite::Connection::open(&db_path).expect("database");
+        connection
+            .execute_batch(
+                "CREATE TABLE session (
+                     id TEXT PRIMARY KEY, parent_id TEXT,
+                     time_created INTEGER, time_updated INTEGER);
+                 CREATE TABLE message (
+                     session_id TEXT, time_created INTEGER, time_updated INTEGER);
+                 CREATE TABLE part (
+                     session_id TEXT, time_created INTEGER, time_updated INTEGER);
+                 INSERT INTO session VALUES ('session-1', NULL, 100, 120);",
+            )
+            .expect("schema");
+        drop(connection);
+        let descriptor = descriptor(
+            AgentKind::OpenCode,
+            SessionSource::ProviderDb {
+                agent: AgentKind::OpenCode,
+                db_path,
+                session_id: "session-1".to_string(),
+            },
+        );
+
+        let version = super::super::Explorers::DISK
+            .source_version(&descriptor, None)
+            .await
+            .expect("source version");
+
+        assert_eq!(version.fingerprint, "sv1:db:120:1");
+        assert_eq!(version.estimated_bytes, None);
+        assert_eq!(version.streamability, Streamability::DatabaseRows);
+    }
+
     #[cfg(windows)]
-    #[test]
-    fn windows_change_time_handles_zero_and_pre_epoch_values() {
+    #[tokio::test]
+    async fn a_source_stat_reports_identity_and_change_time() {
+        use std::mem::MaybeUninit;
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            BY_HANDLE_FILE_INFORMATION, FILE_BASIC_INFO, FileBasicInfo, GetFileInformationByHandle,
+            GetFileInformationByHandleEx,
+        };
+
+        let dir = TempDir::new().expect("tempdir");
+        let first_path = dir.path().join("first.jsonl");
+        let second_path = dir.path().join("second.jsonl");
+        tokio::fs::write(&first_path, b"first")
+            .await
+            .expect("write first");
+        tokio::fs::write(&second_path, b"second")
+            .await
+            .expect("write second");
+        let first_file = tokio::fs::File::open(&first_path)
+            .await
+            .expect("open first");
+        let second_file = tokio::fs::File::open(&second_path)
+            .await
+            .expect("open second");
+
+        let first = SourceStat::from_open_file(&first_file)
+            .await
+            .expect("first stat");
+        let first_again = SourceStat::from_open_file(&first_file)
+            .await
+            .expect("second stat");
+        let second = SourceStat::from_open_file(&second_file)
+            .await
+            .expect("other stat");
+
+        let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
+        let mut basic = MaybeUninit::<FILE_BASIC_INFO>::zeroed();
+        // SAFETY: the file owns the valid handle, and both output buffers match the requested types.
+        let (info_ok, basic_ok) = unsafe {
+            (
+                GetFileInformationByHandle(first_file.as_raw_handle(), info.as_mut_ptr()),
+                GetFileInformationByHandleEx(
+                    first_file.as_raw_handle(),
+                    FileBasicInfo,
+                    basic.as_mut_ptr().cast(),
+                    std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+                ),
+            )
+        };
+        assert_ne!(info_ok, 0);
+        assert_ne!(basic_ok, 0);
+        // SAFETY: both handle queries initialized their output buffers after they returned success.
+        let (info, basic) = unsafe { (info.assume_init(), basic.assume_init()) };
+        let file_index = (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow);
+        let expected_identity = format!("{}:{file_index}", info.dwVolumeSerialNumber);
+
+        assert_eq!(first.identity.as_deref(), Some(expected_identity.as_str()));
+        assert_eq!(
+            first.changed_nanos,
+            windows_change_time_to_unix_nanos(basic.ChangeTime)
+        );
+        assert_eq!(first, first_again);
+        assert_ne!(first.identity, second.identity);
         assert_eq!(windows_change_time_to_unix_nanos(0), None);
         assert!(windows_change_time_to_unix_nanos(1).is_some_and(|value| value < 0));
     }

--- a/crates/antiburn-local/src/discovery/source_version.rs
+++ b/crates/antiburn-local/src/discovery/source_version.rs
@@ -1,0 +1,306 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Storage-neutral source identity and version values.
+
+use super::SessionSource;
+use crate::model::AgentKind;
+use crate::platform::environment::DiscoveryEnvironment;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const FINGERPRINT_HEAD_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct SourceDescriptor {
+    pub agent: AgentKind,
+    pub session_id: String,
+    pub environment: DiscoveryEnvironment,
+    pub source: SessionSource,
+    pub updated_at_epoch: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceVersion {
+    pub fingerprint: String,
+    pub estimated_bytes: Option<u64>,
+    pub streamability: Streamability,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Streamability {
+    RecordStream,
+    DatabaseRows,
+    WholeDocumentFallback,
+    InlineMaterialized,
+}
+
+/// Identity and time inputs from an open handle or a path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceStat {
+    pub identity: Option<String>,
+    pub size: u64,
+    pub modified_nanos: Option<i128>,
+    pub changed_nanos: Option<i128>,
+}
+
+impl SourceStat {
+    pub async fn from_open_file(file: &tokio::fs::File) -> Option<Self> {
+        let metadata = file.metadata().await.ok()?;
+        Some(Self::from_open_metadata(file, &metadata))
+    }
+
+    pub async fn from_path(path: &Path) -> Option<Self> {
+        let metadata = tokio::fs::metadata(path).await.ok()?;
+        Some(Self::from_path_metadata(&metadata))
+    }
+
+    #[cfg(unix)]
+    fn from_open_metadata(_file: &tokio::fs::File, metadata: &std::fs::Metadata) -> Self {
+        Self::from_unix_metadata(metadata)
+    }
+
+    #[cfg(windows)]
+    fn from_open_metadata(file: &tokio::fs::File, metadata: &std::fs::Metadata) -> Self {
+        use std::mem::MaybeUninit;
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            BY_HANDLE_FILE_INFORMATION, FILE_BASIC_INFO, FileBasicInfo, GetFileInformationByHandle,
+            GetFileInformationByHandleEx,
+        };
+
+        let handle = file.as_raw_handle();
+        let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
+        let mut basic = MaybeUninit::<FILE_BASIC_INFO>::zeroed();
+        // SAFETY: the file owns the valid handle, and both output buffers match the requested types.
+        let (info_ok, basic_ok) = unsafe {
+            (
+                GetFileInformationByHandle(handle, info.as_mut_ptr()),
+                GetFileInformationByHandleEx(
+                    handle,
+                    FileBasicInfo,
+                    basic.as_mut_ptr().cast(),
+                    std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+                ),
+            )
+        };
+        let identity = (info_ok != 0).then(|| {
+            // SAFETY: GetFileInformationByHandle initialized the buffer after it returned success.
+            let info = unsafe { info.assume_init() };
+            let file_index = (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow);
+            format!("{}:{file_index}", info.dwVolumeSerialNumber)
+        });
+        let changed_nanos = (basic_ok != 0)
+            .then(|| {
+                // SAFETY: GetFileInformationByHandleEx initialized the buffer after it returned success.
+                let basic = unsafe { basic.assume_init() };
+                windows_change_time_to_unix_nanos(basic.ChangeTime)
+            })
+            .flatten();
+        Self {
+            identity,
+            size: metadata.len(),
+            modified_nanos: metadata.modified().ok().and_then(system_time_nanos),
+            changed_nanos,
+        }
+    }
+
+    #[cfg(unix)]
+    fn from_path_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self::from_unix_metadata(metadata)
+    }
+
+    #[cfg(windows)]
+    fn from_path_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            identity: None,
+            size: metadata.len(),
+            modified_nanos: metadata.modified().ok().and_then(system_time_nanos),
+            changed_nanos: None,
+        }
+    }
+
+    #[cfg(unix)]
+    fn from_unix_metadata(metadata: &std::fs::Metadata) -> Self {
+        use std::os::unix::fs::MetadataExt;
+
+        Self {
+            identity: Some(format!("{}:{}", metadata.dev(), metadata.ino())),
+            size: metadata.len(),
+            modified_nanos: metadata.modified().ok().and_then(system_time_nanos),
+            changed_nanos: Some(
+                i128::from(metadata.ctime()) * 1_000_000_000 + i128::from(metadata.ctime_nsec()),
+            ),
+        }
+    }
+}
+
+/// Fingerprint inputs are separate from the filesystem for deterministic tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FingerprintInputs {
+    pub stat: SourceStat,
+    pub head_hash: Option<u64>,
+}
+
+impl FingerprintInputs {
+    pub fn fingerprint(&self) -> String {
+        format!(
+            "sv1:{}:{}:{}:{}:{}",
+            self.stat.identity.as_deref().unwrap_or("-"),
+            self.stat.size,
+            optional_i128(self.stat.modified_nanos),
+            optional_i128(self.stat.changed_nanos),
+            self.head_hash
+                .map(|hash| format!("{hash:016x}"))
+                .unwrap_or_else(|| "-".to_string())
+        )
+    }
+}
+
+pub fn head_hash_of(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x100_0000_01b3;
+
+    bytes
+        .iter()
+        .take(FINGERPRINT_HEAD_BYTES)
+        .fold(OFFSET_BASIS, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(PRIME)
+        })
+}
+
+fn optional_i128(value: Option<i128>) -> String {
+    value.map_or_else(|| "-".to_string(), |value| value.to_string())
+}
+
+fn system_time_nanos(time: SystemTime) -> Option<i128> {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => i128::try_from(duration.as_nanos()).ok(),
+        Err(error) => i128::try_from(error.duration().as_nanos())
+            .ok()
+            .map(|nanos| -nanos),
+    }
+}
+
+#[cfg(windows)]
+fn windows_change_time_to_unix_nanos(change_time: i64) -> Option<i128> {
+    if change_time == 0 {
+        return None;
+    }
+    Some((i128::from(change_time) - 116_444_736_000_000_000i128) * 100)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fixed_inputs(bytes: &[u8]) -> FingerprintInputs {
+        FingerprintInputs {
+            stat: SourceStat {
+                identity: Some("device:file".to_string()),
+                size: 70_001,
+                modified_nanos: Some(100),
+                changed_nanos: Some(200),
+            },
+            head_hash: Some(head_hash_of(bytes)),
+        }
+    }
+
+    #[test]
+    fn the_head_hash_matches_the_canonical_fnv1a64_vectors() {
+        assert_eq!(format!("{:016x}", head_hash_of(b"")), "cbf29ce484222325");
+        assert_eq!(format!("{:016x}", head_hash_of(b"a")), "af63dc4c8601ec8c");
+        assert_eq!(
+            format!("{:016x}", head_hash_of(b"foobar")),
+            "85944171f73967e8"
+        );
+    }
+
+    #[test]
+    fn a_rewrite_inside_the_head_region_changes_the_head_hash_component() {
+        let bytes = vec![b'a'; 70_001];
+        let mut rewritten = bytes.clone();
+        rewritten[100] = b'b';
+
+        assert_ne!(
+            fixed_inputs(&bytes).fingerprint(),
+            fixed_inputs(&rewritten).fingerprint()
+        );
+    }
+
+    #[test]
+    fn a_rewrite_below_the_head_region_leaves_the_head_hash_component() {
+        let bytes = vec![b'a'; 70_001];
+        let mut rewritten = bytes.clone();
+        rewritten[70_000] = b'b';
+
+        assert_eq!(
+            fixed_inputs(&bytes).fingerprint(),
+            fixed_inputs(&rewritten).fingerprint()
+        );
+    }
+
+    #[test]
+    fn an_absent_component_renders_a_placeholder() {
+        let inputs = FingerprintInputs {
+            stat: SourceStat {
+                identity: None,
+                size: 12,
+                modified_nanos: None,
+                changed_nanos: None,
+            },
+            head_hash: None,
+        };
+
+        assert_eq!(inputs.fingerprint(), "sv1:-:12:-:-:-");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_source_stat_reports_identity_and_change_time() {
+        let dir = TempDir::new().expect("tempdir");
+        let first_path = dir.path().join("first.jsonl");
+        let second_path = dir.path().join("second.jsonl");
+        tokio::fs::write(&first_path, b"first")
+            .await
+            .expect("write first");
+        tokio::fs::write(&second_path, b"second")
+            .await
+            .expect("write second");
+        let first_file = tokio::fs::File::open(&first_path)
+            .await
+            .expect("open first");
+        let second_file = tokio::fs::File::open(&second_path)
+            .await
+            .expect("open second");
+
+        let first = SourceStat::from_open_file(&first_file)
+            .await
+            .expect("first stat");
+        let first_again = SourceStat::from_open_file(&first_file)
+            .await
+            .expect("second stat");
+        let second = SourceStat::from_open_file(&second_file)
+            .await
+            .expect("other stat");
+
+        assert!(
+            first
+                .identity
+                .as_deref()
+                .is_some_and(|value| value.contains(':'))
+        );
+        assert!(first.changed_nanos.is_some());
+        assert_eq!(first, first_again);
+        assert_ne!(first.identity, second.identity);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_change_time_handles_zero_and_pre_epoch_values() {
+        assert_eq!(windows_change_time_to_unix_nanos(0), None);
+        assert!(windows_change_time_to_unix_nanos(1).is_some_and(|value| value < 0));
+    }
+}

--- a/crates/antiburn-local/src/discovery/tests.rs
+++ b/crates/antiburn-local/src/discovery/tests.rs
@@ -11,6 +11,86 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use tempfile::TempDir;
 
+#[tokio::test]
+async fn one_read_serves_metadata_preview_and_fingerprint() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("session.jsonl");
+    let content = b"{\"type\":\"user\",\"sessionId\":\"session-1\",\"cwd\":\"/repo\"}\n";
+    tokio::fs::write(&path, content)
+        .await
+        .expect("write source");
+    let log = SessionLog {
+        agent_type: AgentKind::Claude,
+        source: SessionSource::File(path),
+        updated_at: None,
+        environment: Default::default(),
+    };
+
+    let read = session_log_read(&log).await.expect("source read");
+
+    assert!(read.stat.is_some());
+    assert_eq!(read.head_hash, Some(source_version::head_hash_of(content)));
+    assert_eq!(read.content.as_deref(), std::str::from_utf8(content).ok());
+    assert_eq!(read.metadata.session_id.as_deref(), Some("session-1"));
+}
+
+#[tokio::test]
+async fn a_non_claude_file_source_also_has_a_head_hash() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("session.jsonl");
+    let content = b"{\"session_id\":\"session-1\"}\n";
+    tokio::fs::write(&path, content)
+        .await
+        .expect("write source");
+    let log = SessionLog {
+        agent_type: AgentKind::Pi,
+        source: SessionSource::File(path),
+        updated_at: None,
+        environment: Default::default(),
+    };
+
+    let read = session_log_read(&log).await.expect("source read");
+
+    assert_eq!(read.head_hash, Some(source_version::head_hash_of(content)));
+}
+
+#[tokio::test]
+async fn the_preview_output_is_unchanged() {
+    let dir = TempDir::new().expect("tempdir");
+    let invalid_tail = dir.path().join("invalid-tail.jsonl");
+    tokio::fs::write(&invalid_tail, b"valid\n\xf0\x9f")
+        .await
+        .expect("write invalid tail");
+    let oversized = dir.path().join("oversized.jsonl");
+    let oversized_bytes = vec![b'a'; SOURCE_PREVIEW_BYTES as usize + 1];
+    tokio::fs::write(&oversized, &oversized_bytes)
+        .await
+        .expect("write oversized source");
+
+    assert_eq!(
+        session_source_preview(&SessionSource::File(invalid_tail)).await,
+        Some("valid\n".to_string())
+    );
+    assert_eq!(
+        session_source_preview(&SessionSource::File(oversized))
+            .await
+            .map(|content| content.len()),
+        Some(SOURCE_PREVIEW_BYTES as usize)
+    );
+}
+
+#[test]
+fn the_preview_conversion_consumes_its_buffer() {
+    let mut bytes = Vec::with_capacity(64);
+    bytes.extend_from_slice(b"valid");
+    let expected_capacity = bytes.capacity();
+
+    let content = preview_from_owned(bytes).expect("preview");
+
+    assert_eq!(content, "valid");
+    assert_eq!(content.capacity(), expected_capacity);
+}
+
 #[test]
 fn resolved_titles_are_normalized_and_unicode_safely_bounded() {
     let raw = format!("  Reader\n\trequest  {}  ", "🧪".repeat(250));

--- a/crates/antiburn-local/src/discovery/tests.rs
+++ b/crates/antiburn-local/src/discovery/tests.rs
@@ -21,13 +21,15 @@ async fn one_read_serves_metadata_preview_and_fingerprint() {
         .expect("write source");
     let log = SessionLog {
         agent_type: AgentKind::Claude,
-        source: SessionSource::File(path),
+        source: SessionSource::File(path.clone()),
         updated_at: None,
         environment: Default::default(),
     };
 
+    track_head_reads(&path);
     let read = session_log_read(&log).await.expect("source read");
 
+    assert_eq!(take_tracked_head_reads(&path), 1);
     assert!(read.stat.is_some());
     assert_eq!(read.head_hash, Some(source_version::head_hash_of(content)));
     assert_eq!(read.content.as_deref(), std::str::from_utf8(content).ok());
@@ -35,7 +37,24 @@ async fn one_read_serves_metadata_preview_and_fingerprint() {
 }
 
 #[tokio::test]
-async fn a_non_claude_file_source_also_has_a_head_hash() {
+async fn a_non_consuming_inline_source_does_not_clone_content() {
+    let log = SessionLog {
+        agent_type: AgentKind::Cursor,
+        source: SessionSource::Inline {
+            label: "cursor-inline".to_string(),
+            content: "full inline transcript".to_string(),
+        },
+        updated_at: None,
+        environment: Default::default(),
+    };
+
+    let read = session_log_read(&log).await.expect("source read");
+
+    assert!(read.content.is_none());
+}
+
+#[tokio::test]
+async fn a_non_claude_file_source_uses_whole_document_fallback() {
     let dir = TempDir::new().expect("tempdir");
     let path = dir.path().join("session.jsonl");
     let content = b"{\"session_id\":\"session-1\"}\n";
@@ -50,8 +69,27 @@ async fn a_non_claude_file_source_also_has_a_head_hash() {
     };
 
     let read = session_log_read(&log).await.expect("source read");
+    let descriptor = SourceDescriptor {
+        agent: log.agent_type,
+        session_id: "session-1".to_string(),
+        environment: log.environment,
+        source: log.source,
+        updated_at_epoch: log.updated_at,
+    };
+    let expected_fingerprint = FingerprintInputs {
+        stat: read.stat.clone().expect("source stat"),
+        head_hash: Some(source_version::head_hash_of(content)),
+    }
+    .fingerprint();
 
-    assert_eq!(read.head_hash, Some(source_version::head_hash_of(content)));
+    let version = Explorers::DISK
+        .source_version(&descriptor, Some(&read))
+        .await
+        .expect("source version");
+
+    assert_eq!(version.streamability, Streamability::WholeDocumentFallback);
+    assert_eq!(version.estimated_bytes, Some(content.len() as u64));
+    assert_eq!(version.fingerprint, expected_fingerprint);
 }
 
 #[tokio::test]


### PR DESCRIPTION
This is part of a PR stack based at #91; this PR merges into main.

### Stack · GH-70
- #91 — GH-70: local-insights architecture (base: master plan)
  - **#NNN — 0003 (CH-002): Source generations and projection revisions ← this PR**

## What this seam contains

Three-slot seam landing the durable source version contract, migration V9, and the scan-side source generation writer:

```mermaid
flowchart TD
    subgraph s0003["Seam 0003 · T3 · Source generations and projection revisions"]
        c1["c1 · Source-version types, the fingerprint composition and its...<br/><i>crates/antiburn-local/src/discovery/source_vers...</i>"]
        c2["c2 · Migration V9, store model, upsert generation arithmetic, ...<br/><i>apps/desktop/src-tauri/src/store/schema.rs, sto...</i>"]
        c3(["c3 · Explorers::source_version producers, descriptor construct...<br/><i>crates/antiburn-local/src/discovery/source_vers...</i><br/>✓ aa1ec2485 (final)"])
        c1 -->|"✓ 1cf58b5ba"| c2
        c2 -->|"✓ 054670eee"| c3
    end
    report["report · approved"]
    s0003 --> report
    classDef done fill:#d4edda,stroke:#28a745,color:#1e4620
    classDef pending fill:#fff3cd,stroke:#b8860b,color:#5c4400
    class c1,c2,c3,report done
```

- **c1**: storage-neutral source-version types (`SourceRead`, fingerprint composition with FNV-1a 64-bit hash on 64 KiB head), and the preview read split into raw head plus lossy conversion.
- **c2**: schema migration V9 (7 new columns on `session` and `session_analysis`), upsert generation arithmetic, store model updates, and migration tests.
- **c3**: `Explorers::source_version` producers for file, provider-DB, and inline sources; canonical `SourceDescriptor` construction; source fingerprint persistence; `scan.rs:describe_one_with_activity` rewired onto the shared `session_log_read` path so it reuses one bounded head read.

## Why this piece was done

CH-002 is the foundation every later Insights scope area reads. No code consumes generations until CH-005/CH-007, making this the cheapest point to land the schema and the source-version contract.

## What it changes

**Storage**: Migration V9 appends 7 columns (`source_fingerprint`, `generation`, `analyzed_generation`, `revision`, `projection_revision_0`, `projection_revision_1`, `projection_revision_2`) to `session` and `session_analysis`. Existing session_analysis rows take `analyzed_generation: 0` and `revision: 1` on upsert. V1–V8 and the analytics cache fingerprint are unchanged.

**Behavior**: Each readable session row now keeps a compact `sv1:` fingerprint of its source and a generation counter that increases only when that fingerprint changes. A read failure, stat failure, or absent provider fingerprint yields a `NULL` fingerprint; the upsert preserves the stored fingerprint and stored generation, so an unreadable source is never a new generation.

Content is now built only for consumers that use it: ProviderDb renders and Inline clones only for Claude and Codex consumers. Antigravity, Cursor, and OpenCode sessions no longer pay a discarded full-transcript cost per scan. File-backed sources keep the one-read contract: the fingerprint uses the bounded head read that describing a session already performs, and for Claude/Codex sessions the second read of that same head is removed.

**Divergences from plan** (four behavior-preserving, one user-visible fix):
1. The approved plan (line 175) explicitly specified that Inline and ProviderDb keep `SourceRead.content` unset. Following that plan caused a user-visible regression in Claude Desktop Inline sessions: subagent detection, title fallback, fork-parent extraction all depend on preview content. The fix deliberately diverges: content is now set for Claude/Codex consumers only, restoring the old behavior for those agents while keeping non-consuming agents free. This is a **behavior-preserving fix for a regression in the approved plan's specification**.
2. `scan.rs:top_up_analysis` signature changed to inject `session_log_read` result instead of taking a path. Behavior-preserving, test-enabling.
3. Inline and ProviderDb preview content building was narrowed to Claude/Codex. Behavior-preserving.
4. Inline clone guard added (same consumer cohort as ProviderDb render). Behavior-preserving.

## How to review

Read in order:
1. `crates/antiburn-local/src/discovery/source_version.rs` — new types (`SourceRead`, `SourceDescriptor`, `Explorers::source_version` producers for each source kind).
2. `crates/antiburn-local/src/discovery/mod.rs` — integration into `session_source_metadata` and `session_source_content`, fingerprint/descriptor building, new tests.
3. `apps/desktop/src-tauri/src/store/schema.rs` — migration V9 and column definitions.
4. `apps/desktop/src-tauri/src/store/model.rs` — `SessionAnalysis` structure and generation fields.
5. `apps/desktop/src-tauri/src/store/mod.rs` — `session_from_row` and `upsert_session_in` generation arithmetic and fingerprint upsert.
6. `apps/desktop/src-tauri/src/scan.rs` — `describe_one_with_activity` rewrite onto `session_log_read` path, injection of log-read result into `top_up_analysis`, content guard for Claude/Codex consumers.
7. Tests in each crate.

Verify: The one-read contract for file sources (fingerprint reuses the head read from describe-a-session). The generation-preserving upsert for unreadable sources. Claude/Codex content building; non-consuming agents discard no content. Windows `cfg(windows)` fixture integration at line 483 (cannot compile/run on macOS; Windows CI is its first execution).

**Review hotspots** — risk triage of source entities in this diff. Hand-written, source-only.

| Entity | File | Risk | Signals |
|---|---|---|---|
| `SourceRead` (struct, new) | `crates/antiburn-local/src/discovery/source_version.rs` | Medium (0.48) | new public type · discoverer contract boundary · fingerprint/content fields used by scan and store |
| `SourceDescriptor` (struct, new) | `crates/antiburn-local/src/discovery/source_version.rs` | Medium (0.44) | new persisted descriptor · canonical source identity across session lifetime |
| `Explorers::source_version` (fn, new) | `crates/antiburn-local/src/discovery/mod.rs` | Medium (0.46) | new producer · reads every session source three ways · blast 2 (Inline, file, ProviderDb arms call distinct content paths) |
| `describe_one_with_activity` (fn, modified) | `apps/desktop/src-tauri/src/scan.rs` | High (0.62) | scan entry point rewrite · behavior-critical · 437 line diff · reuses head read on session_log_read path · content consumer guard for Claude/Codex · regression fix from approved plan |
| `upsert_session_in` (fn, modified) | `apps/desktop/src-tauri/src/store/mod.rs` | High (0.58) | generation upsert arithmetic · persisted generation tracking · unreadable-source semantics (preserves old generation on NULL fingerprint) |
| `session_from_row` (fn, modified) | `apps/desktop/src-tauri/src/store/mod.rs` | Medium (0.42) | reads new fingerprint/generation columns from session row · used on every session load |
| Migration V9 (schema.rs) | `apps/desktop/src-tauri/src/store/schema.rs` | High (0.64) | schema migration on live databases · 7 new columns · persisted data shape change · deployed to every session row |

## Verification

- Crates/antiburn-local: 694 tests, fmt clean, clippy -D warnings clean.
- Apps/desktop/src-tauri: 400 tests, fmt clean, clippy -D warnings clean.
- `pnpm run slop`: exits 1 on five standing issue #90 findings (none in this seam's diff) plus two pre-existing non-blocking warnings in an untouched file. Per AGENTS.md this seam must not fix standing #90 findings.
- **Windows CI risk**: the `cfg(windows)` SourceStat fixture `a_source_stat_reports_identity_and_change_time` (crates/antiburn-local/src/discovery/source_version.rs line 483) cannot compile on the macOS dev checkout (E0463: missing x86_64-pc-windows-msvc std target). **Windows CI is its first real execution.** Reviewers should watch the Windows jobs specifically for this fixture.

