### PR TITLE
chore(desktop): round macOS nudge windows

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -208,7 +208,7 @@ sizes:
 rounded:
   small: 4px
   control: 5px
-  popover: 10px
+  popover: 10px # outer corner for macOS floating popover and notification surfaces
   full: 9999px
 shadow:
   popover: "0 4px 12px rgb(0 0 0 / 0.15), 0 1px 3px rgb(0 0 0 / 0.08)"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -91,10 +91,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # `tray-icon` gives the menu-bar item; `image-png` lets the tray glyph be
 # decoded from the generated PNG.
-# Two windows need `macos-private-api`. The HUD crate builds a transparent macOS
-# window, and the popover uses the window-effect builder for its rounded
-# material. Tauri's configuration check requires the shell manifest to declare
-# the feature.
+# Three windows need `macos-private-api`. The HUD and nudge crates build
+# transparent macOS windows, and the popover uses the window-effect builder for
+# its rounded material. Tauri's configuration check requires the shell manifest
+# to declare the feature.
 tauri = { version = "2", features = ["image-png", "tray-icon", "macos-private-api"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"

--- a/apps/desktop/src-tauri/crates/nudge/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/nudge/Cargo.toml
@@ -20,7 +20,9 @@ name = "antiburn_nudge"
 path = "src/lib.rs"
 
 [dependencies]
-tauri = { version = "2" }
+# The macOS notification uses a transparent window and a rounded Popover
+# material. Tauri gates both builder methods behind this feature.
+tauri = { version = "2", features = ["macos-private-api"] }
 serde = { version = "1", features = ["derive"] }
 # Facade only — the app installs the subscriber. Lets display resolution report
 # which signal picked the screen, so a misplaced notification is diagnosable from

--- a/apps/desktop/src-tauri/crates/nudge/src/window.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/window.rs
@@ -20,6 +20,9 @@ use tauri::{
     AppHandle, Manager, PhysicalPosition, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
 
+#[cfg(target_os = "macos")]
+use tauri::window::{Effect, EffectState, EffectsBuilder};
+
 use crate::NudgePlacement;
 use crate::geometry::{self, Rect};
 
@@ -28,6 +31,14 @@ use crate::geometry::{self, Rect};
 /// size. 344pt wide matches a native macOS notification banner.
 const NUDGE_WIDTH: f64 = 344.0;
 const NUDGE_HEIGHT: f64 = 168.0;
+
+/// Corner radius of the macOS notification window, in logical pixels.
+///
+/// This is `rounded.popover` from `apps/desktop/design.md`. The material and
+/// the clipped webview surface must agree. `scripts/check-design-drift.mjs`
+/// checks this copy against the design token.
+#[cfg(target_os = "macos")]
+const NUDGE_CORNER_RADIUS: f64 = 10.0;
 
 /// Inset from the screen edges.
 const NUDGE_MARGIN: f64 = 12.0;
@@ -86,13 +97,18 @@ fn build_nudge_window(app: &AppHandle, label: &str) -> tauri::Result<WebviewWind
     {
         // Undecorated with a real window shadow, and first-click-through so a CTA
         // responds to the click that would otherwise only have activated the
-        // window. The card paints its surface and its 16pt corner itself, so
-        // this window needs no vibrancy material. The popover takes the other
-        // route and lets a material draw its corner; see `popover.rs`.
+        // window. The Popover material draws the window corner. The nudge route
+        // clips its surface to the same design token in `src/styles.css`.
+        let effects = EffectsBuilder::new()
+            .effect(Effect::Popover)
+            .state(EffectState::Active)
+            .radius(NUDGE_CORNER_RADIUS)
+            .build();
         builder = builder
             .decorations(false)
-            .shadow(true)
-            .accept_first_mouse(true);
+            .transparent(true)
+            .accept_first_mouse(true)
+            .effects(effects);
     }
 
     #[cfg(target_os = "linux")]

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -18,7 +18,7 @@ if (!container) {
 
 // All three write attributes the stylesheet keys off, so they run before the
 // first paint: `data-platform` guards the platform-specific control rules,
-// `data-route` gives the popover window its corner, and `data-keyboard` gates
+// `data-route` gives floating windows their corners, and `data-keyboard` gates
 // the focus ring.
 applyPlatformAttribute()
 applyRouteAttribute()

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -96,3 +96,14 @@ body {
   border-radius: var(--radius-popover);
   overflow: hidden;
 }
+
+/*
+ * The macOS notification window uses the same Popover material and radius.
+ * Keep the root transparent so the nudge card paints the only visible surface.
+ * Clip at the root so entrance, exit, and expanded states keep the same corner.
+ */
+:root[data-platform="macos"][data-route="nudge"] #root {
+  background-color: transparent;
+  border-radius: var(--radius-popover);
+  overflow: hidden;
+}

--- a/apps/desktop/src/views/NudgeView.tsx
+++ b/apps/desktop/src/views/NudgeView.tsx
@@ -81,10 +81,8 @@ export function NudgeView() {
         key={nudge.id}
         ref={cardRef}
         // The card fills the window edge to edge and paints its own surface.
-        // This build does not enable tauri's `macos-private-api`, so the
-        // notification window is opaque and undecorated — the same chrome as the
-        // popover — and a rounded card would only reveal the window's square
-        // corners behind it.
+        // On macOS, the transparent window material and the route root clip it
+        // to `rounded.popover`. Other platforms keep their opaque window shell.
         //
         // Hover-revealed chrome below is driven by `expanded` (which is exactly
         // the hover state) rather than CSS `:hover`/`group-hover`: the pointer

--- a/scripts/check-design-drift.mjs
+++ b/scripts/check-design-drift.mjs
@@ -34,10 +34,12 @@ const CONTRACT = 'design.md';
 // It declares no tokens, so the contract does not list it as a source.
 const ENTRY_STYLESHEET = 'src/styles.css';
 
-// The window that draws its own corner from `rounded.popover`. The value is a
-// Rust constant there, because the corner comes from the window material and
-// not from a stylesheet.
-const WINDOW_CORNER_SOURCE = 'src-tauri/src/popover.rs';
+// These macOS windows draw their corners from `rounded.popover`. Each value is
+// a Rust constant because the corner comes from the window material, not CSS.
+const WINDOW_CORNER_SOURCES = [
+  { path: 'src-tauri/src/popover.rs', constant: 'CORNER_RADIUS' },
+  { path: 'src-tauri/crates/nudge/src/window.rs', constant: 'NUDGE_CORNER_RADIUS' },
+];
 
 // Each shadow token names one selector that must carry that exact box-shadow.
 const SHADOW_SELECTORS = {
@@ -511,21 +513,23 @@ export function checkDesignDrift(io = fileSystemIo()) {
     }
   }
 
-  // The macOS popover corner. The window material draws it, so the radius is
-  // a Rust constant as well as a token, and the two must agree — a window
-  // corner that differs from the surface corner inside it is visible. Rust is
-  // the one place a token value is copied rather than referenced, so it is the
-  // one place this check has to leave the stylesheets.
-  if (!io.exists(WINDOW_CORNER_SOURCE)) {
-    fail(`rounded.popover: ${WINDOW_CORNER_SOURCE} not found`);
-  } else {
-    const rust = /const\s+CORNER_RADIUS:\s*f64\s*=\s*([\d.]+)\s*;/.exec(io.read(WINDOW_CORNER_SOURCE));
+  // The macOS floating-window corners. The material draws each one, so every
+  // radius is a Rust constant as well as a token. A mismatched surface corner
+  // is visible. Rust is the one place a token value is copied, so this check
+  // must leave the stylesheets here.
+  for (const source of WINDOW_CORNER_SOURCES) {
+    if (!io.exists(source.path)) {
+      fail(`rounded.popover: ${source.path} not found`);
+      continue;
+    }
+    const pattern = new RegExp(`const\\s+${source.constant}:\\s*f64\\s*=\\s*([\\d.]+)\\s*;`);
+    const rust = pattern.exec(io.read(source.path));
     if (!rust) {
-      fail(`rounded.popover: ${WINDOW_CORNER_SOURCE} declares no CORNER_RADIUS`);
+      fail(`rounded.popover: ${source.path} declares no ${source.constant}`);
     } else if (parseFloat(rust[1]) !== parseFloat(rounded.popover)) {
       fail(
-        `rounded.popover ${rounded.popover} != CORNER_RADIUS ${rust[1]} ` +
-          `in ${WINDOW_CORNER_SOURCE}`,
+        `rounded.popover ${rounded.popover} != ${source.constant} ${rust[1]} ` +
+          `in ${source.path}`,
       );
     }
   }

--- a/scripts/check-design-drift.test.mjs
+++ b/scripts/check-design-drift.test.mjs
@@ -110,8 +110,13 @@ body {
 `;
 
 /** The popover window copies `rounded.popover` into a Rust constant. */
-const RUST = `#[cfg(target_os = "macos")]
+const POPOVER_RUST = `#[cfg(target_os = "macos")]
 const CORNER_RADIUS: f64 = 10.0;
+`;
+
+/** The nudge window copies `rounded.popover` into a Rust constant. */
+const NUDGE_RUST = `#[cfg(target_os = "macos")]
+const NUDGE_CORNER_RADIUS: f64 = 10.0;
 `;
 
 /** An in-memory desktop app. Keys are paths relative to apps/desktop. */
@@ -127,11 +132,18 @@ function io(files) {
 }
 
 /** The green fixture, with optional edits to either side of the contract. */
-function fixture({ contract = CONTRACT, css = CSS, rust = RUST, extra = {} } = {}) {
+function fixture({
+  contract = CONTRACT,
+  css = CSS,
+  popoverRust = POPOVER_RUST,
+  nudgeRust = NUDGE_RUST,
+  extra = {},
+} = {}) {
   return io({
     'design.md': contract,
     'src/styles/tokens.css': css,
-    'src-tauri/src/popover.rs': rust,
+    'src-tauri/src/popover.rs': popoverRust,
+    'src-tauri/crates/nudge/src/window.rs': nudgeRust,
     ...extra,
   });
 }
@@ -395,8 +407,19 @@ test('keeps the reduced-transparency dark block out of the system palette', () =
 // --- the popover window corner ----------------------------------------------
 
 test('reports a window corner constant that differs from the token', () => {
-  const rust = RUST.replace('10.0', '12.0');
-  assertFails(checkDesignDrift(fixture({ rust })), 'rounded.popover 10px != CORNER_RADIUS 12.0');
+  const popoverRust = POPOVER_RUST.replace('10.0', '12.0');
+  assertFails(
+    checkDesignDrift(fixture({ popoverRust })),
+    'rounded.popover 10px != CORNER_RADIUS 12.0',
+  );
+});
+
+test('reports a nudge corner constant that differs from the token', () => {
+  const nudgeRust = NUDGE_RUST.replace('10.0', '12.0');
+  assertFails(
+    checkDesignDrift(fixture({ nudgeRust })),
+    'rounded.popover 10px != NUDGE_CORNER_RADIUS 12.0',
+  );
 });
 
 test('reports a token change the window corner constant did not follow', () => {
@@ -409,10 +432,18 @@ test('reports a token change the window corner constant did not follow', () => {
 });
 
 test('reports a window source that declares no corner constant', () => {
-  assertFails(checkDesignDrift(fixture({ rust: '// nothing here\n' })), 'declares no CORNER_RADIUS');
+  assertFails(
+    checkDesignDrift(fixture({ popoverRust: '// nothing here\n' })),
+    'declares no CORNER_RADIUS',
+  );
+  assertFails(
+    checkDesignDrift(fixture({ nudgeRust: '// nothing here\n' })),
+    'declares no NUDGE_CORNER_RADIUS',
+  );
 });
 
 test('reports a window source that is missing', () => {
   const files = io({ 'design.md': CONTRACT, 'src/styles/tokens.css': CSS });
   assertFails(checkDesignDrift(files), 'src-tauri/src/popover.rs not found');
+  assertFails(checkDesignDrift(files), 'src-tauri/crates/nudge/src/window.rs not found');
 });


### PR DESCRIPTION
## Summary

- render macOS nudges with a transparent active Popover material
- use the design system's 10px `rounded.popover` radius for the native window and webview clipping
- extend design-drift checks to keep the Rust nudge radius synchronized with the token

Non-macOS window behavior remains unchanged.

## Validation

- [x] Native visual retest on `feat/issue-155-rounded-nudges`
- [x] User confirmed the rendered notification looks correct
- [x] `node --test scripts/check-design-drift.test.mjs` — 42 passed
- [x] `node scripts/check-design-drift.mjs`
- [x] Desktop test suite — 718 passed
- [x] Nudge Rust tests — 26 passed
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] `pnpm format`
- [x] Rust formatting and workspace checks
- [x] `pnpm run slop` — 100/100, zero findings

Fixes #155
