### PR TITLE
Stack GH-70: 0011 (CH-007) Durable session_evidence storage with atomic dual projection writes

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -72,6 +72,9 @@ mod settings;
 mod startup_registration;
 mod storage_health;
 mod store;
+// The queue has no in-tree caller until CH-008 adds the worker.
+// TODO @agent: CH-008 will remove this re-export.
+pub use store::Store;
 mod tray;
 mod tray_title;
 mod updates;

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -41,11 +41,11 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::dto::DeferredPermissionDir;
 
 pub use model::{
-    AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceClaim, EvidenceFailure, EvidenceRow,
-    EvidenceStatus, MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones,
-    NudgePlacement, ProjectionRevisions, RelationKind, RelationRecord, RepositoryRecord,
-    SessionActivityKey, SessionActivityState, SessionKey, SessionRecord, SourceVersionState,
-    ThemePreference, UsageEvidenceRecord,
+    AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceClaim, EvidenceCompletion,
+    EvidenceFailure, EvidenceRow, EvidenceStatus, MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS,
+    MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, ProjectionRevisions, RelationKind,
+    RelationRecord, RepositoryRecord, SessionActivityKey, SessionActivityState, SessionKey,
+    SessionRecord, SourceVersionState, ThemePreference, UsageEvidenceRecord,
 };
 
 /// Internal-scalar key holding the protected directories the last pass declined
@@ -890,6 +890,7 @@ impl Store {
         let tx = connection.transaction()?;
         tx.execute("DELETE FROM session_relation", [])?;
         tx.execute("DELETE FROM session_analysis", [])?;
+        tx.execute("DELETE FROM session_evidence", [])?;
         let sessions = tx.execute("DELETE FROM session", [])?;
         tx.execute("DELETE FROM scan_state", [])?;
         tx.execute("UPDATE repository SET session_count = 0", [])?;
@@ -912,6 +913,99 @@ impl Store {
     /* --------------------------------------------------------------------
      * Derived analysis
      * ----------------------------------------------------------------- */
+
+    /// Publish metrics, evidence, and the optional start time as one pass.
+    pub fn publish_projections(
+        &self,
+        record: &AnalysisRecord,
+        started_at_epoch: Option<i64>,
+        completion: &EvidenceCompletion,
+    ) -> Result<bool> {
+        let mut connection = self.lock();
+        let transaction = connection.transaction()?;
+        transaction.execute(
+            "INSERT INTO session_analysis (
+                 environment_key, agent, session_id, model_breakdown_json,
+                 inclusive_models_json, source_fingerprint, pricing_generation,
+                 analyzed_generation, parser_revision, analyzer_revision,
+                 metrics_schema_revision)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+             ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
+                 model_breakdown_json = excluded.model_breakdown_json,
+                 inclusive_models_json = excluded.inclusive_models_json,
+                 source_fingerprint = excluded.source_fingerprint,
+                 pricing_generation = excluded.pricing_generation,
+                 analyzed_generation = excluded.analyzed_generation,
+                 parser_revision = excluded.parser_revision,
+                 analyzer_revision = excluded.analyzer_revision,
+                 metrics_schema_revision = excluded.metrics_schema_revision",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id,
+                record.model_breakdown_json,
+                record.inclusive_models_json,
+                record.source_fingerprint,
+                record.pricing_generation,
+                record.analyzed_generation,
+                record.parser_revision,
+                record.analyzer_revision,
+                record.metrics_schema_revision,
+            ],
+        )?;
+        if let Some(started_at_epoch) = started_at_epoch {
+            transaction.execute(
+                "UPDATE session SET started_at_epoch = ?4
+                  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+                params![
+                    record.key.environment_key,
+                    record.key.agent,
+                    record.key.session_id,
+                    started_at_epoch,
+                ],
+            )?;
+        }
+        let updated = transaction.execute(
+            "UPDATE session_evidence AS evidence
+                SET status = ?4, analyzed_generation = ?5,
+                    processed_fingerprint = ?6, parser_revision = ?7,
+                    analyzer_revision = ?8, evidence_schema_revision = ?9,
+                    evidence_json = ?10, diagnostics_json = ?11,
+                    analyzed_at_epoch = ?12, retry_count = 0, last_error = NULL,
+                    claimed_at_epoch = NULL, lease_expires_at_epoch = NULL,
+                    next_attempt_at_epoch = NULL
+              WHERE evidence.environment_key = ?1
+                AND evidence.agent = ?2 AND evidence.session_id = ?3
+                AND evidence.status = 'processing' AND evidence.claim_fence = ?13
+                AND EXISTS (
+                    SELECT 1 FROM session
+                     WHERE session.environment_key = evidence.environment_key
+                       AND session.agent = evidence.agent
+                       AND session.session_id = evidence.session_id
+                       AND session.source_generation = ?5
+                )",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id,
+                completion.status.as_str(),
+                record.analyzed_generation,
+                record.source_fingerprint,
+                record.parser_revision,
+                record.analyzer_revision,
+                completion.evidence_schema_revision,
+                completion.evidence_json,
+                completion.diagnostics_json,
+                time::OffsetDateTime::now_utc().unix_timestamp(),
+                completion.claim_fence,
+            ],
+        )?;
+        if updated == 0 {
+            return Ok(false);
+        }
+        transaction.commit()?;
+        Ok(true)
+    }
 
     /// Cache one session's derived analysis.
     pub fn save_analysis(

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -41,10 +41,10 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::dto::DeferredPermissionDir;
 
 pub use model::{
-    AnalysisRecord, AppSettings, DiskSpaceDisplay, MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS,
-    MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, RelationKind, RelationRecord, RepositoryRecord,
-    SessionActivityKey, SessionActivityState, SessionKey, SessionRecord, SourceVersionState,
-    ThemePreference, UsageEvidenceRecord,
+    AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceRow, EvidenceStatus, MAX_ACTIVITY_DAYS,
+    MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, RelationKind, RelationRecord,
+    RepositoryRecord, SessionActivityKey, SessionActivityState, SessionKey, SessionRecord,
+    SourceVersionState, ThemePreference, UsageEvidenceRecord,
 };
 
 /// Internal-scalar key holding the protected directories the last pass declined
@@ -587,6 +587,25 @@ impl Store {
                         started_at_epoch: row.get(2)?,
                     })
                 },
+            )
+            .optional()?)
+    }
+
+    /// One session's persisted evidence and queue state.
+    pub fn evidence(&self, key: &SessionKey) -> Result<Option<EvidenceRow>> {
+        let connection = self.lock();
+        Ok(connection
+            .query_row(
+                "SELECT environment_key, agent, session_id, status,
+                        analyzed_generation, processed_fingerprint,
+                        parser_revision, analyzer_revision, evidence_schema_revision,
+                        evidence_json, diagnostics_json, retry_count, claim_fence,
+                        claimed_at_epoch, lease_expires_at_epoch,
+                        next_attempt_at_epoch, analyzed_at_epoch, last_error
+                   FROM session_evidence
+                  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+                params![key.environment_key, key.agent, key.session_id],
+                evidence_from_row,
             )
             .optional()?)
     }
@@ -1299,6 +1318,35 @@ fn delete_session_in(connection: &Connection, key: &SessionKey) -> Result<bool> 
         parameters,
     )?;
     Ok(removed > 0)
