### PR TITLE
feat(desktop): live-update the open session detail pane

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -772,6 +772,29 @@ pub async fn get_session_analysis(
     })
 }
 
+/// The cheap fingerprint of one session's analysis inputs.
+///
+/// The session-detail popover polls this while it is open, and re-runs the
+/// full analysis only when the value changes. This command reads file
+/// metadata alone, never a transcript, so a poll costs almost nothing.
+#[tauri::command]
+pub async fn get_session_analysis_fingerprint(
+    agent: String,
+    session_id: String,
+    wsl_distro: Option<String>,
+) -> CommandResult<String> {
+    let Some(kind) = kind_from_slug(&agent) else {
+        return Err(format!("unknown agent {agent}"));
+    };
+    let Some(source) = analysis::locate(kind, &session_id, wsl_distro.as_deref()).await else {
+        return Ok(analysis::MISSING_FINGERPRINT.to_string());
+    };
+    Ok(
+        analysis::fingerprint_with_subagents(kind, &session_id, wsl_distro.as_deref(), &source)
+            .await,
+    )
+}
+
 /// One sub-agent's own analysis, opened from the roster.
 #[tauri::command]
 pub async fn get_subagent_analysis(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -156,6 +156,7 @@ pub fn run() {
             commands::get_consent_diagnostics,
             commands::recheck_folder_permissions,
             commands::get_session_analysis,
+            commands::get_session_analysis_fingerprint,
             commands::get_settings,
             commands::get_storage_health,
             commands::get_subagent_analysis,

--- a/apps/desktop/src/components/session/analysis/ContextTokensChart.tsx
+++ b/apps/desktop/src/components/session/analysis/ContextTokensChart.tsx
@@ -13,6 +13,7 @@ import {
   YAxis,
 } from "recharts"
 
+import { prefersReducedMotion, slowAnimationDurationMs } from "../../../lib/popoverHeight"
 import { modelShortName } from "../../../lib/presentation/models"
 import {
   axisScale,
@@ -261,6 +262,11 @@ export function ContextTokensChart({
   const data = contextTokenSeries(buckets)
   const fillId = `context-tokens-fill-${useId().replace(/:/g, "")}`
   const hasContext = contextWindow != null
+  // A live poll can grow this chart's data mid-session, unlike the other
+  // analysis charts, which only ever draw once. The transition makes that
+  // arrival readable instead of a silent jump cut.
+  const animate = !prefersReducedMotion()
+  const animationDurationMs = slowAnimationDurationMs()
 
   const peak = data.reduce((m, d) => Math.max(m, d.contextTokens), 0)
   const tokenPeak = data.reduce(
@@ -412,7 +418,9 @@ export function ContextTokensChart({
             stroke="none"
             fill={row.colorVar}
             fillOpacity={0.22}
-            isAnimationActive={false}
+            isAnimationActive={animate}
+            animationDuration={animationDurationMs}
+            animationEasing="ease-out"
           />
         ))}
         {hasContext && (
@@ -423,7 +431,9 @@ export function ContextTokensChart({
             stroke="var(--color-token-in)"
             strokeWidth={1.5}
             fill={`url(#${fillId})`}
-            isAnimationActive={false}
+            isAnimationActive={animate}
+            animationDuration={animationDurationMs}
+            animationEasing="ease-out"
           />
         )}
       </AreaChart>

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -860,6 +860,27 @@ export async function getSessionAnalysis(
   })
 }
 
+/**
+ * A cheap fingerprint of one session's transcript.
+ *
+ * A poll compares this value tick to tick instead of re-running the full
+ * analysis: the fingerprint changes only when the transcript itself changes,
+ * so an unchanged value proves a re-analysis would find nothing new. `"-"`
+ * means the transcript is missing.
+ */
+export async function getSessionAnalysisFingerprint(
+  agent: string,
+  sessionId: string,
+  wslDistro?: string | null,
+): Promise<string> {
+  if (!hasShell()) return "-"
+  return invoke<string>("get_session_analysis_fingerprint", {
+    agent,
+    sessionId,
+    wslDistro: wslDistro ?? null,
+  })
+}
+
 /** One sub-agent's own analysis. */
 export async function getSubagentAnalysis(
   agent: string,

--- a/apps/desktop/src/lib/popoverHeight.ts
+++ b/apps/desktop/src/lib/popoverHeight.ts
@@ -70,3 +70,27 @@ export function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches
 }
+
+/**
+ * The design system's slow duration (`--duration-slow`, `design.md`), in
+ * milliseconds, for a JS-driven animation that cannot consume the CSS custom
+ * property directly (a Recharts `animationDuration`, say).
+ *
+ * Read from the live custom property rather than a copied number, so the
+ * token stays the one source of truth. Falls back to the token's documented
+ * value where the property is unset, such as a test environment with no
+ * stylesheet loaded.
+ */
+export function slowAnimationDurationMs(): number {
+  const fallback = 300
+  if (typeof window === "undefined" || typeof getComputedStyle !== "function") return fallback
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--duration-slow")
+    .trim()
+  const ms = raw.endsWith("ms")
+    ? Number.parseFloat(raw)
+    : raw.endsWith("s")
+      ? Number.parseFloat(raw) * 1000
+      : NaN
+  return Number.isFinite(ms) ? ms : fallback
+}

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -2,9 +2,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { sessionKey } from "./PopoverSession"
+import type * as Ipc from "../../lib/ipc"
+import { ANALYSIS_POLL_MS, PopoverSession, sessionKey } from "./PopoverSession"
+import type { SessionSubject } from "./SessionPane"
+
+const getSessionAnalysis = vi.hoisted(() => vi.fn())
+const getSessionAnalysisFingerprint = vi.hoisted(() => vi.fn())
+
+// Only the two commands the live poll touches are overridden; every other
+// wrapper keeps its real "no shell" fallback (`hasShell()` is false outside
+// Tauri), which is exactly the degraded-but-safe behavior the store should
+// see in this environment.
+vi.mock("../../lib/ipc", async (importOriginal) => {
+  const actual = await importOriginal<typeof Ipc>()
+  return { ...actual, getSessionAnalysis, getSessionAnalysisFingerprint }
+})
 
 /**
  * `sessionKey` tags the analysis load a subject's payload belongs to. Get it
@@ -77,5 +91,75 @@ describe("sessionKey", () => {
     })
 
     expect(topLevel).not.toBe(subagent)
+  })
+})
+
+/**
+ * The live poll behind an open detail pane: it re-loads the analysis only
+ * when the transcript's fingerprint actually moves, and it never runs
+ * against an empty stack.
+ */
+describe("PopoverSession live analysis poll", () => {
+  const subject: SessionSubject = {
+    agent: "claude-code",
+    sessionId: "session-1",
+    wslDistro: null,
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    getSessionAnalysis.mockReset()
+    getSessionAnalysis.mockResolvedValue(null)
+    getSessionAnalysisFingerprint.mockReset()
+    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-1")
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("re-loads the analysis when the fingerprint changes on a tick", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    // Let `loadAnalysisFor` and the fingerprint seed that follows it settle,
+    // so the poll's own baseline is in place before the first tick.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
+
+    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-2")
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("does not re-load the analysis when the fingerprint is unchanged", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
+
+    // The mock keeps returning "fingerprint-1" from the seed above.
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it("stops polling once the detail pane closes", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+    getSessionAnalysisFingerprint.mockClear()
+
+    session.goBack()
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 3)
+
+    expect(getSessionAnalysisFingerprint).not.toHaveBeenCalled()
+    unsubscribe()
   })
 })

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -170,7 +170,7 @@ export const ANALYSIS_POLL_MS = 10_000
  * so the header's relative-time text ("last just now") stays current even
  * when nothing else about the session has changed.
  */
-export const NOW_TICK_MS = 30_000
+const NOW_TICK_MS = 30_000
 
 /** Narrow the shell's status string to the repository list's union. */
 function repositoryStatus(status: string): LocalRepositoryStatus {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -14,6 +14,7 @@ import {
   getLiveUsage,
   getProviderUsage,
   getSessionAnalysis,
+  getSessionAnalysisFingerprint,
   getSettings,
   getStorageHealth,
   getSubagentAnalysis,
@@ -106,6 +107,14 @@ export interface PopoverSnapshot {
    * earlier result is still on screen. Drives the detail header's spinner.
    */
   analysisRefreshing: boolean
+  /**
+   * A timestamp bumped every `NOW_TICK_MS` while a detail pane is open.
+   *
+   * The value itself has no reader: its purpose is to change the snapshot
+   * reference so the header's relative-time text ("last just now") re-renders
+   * on its own clock, not the arrival of new data.
+   */
+  now: number
 }
 
 /**
@@ -142,6 +151,27 @@ async function loadAnalysis(subject: SessionSubject): Promise<SessionAnalysisPay
   return getSessionAnalysis(subject.agent, subject.sessionId, subject.wslDistro)
 }
 
+/**
+ * Fetch one subject's transcript fingerprint, for the live-detail poll.
+ *
+ * The parent fingerprint covers the parent transcript and every sub-agent
+ * transcript, so a sub-agent subject fingerprints its parent session.
+ */
+async function loadAnalysisFingerprint(subject: SessionSubject): Promise<string> {
+  const sessionId = subject.subagent?.parentSessionId ?? subject.sessionId
+  return getSessionAnalysisFingerprint(subject.agent, sessionId, subject.wslDistro)
+}
+
+/** How often the open detail pane checks its transcript for new activity. */
+export const ANALYSIS_POLL_MS = 10_000
+
+/**
+ * How often the store forces a snapshot change while a detail pane is open,
+ * so the header's relative-time text ("last just now") stays current even
+ * when nothing else about the session has changed.
+ */
+export const NOW_TICK_MS = 30_000
+
 /** Narrow the shell's status string to the repository list's union. */
 function repositoryStatus(status: string): LocalRepositoryStatus {
   switch (status) {
@@ -173,6 +203,18 @@ export class PopoverSession {
   private analysisRefreshCount = 0
   private liveUsageRevision = 0
 
+  /**
+   * The key of the subject the poll's fingerprint belongs to, and the last
+   * fingerprint fetched for it. `null` fingerprint means no baseline has
+   * landed yet, so a poll tick must not treat it as a change.
+   */
+  private analysisFingerprintKey: string | null = null
+  private analysisFingerprint: string | null = null
+  /** Set while a poll tick's fetch is in flight, so ticks never overlap. */
+  private analysisPollInFlight = false
+  private analysisPollTimer: ReturnType<typeof setInterval> | null = null
+  private nowTickTimer: ReturnType<typeof setInterval> | null = null
+
   private stopSettingsListening: (() => void) | null = null
   private stopSessionsInvalidatedListening: (() => void) | null = null
   private stopSessionEntryChangedListening: (() => void) | null = null
@@ -196,6 +238,7 @@ export class PopoverSession {
     stack: [],
     analysis: null,
     analysisRefreshing: false,
+    now: Date.now(),
   }
 
   getSnapshot = (): PopoverSnapshot => this.snapshot
@@ -216,21 +259,27 @@ export class PopoverSession {
   openSession = (subject: SessionSubject): void => {
     this.update({ stack: [...this.snapshot.stack, subject] })
     this.syncHeight()
-    this.loadAnalysisFor(subject)
+    this.openAnalysis(subject)
   }
 
   goBack = (): void => {
     this.update({ stack: this.snapshot.stack.slice(0, -1) })
     this.syncHeight()
     const top = this.snapshot.stack.at(-1)
-    if (top) this.loadAnalysisFor(top)
+    if (top) {
+      this.openAnalysis(top)
+    } else {
+      this.analysisFingerprintKey = null
+      this.analysisFingerprint = null
+      this.syncDetailTimers()
+    }
   }
 
   /** Replace the top of the stack, for the newer/older traversal. */
   replaceTop = (subject: SessionSubject): void => {
     this.update({ stack: [...this.snapshot.stack.slice(0, -1), subject] })
     this.syncHeight()
-    this.loadAnalysisFor(subject)
+    this.openAnalysis(subject)
   }
 
   /** The shown session's local records were deleted: go back and re-list. */
@@ -295,6 +344,18 @@ export class PopoverSession {
     // event's propagation path, so every surface listening on `document` has
     // already had its chance to claim the key first.
     window.addEventListener("keydown", this.onWindowKeyDown)
+
+    // A stack carried over from a previous start (the window never really
+    // unmounts, but the listener count can still hit zero and come back)
+    // needs a fresh fingerprint baseline before the poll resumes on it.
+    const top = this.snapshot.stack.at(-1)
+    if (top) {
+      const key = sessionKey(top)
+      this.analysisFingerprintKey = key
+      this.analysisFingerprint = null
+      this.seedAnalysisFingerprint(top, generation, key)
+    }
+    this.syncDetailTimers()
   }
 
   private stop(): void {
@@ -314,6 +375,10 @@ export class PopoverSession {
     this.stopPopoverShownListening = null
     this.stopLiveUsageListening?.()
     this.stopLiveUsageListening = null
+    this.stopAnalysisPolling()
+    this.stopNowTicking()
+    this.analysisFingerprintKey = null
+    this.analysisFingerprint = null
     window.removeEventListener("keydown", this.onWindowKeyDown)
   }
 
@@ -585,6 +650,102 @@ export class PopoverSession {
         status: repositoryStatus(payload.status),
       })),
     })
+  }
+
+  /**
+   * Load a subject's analysis, then seed the live poll's fingerprint baseline
+   * from the freshly-loaded transcript, and make sure the poll and the
+   * relative-time ticker are running — a detail pane is now open.
+   *
+   * The baseline is fetched only after `loadAnalysisFor` settles, not next to
+   * it: that way the poll's first tick compares against a transcript state at
+   * least as new as what is already on screen, and never fires a refresh on
+   * data the reader has not even seen yet.
+   */
+  private openAnalysis(subject: SessionSubject): void {
+    const generation = this.generation
+    const key = sessionKey(subject)
+    this.analysisFingerprintKey = key
+    this.analysisFingerprint = null
+    void this.loadAnalysisFor(subject).then(() => {
+      if (generation !== this.generation || key !== this.analysisFingerprintKey) return
+      this.seedAnalysisFingerprint(subject, generation, key)
+    })
+    this.syncDetailTimers()
+  }
+
+  private seedAnalysisFingerprint(
+    subject: SessionSubject,
+    generation: number,
+    key: string,
+  ): void {
+    void loadAnalysisFingerprint(subject)
+      .then((fingerprint) => {
+        if (generation !== this.generation || key !== this.analysisFingerprintKey) return
+        this.analysisFingerprint = fingerprint
+      })
+      .catch(() => {})
+  }
+
+  /**
+   * One poll tick: fetch the open subject's fingerprint and, if it moved
+   * since the last tick (or the seed), re-load the analysis. Overlapping
+   * ticks are dropped rather than queued — a slow fetch is left to finish on
+   * its own, and the next interval simply tries again.
+   */
+  private tickAnalysisPoll = (): void => {
+    if (this.analysisPollInFlight) return
+    const subject = this.snapshot.stack.at(-1)
+    if (!subject) return
+    const generation = this.generation
+    const key = sessionKey(subject)
+    this.analysisPollInFlight = true
+    void loadAnalysisFingerprint(subject)
+      .then((fingerprint) => {
+        if (generation !== this.generation || key !== this.analysisFingerprintKey) return
+        const previous = this.analysisFingerprint
+        this.analysisFingerprint = fingerprint
+        if (previous !== null && fingerprint !== previous) {
+          void this.refreshAnalysis()
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        this.analysisPollInFlight = false
+      })
+  }
+
+  /** Start or stop the poll and the relative-time ticker to match whether a detail pane is open. */
+  private syncDetailTimers(): void {
+    if (this.snapshot.stack.length > 0) {
+      this.startAnalysisPolling()
+      this.startNowTicking()
+    } else {
+      this.stopAnalysisPolling()
+      this.stopNowTicking()
+    }
+  }
+
+  private startAnalysisPolling(): void {
+    if (this.analysisPollTimer !== null) return
+    this.analysisPollTimer = setInterval(this.tickAnalysisPoll, ANALYSIS_POLL_MS)
+  }
+
+  private stopAnalysisPolling(): void {
+    if (this.analysisPollTimer === null) return
+    clearInterval(this.analysisPollTimer)
+    this.analysisPollTimer = null
+  }
+
+  private startNowTicking(): void {
+    if (this.nowTickTimer !== null) return
+    this.nowTickTimer = setInterval(() => this.update({ now: Date.now() }), NOW_TICK_MS)
+  }
+
+  private stopNowTicking(): void {
+    if (this.nowTickTimer === null) return
+    clearInterval(this.nowTickTimer)
+    this.nowTickTimer = null
   }
 
   private loadAnalysisFor = (subject: SessionSubject): Promise<void> => {


### PR DESCRIPTION
## What

While a Session Detail pane is open, keep it current without the reader navigating away and back.

- **Rust:** new `get_session_analysis_fingerprint` command. It reuses the existing `mtime:size` fingerprint over the parent + sub-agent transcripts and reads file metadata only — no parsing.
- **Store (`PopoverSession`):** while the stack is non-empty, poll that fingerprint every 10 s (`ANALYSIS_POLL_MS`) and call the existing `refreshAnalysis()` only when it moves. The baseline is seeded after the initial load settles, so the first tick never refreshes spuriously. Overlapping ticks are dropped; timers are tied to the store's `start`/`stop` and `generation` guards like the other listeners. A 30 s tick (`NOW_TICK_MS`) bumps the snapshot so "last just now" re-renders.
- **Chart:** `ContextTokensChart` animates data arrival using `--duration-slow` (read from the live token, with a fallback for tests) and honours `prefers-reduced-motion`.
- Tests: fingerprint change → refresh, unchanged → no refresh, empty stack → poll stops.

No `useEffect`; timers live at the external-store boundary.

## Cost

An idle open pane costs one `stat` per transcript file every 10 s. An active session re-parses on change, which is the same work `onPopoverShown` already does. A fingerprint fast-path inside `get_session_analysis` itself (the store already has `cache_is_fresh`) would make the refresh cheaper too, but is left for a follow-up.

## Checks

`type-check`, `lint`, `test` (787), `slop` (score 100), `check-design-drift`, `cargo fmt --check`, `cargo clippy --all-targets --locked -D warnings` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)