### PR TITLE
Stack GH-70: 0007 (CH-004) source validity and pinned-prefix publication

### DIFF
--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -136,6 +136,29 @@ impl RecordSink for SessionCollector {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisitOutcome {
+    /// The adapter reads the source to its end without a source-validity check.
+    /// This outcome states only that the stream completed.
+    Unvalidated,
+    /// The post-read recheck confirms the same source version for the whole source.
+    AcceptedFull,
+    AcceptedPrefix {
+        boundary: u64,
+    },
+    SourceChanged(SourceChangedReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceChangedReason {
+    IdentityMismatch,
+    ShortAtOpen { size: u64, boundary: u64 },
+    HeadRegionMismatch,
+    ShortRead { consumed: u64, boundary: u64 },
+    TruncatedAfterRead { size: u64, boundary: u64 },
+    FingerprintMismatch,
+}
+
 /// Implemented once per vendor format. Stateless and `Sync` so adapters can be
 /// stored as `&'static dyn VendorAdapter` in the registry.
 pub trait VendorAdapter: Sync {
@@ -149,7 +172,11 @@ pub trait VendorAdapter: Sync {
     fn normalize(&self, input: &SessionInput) -> anyhow::Result<NormalizedSession>;
 
     /// Streams one raw session into `sink`, one record at a time.
-    fn visit(&self, input: &SessionInput, sink: &mut dyn RecordSink) -> anyhow::Result<()> {
+    fn visit(
+        &self,
+        input: &SessionInput,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<VisitOutcome> {
         let session = self.normalize(input)?;
         let NormalizedSession {
             events,
@@ -167,6 +194,6 @@ pub trait VendorAdapter: Sync {
             model,
             late_tools: Vec::new(),
         });
-        Ok(())
+        Ok(VisitOutcome::Unvalidated)
     }
 }

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -38,6 +38,7 @@ mod interface;
 mod merge;
 mod model;
 mod pricing;
+mod source_validity;
 mod vendors;
 
 pub use engine::{
@@ -51,13 +52,16 @@ pub use framing::{
 pub use initial_context::{InitialContextBreakdown, InitialContextSourceCount, TrackingStatus};
 pub use interface::{
     NormalizedRecord, RawSource, RecordCoverage, RecordSink, SessionCollector, SessionInput,
-    SessionSummary, VendorAdapter,
+    SessionSummary, SourceChangedReason, VendorAdapter, VisitOutcome,
 };
 pub use merge::merge_subagent_events;
 pub use model::{
     EventSource, ModelRun, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
 };
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
+pub use source_validity::{
+    AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,
+};
 pub use vendors::{adapter_for, has_dedicated_adapter};
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -62,6 +62,7 @@ pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
 pub use source_validity::{
     AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,
 };
+pub use vendors::claude::ClaudeAdapter;
 pub use vendors::{adapter_for, has_dedicated_adapter};
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.

--- a/crates/antiburn-local/src/analysis/source_validity.rs
+++ b/crates/antiburn-local/src/analysis/source_validity.rs
@@ -1,0 +1,385 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Source validation for one file handle.
+//!
+//! The head hash covers only the configured head region. It does not prove that the full prefix is append-only.
+
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom};
+use std::path::Path;
+
+use crate::analysis::interface::SourceChangedReason;
+use crate::discovery::source_version::{
+    FINGERPRINT_HEAD_BYTES, FingerprintInputs, SourceStat, head_hash_of,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceClaim {
+    pub fingerprint: String,
+    pub identity: Option<String>,
+    pub boundary: u64,
+    pub head_hash: Option<u64>,
+}
+
+impl SourceClaim {
+    pub fn from_fingerprint_inputs(inputs: &FingerprintInputs) -> Self {
+        Self {
+            fingerprint: inputs.fingerprint(),
+            identity: inputs.stat.identity.clone(),
+            boundary: inputs.stat.size,
+            head_hash: inputs.head_hash,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppendOnlyGuarantee {
+    Evidenced,
+    Absent,
+}
+
+/// Returns the provider's current append-only guarantee.
+pub fn append_only_guarantee(_agent: &str) -> AppendOnlyGuarantee {
+    AppendOnlyGuarantee::Absent
+}
+
+pub type PinnedOpen = Result<PinnedSource, SourceChangedReason>;
+
+pub struct PinnedSource {
+    file: File,
+    claim: SourceClaim,
+    consumed: u64,
+}
+
+impl PinnedSource {
+    /// Opens the path once and validates the handle before records can stream.
+    pub fn open(path: &Path, claim: SourceClaim) -> anyhow::Result<PinnedOpen> {
+        let mut file = File::open(path)?;
+        let stat = stat_from_handle(&file)?;
+        if stat.identity != claim.identity {
+            return Ok(Err(SourceChangedReason::IdentityMismatch));
+        }
+        if stat.size < claim.boundary {
+            return Ok(Err(SourceChangedReason::ShortAtOpen {
+                size: stat.size,
+                boundary: claim.boundary,
+            }));
+        }
+        let head_hash = read_head_hash(&mut file, claim.boundary)?;
+        if claim.head_hash.is_some() && claim.head_hash != Some(head_hash) {
+            return Ok(Err(SourceChangedReason::HeadRegionMismatch));
+        }
+        file.seek(SeekFrom::Start(0))?;
+        Ok(Ok(Self {
+            file,
+            claim,
+            consumed: 0,
+        }))
+    }
+
+    pub fn claim(&self) -> &SourceClaim {
+        &self.claim
+    }
+
+    pub fn consumed(&self) -> u64 {
+        self.consumed
+    }
+
+    /// Reads from offset zero and delivers at most `limit` bytes.
+    pub fn reader(&mut self, limit: u64) -> PinnedReader<'_> {
+        self.consumed = 0;
+        let seek_error = self.file.seek(SeekFrom::Start(0)).err();
+        PinnedReader {
+            file: &mut self.file,
+            consumed: &mut self.consumed,
+            remaining: limit,
+            seek_error,
+        }
+    }
+
+    pub fn recheck_prefix(&mut self) -> anyhow::Result<Option<SourceChangedReason>> {
+        if self.consumed < self.claim.boundary {
+            return Ok(Some(SourceChangedReason::ShortRead {
+                consumed: self.consumed,
+                boundary: self.claim.boundary,
+            }));
+        }
+        let stat = stat_from_handle(&self.file)?;
+        if stat.size < self.claim.boundary {
+            return Ok(Some(SourceChangedReason::TruncatedAfterRead {
+                size: stat.size,
+                boundary: self.claim.boundary,
+            }));
+        }
+        let head_hash = read_head_hash(&mut self.file, self.claim.boundary)?;
+        if self.claim.head_hash.is_some() && self.claim.head_hash != Some(head_hash) {
+            return Ok(Some(SourceChangedReason::HeadRegionMismatch));
+        }
+        Ok(None)
+    }
+
+    pub fn recheck_full(&mut self) -> anyhow::Result<Option<SourceChangedReason>> {
+        let stat = stat_from_handle(&self.file)?;
+        let size = stat.size;
+        let head_hash = read_head_hash(&mut self.file, size)?;
+        let fingerprint = FingerprintInputs {
+            stat,
+            head_hash: Some(head_hash),
+        }
+        .fingerprint();
+        if fingerprint != self.claim.fingerprint {
+            return Ok(Some(SourceChangedReason::FingerprintMismatch));
+        }
+        Ok(None)
+    }
+}
+
+pub struct PinnedReader<'a> {
+    file: &'a mut File,
+    consumed: &'a mut u64,
+    remaining: u64,
+    seek_error: Option<io::Error>,
+}
+
+impl Read for PinnedReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if let Some(error) = self.seek_error.take() {
+            return Err(error);
+        }
+        if self.remaining == 0 || buffer.is_empty() {
+            return Ok(0);
+        }
+        let available = usize::try_from(self.remaining).unwrap_or(usize::MAX);
+        let read_limit = buffer.len().min(available);
+        let read = self.file.read(&mut buffer[..read_limit])?;
+        self.remaining -= read as u64;
+        *self.consumed += read as u64;
+        Ok(read)
+    }
+}
+
+fn stat_from_handle(file: &File) -> anyhow::Result<SourceStat> {
+    SourceStat::from_open_std_file(file)
+        .ok_or_else(|| anyhow::anyhow!("cannot read source metadata from the open handle"))
+}
+
+fn read_head_hash(file: &mut File, boundary: u64) -> io::Result<u64> {
+    file.seek(SeekFrom::Start(0))?;
+    let expected = usize::try_from(boundary.min(FINGERPRINT_HEAD_BYTES as u64))
+        .expect("the fingerprint head limit fits usize");
+    let mut bytes = Vec::with_capacity(expected);
+    let mut buffer = [0_u8; 8192];
+    while bytes.len() < expected {
+        let remaining = expected - bytes.len();
+        let read_limit = buffer.len().min(remaining);
+        let read = file.read(&mut buffer[..read_limit])?;
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    Ok(head_hash_of(&bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::thread;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    fn write_source(directory: &TempDir, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = directory.path().join(name);
+        std::fs::write(&path, bytes).expect("write source");
+        path
+    }
+
+    fn claim_for_path(path: &Path) -> SourceClaim {
+        let mut file = File::open(path).expect("open source for claim");
+        let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+        let head_hash = read_head_hash(&mut file, stat.size).expect("hash source for claim");
+        SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+            stat,
+            head_hash: Some(head_hash),
+        })
+    }
+
+    #[test]
+    fn a_matching_handle_opens_pinned() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"matching source\n");
+        let claim = claim_for_path(&path);
+
+        let pinned = PinnedSource::open(&path, claim.clone()).expect("open pinned source");
+
+        assert!(pinned.is_ok());
+        assert_eq!(pinned.expect("matching source").claim(), &claim);
+    }
+
+    #[test]
+    fn a_replaced_path_is_rejected_before_any_record() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"byte-identical source\n");
+        let replacement = write_source(&directory, "replacement.jsonl", b"byte-identical source\n");
+        let claim = claim_for_path(&path);
+        std::fs::rename(replacement, &path).expect("replace source path");
+
+        let result = PinnedSource::open(&path, claim).expect("validate replacement");
+
+        assert!(matches!(result, Err(SourceChangedReason::IdentityMismatch)));
+    }
+
+    #[test]
+    fn a_source_below_the_boundary_is_rejected_at_open() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"complete source\n");
+        let claim = claim_for_path(&path);
+        std::fs::write(&path, b"short").expect("shorten source");
+
+        let result = PinnedSource::open(&path, claim.clone()).expect("validate short source");
+
+        assert!(matches!(
+            result,
+            Err(SourceChangedReason::ShortAtOpen { size: 5, boundary })
+                if boundary == claim.boundary
+        ));
+    }
+
+    #[test]
+    fn a_rewritten_head_region_is_rejected_at_open() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"original head\n");
+        let claim = claim_for_path(&path);
+        std::fs::write(&path, b"rewrittenhead\n").expect("rewrite source head");
+
+        let result = PinnedSource::open(&path, claim).expect("validate rewritten source");
+
+        assert!(matches!(
+            result,
+            Err(SourceChangedReason::HeadRegionMismatch)
+        ));
+    }
+
+    #[test]
+    fn a_short_read_is_reported_from_the_consumed_count() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"12345678");
+        let claim = claim_for_path(&path);
+        let mut pinned = PinnedSource::open(&path, claim.clone())
+            .expect("open pinned source")
+            .expect("matching source");
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open source for truncation")
+            .set_len(3)
+            .expect("truncate source");
+        let mut bytes = Vec::new();
+        pinned
+            .reader(claim.boundary)
+            .read_to_end(&mut bytes)
+            .expect("read shortened source");
+
+        let result = pinned.recheck_prefix().expect("recheck prefix");
+
+        assert_eq!(bytes, b"123");
+        assert_eq!(
+            result,
+            Some(SourceChangedReason::ShortRead {
+                consumed: 3,
+                boundary: claim.boundary,
+            })
+        );
+    }
+
+    #[test]
+    fn a_truncation_after_the_read_is_reported_from_the_pinned_size() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"12345678");
+        let claim = claim_for_path(&path);
+        let mut pinned = PinnedSource::open(&path, claim.clone())
+            .expect("open pinned source")
+            .expect("matching source");
+        let mut bytes = Vec::new();
+        pinned
+            .reader(claim.boundary)
+            .read_to_end(&mut bytes)
+            .expect("read source");
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open source for truncation")
+            .set_len(3)
+            .expect("truncate source");
+
+        let result = pinned.recheck_prefix().expect("recheck prefix");
+
+        assert_eq!(bytes, b"12345678");
+        assert_eq!(
+            result,
+            Some(SourceChangedReason::TruncatedAfterRead {
+                size: 3,
+                boundary: claim.boundary,
+            })
+        );
+    }
+
+    #[test]
+    fn an_append_past_the_boundary_passes_the_prefix_recheck() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"first record\n");
+        let claim = claim_for_path(&path);
+        let mut pinned = PinnedSource::open(&path, claim.clone())
+            .expect("open pinned source")
+            .expect("matching source");
+        let mut bytes = Vec::new();
+        pinned
+            .reader(claim.boundary)
+            .read_to_end(&mut bytes)
+            .expect("read prefix");
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open source for append")
+            .write_all(b"second record\n")
+            .expect("append source");
+
+        assert_eq!(pinned.recheck_prefix().expect("recheck prefix"), None);
+        assert_eq!(bytes, b"first record\n");
+    }
+
+    #[test]
+    fn a_same_size_rewrite_after_the_head_region_fails_the_full_recheck() {
+        let directory = TempDir::new().expect("tempdir");
+        let bytes = vec![b'a'; FINGERPRINT_HEAD_BYTES + 1024];
+        let path = write_source(&directory, "session.jsonl", &bytes);
+        let claim = claim_for_path(&path);
+        let mut pinned = PinnedSource::open(&path, claim)
+            .expect("open pinned source")
+            .expect("matching source");
+        let mut read = Vec::new();
+        pinned
+            .reader(u64::MAX)
+            .read_to_end(&mut read)
+            .expect("read full source");
+        thread::sleep(Duration::from_millis(10));
+        let mut writer = OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open source for rewrite");
+        writer
+            .seek(SeekFrom::Start(FINGERPRINT_HEAD_BYTES as u64 + 100))
+            .expect("seek after head region");
+        writer.write_all(b"b").expect("rewrite source");
+        writer.sync_all().expect("sync rewrite");
+
+        assert_eq!(
+            pinned.recheck_full().expect("recheck full source"),
+            Some(SourceChangedReason::FingerprintMismatch)
+        );
+    }
+}

