### PR TITLE
Polish session rows and discovery logging

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -232,8 +232,8 @@ motion:
   progress-pulse: "1.5s loop"
   segmented-indicator: "120ms ease-out slide; reduced motion swaps to a 60ms per-segment crossfade"
   text-roll: "300ms overshoot per character, 45ms stagger; retune with --text-roll-duration / --text-roll-stagger / --text-roll-ease"
-  session-hygiene-fan: "hover fan-out 240ms ease-out-quart + quick fade-in, 15ms outward stagger; hover-out fades 200ms in place (transform snap-back waits for the fade); the row's model names crossfade out of the fan's path over 200ms; reduced motion fades only"
-  session-hygiene-mark: "check/cross marks rise in above their glyphs after a hover held 2s, left to right at 200ms apart (~1s across a full row), each a 300ms ease-out-quart rise + scale + fade; off hover they drop and fade quick; reduced motion fades only"
+  session-hygiene-fan: "hover fan-out 240ms ease-out-quart + quick fade-in, 15ms outward stagger; hover-out fades 200ms in place (transform snap-back waits for the fade); the row's repository names crossfade to 20% opacity over 200ms; reduced motion fades only"
+  session-hygiene-mark: "check/cross marks rise in above their glyphs after a hover held 400ms, left to right at 50ms apart, each a 300ms ease-out-quart rise + scale + fade; off hover they drop and fade quick; reduced motion fades only"
 components:
   button-secondary:
     className: ui-push-button

