### PR TITLE
chore(release): prepare antiburn-local 0.1.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # `libsqlite3-sys` sets `links = "sqlite3"`, so a dependency graph may
+      # contain exactly one version of it — a resolution rule that binds our
+      # embedders, not only us. Consumers on SQLx 0.8 need `libsqlite3-sys
+      # ^0.30.1`, which only rusqlite 0.31/0.32 satisfy. Bumping this crate
+      # breaks their resolve without breaking ours, so the failure surfaces
+      # downstream and late; that is exactly what happened once already.
+      # Revisit when SQLx widens its requirement. See the comment on the
+      # dependency in crates/antiburn-local/Cargo.toml.
+      - dependency-name: "rusqlite"
+      - dependency-name: "libsqlite3-sys"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1787,17 +1787,14 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2425,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.2"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3633,16 +3630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
-dependencies = [
- "hashbrown 0.16.1",
- "thiserror 2.0.20",
-]
-
-[[package]]
 name = "rtsan-standalone"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.13.1",
  "fallible-iterator",
@@ -3684,7 +3671,6 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -4265,18 +4251,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
-dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -81,7 +81,10 @@ base64 = "0.23"
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "form", "json", "rustls-no-provider"] }
 # The app-owned local database. `bundled` compiles SQLite from source, so the
 # app never depends on a system library and CI needs no extra packages.
-rusqlite = { version = "0.40.2", features = ["bundled"] }
+# Held at 0.32 to match `antiburn-local`: `libsqlite3-sys` sets
+# `links = "sqlite3"`, so the app and the engine it path-depends on must agree
+# on one version. The engine's own pin carries the full reasoning.
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 # Only to install the process-wide crypto provider `reqwest`'s
 # `rustls-no-provider` feature leaves unset — `ring`, matching what
 # `tauri-plugin-updater`'s own rustls dependency already resolves to.

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,7 +21,49 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
-## [0.1.5] - 2026-08-25
+## [0.1.6] - 2026-08-25
+
+### Changed
+
+- **Breaking:** `VendorAdapter::visit` returns `VisitOutcome` rather than `()`.
+  The default implementation returns `VisitOutcome::Unvalidated`, so an adapter
+  that does not check source validity only needs its signature updated. Callers
+  that discarded the unit result must now handle the outcome, because a
+  successful return no longer means the records describe a single coherent
+  source.
+- **rusqlite moves back to the 0.32 line** from 0.40. `libsqlite3-sys` sets
+  `links = "sqlite3"`, so a dependency graph may contain exactly one version of
+  it — a constraint on resolution, not on the build, which therefore binds even
+  when the conflicting dependency's features are off. An embedder that also uses
+  SQLx 0.8 needs `libsqlite3-sys ^0.30.1`, which only rusqlite 0.31 and 0.32
+  satisfy; against 0.40 such a graph simply fails to resolve, and the failure
+  lands downstream rather than here. The engine used no API newer than 0.32, so
+  the newer line bought nothing. `.github/dependabot.yml` now ignores `rusqlite`
+  and `libsqlite3-sys` so an automated bump cannot silently reintroduce this.
+- Per-agent discovery completion now logs at `debug` rather than `info`. It
+  reported once per agent per scan, which is scan bookkeeping rather than
+  something an embedder's default log level should carry.
+
+### Added
+
+- `analysis::source_validity` decides whether a transcript that was read still
+  describes the source it claimed to: `SourceClaim`, `PinnedSource`,
+  `PinnedOpen`, `PinnedReader`, `AppendOnlyGuarantee`, and
+  `append_only_guarantee`. `PinnedSource::open` pins a claimed source,
+  `recheck_prefix` and `recheck_full` re-verify it after reading, and each
+  returns the specific way it diverged rather than a bare failure.
+- `analysis::VisitOutcome` and `analysis::SourceChangedReason` report that
+  verdict to a caller. `AcceptedFull`, `AcceptedPrefix { boundary }`, and
+  `Unvalidated` distinguish a fully verified read from a verified prefix and
+  from no check at all, so a partial result is usable instead of merely
+  suspect. `SourceChangedReason` names the divergence — identity mismatch, a
+  short file at open, a head-region mismatch, a short read, truncation after
+  reading, or a fingerprint mismatch.
+- `ClaudeAdapter` is exported, and `ClaudeAdapter::visit_claimed` streams a
+  Claude transcript against a `SourceClaim`, validating the read rather than
+  trusting it.
+- `discovery::SourceStat::from_open_std_file` stats an already-open
+  `std::fs::File`, which is what the pinned-read path holds.
 
 ### Added
 

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -3,8 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "antiburn-local"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -132,12 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,11 +203,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "foldhash",
+ "ahash",
 ]
 
 [[package]]
