### PR TITLE
fix(desktop): clarify efficiency metrics

### DIFF
--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -159,7 +159,7 @@ describe("SessionDetailPresentation — chrome", () => {
     expect(screen.queryByText("Cost")).toBeNull()
   })
 
-  it("shows the Efficiency card under the Cost card, with an unpriced hint", () => {
+  it("shows the Efficiency card under the Cost card with a definition", () => {
     view({
       cost: cost(),
       efficiency: {
@@ -175,7 +175,9 @@ describe("SessionDetailPresentation — chrome", () => {
     })
     expect(screen.getByText("Efficiency")).toBeTruthy()
     expect(screen.getByText("$/MTok")).toBeTruthy()
-    expect(screen.getByText("3 turns unpriced")).toBeTruthy()
+    expect(
+      screen.getByText("Relative to real work: context growth and output tokens."),
+    ).toBeTruthy()
   })
 
   it("omits the Efficiency card when the session is unpriced", () => {

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -35,7 +35,7 @@ import {
   isEmptySummary,
 } from "../../lib/presentation/sessionAnalysis"
 import { resultComponentCost, type LocalSessionCost } from "../../lib/presentation/sessionCosts"
-import { efficiencyMetrics, unpricedTurnsHint } from "../../lib/presentation/sessionEfficiency"
+import { efficiencyMetrics } from "../../lib/presentation/sessionEfficiency"
 import type {
   ActiveSessionsSummary,
   SessionEfficiency,
@@ -239,20 +239,23 @@ function RelationControl({
 
 function Card({
   title,
+  subtitle,
   info,
   hint,
   children,
 }: {
   title: string
+  subtitle?: string
   info?: string
   hint?: string
   children: ReactNode
 }) {
   return (
-    <div className="mx-3 mb-3 rounded-xl bg-surface-secondary/40 p-3">
-      <div className="mb-2 flex items-baseline justify-between">
+    <div className="flex flex-col gap-y-2 mx-3 mb-3 rounded-xl bg-surface-secondary/40 p-3">
+      <div className="flex items-baseline justify-between">
         <div className="flex items-center gap-1">
           <h3 className="type-headline text-label">{title}</h3>
+
           {info && (
             <Tooltip label={info} side="top" interactive delayMs={150}>
               <button
@@ -265,8 +268,12 @@ function Card({
             </Tooltip>
           )}
         </div>
+
         {hint && <span className="type-caption text-label-tertiary">{hint}</span>}
       </div>
+
+      {subtitle && <span className="-mt-1 type-caption text-label-tertiary">{subtitle}</span>}
+
       {children}
     </div>
   )
@@ -481,7 +488,6 @@ export function SessionDetailPresentation({
     : null
 
   const efficiencyCard = efficiency ? efficiencyMetrics(efficiency, session.agent) : null
-  const efficiencyHint = efficiencyCard ? unpricedTurnsHint(efficiencyCard.unpricedTurns) : null
 
   const firstSession = summary?.sessions[0]
 
@@ -793,7 +799,10 @@ export function SessionDetailPresentation({
             )}
 
             {cost && tokensCard && efficiencyCard && (
-              <Card title="Efficiency" {...(efficiencyHint ? { hint: efficiencyHint } : {})}>
+              <Card
+                title="Efficiency"
+                subtitle="Relative to real work: context growth and output tokens."
+              >
                 <EfficiencyBreakdown metrics={efficiencyCard} />
               </Card>
             )}

--- a/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
@@ -98,7 +98,7 @@ export function CostBreakdown({ cost, split }: CostBreakdownProps) {
   const totalUsd = cost.totalCostUsd
 
   return (
-    <div className="mt-2 space-y-1 border-t border-separator pt-2">
+    <div className="space-y-1 border-t border-separator pt-2">
       {split && (
         <div className="mb-1 space-y-1 border-b border-separator pb-1">
           <CostRowLine

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
@@ -29,8 +29,8 @@ describe("EfficiencyBreakdown", () => {
   it("renders the three rows with their values and band words", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
     expect(screen.getByText("$/MTok")).toBeTruthy()
-    expect(screen.getByText("New Work %")).toBeTruthy()
-    expect(screen.getByText("Rewrite %")).toBeTruthy()
+    expect(screen.getByText("Real Work %")).toBeTruthy()
+    expect(screen.getByText("Rewrite Waste %")).toBeTruthy()
     expect(screen.getByText("$40.00")).toBeTruthy()
     expect(screen.getByText("34%")).toBeTruthy()
     expect(screen.getByText("12%")).toBeTruthy()
@@ -45,10 +45,10 @@ describe("EfficiencyBreakdown", () => {
     expect(cost.children).toHaveLength(4)
     expect(cost.children[0]?.getAttribute("class")).toContain("bg-system-green")
     expect(cost.children[2]?.getAttribute("class")).toContain("bg-system-orange")
-    // New work reads higher-is-better, so its good segment sits on the right.
-    const newWork = screen.getByTestId("thermometer-newWorkShare")
-    expect(newWork.children[0]?.getAttribute("class")).toContain("bg-system-orange")
-    expect(newWork.children[2]?.getAttribute("class")).toContain("bg-system-green")
+    // Real work reads higher-is-better, so its good segment sits on the right.
+    const realWork = screen.getByTestId("thermometer-realWorkShare")
+    expect(realWork.children[0]?.getAttribute("class")).toContain("bg-system-orange")
+    expect(realWork.children[2]?.getAttribute("class")).toContain("bg-system-green")
   })
 
   it("colours a good reading green and names a bad one by direction", () => {
@@ -97,7 +97,7 @@ describe("EfficiencyBreakdown", () => {
   it("gives each row its own info mark", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "codex")} />)
     expect(screen.getByLabelText("About $/MTok")).toBeTruthy()
-    expect(screen.getByLabelText("About New Work %")).toBeTruthy()
-    expect(screen.getByLabelText("About Rewrite %")).toBeTruthy()
+    expect(screen.getByLabelText("About Real Work %")).toBeTruthy()
+    expect(screen.getByLabelText("About Rewrite Waste %")).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { cn } from "../../../lib/cn"
 import { Info } from "lucide-react"
 
+import { cn } from "../../../lib/cn"
 import {
   efficiencyBandWord,
   efficiencyMetricDescription,
@@ -35,63 +35,61 @@ const BAND_SEGMENT_CLASS: Record<EfficiencyBand, string> = {
   bad: "bg-system-orange/50",
 }
 
-const BAND_MARK_CLASS: Record<EfficiencyBand, string> = {
-  good: "bg-system-green",
-  ok: "bg-label",
-  bad: "bg-system-orange",
-}
-
-type MetricKey = "costPerMTok" | "newWorkShare" | "rewriteShare"
+type MetricKey = "costPerMTok" | "realWorkShare" | "rewriteShare"
 
 const ROWS: { key: MetricKey; label: string; format: (value: number) => string }[] = [
   { key: "costPerMTok", label: "$/MTok", format: formatCostPerMTok },
-  { key: "newWorkShare", label: "New Work %", format: formatSharePercent },
-  { key: "rewriteShare", label: "Rewrite %", format: formatSharePercent },
+  { key: "realWorkShare", label: "Real Work %", format: formatSharePercent },
+  { key: "rewriteShare", label: "Rewrite Waste %", format: formatSharePercent },
 ]
 
 function Thermometer({
   value,
-  band,
   metricKey,
   profile,
+  title,
 }: {
   value: number
-  band: EfficiencyBand
   metricKey: MetricKey
   profile: EfficiencyProfile
+  title: string
 }) {
   const scale = efficiencyThermometer(value, metricKey, profile)
   return (
     <div
-      className="relative flex h-1.5 overflow-hidden rounded-full"
+      className="relative flex h-full items-center"
+      title={title}
       data-testid={`thermometer-${metricKey}`}
       data-position={scale.position.toFixed(3)}
       aria-hidden
     >
       {scale.segments.map((segment, index) => (
-        <span key={index} className={`flex-1 ${BAND_SEGMENT_CLASS[segment]}`} />
+        <span
+          key={index}
+          className={cn(
+            "h-1.5 flex-1",
+            index === 0 && "rounded-s-full",
+            index === scale.segments.length - 1 && "rounded-e-full",
+            BAND_SEGMENT_CLASS[segment],
+          )}
+        />
       ))}
       <span
-        className={`absolute inset-y-0 w-0.5 -translate-x-1/2 ${BAND_MARK_CLASS[band]}`}
+        className="absolute inset-y-1 w-1.5 -translate-x-1/2 rounded-full border border-label bg-surface opacity-80 dark:bg-separator"
         style={{ left: `${scale.position * 100}%` }}
       />
     </div>
   )
 }
 
-/** The info mark after a row label. Its tooltip explains the metric and its bands. */
-function RowInfo({
-  label,
-  metricKey,
-  profile,
-}: {
-  label: string
-  metricKey: MetricKey
-  profile: EfficiencyProfile
-}) {
-  const text = `${efficiencyMetricDescription(metricKey)} ${efficiencyThresholdsText(metricKey, profile)}`
+function RowInfo({ label, metricKey }: { label: string; metricKey: MetricKey }) {
   return (
-    <Tooltip label={text} side="top" interactive delayMs={150}>
+    <Tooltip
+      label={efficiencyMetricDescription(metricKey)}
+      side="top"
+      interactive
+      delayMs={150}
+    >
       <button
         type="button"
         aria-label={`About ${label}`}
@@ -120,14 +118,14 @@ function EfficiencyRowLine({
     <div className="col-span-4 grid grid-cols-subgrid items-center gap-x-3 -mx-1 px-1 py-1 rounded-control type-caption transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover">
       <span className="flex items-center gap-1 text-label-tertiary">
         {label}
-        <RowInfo label={label} metricKey={metricKey} profile={profile} />
+        <RowInfo label={label} metricKey={metricKey} />
       </span>
       {metric ? (
         <Thermometer
           value={metric.value}
-          band={metric.band}
           metricKey={metricKey}
           profile={profile}
+          title={efficiencyThresholdsText(metricKey, profile)}
         />
       ) : (
         <span />

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
@@ -14,7 +14,6 @@ import {
   efficiencyThermometer,
   formatCostPerMTok,
   formatSharePercent,
-  unpricedTurnsHint,
 } from "./sessionEfficiency"
 
 function totals(over: Partial<SessionEfficiency> = {}): SessionEfficiency {
@@ -35,7 +34,7 @@ describe("efficiencyMetrics", () => {
   it("derives the three ratios from the totals", () => {
     const m = efficiencyMetrics(totals(), "claude-code")
     expect(m.costPerMTok?.value).toBeCloseTo(40)
-    expect(m.newWorkShare?.value).toBeCloseTo(0.34)
+    expect(m.realWorkShare?.value).toBeCloseTo(0.34)
     expect(m.rewriteShare?.value).toBeCloseTo(0.12)
     expect(m.unpricedTurns).toBe(0)
     expect(m.profile).toBe("claude")
@@ -44,17 +43,17 @@ describe("efficiencyMetrics", () => {
   it("bands a ok Claude session as ok on every metric", () => {
     const m = efficiencyMetrics(totals(), "claude-code")
     expect(m.costPerMTok?.band).toBe("ok")
-    expect(m.newWorkShare?.band).toBe("ok")
+    expect(m.realWorkShare?.band).toBe("ok")
     expect(m.rewriteShare?.band).toBe("ok")
   })
 
-  it("bands the Claude edges: cost, rewrite, and new work", () => {
+  it("bands the Claude edges: cost, rewrite, and real work", () => {
     const cheap = efficiencyMetrics(
       totals({ totalUsd: 5, newWorkUsd: 4, rewriteUsd: 0.2 }),
       "claude-code",
     )
     expect(cheap.costPerMTok?.band).toBe("good")
-    expect(cheap.newWorkShare?.band).toBe("good")
+    expect(cheap.realWorkShare?.band).toBe("good")
     expect(cheap.rewriteShare?.band).toBe("good")
 
     const dear = efficiencyMetrics(
@@ -62,7 +61,7 @@ describe("efficiencyMetrics", () => {
       "claude-code",
     )
     expect(dear.costPerMTok?.band).toBe("bad")
-    expect(dear.newWorkShare?.band).toBe("bad")
+    expect(dear.realWorkShare?.band).toBe("bad")
     expect(dear.rewriteShare?.band).toBe("bad")
   })
 
@@ -70,9 +69,9 @@ describe("efficiencyMetrics", () => {
     // Rewrite 22% sits between the 20% ok top and the 25% bad edge.
     const rewrite = efficiencyMetrics(totals({ rewriteUsd: 2.2 }), "claude-code")
     expect(rewrite.rewriteShare?.band).toBe("ok")
-    // New work 19% sits between the 18% bad edge and the 20% ok floor.
-    const newWork = efficiencyMetrics(totals({ newWorkUsd: 1.9 }), "claude-code")
-    expect(newWork.newWorkShare?.band).toBe("ok")
+    // Real work at 19% sits between the bad edge and the good edge.
+    const realWork = efficiencyMetrics(totals({ newWorkUsd: 1.9 }), "claude-code")
+    expect(realWork.realWorkShare?.band).toBe("ok")
   })
 
   it("reads a Codex session against the Codex bands", () => {
@@ -88,20 +87,20 @@ describe("efficiencyMetrics", () => {
       "codex",
     )
     expect(good.costPerMTok?.band).toBe("good")
-    expect(good.newWorkShare?.band).toBe("good")
+    expect(good.realWorkShare?.band).toBe("good")
   })
 
   it("returns null metrics when there is no spend", () => {
     const m = efficiencyMetrics(totals({ totalUsd: 0, newWorkUsd: 0, rewriteUsd: 0 }), "codex")
     expect(m.costPerMTok).toBeNull()
-    expect(m.newWorkShare).toBeNull()
+    expect(m.realWorkShare).toBeNull()
     expect(m.rewriteShare).toBeNull()
   })
 
   it("returns a null cost per MTok when the token denominator is zero", () => {
     const m = efficiencyMetrics(totals({ growthTokens: 0, outputTokens: 0 }), "claude-code")
     expect(m.costPerMTok).toBeNull()
-    expect(m.newWorkShare).not.toBeNull()
+    expect(m.realWorkShare).not.toBeNull()
   })
 
   it("carries the unpriced turn count through", () => {
@@ -139,15 +138,15 @@ describe("formatting", () => {
     expect(efficiencyThermometer(120, "costPerMTok", "claude").position).toBeCloseTo(5 / 6)
     expect(efficiencyThermometer(999, "costPerMTok", "claude").position).toBe(1)
     // Higher is better: bad | ok | good, edges at 18% and 36%.
-    const newWork = efficiencyThermometer(0.27, "newWorkShare", "claude")
-    expect(newWork.segments).toEqual(["bad", "ok", "good"])
-    expect(newWork.position).toBeCloseTo(0.5)
+    const realWork = efficiencyThermometer(0.27, "realWorkShare", "claude")
+    expect(realWork.segments).toEqual(["bad", "ok", "good"])
+    expect(realWork.position).toBeCloseTo(0.5)
   })
 
   it("describes each metric in a sentence", () => {
-    expect(efficiencyMetricDescription("costPerMTok")).toMatch(/per million tokens/)
-    expect(efficiencyMetricDescription("newWorkShare")).toMatch(/fresh context/)
-    expect(efficiencyMetricDescription("rewriteShare")).toMatch(/compaction/)
+    expect(efficiencyMetricDescription("costPerMTok")).toMatch(/Cost for real work/)
+    expect(efficiencyMetricDescription("realWorkShare")).toMatch(/spent on real work/)
+    expect(efficiencyMetricDescription("rewriteShare")).toMatch(/rewriting the cache/)
   })
 
   it("names the direction of a bad reading", () => {
@@ -155,24 +154,18 @@ describe("formatting", () => {
     expect(efficiencyBandWord("ok", "rewriteShare")).toBe("ok")
     expect(efficiencyBandWord("bad", "costPerMTok")).toBe("high")
     expect(efficiencyBandWord("bad", "rewriteShare")).toBe("high")
-    expect(efficiencyBandWord("bad", "newWorkShare")).toBe("low")
+    expect(efficiencyBandWord("bad", "realWorkShare")).toBe("low")
   })
 
   it("spells the thresholds for the agent's profile", () => {
     expect(efficiencyThresholdsText("costPerMTok", "claude")).toBe(
-      "Good below $33, ok $33–$80, high above $80.",
+      "[Good = below $33; High = over $80; otherwise OK]",
     )
-    expect(efficiencyThresholdsText("newWorkShare", "codex")).toBe(
-      "Good above 33%, ok 17%–33%, low below 17%.",
+    expect(efficiencyThresholdsText("realWorkShare", "codex")).toBe(
+      "[Good = over 33%; Low = below 17%; otherwise OK]",
     )
     expect(efficiencyThresholdsText("rewriteShare", "codex")).toBe(
-      "Good below 8%, ok 8%–14%, high above 14%.",
+      "[Good = below 8%; High = over 14%; otherwise OK]",
     )
-  })
-
-  it("hints about unpriced turns only when there are some", () => {
-    expect(unpricedTurnsHint(0)).toBeNull()
-    expect(unpricedTurnsHint(1)).toBe("1 turn unpriced")
-    expect(unpricedTurnsHint(3)).toBe("3 turns unpriced")
   })
 })

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.ts
@@ -28,8 +28,8 @@ export interface EfficiencyMetric {
 export interface EfficiencyMetrics {
   /** Dollars per million tokens of context growth plus output. */
   costPerMTok: EfficiencyMetric | null
-  /** Share of the spend that was new work, in the range 0 to 1. */
-  newWorkShare: EfficiencyMetric | null
+  /** Share of the spend that was real work, in the range 0 to 1. */
+  realWorkShare: EfficiencyMetric | null
   /** Share of the spend that was rewrite, in the range 0 to 1. */
   rewriteShare: EfficiencyMetric | null
   unpricedTurns: number
@@ -50,19 +50,19 @@ interface BandEdges {
 interface ProfileEdges {
   costPerMTok: BandEdges
   rewriteShare: BandEdges
-  newWorkShare: BandEdges
+  realWorkShare: BandEdges
 }
 
 const EDGES: Record<EfficiencyProfile, ProfileEdges> = {
   claude: {
     costPerMTok: { good: 33, bad: 80, higherIsBetter: false },
     rewriteShare: { good: 0.1, bad: 0.25, higherIsBetter: false },
-    newWorkShare: { good: 0.36, bad: 0.18, higherIsBetter: true },
+    realWorkShare: { good: 0.36, bad: 0.18, higherIsBetter: true },
   },
   codex: {
     costPerMTok: { good: 20, bad: 46, higherIsBetter: false },
     rewriteShare: { good: 0.08, bad: 0.14, higherIsBetter: false },
-    newWorkShare: { good: 0.33, bad: 0.17, higherIsBetter: true },
+    realWorkShare: { good: 0.33, bad: 0.17, higherIsBetter: true },
   },
 }
 
@@ -136,8 +136,8 @@ export function efficiencyMetrics(totals: SessionEfficiency, agent: string): Eff
       hasSpend && denominatorTokens > 0
         ? metric((totals.totalUsd / denominatorTokens) * 1e6, edges.costPerMTok)
         : null,
-    newWorkShare: hasSpend
-      ? metric(totals.newWorkUsd / totals.totalUsd, edges.newWorkShare)
+    realWorkShare: hasSpend
+      ? metric(totals.newWorkUsd / totals.totalUsd, edges.realWorkShare)
       : null,
     rewriteShare: hasSpend
       ? metric(totals.rewriteUsd / totals.totalUsd, edges.rewriteShare)
@@ -166,7 +166,7 @@ function formatEdge(metricKey: keyof ProfileEdges, value: number): string {
 
 /**
  * The band word after a value. A bad reading names its direction: a high
- * cost or rewrite share, a low new-work share.
+ * cost or rewrite share, or a low real-work share.
  */
 export function efficiencyBandWord(
   band: EfficiencyBand,
@@ -180,11 +180,11 @@ export function efficiencyBandWord(
 export function efficiencyMetricDescription(metricKey: keyof ProfileEdges): string {
   switch (metricKey) {
     case "costPerMTok":
-      return "The all-in spend per million tokens of context growth plus output. A lower figure means each token of progress cost less."
-    case "newWorkShare":
-      return "The share of the spend that went to output and to fresh context that grew the window. The rest re-read or re-sent context."
+      return "Cost for real work. Waste increases this cost, so high efficiency is a low number here."
+    case "realWorkShare":
+      return "How much you spent on real work. The rest of your spend was just re-reading or re-sending context."
     case "rewriteShare":
-      return "The share of the spend that re-sent context without growing it, after a compaction, a cache miss, or a model switch."
+      return "How much you spent rewriting the cache: usually after compaction, a cache miss, or a model switch."
   }
 }
 
@@ -196,13 +196,7 @@ export function efficiencyThresholdsText(
   const edges = EDGES[profile][metricKey]
   const fmt = (value: number) => formatEdge(metricKey, value)
   if (edges.higherIsBetter) {
-    return `Good above ${fmt(edges.good)}, ok ${fmt(edges.bad)}–${fmt(edges.good)}, low below ${fmt(edges.bad)}.`
+    return `[Good = over ${fmt(edges.good)}; Low = below ${fmt(edges.bad)}; otherwise OK]`
   }
-  return `Good below ${fmt(edges.good)}, ok ${fmt(edges.good)}–${fmt(edges.bad)}, high above ${fmt(edges.bad)}.`
-}
-
-/** `3 turns unpriced` — the card hint when some turns had no price. */
-export function unpricedTurnsHint(count: number): string | null {
-  if (count <= 0) return null
-  return `${count} turn${count === 1 ? "" : "s"} unpriced`
+  return `[Good = below ${fmt(edges.good)}; High = over ${fmt(edges.bad)}; otherwise OK]`
 }


### PR DESCRIPTION
## Summary

- rename the new-work efficiency ratio to real work and clarify the metric labels
- move threshold guidance onto the thermometer while simplifying row tooltips
- refine the Efficiency card spacing and marker treatment
- update the presentation tests for the revised contract

## Verification

- pnpm --filter @antiburn/desktop format
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop knip
- pnpm --filter @antiburn/desktop test
- pnpm --filter @antiburn/desktop build
- pnpm run slop
- CI control-plane and design-contract checks