+}
+
+fn evidence_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EvidenceRow> {
+    let status: EvidenceStatus = row
+        .get::<_, String>(3)?
+        .parse()
+        .map_err(|_| rusqlite::Error::InvalidQuery)?;
+    Ok(EvidenceRow {
+        key: SessionKey::new(
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ),
+        status,
+        analyzed_generation: row.get(4)?,
+        processed_fingerprint: row.get(5)?,
+        parser_revision: row.get(6)?,
+        analyzer_revision: row.get(7)?,
+        evidence_schema_revision: row.get(8)?,
+        evidence_json: row.get(9)?,
+        diagnostics_json: row.get(10)?,
+        retry_count: row.get(11)?,
+        claim_fence: row.get(12)?,
+        claimed_at_epoch: row.get(13)?,
+        lease_expires_at_epoch: row.get(14)?,
+        next_attempt_at_epoch: row.get(15)?,
+        analyzed_at_epoch: row.get(16)?,
+        last_error: row.get(17)?,
+    })
 }
 
 fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> {

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -41,10 +41,11 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::dto::DeferredPermissionDir;
 
 pub use model::{
-    AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceRow, EvidenceStatus, MAX_ACTIVITY_DAYS,
-    MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, ProjectionRevisions,
-    RelationKind, RelationRecord, RepositoryRecord, SessionActivityKey, SessionActivityState,
-    SessionKey, SessionRecord, SourceVersionState, ThemePreference, UsageEvidenceRecord,
+    AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceClaim, EvidenceFailure, EvidenceRow,
+    EvidenceStatus, MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones,
+    NudgePlacement, ProjectionRevisions, RelationKind, RelationRecord, RepositoryRecord,
+    SessionActivityKey, SessionActivityState, SessionKey, SessionRecord, SourceVersionState,
+    ThemePreference, UsageEvidenceRecord,
 };
 
 /// Internal-scalar key holding the protected directories the last pass declined
@@ -697,6 +698,174 @@ impl Store {
         )?;
         transaction.commit()?;
         Ok(enrolled + requeued)
+    }
+
+    /// Claim the next eligible evidence row for an enabled agent.
+    pub fn claim_next_evidence(
+        &self,
+        agents: &[&str],
+        now_epoch: i64,
+        lease_secs: i64,
+    ) -> Result<Option<EvidenceClaim>> {
+        if agents.is_empty() {
+            return Ok(None);
+        }
+
+        let mut connection = self.lock();
+        let transaction = connection.transaction()?;
+        let agent_placeholders = vec!["?"; agents.len()].join(", ");
+        let mut values: Vec<rusqlite::types::Value> = agents
+            .iter()
+            .map(|agent| rusqlite::types::Value::Text((*agent).to_string()))
+            .collect();
+        values.push(rusqlite::types::Value::Integer(now_epoch));
+        let now_parameter = values.len();
+        let candidate = transaction
+            .query_row(
+                &format!(
+                    "SELECT evidence.environment_key, evidence.agent, evidence.session_id
+                       FROM session_evidence AS evidence
+                       JOIN session
+                         ON session.environment_key = evidence.environment_key
+                        AND session.agent = evidence.agent
+                        AND session.session_id = evidence.session_id
+                      WHERE evidence.agent IN ({agent_placeholders})
+                        AND (
+                            evidence.status = 'pending'
+                            OR (evidence.status = 'processing'
+                                AND evidence.lease_expires_at_epoch <= ?{now_parameter})
+                        )
+                        AND (evidence.next_attempt_at_epoch IS NULL
+                             OR evidence.next_attempt_at_epoch <= ?{now_parameter})
+                      ORDER BY evidence.next_attempt_at_epoch,
+                               evidence.claimed_at_epoch,
+                               evidence.environment_key, evidence.agent, evidence.session_id
+                      LIMIT 1"
+                ),
+                rusqlite::params_from_iter(values.iter()),
+                |row| {
+                    Ok(SessionKey::new(
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some(key) = candidate else {
+            transaction.commit()?;
+            return Ok(None);
+        };
+
+        transaction.execute(
+            "UPDATE session_evidence
+                SET status = 'processing', claim_fence = claim_fence + 1,
+                    claimed_at_epoch = ?4, lease_expires_at_epoch = ?5
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                key.environment_key,
+                key.agent,
+                key.session_id,
+                now_epoch,
+                now_epoch + lease_secs,
+            ],
+        )?;
+        let (source_generation, claim_fence, retry_count) = transaction.query_row(
+            "SELECT session.source_generation, evidence.claim_fence, evidence.retry_count
+               FROM session_evidence AS evidence
+               JOIN session
+                 ON session.environment_key = evidence.environment_key
+                AND session.agent = evidence.agent
+                AND session.session_id = evidence.session_id
+              WHERE evidence.environment_key = ?1
+                AND evidence.agent = ?2 AND evidence.session_id = ?3",
+            params![key.environment_key, key.agent, key.session_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        transaction.commit()?;
+        Ok(Some(EvidenceClaim {
+            key,
+            source_generation,
+            claim_fence,
+            retry_count,
+        }))
+    }
+
+    /// Extend a claim when its fence and source generation remain current.
+    pub fn renew_evidence_lease(
+        &self,
+        claim: &EvidenceClaim,
+        now_epoch: i64,
+        lease_secs: i64,
+    ) -> Result<bool> {
+        let connection = self.lock();
+        let updated = connection.execute(
+            "UPDATE session_evidence AS evidence
+                SET claimed_at_epoch = ?6, lease_expires_at_epoch = ?7
+              WHERE evidence.environment_key = ?1
+                AND evidence.agent = ?2 AND evidence.session_id = ?3
+                AND evidence.status = 'processing' AND evidence.claim_fence = ?4
+                AND EXISTS (
+                    SELECT 1 FROM session
+                     WHERE session.environment_key = evidence.environment_key
+                       AND session.agent = evidence.agent
+                       AND session.session_id = evidence.session_id
+                       AND session.source_generation = ?5
+                )",
+            params![
+                claim.key.environment_key,
+                claim.key.agent,
+                claim.key.session_id,
+                claim.claim_fence,
+                claim.source_generation,
+                now_epoch,
+                now_epoch + lease_secs,
+            ],
+        )?;
+        Ok(updated > 0)
+    }
+
+    /// Record a retry or terminal failure for a current claim.
+    pub fn fail_evidence(
+        &self,
+        claim: &EvidenceClaim,
+        failure: EvidenceFailure,
+        last_error: &str,
+    ) -> Result<bool> {
+        let (status, next_attempt_at_epoch) = match failure {
+            EvidenceFailure::Retry {
+                next_attempt_at_epoch,
+            } => ("pending", Some(next_attempt_at_epoch)),
+            EvidenceFailure::Failed => ("failed", None),
+        };
+        let connection = self.lock();
+        let updated = connection.execute(
+            "UPDATE session_evidence AS evidence
+                SET status = ?6, retry_count = retry_count + 1,
+                    last_error = ?7, claimed_at_epoch = NULL,
+                    lease_expires_at_epoch = NULL, next_attempt_at_epoch = ?8
+              WHERE evidence.environment_key = ?1
+                AND evidence.agent = ?2 AND evidence.session_id = ?3
+                AND evidence.status = 'processing' AND evidence.claim_fence = ?4
+                AND EXISTS (
+                    SELECT 1 FROM session
+                     WHERE session.environment_key = evidence.environment_key
+                       AND session.agent = evidence.agent
+                       AND session.session_id = evidence.session_id
+                       AND session.source_generation = ?5
+                )",
+            params![
+                claim.key.environment_key,
+                claim.key.agent,
+                claim.key.session_id,
+                claim.claim_fence,
+                claim.source_generation,
+                status,
+                last_error,
+                next_attempt_at_epoch,
+            ],
+        )?;
+        Ok(updated > 0)
     }
 
     /// Forget all locally stored session data: every session, its analysis, its

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -42,9 +42,9 @@ use crate::dto::DeferredPermissionDir;
 
 pub use model::{
     AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceRow, EvidenceStatus, MAX_ACTIVITY_DAYS,
-    MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, RelationKind, RelationRecord,
-    RepositoryRecord, SessionActivityKey, SessionActivityState, SessionKey, SessionRecord,
-    SourceVersionState, ThemePreference, UsageEvidenceRecord,
+    MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, ProjectionRevisions,
+    RelationKind, RelationRecord, RepositoryRecord, SessionActivityKey, SessionActivityState,
+    SessionKey, SessionRecord, SourceVersionState, ThemePreference, UsageEvidenceRecord,
 };
 
 /// Internal-scalar key holding the protected directories the last pass declined
@@ -483,7 +483,10 @@ impl Store {
         let mut connection = self.lock();
         let tx = connection.transaction()?;
         for record in records {
-            upsert_session_in(&tx, record)?;
+            let (previous_generation, source_generation) = upsert_session_in(&tx, record)?;
+            if previous_generation.is_none_or(|previous| source_generation > previous) {
+                mark_evidence_pending_in(&tx, &record.key)?;
+            }
         }
         tx.commit()?;
         Ok(())
@@ -608,6 +611,92 @@ impl Store {
                 evidence_from_row,
             )
             .optional()?)
+    }
+
+    /// Enroll missing evidence rows and requeue stale transcript projections.
+    pub fn reconcile_evidence_revisions(
+        &self,
+        agents: &[&str],
+        revisions: ProjectionRevisions,
+    ) -> Result<usize> {
+        if agents.is_empty() {
+            return Ok(0);
+        }
+
+        let mut connection = self.lock();
+        let transaction = connection.transaction()?;
+        let agent_placeholders = vec!["?"; agents.len()].join(", ");
+        let agent_values: Vec<rusqlite::types::Value> = agents
+            .iter()
+            .map(|agent| rusqlite::types::Value::Text((*agent).to_string()))
+            .collect();
+        let enrolled = transaction.execute(
+            &format!(
+                "INSERT INTO session_evidence (environment_key, agent, session_id)
+                 SELECT session.environment_key, session.agent, session.session_id
+                   FROM session
+                  WHERE session.agent IN ({agent_placeholders})
+                    AND NOT EXISTS (
+                        SELECT 1 FROM session_evidence
+                         WHERE session_evidence.environment_key = session.environment_key
+                           AND session_evidence.agent = session.agent
+                           AND session_evidence.session_id = session.session_id
+                    )"
+            ),
+            rusqlite::params_from_iter(agent_values.iter()),
+        )?;
+
+        let parser_parameter = agents.len() + 1;
+        let analyzer_parameter = agents.len() + 2;
+        let metrics_parameter = agents.len() + 3;
+        let evidence_parameter = agents.len() + 4;
+        let update_sql = format!(
+            "UPDATE session_evidence AS evidence
+                SET status = 'pending', last_error = NULL,
+                    next_attempt_at_epoch = NULL, retry_count = 0
+              WHERE evidence.agent IN ({agent_placeholders})
+                AND (
+                    evidence.status <> 'pending'
+                    OR evidence.last_error IS NOT NULL
+                    OR evidence.next_attempt_at_epoch IS NOT NULL
+                    OR evidence.retry_count <> 0
+                )
+                AND EXISTS (
+                    SELECT 1 FROM session
+                     WHERE session.environment_key = evidence.environment_key
+                       AND session.agent = evidence.agent
+                       AND session.session_id = evidence.session_id
+                       AND (
+                           evidence.analyzed_generation IS NOT session.source_generation
+                           OR evidence.parser_revision IS NOT ?{parser_parameter}
+                           OR evidence.analyzer_revision IS NOT ?{analyzer_parameter}
+                           OR evidence.evidence_schema_revision IS NOT ?{evidence_parameter}
+                           OR NOT EXISTS (
+                               SELECT 1 FROM session_analysis AS analysis
+                                WHERE analysis.environment_key = session.environment_key
+                                  AND analysis.agent = session.agent
+                                  AND analysis.session_id = session.session_id
+                                  AND analysis.analyzed_generation = session.source_generation
+                                  AND analysis.parser_revision = ?{parser_parameter}
+                                  AND analysis.analyzer_revision = ?{analyzer_parameter}
+                                  AND analysis.metrics_schema_revision = ?{metrics_parameter}
+                           )
+                       )
+                )"
+        );
+        let mut update_values = agent_values;
+        update_values.extend([
+            rusqlite::types::Value::Integer(revisions.parser_revision),
+            rusqlite::types::Value::Integer(revisions.analyzer_revision),
+            rusqlite::types::Value::Integer(revisions.metrics_schema_revision),
+            rusqlite::types::Value::Integer(revisions.evidence_schema_revision),
+        ]);
+        let requeued = transaction.execute(
+            &update_sql,
+            rusqlite::params_from_iter(update_values.iter()),
+        )?;
+        transaction.commit()?;
+        Ok(enrolled + requeued)
     }
 
     /// Forget all locally stored session data: every session, its analysis, its
@@ -1206,7 +1295,22 @@ pub fn iso_from_epoch(epoch: Option<i64>) -> String {
         .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string())
 }
 
-fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<()> {
+fn upsert_session_in(
+    connection: &Connection,
+    record: &SessionRecord,
+) -> Result<(Option<i64>, i64)> {
+    let previous_generation = connection
+        .query_row(
+            "SELECT source_generation FROM session
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
     let now = now_rfc3339();
     connection.execute(
         "INSERT INTO session (
@@ -1298,6 +1402,28 @@ fn upsert_session_in(connection: &Connection, record: &SessionRecord) -> Result<
             ],
         )?;
     }
+    let source_generation = connection.query_row(
+        "SELECT source_generation FROM session
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+        params![
+            record.key.environment_key,
+            record.key.agent,
+            record.key.session_id
+        ],
+        |row| row.get(0),
+    )?;
+    Ok((previous_generation, source_generation))
+}
+
+fn mark_evidence_pending_in(connection: &Connection, key: &SessionKey) -> Result<()> {
+    connection.execute(
+        "INSERT INTO session_evidence (environment_key, agent, session_id)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
+             status = 'pending', last_error = NULL,
+             next_attempt_at_epoch = NULL, retry_count = 0",
+        params![key.environment_key, key.agent, key.session_id],
+    )?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -216,6 +216,22 @@ pub struct ProjectionRevisions {
     pub evidence_schema_revision: i64,
 }
 
+/// A claimed evidence row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceClaim {
+    pub key: SessionKey,
+    pub source_generation: i64,
+    pub claim_fence: i64,
+    pub retry_count: i64,
+}
+
+/// The two failure outcomes available after a claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceFailure {
+    Retry { next_attempt_at_epoch: i64 },
+    Failed,
+}
+
 /// One session's token evidence, as the provider-usage aggregation reads it.
 ///
 /// A projection rather than a record: the aggregation needs three columns out

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -149,6 +149,64 @@ pub struct AnalysisRecord {
     pub metrics_schema_revision: i64,
 }
 
+/// The persisted lifecycle state for one session's evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceStatus {
+    Pending,
+    Processing,
+    Ready,
+    Unsupported,
+    Failed,
+}
+
+impl EvidenceStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EvidenceStatus::Pending => "pending",
+            EvidenceStatus::Processing => "processing",
+            EvidenceStatus::Ready => "ready",
+            EvidenceStatus::Unsupported => "unsupported",
+            EvidenceStatus::Failed => "failed",
+        }
+    }
+}
+
+impl std::str::FromStr for EvidenceStatus {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "pending" => Ok(EvidenceStatus::Pending),
+            "processing" => Ok(EvidenceStatus::Processing),
+            "ready" => Ok(EvidenceStatus::Ready),
+            "unsupported" => Ok(EvidenceStatus::Unsupported),
+            "failed" => Ok(EvidenceStatus::Failed),
+            _ => Err("unknown evidence status"),
+        }
+    }
+}
+
+/// A persisted evidence row and its queue state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceRow {
+    pub key: SessionKey,
+    pub status: EvidenceStatus,
+    pub analyzed_generation: Option<i64>,
+    pub processed_fingerprint: Option<String>,
+    pub parser_revision: Option<i64>,
+    pub analyzer_revision: Option<i64>,
+    pub evidence_schema_revision: Option<i64>,
+    pub evidence_json: Option<String>,
+    pub diagnostics_json: Option<String>,
+    pub retry_count: i64,
+    pub claim_fence: i64,
+    pub claimed_at_epoch: Option<i64>,
+    pub lease_expires_at_epoch: Option<i64>,
+    pub next_attempt_at_epoch: Option<i64>,
+    pub analyzed_at_epoch: Option<i64>,
+    pub last_error: Option<String>,
+}
+
 /// One session's token evidence, as the provider-usage aggregation reads it.
 ///
 /// A projection rather than a record: the aggregation needs three columns out

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -232,6 +232,32 @@ pub enum EvidenceFailure {
     Failed,
 }
 