@@ -209,17 +215,14 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -257,9 +260,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.2"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -391,20 +394,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
-dependencies = [
- "hashbrown 0.16.1",
- "thiserror",
-]
-
-[[package]]
 name = "rusqlite"
-version = "0.40.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -412,7 +405,6 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -546,18 +538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
-dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,26 +570,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -762,6 +722,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +798,26 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MPL-2.0"
@@ -24,7 +24,18 @@ anyhow = "1"
 async-trait = "0.1"
 # Bounded-concurrency stream combinators for the discovery fan-out.
 futures-util = "0.3"
-rusqlite = { version = "0.40.2", features = ["bundled"] }
+# Held at the 0.32 line deliberately — do not bump without checking consumers.
+# `libsqlite3-sys` sets `links = "sqlite3"`, so a dependency graph may contain
+# exactly one version of it. That is a resolution-graph rule, not a build rule:
+# it binds even when the conflicting dependency's features are off. Embedders
+# that also use SQLx 0.8 (which requires `libsqlite3-sys ^0.30.1`) can therefore
+# only resolve alongside rusqlite 0.31 or 0.32; 0.33+ moves to a
+# `libsqlite3-sys` line SQLx 0.8 cannot accept, and the whole graph fails to
+# resolve. The engine uses no API newer than 0.32, so the newer line bought
+# nothing and cost every SQLx-embedding consumer a build. A bump needs SQLx to
+# widen its own requirement first. `.github/dependabot.yml` ignores this crate
+# for the same reason.
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = { version = "0.3", features = ["formatting", "parsing"] }


### PR DESCRIPTION
Cuts `antiburn-local-v0.1.6` and, with it, returns rusqlite to the 0.32 line.

## Why this release exists

v0.1.5 cannot be consumed. `libsqlite3-sys` declares `links = "sqlite3"`, so a
dependency graph may hold exactly one version of it — a constraint on
*resolution* rather than on the build, which is why it binds even where the
conflicting dependency's features are off.

An embedder that also uses SQLx 0.8 needs `libsqlite3-sys ^0.30.1`. On a 0.x
crate that caret means `>=0.30.1, <0.31.0`, so only rusqlite 0.31 and 0.32
satisfy it. Against v0.1.5's rusqlite 0.40.2 such a graph does not resolve at
all — not a warning, a hard resolver failure — and it lands downstream rather
than here, which is why our own CI stayed green.

The 0.40 bump arrived from an automated update (eede059) rather than a need. The
engine uses no rusqlite API newer than 0.32, so it bought nothing and cost every
SQLx-embedding consumer their build.

`.github/dependabot.yml` now ignores `rusqlite` and `libsqlite3-sys`. Without
that the next automated run silently reintroduces this, and again nothing here
would catch it.

## This app comes down too

`apps/desktop/src-tauri` pins rusqlite directly *and* path-depends on the engine,
so the same `links` rule forces it to the 0.32 line. It needs no source change.

## Also in 0.1.6

The source-validity work already merged to `main` since the v0.1.5 tag ships
here as well: the pinned read path (`PinnedSource`, `SourceClaim`,
`PinnedReader`, `AppendOnlyGuarantee`), Claude read validation,
`ClaudeAdapter::visit_claimed`, and `SourceStat::from_open_std_file`.

**This includes a breaking change:** `VendorAdapter::visit` now returns
`VisitOutcome` instead of `()`. The default implementation returns
`VisitOutcome::Unvalidated`, so an adapter that does not check source validity
needs only its signature updated. Kept as a patch bump deliberately — semver
permits it under 0.x and the changelog states the break — because the one known
consumer neither implements the trait nor calls `visit`.

## Verification

| Check | Result |
| --- | --- |
| Engine tests on rusqlite 0.32.1 | 775 passed, 0 failed |
| Engine `cargo fmt --check` / `clippy -D warnings` | clean |
| `apps/desktop` `cargo check --all-targets` | clean, no source change |
| Both lockfiles, `cargo metadata --locked` | OK |
| `verify-release-version.mjs engine antiburn-local-v0.1.6` | OK |

Verified against the downstream consumer through a temporary local `[patch]`
(since removed): it compiles with **no source change**, its Rust suite passes
1188 tests, and its root workspace — the one carrying SQLx 0.8 — resolves and
compiles again. Both workspaces are healthy simultaneously for the first time
since the pin moved to v0.1.5.

## Note for the release runbook

`cargo update` on `apps/desktop/src-tauri/Cargo.toml` re-resolves shared
transitive dependencies and silently *downgrades* ~12 packages (`windows-sys`
0.61.2 → 0.52/0.59/0.60, `getrandom` 0.4.3 → 0.3.4) — 28 changed lines instead
of the intended few. Scoping it with `--package <name> --precise <version>` and
then proving the result with `cargo metadata --locked` keeps the diff to the
subtree that actually changed. Worth folding into `docs/runbooks/release.md`
Part 3 separately.