### PR TITLE
Stack GH-70: 0009 (CH-006) One truthful in-memory evidence value from the same pass

### DIFF
--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -1,0 +1,504 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::analysis::{PartialReason, RawSource, VisitOutcome};
+
+pub const EVIDENCE_STRING_CAP: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", content = "value", rename_all = "snake_case")]
+pub enum EvidenceValue<T> {
+    // TODO @agent: CH-009 will remove this.
+    #[cfg(debug_assertions)]
+    Unimplemented,
+    Unsupported,
+    Partial {
+        observed: T,
+        reason: CoverageReason,
+    },
+    Complete(T),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageReason {
+    Oversized,
+    MalformedRecord,
+    IncompleteTail,
+    Cancelled,
+    ReadFailed,
+    UnrecognizedRecordType,
+    PinnedPrefix,
+}
+
+impl From<PartialReason> for CoverageReason {
+    fn from(reason: PartialReason) -> Self {
+        match reason {
+            PartialReason::Oversized => Self::Oversized,
+            PartialReason::MalformedRecord => Self::MalformedRecord,
+            PartialReason::IncompleteTail => Self::IncompleteTail,
+            PartialReason::Cancelled => Self::Cancelled,
+            PartialReason::ReadFailed => Self::ReadFailed,
+            PartialReason::UnrecognizedRecordType => Self::UnrecognizedRecordType,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextEvidence {
+    pub max_request_context_tokens: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceCapabilities {
+    pub request_context_tokens: bool,
+    pub cache_write_tokens: bool,
+}
+
+impl SourceCapabilities {
+    pub fn claude() -> Self {
+        Self {
+            request_context_tokens: true,
+            cache_write_tokens: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceCoverage {
+    Complete,
+    Partial(CoverageReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    Jsonl,
+    File,
+    Sqlite,
+}
+
+impl From<&RawSource> for SourceKind {
+    fn from(source: &RawSource) -> Self {
+        match source {
+            RawSource::Jsonl(_) => Self::Jsonl,
+            RawSource::File(_) => Self::File,
+            RawSource::Sqlite(_) => Self::Sqlite,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderingObservation {
+    Monotonic,
+    OutOfOrder,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceAcceptance {
+    NotObserved,
+    Unvalidated,
+    AcceptedFull,
+    AcceptedPrefix { boundary: u64 },
+    SourceChanged,
+}
+
+impl From<VisitOutcome> for SourceAcceptance {
+    fn from(outcome: VisitOutcome) -> Self {
+        match outcome {
+            VisitOutcome::Unvalidated => Self::Unvalidated,
+            VisitOutcome::AcceptedFull => Self::AcceptedFull,
+            VisitOutcome::AcceptedPrefix { boundary } => Self::AcceptedPrefix { boundary },
+            VisitOutcome::SourceChanged(_) => Self::SourceChanged,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionProvenance {
+    pub parser_revision: i64,
+    pub analyzer_revision: i64,
+    pub evidence_schema_revision: i64,
+    pub source_kind: SourceKind,
+    pub source_acceptance: SourceAcceptance,
+    pub ordering: OrderingObservation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParseDiagnostics {
+    pub records_observed: u64,
+    pub records_unusable: u64,
+    pub unusable_reasons: BTreeMap<CoverageReason, u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionEvidenceIdentity {
+    pub agent: String,
+    pub session_id: String,
+}
+
+impl SessionEvidenceIdentity {
+    pub fn new(agent: &str, session_id: &str) -> Self {
+        Self {
+            agent: capped_string(agent),
+            session_id: capped_string(session_id),
+        }
+    }
+}
+
+fn capped_string(value: &str) -> String {
+    let mut end = value.len().min(EVIDENCE_STRING_CAP);
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_owned()
+}
+
+/// Contains the source facts that an accumulator needs at construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceSource {
+    pub agent: String,
+    pub session_id: String,
+    pub kind: SourceKind,
+    pub capabilities: SourceCapabilities,
+}
+
+// TODO @agent: CH-009 will remove this.
+#[cfg(debug_assertions)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnfinishedGroup;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionEvidence {
+    pub schema_revision: i64,
+    pub identity: SessionEvidenceIdentity,
+    pub context: EvidenceValue<ContextEvidence>,
+    pub capabilities: SourceCapabilities,
+    pub coverage: EvidenceCoverage,
+    pub provenance: SessionProvenance,
+    pub diagnostics: ParseDiagnostics,
+    // TODO @agent: CH-009 will remove this.
+    #[cfg(debug_assertions)]
+    pub time_range: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub eligibility: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub models: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub tools: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub context_sources: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub subagents: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub cache: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub compactions: EvidenceValue<UnfinishedGroup>,
+    #[cfg(debug_assertions)]
+    pub quota_incidents: EvidenceValue<UnfinishedGroup>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::analysis::{ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION};
+
+    #[test]
+    fn evidence_value_serde_shape_is_adjacently_tagged() {
+        let complete = EvidenceValue::Complete(ContextEvidence {
+            max_request_context_tokens: 7,
+        });
+        let partial = EvidenceValue::Partial {
+            observed: ContextEvidence {
+                max_request_context_tokens: 7,
+            },
+            reason: CoverageReason::MalformedRecord,
+        };
+        let unsupported: EvidenceValue<ContextEvidence> = EvidenceValue::Unsupported;
+
+        assert_eq!(
+            serde_json::to_value(complete).unwrap(),
+            json!({"state": "complete", "value": {"maxRequestContextTokens": 7}})
+        );
+        assert_eq!(
+            serde_json::to_value(partial).unwrap(),
+            json!({
+                "state": "partial",
+                "value": {
+                    "observed": {"maxRequestContextTokens": 7},
+                    "reason": "malformed_record"
+                }
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(unsupported).unwrap(),
+            json!({"state": "unsupported"})
+        );
+    }
+
+    #[test]
+    fn evidence_value_round_trips_through_json() {
+        let values = [
+            EvidenceValue::Complete(ContextEvidence {
+                max_request_context_tokens: 7,
+            }),
+            EvidenceValue::Partial {
+                observed: ContextEvidence {
+                    max_request_context_tokens: 7,
+                },
+                reason: CoverageReason::MalformedRecord,
+            },
+            EvidenceValue::Unsupported,
+        ];
+
+        for value in values {
+            let encoded = serde_json::to_string(&value).unwrap();
+            let decoded: EvidenceValue<ContextEvidence> = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn complete_zero_is_distinguishable_from_unsupported() {
+        let complete = serde_json::to_value(EvidenceValue::Complete(ContextEvidence {
+            max_request_context_tokens: 0,
+        }))
+        .unwrap();
+        let unsupported =
+            serde_json::to_value(EvidenceValue::<ContextEvidence>::Unsupported).unwrap();
+
+        assert_ne!(complete, unsupported);
+        assert_ne!(complete, serde_json::Value::Null);
+        assert_ne!(unsupported, serde_json::Value::Null);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn unimplemented_serializes_as_its_own_state() {
+        assert_eq!(
+            serde_json::to_value(EvidenceValue::<UnfinishedGroup>::Unimplemented).unwrap(),
+            json!({"state": "unimplemented"})
+        );
+    }
+
+    #[test]
+    fn complete_session_evidence_serializes_to_the_exact_object() {
+        let evidence = session_evidence(
+            EvidenceValue::Complete(ContextEvidence {
+                max_request_context_tokens: 7,
+            }),
+            EvidenceCoverage::Complete,
+            SourceAcceptance::AcceptedFull,
+            BTreeMap::new(),
+        );
+
+        assert_eq!(
+            serde_json::to_value(evidence).unwrap(),
+            json!({
+                "schemaRevision": 1,
+                "identity": {"agent": "claude", "sessionId": "s1"},
+                "context": {"state": "complete", "value": {"maxRequestContextTokens": 7}},
+                "capabilities": {"requestContextTokens": true, "cacheWriteTokens": true},
+                "coverage": "complete",
+                "provenance": {
+                    "parserRevision": 1,
+                    "analyzerRevision": 1,
+                    "evidenceSchemaRevision": 1,
+                    "sourceKind": "file",
+                    "sourceAcceptance": "accepted_full",
+                    "ordering": "monotonic"
+                },
+                "diagnostics": {
+                    "recordsObserved": 3,
+                    "recordsUnusable": 0,
+                    "unusableReasons": {}
+                },
+                "timeRange": {"state": "unimplemented"},
+                "eligibility": {"state": "unimplemented"},
+                "models": {"state": "unimplemented"},
+                "tools": {"state": "unimplemented"},
+                "contextSources": {"state": "unimplemented"},
+                "subagents": {"state": "unimplemented"},
+                "cache": {"state": "unimplemented"},
+                "compactions": {"state": "unimplemented"},
+                "quotaIncidents": {"state": "unimplemented"}
+            })
+        );
+    }
+
+    #[test]
+    fn partial_session_evidence_serializes_to_the_exact_object() {
+        let reasons = BTreeMap::from([(CoverageReason::MalformedRecord, 1)]);
+        let evidence = session_evidence(
+            EvidenceValue::Partial {
+                observed: ContextEvidence {
+                    max_request_context_tokens: 7,
+                },
+                reason: CoverageReason::MalformedRecord,
+            },
+            EvidenceCoverage::Partial(CoverageReason::MalformedRecord),
+            SourceAcceptance::AcceptedPrefix { boundary: 4096 },
+            reasons,
+        );
+
+        assert_eq!(
+            serde_json::to_value(evidence).unwrap(),
+            json!({
+                "schemaRevision": 1,
+                "identity": {"agent": "claude", "sessionId": "s1"},
+                "context": {
+                    "state": "partial",
+                    "value": {
+                        "observed": {"maxRequestContextTokens": 7},
+                        "reason": "malformed_record"
+                    }
+                },
+                "capabilities": {"requestContextTokens": true, "cacheWriteTokens": true},
+                "coverage": {"partial": "malformed_record"},
+                "provenance": {
+                    "parserRevision": 1,
+                    "analyzerRevision": 1,
+                    "evidenceSchemaRevision": 1,
+                    "sourceKind": "file",
+                    "sourceAcceptance": {"accepted_prefix": {"boundary": 4096}},
+                    "ordering": "monotonic"
+                },
+                "diagnostics": {
+                    "recordsObserved": 3,
+                    "recordsUnusable": 1,
+                    "unusableReasons": {"malformed_record": 1}
+                },
+                "timeRange": {"state": "unimplemented"},
+                "eligibility": {"state": "unimplemented"},
+                "models": {"state": "unimplemented"},
+                "tools": {"state": "unimplemented"},
+                "contextSources": {"state": "unimplemented"},
+                "subagents": {"state": "unimplemented"},
+                "cache": {"state": "unimplemented"},
+                "compactions": {"state": "unimplemented"},
+                "quotaIncidents": {"state": "unimplemented"}
+            })
+        );
+    }
+
+    #[test]
+    fn coverage_reason_maps_every_partial_reason() {
+        let cases = [
+            (
+                PartialReason::Oversized,
+                CoverageReason::Oversized,
+                "oversized",
+            ),
+            (
+                PartialReason::MalformedRecord,
+                CoverageReason::MalformedRecord,
+                "malformed_record",
+            ),
+            (
+                PartialReason::IncompleteTail,
+                CoverageReason::IncompleteTail,
+                "incomplete_tail",
+            ),
+            (
+                PartialReason::Cancelled,
+                CoverageReason::Cancelled,
+                "cancelled",
+            ),
+            (
+                PartialReason::ReadFailed,
+                CoverageReason::ReadFailed,
+                "read_failed",
+            ),
+            (
+                PartialReason::UnrecognizedRecordType,
+                CoverageReason::UnrecognizedRecordType,
+                "unrecognized_record_type",
+            ),
+        ];
+        let mut mapped = BTreeSet::new();
+
+        for (partial, expected, serialized) in cases {
+            let actual = CoverageReason::from(partial);
+            assert_eq!(actual, expected);
+            assert_eq!(serde_json::to_value(actual).unwrap(), json!(serialized));
+            mapped.insert(actual);
+        }
+
+        assert_eq!(mapped.len(), 6);
+        assert!(!mapped.contains(&CoverageReason::PinnedPrefix));
+    }
+
+    #[test]
+    fn identity_strings_are_capped() {
+        let prefix = "a".repeat(EVIDENCE_STRING_CAP - 1);
+        let over_cap = format!("{prefix}ésuffix");
+        let identity = SessionEvidenceIdentity::new(&over_cap, &over_cap);
+
+        assert!(identity.agent.len() <= EVIDENCE_STRING_CAP);
+        assert!(identity.session_id.len() <= EVIDENCE_STRING_CAP);
+        assert_eq!(identity.agent, prefix);
+        assert_eq!(identity.session_id, prefix);
+        assert!(identity.agent.is_char_boundary(identity.agent.len()));
+        assert!(
+            identity
+                .session_id
+                .is_char_boundary(identity.session_id.len())
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    fn session_evidence(
+        context: EvidenceValue<ContextEvidence>,
+        coverage: EvidenceCoverage,
+        source_acceptance: SourceAcceptance,
+        unusable_reasons: BTreeMap<CoverageReason, u64>,
+    ) -> SessionEvidence {
+        SessionEvidence {
+            schema_revision: EVIDENCE_SCHEMA_REVISION,
+            identity: SessionEvidenceIdentity::new("claude", "s1"),
+            context,
+            capabilities: SourceCapabilities::claude(),
+            coverage,
+            provenance: SessionProvenance {
+                parser_revision: PARSER_REVISION,
+                analyzer_revision: ANALYZER_REVISION,
+                evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+                source_kind: SourceKind::File,
+                source_acceptance,
+                ordering: OrderingObservation::Monotonic,
+            },
+            diagnostics: ParseDiagnostics {
+                records_observed: 3,
+                records_unusable: u64::from(!unusable_reasons.is_empty()),
+                unusable_reasons,
+            },
+            time_range: EvidenceValue::Unimplemented,
+            eligibility: EvidenceValue::Unimplemented,
+            models: EvidenceValue::Unimplemented,
+            tools: EvidenceValue::Unimplemented,
+            context_sources: EvidenceValue::Unimplemented,
+            subagents: EvidenceValue::Unimplemented,
+            cache: EvidenceValue::Unimplemented,
+            compactions: EvidenceValue::Unimplemented,
+            quota_incidents: EvidenceValue::Unimplemented,
+        }
+    }
+}

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -1,0 +1,449 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+
+#[cfg(debug_assertions)]
+use crate::analysis::evidence::UnfinishedGroup;
+use crate::analysis::evidence::{
+    ContextEvidence, CoverageReason, EvidenceCoverage, EvidenceSource, EvidenceValue,
+    OrderingObservation, ParseDiagnostics, SessionEvidence, SessionEvidenceIdentity,
+    SessionProvenance, SourceAcceptance, SourceCapabilities, SourceKind,
+};
+use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary, VisitOutcome};
+use crate::analysis::metrics_sink::SessionMetricsAccumulator;
+use crate::analysis::{
+    ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION, SessionMetrics,
+};
+
+pub struct SessionEvidenceAccumulator {
+    identity: SessionEvidenceIdentity,
+    capabilities: SourceCapabilities,
+    source_kind: SourceKind,
+    source_acceptance: SourceAcceptance,
+    ordering: OrderingObservation,
+    diagnostics: ParseDiagnostics,
+    max_request_context_tokens: u64,
+    coverage_reason: Option<CoverageReason>,
+    last_ts_ms: Option<i64>,
+    summary_observed: bool,
+}
+
+impl SessionEvidenceAccumulator {
+    pub fn new(source: EvidenceSource) -> Self {
+        Self {
+            identity: SessionEvidenceIdentity::new(&source.agent, &source.session_id),
+            capabilities: source.capabilities,
+            source_kind: source.kind,
+            source_acceptance: SourceAcceptance::NotObserved,
+            ordering: OrderingObservation::Monotonic,
+            diagnostics: ParseDiagnostics {
+                records_observed: 0,
+                records_unusable: 0,
+                unusable_reasons: BTreeMap::new(),
+            },
+            max_request_context_tokens: 0,
+            coverage_reason: None,
+            last_ts_ms: None,
+            summary_observed: false,
+        }
+    }
+
+    /// Folds one record without taking it.
+    pub fn observe(&mut self, record: &NormalizedRecord) {
+        self.diagnostics.records_observed = self.diagnostics.records_observed.saturating_add(1);
+        match record {
+            NormalizedRecord::MetricsEvent(event) => {
+                self.max_request_context_tokens = self
+                    .max_request_context_tokens
+                    .max(event.usage.context_tokens());
+                if let Some(timestamp) = event.ts_ms {
+                    if self.last_ts_ms.is_some_and(|last| timestamp < last) {
+                        self.ordering = OrderingObservation::OutOfOrder;
+                    }
+                    self.last_ts_ms = Some(timestamp);
+                }
+            }
+            NormalizedRecord::Unusable(reason) => {
+                let reason = CoverageReason::from(*reason);
+                self.diagnostics.records_unusable =
+                    self.diagnostics.records_unusable.saturating_add(1);
+                let count = self.diagnostics.unusable_reasons.entry(reason).or_default();
+                *count = count.saturating_add(1);
+                self.set_coverage_reason(reason);
+            }
+        }
+    }
+
+    /// Folds the end-of-stream facts without taking them.
+    pub fn observe_summary(&mut self, summary: &SessionSummary) {
+        self.capabilities.cache_write_tokens = summary.cache_write_tokens_available;
+        self.summary_observed = true;
+    }
+
+    /// Attaches the source outcome after the adapter returns.
+    pub fn observe_source_outcome(&mut self, outcome: VisitOutcome) {
+        if matches!(outcome, VisitOutcome::AcceptedPrefix { .. }) {
+            self.set_coverage_reason(CoverageReason::PinnedPrefix);
+        }
+        self.source_acceptance = SourceAcceptance::from(outcome);
+    }
+
+    pub fn evidence(&self) -> SessionEvidence {
+        let context = ContextEvidence {
+            max_request_context_tokens: self.max_request_context_tokens,
+        };
+        let context = if !self.capabilities.request_context_tokens {
+            EvidenceValue::Unsupported
+        } else if let Some(reason) = self.coverage_reason {
+            EvidenceValue::Partial {
+                observed: context,
+                reason,
+            }
+        } else {
+            EvidenceValue::Complete(context)
+        };
+        let coverage = self
+            .coverage_reason
+            .map_or(EvidenceCoverage::Complete, EvidenceCoverage::Partial);
+
+        SessionEvidence {
+            schema_revision: EVIDENCE_SCHEMA_REVISION,
+            identity: self.identity.clone(),
+            context,
+            capabilities: self.capabilities,
+            coverage,
+            provenance: SessionProvenance {
+                parser_revision: PARSER_REVISION,
+                analyzer_revision: ANALYZER_REVISION,
+                evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+                source_kind: self.source_kind,
+                source_acceptance: self.source_acceptance,
+                ordering: self.ordering,
+            },
+            diagnostics: self.diagnostics.clone(),
+            #[cfg(debug_assertions)]
+            time_range: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            eligibility: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            models: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            tools: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            context_sources: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            subagents: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            cache: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            compactions: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+            #[cfg(debug_assertions)]
+            quota_incidents: EvidenceValue::<UnfinishedGroup>::Unimplemented,
+        }
+    }
+
+    fn set_coverage_reason(&mut self, reason: CoverageReason) {
+        if self.coverage_reason.is_none() {
+            self.coverage_reason = Some(reason);
+        }
+    }
+
+    fn can_publish(&self) -> bool {
+        self.summary_observed
+            && !matches!(
+                self.source_acceptance,
+                SourceAcceptance::NotObserved | SourceAcceptance::SourceChanged
+            )
+    }
+}
+
+impl RecordSink for SessionEvidenceAccumulator {
+    fn record(&mut self, record: NormalizedRecord) {
+        self.observe(&record);
+    }
+
+    fn finish(&mut self, summary: SessionSummary) {
+        self.observe_summary(&summary);
+    }
+}
+
+pub struct CompositeSink {
+    metrics: SessionMetricsAccumulator,
+    evidence: SessionEvidenceAccumulator,
+}
+
+impl CompositeSink {
+    pub fn new(metrics: SessionMetricsAccumulator, evidence: SessionEvidenceAccumulator) -> Self {
+        Self { metrics, evidence }
+    }
+
+    pub fn metrics(&self) -> Option<SessionMetrics> {
+        self.evidence.can_publish().then(|| self.metrics.metrics())
+    }
+
+    pub fn evidence(&self) -> Option<SessionEvidence> {
+        self.evidence
+            .can_publish()
+            .then(|| self.evidence.evidence())
+    }
+
+    pub fn observe_source_outcome(&mut self, outcome: VisitOutcome) {
+        self.evidence.observe_source_outcome(outcome);
+    }
+
+    pub fn into_parts(self) -> Option<(SessionMetricsAccumulator, SessionEvidenceAccumulator)> {
+        self.evidence
+            .can_publish()
+            .then_some((self.metrics, self.evidence))
+    }
+}
+
+impl RecordSink for CompositeSink {
+    fn record(&mut self, record: NormalizedRecord) {
+        self.evidence.observe(&record);
+        self.metrics.record(record);
+    }
+
+    fn finish(&mut self, summary: SessionSummary) {
+        self.evidence.observe_summary(&summary);
+        self.metrics.finish(summary);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::analysis::model::NormalizedEvent;
+    use crate::analysis::{EventSource, PartialReason, Role, SourceChangedReason, Usage};
+
+    #[test]
+    fn context_depth_is_complete_zero_without_a_usage_bearing_record() {
+        let mut accumulator = accumulator(true);
+        accumulator.finish(SessionSummary::default());
+
+        assert_eq!(
+            accumulator.evidence().context,
+            EvidenceValue::Complete(ContextEvidence {
+                max_request_context_tokens: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn context_depth_is_the_maximum_across_every_event_source() {
+        let mut accumulator = accumulator(true);
+        accumulator.record(metric_record(EventSource::Parent, 5, Some(1)));
+        accumulator.record(metric_record(EventSource::Subagent, 12, Some(2)));
+        accumulator.finish(SessionSummary::default());
+
+        assert_eq!(
+            accumulator.evidence().context,
+            EvidenceValue::Complete(ContextEvidence {
+                max_request_context_tokens: 12,
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_record_downgrades_context_to_partial() {
+        assert_partial_after_unusable(
+            PartialReason::MalformedRecord,
+            CoverageReason::MalformedRecord,
+        );
+    }
+
+    #[test]
+    fn oversized_record_downgrades_context_to_partial() {
+        assert_partial_after_unusable(PartialReason::Oversized, CoverageReason::Oversized);
+    }
+
+    #[test]
+    fn the_first_unusable_reason_is_the_reported_reason() {
+        let mut accumulator = accumulator(true);
+        accumulator.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
+        accumulator.record(NormalizedRecord::Unusable(PartialReason::Oversized));
+        accumulator.finish(SessionSummary::default());
+        let evidence = accumulator.evidence();
+
+        assert_eq!(
+            evidence.coverage,
+            EvidenceCoverage::Partial(CoverageReason::MalformedRecord)
+        );
+        assert_eq!(
+            evidence.diagnostics.unusable_reasons,
+            BTreeMap::from([
+                (CoverageReason::MalformedRecord, 1),
+                (CoverageReason::Oversized, 1),
+            ])
+        );
+        let first = serde_json::to_string(&evidence.diagnostics.unusable_reasons).unwrap();
+        let second = serde_json::to_string(&evidence.diagnostics.unusable_reasons).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn unsupported_capability_yields_unsupported_not_zero() {
+        let mut accumulator = accumulator(false);
+        accumulator.record(metric_record(EventSource::Parent, 7, Some(1)));
+        accumulator.finish(SessionSummary::default());
+
+        assert_eq!(accumulator.evidence().context, EvidenceValue::Unsupported);
+    }
+
+    #[test]
+    fn diagnostics_counters_and_reason_map_stay_bounded() {
+        let mut accumulator = accumulator(true);
+        let reasons = [
+            PartialReason::Oversized,
+            PartialReason::MalformedRecord,
+            PartialReason::IncompleteTail,
+            PartialReason::Cancelled,
+            PartialReason::ReadFailed,
+            PartialReason::UnrecognizedRecordType,
+        ];
+        for _ in 0..20 {
+            for reason in reasons {
+                accumulator.record(NormalizedRecord::Unusable(reason));
+            }
+        }
+        accumulator.finish(SessionSummary {
+            cache_write_tokens_available: true,
+            ..SessionSummary::default()
+        });
+        let evidence = accumulator.evidence();
+
+        assert!(evidence.diagnostics.unusable_reasons.len() <= 7);
+        assert_eq!(evidence.diagnostics.records_observed, 120);
+        assert_eq!(evidence.diagnostics.records_unusable, 120);
+        assert!(evidence.capabilities.cache_write_tokens);
+    }
+
+    #[test]
+    fn source_outcome_maps_every_visit_outcome() {
+        let outcomes = [
+            (VisitOutcome::Unvalidated, SourceAcceptance::Unvalidated),
+            (VisitOutcome::AcceptedFull, SourceAcceptance::AcceptedFull),
+            (
+                VisitOutcome::AcceptedPrefix { boundary: 4096 },
+                SourceAcceptance::AcceptedPrefix { boundary: 4096 },
+            ),
+            (
+                VisitOutcome::SourceChanged(SourceChangedReason::IdentityMismatch),
+                SourceAcceptance::SourceChanged,
+            ),
+        ];
+        assert_eq!(
+            accumulator(true).evidence().provenance.source_acceptance,
+            SourceAcceptance::NotObserved
+        );
+
+        for (outcome, expected) in outcomes {
+            let mut accumulator = accumulator(true);
+            accumulator.observe_source_outcome(outcome);
+            assert_eq!(
+                accumulator.evidence().provenance.source_acceptance,
+                expected
+            );
+        }
+
+        let mut accepted = accumulator(true);
+        accepted.observe_source_outcome(VisitOutcome::AcceptedFull);
+        assert_eq!(accepted.evidence().coverage, EvidenceCoverage::Complete);
+    }
+
+    #[test]
+    fn accepted_prefix_downgrades_coverage_to_partial() {
+        let mut prefix_accumulator = accumulator(true);
+        prefix_accumulator.record(metric_record(EventSource::Parent, 7, Some(1)));
+        prefix_accumulator.observe_source_outcome(VisitOutcome::AcceptedPrefix { boundary: 4096 });
+        let evidence = prefix_accumulator.evidence();
+
+        assert_eq!(
+            evidence.coverage,
+            EvidenceCoverage::Partial(CoverageReason::PinnedPrefix)
+        );
+        assert_eq!(
+            evidence.context,
+            EvidenceValue::Partial {
+                observed: ContextEvidence {
+                    max_request_context_tokens: 7,
+                },
+                reason: CoverageReason::PinnedPrefix,
+            }
+        );
+
+        let mut earlier_reason = accumulator(true);
+        earlier_reason.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
+        earlier_reason.observe_source_outcome(VisitOutcome::AcceptedPrefix { boundary: 4096 });
+        assert_eq!(
+            earlier_reason.evidence().coverage,
+            EvidenceCoverage::Partial(CoverageReason::MalformedRecord)
+        );
+    }
+
+    #[test]
+    fn source_changed_without_summary_keeps_projections_unpublished() {
+        let mut composite = CompositeSink::new(
+            SessionMetricsAccumulator::new("claude", "s1"),
+            accumulator(true),
+        );
+        composite.record(metric_record(EventSource::Parent, 7, Some(1)));
+        composite.observe_source_outcome(VisitOutcome::SourceChanged(
+            SourceChangedReason::IdentityMismatch,
+        ));
+
+        assert!(composite.metrics().is_none());
+        assert!(composite.evidence().is_none());
+        assert!(composite.into_parts().is_none());
+    }
+
+    fn accumulator(request_context_tokens: bool) -> SessionEvidenceAccumulator {
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: "s1".to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities {
+                request_context_tokens,
+                cache_write_tokens: false,
+            },
+        })
+    }
+
+    fn metric_record(
+        source: EventSource,
+        context_tokens: u64,
+        ts_ms: Option<i64>,
+    ) -> NormalizedRecord {
+        let mut event = NormalizedEvent::new(Role::Assistant);
+        event.source = source;
+        event.ts_ms = ts_ms;
+        event.usage = Usage {
+            input_tokens: context_tokens,
+            ..Usage::default()
+        };
+        NormalizedRecord::MetricsEvent(Box::new(event))
+    }
+
+    fn assert_partial_after_unusable(partial: PartialReason, reason: CoverageReason) {
+        let mut accumulator = accumulator(true);
+        accumulator.record(metric_record(EventSource::Parent, 7, Some(1)));
+        accumulator.record(NormalizedRecord::Unusable(partial));
+        accumulator.finish(SessionSummary::default());
+        let evidence = accumulator.evidence();
+
+        assert_eq!(
+            evidence.context,
+            EvidenceValue::Partial {
+                observed: ContextEvidence {
+                    max_request_context_tokens: 7,
+                },
+                reason,
+            }
+        );
+        assert_eq!(evidence.coverage, EvidenceCoverage::Partial(reason));
+    }
+}

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -33,6 +33,7 @@
 
 mod efficiency;
 mod engine;
+mod evidence;
 mod framing;
 mod initial_context;
 mod interface;
@@ -47,6 +48,13 @@ pub use efficiency::{EfficiencyTotals, thread_efficiency};
 pub use engine::{
     ActiveSessionsSummary, BUCKETS, Bucket, CONTEXT_WINDOW, SessionCost, SessionMetrics, SkillUse,
     ToolMix, aggregate_metrics, analyze_session,
+};
+#[cfg(debug_assertions)]
+pub use evidence::UnfinishedGroup;
+pub use evidence::{
+    ContextEvidence, CoverageReason, EVIDENCE_STRING_CAP, EvidenceCoverage, EvidenceSource,
+    EvidenceValue, OrderingObservation, ParseDiagnostics, SessionEvidence, SessionEvidenceIdentity,
+    SessionProvenance, SourceAcceptance, SourceCapabilities, SourceKind,
 };
 pub use framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,
@@ -72,6 +80,7 @@ pub use vendors::{adapter_for, has_dedicated_adapter};
 pub const PARSER_REVISION: i64 = 1;
 pub const ANALYZER_REVISION: i64 = 1;
 pub const METRICS_SCHEMA_REVISION: i64 = 1;
+pub const EVIDENCE_SCHEMA_REVISION: i64 = 1;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -34,6 +34,7 @@
 mod efficiency;
 mod engine;
 mod evidence;
+mod evidence_sink;
 mod framing;
 mod initial_context;
 mod interface;
@@ -56,6 +57,7 @@ pub use evidence::{
     EvidenceValue, OrderingObservation, ParseDiagnostics, SessionEvidence, SessionEvidenceIdentity,
     SessionProvenance, SourceAcceptance, SourceCapabilities, SourceKind,
 };
+pub use evidence_sink::{CompositeSink, SessionEvidenceAccumulator};
 pub use framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,
     SCAN_QUANTUM_BYTES,

--- a/crates/antiburn-local/tests/claude_characterization.rs
+++ b/crates/antiburn-local/tests/claude_characterization.rs
@@ -3,9 +3,11 @@ use std::fs;
 use std::path::PathBuf;
 
 use antiburn_local::analysis::{
-    MAX_RECORD_BYTES, NormalizedSession, PartialReason, RawSource, RecordCoverage,
-    SessionCollector, SessionInput, SessionMetricsAccumulator, adapter_for, analyze_session,
-    analyze_sources_with, merge_metrics, merge_subagent_events, normalize_source,
+    ANALYZER_REVISION, CompositeSink, EVIDENCE_SCHEMA_REVISION, EvidenceCoverage, EvidenceSource,
+    EvidenceValue, MAX_RECORD_BYTES, NormalizedSession, OrderingObservation, PARSER_REVISION,
+    PartialReason, RawSource, RecordCoverage, SessionCollector, SessionEvidenceAccumulator,
+    SessionInput, SessionMetricsAccumulator, SourceCapabilities, SourceKind, adapter_for,
+    analyze_session, analyze_sources_with, merge_metrics, merge_subagent_events, normalize_source,
 };
 use serde_json::{Value, json};
 
@@ -165,6 +167,37 @@ fn stream_claude(input: &SessionInput) -> SessionMetricsAccumulator {
     accumulator
 }
 
+fn stream_composite(input: &SessionInput) -> CompositeSink {
+    let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::from(&input.source),
+        capabilities: SourceCapabilities::claude(),
+    });
+    let mut composite = CompositeSink::new(metrics, evidence);
+    let outcome = adapter_for("claude")
+        .visit(input, &mut composite)
+        .expect("Claude source must be visited");
+    composite.observe_source_outcome(outcome);
+    composite
+}
+
+fn fixture_names() -> [&'static str; 10] {
+    [
+        "records_all_kinds",
+        "timestamps_repeated_and_out_of_order",
+        "malformed_between_valid",
+        "incomplete_final_record",
+        "unrecognized_type",
+        "parent_with_task_spawn",
+        "subagent_child",
+        "multi_model_session",
+        "compaction_with_cache_rehydration",
+        "inferred_cache_rehydration",
+    ]
+}
+
 fn collect_claude(
     input: &SessionInput,
 ) -> (RecordCoverage, BTreeSet<PartialReason>, NormalizedSession) {
@@ -200,6 +233,103 @@ fn oversized_metric_jsonl(payload_bytes: usize) -> String {
     source.push_str(&assistant_record("second-neighbour", 1_761_000_002, 4, 5));
     source.push('\n');
     source
+}
+
+#[test]
+fn composite_metrics_json_equals_the_streaming_metrics_json_for_every_fixture() {
+    for name in fixture_names() {
+        let input = input(name);
+        let composite = stream_composite(&input);
+        let composite_json = serde_json::to_string_pretty(
+            &composite
+                .metrics()
+                .expect("finished source must publish metrics"),
+        )
+        .expect("composite metrics must serialize");
+        let streaming_json = serde_json::to_string_pretty(&stream_claude(&input).metrics())
+            .expect("streaming metrics must serialize");
+        let composite_value: Value =
+            serde_json::from_str(&composite_json).expect("composite JSON must parse");
+        let streaming_value: Value =
+            serde_json::from_str(&streaming_json).expect("streaming JSON must parse");
+
+        assert_eq!(composite_value, streaming_value, "fixture {name}");
+    }
+}
+
+#[test]
+fn evidence_context_depth_equals_the_fixture_maximum() {
+    for name in fixture_names() {
+        let input = input(name);
+        let expected = normalize_source(&input)
+            .expect("fixture must normalize")
+            .events
+            .iter()
+            .map(|event| event.usage.context_tokens())
+            .max()
+            .unwrap_or(0);
+        let evidence = stream_composite(&input)
+            .evidence()
+            .expect("finished source must publish evidence");
+        let observed = match evidence.context {
+            EvidenceValue::Complete(context)
+            | EvidenceValue::Partial {
+                observed: context, ..
+            } => context.max_request_context_tokens,
+            EvidenceValue::Unsupported => panic!("Claude context evidence must be supported"),
+            #[cfg(debug_assertions)]
+            EvidenceValue::Unimplemented => panic!("context evidence must be implemented"),
+        };
+
+        assert_eq!(observed, expected, "fixture {name}");
+    }
+}
+
+#[test]
+fn evidence_coverage_is_complete_for_every_clean_fixture() {
+    for name in fixture_names() {
+        let input = input(name);
+        let (coverage, _, _) = collect_claude(&input);
+        if coverage == RecordCoverage::Partial {
+            continue;
+        }
+        let evidence = stream_composite(&input)
+            .evidence()
+            .expect("finished source must publish evidence");
+
+        assert_eq!(
+            evidence.coverage,
+            EvidenceCoverage::Complete,
+            "fixture {name}"
+        );
+        assert!(matches!(evidence.context, EvidenceValue::Complete(_)));
+    }
+}
+
+#[test]
+fn fixture_provenance_records_the_source_kind_and_ordering() {
+    let monotonic = stream_composite(&input("parent_with_task_spawn"))
+        .evidence()
+        .expect("finished source must publish evidence");
+    assert_eq!(monotonic.provenance.source_kind, SourceKind::Jsonl);
+    assert_eq!(monotonic.provenance.parser_revision, PARSER_REVISION);
+    assert_eq!(monotonic.provenance.analyzer_revision, ANALYZER_REVISION);
+    assert_eq!(
+        monotonic.provenance.evidence_schema_revision,
+        EVIDENCE_SCHEMA_REVISION
+    );
+    assert_eq!(
+        monotonic.provenance.ordering,
+        OrderingObservation::Monotonic
+    );
+
+    let out_of_order = stream_composite(&input("timestamps_repeated_and_out_of_order"))
+        .evidence()
+        .expect("finished source must publish evidence");
+    assert_eq!(
+        out_of_order.provenance.ordering,
+        OrderingObservation::OutOfOrder
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is part of a PR stack based at #91; this PR merges into main.

### Stack · GH-70

This seam continues the Local Insights work from the master plan. See the full stack context in the base PR #91.

**[Note: This branch was previously used for seam 0010 (PR #189, now merged and remote-deleted). Opening a new PR on the recovered branch with seam 0009's code.]**

## What this seam contains

Adds the SessionEvidence type family (evidence.rs, new) and a composite sink (evidence_sink.rs, new) that fills max_request_context_tokens online beside the shipped metrics accumulator, in one pass, with metrics output unchanged.

See the seam plan: .seams/GH-70/0009-CH-006-in-memory-session-evidence-plan.md

## Why this piece was done

CH-006 locks the in-memory evidence contract that CH-007 persists and CH-009 fills. It exists so evidence rides the metrics pass rather than paying a second transcript read, and so the three-state Complete/Partial/Unsupported semantics are fixed before anything durable depends on them.

## What it changes

- New: crates/antiburn-local/src/analysis/evidence.rs — the SessionEvidence type family (one real ContextEvidence group + nine debug-only shells)
- New: crates/antiburn-local/src/analysis/evidence_sink.rs — SessionEvidenceAccumulator and CompositeSink
- Edit: crates/antiburn-local/src/analysis/mod.rs — re-exports and EVIDENCE_SCHEMA_REVISION constant
- Edit: crates/antiburn-local/tests/claude_characterization.rs — four integration tests proving SessionMetrics equivalence and evidence correctness

Observable change: none. Nothing is stored, nothing crosses IPC, no screen changes, and the metrics the desktop shows stay byte-identical.

<details>
<summary>Full file list</summary>

- crates/antiburn-local/src/analysis/evidence.rs (new, ~504 lines)
- crates/antiburn-local/src/analysis/evidence_sink.rs (new, ~449 lines)
- crates/antiburn-local/src/analysis/mod.rs (modified)
- crates/antiburn-local/tests/claude_characterization.rs (modified)

</details>

## How to review

Read the seam plan and report at .seams/GH-70/0009-CH-006-in-memory-session-evidence-plan.md and .seams/GH-70/0009-CH-006-in-memory-evidence-value-report.md.

The evidence type family is locked by whole-object JSON assertions. CompositeSink borrows each record for evidence, then moves it into the metrics accumulator — no clone, no second pass. SessionMetrics serialized output is unchanged and proven by JSON equivalence on every characterization fixture (test 18).

**Review hotspots**: none — this is a new module with locked types and new unit + integration tests. The risk flags are protocol-contract-definition and serde-shape-lock (addressed by test suite), release-build-gating (proven by `cargo check --release`), and metrics-output-equivalence (proven by test 18's JSON serialization comparison).
