### PR TITLE
feat(popover): merge app name into footer version, link to GitHub

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1166,6 +1166,14 @@ pub fn open_folder_access_settings(app: tauri::AppHandle) -> CommandResult<()> {
     app.opener().open_url(url, None::<&str>).map_err(fail)
 }
 
+/// Open the antiburn GitHub repository in the system browser.
+#[tauri::command]
+pub fn open_github_repo(app: tauri::AppHandle) -> CommandResult<()> {
+    app.opener()
+        .open_url("https://github.com/antiburn/antiburn", None::<&str>)
+        .map_err(fail)
+}
+
 /// Probe outcomes from this run, for the reader to copy into a bug report.
 ///
 /// Every entry uses the same vocabulary — `granted`, `denied`, `recorded-denial`

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -141,6 +141,7 @@ pub fn run() {
             commands::get_folder_permissions,
             commands::request_folder_access,
             commands::open_folder_access_settings,
+            commands::open_github_repo,
             commands::open_overlay_window,
             commands::get_consent_diagnostics,
             commands::recheck_folder_permissions,

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -90,7 +90,7 @@ describe("App", () => {
     render(<App />)
 
     expect(screen.queryByTestId("route-loading")).not.toBeInTheDocument()
-    await screen.findByRole("heading", { name: "antiburn" })
+    await screen.findByRole("button", { name: "antiburn v0.1.0" })
     expect(
       screen.queryByRole("heading", { name: "Stop hitting your token limits." }),
     ).not.toBeInTheDocument()

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1340,6 +1340,12 @@ export async function openFolderAccessSettings(): Promise<void> {
   await invoke("open_folder_access_settings")
 }
 
+/** Open the antiburn GitHub repository in the system browser. */
+export async function openGithubRepo(): Promise<void> {
+  if (!hasShell()) return
+  await invoke("open_github_repo")
+}
+
 /** Probe outcomes from this run, for a bug report. */
 export async function getConsentDiagnostics(): Promise<ProbeRecord[]> {
   if (!hasShell()) return []

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -464,18 +464,25 @@ describe("PopoverView", () => {
     expect(footer).not.toBeNull()
     expect(footer).toHaveTextContent("antiburn")
     expect(footer?.querySelector('[data-testid="usage-limits-bar"]')).toBeNull()
-    expect(screen.getByRole("heading", { name: "antiburn" })).toBeInTheDocument()
-    const version = screen.getByText("v0.1.0 debug")
-    expect(version).toHaveClass("type-caption", "text-label-secondary")
-    expect(version.parentElement).toHaveClass("gap-2")
+    const nameAndVersion = screen.getByRole("button", { name: "antiburn v0.1.0 debug" })
+    expect(nameAndVersion).toHaveClass("type-caption", "text-label-secondary")
+  })
+
+  it("opens the GitHub repo when the name and version are clicked", async () => {
+    render(<PopoverView />)
+    await screen.findByTestId("usage-limits-bar")
+
+    fireEvent.click(screen.getByRole("button", { name: "antiburn v0.1.0 debug" }))
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("open_github_repo"))
   })
 
   it("omits the debug label from a release build", async () => {
     mockCommands({ app_info: { appVersion: "0.1.0", debugBuild: false } })
     render(<PopoverView />)
 
-    expect(await screen.findByText("v0.1.0")).toBeInTheDocument()
-    expect(screen.queryByText("v0.1.0 debug")).toBeNull()
+    expect(await screen.findByRole("button", { name: "antiburn v0.1.0" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "antiburn v0.1.0 debug" })).toBeNull()
   })
 
   it("omits the version when app info cannot load", async () => {
@@ -520,7 +527,7 @@ describe("PopoverView", () => {
     await screen.findByText("Wire the tray popover")
     expect(screen.queryByTestId("usage-limits-bar")).not.toBeInTheDocument()
     // The plain footer is unaffected — it never depended on usage at all.
-    expect(screen.getByRole("heading", { name: "antiburn" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "antiburn v0.1.0 debug" })).toBeInTheDocument()
   })
 
   it("persists the usage-limits toggle through set_settings, and opens the meters", async () => {
@@ -862,7 +869,7 @@ describe("PopoverView — window behaviour", () => {
   it("moves focus to the heading of the surface that takes over", async () => {
     render(<PopoverView />)
 
-    const activity = await screen.findByRole("heading", { name: "antiburn" })
+    const activity = await screen.findByRole("button", { name: "antiburn v0.1.0 debug" })
     await waitFor(() => expect(activity).toHaveFocus())
 
     fireEvent.click(await screen.findByRole("button", { name: "Codex at 40 percent" }))

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -143,7 +143,6 @@ function PopoverFooter({
         type="button"
         data-view-heading
         onClick={() => void openGithubRepo()}
-        aria-label={`antiburn${versionLabel} — open the GitHub repository`}
         className="type-caption whitespace-nowrap text-label-secondary outline-none hover:underline"
       >
         antiburn{versionLabel}

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -16,6 +16,7 @@ import { attentionBanners } from "../lib/attention"
 import {
   DEFAULT_SETTINGS,
   noteInteraction,
+  openGithubRepo,
   openSettingsWindow,
   type LiveUsageSummaryPayload,
   type ProviderUsageSummaryPayload,
@@ -119,7 +120,8 @@ function usageEvidence(
 
 /**
  * The activity surface's bottom bar shows the app name and version.
- * The name also carries the surface's focus heading.
+ * The name also carries the surface's focus heading, and opens the
+ * project's GitHub repository when clicked.
  * The settings control opens the standalone Settings window.
  */
 function PopoverFooter({
@@ -131,21 +133,21 @@ function PopoverFooter({
   debugBuild: boolean
   onOpenSettings: () => void
 }) {
+  const versionLabel = appVersion ? ` v${appVersion}${debugBuild ? " debug" : ""}` : ""
+
   return (
     <div className="flex h-11 shrink-0 items-center gap-2 border-t border-separator px-4">
-      <div className="flex items-baseline gap-2">
-        {/* Focused by the popover when this surface takes over, so a keyboard
-            or screen-reader user lands in the view rather than on <body>. */}
-        <h1 data-view-heading tabIndex={-1} className="type-headline text-label outline-none">
-          antiburn
-        </h1>
-        {appVersion && (
-          <span className="type-caption whitespace-nowrap text-label-secondary">
-            v{appVersion}
-            {debugBuild ? " debug" : ""}
-          </span>
-        )}
-      </div>
+      {/* Focused by the popover when this surface takes over, so a keyboard
+          or screen-reader user lands in the view rather than on <body>. */}
+      <button
+        type="button"
+        data-view-heading
+        onClick={() => void openGithubRepo()}
+        aria-label={`antiburn${versionLabel} — open the GitHub repository`}
+        className="type-caption whitespace-nowrap text-label-secondary outline-none hover:underline"
+      >
+        antiburn{versionLabel}
+      </button>
       <button
         type="button"
         onClick={onOpenSettings}


### PR DESCRIPTION
## Summary

- Merge the footer application name and version into one quiet label.
- Open the Antiburn GitHub repository when the footer label is selected.
- Preserve the existing keyboard and screen-reader focus target.

## Validation

- TypeScript, Rust, design, and code-quality checks passed.