### PR TITLE
Stack GH-70: 0010 (CH-005) Analysis poll retries an unavailable read

### DIFF
--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type * as Ipc from "../../lib/ipc"
+import type { SessionAnalysisPayload } from "../../lib/ipc"
 import { ANALYSIS_POLL_MS, PopoverSession, sessionKey } from "./PopoverSession"
 import type { SessionSubject } from "./SessionPane"
 
@@ -106,8 +107,8 @@ describe("PopoverSession live analysis poll", () => {
   }
 
   const analysisPayload = (
-    overrides: Partial<Ipc.SessionAnalysisPayload> = {},
-  ): Ipc.SessionAnalysisPayload => ({
+    overrides: Partial<SessionAnalysisPayload> = {},
+  ): SessionAnalysisPayload => ({
     summary: null,
     supportsAnalysis: true,
     title: null,
@@ -127,7 +128,7 @@ describe("PopoverSession live analysis poll", () => {
     ...overrides,
   })
 
-  const usableAnalysis = (): Ipc.SessionAnalysisPayload =>
+  const usableAnalysis = (): SessionAnalysisPayload =>
     analysisPayload({
       summary: {
         sessionCount: 1,

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -10,14 +10,13 @@ import type { SessionSubject } from "./SessionPane"
 
 const getSessionAnalysis = vi.hoisted(() => vi.fn())
 const getSessionAnalysisFingerprint = vi.hoisted(() => vi.fn())
+const getSubagentAnalysis = vi.hoisted(() => vi.fn())
 
-// Only the two commands the live poll touches are overridden; every other
-// wrapper keeps its real "no shell" fallback (`hasShell()` is false outside
-// Tauri), which is exactly the degraded-but-safe behavior the store should
-// see in this environment.
+// The analysis commands are overridden. All other wrappers keep their real
+// no-shell fallback because `hasShell()` is false outside Tauri.
 vi.mock("../../lib/ipc", async (importOriginal) => {
   const actual = await importOriginal<typeof Ipc>()
-  return { ...actual, getSessionAnalysis, getSessionAnalysisFingerprint }
+  return { ...actual, getSessionAnalysis, getSessionAnalysisFingerprint, getSubagentAnalysis }
 })
 
 /**
@@ -106,12 +105,53 @@ describe("PopoverSession live analysis poll", () => {
     wslDistro: null,
   }
 
+  const analysisPayload = (
+    overrides: Partial<Ipc.SessionAnalysisPayload> = {},
+  ): Ipc.SessionAnalysisPayload => ({
+    summary: null,
+    supportsAnalysis: true,
+    title: null,
+    wslDistro: null,
+    isActive: false,
+    cost: null,
+    topLevelCost: null,
+    subagentsCost: null,
+    inclusiveTokens: null,
+    subagentsTokens: null,
+    efficiency: null,
+    models: [],
+    modelRuns: [],
+    orchestration: null,
+    relations: null,
+    sourcePath: null,
+    ...overrides,
+  })
+
+  const usableAnalysis = (): Ipc.SessionAnalysisPayload =>
+    analysisPayload({
+      summary: {
+        sessionCount: 1,
+        avgDurationSecs: 1,
+        avgActiveSecs: 1,
+        toolMix: { edit: 0, read: 0, search: 0, test: 0, bash: 0, other: 0 },
+        grepTotal: 0,
+        tokensInTotal: 0,
+        tokensOutTotal: 0,
+        peakContextTokens: 0,
+        contextWindow: 0,
+        buckets: [],
+        sessions: [],
+      },
+    })
+
   beforeEach(() => {
     vi.useFakeTimers()
     getSessionAnalysis.mockReset()
     getSessionAnalysis.mockResolvedValue(null)
     getSessionAnalysisFingerprint.mockReset()
     getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-1")
+    getSubagentAnalysis.mockReset()
+    getSubagentAnalysis.mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -146,6 +186,115 @@ describe("PopoverSession live analysis poll", () => {
     await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
 
     expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it("re-loads on the next tick after an unavailable read, fingerprint unchanged", async () => {
+    getSessionAnalysis.mockResolvedValue(analysisPayload())
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("stops retrying once a usable analysis lands", async () => {
+    getSessionAnalysis
+      .mockResolvedValueOnce(analysisPayload())
+      .mockResolvedValue(usableAnalysis())
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 4)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("latches after three unavailable retries", async () => {
+    getSessionAnalysis.mockResolvedValue(analysisPayload())
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 12)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(4)
+    unsubscribe()
+  })
+
+  it("re-arms the budget after a usable analysis settles", async () => {
+    getSessionAnalysis
+      .mockResolvedValueOnce(analysisPayload())
+      .mockResolvedValueOnce(usableAnalysis())
+      .mockResolvedValueOnce(analysisPayload())
+      .mockResolvedValue(usableAnalysis())
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-2")
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(4)
+    unsubscribe()
+  })
+
+  it("does not retry a sub-agent subject", async () => {
+    getSubagentAnalysis.mockResolvedValue(analysisPayload())
+    const subagent: SessionSubject = {
+      ...subject,
+      subagent: { parentSessionId: subject.sessionId, subagentId: "subagent-1" },
+    }
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subagent)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 3)
+    expect(getSubagentAnalysis).toHaveBeenCalledTimes(1)
+
+    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-2")
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+
+    expect(getSubagentAnalysis).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("does not retry when the agent does not support analysis", async () => {
+    getSessionAnalysis.mockResolvedValue(analysisPayload({ supportsAnalysis: false }))
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 2)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it("retries a rejected read", async () => {
+    getSessionAnalysis.mockRejectedValueOnce(new Error("read failed"))
+    getSessionAnalysis.mockResolvedValue(usableAnalysis())
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
     unsubscribe()
   })
 

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -74,6 +74,18 @@ type PopoverAnalysisState = {
   error: boolean
 } | null
 
+/** Whether the settled analysis for `key` has nothing usable. */
+function isUnavailableAnalysis(state: PopoverAnalysisState, key: string): boolean {
+  if (state === null || state.key !== key) return false
+  if (state.error) return true
+  return (
+    state.payload !== null &&
+    state.payload.supportsAnalysis &&
+    state.payload.summary === null &&
+    state.payload.cost === null
+  )
+}
+
 export interface PopoverSnapshot {
   appVersion: string | null
   debugBuild: boolean
@@ -165,6 +177,9 @@ async function loadAnalysisFingerprint(subject: SessionSubject): Promise<string>
 /** How often the open detail pane checks its transcript for new activity. */
 export const ANALYSIS_POLL_MS = 10_000
 
+/** How many times a subject can re-read an unavailable analysis. */
+const MAX_UNAVAILABLE_ANALYSIS_RETRIES = 3
+
 /**
  * How often the store forces a snapshot change while a detail pane is open,
  * so the header's relative-time text ("last just now") stays current even
@@ -210,6 +225,8 @@ export class PopoverSession {
    */
   private analysisFingerprintKey: string | null = null
   private analysisFingerprint: string | null = null
+  private analysisRetryKey: string | null = null
+  private analysisRetryCount = 0
   /** Set while a poll tick's fetch is in flight, so ticks never overlap. */
   private analysisPollInFlight = false
   private analysisPollTimer: ReturnType<typeof setInterval> | null = null
@@ -379,6 +396,8 @@ export class PopoverSession {
     this.stopNowTicking()
     this.analysisFingerprintKey = null
     this.analysisFingerprint = null
+    this.analysisRetryKey = null
+    this.analysisRetryCount = 0
     window.removeEventListener("keydown", this.onWindowKeyDown)
   }
 
@@ -667,6 +686,8 @@ export class PopoverSession {
     const key = sessionKey(subject)
     this.analysisFingerprintKey = key
     this.analysisFingerprint = null
+    this.analysisRetryKey = key
+    this.analysisRetryCount = 0
     void this.loadAnalysisFor(subject).then(() => {
       if (generation !== this.generation || key !== this.analysisFingerprintKey) return
       this.seedAnalysisFingerprint(subject, generation, key)
@@ -706,6 +727,19 @@ export class PopoverSession {
         const previous = this.analysisFingerprint
         this.analysisFingerprint = fingerprint
         if (previous !== null && fingerprint !== previous) {
+          void this.refreshAnalysis()
+          return
+        }
+        if (subject.subagent) return
+        if (key !== this.analysisRetryKey) {
+          this.analysisRetryKey = key
+          this.analysisRetryCount = 0
+        }
+        if (
+          isUnavailableAnalysis(this.snapshot.analysis, key) &&
+          this.analysisRetryCount < MAX_UNAVAILABLE_ANALYSIS_RETRIES
+        ) {
+          this.analysisRetryCount += 1
           void this.refreshAnalysis()
         }
       })
@@ -756,6 +790,10 @@ export class PopoverSession {
       .then((payload) => {
         if (generation !== this.generation || token !== this.analysisToken) return
         this.update({ analysis: { key, payload, error: false } })
+        if (!isUnavailableAnalysis(this.snapshot.analysis, key)) {
+          this.analysisRetryKey = key
+          this.analysisRetryCount = 0
+        }
       })
       .catch(() => {
         if (generation !== this.generation || token !== this.analysisToken) return


### PR DESCRIPTION
This is part of GH-70 session-evidence stack.

### Stack · GH-70
- **#TBD — GH-70: [awaiting base PR] (base: master plan)**
  - **#TBD — Stack GH-70: 0010 (CH-005) ← this PR**

### Seam: Analysis poll retries an unavailable read

What this seam contains: PopoverSession now detects when an analysis load returns unavailable (no summary, no cost) and retries the read on the next 10s poll tick, even when the fingerprint hash hasn't changed. This keeps a detail pane from staying blank while its transcript is still being written. The retry budget is three reads per subject and latches — counter increments only and resets only when usable analysis arrives, subject changes, openAnalysis runs, or stop() runs.

Why this piece was done: Session detail panes can open before their transcript is fully written, causing the analysis panel to render blank initially. The fingerprint-based refresh only fires when the transcript changes, missing the case where a concurrent initial load was unavailable. Polling with a retry gate solves this without over-refreshing.

What it changes:
- Add `isUnavailableAnalysis()` to detect settled-but-empty analysis state
- Track `analysisRetryKey` and `analysisRetryCount` to gate up to 3 retries per subject
- Reset retry state on `seedAnalysisFingerprint()`, `openAnalysis()`, and `stop()`
- Retry applies only to top-level sessions; sub-agent subjects skip it and keep fingerprint-change refresh
- **Full file list**: apps/desktop/src/views/popover/PopoverSession.ts, apps/desktop/src/views/popover/PopoverSession.test.ts (82 total test cases, 7 new)

How to review: Read the new `isUnavailableAnalysis()` utility first to understand the settled-but-empty case, then trace the retry state machine in `seedAnalysisFingerprint()` (initialization), the poll tick's branch (line ~730, the retry gate and call to `refreshAnalysis()`), and `loadAnalysisFor()` (latch reset). Verify the reset points cover all state-change cases and that subagent subjects truly skip retry.

**Review hotspots**: Medium risk — public method `seedAnalysisFingerprint()` adds retry state init; polling interval ANALYSIS_POLL_MS (10s) now has observable retry behavior; test coverage expanded to verify latch semantics.
