### PR TITLE
Give the open usage bar its row back

### DIFF
--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
@@ -101,7 +101,7 @@ function filledSegments(): number {
   return Array.from(segments).filter((node) => node.className.includes("bg-brand-tint")).length
 }
 
-describe("UsageLimitsBar — the pill row", () => {
+describe("UsageLimitsBar — the ring row", () => {
   it("states each provider's worst window as an accessible percentage", () => {
     bar()
     expect(screen.getByRole("button", { name: "Claude at 42 percent" })).toBeInTheDocument()
@@ -128,6 +128,16 @@ describe("UsageLimitsBar — the pill row", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Refreshing usage limits")
     expect(screen.getByRole("button", { name: "Claude at 42 percent" })).toBeInTheDocument()
   })
+
+  it("draws the reading as a ring alone, with the figure only on hover", () => {
+    // The row states no percentage: the ring is the glance, and the meters a
+    // click away are the readout. A figure printed here would be the same
+    // number twice.
+    bar()
+    const seat = screen.getByRole("button", { name: "Claude at 42 percent" })
+    expect(seat).toHaveTextContent("")
+    expect(seat).toHaveAttribute("title", "Claude — 42%")
+  })
 })
 
 describe("UsageLimitsBar — the disclosure", () => {
@@ -150,6 +160,50 @@ describe("UsageLimitsBar — the disclosure", () => {
     expect(open).toHaveAttribute("aria-pressed", "true")
     expect(open).toHaveAttribute("aria-controls", expect.any(String))
     expect(screen.getByRole("region", { name: "Usage limits" })).toBeInTheDocument()
+  })
+
+  it("drops the ring row and moves itself into the meters while open", () => {
+    // The point of the open state is the space the row gives back. The
+    // meters restate every ring, so keeping both spends the popover's height
+    // on one reading twice.
+    bar({ expanded: true })
+    expect(
+      screen.queryByRole("button", { name: "Claude at 42 percent" }),
+    ).not.toBeInTheDocument()
+    const region = screen.getByRole("region", { name: "Usage limits" })
+    expect(region).toContainElement(
+      screen.getByRole("button", { name: "Collapse usage limits" }),
+    )
+  })
+
+  it("carries the refresh spinner with it into the open meters", () => {
+    bar({ expanded: true, refreshing: true })
+    const region = screen.getByRole("region", { name: "Usage limits" })
+    expect(region).toContainElement(screen.getByRole("status"))
+  })
+
+  it("keeps the settings gear's treatment in both states", () => {
+    // One treatment open and closed, at the reader's request, and the same
+    // one the footer's gear uses: the meters below say whether it is open,
+    // and an orange glyph competed with the orange arcs and segments around
+    // it. `PopoverView.tsx` holds the gear this matches.
+    const { rerender } = bar()
+    expect(screen.getByRole("button", { name: "Expand usage limits" }).className).toContain(
+      "text-label-secondary",
+    )
+
+    rerender(
+      <UsageLimitsBar
+        live={liveSummary()}
+        expanded
+        onToggleExpanded={vi.fn()}
+        refreshing={false}
+        onViewAll={vi.fn()}
+      />,
+    )
+    const open = screen.getByRole("button", { name: "Collapse usage limits" })
+    expect(open.className).toContain("text-label-secondary")
+    expect(open.className).not.toContain("text-brand")
   })
 
   it("names its provider group so two providers stay tellable apart", () => {
@@ -247,9 +301,11 @@ describe("UsageLimitsBar — degraded state", () => {
     // the error is the provider's only trace. The bar must not read as "your
     // Claude usage vanished".
     bar({ live: liveSummary({ providers: [], errors: [sourceError()] }) })
-    const pill = screen.getByTestId("usage-limits-unavailable")
-    expect(pill).toHaveAccessibleName("Claude, usage unavailable (rate limited)")
-    expect(pill).toHaveTextContent("rate limited")
+    const seat = screen.getByTestId("usage-limits-unavailable")
+    expect(seat).toHaveAccessibleName("Claude, usage unavailable (rate limited)")
+    // The row states no words any more, so the failure has to survive on
+    // hover. It is also spelled out in full in the expanded listing.
+    expect(seat).toHaveAttribute("title", "Claude — rate limited")
   })
 
   it("explains the failure in the expanded listing", () => {

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { BarChartHorizontalBig, Loader2 } from "lucide-react"
-import { useId } from "react"
+import { useId, type ReactNode } from "react"
 
 import { cn } from "../../lib/cn"
 import type {
@@ -29,6 +29,17 @@ import { SegmentFigure } from "../ui/SegmentFigure"
 import { providerMark } from "./ProviderUsagePrimitives"
 import { UsageRing } from "./UsageRing"
 
+/**
+ * The diameter of a provider's ring on the closed bar, in logical pixels.
+ *
+ * Larger than the 22 it was inside a pill. The pill and the percentage beside
+ * it are gone, so the arc is the whole reading, and an arc has to be big
+ * enough to tell a low share from an empty one. It stops short of a size that
+ * competes with the session rows under it. Local geometry for this one
+ * visualization, not a shared token.
+ */
+const RING_SIZE = 26
+
 export interface UsageLimitsBarProps {
   /** The provider's own limit figures, when a source could prove any. */
   live?: LiveUsageSummaryPayload
@@ -42,9 +53,14 @@ export interface UsageLimitsBarProps {
 }
 
 /**
- * The popover's usage-limits bar: one pill per provider carrying the worst
- * live window as a mini radial and a percentage, and a chart-icon disclosure
- * that drops per-provider segmented meters below the row.
+ * The popover's usage-limits bar: one ring per provider carrying the worst
+ * live window, and a chart-icon disclosure that replaces the row with
+ * per-provider segmented meters.
+ *
+ * The two states do not stack. A closed bar is the ring row. An open one is
+ * the meters alone, with the disclosure moved onto the first provider's name:
+ * the meters restate every ring above them, and the popover needs the row's
+ * height for the activity list more than it needs the same reading twice.
  *
  * Nothing here is the local spend estimate. This bar reports only what a
  * provider itself says about the reader's standing against its own allowance.
@@ -71,45 +87,35 @@ export function UsageLimitsBar({
 
   if (limited.length === 0 && unavailable.length === 0) return null
 
+  // The provider whose name line carries the disclosure while the meters are
+  // open — the topmost group, whichever list it came from.
+  const firstGroup = limited[0]?.provider ?? unavailable[0]?.provider
+
+  const disclosure = (compact: boolean) => (
+    <LimitsDisclosure
+      expanded={expanded}
+      onToggle={onToggleExpanded}
+      regionId={regionId}
+      refreshing={refreshing}
+      compact={compact}
+    />
+  )
+
   return (
     <div data-testid="usage-limits-bar" className="relative shrink-0 border-b border-separator">
-      <div className="flex min-w-0 items-center gap-2 px-3 py-3">
-        <div className="flex min-w-0 flex-1 items-center gap-3.5">
-          {limited.map((provider) => (
-            <ProviderRadial key={provider.provider} provider={provider} onOpen={onViewAll} />
-          ))}
-          {unavailable.map((entry) => (
-            <UnavailableRadial key={entry.provider} entry={entry} />
-          ))}
+      {!expanded && (
+        <div className="flex min-w-0 items-center gap-2 px-3 py-2.5">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            {limited.map((provider) => (
+              <ProviderRadial key={provider.provider} provider={provider} onOpen={onViewAll} />
+            ))}
+            {unavailable.map((entry) => (
+              <UnavailableRadial key={entry.provider} entry={entry} />
+            ))}
+          </div>
+          {disclosure(false)}
         </div>
-
-        {refreshing && (
-          <span role="status" className="inline-flex shrink-0 items-center text-label-tertiary">
-            <Loader2 size={12} strokeWidth={2} aria-hidden="true" className="animate-spin" />
-            <span className="sr-only">Refreshing usage limits</span>
-          </span>
-        )}
-
-        {/* A chart icon with a pressed state rather than a rotating chevron:
-            the control shows what it reveals — the per-window meters — and
-            its fill shows whether they are open. */}
-        <button
-          type="button"
-          onClick={onToggleExpanded}
-          aria-expanded={expanded}
-          aria-pressed={expanded}
-          aria-controls={expanded ? regionId : undefined}
-          aria-label={expanded ? "Collapse usage limits" : "Expand usage limits"}
-          // The same height as the provider pills on the row. The open state
-          // is the orange glyph alone, with no filled pill behind it.
-          className={cn(
-            "flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors duration-[var(--duration-fast)] hover:bg-brand-tint/[0.08]",
-            expanded ? "text-brand" : "text-label-tertiary",
-          )}
-        >
-          <BarChartHorizontalBig size={15} strokeWidth={2} aria-hidden="true" />
-        </button>
-      </div>
+      )}
 
       {expanded && (
         <div
@@ -120,17 +126,85 @@ export function UsageLimitsBar({
           // gutters, and clear space between providers and between their
           // meters. The gutter splits between this region and each group, so
           // a group's hover highlight has room without moving the text.
-          className="space-y-1 px-2 pb-2"
+          //
+          // The top padding also holds the disclosure still. The button moves
+          // from this bar's own row onto the first provider's name line, and
+          // the two must sit at the same height, or the control jumps under
+          // the pointer that just clicked it.
+          className="space-y-1 px-2 pt-3 pb-2"
         >
           {limited.map((provider) => (
-            <ProviderGroup key={provider.provider} provider={provider} now={at} />
+            <ProviderGroup
+              key={provider.provider}
+              provider={provider}
+              now={at}
+              action={provider.provider === firstGroup ? disclosure(true) : undefined}
+            />
           ))}
           {unavailable.map((entry) => (
-            <UnavailableGroup key={entry.provider} entry={entry} />
+            <UnavailableGroup
+              key={entry.provider}
+              entry={entry}
+              action={entry.provider === firstGroup ? disclosure(true) : undefined}
+            />
           ))}
         </div>
       )}
     </div>
+  )
+}
+
+/**
+ * The chart-icon disclosure, and the refresh spinner that sits beside it.
+ *
+ * The same size, weight, and grey as the settings gear in the popover footer
+ * (`PopoverView.tsx`), and the same in both states. The control marks itself
+ * pressed for assistive technology, but the meters under it are the sighted
+ * answer to "is it open", and an orange glyph competed with the orange arcs
+ * and segments it sits among.
+ *
+ * `compact` is the open placement: the button shares a line with a provider's
+ * name, so it pulls its own padding back out of the line box and leaves the
+ * line the height the name alone would give it.
+ */
+function LimitsDisclosure({
+  expanded,
+  onToggle,
+  regionId,
+  refreshing,
+  compact,
+}: {
+  expanded: boolean
+  onToggle: () => void
+  regionId: string
+  refreshing: boolean
+  compact: boolean
+}) {
+  return (
+    <>
+      {refreshing && (
+        <span role="status" className="inline-flex shrink-0 items-center text-label-tertiary">
+          <Loader2 size={12} strokeWidth={2} aria-hidden="true" className="animate-spin" />
+          <span className="sr-only">Refreshing usage limits</span>
+        </span>
+      )}
+      {/* A chart icon rather than a rotating chevron: the control shows what
+          it reveals — the per-window meters. */}
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-pressed={expanded}
+        aria-controls={expanded ? regionId : undefined}
+        aria-label={expanded ? "Collapse usage limits" : "Expand usage limits"}
+        className={cn(
+          "flex h-7 w-7 shrink-0 items-center justify-center rounded-control text-label-secondary transition-colors duration-[var(--duration-fast)] hover:bg-surface-hover",
+          compact && "-my-1.5",
+        )}
+      >
+        <BarChartHorizontalBig size={14} strokeWidth={1.75} aria-hidden="true" />
+      </button>
+    </>
   )
 }
 
@@ -140,7 +214,16 @@ export function UsageLimitsBar({
  * name back, so that two providers with the same window label stay tellable
  * apart.
  */
-function ProviderGroup({ provider, now }: { provider: LiveProviderUsagePayload; now: number }) {
+function ProviderGroup({
+  provider,
+  now,
+  action,
+}: {
+  provider: LiveProviderUsagePayload
+  now: number
+  /** The disclosure, on the topmost group only. */
+  action?: ReactNode
+}) {
   return (
     <div
       role="group"
@@ -149,9 +232,12 @@ function ProviderGroup({ provider, now }: { provider: LiveProviderUsagePayload; 
     >
       {/* The same type size and color as the window labels and figures
           below; the uppercase alone marks the grouping. */}
-      <h3 className="pb-1.5 type-footnote font-medium tracking-wide uppercase text-label">
-        {provider.displayName}
-      </h3>
+      <div className="flex items-center justify-between gap-2 pb-1.5">
+        <h3 className="type-footnote font-medium tracking-wide uppercase text-label">
+          {provider.displayName}
+        </h3>
+        {action}
+      </div>
       <div className="space-y-2.5">
         {liveWindows(provider).map((window) => (
           <WindowMeterRow
@@ -167,10 +253,14 @@ function ProviderGroup({ provider, now }: { provider: LiveProviderUsagePayload; 
 }
 
 /**
- * One provider's mini radial and worst-window percentage, dressed as a pill
- * button so that it reads as interactive. A click opens the full Usage view —
- * the review removed the separate "Show All…" text button, so the radials
- * themselves are the entry point.
+ * One provider's worst-window reading, as a ring and nothing else. A click
+ * opens the full Usage view — the review removed the separate "Show All…"
+ * text button, so the radials themselves are the entry point.
+ *
+ * The pill and the percentage beside it are both gone. The figure they stated
+ * is restated by every meter one click away, and the row's job here is a
+ * glance, not a readout. The words survive on hover and for assistive
+ * technology, so nothing that was said is now unsayable.
  */
 function ProviderRadial({
   provider,
@@ -180,11 +270,13 @@ function ProviderRadial({
   onOpen?: (() => void) | undefined
 }) {
   const percent = maxLiveUsedPercent(provider)
+  const figure = percent != null ? `${Math.round(percent)}%` : "no stated figure"
   return (
     <button
       type="button"
       onClick={onOpen}
-      className="flex shrink-0 items-center gap-1.5 rounded-full border border-separator px-2.5 py-1 transition-colors duration-[var(--duration-fast)] hover:bg-brand-tint/[0.08]"
+      title={`${provider.displayName} — ${figure}`}
+      className="shrink-0 rounded-full p-1 transition-colors duration-[var(--duration-fast)] hover:bg-brand-tint/[0.08]"
       aria-label={`${provider.displayName}${
         percent != null ? ` at ${Math.round(percent)} percent` : ", no stated figure"
       }`}
@@ -193,12 +285,9 @@ function ProviderRadial({
         percent={percent}
         mark={providerMark(provider.provider)}
         glyph={providerInitial(provider.displayName)}
-        size={22}
-        className="shrink-0 text-label-secondary"
+        size={RING_SIZE}
+        className="block text-label-secondary"
       />
-      <span aria-hidden="true" className="type-footnote leading-none text-label">
-        <SegmentFigure>{percent != null ? `${Math.round(percent)}%` : "—"}</SegmentFigure>
-      </span>
     </button>
   )
 }
@@ -207,27 +296,30 @@ function ProviderRadial({
  * One provider's seat on the bar while its live reading is unavailable — a
  * failed source with nothing cached to fall back on.
  *
- * The same pill silhouette as `ProviderRadial`, so the provider visibly keeps
- * its place, with the indeterminate dashed ring and the failure in two words.
- * It is not a button: a click would open a surface with nothing on it.
+ * The same silhouette as `ProviderRadial`, so the provider visibly keeps its
+ * place, drawn with the indeterminate dashed ring. It is not a button: a
+ * click would open a surface with nothing on it.
+ *
+ * The failure is named on hover and to assistive technology, and in full in
+ * the open meters. A dashed ring on its own says "no reading", which is the
+ * part a glance needs.
  */
 function UnavailableRadial({ entry }: { entry: UnavailableLiveProvider }) {
+  const reason = liveUnavailableReason(entry.category)
   return (
     <div
       data-testid="usage-limits-unavailable"
-      className="flex shrink-0 items-center gap-1.5 rounded-full border border-separator px-2.5 py-1"
-      aria-label={`${entry.displayName}, usage unavailable (${liveUnavailableReason(entry.category)})`}
+      className="shrink-0 p-1"
+      title={`${entry.displayName} — ${reason}`}
+      aria-label={`${entry.displayName}, usage unavailable (${reason})`}
     >
       <UsageRing
         percent={null}
         mark={providerMark(entry.provider)}
         glyph={providerInitial(entry.displayName)}
-        size={22}
-        className="shrink-0 text-label-tertiary"
+        size={RING_SIZE}
+        className="block text-label-tertiary"
       />
-      <span aria-hidden="true" className="type-footnote leading-none text-label-tertiary">
-        {liveUnavailableReason(entry.category)}
-      </span>
     </div>
   )
 }
@@ -237,12 +329,22 @@ function UnavailableRadial({ entry }: { entry: UnavailableLiveProvider }) {
  * same eyebrow as `ProviderGroup`, then the failure and what it means in
  * place of the meters.
  */
-function UnavailableGroup({ entry }: { entry: UnavailableLiveProvider }) {
+function UnavailableGroup({
+  entry,
+  action,
+}: {
+  entry: UnavailableLiveProvider
+  /** The disclosure, when no provider above this one can carry it. */
+  action?: ReactNode
+}) {
   return (
     <div role="group" aria-label={entry.displayName} className="rounded-md px-2 py-2">
-      <h3 className="pb-1.5 type-footnote font-medium tracking-wide uppercase text-label">
-        {entry.displayName}
-      </h3>
+      <div className="flex items-center justify-between gap-2 pb-1.5">
+        <h3 className="type-footnote font-medium tracking-wide uppercase text-label">
+          {entry.displayName}
+        </h3>
+        {action}
+      </div>
       <p className="type-footnote text-label-secondary">
         Usage unavailable — {liveUnavailableReason(entry.category)}.
       </p>

--- a/apps/desktop/src/components/providerUsage/UsageRing.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageRing.test.tsx
@@ -48,6 +48,18 @@ describe("UsageRing", () => {
     expect(container.querySelector("circle")).not.toHaveAttribute("stroke-dasharray", "2 2")
   })
 
+  it("draws the remainder behind a stated arc, so a small share reads as one", () => {
+    // The usage bar states no figure beside the ring any more. An arc with
+    // nothing behind it states a length; an arc on a track states a share.
+    const { container } = render(<UsageRing percent={14} />)
+    expect(container.querySelector('[data-testid="usage-ring-track"]')).toBeInTheDocument()
+  })
+
+  it("draws no second track under the indeterminate ring", () => {
+    const { container } = render(<UsageRing percent={null} />)
+    expect(container.querySelector('[data-testid="usage-ring-track"]')).toBeNull()
+  })
+
   it("clamps rather than overdrawing a figure past its own limit", () => {
     const { container } = render(<UsageRing percent={140} />)
     expect(arcOffset(container)).toBeCloseTo(0, 5)

--- a/apps/desktop/src/components/providerUsage/UsageRing.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageRing.tsx
@@ -39,7 +39,7 @@ function markTransform(mark: BrandMark): string {
  *
  * Two states, and the difference between them is load-bearing:
  *
- * - **Determinate.** A stated percentage. A solid arc.
+ * - **Determinate.** A stated percentage. A solid arc over a plain track.
  * - **Indeterminate.** A provider that reports a window but no figure for it.
  *   A dashed track and no arc — visibly a ring with nothing in it rather than
  *   a ring at zero, which would be a claim.
@@ -83,9 +83,7 @@ export function UsageRing({
     >
       {clamped == null && (
         // The indeterminate state keeps its dashed track. Without it the ring
-        // would vanish. A stated percentage draws the arc alone: the caption
-        // beside the ring already gives the number, so a grey remainder adds
-        // nothing.
+        // would vanish.
         <circle
           cx="16"
           cy="16"
@@ -98,21 +96,36 @@ export function UsageRing({
         />
       )}
       {clamped != null && (
-        <circle
-          cx="16"
-          cy="16"
-          r={radius}
-          fill="none"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          stroke="var(--color-brand-tint)"
-          strokeDasharray={circumference}
-          strokeDashoffset={circumference * (1 - clamped / 100)}
-          // Twelve o'clock, clockwise. A ring that starts at three o'clock
-          // reads as an arbitrary wedge rather than as a gauge.
-          transform="rotate(-90 16 16)"
-          data-testid="usage-ring-arc"
-        />
+        <>
+          {/* The remainder the arc is measured against. The usage bar states
+              no figure beside the ring any more, so the ring alone carries the
+              reading, and an arc with no track states a length and not a
+              share. The same grey as an unfilled segment on a meter. */}
+          <circle
+            cx="16"
+            cy="16"
+            r={radius}
+            fill="none"
+            strokeWidth="2.5"
+            stroke="var(--color-surface-tertiary)"
+            data-testid="usage-ring-track"
+          />
+          <circle
+            cx="16"
+            cy="16"
+            r={radius}
+            fill="none"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            stroke="var(--color-brand-tint)"
+            strokeDasharray={circumference}
+            strokeDashoffset={circumference * (1 - clamped / 100)}
+            // Twelve o'clock, clockwise. A ring that starts at three o'clock
+            // reads as an arbitrary wedge rather than as a gauge.
+            transform="rotate(-90 16 16)"
+            data-testid="usage-ring-arc"
+          />
+        </>
       )}
       {mark && (
         // Scaled from the mark's own box into the ring's 32-unit one and


### PR DESCRIPTION
## Summary

The usage-limits bar stacked two readings on the popover's activity surface: a row of provider pills above, and, once the disclosure was open, per-window meters below that restated every one of them. The popover has a fixed height, so the row cost the activity list about four session rows to say the same thing twice.

- the two states no longer stack — a closed bar is the ring row, an open one is the meters alone
- the disclosure moves onto the first provider's name line while open, at the same height it sat at while closed, so it does not move under the pointer that just clicked it
- the closed row drops the pill container and the percentage beside each ring; the ring alone carries the reading, at 26px rather than 22
- a stated arc now draws over a plain track, because a ring with no figure beside it needs a remainder to be read against; the indeterminate ring keeps its dashed one
- the disclosure takes the settings gear's size, weight, and grey, in both states

Nothing the row used to state in words is now unsayable. A provider's figure, and a failed source's reason, survive on hover and for assistive technology, and the open meters spell both out in full.

## Screenshots

<!-- Keith: drag the two popover captures in here -->

**Closed** — two bare rings, no pill, no figure.

**Open** — rings gone, the chart icon on the `CLAUDE` line.

## Validation

Button centre measured from the top of the bar, in a real browser against the compiled stylesheet:

| | before | after |
|---|---|---|
| Closed | 26.38px | 24.38px |
| Open | 17.44px | 23.94px |
| **Drift** | **−8.94px** | **−0.44px** |

- `vitest run` — 714 passed, 75 files
- desktop type-check — passed
- desktop lint — passed
- prettier — passed
- design-contract check — in sync
- `pnpm run slop` — 0 errors; 2 warnings, both standing in `ContextTokensChart.tsx`, untouched here
- inspected in the native Tauri popover under the current system theme

## Notes for review

- `UsageRing` gained the remainder track. Only this bar uses that component, so nothing else changes.
- The compact disclosure renders inside the first provider's group, which is what aligns it by layout rather than by magic offsets. Side effect: hovering the icon also lights that group's hover tint, visible in the open screenshot. Easy to suppress if it reads wrong.
- The drift is a function of the ring size, the region's top padding, and the eyebrow's line box. Nothing enforces it at build time — jsdom cannot measure layout — so the reason lives in a comment on the padding.
