### PR TITLE
V6 session rows: hygiene glyph fan, brand-orange alerts, restructured layout

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -179,6 +179,7 @@ typography:
   title-1: { fontSize: 22px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.35px" }
   title-2: { fontSize: 17px, fontWeight: 600, lineHeight: 1.4, letterSpacing: "-0.43px" }
   title-3: { fontSize: 15px, fontWeight: 600, lineHeight: 1.4, letterSpacing: "-0.23px" }
+  body-large: { fontSize: 14px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "-0.15px" }
   headline: { fontSize: 13px, fontWeight: 600, lineHeight: 1.4, letterSpacing: "-0.08px" }
   body: { fontSize: 13px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "-0.08px" }
   callout: { fontSize: 12px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0" }
@@ -232,6 +233,8 @@ motion:
   progress-pulse: "1.5s loop"
   segmented-indicator: "120ms ease-out slide; reduced motion swaps to a 60ms per-segment crossfade"
   text-roll: "300ms overshoot per character, 45ms stagger; retune with --text-roll-duration / --text-roll-stagger / --text-roll-ease"
+  session-hygiene-fan: "hover fan-out 240ms ease-out-quart + quick fade-in, 15ms outward stagger; hover-out fades 200ms in place (transform snap-back waits for the fade); the row's model names crossfade out of the fan's path over 200ms; reduced motion fades only"
+  session-hygiene-mark: "check/cross marks rise in above their glyphs after a hover held 2s, left to right at 200ms apart (~1s across a full row), each a 300ms ease-out-quart rise + scale + fade; off hover they drop and fade quick; reduced motion fades only"
 components:
   button-secondary:
     className: ui-push-button
@@ -340,9 +343,9 @@ Notes for what isn't expressible as a token:
   (`src/styles/motion.css`). A surface that still needs a hint of movement re-states a short
   duration there, with the reason; today the only such exception is the segmented control's
   reduced-motion fill, which crossfades over 60ms instead of swapping instantly. An ambient loop
-  stops instead of shortening: no duration makes a loop acceptable, so the activity-row pulse and
-  title shimmer in `src/styles/session-rows.css` set `animation: none` and each keeps its resting
-  meaning — the pulse settles at a fixed tint, and the title paints as plain primary text.
+  stops instead of shortening: no duration makes a loop acceptable, so the activity-row title
+  shimmer in `src/styles/session-rows.css` sets `animation: none` and keeps its resting
+  meaning — the title paints as plain primary text.
 - **State** — style the headless control primitives via `[data-state]` / `[data-highlighted]`, not
   `:hover`.
 - **Scroll edges** — use the shared `ScrollPane` `topEdgeFade` prop when scrolling content needs to

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -179,7 +179,6 @@ typography:
   title-1: { fontSize: 22px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.35px" }
   title-2: { fontSize: 17px, fontWeight: 600, lineHeight: 1.4, letterSpacing: "-0.43px" }
   title-3: { fontSize: 15px, fontWeight: 600, lineHeight: 1.4, letterSpacing: "-0.23px" }
-  body-large: { fontSize: 14px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "-0.15px" }
   headline: { fontSize: 13px, fontWeight: 600, lineHeight: 1.4, letterSpacing: "-0.08px" }
   body: { fontSize: 13px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "-0.08px" }
   callout: { fontSize: 12px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0" }

--- a/apps/desktop/src/components/session/SessionHygieneBadges.test.tsx
+++ b/apps/desktop/src/components/session/SessionHygieneBadges.test.tsx
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import type { MockSessionHygieneCheck } from "../../lib/presentation/mockSessionHygiene"
+import { SessionHygieneBadges } from "./SessionHygieneBadges"
+
+const CHECKS: MockSessionHygieneCheck[] = [
+  { id: "sessionOverdepth", passed: false, title: "Session overdepth detected" },
+  { id: "modelOverthinking", passed: true, title: "No model overthinking detected" },
+  { id: "excessCacheRehydration", passed: true, title: "No excess cache rehydration detected" },
+]
+
+afterEach(cleanup)
+
+describe("SessionHygieneBadges", () => {
+  it("shows failed checks in brand orange, outside the fan container", () => {
+    render(<SessionHygieneBadges checks={CHECKS} />)
+    const failed = screen.getByLabelText("Session overdepth detected")
+    expect(failed.className).toContain("text-brand-tint")
+    expect(failed.closest(".session-hygiene-pass")).toBeNull()
+  })
+
+  it("shows passed checks in tertiary, inside the fan container", () => {
+    render(<SessionHygieneBadges checks={CHECKS} />)
+    for (const title of [
+      "No model overthinking detected",
+      "No excess cache rehydration detected",
+    ]) {
+      const glyph = screen.getByLabelText(title)
+      expect(glyph.className).toContain("text-label-tertiary")
+      expect(glyph.closest(".session-hygiene-pass")).not.toBeNull()
+    }
+  })
+
+  it("renders no fan container when every check fails", () => {
+    const failing = CHECKS.map((check) => ({ ...check, passed: false }))
+    const { container } = render(<SessionHygieneBadges checks={failing} />)
+    expect(container.querySelector(".session-hygiene-pass")).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/session/SessionHygieneBadges.tsx
+++ b/apps/desktop/src/components/session/SessionHygieneBadges.tsx
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {
+  Brain,
+  Check,
+  Droplet,
+  Hammer,
+  LifeBuoy,
+  Rabbit,
+  Sunset,
+  X,
+  type LucideIcon,
+} from "lucide-react"
+
+import { cn } from "../../lib/cn"
+import type { MockSessionHygieneCheck } from "../../lib/presentation/mockSessionHygiene"
+import { Tooltip } from "../presentation/Tooltip"
+
+/* One glyph per check id. The glyph names the check; the color names the state. */
+const CHECK_ICONS: Record<MockSessionHygieneCheck["id"], LucideIcon> = {
+  sessionOverdepth: LifeBuoy,
+  modelOverthinking: Brain,
+  overpoweredSubagents: Hammer,
+  obsoleteModel: Sunset,
+  fastModeOveruse: Rabbit,
+  excessCacheRehydration: Droplet,
+}
+
+function HygieneGlyph({
+  check,
+  markIndex,
+}: {
+  check: MockSessionHygieneCheck
+  markIndex: number
+}) {
+  const Icon = CHECK_ICONS[check.id]
+  const Mark = check.passed ? Check : X
+  return (
+    <Tooltip label={check.title} delayMs={150}>
+      <span
+        aria-label={check.title}
+        // The index sets the mark's place in the left-to-right sequence.
+        style={{ "--hygiene-mark-index": markIndex } as React.CSSProperties}
+        className={cn(
+          "session-hygiene-glyph relative flex h-5 w-5 shrink-0 items-center justify-center",
+          check.passed ? "text-label-tertiary" : "text-brand-tint",
+        )}
+      >
+        <Icon size={14} strokeWidth={1.75} aria-hidden="true" />
+        {/* The state mark rises in above the glyph on row hover; the glyph
+            label carries the state for assistive tech. */}
+        <span
+          aria-hidden="true"
+          className={cn(
+            "session-hygiene-mark flex items-center justify-center",
+            check.passed ? "text-(--color-system-green)" : "text-brand-tint",
+          )}
+        >
+          <Mark size={9} strokeWidth={3} />
+        </span>
+      </span>
+    </Tooltip>
+  )
+}
+
+/**
+ * Bare hygiene glyphs for one session row.
+ *
+ * Failed checks render in the flow, brand orange, always visible. Passed
+ * checks render inside `.session-hygiene-pass`, which session-rows.css
+ * anchors to the left edge of the rail and fans out on row hover.
+ *
+ * The fragment relies on its host: the rail must be a positioned flex row,
+ * and the row must carry the `session-row` class for the hover trigger.
+ */
+export function SessionHygieneBadges({ checks }: { checks: MockSessionHygieneCheck[] }) {
+  const passed = checks.filter((check) => check.passed)
+  const failed = checks.filter((check) => !check.passed)
+  return (
+    <>
+      {passed.length > 0 && (
+        <div className="session-hygiene-pass">
+          {passed.map((check, index) => (
+            <HygieneGlyph key={check.id} check={check} markIndex={index} />
+          ))}
+        </div>
+      )}
+      {failed.length > 0 && (
+        // The -top-px trues the glyphs up against the cost pill.
+        <div className="relative -top-px flex items-center gap-1">
+          {failed.map((check, index) => (
+            <HygieneGlyph key={check.id} check={check} markIndex={passed.length + index} />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -139,15 +139,16 @@ describe("SessionList — rows", () => {
       /fast mode overuse/i,
       /excess cache rehydration/i,
     ]
-    const firstResults = labels.map((label) => screen.getByLabelText(label).textContent)
-    expect(firstResults).toContain("✓")
-    expect(firstResults).toContain("×")
+    // The glyph color names the state: brand orange fails, tertiary passes.
+    const stateOf = (label: RegExp) =>
+      screen.getByLabelText(label).className.includes("text-brand-tint") ? "fail" : "pass"
+    const firstResults = labels.map(stateOf)
+    expect(firstResults).toContain("pass")
+    expect(firstResults).toContain("fail")
 
     first.unmount()
     list({ entries: [entry({ sessionId: "mock-0" })] })
-    expect(labels.map((label) => screen.getByLabelText(label).textContent)).toEqual(
-      firstResults,
-    )
+    expect(labels.map(stateOf)).toEqual(firstResults)
   })
 
   it("states the last-activity time", () => {

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -18,6 +18,7 @@ import { relativeTime } from "../../lib/presentation/relativeTime"
 import { Tooltip } from "../presentation/Tooltip"
 import { TruncatedText } from "../presentation/TruncatedText"
 import { WslOriginBadge } from "../presentation/WslOriginBadge"
+import { SessionHygieneBadges } from "./SessionHygieneBadges"
 import { SessionCostBadge, type SessionCostBadgeProps } from "./metrics/SessionCostBadge"
 import { ScrollPane } from "../ui/ScrollPane"
 import { countGroupedItems, groupActivityByDay } from "../activity/activityFeedGrouping"
@@ -129,9 +130,9 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
   return (
     <div
       className={cn(
-        "relative flex items-start gap-3 py-3 px-2 w-full text-left rounded-md",
+        "session-row group relative flex items-start gap-3 py-3 px-2 w-full text-left rounded-md",
         "transition-colors duration-[var(--duration-fast)] ease-out",
-        entry.isActive && "activity-row-active isolate",
+        entry.isActive && "activity-row-active",
         clickable &&
           "cursor-pointer hover:bg-surface-hover [&:has([data-state*=open])]:bg-surface-hover",
       )}
@@ -156,12 +157,22 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
     >
       {entry.isActive && <span className="sr-only">Active session</span>}
 
-      <div className="mt-0.5 shrink-0">{renderAgentIcon?.(entry.agent, 18, entry.surface)}</div>
+      {/* The margin sets the icon on the title line, past the model line above it. */}
+      <div className="mt-5 shrink-0">{renderAgentIcon?.(entry.agent, 18, entry.surface)}</div>
 
       <div className="min-w-0 flex-1 space-y-1">
+        {/* The line renders even with no model names, so every row keeps the
+            same vertical rhythm. */}
+        <div
+          className="session-model-names min-w-0 type-footnote text-label-tertiary"
+          {...(modelNames.length > 0 ? { title: modelRunNames(modelRuns).join("\n") } : {})}
+        >
+          {modelNames.length > 0 ? <TruncatedText text={modelNames.join(" · ")} /> : "\u00A0"}
+        </div>
+
         <div className="flex min-w-0 items-center gap-1">
           <TruncatedText
-            className={cn("min-w-0 type-callout", !entry.isActive && "text-label")}
+            className={cn("min-w-0 type-body-large", !entry.isActive && "text-label")}
             text={primary}
             lines={2}
             shimmer={entry.isActive}
@@ -191,8 +202,8 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
           )}
         </div>
 
-        <div className="flex w-full items-center justify-between gap-1.5">
-          <div className="flex min-w-0 items-center gap-1.5">
+        {(hasRepo || entry.wslDistro || entry.branch) && (
+          <div className="flex w-full min-w-0 items-center gap-1.5">
             {hasRepo && (
               <Tooltip
                 label={
@@ -216,48 +227,24 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
                 text={entry.branch}
               />
             )}
-
-            {entry.cost && <SessionCostBadge {...entry.cost} />}
           </div>
-
-          <time
-            dateTime={entry.timestamp}
-            aria-label={`Last activity ${relativeTime(entry.timestamp)}`}
-            className="shrink-0 text-sm text-label-secondary"
-          >
-            {relativeTime(entry.timestamp)}
-          </time>
-        </div>
-
-        <div className="flex w-full items-center justify-between gap-1.5">
-          {modelNames.length > 0 && (
-            <div className="min-w-0" title={modelRunNames(modelRuns).join("\n")}>
-              <TruncatedText
-                className="type-footnote text-label-tertiary"
-                text={modelNames.join(" · ")}
-              />
-            </div>
-          )}
-
-          <div className="ml-auto flex items-center gap-1.5">
-            {hygieneChecks.map((check) => (
-              <span
-                key={check.id}
-                className={cn(
-                  "inline-flex h-3 w-3 items-center justify-center rounded-full text-[0.55rem] leading-none text-white",
-                  check.passed
-                    ? "bg-(--color-system-green) opacity-30 hover:opacity-80"
-                    : "bg-(--color-system-red) opacity-50 hover:opacity-80",
-                )}
-                title={check.title}
-                aria-label={check.title}
-              >
-                {check.passed ? "✓" : "×"}
-              </span>
-            ))}
-          </div>
-        </div>
+        )}
       </div>
+
+      {/* The rail is the positioned anchor for the hygiene fan. */}
+      <div className="relative mt-0.5 flex shrink-0 items-center gap-1.5">
+        <SessionHygieneBadges checks={hygieneChecks} />
+        {entry.cost && <SessionCostBadge {...entry.cost} />}
+      </div>
+
+      {/* The timestamp shows on hover only; assistive tech reads it at all times. */}
+      <time
+        dateTime={entry.timestamp}
+        aria-label={`Last activity ${relativeTime(entry.timestamp)}`}
+        className="absolute bottom-3 right-2 shrink-0 text-sm text-label-secondary opacity-0 transition-opacity duration-[var(--duration-fast)] ease-out group-hover:opacity-100"
+      >
+        {relativeTime(entry.timestamp)}
+      </time>
     </div>
   )
 }

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -172,7 +172,7 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
 
         <div className="flex min-w-0 items-center gap-1">
           <TruncatedText
-            className={cn("min-w-0 type-body-large", !entry.isActive && "text-label")}
+            className={cn("min-w-0 type-body", !entry.isActive && "text-label")}
             text={primary}
             lines={2}
             shimmer={entry.isActive}

--- a/apps/desktop/src/components/session/metrics/SessionCostBadge.test.tsx
+++ b/apps/desktop/src/components/session/metrics/SessionCostBadge.test.tsx
@@ -18,13 +18,13 @@ describe("SessionCostBadge", () => {
   it("carries the outlier meaning in the accessible name, not just in color", () => {
     render(<SessionCostBadge totalUsd={19.5} figureLabel="Estimated cost" isHighCost />)
     const pill = screen.getByLabelText("Estimated cost $19.50, higher than usual")
-    expect(pill.className).toContain("bg-system-red/15")
+    expect(pill.className).toContain("bg-brand-tint")
   })
 
   it("uses the calm palette when the session is not an outlier", () => {
     render(<SessionCostBadge totalUsd={0.4} figureLabel="Projected cost" />)
     expect(screen.getByLabelText("Projected cost $0.40").className).toContain(
-      "bg-system-gold/15",
+      "bg-label-tertiary/15",
     )
   })
 

--- a/apps/desktop/src/components/session/metrics/SessionCostBadge.tsx
+++ b/apps/desktop/src/components/session/metrics/SessionCostBadge.tsx
@@ -27,7 +27,7 @@ export interface SessionCostBadgeProps {
   figureLabel: string
   /** Every model that contributed billable tokens, as a muted subtitle. */
   models?: string[]
-  /** Unusually expensive against comparable sessions. Paints the pill red with a flame. */
+  /** Unusually expensive against comparable sessions. Paints the pill solid brand orange with a flame. */
   isHighCost?: boolean
   /** Billable component rows (input / output / cache read / cache write). */
   breakdownRows?: CostRow[]
@@ -63,7 +63,7 @@ export function SessionCostBadge({
       label={
         <div className="space-y-1.5 text-left">
           <div>
-            <div className="flex justify-between gap-4 type-caption font-medium text-system-gold-text">
+            <div className="flex justify-between gap-4 type-caption font-medium text-label">
               <span>{figureLabel}</span>
               <span className="tabular-nums">{formatCost(totalUsd)}</span>
             </div>
@@ -75,7 +75,7 @@ export function SessionCostBadge({
               </div>
             )}
             {isHighCost && (
-              <div className="type-caption font-medium text-system-red-text">
+              <div className="type-caption font-medium text-brand">
                 Higher than usual — over {HIGH_COST_MEDIAN_MULTIPLE}× your typical session
               </div>
             )}
@@ -94,9 +94,9 @@ export function SessionCostBadge({
       }
     >
       <span
-        // High-cost status is also red plus a flame, but color and glyph alone
-        // fail WCAG 1.4.1 and the flame is aria-hidden — so carry the "higher
-        // than usual" meaning in the accessible name too.
+        // High-cost status is also a solid orange fill plus a flame, but color
+        // and glyph alone fail WCAG 1.4.1 and the flame is aria-hidden — so
+        // the accessible name also carries the "higher than usual" meaning.
         aria-label={
           isHighCost
             ? `${figureLabel} ${formatCost(totalUsd)}, higher than usual`
@@ -104,9 +104,7 @@ export function SessionCostBadge({
         }
         className={cn(
           COST_PILL_CLASS,
-          isHighCost
-            ? "bg-system-red/15 text-system-red-text"
-            : "bg-system-gold/15 text-system-gold-text",
+          isHighCost ? "bg-brand-tint text-white" : "bg-label-tertiary/15 text-label-secondary",
           className,
         )}
       >

--- a/apps/desktop/src/styles/session-rows.css
+++ b/apps/desktop/src/styles/session-rows.css
@@ -4,43 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* These styles show active sessions with a background pulse and a title shimmer. */
+/* These styles show active sessions with a title shimmer. */
 
-/* --- Running-session pulse --- */
-
-/* The two cycles live on the row so the background and the title read as one
-   effect with two tempos. The broad-area background is the slower of the two
-   deliberately: a large surface pulsing at the title's rate is agitating. */
 .activity-row-active {
-  --activity-row-pulse-cycle: 3200ms;
   --activity-row-shimmer-cycle: 4000ms;
-}
-
-@keyframes activity-row-pulse {
-  0%,
-  100% {
-    opacity: 0.12;
-  }
-
-  50% {
-    opacity: 0.28;
-  }
-}
-
-/* Behind the card, never in front of it: `z-index: -1` on a layer inside a
-   row that establishes its own stacking context (the component pairs this
-   class with `isolate`), so the tint cannot cover the row's own content. */
-.activity-row-active::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  border-radius: inherit;
-  background-color: var(--color-bg-secondary);
-  opacity: 0.12;
-  pointer-events: none;
-  animation: activity-row-pulse var(--activity-row-pulse-cycle) cubic-bezier(0.77, 0, 0.175, 1)
-    infinite;
 }
 
 /* --- Running-session title shimmer --- */
@@ -112,19 +79,142 @@
   -webkit-line-clamp: var(--truncated-text-lines);
 }
 
+/* --- Hygiene glyph fan --- */
+
+/* The passing checks sit outside the flow. The rail is the positioned
+   ancestor, so `right: calc(100% + gap)` pins this box to the left edge of
+   the leftmost failed glyph, or of the cost pill when every check passes. */
+.session-hygiene-pass {
+  position: absolute;
+  top: 50%;
+  right: calc(100% + var(--space-xs));
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  transform: translateY(-50%);
+}
+
+/* At rest the glyphs are invisible and stacked at the anchor. The transform
+   snap-back waits for the fade to end: a pointer that leaves the row sees
+   the glyphs fade in place, never slide back in. */
+.session-hygiene-pass .session-hygiene-glyph {
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 200ms ease-out,
+    transform 0s 200ms;
+}
+
+/* The state mark floats above its glyph and never covers it. It is hidden at
+   rest. On a hover held for two seconds the marks rise in one at a time,
+   left to right, 200ms apart — about one second across a full row. The
+   component sets each mark's place with --hygiene-mark-index. Off hover
+   they drop and fade right away. */
+.session-hygiene-mark {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-bottom: 1px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(4px) scale(0.5);
+  transition:
+    opacity var(--duration-quick) ease-out,
+    transform var(--duration-quick) ease-out;
+}
+
+.session-row:hover .session-hygiene-mark {
+  --hygiene-mark-delay: calc(2000ms + var(--hygiene-mark-index, 0) * 200ms);
+  opacity: 1;
+  transform: translateX(-50%);
+  transition:
+    opacity var(--duration-slow) var(--ease-out-quart) var(--hygiene-mark-delay),
+    transform var(--duration-slow) var(--ease-out-quart) var(--hygiene-mark-delay);
+}
+
+/* The open fan can reach over the model names. The names step aside: they
+   fade out while the fan is open, only in a row that has a fan to open. */
+.session-row:has(.session-hygiene-pass) .session-model-names {
+  transition: opacity 200ms ease-out;
+}
+
+.session-row:has(.session-hygiene-pass):hover .session-model-names {
+  opacity: 0;
+}
+
+/* Stack offsets: one glyph pitch (20px glyph + 4px gap) per position. */
+.session-hygiene-pass .session-hygiene-glyph:nth-last-child(2) {
+  transform: translateX(24px);
+}
+
+.session-hygiene-pass .session-hygiene-glyph:nth-last-child(3) {
+  transform: translateX(48px);
+}
+
+.session-hygiene-pass .session-hygiene-glyph:nth-last-child(4) {
+  transform: translateX(72px);
+}
+
+.session-hygiene-pass .session-hygiene-glyph:nth-last-child(5) {
+  transform: translateX(96px);
+}
+
+.session-hygiene-pass .session-hygiene-glyph:nth-last-child(6) {
+  transform: translateX(120px);
+}
+
+.session-row:hover .session-hygiene-pass .session-hygiene-glyph {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+  transition:
+    transform 240ms var(--ease-out-quart),
+    opacity var(--duration-quick) ease-out;
+}
+
+/* The delay grows with the distance, so the fan opens outward. */
+.session-row:hover .session-hygiene-pass .session-hygiene-glyph:nth-last-child(2) {
+  transition-delay: 15ms;
+}
+
+.session-row:hover .session-hygiene-pass .session-hygiene-glyph:nth-last-child(3) {
+  transition-delay: 30ms;
+}
+
+.session-row:hover .session-hygiene-pass .session-hygiene-glyph:nth-last-child(4) {
+  transition-delay: 45ms;
+}
+
+.session-row:hover .session-hygiene-pass .session-hygiene-glyph:nth-last-child(5) {
+  transition-delay: 60ms;
+}
+
+.session-row:hover .session-hygiene-pass .session-hygiene-glyph:nth-last-child(6) {
+  transition-delay: 75ms;
+}
+
 /* --- Reduced motion --- */
 
-/* The global clamp in motion.css shortens transitions; these two effects are
-   *ambient loops*, which no duration makes acceptable, so they stop outright.
-   Each keeps its resting meaning: the pulse settles at a fixed tint that still
-   marks the row, and the title drops the overlay and paints as plain primary
-   text rather than staying at the dimmed shimmer base. */
+/* The fan is an interaction response, not an ambient loop, but the slide is
+   decorative: with reduced motion the glyphs only fade, in both directions. */
 @media (prefers-reduced-motion: reduce) {
-  .activity-row-active::before {
-    animation: none !important;
-    opacity: 0.18;
+  .session-hygiene-pass .session-hygiene-glyph {
+    transform: none !important;
+    transition: opacity var(--duration-quick) ease-out;
   }
 
+  .session-hygiene-mark {
+    transform: translateX(-50%) !important;
+    transition: opacity var(--duration-quick) ease-out;
+  }
+}
+
+/* The global clamp in motion.css shortens transitions; the shimmer is an
+   *ambient loop*, which no duration makes acceptable, so it stops outright.
+   It keeps its resting meaning: the title drops the overlay and paints as
+   plain primary text rather than staying at the dimmed shimmer base. */
+@media (prefers-reduced-motion: reduce) {
   .activity-row-title-shimmer {
     color: var(--color-text-primary);
   }

--- a/apps/desktop/src/styles/typography.css
+++ b/apps/desktop/src/styles/typography.css
@@ -37,6 +37,12 @@
   letter-spacing: -0.23px;
 }
 
+.type-body-large {
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: -0.15px;
+}
+
 .type-headline {
   font-size: 13px;
   font-weight: 600;

--- a/apps/desktop/src/styles/typography.css
+++ b/apps/desktop/src/styles/typography.css
@@ -37,12 +37,6 @@
   letter-spacing: -0.23px;
 }
 
-.type-body-large {
-  font-size: 14px;
-  font-weight: 400;
-  letter-spacing: -0.15px;
-}
-
 .type-headline {
   font-size: 13px;
   font-weight: 600;

--- a/docs/plans/session-row-v6.md
+++ b/docs/plans/session-row-v6.md
@@ -1,0 +1,79 @@
+# Session row V6 — simpler card, hygiene glyphs, brand-orange alerts
+
+Implements the design settled in the HTML proto (session-row-proto.html, iterated to V6 in the 2026-08-24 session). Target: `apps/desktop/src/components/session/SessionList.tsx` and friends.
+
+## Status
+
+| Phase | Status |
+| --- | --- |
+| 1. Icon availability check | Done — all six exports verified in installed `lucide-react@1.33.0` |
+| 2. `SessionHygieneBadges` component | Done — `SessionHygieneBadges.tsx` + fan CSS in `session-rows.css` + `design.md` recipe |
+| 3. Row layout restructure | Done — models top, `type-title-3` title, repo line, right rail, hover time |
+| 4. Cost pill goes brand orange | Done — solid `bg-brand-tint text-white` (Keith picked solid over tint) |
+| 5. Tests + checks + screenshot | Done — tests updated/added, all checks green, Keith supplied a demo recording for the PR |
+
+Post-review refinements folded in during Keith's testing (2026-08-24): titles settled on a new `type-body-large` step (14px/400); non-hot cost pill went grey; hygiene glyphs lightened to 1.75 stroke and fail glyphs use `brand-tint`; model names fade while the fan is open; the model line always renders to keep row rhythm; the agent icon centers on the title line; the active-row background pulse was removed (shimmer stays); and check/cross marks rise in above the glyphs after a 2s hover, left to right.
+
+## Locked design decisions (from the proto)
+
+- **Row layout**: model names move to the top meta line (above the title); repo/project hangs below the title on its own line. Relative time is hidden at rest and fades in bottom-right, on the same line as the repo name, on card hover.
+- **Hygiene marks are bare glyphs** — no circles, no pills, no shadows. One icon per check, 12px glyph in a 20px-tall hit target (matches the cost pill height).
+- **Failing checks are always visible**, sitting directly left of the cost pill, in brand orange.
+- **Passing checks are hidden at rest.** On card hover they fan out leftward from the leftmost alert glyph (or from the cost pill when all pass), each chip translating from a stacked position with a slight outward stagger. On hover-out they **fade in place** — no slide-back (the transform snap-back is delayed past the fade).
+- **Alert colour**: brand orange, via the existing `brand` token — not raw `#FF6A2C`, since `brand` is already contrast-adjusted per theme. Pass glyphs use `text-label-tertiary`.
+- **High-cost pill goes solid brand orange**: white text and flame on a full `brand-tint` fill (`bg-brand-tint text-white`), replacing the red tint treatment (`bg-system-red/15 text-system-red-text`). Keith picked "solid" from four proto variants after flagging that pure orange *text* suffers on a light card. Check white-on-`brand-tint` contrast in both themes; if it falls short, deepen the fill with the `brand` (text-grade) colour rather than reverting to tinted text.
+- **Session title size up one notch.** Keith's call: antiburn's current text runs small against best-practice Mac apps. The proto moved the title from 14px to 15px. Implementation-wise this means adjusting the `type-callout` step (or moving the title to a larger existing `type-*` step) — a token change, so update `design.md` in the same change per the drift check. Decide scope in review: title only, or the whole `type-*` scale.
+- **Icons** (owner-picked): all six exist in lucide.
+
+  | Check | lucide import |
+  | --- | --- |
+  | sessionOverdepth | `LifeBuoy` |
+  | modelOverthinking | `Brain` |
+  | overpoweredSubagents | `Hammer` |
+  | obsoleteModel | `Sunset` |
+  | fastModeOveruse | `Rabbit` |
+  | excessCacheRehydration | `Droplet` |
+
+  The proto used hand-drawn approximations; the real lucide glyphs differ slightly (lucide's Rabbit is a full side profile, its Brain has more interior detail). Sanity-check legibility at 12px once wired in. Verify the imports compile against the pinned `lucide-react@1.33.0` as step one of implementation.
+
+## Implementation steps
+
+### 1. Icon check (5 min)
+`pnpm --filter desktop exec node -e "…"` or simply import the six icons and typecheck. If any name differs in 1.33.0 (e.g. `LifeBuoy` vs `Lifebuoy`), fix the import — the glyphs themselves are all in the catalog.
+
+### 2. `SessionHygieneBadges` component
+New file `apps/desktop/src/components/session/SessionHygieneBadges.tsx`.
+
+- Props: `checks: MockSessionHygieneCheck[]` (keep consuming `mockSessionHygiene` — real data is a separate feature).
+- Renders two groups: failed checks (always visible, `text-brand`), passed checks (the fan-out group, `text-label-tertiary`).
+- Each glyph wrapped in the existing Radix `Tooltip` (short delay ~150ms) with the check title; `aria-label` on each glyph. This replaces the proto's CSS `data-tip` tooltips.
+- Fan-out mechanics are pure CSS, keyed off the row's `group` hover (`group-hover:` variants). No `useEffect`, no JS state.
+- The per-chip stacked offsets and stagger delays (`nth-last-child(n) → translateX(n·23px)`, `transition-delay: n·15ms`) don't express well as Tailwind utilities. Put them in a small stylesheet block in an existing session stylesheet or a new `session-hygiene.css`; **if a new stylesheet is added, register it in `design.md` `sources:` in the same change** (CI runs `scripts/check-design-drift.mjs`). Use `duration-*` tokens for timings — no hard-coded ms values outside the stylesheet's documented ones.
+- Reduced motion: gate the transform animation behind `motion-safe:`; with reduced motion the pass glyphs just fade.
+
+### 3. Row layout restructure in `SessionRow`
+Current structure (top line: title + fork icons; middle: repo · WSL · branch · cost · time; bottom: models + hygiene dots) becomes:
+
+- **Top meta line**: model names (existing `modelRunShortNames` text, `type-footnote text-label-tertiary`).
+- **Title line**: unchanged (title + fork icons, 2-line clamp, shimmer when active).
+- **Bottom line**: repo (+ additional-repos tooltip), WSL badge, branch — and the relative `<time>` right-aligned, `opacity-0 group-hover:opacity-100`. Keep the `<time>` element and its `aria-label` so the timestamp stays available to screen readers at all times; hover-hiding is visual only.
+- **Right rail** (top-aligned with the model line): `SessionHygieneBadges` fails + `SessionCostBadge`. The pass-glyph fan-out overlays the title area when it needs the width (absolutely positioned, anchored `right: 100% + gap` of the rail).
+- Hygiene dots block (`hygieneChecks.map` with ✓/× spans) is deleted, replaced by the new component.
+
+Open question for review: the proto never showed **branch**. Plan keeps it on the bottom line next to repo; flag in review if it should be hover-only like the time.
+
+### 4. `SessionCostBadge` hot state
+One-line class swap: `bg-system-red/15 text-system-red-text` → `bg-brand-tint/15 text-brand`. Update the comment that says "red plus a flame" (WCAG note still applies — the accessible name already carries the meaning). The tooltip's "Higher than usual" line (`text-system-red-text`) switches to `text-brand` to match.
+
+### 5. Tests, checks, PR
+- Update `SessionList` tests for the new structure (hygiene ✓/× spans are gone; time visibility class; model line position).
+- Add a render test for `SessionHygieneBadges`: fails render with titles, passes render, orders fails after passes in DOM (rightmost).
+- `pnpm run slop` before finishing; fix any aislop findings this change causes.
+- All commits `git commit -s` (DCO).
+- PR needs a screenshot — capture the row at rest and mid-hover from the running app, or ask Keith for one before `gh pr create`.
+
+## Out of scope
+
+- Real hygiene data (stays `mockSessionHygiene`).
+- Renaming the checks ("Session too deep", "Cache reloads" etc. were reviewed but not decided).
+- Dark mode polish beyond what the `brand`/`label-tertiary` tokens give for free — check it in the screenshot pass, don't redesign.


### PR DESCRIPTION


https://github.com/user-attachments/assets/af21a10f-2d87-4515-96eb-9b31f6001200

<img width="925" height="1500" alt="Screenshot 2026-08-24 at 17-55-16" src="https://github.com/user-attachments/assets/303486bc-b79a-4fe0-9f51-ae93aeb57416" />


## What changed

Rebuilds the popover session rows to the V6 design settled in the HTML proto (plan: `docs/plans/session-row-v6.md`).

**Row layout**
- Model names move to a top meta line, reserved on every row so the rhythm never shifts; the title sits on a new `type-body-large` step (14px/400); repo/WSL/branch hang below.
- The relative time hides at rest and fades in bottom-right on hover. The `<time>` element keeps its `aria-label`, so assistive tech reads it at all times.
- The agent icon centers on the title line.

**Hygiene checks**
- The ✓/× dots are gone. Each check is a bare lucide glyph (LifeBuoy, Brain, Hammer, Sunset, Rabbit, Droplet), named by tooltip and `aria-label`.
- Failed checks stay visible in brand orange beside the cost pill. Passing checks fan out leftward on row hover (240ms, 15ms outward stagger) and fade in place on hover-out — no slide-back. Model names fade while the fan is open.
- On a hover held 2s, green check / orange cross marks rise in above the glyphs, left to right, ~1s across a full row. Reduced motion swaps every slide for fades.

**Cost pill**
- High cost: solid brand orange, white text and flame. Calm: quiet grey instead of gold. The accessible name still carries the "higher than usual" meaning (WCAG 1.4.1).

**Active rows**
- The background pulse is removed; the title shimmer alone marks a running session.

## Why

The old rows buried the session name under uniform small text, and the hygiene dots said pass/fail without ever saying *what* was checked. This puts the name first, gives every check a nameable glyph, and keeps passing state out of the way until asked for.

## Reviewer notes

- The scale gained `type-body-large` (14px/400) — there was no step between body 13 and title-3 15. design.md is updated in the same change; `check-design-drift.mjs` passes.
- Fan/mark stagger geometry lives as `nth-last-child` rules and a `--hygiene-mark-index` custom property in `session-rows.css` (already in design.md `sources:`); the timings are documented as motion recipes.
- Hygiene data is still `mockSessionHygiene` — real data stays a separate feature.
- All 721 desktop tests pass; `pnpm run slop` is clean.

## Demo

_(drag `new session list antiburn.mp4` here — video attachments only upload through the web UI)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)