### PR TITLE
feat(desktop): prevent browser defaults in webviews

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-prevent-default",
  "tauri-plugin-updater",
  "tempfile",
  "time",
@@ -1087,6 +1088,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embed-resource"
@@ -2135,6 +2142,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -4312,6 +4328,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4860,6 +4897,20 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-prevent-default"
+version = "5.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674bac5c9831f4ca7ae42840768ac968b76353dcbe30bb0aad149c56f0be1389"
+dependencies = [
+ "bitflags 2.13.1",
+ "itertools",
+ "serde",
+ "strum",
+ "tauri",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -98,6 +98,9 @@ serde_json = "1"
 tauri = { version = "2", features = ["image-png", "tray-icon", "macos-private-api"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
+# The plugin prevents browser-only menus and shortcuts in application webviews.
+# The explicit policy in `src/webview_defaults.rs` keeps focus traversal intact.
+tauri-plugin-prevent-default = "5"
 # Emits structured shell events through the process subscriber.
 tracing = "0.1"
 # RFC 3339 stamps for the store's own timestamps.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -76,6 +76,7 @@ mod tray;
 mod tray_title;
 mod updates;
 mod usage_alerts;
+mod webview_defaults;
 mod window_placement;
 
 use std::sync::Mutex;
@@ -122,6 +123,7 @@ pub fn run() {
     let builder = antiburn_nudge::register(tauri::Builder::default())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(webview_defaults::plugin())
         .invoke_handler(tauri::generate_handler![
             commands::add_scan_root,
             commands::app_info,

--- a/apps/desktop/src-tauri/src/webview_defaults.rs
+++ b/apps/desktop/src-tauri/src/webview_defaults.rs
@@ -1,0 +1,166 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! This module removes browser-only behavior from application webviews.
+
+use tauri::{Runtime, plugin::TauriPlugin};
+use tauri_plugin_prevent_default::{Builder, Flags};
+
+#[cfg(target_os = "macos")]
+use tauri_plugin_prevent_default::{
+    KeyboardShortcut,
+    ModifierKey::{AltKey, MetaKey},
+};
+
+fn flags_for(debug: bool) -> Flags {
+    let app_flags = Flags::CONTEXT_MENU
+        | Flags::FIND
+        | Flags::CARET_BROWSING
+        | Flags::DOWNLOADS
+        | Flags::SOURCE
+        | Flags::OPEN
+        | Flags::PRINT;
+
+    if debug {
+        app_flags
+    } else {
+        app_flags | Flags::DEV_TOOLS | Flags::RELOAD
+    }
+}
+
+pub(super) fn plugin<R: Runtime>() -> TauriPlugin<R> {
+    let debug = cfg!(debug_assertions);
+    let builder = Builder::new().with_flags(flags_for(debug));
+
+    #[cfg(target_os = "macos")]
+    let builder = add_macos_shortcuts(builder, debug);
+
+    builder.build()
+}
+
+#[cfg(target_os = "macos")]
+fn add_macos_shortcuts(mut builder: Builder, debug: bool) -> Builder {
+    for shortcut in macos_shortcuts(debug) {
+        builder = builder.shortcut(shortcut);
+    }
+    builder
+}
+
+#[cfg(target_os = "macos")]
+fn macos_shortcuts(debug: bool) -> Vec<KeyboardShortcut> {
+    let mut shortcuts = vec![
+        KeyboardShortcut::with_meta("f"),
+        KeyboardShortcut::with_meta("g"),
+        KeyboardShortcut::with_shift_meta("g"),
+        KeyboardShortcut::with_shift_meta("j"),
+        KeyboardShortcut::with_modifiers("l", &[AltKey, MetaKey]),
+        KeyboardShortcut::with_modifiers("u", &[AltKey, MetaKey]),
+        KeyboardShortcut::with_meta("o"),
+        KeyboardShortcut::with_meta("p"),
+        KeyboardShortcut::with_shift_meta("p"),
+    ];
+
+    if !debug {
+        shortcuts.extend([
+            KeyboardShortcut::with_modifiers("c", &[AltKey, MetaKey]),
+            KeyboardShortcut::with_modifiers("i", &[AltKey, MetaKey]),
+            KeyboardShortcut::with_modifiers("j", &[AltKey, MetaKey]),
+            KeyboardShortcut::with_meta("r"),
+            KeyboardShortcut::with_shift_meta("r"),
+        ]);
+    }
+
+    shortcuts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    use tauri_plugin_prevent_default::ModifierKey::{AltKey, MetaKey, ShiftKey};
+
+    #[test]
+    fn release_blocks_browser_defaults_but_preserves_focus_movement() {
+        let flags = flags_for(false);
+        let expected = Flags::CONTEXT_MENU
+            | Flags::FIND
+            | Flags::CARET_BROWSING
+            | Flags::DEV_TOOLS
+            | Flags::DOWNLOADS
+            | Flags::RELOAD
+            | Flags::SOURCE
+            | Flags::OPEN
+            | Flags::PRINT;
+
+        assert_eq!(flags, expected);
+        assert!(flags.contains(Flags::CONTEXT_MENU));
+        assert!(flags.contains(Flags::FIND));
+        assert!(flags.contains(Flags::CARET_BROWSING));
+        assert!(flags.contains(Flags::DEV_TOOLS));
+        assert!(flags.contains(Flags::DOWNLOADS));
+        assert!(flags.contains(Flags::RELOAD));
+        assert!(flags.contains(Flags::SOURCE));
+        assert!(flags.contains(Flags::OPEN));
+        assert!(flags.contains(Flags::PRINT));
+        assert!(!flags.contains(Flags::FOCUS_MOVE));
+    }
+
+    #[test]
+    fn debug_keeps_reload_and_developer_tools_available() {
+        let flags = flags_for(true);
+        let expected = Flags::CONTEXT_MENU
+            | Flags::FIND
+            | Flags::CARET_BROWSING
+            | Flags::DOWNLOADS
+            | Flags::SOURCE
+            | Flags::OPEN
+            | Flags::PRINT;
+
+        assert_eq!(flags, expected);
+        assert!(flags.contains(Flags::CONTEXT_MENU));
+        assert!(!flags.contains(Flags::DEV_TOOLS));
+        assert!(!flags.contains(Flags::RELOAD));
+        assert!(!flags.contains(Flags::FOCUS_MOVE));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn release_blocks_macos_browser_shortcuts() {
+        let shortcuts = macos_shortcuts(false);
+
+        assert!(has_shortcut(&shortcuts, "f", &[MetaKey]));
+        assert!(has_shortcut(&shortcuts, "j", &[ShiftKey, MetaKey]));
+        assert!(has_shortcut(&shortcuts, "l", &[AltKey, MetaKey]));
+        assert!(has_shortcut(&shortcuts, "u", &[AltKey, MetaKey]));
+        assert!(has_shortcut(&shortcuts, "o", &[MetaKey]));
+        assert!(has_shortcut(&shortcuts, "p", &[MetaKey]));
+        assert!(has_shortcut(&shortcuts, "r", &[MetaKey]));
+        assert!(has_shortcut(&shortcuts, "i", &[AltKey, MetaKey]));
+        assert!(!shortcuts.iter().any(|shortcut| shortcut.key() == "Tab"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn debug_keeps_macos_reload_and_developer_tools_available() {
+        let shortcuts = macos_shortcuts(true);
+
+        assert!(has_shortcut(&shortcuts, "f", &[MetaKey]));
+        assert!(has_shortcut(&shortcuts, "p", &[MetaKey]));
+        assert!(!has_shortcut(&shortcuts, "r", &[MetaKey]));
+        assert!(!has_shortcut(&shortcuts, "i", &[AltKey, MetaKey]));
+        assert!(!shortcuts.iter().any(|shortcut| shortcut.key() == "Tab"));
+    }
+
+    #[cfg(target_os = "macos")]
+    fn has_shortcut(
+        shortcuts: &[KeyboardShortcut],
+        key: &str,
+        modifiers: &[tauri_plugin_prevent_default::ModifierKey],
+    ) -> bool {
+        shortcuts
+            .iter()
+            .any(|shortcut| shortcut.key() == key && shortcut.modifiers() == modifiers)
+    }
+}


### PR DESCRIPTION
## Summary

- add the Tauri-listed community plugin `tauri-plugin-prevent-default` v5
- suppress browser context menus and browser-only shortcuts in every desktop webview
- preserve forward and reverse keyboard focus traversal, including `Shift+Tab`
- keep reload and DevTools keyboard shortcuts available only in debug builds
- add macOS Command-key equivalents and policy tests
- leave the native tray context menu unchanged

## Validation

- `cargo test --locked --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `cargo check --release --locked`
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo deny --locked check licenses`
- `cargo deny --locked check advisories`
- `pnpm run slop`
- `pnpm --filter @antiburn/desktop dev:bundle`
- built and launched the debug macOS application bundle