+/// The two successful publication states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishedEvidence {
+    Ready,
+    Unsupported,
+}
+
+impl PublishedEvidence {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PublishedEvidence::Ready => "ready",
+            PublishedEvidence::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// The evidence values produced by one analyzed pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceCompletion {
+    pub claim_fence: i64,
+    pub status: PublishedEvidence,
+    pub evidence_schema_revision: i64,
+    pub evidence_json: String,
+    pub diagnostics_json: Option<String>,
+}
+
 /// One session's token evidence, as the provider-usage aggregation reads it.
 ///
 /// A projection rather than a record: the aggregation needs three columns out

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -207,6 +207,15 @@ pub struct EvidenceRow {
     pub last_error: Option<String>,
 }
 
+/// The current revisions for both transcript-derived projections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectionRevisions {
+    pub parser_revision: i64,
+    pub analyzer_revision: i64,
+    pub metrics_schema_revision: i64,
+    pub evidence_schema_revision: i64,
+}
+
 /// One session's token evidence, as the provider-usage aggregation reads it.
 ///
 /// A projection rather than a record: the aggregation needs three columns out

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -14,7 +14,7 @@
 
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
-pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4, V5, V6, V7, V8, V9, V10];
+pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
 ///
@@ -302,4 +302,30 @@ ALTER TABLE session_analysis ADD COLUMN metrics_schema_revision INTEGER NOT NULL
 const V10: &str = r#"
 ALTER TABLE usage_analytics_event RENAME TO analytics_event;
 ALTER TABLE usage_analytics_identity RENAME TO analytics_identity;
