### PR TITLE
Silence clean aislop hooks and compact findings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "AISLOP_NO_TELEMETRY=1 \"$CLAUDE_PROJECT_DIR/node_modules/.bin/aislop\" hook claude"
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/claude-aislop-hook.mjs\""
           }
         ]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ pnpm run slop
 ```
 
 This command expands to `aislop ci --changes --base origin/main` and uses the
-pinned `aislop 0.14.0`. CI runs the same script against the pull request base
+pinned `aislop 0.14.1`. CI runs the same script against the pull request base
 SHA. Run `git fetch origin main` first to make the local result close to the CI
 result. The results are not identical because the bases differ.
 
@@ -170,12 +170,22 @@ justification in ASD-STE100 and name #90.
 ## Edit-time agent hooks
 
 The repository commits `PostToolUse` hooks that give advisory aislop findings.
-Claude Code runs one after each matched `Edit`, `Write` or `MultiEdit`. Codex
-runs one after each `apply_patch`, through the committed adapter
+Claude Code runs one after each matched `Edit`, `Write` or `MultiEdit`, through
+`scripts/claude-aislop-hook.mjs`. Codex runs one after each `apply_patch`, through
 `scripts/codex-aislop-hook.mjs`, after no other Codex edit path, and only when
-you complete both trust steps below. Both hooks run the repository-pinned
-`node_modules/.bin/aislop` 0.14.0. The findings are advisory, so no hook blocks
+you complete both trust steps below. Both adapters run the repository-pinned
+`node_modules/.bin/aislop` 0.14.1. The findings are advisory, so no hook blocks
 an edit.
+
+Both adapters omit hook output when aislop finds no issue. When aislop finds an
+issue, they return only the counts and one line per finding. They do not put the
+score, accountability data, or suggested actions into the agent context. The
+compact context has this shape:
+
+```text
+aislop: 1 error
+error src/example.rs:12:4 ai-slop/example-rule: The finding message.
+```
 
 The hook judges the whole edited file, so it can report standing #90 findings
 in a file you touch. Hook runs also disable the `format` and `lint` checks, so

--- a/scripts/aislop-hook-output.mjs
+++ b/scripts/aislop-hook-output.mjs
@@ -1,0 +1,129 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const AISLOP_BIN = fileURLToPath(
+  new URL("../node_modules/.bin/aislop", import.meta.url),
+);
+
+function plural(count, noun) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function oneLine(value) {
+  const text = String(value).replace(/\s+/g, " ").trim();
+  return text.length <= 240 ? text : `${text.slice(0, 237)}...`;
+}
+
+function findingLine(finding) {
+  const severity = finding.severity === "error" ? "error" : "warning";
+  const line = Number.isInteger(finding.line) ? `:${finding.line}` : "";
+  const col = Number.isInteger(finding.col) ? `:${finding.col}` : "";
+  return `${severity} ${oneLine(finding.file)}${line}${col} ${oneLine(finding.ruleId)}: ${oneLine(finding.message)}`;
+}
+
+function readCounts(feedback, findings) {
+  const counts = feedback.counts;
+  const values = [counts?.error, counts?.warning, counts?.total];
+  if (!values.every((value) => Number.isInteger(value) && value >= 0)) {
+    throw new Error("invalid aislop counts");
+  }
+  if (counts.error + counts.warning !== counts.total || findings.length > counts.total) {
+    throw new Error("inconsistent aislop counts");
+  }
+
+  const shownErrors = findings.filter(({ severity }) => severity === "error").length;
+  const shownWarnings = findings.length - shownErrors;
+  if (shownErrors > counts.error || shownWarnings > counts.warning) {
+    throw new Error("inconsistent aislop findings");
+  }
+  return counts;
+}
+
+export function compactAislopOutput(stdout) {
+  if (stdout.trim() === "") return "";
+
+  const envelope = JSON.parse(stdout);
+  const additionalContext = envelope?.hookSpecificOutput?.additionalContext;
+  if (typeof additionalContext !== "string") {
+    throw new Error("missing additionalContext");
+  }
+
+  const feedback = JSON.parse(additionalContext);
+  if (feedback?.schema !== "aislop.hook.v2" || !Array.isArray(feedback.findings)) {
+    throw new Error("invalid aislop feedback");
+  }
+
+  const findings = feedback.findings;
+  const valid = findings.every(
+    (finding) =>
+      finding &&
+      (finding.severity === "error" || finding.severity === "warning") &&
+      typeof finding.file === "string" &&
+      typeof finding.ruleId === "string" &&
+      typeof finding.message === "string",
+  );
+  if (!valid) throw new Error("invalid aislop finding");
+
+  const { error: errors, warning: warnings, total } = readCounts(feedback, findings);
+  if (total === 0) return "";
+  const counts = [];
+  if (errors > 0) counts.push(plural(errors, "error"));
+  if (warnings > 0) counts.push(plural(warnings, "warning"));
+  if (counts.length === 0) counts.push(plural(total, "finding"));
+
+  const shown = findings.length < total ? ` (${findings.length} shown)` : "";
+  const context = [`aislop: ${counts.join(", ")}${shown}`, ...findings.map(findingLine)].join(
+    "\n",
+  );
+
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: context,
+    },
+  });
+}
+
+function reportFailure(label) {
+  process.stderr.write(`${label} failed\n`);
+}
+
+export function runAislopHook(stdinText, bin = AISLOP_BIN, label = "aislop hook") {
+  return new Promise((resolve) => {
+    const child = spawn(bin, ["hook", "claude"], {
+      cwd: process.cwd(),
+      env: { ...process.env, AISLOP_NO_TELEMETRY: "1" },
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    let stdout = "";
+    let settled = false;
+
+    const finish = (code) => {
+      if (settled) return;
+      settled = true;
+      if (code !== 0) reportFailure(label);
+      resolve(code);
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(1));
+    child.on("close", (code, signal) => {
+      if (code !== 0 || signal !== null) {
+        finish(1);
+        return;
+      }
+
+      try {
+        process.stdout.write(compactAislopOutput(stdout));
+        finish(0);
+      } catch {
+        finish(1);
+      }
+    });
+    child.stdin.on("error", () => {});
+    child.stdin.end(stdinText);
+  });
+}

--- a/scripts/check-agent-hooks.test.mjs
+++ b/scripts/check-agent-hooks.test.mjs
@@ -6,6 +6,8 @@ import { dirname, join, resolve } from "node:path";
 import { after, before, test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { compactAislopOutput } from "./aislop-hook-output.mjs";
+import { run as runClaude } from "./claude-aislop-hook.mjs";
 import { AISLOP_BIN, patchFiles, run } from "./codex-aislop-hook.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -48,20 +50,30 @@ function assertProbeResult(result, path = probeRelative) {
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal("decision" in output, false);
-  const feedback = JSON.parse(output.hookSpecificOutput.additionalContext);
-  assert.equal(feedback.findings.length, 1);
-  assert.deepEqual(
-    {
-      ruleId: feedback.findings[0].ruleId,
-      severity: feedback.findings[0].severity,
-      file: feedback.findings[0].file,
-    },
-    { ruleId: "ai-slop/hardcoded-url", severity: "error", file: path },
+  const context = output.hookSpecificOutput.additionalContext;
+  assert.match(context, /^aislop: 1 error\n/);
+  assert.match(
+    context,
+    new RegExp(
+      `^error ${path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:1 ai-slop/hardcoded-url:`,
+      "m",
+    ),
   );
+  assert.equal(context.split("\n").length, 2);
+  assert.doesNotMatch(context, /suggestedActions|accountability|no_action/);
   assert.doesNotMatch(result.stderr, /\[telemetry\]/);
 }
 
-async function captureRun(input, bin) {
+function hookEnvelope(feedback) {
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: JSON.stringify(feedback),
+    },
+  });
+}
+
+async function captureRun(input, bin, runner = run) {
   let stderr = "";
   const originalWrite = process.stderr.write;
   process.stderr.write = (chunk) => {
@@ -69,7 +81,7 @@ async function captureRun(input, bin) {
     return true;
   };
   try {
-    return { code: await run(input, bin), stderr };
+    return { code: await runner(input, bin), stderr };
   } finally {
     process.stderr.write = originalWrite;
   }
@@ -86,6 +98,7 @@ before(() => {
   writeFileSync(join(fx, "clean.rs"), "fn main() {}\n");
   writeFileSync(join(fx, 'a "q"\\b.rs'), probeSource);
   executable(join(fx, "fail-bin"), "#!/bin/sh\nexit 3\n");
+  executable(join(fx, "malformed-bin"), "#!/bin/sh\ncat >/dev/null\nprintf 'not json'\n");
   executable(join(fx, "signal-bin"), "#!/bin/sh\nkill -TERM $$\n");
   executable(join(shadow, "aislop"), "#!/bin/sh\necho shadow-aislop\n");
 });
@@ -97,7 +110,7 @@ after(() => {
 test("the hook uses the pinned aislop executable", () => {
   const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
   const version = packageJson.devDependencies.aislop;
-  assert.equal(version, "0.14.0");
+  assert.equal(version, "0.14.1");
   assert.equal(execFileSync(AISLOP_BIN, ["--version"], { encoding: "utf8" }).trim(), version);
   assert.match(AISLOP_BIN, /node_modules\/.bin\/aislop$/);
 });
@@ -110,8 +123,7 @@ test("the committed hook files have the required shapes", () => {
   assert.equal(claudeGroup.matcher, "Edit|Write|MultiEdit");
   assert.equal(claudeGroup.hooks.length, 1);
   const claudeCommand = claudeGroup.hooks[0].command;
-  assert.match(claudeCommand, /AISLOP_NO_TELEMETRY=1/);
-  assert.match(claudeCommand, /node_modules\/.bin\/aislop/);
+  assert.match(claudeCommand, /scripts\/claude-aislop-hook\.mjs/);
   const serialized = JSON.stringify(claude);
   assert.doesNotMatch(serialized, /"__aislop":(?!null)/);
   assert.ok(
@@ -166,35 +178,106 @@ test("the parser follows the apply_patch structure", () => {
   );
 });
 
-test("the Claude hook reports one finding without telemetry", () => {
+test("the compact output omits clean scans and trims finding feedback", () => {
+  const clean = hookEnvelope({
+    schema: "aislop.hook.v2",
+    counts: { error: 0, warning: 0, fixable: 0, total: 0 },
+    findings: [],
+    suggestedActions: [{ id: "no_action", label: "No findings. No action needed." }],
+  });
+  assert.equal(compactAislopOutput(clean), "");
+
+  const found = hookEnvelope({
+    schema: "aislop.hook.v2",
+    counts: { error: 1, warning: 1, fixable: 0, total: 2 },
+    findings: [
+      {
+        severity: "error",
+        file: "src/one.rs",
+        line: 4,
+        col: 2,
+        ruleId: "ai-slop/example",
+        message: "First finding",
+      },
+      {
+        severity: "warning",
+        file: "src/two.rs",
+        line: 8,
+        ruleId: "complexity/example",
+        message: "Second finding",
+      },
+    ],
+    accountability: { reason: "Verbose text" },
+  });
+  const compact = JSON.parse(compactAislopOutput(found));
+  assert.equal(
+    compact.hookSpecificOutput.additionalContext,
+    "aislop: 1 error, 1 warning\n" +
+      "error src/one.rs:4:2 ai-slop/example: First finding\n" +
+      "warning src/two.rs:8 complexity/example: Second finding",
+  );
+
+  assert.throws(
+    () =>
+      compactAislopOutput(
+        hookEnvelope({
+          schema: "aislop.hook.v2",
+          counts: { error: 0, warning: 0, total: 0 },
+          findings: [{ severity: "error" }],
+        }),
+      ),
+    /invalid aislop finding/,
+  );
+  assert.throws(
+    () =>
+      compactAislopOutput(
+        hookEnvelope({
+          schema: "aislop.hook.v2",
+          counts: { error: 0, warning: 0, total: 0 },
+          findings: [
+            {
+              severity: "error",
+              file: "src/one.rs",
+              line: 4,
+              ruleId: "ai-slop/example",
+              message: "First finding",
+            },
+          ],
+        }),
+      ),
+    /inconsistent aislop counts/,
+  );
+});
+
+test("the Claude hook is silent when clean and concise when it finds slop", () => {
   const claude = JSON.parse(readFileSync(join(root, ".claude/settings.json"), "utf8"));
   const command = claude.hooks.PostToolUse[0].hooks[0].command;
   const env = { ...telemetryEnv, CLAUDE_PROJECT_DIR: root };
-  const input = JSON.stringify({ tool_input: { edits: [{ file_path: probeRelative }] } });
-  assertProbeResult(runCommand(command, input, env));
+  const input = (path) => JSON.stringify({ tool_input: { edits: [{ file_path: path }] } });
+  assertProbeResult(runCommand(command, input(probeRelative), env));
+
+  const clean = runCommand(command, input(cleanRelative), env);
+  assert.equal(clean.status, 0, clean.stderr);
+  assert.equal(clean.stdout, "");
+  assert.doesNotMatch(clean.stderr, /\[telemetry\]/);
 });
 
-test("the Codex hook preserves paths and reports without telemetry", () => {
+test("the Codex hook preserves paths, stays silent when clean, and reports concisely", () => {
   const codex = JSON.parse(readFileSync(join(root, ".codex/hooks.json"), "utf8"));
   const command = codex.hooks.PostToolUse[0].hooks[0].command;
   assertProbeResult(runCommand(command, eventFor(probeRelative)));
 
   const clean = runCommand(command, eventFor(cleanRelative));
   assert.equal(clean.status, 0, clean.stderr);
-  const cleanEnvelope = JSON.parse(clean.stdout);
-  assert.deepEqual(Object.keys(cleanEnvelope), ["hookSpecificOutput"]);
-  assert.equal(cleanEnvelope.hookSpecificOutput.hookEventName, "PostToolUse");
-  const cleanFeedback = JSON.parse(cleanEnvelope.hookSpecificOutput.additionalContext);
-  assert.equal(cleanFeedback.schema, "aislop.hook.v2");
-  assert.deepEqual(cleanFeedback.counts, { error: 0, warning: 0, fixable: 0, total: 0 });
-  assert.deepEqual(cleanFeedback.findings, []);
+  assert.equal(clean.stdout, "");
   assert.doesNotMatch(clean.stderr, /\[telemetry\]/);
 
   assertProbeResult(runCommand(command, eventFor(quotedRelative)), quotedRelative);
 });
 
-test("the adapter applies its silent and fault exit contract", async () => {
+test("the adapters apply their silent and fault exit contracts", async () => {
   const failBin = join(fx, "fail-bin");
+  const malformedBin = join(fx, "malformed-bin");
   const signalBin = join(fx, "signal-bin");
   const silentInputs = [
     "",
@@ -215,8 +298,14 @@ test("the adapter applies its silent and fault exit contract", async () => {
     assertOneLine(result.stderr);
   }
 
-  for (const bin of [join(fx, "missing-bin"), failBin, signalBin]) {
+  for (const bin of [join(fx, "missing-bin"), failBin, malformedBin, signalBin]) {
     const result = await captureRun(eventFor(probeRelative), bin);
+    assert.equal(result.code, 1);
+    assertOneLine(result.stderr);
+  }
+
+  for (const bin of [join(fx, "missing-bin"), failBin, malformedBin, signalBin]) {
+    const result = await captureRun("{}", bin, runClaude);
     assert.equal(result.code, 1);
     assertOneLine(result.stderr);
   }
@@ -240,7 +329,7 @@ test("the absolute pin ignores an aislop shadow on PATH", () => {
     execFileSync("/bin/sh", ["-c", "command -v aislop"], { env, encoding: "utf8" }).trim(),
     join(shadow, "aislop"),
   );
-  assert.equal(execFileSync(AISLOP_BIN, ["--version"], { env, encoding: "utf8" }).trim(), "0.14.0");
+  assert.equal(execFileSync(AISLOP_BIN, ["--version"], { env, encoding: "utf8" }).trim(), "0.14.1");
   const codex = JSON.parse(readFileSync(join(root, ".codex/hooks.json"), "utf8"));
   const command = codex.hooks.PostToolUse[0].hooks[0].command;
   assertProbeResult(runCommand(command, eventFor(probeRelative), env));

--- a/scripts/claude-aislop-hook.mjs
+++ b/scripts/claude-aislop-hook.mjs
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+
+import { runAislopHook } from "./aislop-hook-output.mjs";
+
+export async function run(stdinText, bin) {
+  return runAislopHook(stdinText, bin, "claude aislop hook");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  let stdin = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) stdin += chunk;
+  process.exitCode = await run(stdin);
+}

--- a/scripts/codex-aislop-hook.mjs
+++ b/scripts/codex-aislop-hook.mjs
@@ -1,9 +1,8 @@
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-export const AISLOP_BIN = fileURLToPath(
-  new URL("../node_modules/.bin/aislop", import.meta.url),
-);
+import { AISLOP_BIN, runAislopHook } from "./aislop-hook-output.mjs";
+
+export { AISLOP_BIN };
 
 export function patchFiles(patch) {
   const entries = [];
@@ -57,10 +56,6 @@ export function patchFiles(patch) {
     .filter((path) => path && !seen.has(path) && seen.add(path));
 }
 
-function reportFailure() {
-  process.stderr.write("codex aislop hook failed\n");
-}
-
 export async function run(stdinText, bin = AISLOP_BIN) {
   if (stdinText.trim() === "") return 0;
 
@@ -87,25 +82,7 @@ export async function run(stdinText, bin = AISLOP_BIN) {
     tool_input: { edits: files.map((file_path) => ({ file_path })) },
   });
 
-  return new Promise((resolve) => {
-    const child = spawn(bin, ["hook", "claude"], {
-      cwd: process.cwd(),
-      env: { ...process.env, AISLOP_NO_TELEMETRY: "1" },
-      stdio: ["pipe", "inherit", "inherit"],
-    });
-    let done = false;
-    const finish = (code) => {
-      if (done) return;
-      done = true;
-      if (code !== 0) reportFailure();
-      resolve(code);
-    };
-
-    child.on("error", () => finish(1));
-    child.on("exit", (code, signal) => finish(code === 0 && signal === null ? 0 : 1));
-    child.stdin.on("error", () => {});
-    child.stdin.end(input);
-  });
+  return runAislopHook(input, bin, "codex aislop hook");
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary

- route both Claude Code and Codex edit-time aislop hooks through one repository-owned output adapter
- emit no stdout or `additionalContext` when the scan has no findings
- replace aislop's full feedback JSON with a count header and one bounded line per finding
- fail with one stderr line when aislop exits unsuccessfully or returns malformed/inconsistent feedback
- document the behavior and cover clean, finding, malformed-output, path, pinning, and telemetry cases for both harnesses

`aislop` 0.14.1 does not have a quiet hook option. Its hidden `hook claude` command only adds `--stop` and `--on-file-changed`, and a successful edit scan still emits the full `aislop.hook.v2` envelope. The adapters therefore filter that pinned output locally.

## Expected PostToolUse display

The harness can still show its own completion marker. A clean scan must not show a `hook context` line and must not add content to the model context.

### Codex or Claude Code: no slop found

```text
• PostToolUse hook (completed)
```

There is no output below the completion marker. Some Claude Code display modes hide the completion marker too.

### Codex or Claude Code: slop found

```text
• PostToolUse hook (completed)
  hook context: aislop: 1 error
  error src/example.rs:12:4 ai-slop/example-rule: The finding message.
```

For multiple findings, the first line gives error and warning counts, followed by one line per reported finding. The context excludes the score, baseline, accountability object, next steps, and `no_action` suggestion.

## Verification

- `node --test scripts/check-agent-hooks.test.mjs` — 9/9 pass
- `pnpm run slop` — score 100, zero diagnostics
- `git diff origin/main...HEAD --check`