--- a/crates/antiburn-local/src/analysis/source_validity.rs
+++ b/crates/antiburn-local/src/analysis/source_validity.rs
@@ -40,7 +40,9 @@ pub enum AppendOnlyGuarantee {
     Absent,
 }
 
-/// Returns the provider's current append-only guarantee.
+/// Repository fixtures must be synthetic under `CONTRIBUTING.md`.
+/// They cannot prove how a third-party writer updates files.
+/// One local observation cannot establish a repeatable guarantee.
 pub fn append_only_guarantee(_agent: &str) -> AppendOnlyGuarantee {
     AppendOnlyGuarantee::Absent
 }

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -11,7 +11,7 @@ use crate::analysis::model::{
 };
 use crate::analysis::{
     NormalizedRecord, PartialReason, RawSource, RecordCoverage, RecordSink, SessionCollector,
-    SessionInput, adapter_for, analyze_sources, normalize_source,
+    SessionInput, SessionSummary, VisitOutcome, adapter_for, analyze_sources, normalize_source,
 };
 
 fn jsonl_input(agent: &str, jsonl: &str) -> SessionInput {
@@ -19,6 +19,22 @@ fn jsonl_input(agent: &str, jsonl: &str) -> SessionInput {
         agent: agent.into(),
         session_id: "s".into(),
         source: RawSource::Jsonl(jsonl.into()),
+    }
+}
+
+#[derive(Default)]
+struct CountingSink {
+    records: usize,
+    finishes: usize,
+}
+
+impl RecordSink for CountingSink {
+    fn record(&mut self, _record: NormalizedRecord) {
+        self.records += 1;
+    }
+
+    fn finish(&mut self, _summary: SessionSummary) {
+        self.finishes += 1;
     }
 }
 