+"#;
+
+/// v11 — durable session evidence and its work lifecycle.
+///
+/// # Data policy (schema-level contract)
+///
+/// This table stores derived facts and never stores transcript text.
+/// Session deletion and clear-local-session-data remove these facts.
+/// Transcript file removal does not remove these facts.
+const V11: &str = r#"
+CREATE TABLE session_evidence (
+    environment_key TEXT NOT NULL, agent TEXT NOT NULL, session_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    analyzed_generation INTEGER, processed_fingerprint TEXT,
+    parser_revision INTEGER, analyzer_revision INTEGER, evidence_schema_revision INTEGER,
+    evidence_json TEXT, diagnostics_json TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0, claim_fence INTEGER NOT NULL DEFAULT 0,
+    claimed_at_epoch INTEGER, lease_expires_at_epoch INTEGER,
+    next_attempt_at_epoch INTEGER, analyzed_at_epoch INTEGER, last_error TEXT,
+    PRIMARY KEY (environment_key, agent, session_id),
+    FOREIGN KEY (environment_key, agent, session_id)
+      REFERENCES session (environment_key, agent, session_id) ON DELETE CASCADE,
+    CHECK (status IN ('pending','processing','ready','unsupported','failed'))
+) STRICT;
+CREATE INDEX session_evidence_status
+    ON session_evidence (status, next_attempt_at_epoch, lease_expires_at_epoch);
 "#;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -29,6 +29,104 @@ fn session(session_id: &str, updated_at: i64) -> SessionRecord {
     }
 }
 