--- a/apps/desktop/src/components/session/SessionHygieneBadges.tsx
+++ b/apps/desktop/src/components/session/SessionHygieneBadges.tsx
@@ -46,6 +46,7 @@ function HygieneGlyph({
         className={cn(
           "session-hygiene-glyph relative flex h-5 w-5 shrink-0 items-center justify-center",
           check.passed ? "text-label-tertiary" : "text-brand-tint",
+          !check.passed && "mt-[1.5px]",
         )}
       >
         <Icon size={14} strokeWidth={1.75} aria-hidden="true" />

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -130,7 +130,7 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
   return (
     <div
       className={cn(
-        "session-row group relative flex items-start gap-3 py-3 px-2 w-full text-left rounded-md",
+        "session-row group relative flex items-start gap-3 py-4 px-2 w-full text-left rounded-md",
         "transition-colors duration-[var(--duration-fast)] ease-out",
         entry.isActive && "activity-row-active",
         clickable &&
@@ -157,17 +157,40 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
     >
       {entry.isActive && <span className="sr-only">Active session</span>}
 
-      {/* The margin sets the icon on the title line, past the model line above it. */}
       <div className="mt-5 shrink-0">{renderAgentIcon?.(entry.agent, 18, entry.surface)}</div>
 
       <div className="min-w-0 flex-1 space-y-1">
-        {/* The line renders even with no model names, so every row keeps the
-            same vertical rhythm. */}
-        <div
-          className="session-model-names min-w-0 type-footnote text-label-tertiary"
-          {...(modelNames.length > 0 ? { title: modelRunNames(modelRuns).join("\n") } : {})}
-        >
-          {modelNames.length > 0 ? <TruncatedText text={modelNames.join(" · ")} /> : "\u00A0"}
+        <div className="flex items-end justify-between gap-x-1">
+          <div className="session-repo-names flex gap-x-2">
+            {hasRepo && (
+              <Tooltip
+                label={
+                  entry.additionalRepos?.length
+                    ? `Also observed: ${entry.additionalRepos.join(", ")}`
+                    : entry.repo
+                }
+              >
+                <span className="min-w-0 truncate text-sm text-label-secondary">
+                  {entry.repo}
+                  {entry.additionalRepos?.length ? ` +${entry.additionalRepos.length}` : ""}
+                </span>
+              </Tooltip>
+            )}
+
+            <WslOriginBadge distro={entry.wslDistro} {...(wslIcon ? { icon: wslIcon } : {})} />
+
+            {entry.branch && (
+              <TruncatedText
+                className="min-w-0 truncate type-footnote leading-[13px] tracking-wide text-label-secondary"
+                text={entry.branch}
+              />
+            )}
+          </div>
+
+          <div className="relative flex shrink-0 items-center gap-1.5">
+            <SessionHygieneBadges checks={hygieneChecks} />
+            {entry.cost && <SessionCostBadge {...entry.cost} />}
+          </div>
         </div>
 
         <div className="flex min-w-0 items-center gap-1">
@@ -177,6 +200,7 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
             lines={2}
             shimmer={entry.isActive}
           />
+
           {entry.hasForkParent && (
             <Tooltip label="Forked from another session" delayMs={500}>
               <span
@@ -202,49 +226,23 @@ function SessionRow({ entry, onOpen, renderAgentIcon, wslIcon }: SessionRowProps
           )}
         </div>
 
-        {(hasRepo || entry.wslDistro || entry.branch) && (
-          <div className="flex w-full min-w-0 items-center gap-1.5">
-            {hasRepo && (
-              <Tooltip
-                label={
-                  entry.additionalRepos?.length
-                    ? `Also observed: ${entry.additionalRepos.join(", ")}`
-                    : entry.repo
-                }
-              >
-                <span className="min-w-0 truncate text-sm text-label-secondary">
-                  {entry.repo}
-                  {entry.additionalRepos?.length ? ` +${entry.additionalRepos.length}` : ""}
-                </span>
-              </Tooltip>
-            )}
-
-            <WslOriginBadge distro={entry.wslDistro} {...(wslIcon ? { icon: wslIcon } : {})} />
-
-            {entry.branch && (
-              <TruncatedText
-                className="min-w-0 truncate type-footnote leading-[13px] tracking-wide text-label-secondary"
-                text={entry.branch}
-              />
-            )}
+        <div className="flex w-full justify-between min-w-0 items-center gap-x-1.5">
+          <div
+            className="min-w-0 type-footnote text-label-tertiary"
+            {...(modelNames.length > 0 ? { title: modelRunNames(modelRuns).join("\n") } : {})}
+          >
+            {modelNames.length > 0 ? <TruncatedText text={modelNames.join(" · ")} /> : "\u00A0"}
           </div>
-        )}
-      </div>
 
-      {/* The rail is the positioned anchor for the hygiene fan. */}
-      <div className="relative mt-0.5 flex shrink-0 items-center gap-1.5">
-        <SessionHygieneBadges checks={hygieneChecks} />
-        {entry.cost && <SessionCostBadge {...entry.cost} />}
+          <time
+            dateTime={entry.timestamp}
+            aria-label={`Last activity ${relativeTime(entry.timestamp)}`}
+            className="text-sm text-label-secondary"
+          >
+            {relativeTime(entry.timestamp)}
+          </time>
+        </div>
       </div>
-
-      {/* The timestamp shows on hover only; assistive tech reads it at all times. */}
-      <time
-        dateTime={entry.timestamp}
-        aria-label={`Last activity ${relativeTime(entry.timestamp)}`}
-        className="absolute bottom-3 right-2 shrink-0 text-sm text-label-secondary opacity-0 transition-opacity duration-[var(--duration-fast)] ease-out group-hover:opacity-100"
-      >
-        {relativeTime(entry.timestamp)}
-      </time>
     </div>
   )
 }

--- a/apps/desktop/src/styles/session-rows.css
+++ b/apps/desktop/src/styles/session-rows.css
@@ -125,7 +125,7 @@
 }
 
 .session-row:hover .session-hygiene-mark {
-  --hygiene-mark-delay: calc(2000ms + var(--hygiene-mark-index, 0) * 200ms);
+  --hygiene-mark-delay: calc(400ms + var(--hygiene-mark-index, 0) * 50ms);
   opacity: 1;
   transform: translateX(-50%);
   transition:
@@ -133,14 +133,12 @@
     transform var(--duration-slow) var(--ease-out-quart) var(--hygiene-mark-delay);
 }
 
-/* The open fan can reach over the model names. The names step aside: they
-   fade out while the fan is open, only in a row that has a fan to open. */
-.session-row:has(.session-hygiene-pass) .session-model-names {
+.session-row:has(.session-hygiene-pass) .session-repo-names {
   transition: opacity 200ms ease-out;
 }
 
-.session-row:has(.session-hygiene-pass):hover .session-model-names {
-  opacity: 0;
+.session-row:has(.session-hygiene-pass):hover .session-repo-names {
+  opacity: 0.2;
 }
 
 /* Stack offsets: one glyph pitch (20px glyph + 4px gap) per position. */

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -1732,7 +1732,7 @@ impl Explorers {
         while let Some(result) = set.join_next().await {
             completed += 1;
             if let Ok((name, logs)) = result {
-                ::tracing::info!(
+                ::tracing::debug!(
                     event = "repo_discovery_agent_done",
                     agent = name,
                     sessions = logs.len(),
@@ -1795,7 +1795,7 @@ impl Explorers {
         while let Some(result) = set.join_next().await {
             completed += 1;
             if let Ok((name, cwds)) = result {
-                ::tracing::info!(
+                ::tracing::debug!(
                     event = "repo_discovery_agent_done",
                     agent = name,
                     cwds = cwds.len(),


### PR DESCRIPTION
## Summary

- reorganize session rows so repository metadata and hygiene badges lead the title while model and activity details stay visible below it
- tighten hygiene badge alignment and reveal timing, with the design contract updated to match
- lower per-agent repository discovery completion messages from info to debug

## Test plan

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test`
- `pnpm --filter @antiburn/desktop build`
- `node scripts/check-design-drift.mjs`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `pnpm run slop`