### PR TITLE
chore(release): prepare antiburn-local 0.1.7

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,7 +21,7 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
-## [0.1.6] - 2026-08-25
+## [0.1.7] - 2026-08-25
 
 ### Changed
 
@@ -46,6 +46,12 @@ version and refuses the release if there is none.
 
 ### Added
 
+- `analysis::EfficiencyTotals` and `analysis::thread_efficiency` split the cost
+  of priced assistant turns into new work, cached carry, and rewritten input.
+  The calculation merges records for one message, orders turns by timestamp,
+  and reports unpriced turns separately. Callers calculate each parent or
+  sub-agent event stream on its own, then combine totals with
+  `EfficiencyTotals::add`.
 - `analysis::source_validity` decides whether a transcript that was read still
   describes the source it claimed to: `SourceClaim`, `PinnedSource`,
   `PinnedOpen`, `PinnedReader`, `AppendOnlyGuarantee`, and

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MPL-2.0"


### PR DESCRIPTION
Supersedes the untagged 0.1.6 metadata after the engine gained the public efficiency API.

- bumps the engine and both lockfiles to 0.1.7
- keeps one complete changelog section for changes since 0.1.5
- adds release notes for `EfficiencyTotals` and `thread_efficiency`

Validated locally with the engine test suite, locked Cargo metadata, release-version checks, classifier tests, and `pnpm run slop`.

The app release follows after this engine tree is tagged.