+fn projection_revisions() -> ProjectionRevisions {
+    ProjectionRevisions {
+        parser_revision: 1,
+        analyzer_revision: 1,
+        metrics_schema_revision: 1,
+        evidence_schema_revision: 1,
+    }
+}
+
+fn seed_current_session_evidence(store: &Store, session_id: &str) -> SessionRecord {
+    let mut record = session(session_id, 1_000);
+    record.source_fingerprint = Some("sv1:current".into());
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+    store
+        .save_analysis(
+            &AnalysisRecord {
+                key: record.key.clone(),
+                model_breakdown_json: "{}".into(),
+                inclusive_models_json: "[]".into(),
+                source_fingerprint: "sv1:current".into(),
+                pricing_generation: 1,
+                analyzed_generation: 1,
+                parser_revision: 1,
+                analyzer_revision: 1,
+                metrics_schema_revision: 1,
+            },
+            None,
+        )
+        .unwrap();
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence
+                SET status = 'ready', analyzed_generation = 1,
+                    processed_fingerprint = 'sv1:current', parser_revision = 1,
+                    analyzer_revision = 1, evidence_schema_revision = 1,
+                    evidence_json = '{\"groups\":[]}', diagnostics_json = '[]',
+                    retry_count = 0, claim_fence = 4, analyzed_at_epoch = 900
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    record
+}
+
+fn assert_unchanged_session_evidence(
+    session_id: &str,
+    status: &str,
+    retry_count: i64,
+    claimed_at_epoch: Option<i64>,
+    lease_expires_at_epoch: Option<i64>,
+    next_attempt_at_epoch: Option<i64>,
+    last_error: Option<&str>,
+) {
+    let store = store();
+    let record = seed_current_session_evidence(&store, session_id);
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence
+                SET status = ?4, retry_count = ?5, claimed_at_epoch = ?6,
+                    lease_expires_at_epoch = ?7, next_attempt_at_epoch = ?8,
+                    last_error = ?9
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id,
+                status,
+                retry_count,
+                claimed_at_epoch,
+                lease_expires_at_epoch,
+                next_attempt_at_epoch,
+                last_error,
+            ],
+        )
+        .unwrap();
+    let before = store.evidence(&record.key).unwrap().unwrap();
+
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        0
+    );
+
+    assert_eq!(store.evidence(&record.key).unwrap().unwrap(), before);
+}
+
 #[test]
 fn a_fresh_database_is_migrated_to_the_latest_version() {
     let store = store();
@@ -1303,6 +1401,232 @@ fn the_generation_increments_only_when_the_fingerprint_changes() {
         .unwrap()
         .expect("source state");
     assert_eq!(unreadable, second);
+}
+
+#[test]
+fn a_new_source_generation_marks_session_evidence_pending() {
+    let store = store();
+    let mut record = seed_current_session_evidence(&store, "new-generation-evidence");
+    record.source_fingerprint = Some("sv1:changed".into());
+
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+
+    assert_eq!(
+        store
+            .session_source_state(&record.key)
+            .unwrap()
+            .unwrap()
+            .source_generation,
+        2
+    );
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
+fn marking_session_evidence_pending_keeps_the_last_completed_payload() {
+    let store = store();
+    let mut record = seed_current_session_evidence(&store, "preserved-evidence");
+    let before = store.evidence(&record.key).unwrap().unwrap();
+    record.source_fingerprint = Some("sv1:changed".into());
+
+    store.upsert_sessions(&[record.clone()]).unwrap();
+
+    let after = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(after.status, EvidenceStatus::Pending);
+    assert_eq!(after.evidence_json, before.evidence_json);
+    assert_eq!(after.diagnostics_json, before.diagnostics_json);
+    assert_eq!(after.analyzed_generation, before.analyzed_generation);
+    assert_eq!(after.processed_fingerprint, before.processed_fingerprint);
+    assert_eq!(after.parser_revision, before.parser_revision);
+    assert_eq!(after.analyzer_revision, before.analyzer_revision);
+    assert_eq!(
+        after.evidence_schema_revision,
+        before.evidence_schema_revision
+    );
+    assert_eq!(after.claim_fence, before.claim_fence);
+    assert_eq!(after.retry_count, 0);
+    assert_eq!(after.next_attempt_at_epoch, None);
+    assert_eq!(after.last_error, None);
+}
+
+#[test]
+fn an_unchanged_fingerprint_leaves_a_ready_session_evidence_row_alone() {
+    assert_unchanged_session_evidence("unchanged-ready", "ready", 0, None, None, None, None);
+}
+
+#[test]
+fn an_unchanged_fingerprint_leaves_a_processing_session_evidence_claim_alone() {
+    assert_unchanged_session_evidence(
+        "unchanged-processing",
+        "processing",
+        2,
+        Some(100),
+        Some(200),
+        None,
+        None,
+    );
+}
+
+#[test]
+fn an_unchanged_fingerprint_keeps_session_evidence_retry_backoff() {
+    assert_unchanged_session_evidence(
+        "unchanged-backoff",
+        "pending",
+        3,
+        None,
+        None,
+        Some(300),
+        Some("try later"),
+    );
+}
+
+#[test]
+fn an_unchanged_fingerprint_leaves_a_failed_session_evidence_row_failed() {
+    assert_unchanged_session_evidence(
+        "unchanged-failed",
+        "failed",
+        4,
+        None,
+        None,
+        None,
+        Some("terminal"),
+    );
+}
+
+#[test]
+fn reconciling_enrolls_a_session_evidence_row_for_an_upgraded_session() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    for &sql in &super::schema::MIGRATIONS[..10] {
+        connection.execute_batch(sql).unwrap();
+    }
+    connection
+        .execute(
+            "INSERT INTO session (
+                 environment_key, agent, session_id, source_kind, source_label,
+                 first_seen_at, last_seen_at, source_fingerprint, source_generation)
+             VALUES ('native', 'claude-code', 'upgrade-enrollment', 'file',
+                     '/home/avery/.claude/projects/demo/upgrade-enrollment.jsonl',
+                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                     'sv1:current', 1)",
+            [],
+        )
+        .unwrap();
+    connection.pragma_update(None, "user_version", 10).unwrap();
+    let store = Store::from_connection(
+        connection,
+        Path::new("/tmp/antiburn-evidence-enrollment-test").to_path_buf(),
+    )
+    .unwrap();
+    let mut record = session("upgrade-enrollment", 1_000);
+    record.source_fingerprint = Some("sv1:current".into());
+
+    store.upsert_sessions(&[record.clone()]).unwrap();
+    assert!(store.evidence(&record.key).unwrap().is_none());
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+    assert_eq!(
+        store
+            .session_source_state(&record.key)
+            .unwrap()
+            .unwrap()
+            .source_generation,
+        1
+    );
+}
+
+#[test]
+fn a_revision_change_requeues_session_evidence_without_touching_the_generation() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "revision-requeue");
+    let before = store.session_source_state(&record.key).unwrap().unwrap();
+    let revisions = ProjectionRevisions {
+        evidence_schema_revision: 2,
+        ..projection_revisions()
+    };
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], revisions)
+            .unwrap(),
+        1
+    );
+
+    let evidence = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(evidence.status, EvidenceStatus::Pending);
+    assert_eq!(evidence.evidence_json.as_deref(), Some("{\"groups\":[]}"));
+    assert_eq!(
+        store.session_source_state(&record.key).unwrap().unwrap(),
+        before
+    );
+}
+
+#[test]
+fn a_catalog_change_requeues_no_session_evidence() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "catalog-no-requeue");
+    store
+        .save_analysis(
+            &AnalysisRecord {
+                key: record.key.clone(),
+                model_breakdown_json: "{}".into(),
+                inclusive_models_json: "[]".into(),
+                source_fingerprint: "sv1:current".into(),
+                pricing_generation: 2,
+                analyzed_generation: 1,
+                parser_revision: 1,
+                analyzer_revision: 1,
+                metrics_schema_revision: 1,
+            },
+            None,
+        )
+        .unwrap();
+    let before = store.evidence(&record.key).unwrap().unwrap();
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        0
+    );
+    assert_eq!(store.evidence(&record.key).unwrap().unwrap(), before);
+}
+
+#[test]
+fn reconciling_session_evidence_skips_a_disabled_agent() {
+    let store = store();
+    let claude = session("enabled-evidence", 1_000);
+    let mut codex = session("disabled-evidence", 1_000);
+    codex.key.agent = "codex".into();
+    store
+        .upsert_sessions(&[claude.clone(), codex.clone()])
+        .unwrap();
+    store
+        .lock()
+        .execute("DELETE FROM session_evidence", [])
+        .unwrap();
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        1
+    );
+    assert!(store.evidence(&claude.key).unwrap().is_some());
+    assert!(store.evidence(&codex.key).unwrap().is_none());
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -365,6 +365,119 @@ fn the_session_table_shape_is_stable() {
 }
 
 #[test]