@@ -374,6 +390,52 @@ const CODEX_FIXTURE: &str = concat!(
     "\n",
     r#"{"timestamp":"2024-06-01T12:00:35Z","type":"event_msg","payload":{"type":"agent_message","message":"done"}}"#,
 );
+
+#[test]
+fn a_legacy_adapter_read_reports_unvalidated() {
+    let input = jsonl_input(
+        "cursor",
+        r#"{"role":"assistant","content":"done","model":"claude-sonnet-4"}"#,
+    );
+    let mut sink = CountingSink::default();
+
+    let outcome = adapter_for("cursor")
+        .visit(&input, &mut sink)
+        .expect("legacy visit must complete");
+
+    assert_eq!(outcome, VisitOutcome::Unvalidated);
+    assert_eq!(sink.finishes, 1);
+}
+
+#[test]
+fn a_legacy_adapter_stream_is_unchanged() {
+    let source = concat!(
+        r#"{"timestamp":"2024-06-01T12:00:00Z","type":"session_meta","payload":{"model":"gpt-5.4"}}"#,
+        "\n",
+        r#"{"timestamp":"2024-06-01T12:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"model_context_window":258400,"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":10}}}}"#,
+    );
+    let input = jsonl_input("codex", source);
+    let adapter = adapter_for("codex");
+    let expected = adapter
+        .normalize(&input)
+        .expect("Codex source must normalize");
+    let mut collector = SessionCollector::new(input.agent.clone(), input.session_id.clone());
+    let outcome = adapter
+        .visit(&input, &mut collector)
+        .expect("default visit must complete");
+    let actual = collector
+        .into_session()
+        .expect("visited session must finish");
+    let mut counter = CountingSink::default();
+    adapter
+        .visit(&input, &mut counter)
+        .expect("counted visit must complete");
+
+    assert_eq!(outcome, VisitOutcome::Unvalidated);
+    assert_eq!(actual, expected);
+    assert_eq!(counter.records, expected.events.len());
+    assert_eq!(counter.finishes, 1);
+}
 
 #[test]
 fn a_non_claude_adapter_visits_through_the_default_implementation() {

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -24,7 +24,7 @@ use super::jsonl::{
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, RecordSkip};
 use crate::analysis::interface::{
     NormalizedRecord, RawSource, RecordSink, SessionCollector, SessionInput, SessionSummary,
-    VendorAdapter,
+    VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, ToolCall, Usage};
 
@@ -41,17 +41,21 @@ impl VendorAdapter for ClaudeAdapter {
         collector.into_session()
     }
 
-    fn visit(&self, input: &SessionInput, sink: &mut dyn RecordSink) -> anyhow::Result<()> {
-        (|| -> anyhow::Result<()> {
+    fn visit(
+        &self,
+        input: &SessionInput,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<VisitOutcome> {
+        (|| -> anyhow::Result<VisitOutcome> {
             match &input.source {
                 RawSource::File(path) => {
                     let file = File::open(path)?;
-                    self.visit_reader(BufReader::new(file), sink)
+                    self.visit_reader(BufReader::new(file), sink)?;
                 }
                 RawSource::Jsonl(content) => {
                     let suffix: &[u8] = if content.ends_with('\n') { b"" } else { b"\n" };
                     let source = Cursor::new(content.as_bytes()).chain(suffix);
-                    self.visit_reader(BufReader::new(source), sink)
+                    self.visit_reader(BufReader::new(source), sink)?;
                 }
                 RawSource::Sqlite(path) => {
                     anyhow::bail!(
@@ -60,6 +64,7 @@ impl VendorAdapter for ClaudeAdapter {
                     )
                 }
             }
+            Ok(VisitOutcome::Unvalidated)
         })()
         .with_context(|| format!("reading claude session {}", input.session_id))
     }

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -27,6 +27,7 @@ use crate::analysis::interface::{
     VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, ToolCall, Usage};
+use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
 
 pub struct ClaudeAdapter;
 
@@ -47,15 +48,15 @@ impl VendorAdapter for ClaudeAdapter {
         sink: &mut dyn RecordSink,
     ) -> anyhow::Result<VisitOutcome> {
         (|| -> anyhow::Result<VisitOutcome> {
-            match &input.source {
+            let summary = match &input.source {
                 RawSource::File(path) => {
                     let file = File::open(path)?;
-                    self.visit_reader(BufReader::new(file), sink)?;
+                    self.visit_reader(BufReader::new(file), sink)?
                 }
                 RawSource::Jsonl(content) => {
                     let suffix: &[u8] = if content.ends_with('\n') { b"" } else { b"\n" };
                     let source = Cursor::new(content.as_bytes()).chain(suffix);
-                    self.visit_reader(BufReader::new(source), sink)?;
+                    self.visit_reader(BufReader::new(source), sink)?
                 }
                 RawSource::Sqlite(path) => {
                     anyhow::bail!(
@@ -63,7 +64,8 @@ impl VendorAdapter for ClaudeAdapter {
                         path.display()
                     )
                 }
-            }
+            };
+            sink.finish(summary);
             Ok(VisitOutcome::Unvalidated)
         })()
         .with_context(|| format!("reading claude session {}", input.session_id))
@@ -71,7 +73,52 @@ impl VendorAdapter for ClaudeAdapter {
 }
 
 impl ClaudeAdapter {
-    fn visit_reader(&self, reader: impl BufRead, sink: &mut dyn RecordSink) -> anyhow::Result<()> {
+    pub fn visit_claimed(
+        &self,
+        input: &SessionInput,
+        claim: &SourceClaim,
+        guarantee: AppendOnlyGuarantee,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<VisitOutcome> {
+        (|| -> anyhow::Result<VisitOutcome> {
+            let RawSource::File(path) = &input.source else {
+                anyhow::bail!("a claimed Claude source must be a file");
+            };
+            let mut pinned = match PinnedSource::open(path, claim.clone())? {
+                Ok(pinned) => pinned,
+                Err(reason) => return Ok(VisitOutcome::SourceChanged(reason)),
+            };
+            let limit = match guarantee {
+                AppendOnlyGuarantee::Evidenced => claim.boundary,
+                AppendOnlyGuarantee::Absent => u64::MAX,
+            };
+            let summary = self.visit_reader(BufReader::new(pinned.reader(limit)), sink)?;
+            let outcome = match guarantee {
+                AppendOnlyGuarantee::Evidenced => match pinned.recheck_prefix()? {
+                    Some(reason) => VisitOutcome::SourceChanged(reason),
+                    None => VisitOutcome::AcceptedPrefix {
+                        boundary: claim.boundary,
+                    },
+                },
+                AppendOnlyGuarantee::Absent => match pinned.recheck_full()? {
+                    Some(reason) => VisitOutcome::SourceChanged(reason),
+                    None => VisitOutcome::AcceptedFull,
+                },
+            };
+            if matches!(outcome, VisitOutcome::SourceChanged(_)) {
+                return Ok(outcome);
+            }
+            sink.finish(summary);
+            Ok(outcome)
+        })()
+        .with_context(|| format!("reading claimed Claude session {}", input.session_id))
+    }
+
+    fn visit_reader(
+        &self,
+        reader: impl BufRead,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<SessionSummary> {
         let mut reader = BoundedJsonlReader::new(reader);
         let mut state = ClaudeStreamState::default();
 
@@ -130,8 +177,7 @@ impl ClaudeAdapter {
             }
         }
 
-        sink.finish(state.into_summary());
-        Ok(())
+        Ok(state.into_summary())
     }
 }
 
@@ -261,9 +307,164 @@ fn model_context_window(model: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, BufReader, Error, Read};
+    use std::fs::OpenOptions;
+    use std::io::{self, BufReader, Error, Read, Seek, SeekFrom, Write};
+    use std::path::Path;
 
     use super::*;
+    use crate::analysis::{PartialReason, RecordCoverage};
+    use crate::discovery::source_version::head_hash_of;
+    use crate::discovery::{FingerprintInputs, SourceStat};
+    use tempfile::TempDir;
+
+    const FIRST_RECORD: &str = concat!(
+        r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"first"}]}}"#,
+        "\n",
+    );
+    const SECOND_RECORD: &str = concat!(
+        r#"{"type":"assistant","timestamp":"2024-06-01T12:01:00Z","message":{"role":"assistant","content":[{"type":"text","text":"second"}]}}"#,
+        "\n",
+    );
+
+    fn file_input(path: &Path) -> SessionInput {
+        SessionInput {
+            agent: "claude".to_string(),
+            session_id: "claimed-session".to_string(),
+            source: RawSource::File(path.to_path_buf()),
+        }
+    }
+
+    fn claim_for_path(path: &Path) -> SourceClaim {
+        let file = File::open(path).expect("open source for claim");
+        let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+        let bytes = std::fs::read(path).expect("read source for claim");
+        SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+            stat,
+            head_hash: Some(head_hash_of(&bytes)),
+        })
+    }
+
+    fn write_source(directory: &TempDir, bytes: &[u8]) -> std::path::PathBuf {
+        let path = directory.path().join("session.jsonl");
+        std::fs::write(&path, bytes).expect("write source");
+        path
+    }
+
+    #[test]
+    fn a_record_whose_newline_is_past_the_boundary_is_not_committed() {
+        let directory = TempDir::new().expect("tempdir");
+        let split = SECOND_RECORD.len() / 2;
+        let generation = [FIRST_RECORD.as_bytes(), &SECOND_RECORD.as_bytes()[..split]].concat();
+        let path = write_source(&directory, &generation);
+        let claim = claim_for_path(&path);
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open source for append")
+            .write_all(&SECOND_RECORD.as_bytes()[split..])
+            .expect("complete second record");
+        let input = file_input(&path);
+        let mut collector = SessionCollector::new("claude", "claimed-session");
+
+        let outcome = ClaudeAdapter
+            .visit_claimed(
+                &input,
+                &claim,
+                AppendOnlyGuarantee::Evidenced,
+                &mut collector,
+            )
+            .expect("visit claimed prefix");
+
+        assert_eq!(
+            outcome,
+            VisitOutcome::AcceptedPrefix {
+                boundary: claim.boundary,
+            }
+        );
+        assert_eq!(collector.coverage(), RecordCoverage::Partial);
+        assert_eq!(
+            collector.partial_reasons(),
+            &std::collections::BTreeSet::from([PartialReason::IncompleteTail])
+        );
+        assert_eq!(
+            collector
+                .into_session()
+                .expect("accepted prefix must publish")
+                .events
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_source_changed_read_cannot_publish() {
+        let directory = TempDir::new().expect("tempdir");
+        let source = [FIRST_RECORD.as_bytes(), SECOND_RECORD.as_bytes()].concat();
+        let path = write_source(&directory, &source);
+        let claim = claim_for_path(&path);
+        let input = file_input(&path);
+        let mut sink = HeadMutatingSink::new(&path);
+
+        let outcome = ClaudeAdapter
+            .visit_claimed(&input, &claim, AppendOnlyGuarantee::Evidenced, &mut sink)
+            .expect("visit changed source");
+
+        assert_eq!(
+            outcome,
+            VisitOutcome::SourceChanged(crate::analysis::SourceChangedReason::HeadRegionMismatch)
+        );
+        assert!(sink.collector.into_session().is_err());
+    }
+
+    #[test]
+    fn an_accepted_prefix_publishes_its_records() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let claim = claim_for_path(&path);
+        let input = file_input(&path);
+        let mut collector = SessionCollector::new("claude", "claimed-session");
+
+        let outcome = ClaudeAdapter
+            .visit_claimed(
+                &input,
+                &claim,
+                AppendOnlyGuarantee::Evidenced,
+                &mut collector,
+            )
+            .expect("visit stable prefix");
+
+        assert_eq!(
+            outcome,
+            VisitOutcome::AcceptedPrefix {
+                boundary: claim.boundary,
+            }
+        );
+        assert_eq!(
+            collector
+                .into_session()
+                .expect("accepted prefix must publish")
+                .events
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_plain_claude_read_reports_unvalidated() {
+        let input = SessionInput {
+            agent: "claude".to_string(),
+            session_id: "plain-session".to_string(),
+            source: RawSource::Jsonl(FIRST_RECORD.to_string()),
+        };
+        let mut sink = CountingSink::default();
+
+        let outcome = ClaudeAdapter
+            .visit(&input, &mut sink)
+            .expect("visit plain source");
+
+        assert_eq!(outcome, VisitOutcome::Unvalidated);
+        assert_eq!(sink.finishes, 1);
+    }
 
     #[test]
     fn a_mid_stream_read_failure_omits_the_whole_session() {
@@ -272,6 +473,55 @@ mod tests {
         let mut collector = SessionCollector::new("claude", "read-failure");
         let result = ClaudeAdapter.visit_reader(reader, &mut collector);
         assert!(result.is_err());
+    }
+
+    struct HeadMutatingSink {
+        collector: SessionCollector,
+        path: std::path::PathBuf,
+        mutated: bool,
+    }
+
+    impl HeadMutatingSink {
+        fn new(path: &Path) -> Self {
+            Self {
+                collector: SessionCollector::new("claude", "claimed-session"),
+                path: path.to_path_buf(),
+                mutated: false,
+            }
+        }
+    }
+
+    impl RecordSink for HeadMutatingSink {
+        fn record(&mut self, record: NormalizedRecord) {
+            if !self.mutated {
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .open(&self.path)
+                    .expect("open source for mutation");
+                file.seek(SeekFrom::Start(0)).expect("seek source head");
+                file.write_all(b"[").expect("rewrite source head");
+                file.sync_all().expect("sync source mutation");
+                self.mutated = true;
+            }
+            self.collector.record(record);
+        }
+
+        fn finish(&mut self, summary: SessionSummary) {
+            self.collector.finish(summary);
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingSink {
+        finishes: usize,
+    }
+
+    impl RecordSink for CountingSink {
+        fn record(&mut self, _record: NormalizedRecord) {}
+
+        fn finish(&mut self, _summary: SessionSummary) {
+            self.finishes += 1;
+        }
     }
 
     struct DataThenError {

--- a/crates/antiburn-local/src/analysis/vendors/mod.rs
+++ b/crates/antiburn-local/src/analysis/vendors/mod.rs
@@ -9,7 +9,7 @@
 //! vendor is ever silently dropped from analysis.
 
 mod antigravity;
-mod claude;
+pub mod claude;
 mod codex;
 mod cursor;
 mod generic_jsonl;

--- a/crates/antiburn-local/src/discovery/source_version.rs
+++ b/crates/antiburn-local/src/discovery/source_version.rs
@@ -118,6 +118,11 @@ impl SourceStat {
         Some(Self::from_path_metadata(&metadata))
     }
 
+    pub fn from_open_std_file(file: &std::fs::File) -> Option<Self> {
+        let metadata = file.metadata().ok()?;
+        Some(Self::from_open_std_metadata(file, &metadata))
+    }
+
     #[cfg(unix)]
     fn from_open_metadata(_file: &tokio::fs::File, metadata: &std::fs::Metadata) -> Self {
         Self::from_unix_metadata(metadata)
@@ -125,14 +130,34 @@ impl SourceStat {
 
     #[cfg(windows)]
     fn from_open_metadata(file: &tokio::fs::File, metadata: &std::fs::Metadata) -> Self {
-        use std::mem::MaybeUninit;
         use std::os::windows::io::AsRawHandle;
+
+        Self::from_windows_handle(file.as_raw_handle(), metadata)
+    }
+
+    #[cfg(unix)]
+    fn from_open_std_metadata(_file: &std::fs::File, metadata: &std::fs::Metadata) -> Self {
+        Self::from_unix_metadata(metadata)
+    }
+
+    #[cfg(windows)]
+    fn from_open_std_metadata(file: &std::fs::File, metadata: &std::fs::Metadata) -> Self {
+        use std::os::windows::io::AsRawHandle;
+
+        Self::from_windows_handle(file.as_raw_handle(), metadata)
+    }
+
+    #[cfg(windows)]
+    fn from_windows_handle(
+        handle: std::os::windows::io::RawHandle,
+        metadata: &std::fs::Metadata,
+    ) -> Self {
+        use std::mem::MaybeUninit;
         use windows_sys::Win32::Storage::FileSystem::{
             BY_HANDLE_FILE_INFORMATION, FILE_BASIC_INFO, FileBasicInfo, GetFileInformationByHandle,
             GetFileInformationByHandleEx,
         };
 
-        let handle = file.as_raw_handle();
         let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
         let mut basic = MaybeUninit::<FILE_BASIC_INFO>::zeroed();
         // SAFETY: the file owns the valid handle, and both output buffers match the requested types.

--- a/crates/antiburn-local/tests/source_validity_timing.rs
+++ b/crates/antiburn-local/tests/source_validity_timing.rs
@@ -274,6 +274,7 @@ fn an_evidenced_guarantee_reads_a_pinned_prefix() {
     );
 }
 
+#[cfg(unix)]
 struct RenameSink {
     collector: SessionCollector,
     path: PathBuf,
@@ -281,6 +282,7 @@ struct RenameSink {
     renamed: bool,
 }
 
+#[cfg(unix)]
 impl RenameSink {
     fn new(path: &Path, replacement: PathBuf) -> Self {
         Self {
@@ -292,6 +294,7 @@ impl RenameSink {
     }
 }
 
+#[cfg(unix)]
 impl RecordSink for RenameSink {
     fn record(&mut self, record: NormalizedRecord) {
         if !self.renamed {

--- a/crates/antiburn-local/tests/source_validity_timing.rs
+++ b/crates/antiburn-local/tests/source_validity_timing.rs
@@ -1,0 +1,367 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use antiburn_local::analysis::{
+    AppendOnlyGuarantee, ClaudeAdapter, NormalizedRecord, RawSource, RecordSink, SessionCollector,
+    SessionInput, SessionSummary, SourceChangedReason, SourceClaim, VisitOutcome,
+    append_only_guarantee,
+};
+use antiburn_local::discovery::source_version::{
+    FINGERPRINT_HEAD_BYTES, FingerprintInputs, SourceStat, head_hash_of,
+};
+use tempfile::TempDir;
+
+fn record(text: &str, minute: usize) -> String {
+    format!(
+        "{{\"type\":\"assistant\",\"timestamp\":\"2024-06-01T12:{minute:02}:00Z\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"text\",\"text\":\"{text}\"}}]}}}}\n"
+    )
+}
+
+fn write_source(directory: &TempDir, name: &str, bytes: &[u8]) -> PathBuf {
+    let path = directory.path().join(name);
+    std::fs::write(&path, bytes).expect("write source");
+    path
+}
+
+fn file_input(path: &Path) -> SessionInput {
+    SessionInput {
+        agent: "claude".to_string(),
+        session_id: "claimed-session".to_string(),
+        source: RawSource::File(path.to_path_buf()),
+    }
+}
+
+fn claim_for_path(path: &Path) -> SourceClaim {
+    let mut file = File::open(path).expect("open source for claim");
+    let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).expect("read source for claim");
+    SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+        stat,
+        head_hash: Some(head_hash_of(&bytes)),
+    })
+}
+
+#[derive(Default)]
+struct CountingSink {
+    records: usize,
+    finishes: usize,
+}
+
+impl RecordSink for CountingSink {
+    fn record(&mut self, _record: NormalizedRecord) {
+        self.records += 1;
+    }
+
+    fn finish(&mut self, _summary: SessionSummary) {
+        self.finishes += 1;
+    }
+}
+
+#[test]
+fn a_replacement_before_pinning_streams_nothing() {
+    let directory = TempDir::new().expect("tempdir");
+    let bytes = record("same bytes", 0);
+    let path = write_source(&directory, "session.jsonl", bytes.as_bytes());
+    let replacement = write_source(&directory, "replacement.jsonl", bytes.as_bytes());
+    let claim = claim_for_path(&path);
+    std::fs::rename(replacement, &path).expect("replace source path");
+    let mut sink = CountingSink::default();
+
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &file_input(&path),
+            &claim,
+            AppendOnlyGuarantee::Evidenced,
+            &mut sink,
+        )
+        .expect("visit replacement");
+
+    assert_eq!(
+        outcome,
+        VisitOutcome::SourceChanged(SourceChangedReason::IdentityMismatch)
+    );
+    assert_eq!(sink.finishes, 0);
+    assert_eq!(sink.records, 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_rename_after_pinning_is_accepted_on_the_original_inode() {
+    let directory = TempDir::new().expect("tempdir");
+    let source = [record("first", 0), record("second", 1)].concat();
+    let path = write_source(&directory, "session.jsonl", source.as_bytes());
+    let replacement = write_source(&directory, "replacement.jsonl", b"");
+    let claim = claim_for_path(&path);
+    let mut sink = RenameSink::new(&path, replacement);
+
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &file_input(&path),
+            &claim,
+            AppendOnlyGuarantee::Evidenced,
+            &mut sink,
+        )
+        .expect("visit renamed source");
+
+    assert_eq!(
+        outcome,
+        VisitOutcome::AcceptedPrefix {
+            boundary: claim.boundary,
+        }
+    );
+    assert_eq!(
+        sink.collector
+            .into_session()
+            .expect("original inode must publish")
+            .events
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn a_rewritten_record_after_the_head_region_passes_the_recheck() {
+    let directory = TempDir::new().expect("tempdir");
+    let (source, rewrite_offset) = large_source();
+    let path = write_source(&directory, "session.jsonl", &source);
+    let claim = claim_for_path(&path);
+    let mut sink = RewriteSink::new(&path, rewrite_offset);
+
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &file_input(&path),
+            &claim,
+            AppendOnlyGuarantee::Evidenced,
+            &mut sink,
+        )
+        .expect("visit rewritten prefix");
+
+    // The prefix recheck covers only the head region.
+    // The append-only guarantee must protect later complete records.
+    assert_eq!(
+        outcome,
+        VisitOutcome::AcceptedPrefix {
+            boundary: claim.boundary,
+        }
+    );
+}
+
+#[test]
+fn two_reads_of_the_same_identity_and_boundary_are_byte_identical() {
+    let directory = TempDir::new().expect("tempdir");
+    let path = write_source(&directory, "session.jsonl", record("first", 0).as_bytes());
+    let claim = claim_for_path(&path);
+    let input = file_input(&path);
+    let mut first = SessionCollector::new("claude", "claimed-session");
+    let first_outcome = ClaudeAdapter
+        .visit_claimed(&input, &claim, AppendOnlyGuarantee::Evidenced, &mut first)
+        .expect("visit first prefix");
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("open source for append")
+        .write_all(record("second", 1).as_bytes())
+        .expect("append source");
+    let mut second = SessionCollector::new("claude", "claimed-session");
+    let second_outcome = ClaudeAdapter
+        .visit_claimed(&input, &claim, AppendOnlyGuarantee::Evidenced, &mut second)
+        .expect("visit second prefix");
+
+    assert_eq!(first_outcome, second_outcome);
+    assert_eq!(
+        serde_json::to_vec(&first.into_session().expect("first prefix must publish"))
+            .expect("serialize first prefix"),
+        serde_json::to_vec(&second.into_session().expect("second prefix must publish"))
+            .expect("serialize second prefix")
+    );
+}
+
+#[test]
+fn claude_carries_no_append_only_guarantee() {
+    assert_eq!(append_only_guarantee("claude"), AppendOnlyGuarantee::Absent);
+}
+
+#[test]
+fn an_absent_guarantee_accepts_a_stable_full_read() {
+    let directory = TempDir::new().expect("tempdir");
+    let path = write_source(&directory, "session.jsonl", record("stable", 0).as_bytes());
+    let claim = claim_for_path(&path);
+    let mut collector = SessionCollector::new("claude", "claimed-session");
+
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &file_input(&path),
+            &claim,
+            AppendOnlyGuarantee::Absent,
+            &mut collector,
+        )
+        .expect("visit stable full source");
+
+    assert_eq!(outcome, VisitOutcome::AcceptedFull);
+    assert!(collector.into_session().is_ok());
+}
+
+#[test]
+fn an_absent_guarantee_takes_the_full_reprocess_path() {
+    let directory = TempDir::new().expect("tempdir");
+    let path = write_source(&directory, "session.jsonl", record("first", 0).as_bytes());
+    let claim = claim_for_path(&path);
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("open source for append")
+        .write_all(record("second", 1).as_bytes())
+        .expect("append source");
+    let mut collector = SessionCollector::new("claude", "claimed-session");
+
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &file_input(&path),
+            &claim,
+            append_only_guarantee("claude"),
+            &mut collector,
+        )
+        .expect("visit full source");
+
+    assert_eq!(
+        outcome,
+        VisitOutcome::SourceChanged(SourceChangedReason::FingerprintMismatch)
+    );
+    assert!(collector.into_session().is_err());
+}
+
+#[test]
+fn an_evidenced_guarantee_reads_a_pinned_prefix() {
+    let directory = TempDir::new().expect("tempdir");
+    let path = write_source(&directory, "session.jsonl", record("first", 0).as_bytes());
+    let claim = claim_for_path(&path);
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("open source for append")
+        .write_all(record("second", 1).as_bytes())
+        .expect("append source");
+    let mut collector = SessionCollector::new("claude", "claimed-session");
+
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &file_input(&path),
+            &claim,
+            AppendOnlyGuarantee::Evidenced,
+            &mut collector,
+        )
+        .expect("visit prefix");
+
+    assert_eq!(
+        outcome,
+        VisitOutcome::AcceptedPrefix {
+            boundary: claim.boundary,
+        }
+    );
+    assert_eq!(
+        collector
+            .into_session()
+            .expect("evidenced prefix must publish")
+            .events
+            .len(),
+        1
+    );
+}
+
+struct RenameSink {
+    collector: SessionCollector,
+    path: PathBuf,
+    replacement: PathBuf,
+    renamed: bool,
+}
+
+impl RenameSink {
+    fn new(path: &Path, replacement: PathBuf) -> Self {
+        Self {
+            collector: SessionCollector::new("claude", "claimed-session"),
+            path: path.to_path_buf(),
+            replacement,
+            renamed: false,
+        }
+    }
+}
+
+impl RecordSink for RenameSink {
+    fn record(&mut self, record: NormalizedRecord) {
+        if !self.renamed {
+            std::fs::rename(&self.replacement, &self.path).expect("replace pinned path");
+            self.renamed = true;
+        }
+        self.collector.record(record);
+    }
+
+    fn finish(&mut self, summary: SessionSummary) {
+        self.collector.finish(summary);
+    }
+}
+
+struct RewriteSink {
+    collector: SessionCollector,
+    path: PathBuf,
+    rewrite_offset: u64,
+    rewritten: bool,
+}
+
+impl RewriteSink {
+    fn new(path: &Path, rewrite_offset: u64) -> Self {
+        Self {
+            collector: SessionCollector::new("claude", "claimed-session"),
+            path: path.to_path_buf(),
+            rewrite_offset,
+            rewritten: false,
+        }
+    }
+}
+
+impl RecordSink for RewriteSink {
+    fn record(&mut self, record: NormalizedRecord) {
+        if !self.rewritten {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .open(&self.path)
+                .expect("open source for rewrite");
+            file.seek(SeekFrom::Start(self.rewrite_offset))
+                .expect("seek rewritten record");
+            file.write_all(b"bbbb").expect("rewrite complete record");
+            file.sync_all().expect("sync complete record");
+            self.rewritten = true;
+        }
+        self.collector.record(record);
+    }
+
+    fn finish(&mut self, summary: SessionSummary) {
+        self.collector.finish(summary);
+    }
+}
+
+fn large_source() -> (Vec<u8>, u64) {
+    let mut source = Vec::new();
+    let mut minute = 0;
+    while source.len() <= FINGERPRINT_HEAD_BYTES + 1024 {
+        source.extend_from_slice(
+            record(
+                &format!("padding-{minute}-{}", "x".repeat(900)),
+                minute % 60,
+            )
+            .as_bytes(),
+        );
+        minute += 1;
+    }
+    let target = record("aaaa", minute % 60);
+    let marker = target.find("aaaa").expect("target marker") as u64;
+    let rewrite_offset = source.len() as u64 + marker;
+    source.extend_from_slice(target.as_bytes());
+    source.extend_from_slice(record("tail", (minute + 1) % 60).as_bytes());
+    (source, rewrite_offset)
+}


### PR DESCRIPTION
This is part of a PR stack based at #91; this PR merges into #169.

### Stack · GH-70
- #169 — 0006 (CH-004): record-sink and Claude transcript normalization (parent)
  - **#NNN — 0007 (CH-004): source validity and pinned-prefix publication ← this PR**

## What this seam contains

Completes CH-004 by giving the Claude read path a source-validity result: a Claude read through one pinned handle now races the writer and answers with one of `Unvalidated`, `AcceptedFull`, `AcceptedPrefix`, or `SourceChanged` (with six reasons). Three commits ship the pinned-source primitives, the validated claimed read, and the append-only guarantee determination with its timing tests.

## Why this piece was done

CH-004 splits source-validity (this seam) from the record-by-record refactor (0006) by risk domain. The guarantee gates whether a later seam publishes. Testing it here proves the upstream path without blocking on publication infrastructure.

## The headline

**The append-only guarantee is `Absent` for every agent.** A synthetic fixture can evidence only the test; `CONTRIBUTING.md:66` forbids captured transcripts as repository fixtures. So **no pinned prefix publishes in production** and Claude takes the full-reprocess path. The mechanism ships fully tested and inert. If real evidence ever arrives, a later seam changes one function's return value.

## What it changes

- **Result type**: `VisitOutcome` gains `Unvalidated`, `AcceptedFull`, `AcceptedPrefix { boundary }`, and `SourceChanged(reason)` with six reasons. `VendorAdapter::visit` becomes `Result<VisitOutcome>`.
- **Legacy adapters**: now report `VisitOutcome::Unvalidated` instead of `AcceptedFull`, because they perform no post-read recheck. Records, diagnostics, and output unchanged.
- **Claude path**: `ClaudeAdapter::visit_claimed` opens one `PinnedSource`, validates it against the claimed generation before streaming, and rechecks from that pinned handle. It calls `sink.finish` only on an accepted outcome.
- **Guarantee function**: `append_only_guarantee(_agent)` returns `Absent`.
- **Structural property**: `AcceptedFull` is constructible only from a successful `PinnedSource::recheck_full`. A failed recheck skips `sink.finish`, making a `SourceChanged` read structurally unable to publish. A failed pre-validation streams nothing.

<details>
<summary>Four structural properties, enforced in code</summary>

1. `AcceptedFull` is constructible only from a successful `PinnedSource::recheck_full` — its one construction site is `vendors/claude.rs:105`.
2. The path is never re-stat-ed. `PinnedSource` stores no path field (`source_validity.rs:52-56`); every stat goes through `stat_from_handle`.
3. A failed recheck skips `sink.finish` (`vendors/claude.rs:109` returns before `:111`), so seam 0006's `SessionCollector::into_session` guard makes a `SourceChanged` read structurally unable to publish.
4. A failed pre-read validation streams nothing — `PinnedSource::open` returns at `:89` before `visit_reader` at `:95`.
</details>

**Real blast radius.** `ClaudeAdapter::normalize` calls the modified `visit`, and desktop analytics reaches that code through `analyze_sources_with`, so that path is shipped though behavior-preserving. Only the new `visit_claimed` pinned-source path is unwired.

## Verification

- `cargo fmt/clippy/test` (antiburn-local): exit 0, run-id `0007-antiburn-local-fmt-clippy-test-20260825T015750Z-6a74`
- `cargo fmt/clippy/test` (desktop): exit 0, run-id `0007-desktop-tauri-fmt-clippy-test-20260825T015808Z-550f`
- `pnpm run slop`: exit 0 clean at score 100, run-id `0007-pnpm-slop-20260825T015822Z-36b5`
- Ten `claude_characterization` goldens: byte identical
- Six mutation runs: each named mutation fails as expected (e.g., removing the `None => AcceptedFull` branch fails `an_absent_guarantee_accepts_a_stable_full_read`)

**Residual risks.** A file that grew between discovery's stat and its head read will recheck as invalid — it fails closed to `SourceChanged` and retries under CH-008's backoff, affecting only files below 64 KiB. The pinned-prefix path is inert under `Absent`, so it is proven by test only and has never run against a real growing transcript; flipping the guarantee in a later seam re-verifies. The `cfg(windows)` branch does not compile on macOS; Windows CI is its only check.

## How to review

Read the approval logic: `vendors/claude.rs:103-111` shows the ordering that prevents `SourceChanged` reads from publishing. Check `source_validity.rs:43-47` for the guarantee comment and reason. Verify `source_validity.rs:170-184` that the head hash bound is `boundary.min(FINGERPRINT_HEAD_BYTES)`, not a blind 64 KiB. Confirm `PinnedSource` carries no path field and every stat goes through `stat_from_handle`.

**Review hotspots** — entity-level risk triage (Medium 2 / High 0 / Critical 0):

| Entity | File | Risk | Signals |
|---|---|---|---|
| `VisitOutcome` (enum, new) | `interface.rs` | Medium | publication semantics · 4 variants · used by CH-005/CH-008 |
| `PinnedSource` (struct, new) | `source_validity.rs` | Medium | pinned-read invariant holder · 3 fields · no path field (key structural property) |