### PR TITLE
fix(popover): refresh session models after analysis

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -41,8 +41,8 @@ use crate::repositories;
 use crate::scan::{self, ScanController};
 use crate::settings;
 use crate::store::{
-    AppSettings, RelationKind, RelationRecord, RepositoryRecord, SessionKey, SessionRecord, Store,
-    iso_from_epoch,
+    AnalysisRecord, AppSettings, RelationKind, RelationRecord, RepositoryRecord, SessionKey,
+    SessionRecord, Store, iso_from_epoch,
 };
 
 /// Anything that goes wrong becomes a string the webview can show.
@@ -522,6 +522,23 @@ fn repository_label(repositories: &[RepositoryRecord], cwd: Option<&str>) -> Str
     }
 }
 
+/// Whether `next` carries model data the popover list would render
+/// differently from `previous`.
+///
+/// Compares only the two fields the list reads (`model_breakdown_json` for
+/// cost, `inclusive_models_json` for the model pills). The fingerprint and
+/// pricing generation can change on every re-analysis without moving either
+/// figure, and an event for that would be noise the popover cannot show.
+fn analysis_changed(previous: Option<&AnalysisRecord>, next: &AnalysisRecord) -> bool {
+    match previous {
+        None => true,
+        Some(previous) => {
+            previous.model_breakdown_json != next.model_breakdown_json
+                || previous.inclusive_models_json != next.inclusive_models_json
+        }
+    }
+}
+
 fn path_is_under(path: &str, root: &str) -> bool {
     let path = path.replace('\\', "/");
     let path = path.trim_end_matches('/');
@@ -686,7 +703,17 @@ pub async fn get_session_analysis(
     let stored = store.session(&key).ok().flatten();
 
     if let Some(record) = analysis.record(&key) {
-        let _ = store.save_analysis(&record);
+        let previous = store.analysis(&key).ok().flatten();
+        if store.save_analysis(&record).is_ok()
+            && analysis_changed(previous.as_ref(), &record)
+            && let Some(session_record) = stored.clone()
+        {
+            let repositories = store.repositories().unwrap_or_default();
+            let now = scan::unix_now();
+            if let Ok(entry) = activity_entry(&store, &repositories, session_record, now) {
+                let _ = app.emit(SESSION_ENTRY_CHANGED_EVENT, &entry);
+            }
+        }
     }
     let orchestration = match &analysis.orchestration {
         Some(orchestration) => {
@@ -955,6 +982,11 @@ pub async fn set_repository_enabled(
 /// Event the shell emits when stored sessions were removed outside a scan
 /// (repository opt-out, index clearing). The popover re-queries on it.
 pub const SESSIONS_INVALIDATED_EVENT: &str = "sessions:invalidated";
+
+/// Event the shell emits when one session's cached analysis changes outside a
+/// scan. The payload is the fresh [`ActivityEntry`] for that session, so the
+/// popover can update the one row without a re-query.
+pub const SESSION_ENTRY_CHANGED_EVENT: &str = "sessions:entry-changed";
 
 /// Re-derive the repository list from what is on disk right now.
 #[tauri::command]
@@ -1405,6 +1437,44 @@ mod tests {
         // A session with no activity still yields a parseable stamp rather
         // than an empty string the list would drop.
         assert_eq!(iso_from_epoch(None), "1970-01-01T00:00:00Z");
+    }
+
+    fn analysis_record(model_breakdown_json: &str, inclusive_models_json: &str) -> AnalysisRecord {
+        AnalysisRecord {
+            key: SessionKey::new("env", "claude-code", "session-1"),
+            model_breakdown_json: model_breakdown_json.into(),
+            inclusive_models_json: inclusive_models_json.into(),
+            source_fingerprint: "fingerprint".into(),
+            pricing_generation: 1,
+        }
+    }
+
+    #[test]
+    fn a_first_analysis_always_counts_as_changed() {
+        let next = analysis_record("{}", "[]");
+        assert!(analysis_changed(None, &next));
+    }
+
+    #[test]
+    fn identical_model_data_is_not_a_change() {
+        let previous = analysis_record(
+            r#"{"claude-fable-5":{}}"#,
+            r#"[{"model":"claude-fable-5"}]"#,
+        );
+        let next = analysis_record(
+            r#"{"claude-fable-5":{}}"#,
+            r#"[{"model":"claude-fable-5"}]"#,
+        );
+        assert!(!analysis_changed(Some(&previous), &next));
+    }
+
+    #[test]
+    fn a_new_model_in_either_field_counts_as_changed() {
+        let previous = analysis_record("{}", "[]");
+        let breakdown_changed = analysis_record(r#"{"claude-fable-5":{}}"#, "[]");
+        let models_changed = analysis_record("{}", r#"[{"model":"claude-fable-5"}]"#);
+        assert!(analysis_changed(Some(&previous), &breakdown_changed));
+        assert!(analysis_changed(Some(&previous), &models_changed));
     }
 
     #[test]

--- a/apps/desktop/src/lib/activityEntries.ts
+++ b/apps/desktop/src/lib/activityEntries.ts
@@ -30,22 +30,17 @@ function surfaceOf(payload: ActivityEntryPayload): AgentSurface {
 }
 
 /**
- * Shape one page of activity payloads into list entries.
+ * Shape one activity payload into a list entry.
  *
- * The high-cost flag is computed across the whole page rather than per row:
- * "unusually expensive" only means anything against a cohort, and the cohort is
- * the sessions the reader is looking at.
+ * `highCostThreshold` is the cohort's outlier threshold, from
+ * `costOutlierThreshold`. Pass `null` when there is no cohort to compare
+ * against — the row's high-cost flag then reads as false, never as an error.
  */
-export function toActivityEntries(
-  payloads: readonly ActivityEntryPayload[],
-): SessionListEntry[] {
-  const threshold = costOutlierThreshold(
-    payloads
-      .map((payload) => payload.cost?.totalUsd)
-      .filter((usd): usd is number => typeof usd === "number"),
-  )
-
-  return payloads.map((payload) => ({
+export function toActivityEntry(
+  payload: ActivityEntryPayload,
+  highCostThreshold: number | null = null,
+): SessionListEntry {
+  return {
     agent: payload.agent,
     sessionId: payload.sessionId,
     repo: payload.repo,
@@ -62,11 +57,30 @@ export function toActivityEntries(
           totalUsd: payload.cost.totalUsd,
           figureLabel: costFigureLabel(payload.isActive),
           models: payload.models,
-          isHighCost: threshold != null && payload.cost.totalUsd > threshold,
+          isHighCost: highCostThreshold != null && payload.cost.totalUsd > highCostThreshold,
           breakdownRows: costBreakdownRows(payload.cost),
         }
       : null,
-  }))
+  }
+}
+
+/**
+ * Shape one page of activity payloads into list entries.
+ *
+ * The high-cost flag is computed across the whole page rather than per row:
+ * "unusually expensive" only means anything against a cohort, and the cohort is
+ * the sessions the reader is looking at.
+ */
+export function toActivityEntries(
+  payloads: readonly ActivityEntryPayload[],
+): SessionListEntry[] {
+  const threshold = costOutlierThreshold(
+    payloads
+      .map((payload) => payload.cost?.totalUsd)
+      .filter((usd): usd is number => typeof usd === "number"),
+  )
+
+  return payloads.map((payload) => toActivityEntry(payload, threshold))
 }
 
 export function indexOfSession(

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1276,7 +1276,9 @@ export async function onSessionEntryChanged(
   handler: (entry: ActivityEntryPayload) => void,
 ): Promise<UnlistenFn> {
   if (!hasShell()) return noShellUnlisten
-  return listen<ActivityEntryPayload>(SESSION_ENTRY_CHANGED_EVENT, (event) => handler(event.payload))
+  return listen<ActivityEntryPayload>(SESSION_ENTRY_CHANGED_EVENT, (event) =>
+    handler(event.payload),
+  )
 }
 
 /**

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1265,6 +1265,21 @@ export async function onSessionsInvalidated(handler: () => void): Promise<Unlist
 }
 
 /**
+ * Event the shell emits when one session's cached analysis changes outside a
+ * scan. Mirrors `SESSION_ENTRY_CHANGED_EVENT` in `src-tauri/src/commands.rs`.
+ * The payload is the fresh entry for that session.
+ */
+export const SESSION_ENTRY_CHANGED_EVENT = "sessions:entry-changed"
+
+/** Subscribe to one session's entry changing. The result unsubscribes. */
+export async function onSessionEntryChanged(
+  handler: (entry: ActivityEntryPayload) => void,
+): Promise<UnlistenFn> {
+  if (!hasShell()) return noShellUnlisten
+  return listen<ActivityEntryPayload>(SESSION_ENTRY_CHANGED_EVENT, (event) => handler(event.payload))
+}
+
+/**
  * Event the shell emits the instant the popover reaches the screen. Mirrors
  * `popover::EVENT_SHOWN` in `src-tauri/src/popover.rs`.
  *

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -285,6 +285,40 @@ describe("PopoverView", () => {
     expect(screen.queryByRole("heading", { name: "Session Detail" })).not.toBeInTheDocument()
   })
 
+  it("refreshes the list after session analysis adds model runs", async () => {
+    let analysisLoaded = false
+    const baseInvoke = invoke.getMockImplementation()!
+    invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "list_recent_sessions") {
+        const modelRuns = analysisLoaded
+          ? [{ model: "claude-fable-5", thinkingMode: "high" }]
+          : []
+        return Promise.resolve([activityEntry({ modelRuns })])
+      }
+      if (command === "get_session_analysis") {
+        analysisLoaded = true
+        return Promise.resolve({
+          ...ANALYTICS,
+          models: ["claude-fable-5"],
+          modelRuns: [{ model: "claude-fable-5", thinkingMode: "high" }],
+        })
+      }
+      return baseInvoke(command, args)
+    })
+
+    render(<PopoverView />)
+
+    fireEvent.click(await screen.findByText("Wire the tray popover"))
+    await waitFor(() =>
+      expect(
+        invoke.mock.calls.filter(([command]) => command === "list_recent_sessions"),
+      ).toHaveLength(2),
+    )
+    fireEvent.click(await screen.findByRole("button", { name: "Back" }, { timeout: 5_000 }))
+
+    expect(await screen.findByText("fable-5/high")).toBeInTheDocument()
+  })
+
   it("brings the list back at the offset it was scrolled to before a session opened", async () => {
     render(<PopoverView />)
     await screen.findByText("Wire the tray popover")

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -285,38 +285,36 @@ describe("PopoverView", () => {
     expect(screen.queryByRole("heading", { name: "Session Detail" })).not.toBeInTheDocument()
   })
 
-  it("refreshes the list after session analysis adds model runs", async () => {
-    let analysisLoaded = false
-    const baseInvoke = invoke.getMockImplementation()!
-    invoke.mockImplementation((command: string, args?: unknown) => {
-      if (command === "list_recent_sessions") {
-        const modelRuns = analysisLoaded
-          ? [{ model: "claude-fable-5", thinkingMode: "high" }]
-          : []
-        return Promise.resolve([activityEntry({ modelRuns })])
-      }
-      if (command === "get_session_analysis") {
-        analysisLoaded = true
-        return Promise.resolve({
-          ...ANALYTICS,
-          models: ["claude-fable-5"],
-          modelRuns: [{ model: "claude-fable-5", thinkingMode: "high" }],
-        })
-      }
-      return baseInvoke(command, args)
+  it("updates the one row a sessions:entry-changed event names, without re-listing", async () => {
+    render(<PopoverView />)
+    await screen.findByText("Wire the tray popover")
+
+    const listCallsBefore = invoke.mock.calls.filter(
+      ([command]) => command === "list_recent_sessions",
+    ).length
+
+    emit("sessions:entry-changed", {
+      ...activityEntry(),
+      modelRuns: [{ model: "claude-fable-5", thinkingMode: "high" }],
     })
 
-    render(<PopoverView />)
-
-    fireEvent.click(await screen.findByText("Wire the tray popover"))
-    await waitFor(() =>
-      expect(
-        invoke.mock.calls.filter(([command]) => command === "list_recent_sessions"),
-      ).toHaveLength(2),
-    )
-    fireEvent.click(await screen.findByRole("button", { name: "Back" }, { timeout: 5_000 }))
-
     expect(await screen.findByText("fable-5/high")).toBeInTheDocument()
+    expect(
+      invoke.mock.calls.filter(([command]) => command === "list_recent_sessions"),
+    ).toHaveLength(listCallsBefore)
+  })
+
+  it("leaves the list unchanged when a sessions:entry-changed event names an unknown session", async () => {
+    render(<PopoverView />)
+    await screen.findByText("Wire the tray popover")
+
+    emit("sessions:entry-changed", {
+      ...activityEntry({ sessionId: "session-unknown" }),
+      modelRuns: [{ model: "claude-fable-5", thinkingMode: "high" }],
+    })
+
+    expect(screen.queryByText("fable-5/high")).not.toBeInTheDocument()
+    expect(screen.getByText("Wire the tray popover")).toBeInTheDocument()
   })
 
   it("brings the list back at the offset it was scrolled to before a session opened", async () => {

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -304,6 +304,40 @@ describe("PopoverView", () => {
     ).toHaveLength(listCallsBefore)
   })
 
+  it("keeps a row's high-cost flag after a sessions:entry-changed event replaces it", async () => {
+    const cheapEntries = Array.from({ length: 7 }, (_, i) =>
+      activityEntry({
+        sessionId: `session-cheap-${i}`,
+        title: `Cheap session ${i}`,
+        cost: {
+          totalUsd: 0.1,
+          inputUsd: 0.05,
+          outputUsd: 0.03,
+          cacheReadUsd: 0.01,
+          cacheWriteUsd: 0.01,
+        },
+      }),
+    )
+    const expensiveEntry = activityEntry({
+      cost: { totalUsd: 10, inputUsd: 5, outputUsd: 3, cacheReadUsd: 1, cacheWriteUsd: 1 },
+    })
+    mockCommands({ list_recent_sessions: [expensiveEntry, ...cheapEntries] })
+
+    render(<PopoverView />)
+    await screen.findByText("Wire the tray popover")
+    expect(await screen.findByLabelText(/higher than usual/i)).toBeInTheDocument()
+
+    emit("sessions:entry-changed", {
+      ...expensiveEntry,
+      modelRuns: [{ model: "claude-fable-5", thinkingMode: "high" }],
+    })
+
+    expect(await screen.findByText("fable-5/high")).toBeInTheDocument()
+    // The row is rebuilt from the pushed payload alone, so its high-cost flag
+    // must be recomputed against the cohort rather than defaulting to false.
+    expect(screen.getByLabelText(/higher than usual/i)).toBeInTheDocument()
+  })
+
   it("leaves the list unchanged when a sessions:entry-changed event names an unknown session", async () => {
     render(<PopoverView />)
     await screen.findByText("Wire the tray popover")

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import type { SessionListEntry } from "../../components/session/SessionList"
-import { toActivityEntries } from "../../lib/activityEntries"
+import { indexOfSession, toActivityEntries, toActivityEntry } from "../../lib/activityEntries"
 import { applyTheme } from "../../lib/appearance"
 import type { AttentionKind } from "../../lib/attention"
 import {
@@ -24,6 +24,7 @@ import {
   onPopoverShown,
   onLiveUsageChanged,
   onScanEvent,
+  onSessionEntryChanged,
   onSessionsInvalidated,
   onSettingsChanged,
   onStorageHealth,
@@ -168,6 +169,7 @@ export class PopoverSession {
 
   private stopSettingsListening: (() => void) | null = null
   private stopSessionsInvalidatedListening: (() => void) | null = null
+  private stopSessionEntryChangedListening: (() => void) | null = null
   private stopStorageHealthListening: (() => void) | null = null
   private stopScanListening: (() => void) | null = null
   private stopPopoverShownListening: (() => void) | null = null
@@ -277,6 +279,7 @@ export class PopoverSession {
     void this.loadInitial(generation)
     void this.listenSettings(generation)
     void this.listenSessionsInvalidated(generation)
+    void this.listenSessionEntryChanged(generation)
     void this.listenStorageHealth(generation)
     void this.listenScanEvent(generation)
     void this.listenPopoverShown(generation)
@@ -297,6 +300,8 @@ export class PopoverSession {
     this.stopSettingsListening = null
     this.stopSessionsInvalidatedListening?.()
     this.stopSessionsInvalidatedListening = null
+    this.stopSessionEntryChangedListening?.()
+    this.stopSessionEntryChangedListening = null
     this.stopStorageHealthListening?.()
     this.stopStorageHealthListening = null
     this.stopScanListening?.()
@@ -376,6 +381,30 @@ export class PopoverSession {
       return
     }
     this.stopSessionsInvalidatedListening = unlisten
+  }
+
+  // Opening a session computes its analysis and the shell caches it, but a
+  // cache write alone does not change what a scan already put in the list.
+  // The shell pushes the one changed row here so the pills stay current
+  // without a full re-query.
+  private listenSessionEntryChanged = async (generation: number): Promise<void> => {
+    const unlisten = await onSessionEntryChanged((entry) => {
+      if (generation !== this.generation) return
+      const entries = this.snapshot.entries
+      if (!entries) return
+      const index = indexOfSession(entries, entry.agent, entry.sessionId, entry.wslDistro)
+      // A session outside the current window is the next scan's business, so
+      // an entry with no match here is not inserted.
+      if (index === -1) return
+      const next = [...entries]
+      next[index] = toActivityEntry(entry)
+      this.update({ entries: next })
+    })
+    if (generation !== this.generation) {
+      unlisten()
+      return
+    }
+    this.stopSessionEntryChangedListening = unlisten
   }
 
   // Storage health changes rarely and matters immediately, so it is pushed
@@ -543,9 +572,6 @@ export class PopoverSession {
       .then((payload) => {
         if (generation !== this.generation || token !== this.analysisToken) return
         this.update({ analysis: { key, payload, error: false } })
-        if (!subject.subagent) {
-          void this.refreshEntries(this.windowDays()).catch(() => {})
-        }
       })
       .catch(() => {
         if (generation !== this.generation || token !== this.analysisToken) return

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -45,6 +45,7 @@ import {
   type PopoverSurface,
 } from "../../lib/popoverHeight"
 import { localSessionKey } from "../../lib/presentation/localIdentity"
+import { costOutlierThreshold } from "../../lib/presentation/sessionAnalysis"
 import { isFloatingHudEnabled, openOverlayWindow } from "../../lib/overlayWindow"
 import { isMacOS } from "../../lib/platform"
 import type { LocalRepositoryItem, LocalRepositoryStatus } from "../../lib/types/repository"
@@ -396,8 +397,16 @@ export class PopoverSession {
       // A session outside the current window is the next scan's business, so
       // an entry with no match here is not inserted.
       if (index === -1) return
+      // The cohort for the high-cost flag is the list on screen, with the
+      // replaced row's own cost swapped in — the same set `toActivityEntries`
+      // would see on a full re-list.
+      const threshold = costOutlierThreshold(
+        entries
+          .map((row, i) => (i === index ? entry.cost?.totalUsd : row.cost?.totalUsd))
+          .filter((usd): usd is number => typeof usd === "number"),
+      )
       const next = [...entries]
-      next[index] = toActivityEntry(entry)
+      next[index] = toActivityEntry(entry, threshold)
       this.update({ entries: next })
     })
     if (generation !== this.generation) {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -543,6 +543,9 @@ export class PopoverSession {
       .then((payload) => {
         if (generation !== this.generation || token !== this.analysisToken) return
         this.update({ analysis: { key, payload, error: false } })
+        if (!subject.subagent) {
+          void this.refreshEntries(this.windowDays()).catch(() => {})
+        }
       })
       .catch(() => {
         if (generation !== this.generation || token !== this.analysisToken) return


### PR DESCRIPTION
## Summary

- refresh the bounded session-list snapshot after a top-level analysis succeeds
- keep model runs and cost presentation in sync with the analysis cache
- cover a newly listed session whose models become available after opening detail

## Testing

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop knip`
- `pnpm --filter @antiburn/desktop test`
- `pnpm --filter @antiburn/desktop build`
- `pnpm run slop`