+fn session_evidence_table_shape_is_stable() {
+    let store = store();
+    let connection = store.lock();
+    let mut statement = connection
+        .prepare("SELECT name FROM pragma_table_info('session_evidence')")
+        .unwrap();
+    let columns: Vec<String> = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+
+    assert_eq!(
+        columns,
+        vec![
+            "environment_key",
+            "agent",
+            "session_id",
+            "status",
+            "analyzed_generation",
+            "processed_fingerprint",
+            "parser_revision",
+            "analyzer_revision",
+            "evidence_schema_revision",
+            "evidence_json",
+            "diagnostics_json",
+            "retry_count",
+            "claim_fence",
+            "claimed_at_epoch",
+            "lease_expires_at_epoch",
+            "next_attempt_at_epoch",
+            "analyzed_at_epoch",
+            "last_error",
+        ]
+    );
+}
+
+#[test]
+fn session_evidence_status_index_exists() {
+    let store = store();
+    let connection = store.lock();
+    let columns: Vec<String> = connection
+        .prepare("SELECT name FROM pragma_index_info('session_evidence_status') ORDER BY seqno")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+
+    assert_eq!(
+        columns,
+        vec!["status", "next_attempt_at_epoch", "lease_expires_at_epoch"]
+    );
+}
+
+#[test]
+fn session_evidence_rejects_an_unknown_status() {
+    let store = store();
+    store
+        .upsert_sessions(&[session("bad-status", 1_000)])
+        .unwrap();
+    let result = store.lock().execute(
+        "INSERT INTO session_evidence (environment_key, agent, session_id, status)
+         VALUES ('native', 'claude-code', 'bad-status', 'unknown')",
+        [],
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn session_evidence_survives_an_upgrade_from_the_shipped_head() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    for &sql in &super::schema::MIGRATIONS[..10] {
+        connection.execute_batch(sql).unwrap();
+    }
+    connection
+        .execute(
+            "INSERT INTO session (
+                 environment_key, agent, session_id, source_kind, source_label,
+                 first_seen_at, last_seen_at)
+             VALUES ('native', 'claude-code', 'upgrade', 'file',
+                     '/home/avery/.claude/projects/demo/upgrade.jsonl',
+                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+    connection.pragma_update(None, "user_version", 10).unwrap();
+
+    let store = Store::from_connection(
+        connection,
+        Path::new("/tmp/antiburn-evidence-migration-test").to_path_buf(),
+    )
+    .expect("V11 migrates the shipped schema");
+    let key = SessionKey::new("native", "claude-code", "upgrade");
+
+    assert_eq!(store.session_count().unwrap(), 1);
+    assert!(store.evidence(&key).unwrap().is_none());
+    store
+        .lock()
+        .execute(
+            "INSERT INTO session_evidence (environment_key, agent, session_id)
+             VALUES ('native', 'claude-code', 'upgrade')",
+            [],
+        )
+        .unwrap();
+    assert_eq!(
+        store.evidence(&key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
 fn clearing_local_data_forgets_session_records_and_keeps_the_readers_choices() {
     let store = store();
     store.upsert_sessions(&[session("abc", 2_000)]).unwrap();

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -611,27 +611,31 @@ fn session_evidence_survives_an_upgrade_from_the_shipped_head() {
     let key = SessionKey::new("native", "claude-code", "upgrade");
 
     assert_eq!(store.session_count().unwrap(), 1);
-    
+
     // Verify the original session row survives the migration unchanged.
     let session_record = store
         .session(&key)
         .unwrap()
         .expect("session row survives migration");
     assert_eq!(session_record.source_kind, "file");
-    assert_eq!(session_record.source_label, "/home/avery/.claude/projects/demo/upgrade.jsonl");
-    
+    assert_eq!(
+        session_record.source_label,
+        "/home/avery/.claude/projects/demo/upgrade.jsonl"
+    );
+
     // Verify the timestamp fields survive unchanged.
-    let (first_seen, last_seen): (String, String) = store.lock()
+    let (first_seen, last_seen): (String, String) = store
+        .lock()
         .query_row(
             "SELECT first_seen_at, last_seen_at FROM session
              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
             rusqlite::params!["native", "claude-code", "upgrade"],
-            |row| Ok((row.get(0)?, row.get(1)?))
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
     assert_eq!(first_seen, "2026-01-01T00:00:00Z");
     assert_eq!(last_seen, "2026-01-01T00:00:00Z");
-    
+
     assert!(store.evidence(&key).unwrap().is_none());
     store
         .lock()

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -4,6 +4,7 @@
 
 use std::path::Path;
 
+use super::model::PublishedEvidence;
 use super::*;
 
 fn store() -> Store {
@@ -35,6 +36,56 @@ fn projection_revisions() -> ProjectionRevisions {
         analyzer_revision: 1,
         metrics_schema_revision: 1,
         evidence_schema_revision: 1,
+    }
+}
+
+fn projection_record(key: SessionKey, fingerprint: &str, generation: i64) -> AnalysisRecord {
+    AnalysisRecord {
+        key,
+        model_breakdown_json: "{}".into(),
+        inclusive_models_json: "[]".into(),
+        source_fingerprint: fingerprint.into(),
+        pricing_generation: 1,
+        analyzed_generation: generation,
+        parser_revision: 1,
+        analyzer_revision: 1,
+        metrics_schema_revision: 1,
+    }
+}
+
+fn claimed_projection(
+    store: &Store,
+    session_id: &str,
+    now_epoch: i64,
+    lease_secs: i64,
+) -> (AnalysisRecord, EvidenceClaim) {
+    let mut session = session(session_id, 1_000);
+    let fingerprint = format!("sv1:{session_id}");
+    session.source_fingerprint = Some(fingerprint.clone());
+    store
+        .upsert_sessions(std::slice::from_ref(&session))
+        .unwrap();
+    let claim = store
+        .claim_next_evidence(&["claude-code"], now_epoch, lease_secs)
+        .unwrap()
+        .unwrap();
+    (
+        projection_record(session.key, &fingerprint, claim.source_generation),
+        claim,
+    )
+}
+
+fn evidence_completion(
+    claim: &EvidenceClaim,
+    status: PublishedEvidence,
+    evidence_json: String,
+) -> EvidenceCompletion {
+    EvidenceCompletion {
+        claim_fence: claim.claim_fence,
+        status,
+        evidence_schema_revision: 1,
+        evidence_json,
+        diagnostics_json: Some("[]".into()),
     }
 }
 
@@ -560,6 +611,27 @@ fn session_evidence_survives_an_upgrade_from_the_shipped_head() {
     let key = SessionKey::new("native", "claude-code", "upgrade");
 
     assert_eq!(store.session_count().unwrap(), 1);
+    
+    // Verify the original session row survives the migration unchanged.
+    let session_record = store
+        .session(&key)
+        .unwrap()
+        .expect("session row survives migration");
+    assert_eq!(session_record.source_kind, "file");
+    assert_eq!(session_record.source_label, "/home/avery/.claude/projects/demo/upgrade.jsonl");
+    
+    // Verify the timestamp fields survive unchanged.
+    let (first_seen, last_seen): (String, String) = store.lock()
+        .query_row(
+            "SELECT first_seen_at, last_seen_at FROM session
+             WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            rusqlite::params!["native", "claude-code", "upgrade"],
+            |row| Ok((row.get(0)?, row.get(1)?))
+        )
+        .unwrap();
+    assert_eq!(first_seen, "2026-01-01T00:00:00Z");
+    assert_eq!(last_seen, "2026-01-01T00:00:00Z");
+    
     assert!(store.evidence(&key).unwrap().is_none());
     store
         .lock()
@@ -1858,6 +1930,226 @@ fn failing_session_evidence_terminally_marks_it_failed() {
     assert_eq!(evidence.last_error.as_deref(), Some("terminal"));
     assert_ne!(evidence.status, EvidenceStatus::Ready);
     assert_ne!(evidence.status, EvidenceStatus::Unsupported);
+}
+
+#[test]
+fn publishing_session_evidence_writes_both_projections_and_the_start_time() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "publish-both", 100, 60);
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Unsupported,
+        "{\"unsupported\":true}".into(),
+    );
+
+    assert!(
+        store
+            .publish_projections(&record, Some(50), &completion)
+            .unwrap()
+    );
+
+    assert_eq!(store.analysis(&record.key).unwrap(), Some(record.clone()));
+    assert_eq!(
+        store
+            .session_source_state(&record.key)
+            .unwrap()
+            .unwrap()
+            .started_at_epoch,
+        Some(50)
+    );
+    let evidence = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(evidence.status, EvidenceStatus::Unsupported);
+    assert_eq!(
+        evidence.analyzed_generation,
+        Some(record.analyzed_generation)
+    );
+    assert_eq!(
+        evidence.processed_fingerprint.as_deref(),
+        Some(record.source_fingerprint.as_str())
+    );
+    assert_eq!(evidence.parser_revision, Some(record.parser_revision));
+    assert_eq!(evidence.analyzer_revision, Some(record.analyzer_revision));
+    assert_eq!(evidence.evidence_schema_revision, Some(1));
+    assert_eq!(evidence.retry_count, 0);
+    assert_eq!(evidence.last_error, None);
+    assert_eq!(evidence.claimed_at_epoch, None);
+    assert_eq!(evidence.lease_expires_at_epoch, None);
+    assert_eq!(evidence.next_attempt_at_epoch, None);
+    assert!(evidence.analyzed_at_epoch.is_some());
+}
+
+#[test]
+fn published_session_evidence_and_analysis_describe_the_same_pass() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "same-pass", 100, 60);
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        store
+            .publish_projections(&record, None, &completion)
+            .unwrap()
+    );
+
+    let analysis = store.analysis(&record.key).unwrap().unwrap();
+    let evidence = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(
+        evidence.analyzed_generation,
+        Some(analysis.analyzed_generation)
+    );
+    assert_eq!(
+        evidence.processed_fingerprint,
+        Some(analysis.source_fingerprint)
+    );
+    assert_eq!(evidence.parser_revision, Some(analysis.parser_revision));
+    assert_eq!(evidence.analyzer_revision, Some(analysis.analyzer_revision));
+}
+
+#[test]
+fn a_stale_generation_publishes_no_session_evidence_and_no_analysis() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "stale-publish-generation", 100, 60);
+    let sentinel = projection_record(record.key.clone(), "sv1:sentinel", 0);
+    store.save_analysis(&sentinel, Some(77)).unwrap();
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET source_generation = source_generation + 1
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let source_before = store.session_source_state(&record.key).unwrap().unwrap();
+    let analysis_before = store.analysis(&record.key).unwrap().unwrap();
+    let evidence_before = store.evidence(&record.key).unwrap().unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        !store
+            .publish_projections(&record, Some(88), &completion)
+            .unwrap()
+    );
+
+    assert_eq!(
+        store.session_source_state(&record.key).unwrap().unwrap(),
+        source_before
+    );
+    assert_eq!(
+        store.analysis(&record.key).unwrap().unwrap(),
+        analysis_before
+    );
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap(),
+        evidence_before
+    );
+}
+
+#[test]
+fn a_stale_fence_publishes_no_session_evidence_and_no_analysis() {
+    let store = store();
+    let (record, first_claim) = claimed_projection(&store, "stale-publish-fence", 100, 10);
+    let current_claim = store
+        .claim_next_evidence(&["claude-code"], 110, 60)
+        .unwrap()
+        .unwrap();
+    assert!(current_claim.claim_fence > first_claim.claim_fence);
+    let sentinel = projection_record(record.key.clone(), "sv1:sentinel", 0);
+    store.save_analysis(&sentinel, Some(77)).unwrap();
+    let source_before = store.session_source_state(&record.key).unwrap().unwrap();
+    let analysis_before = store.analysis(&record.key).unwrap().unwrap();
+    let evidence_before = store.evidence(&record.key).unwrap().unwrap();
+    let completion = evidence_completion(&first_claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        !store
+            .publish_projections(&record, Some(88), &completion)
+            .unwrap()
+    );
+
+    assert_eq!(
+        store.session_source_state(&record.key).unwrap().unwrap(),
+        source_before
+    );
+    assert_eq!(
+        store.analysis(&record.key).unwrap().unwrap(),
+        analysis_before
+    );
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap(),
+        evidence_before
+    );
+}
+
+#[test]
+fn deleting_a_session_removes_its_session_evidence() {
+    let store = store();
+    let mut record = session("delete-evidence", 1_000);
+    record.source_fingerprint = Some("sv1:delete".into());
+    store
+        .upsert_sessions(std::slice::from_ref(&record))
+        .unwrap();
+    assert!(store.evidence(&record.key).unwrap().is_some());
+
+    assert!(store.delete_session(&record.key).unwrap());
+
+    assert!(store.evidence(&record.key).unwrap().is_none());
+}
+
+#[test]
+fn clearing_local_session_data_removes_every_session_evidence_row() {
+    let store = store();
+    let mut first = session("clear-evidence-one", 1_000);
+    first.source_fingerprint = Some("sv1:clear-one".into());
+    let mut second = session("clear-evidence-two", 1_000);
+    second.source_fingerprint = Some("sv1:clear-two".into());
+    store.upsert_sessions(&[first, second]).unwrap();
+
+    assert_eq!(store.clear_local_session_data().unwrap(), 2);
+
+    let count: i64 = store
+        .lock()
+        .query_row("SELECT COUNT(*) FROM session_evidence", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn a_session_evidence_payload_round_trips_through_the_store() {
+    use antiburn_local::analysis::{
+        EvidenceSource, SessionEvidence, SessionEvidenceAccumulator, SourceCapabilities, SourceKind,
+    };
+
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "payload-round-trip", 100, 60);
+    let payload = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: "claude-code".into(),
+        session_id: "payload-round-trip".into(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::claude(),
+    })
+    .evidence();
+    let payload_json = serde_json::to_string(&payload).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, payload_json);
+
+    assert!(
+        store
+            .publish_projections(&record, None, &completion)
+            .unwrap()
+    );
+
+    let stored_json = store
+        .evidence(&record.key)
+        .unwrap()
+        .unwrap()
+        .evidence_json
+        .unwrap();
+    let restored: SessionEvidence = serde_json::from_str(&stored_json).unwrap();
+    assert_eq!(restored, payload);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1546,6 +1546,14 @@ fn reconciling_enrolls_a_session_evidence_row_for_an_upgraded_session() {
             .source_generation,
         1
     );
