### PR TITLE
chore(release): prepare antiburn-local 0.1.5

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,16 +21,64 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-08-25
+
+### Added
+
+- `analysis::framing` frames a JSONL transcript one record at a time.
+  `BoundedJsonlReader` and `FramedRecord` hold each record under
+  `MAX_RECORD_BYTES`, so a single oversized or malformed line cannot make a scan
+  allocate without bound, and the caller can cancel between records.
+- `analysis::interface` adds a streaming seam for transcript records:
+  `RecordSink`, `NormalizedRecord`, `RecordSkip`, `RecordCoverage`,
+  `PartialReason`, `SessionSummary`, and `SessionCollector`. An adapter reports
+  one record at a time and finishes with a `SessionSummary`. `SessionCollector`
+  accumulates the same `NormalizedSession` the whole-document path produces and
+  reports the coverage and the partial reasons for it.
+- `discovery::source_version` gives a session source a storage-neutral identity
+  and version: `SourceDescriptor`, `SourceVersion`, `SourceStat`,
+  `FingerprintInputs`, `Streamability`, `head_hash_of`, and
+  `FINGERPRINT_HEAD_BYTES`, with `SourceRead` in `discovery`.
+  `Explorers::source_version` builds the value, and a scan keeps the
+  fingerprint, so a caller can tell an unchanged source from a grown one without
+  reading the transcript again.
+- `analysis::merge::merge_subagent_events` folds a sub-agent transcript into its
+  parent session, and `EventSource` records which transcript an event came from.
+- `SessionMetrics` carries `model_runs: Vec<ModelRun>`, `compaction_count`, and
+  `cache_rehydration_count`. A `Bucket` carries `cache_read_tokens`,
+  `cache_write_tokens`, `is_cache_rehydration`, `subagent_tokens`,
+  `secs_since_prior_turn`, `subagent_launches`, `user_prompts`, `last_tool`,
+  `model`, `thinking_mode`, `speed`, `has_thinking`, `compaction_trigger`
+  (`CompactionTrigger`), `compaction_pre_tokens`, and `compaction_post_tokens`.
+
 ### Changed
 
 - Analysis and discovery now emit structured local diagnostic events at silent
   recovery seams. This change does not alter analysis results or public APIs.
+- The bundled TOML integration now uses `toml` 1.1.4.
+
+### Removed
+
+- The session pattern analytics surface: `Phase`, `PhaseSegment`,
+  `PhaseDistribution`, `MIN_PHASE_WEIGHT`, and `active_time_fraction`. What they
+  reported did not describe the sessions they claimed to describe.
+- The local skill detail surface: `SkillDetail`, `LocalSkillDetails`, and
+  `SkillScope`.
+
 ### Fixed
 
 - Codex title discovery now distinguishes user-set names and generated titles
   from raw first-message fallbacks in the current state database. Generated
   session-index names can replace raw prompts, while legacy title-only state
   databases keep their existing rename behavior.
+- Codex cache rehydration is now inferred when the cached prefix stays cached,
+  and the `token_count` row Codex repeats on resume no longer counts twice.
+- A Codex compaction is now detected from a top-level compacted record.
+- A session keeps its own context window in its summary rather than the
+  reference window.
+- A multi-model session now reports stable cost totals across repeated analysis.
+- Codex task titles are restored.
+- The spawn-edges sidecar is flushed before its rename.
 
 ## [0.1.4] - 2026-08-21
 

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MPL-2.0"


### PR DESCRIPTION
Promotes the `[Unreleased]` section to `0.1.5` and bumps the crate version.
`release-engine.yml` reads the section matching the tagged version and refuses
the release if there is none.

The section is written out in full rather than carried over. Roughly 16
engine-touching merges landed since `antiburn-local-v0.1.4`, and they include
**public API removals** — `Phase`, `PhaseSegment`, `PhaseDistribution`,
`MIN_PHASE_WEIGHT`, `active_time_fraction`, `SkillDetail`, `LocalSkillDetails`,
and `SkillScope`. The version stays `0.1.5` because consumers pin the crate by
full commit SHA rather than a caret range, so the compatibility claim in a
`0.1.x` bump binds nobody in practice; the removals go on record in the
changelog instead.

The app lockfile records the engine version through its path dependency, so it
is bumped in step. Its engine entry is edited in place rather than regenerated:
`cargo update` under the app manifest also re-resolves shared transitive
dependencies (`windows-sys`, `getrandom`) downward, which would turn a
release-metadata bump into a dependency change and drop this out of the narrow
release gate.

## Verified locally

- `node scripts/verify-release-version.mjs engine antiburn-local-v0.1.5`
- The changelog heading extracts under both the CI grep and the workflow's awk.
- `isPureEngineReleaseChange` returns `true` — four files, manifests
  version-only.
- `pnpm run slop` — 0 errors, 0 warnings.