+    assert_eq!(
+        store
+            .claim_next_evidence(&["claude-code"], 100, 60)
+            .unwrap()
+            .unwrap()
+            .key,
+        record.key
+    );
 }
 
 #[test]
@@ -1627,6 +1635,229 @@ fn reconciling_session_evidence_skips_a_disabled_agent() {
     );
     assert!(store.evidence(&claude.key).unwrap().is_some());
     assert!(store.evidence(&codex.key).unwrap().is_none());
+}
+
+#[test]
+fn the_first_session_evidence_claim_excludes_a_second_claim() {
+    let store = store();
+    let mut record = session("exclusive-claim", 1_000);
+    record.source_fingerprint = Some("sv1:exclusive".into());
+    store.upsert_sessions(&[record]).unwrap();
+
+    let first = store
+        .claim_next_evidence(&["claude-code"], 100, 60)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(first.claim_fence, 1);
+    assert!(
+        store
+            .claim_next_evidence(&["claude-code"], 100, 60)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn reclaiming_an_abandoned_session_evidence_row_raises_the_fence() {
+    let store = store();
+    let mut record = session("reclaimed-claim", 1_000);
+    record.source_fingerprint = Some("sv1:reclaim".into());
+    store.upsert_sessions(&[record]).unwrap();
+    let first = store
+        .claim_next_evidence(&["claude-code"], 100, 10)
+        .unwrap()
+        .unwrap();
+
+    let reclaimed = store
+        .claim_next_evidence(&["claude-code"], 110, 10)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(reclaimed.key, first.key);
+    assert_eq!(reclaimed.source_generation, first.source_generation);
+    assert_eq!(reclaimed.claim_fence, first.claim_fence + 1);
+}
+
+#[test]
+fn a_late_session_evidence_transition_is_rejected() {
+    let store = store();
+    let mut record = session("late-transition", 1_000);
+    record.source_fingerprint = Some("sv1:late".into());
+    store.upsert_sessions(&[record]).unwrap();
+    let first = store
+        .claim_next_evidence(&["claude-code"], 100, 10)
+        .unwrap()
+        .unwrap();
+    let current = store
+        .claim_next_evidence(&["claude-code"], 110, 10)
+        .unwrap()
+        .unwrap();
+    let before = store.evidence(&current.key).unwrap().unwrap();
+
+    assert!(
+        !store
+            .fail_evidence(&first, EvidenceFailure::Failed, "late")
+            .unwrap()
+    );
+    assert_eq!(store.evidence(&current.key).unwrap().unwrap(), before);
+}
+
+#[test]
+fn a_stale_generation_rejects_a_session_evidence_lease_renewal() {
+    let store = store();
+    let mut record = session("stale-renewal", 1_000);
+    record.source_fingerprint = Some("sv1:renewal".into());
+    store.upsert_sessions(&[record.clone()]).unwrap();
+    let claim = store
+        .claim_next_evidence(&["claude-code"], 100, 60)
+        .unwrap()
+        .unwrap();
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET source_generation = source_generation + 1
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let before = store.evidence(&record.key).unwrap().unwrap();
+
+    assert!(!store.renew_evidence_lease(&claim, 110, 60).unwrap());
+    assert_eq!(store.evidence(&record.key).unwrap().unwrap(), before);
+}
+
+#[test]
+fn a_stale_generation_rejects_a_session_evidence_failure() {
+    let store = store();
+    let mut record = session("stale-failure", 1_000);
+    record.source_fingerprint = Some("sv1:failure".into());
+    store.upsert_sessions(&[record.clone()]).unwrap();
+    let claim = store
+        .claim_next_evidence(&["claude-code"], 100, 60)
+        .unwrap()
+        .unwrap();
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET source_generation = source_generation + 1
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let before = store.evidence(&record.key).unwrap().unwrap();
+
+    assert!(
+        !store
+            .fail_evidence(&claim, EvidenceFailure::Failed, "stale")
+            .unwrap()
+    );
+    assert_eq!(store.evidence(&record.key).unwrap().unwrap(), before);
+}
+
+#[test]
+fn a_session_evidence_claim_is_not_eligible_before_its_next_attempt() {
+    let store = store();
+    let mut record = session("delayed-claim", 1_000);
+    record.source_fingerprint = Some("sv1:delayed".into());
+    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence SET next_attempt_at_epoch = 200
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+
+    assert!(
+        store
+            .claim_next_evidence(&["claude-code"], 199, 60)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        store
+            .claim_next_evidence(&["claude-code"], 200, 60)
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
+fn failing_session_evidence_with_retry_returns_it_to_pending_with_backoff() {
+    let store = store();
+    let mut record = session("retry-failure", 1_000);
+    record.source_fingerprint = Some("sv1:retry".into());
+    store.upsert_sessions(&[record.clone()]).unwrap();
+    let claim = store
+        .claim_next_evidence(&["claude-code"], 100, 60)
+        .unwrap()
+        .unwrap();
+
+    assert!(
+        store
+            .fail_evidence(
+                &claim,
+                EvidenceFailure::Retry {
+                    next_attempt_at_epoch: 300,
+                },
+                "try later",
+            )
+            .unwrap()
+    );
+
+    let evidence = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(evidence.status, EvidenceStatus::Pending);
+    assert_eq!(evidence.retry_count, 1);
+    assert_eq!(evidence.next_attempt_at_epoch, Some(300));
+    assert_eq!(evidence.last_error.as_deref(), Some("try later"));
+    assert_eq!(evidence.claimed_at_epoch, None);
+    assert_eq!(evidence.lease_expires_at_epoch, None);
+    assert!(
+        store
+            .claim_next_evidence(&["claude-code"], 299, 60)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn failing_session_evidence_terminally_marks_it_failed() {
+    let store = store();
+    let mut record = session("terminal-failure", 1_000);
+    record.source_fingerprint = Some("sv1:terminal".into());
+    store.upsert_sessions(&[record.clone()]).unwrap();
+    let claim = store
+        .claim_next_evidence(&["claude-code"], 100, 60)
+        .unwrap()
+        .unwrap();
+
+    assert!(
+        store
+            .fail_evidence(&claim, EvidenceFailure::Failed, "terminal")
+            .unwrap()
+    );
+
+    let evidence = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(evidence.status, EvidenceStatus::Failed);
+    assert_eq!(evidence.retry_count, 1);
+    assert_eq!(evidence.next_attempt_at_epoch, None);
+    assert_eq!(evidence.last_error.as_deref(), Some("terminal"));
+    assert_ne!(evidence.status, EvidenceStatus::Ready);
+    assert_ne!(evidence.status, EvidenceStatus::Unsupported);
 }
 
 #[test]


### PR DESCRIPTION
This is part of a PR stack based at #189; this PR merges into main.

## Stack · GH-70
- #189 — GH-70: In-memory session evidence ← previous PR (base)
  - **#NNNN — 0011 (CH-007): Durable session_evidence storage with atomic dual projection writes ← this PR**

## What this seam contains

Migration **V11** creates the `session_evidence` table alongside the session metrics. The table records lifecycle state (pending, being processed, ready, unsupported, or failed), making it a durable work queue that resumes across restarts instead of losing progress. This seam ships the storage primitives that drive that queue: 

- Row and lifecycle types (`ProjectionRevisions`, `EvidenceClaim`, `EvidenceFailure`, `EvidenceCompletion`, `PublishedEvidence`)
- Generation-change detection in `upsert_session_in` with `reconcile_evidence_revisions` for bulk enrollment of pre-existing sessions
- Fenced lifecycle primitives: `claim_next_evidence`, `renew_evidence_lease`, `fail_evidence`, and the reclaim path
- Atomic `publish_projections` write: saves a session's metrics and evidence together or saves neither, using one canonical description of the analyzed pass to prevent drift

See the [seam report](.seams/GH-70/0011-CH-007-durable-session-evidence-report.md) for full verification binding and evidence.

## Why this piece was done

The work queue primitives are necessary for CH-008 (the first caller, a worker that analyzes sessions asynchronously). They unlock the ability to track evidence through its lifecycle and guarantee atomic writes across both projections. This seam ships the plumbing; no production code calls these primitives yet.

## What it changes

- **apps/desktop/src-tauri/src/store/schema.rs** — migration V11 creates `session_evidence` table
- **apps/desktop/src-tauri/src/store/model.rs** — new lifecycle types and row shape
- **apps/desktop/src-tauri/src/store/mod.rs** — `Store` methods for claiming, renewing, failing, and publishing evidence
- **apps/desktop/src-tauri/src/store/tests.rs** — comprehensive tests for all lifecycle paths, dual-write atomicity, and bulk reconciliation
- **apps/desktop/src-tauri/src/lib.rs** — re-export to keep queue API available (deferred cleanup under CH-008)

Nothing user-visible changes — no screen, number, IPC message, or export — and no evidence is written, because every antiburn database self-upgrades on first open. Stored metrics, the ten shipped migrations, and all displayed numbers are unchanged.

## How to review

Read in this order:

1. **schema.rs** — migration V11 and the `session_evidence` table structure
2. **model.rs** — lifecycle types that encode the work-queue state machine
3. **mod.rs** — the four primitives (`reconcile_evidence_revisions`, `claim_next_evidence`, `renew_evidence_lease`, `fail_evidence`, `publish_projections`)
4. **tests.rs** — state transitions, fencing, lease reclaim, and the both-or-neither publish invariant

Verify that the lifecycle types permit no path to "ready" that bypasses `publish_projections`, and that the dual-write atomicity is guaranteed by the transaction boundary. Every antiburn database self-upgrades on first open; stored metrics and displayed numbers are unchanged.

**Review hotspots** — entity-level risk triage of this PR's diff (Medium 2 / High 0 / Critical 0; source entities only). Read these first:

| Entity | File | Risk (score) | Signals |
|---|---|---|---|
| Migration V11 (new migration) | [apps/desktop/src-tauri/src/store/schema.rs](https://github.com/antiburn/antiburn/pull/NNNN/files#diff-0ba1c9e4f1cbecbb7bdaab8e4a3f60e60bb8a0b4) | Medium (0.51) | irreversible on first open · blast 1 (database.rs) |
| `Store::publish_projections` (new method) | [apps/desktop/src-tauri/src/store/mod.rs](https://github.com/antiburn/antiburn/pull/NNNN/files#diff-a1c8e1c6b8e1f4f0) | Medium (0.48) | atomic dual-write invariant · called by CH-008 |
