### PR TITLE
Stack GH-70: 0012 (CH-008) Processing decoupled from scan by a restart-safe durable worker

### DIFF
--- a/apps/desktop/src-tauri/src/agents.rs
+++ b/apps/desktop/src-tauri/src/agents.rs
@@ -47,6 +47,11 @@ pub fn kind_from_slug(slug: &str) -> Option<AgentKind> {
     AgentKind::from_slug(slug)
 }
 
+/// Return the agents that use the durable evidence queue.
+pub fn evidence_cohort() -> [&'static str; 1] {
+    [AgentKind::Claude.slug()]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,6 +99,11 @@ mod tests {
         ] {
             assert!(!supports_analysis(kind), "{kind:?}");
         }
+    }
+
+    #[test]
+    fn the_evidence_cohort_uses_the_discovery_slug() {
+        assert_eq!(evidence_cohort(), [AgentKind::Claude.slug()]);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -17,15 +17,17 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::Read;
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
 use antiburn_local::analysis::{
-    ANALYZER_REVISION, ActiveSessionsSummary, ClaudeAdapter, EfficiencyTotals,
-    METRICS_SCHEMA_REVISION, ModelRun, NormalizedSession, PARSER_REVISION, RawSource, SessionCost,
-    SessionInput, SessionMetrics, SessionMetricsAccumulator, SkillUse, SourceClaim, VendorAdapter,
-    VisitOutcome, aggregate_metrics, analyze_session, analyze_sources_with, append_only_guarantee,
-    merge_metrics, merge_subagent_events, normalize_source, price_breakdown, pricing_generation,
+    ANALYZER_REVISION, ActiveSessionsSummary, ClaudeAdapter, CompositeSink,
+    EVIDENCE_SCHEMA_REVISION, EfficiencyTotals, EvidenceSource, METRICS_SCHEMA_REVISION, ModelRun,
+    NormalizedSession, PARSER_REVISION, RawSource, SessionCost, SessionEvidence,
+    SessionEvidenceAccumulator, SessionInput, SessionMetrics, SessionMetricsAccumulator, SkillUse,
+    SourceCapabilities, SourceClaim, SourceKind, VendorAdapter, VisitOutcome, aggregate_metrics,
+    analyze_session, analyze_sources_with, append_only_guarantee, merge_metrics,
+    merge_subagent_events, normalize_source, price_breakdown, pricing_generation,
 };
 use antiburn_local::discovery::{
     ACTIVE_SESSION_WINDOW_SECS, Explorers, FORK_OBSERVATION_KEY, FingerprintInputs,
@@ -36,7 +38,7 @@ use antiburn_local::pricing::ModelTokens;
 
 use crate::agents::{supports_analysis, vendor_label};
 use crate::dto::{BillableTokens, OrchestrationStatus, SubagentMember};
-use crate::store::{AnalysisRecord, SessionKey};
+use crate::store::{AnalysisRecord, ProjectionRevisions, SessionKey};
 
 /// Minimum sub-agents before a session reads as an orchestrator. One delegated
 /// task is ordinary; two or more is genuine fan-out. Mirrors the webview's
@@ -63,6 +65,72 @@ impl CancelFlag {
     pub fn cancelled(&self) -> bool {
         self.0.load(Ordering::SeqCst)
     }
+
+    pub(crate) fn flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.0)
+    }
+}
+
+/// This signal keeps cancellation and progress within one evidence claim.
+#[derive(Clone)]
+pub struct PassSignal {
+    cancel: Arc<AtomicBool>,
+    progress: Arc<AtomicU64>,
+}
+
+impl PassSignal {
+    pub fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            progress: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn from_cancel(cancel: CancelFlag) -> Self {
+        let signal = Self {
+            cancel: cancel.flag(),
+            progress: Arc::new(AtomicU64::new(0)),
+        };
+        if cancel.cancelled() {
+            signal.cancel();
+        }
+        signal
+    }
+
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::SeqCst);
+    }
+
+    pub fn progress(&self) -> u64 {
+        self.progress.load(Ordering::SeqCst)
+    }
+
+    /// This observation advances progress and reports the current cancellation state.
+    pub fn observe(&self) -> bool {
+        self.progress.fetch_add(1, Ordering::SeqCst);
+        self.cancel.load(Ordering::SeqCst)
+    }
+}
+
+impl Default for PassSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassOutcome {
+    Published,
+    SourceChanged,
+    SourceMissing,
+    Unsupported,
+    Unreadable,
+}
+
+pub struct EvidencePass {
+    pub analysis: SessionAnalysis,
+    pub evidence: Option<SessionEvidence>,
+    pub outcome: PassOutcome,
 }
 
 pub struct StreamedSession {
@@ -70,6 +138,7 @@ pub struct StreamedSession {
     pub merged: SessionMetrics,
     pub subagents: Vec<SessionMetrics>,
     pub started_at_epoch: Option<i64>,
+    pub evidence: Option<SessionEvidence>,
 }
 
 enum StreamOutcome {
@@ -78,6 +147,8 @@ enum StreamOutcome {
         parent_fingerprint: Option<String>,
     },
     SourceChanged,
+    ParentMissing,
+    ParentUnsupported,
     ParentUnreadable,
 }
 
@@ -88,8 +159,11 @@ enum ComputedAnalysis {
         subagents: Vec<SessionMetrics>,
         started_at_epoch: Option<i64>,
         parent_fingerprint: Option<String>,
+        evidence: Box<Option<SessionEvidence>>,
     },
     SourceChanged,
+    Missing,
+    Unsupported,
     Unavailable,
 }
 
@@ -215,6 +289,7 @@ impl SessionAnalysis {
         if self.source_changed {
             return None;
         }
+        let revisions = projection_revisions();
         Some(AnalysisRecord {
             key: key.clone(),
             model_breakdown_json: serde_json::to_string(&self.inclusive_model_breakdown)
@@ -224,9 +299,9 @@ impl SessionAnalysis {
             source_fingerprint: self.fingerprint.clone(),
             pricing_generation: pricing_generation() as i64,
             analyzed_generation: self.analyzed_generation,
-            parser_revision: PARSER_REVISION,
-            analyzer_revision: ANALYZER_REVISION,
-            metrics_schema_revision: METRICS_SCHEMA_REVISION,
+            parser_revision: revisions.parser_revision,
+            analyzer_revision: revisions.analyzer_revision,
+            metrics_schema_revision: revisions.metrics_schema_revision,
         })
     }
 }
@@ -452,15 +527,28 @@ fn stream_claude_with_hooks(
         if cancelled() {
             return StreamOutcome::ParentUnreadable;
         }
-        let mut accumulator =
-            SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+        let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+        let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: input.agent.clone(),
+            session_id: input.session_id.clone(),
+            kind: SourceKind::from(&input.source),
+            capabilities: SourceCapabilities::claude(),
+        });
+        let mut accumulator = CompositeSink::new(metrics, evidence);
         let result = match &input.source {
             RawSource::File(path) => {
                 let claim = match claim_file(path) {
                     Ok(claim) => claim,
-                    Err(_) if cancelled() || index == 0 => {
-                        return StreamOutcome::ParentUnreadable;
+                    Err(_) if cancelled() => return StreamOutcome::ParentUnreadable,
+                    Err(error)
+                        if index == 0
+                            && error.downcast_ref::<std::io::Error>().is_some_and(|error| {
+                                error.kind() == std::io::ErrorKind::NotFound
+                            }) =>
+                    {
+                        return StreamOutcome::ParentMissing;
                     }
+                    Err(_) if index == 0 => return StreamOutcome::ParentUnreadable,
                     Err(_) => continue,
                 };
                 let fingerprint = claim.fingerprint.clone();
@@ -483,13 +571,24 @@ fn stream_claude_with_hooks(
                 }
                 ClaudeAdapter.visit(input, &mut accumulator)
             }
-            RawSource::Sqlite(_) if index == 0 => return StreamOutcome::ParentUnreadable,
+            RawSource::Sqlite(_) if index == 0 => return StreamOutcome::ParentUnsupported,
             RawSource::Sqlite(_) => continue,
         };
         match result {
-            Ok(VisitOutcome::SourceChanged(_)) => return StreamOutcome::SourceChanged,
-            Ok(_) if cancelled() => return StreamOutcome::ParentUnreadable,
-            Ok(_) => accumulators.push(accumulator),
+            Ok(outcome @ VisitOutcome::SourceChanged(_)) => {
+                accumulator.observe_source_outcome(outcome);
+                return StreamOutcome::SourceChanged;
+            }
+            Ok(outcome) => {
+                accumulator.observe_source_outcome(outcome);
+                if cancelled() {
+                    return StreamOutcome::ParentUnreadable;
+                }
+                let Some(parts) = accumulator.into_parts() else {
+                    return StreamOutcome::ParentUnreadable;
+                };
+                accumulators.push(parts);
+            }
             Err(_) if cancelled() || index == 0 => {
                 return StreamOutcome::ParentUnreadable;
             }
@@ -499,10 +598,11 @@ fn stream_claude_with_hooks(
     if cancelled() {
         return StreamOutcome::ParentUnreadable;
     }
-    let Some((parent, children)) = accumulators.split_first() else {
+    let (metrics, evidence): (Vec<_>, Vec<_>) = accumulators.into_iter().unzip();
+    let Some((parent, children)) = metrics.split_first() else {
         return StreamOutcome::ParentUnreadable;
     };
-    let started_at_epoch = accumulators
+    let started_at_epoch = metrics
         .iter()
         .filter_map(SessionMetricsAccumulator::earliest_ts_ms)
         .min()
@@ -519,6 +619,7 @@ fn stream_claude_with_hooks(
             merged,
             subagents,
             started_at_epoch,
+            evidence: evidence.first().map(SessionEvidenceAccumulator::evidence),
         }),
         parent_fingerprint,
     }
@@ -575,11 +676,37 @@ pub async fn analyze(
     claimed: ClaimedSource,
     cancel: CancelFlag,
 ) -> SessionAnalysis {
+    let pass = analyze_for_evidence(
+        agent,
+        session_id,
+        wsl_distro,
+        claimed,
+        PassSignal::from_cancel(cancel),
+    )
+    .await;
+    debug_assert!(
+        pass.evidence.is_none()
+            || (agent == AgentKind::Claude && pass.outcome == PassOutcome::Published)
+    );
+    pass.analysis
+}
+
+pub async fn analyze_for_evidence(
+    agent: AgentKind,
+    session_id: &str,
+    wsl_distro: Option<&str>,
+    claimed: ClaimedSource,
+    signal: PassSignal,
+) -> EvidencePass {
     let Some(source) = locate(agent, session_id, wsl_distro).await else {
-        return SessionAnalysis::unavailable();
+        return unavailable_evidence_pass(PassOutcome::SourceMissing, None, None);
     };
     let Some(raw) = raw_source(&source).await else {
-        return SessionAnalysis::unavailable();
+        return unavailable_evidence_pass(
+            PassOutcome::Unreadable,
+            source_path(&source),
+            Some(fingerprint_of(&source)),
+        );
     };
 
     let label = vendor_label(agent);
@@ -633,9 +760,11 @@ pub async fn analyze(
 
     // The engine's analysis is synchronous and CPU-bound; keep it off the
     // runtime's worker threads.
+    let signal_for_pass = signal.clone();
     let computed = tauri::async_runtime::spawn_blocking(move || {
         if is_claude {
-            return match stream_claude(&inputs, &cancel) {
+            let cancelled = || signal_for_pass.observe();
+            return match stream_claude_with_hooks(&inputs, &cancelled, &test_subagent_after_claim) {
                 StreamOutcome::Published {
                     session,
                     parent_fingerprint,
@@ -645,8 +774,11 @@ pub async fn analyze(
                     subagents: session.subagents,
                     started_at_epoch: session.started_at_epoch,
                     parent_fingerprint,
+                    evidence: Box::new(session.evidence),
                 },
                 StreamOutcome::SourceChanged => ComputedAnalysis::SourceChanged,
+                StreamOutcome::ParentMissing => ComputedAnalysis::Missing,
+                StreamOutcome::ParentUnsupported => ComputedAnalysis::Unsupported,
                 StreamOutcome::ParentUnreadable => ComputedAnalysis::Unavailable,
             };
         }
@@ -671,43 +803,66 @@ pub async fn analyze(
             subagents: sessions,
             started_at_epoch: None,
             parent_fingerprint: None,
+            evidence: Box::new(None),
         }
     })
     .await;
 
+    debug_assert!(agent != AgentKind::Claude || signal.progress() > 0);
     let Ok(computed) = computed else {
-        return SessionAnalysis::unavailable();
+        return unavailable_evidence_pass(PassOutcome::Unreadable, source_path, Some(fingerprint));
     };
-    let (parent_metrics, merged, subagents, started_at_epoch, parent_fingerprint) = match computed {
-        ComputedAnalysis::Published {
-            parent,
-            merged,
-            subagents,
-            started_at_epoch,
-            parent_fingerprint,
-        } => (
-            *parent,
-            *merged,
-            subagents,
-            started_at_epoch,
-            parent_fingerprint,
-        ),
-        ComputedAnalysis::SourceChanged => {
-            return SessionAnalysis {
-                source_path,
-                fingerprint,
-                source_changed: true,
-                ..SessionAnalysis::unavailable()
-            };
-        }
-        ComputedAnalysis::Unavailable => {
-            return SessionAnalysis {
-                source_path,
-                fingerprint,
-                ..SessionAnalysis::unavailable()
-            };
-        }
-    };
+    let (parent_metrics, merged, subagents, started_at_epoch, parent_fingerprint, evidence) =
+        match computed {
+            ComputedAnalysis::Published {
+                parent,
+                merged,
+                subagents,
+                started_at_epoch,
+                parent_fingerprint,
+                evidence,
+            } => (
+                *parent,
+                *merged,
+                subagents,
+                started_at_epoch,
+                parent_fingerprint,
+                *evidence,
+            ),
+            ComputedAnalysis::SourceChanged => {
+                return EvidencePass {
+                    analysis: SessionAnalysis {
+                        source_path,
+                        fingerprint,
+                        source_changed: true,
+                        ..SessionAnalysis::unavailable()
+                    },
+                    evidence: None,
+                    outcome: PassOutcome::SourceChanged,
+                };
+            }
+            ComputedAnalysis::Missing => {
+                return unavailable_evidence_pass(
+                    PassOutcome::SourceMissing,
+                    source_path,
+                    Some(fingerprint),
+                );
+            }
+            ComputedAnalysis::Unsupported => {
+                return unavailable_evidence_pass(
+                    PassOutcome::Unsupported,
+                    source_path,
+                    Some(fingerprint),
+                );
+            }
+            ComputedAnalysis::Unavailable => {
+                return unavailable_evidence_pass(
+                    PassOutcome::Unreadable,
+                    source_path,
+                    Some(fingerprint),
+                );
+            }
+        };
     let analyzed_generation = attributed_generation(&claimed, parent_fingerprint.as_deref());
     let by_id: HashMap<String, SessionMetrics> = subagents
         .into_iter()
@@ -780,25 +935,94 @@ pub async fn analyze(
     let skills = metrics.skill_uses.clone();
     let summary = aggregate_metrics(vec![metrics.clone()]);
 
-    SessionAnalysis {
-        efficiency: Some(metrics.efficiency),
-        metrics: Some(metrics),
-        summary: Some(summary),
-        cost,
-        top_level_cost,
-        subagents_cost,
-        inclusive_tokens,
-        subagents_tokens,
-        models,
-        model_runs,
-        inclusive_model_breakdown,
-        skills,
-        orchestration,
-        source_path,
-        fingerprint,
-        analyzed_generation,
-        started_at_epoch,
-        source_changed: false,
+    EvidencePass {
+        analysis: SessionAnalysis {
+            efficiency: Some(metrics.efficiency),
+            metrics: Some(metrics),
+            summary: Some(summary),
+            cost,
+            top_level_cost,
+            subagents_cost,
+            inclusive_tokens,
+            subagents_tokens,
+            models,
+            model_runs,
+            inclusive_model_breakdown,
+            skills,
+            orchestration,
+            source_path,
+            fingerprint,
+            analyzed_generation,
+            started_at_epoch,
+            source_changed: false,
+        },
+        evidence,
+        outcome: PassOutcome::Published,
+    }
+}
+
+fn unavailable_evidence_pass(
+    outcome: PassOutcome,
+    source_path: Option<String>,
+    fingerprint: Option<String>,
+) -> EvidencePass {
+    EvidencePass {
+        analysis: SessionAnalysis {
+            source_path,
+            fingerprint: fingerprint.unwrap_or_else(|| MISSING_FINGERPRINT.to_string()),
+            ..SessionAnalysis::unavailable()
+        },
+        evidence: None,
+        outcome,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn evidence_pass(inputs: &[SessionInput], cancelled: &dyn Fn() -> bool) -> EvidencePass {
+    evidence_pass_with_hook(inputs, cancelled, &test_subagent_after_claim)
+}
+
+#[cfg(test)]
+fn evidence_pass_with_hook(
+    inputs: &[SessionInput],
+    cancelled: &dyn Fn() -> bool,
+    after_claim: &dyn Fn(usize, &std::path::Path),
+) -> EvidencePass {
+    match stream_claude_with_hooks(inputs, cancelled, after_claim) {
+        StreamOutcome::Published { session, .. } => {
+            let StreamedSession {
+                merged, evidence, ..
+            } = *session;
+            EvidencePass {
+                analysis: SessionAnalysis {
+                    metrics: Some(merged),
+                    ..SessionAnalysis::unavailable()
+                },
+                evidence,
+                outcome: PassOutcome::Published,
+            }
+        }
+        StreamOutcome::SourceChanged => {
+            unavailable_evidence_pass(PassOutcome::SourceChanged, None, None)
+        }
+        StreamOutcome::ParentMissing => {
+            unavailable_evidence_pass(PassOutcome::SourceMissing, None, None)
+        }
+        StreamOutcome::ParentUnsupported => {
+            unavailable_evidence_pass(PassOutcome::Unsupported, None, None)
+        }
+        StreamOutcome::ParentUnreadable => {
+            unavailable_evidence_pass(PassOutcome::Unreadable, None, None)
+        }
+    }
+}
+
+pub fn projection_revisions() -> ProjectionRevisions {
+    ProjectionRevisions {
+        parser_revision: PARSER_REVISION,
+        analyzer_revision: ANALYZER_REVISION,
+        metrics_schema_revision: METRICS_SCHEMA_REVISION,
+        evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
     }
 }
 
@@ -839,7 +1063,10 @@ pub async fn analyze_subagent(
                 StreamOutcome::Published { session, .. } => {
                     Some((session.parent, session.started_at_epoch))
                 }
-                StreamOutcome::SourceChanged | StreamOutcome::ParentUnreadable => None,
+                StreamOutcome::SourceChanged
+                | StreamOutcome::ParentMissing
+                | StreamOutcome::ParentUnsupported
+                | StreamOutcome::ParentUnreadable => None,
             };
         }
         analyze_sources_with(vec![input], true)
@@ -1315,6 +1542,120 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn an_inline_source_still_publishes_metrics() {
+        let pass = evidence_pass(
+            &[inline_input(
+                claude_record("inline-metrics", 1_760_000_000),
+                "inline-metrics",
+            )],
+            &|| false,
+        );
+
+        assert_eq!(pass.outcome, PassOutcome::Published);
+        assert!(pass.analysis.metrics.is_some());
+    }
+
+    #[test]
+    fn a_published_claude_pass_carries_evidence() {
+        let pass = evidence_pass(
+            &[inline_input(
+                claude_record("inline-evidence", 1_760_000_000),
+                "inline-evidence",
+            )],
+            &|| false,
+        );
+
+        let evidence = pass.evidence.expect("published evidence");
+        assert_eq!(pass.outcome, PassOutcome::Published);
+        assert_eq!(evidence.schema_revision, EVIDENCE_SCHEMA_REVISION);
+    }
+
+    #[test]
+    fn a_changed_source_publishes_neither_projection() {
+        let directory = tempfile::TempDir::new().expect("tempdir");
+        let path = directory.path().join("changed.jsonl");
+        std::fs::write(&path, claude_record("before", 1_760_000_000)).expect("write source");
+        let change_source = |_: usize, path: &std::path::Path| {
+            use std::io::Write;
+            std::fs::OpenOptions::new()
+                .append(true)
+                .open(path)
+                .expect("open source")
+                .write_all(claude_record("after", 1_760_000_001).as_bytes())
+                .expect("change source");
+        };
+
+        let pass =
+            evidence_pass_with_hook(&[file_input(&path, "changed")], &|| false, &change_source);
+
+        assert_eq!(pass.outcome, PassOutcome::SourceChanged);
+        assert!(pass.analysis.metrics.is_none());
+        assert!(pass.evidence.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_deleted_source_is_missing_not_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::TempDir::new().expect("tempdir");
+        let deleted = directory.path().join("deleted.jsonl");
+        let unreadable = directory.path().join("unreadable.jsonl");
+        std::fs::write(&deleted, claude_record("deleted", 1_760_000_000))
+            .expect("write deleted source");
+        std::fs::write(&unreadable, claude_record("unreadable", 1_760_000_000))
+            .expect("write unreadable source");
+        let deleted_input = file_input(&deleted, "deleted");
+        let unreadable_input = file_input(&unreadable, "unreadable");
+        std::fs::remove_file(&deleted).expect("remove source");
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000))
+            .expect("remove read permission");
+
+        let missing = evidence_pass(&[deleted_input], &|| false);
+        let unreadable_pass = evidence_pass(&[unreadable_input], &|| false);
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o600))
+            .expect("restore read permission");
+
+        assert_eq!(missing.outcome, PassOutcome::SourceMissing);
+        assert_eq!(unreadable_pass.outcome, PassOutcome::Unreadable);
+    }
+
+    #[test]
+    fn an_unsupported_schema_terminates() {
+        let pass = evidence_pass(
+            &[SessionInput {
+                agent: "claude".to_string(),
+                session_id: "unsupported".to_string(),
+                source: RawSource::Sqlite(std::path::PathBuf::from("unsupported.sqlite")),
+            }],
+            &|| false,
+        );
+
+        assert_eq!(pass.outcome, PassOutcome::Unsupported);
+        assert!(pass.analysis.metrics.is_none());
+        assert!(pass.evidence.is_none());
+    }
+
+    #[test]
+    fn a_pass_signal_counts_every_record_and_carries_cancellation() {
+        use std::io::Cursor;
+
+        let first = PassSignal::new();
+        let second = PassSignal::new();
+        let mut reader = antiburn_local::analysis::BoundedJsonlReader::new(Cursor::new(
+            b"one\ntwo\n".as_slice(),
+        ));
+        while reader.next_record(&|| first.observe()).is_some() {}
+
+        assert!(first.progress() > 0);
+        assert!(!first.observe());
+        first.cancel();
+        assert!(first.observe());
+        assert!(!second.observe());
+        assert_eq!(second.progress(), 1);
+    }
+
     #[tokio::test]
     async fn a_changed_subagent_source_rejects_the_direct_subagent_view() {
         let directory = tempfile::TempDir::new().expect("tempdir");
@@ -1443,6 +1784,9 @@ mod tests {
             StreamOutcome::ParentUnreadable => SessionAnalysis::unavailable(),
             StreamOutcome::Published { .. } => panic!("cancelled child read must not publish"),
             StreamOutcome::SourceChanged => panic!("cancelled child read is not a source change"),
+            StreamOutcome::ParentMissing | StreamOutcome::ParentUnsupported => {
+                panic!("cancelled child read must stay unreadable")
+            }
         };
 
         assert_eq!(child_cancel_checks.get(), 3);

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -563,6 +563,28 @@ fn analysis_changed(previous: Option<&AnalysisRecord>, next: &AnalysisRecord) ->
     }
 }
 
+fn cache_detail_analysis(
+    store: &Store,
+    record: &AnalysisRecord,
+    started_at_epoch: Option<i64>,
+) -> bool {
+    if crate::agents::evidence_cohort().contains(&record.key.agent.as_str()) {
+        return false;
+    }
+    let previous = store.analysis(&record.key).ok().flatten();
+    store.save_analysis(record, started_at_epoch).is_ok()
+        && analysis_changed(previous.as_ref(), record)
+}
+
+fn cache_detail_relations(store: &Store, key: &SessionKey, members: &[RelationRecord]) -> bool {
+    if crate::agents::evidence_cohort().contains(&key.agent.as_str()) {
+        return false;
+    }
+    store
+        .replace_relations(key, RelationKind::Subagent, members)
+        .is_ok()
+}
+
 fn path_is_under(path: &str, root: &str) -> bool {
     let path = path.replace('\\', "/");
     let path = path.trim_end_matches('/');
@@ -746,19 +768,14 @@ pub async fn get_session_analysis(
 
     let stored = store.session(&key).ok().flatten();
 
-    if let Some(record) = analysis.record(&key) {
-        let previous = store.analysis(&key).ok().flatten();
-        if store
-            .save_analysis(&record, analysis.started_at_epoch)
-            .is_ok()
-            && analysis_changed(previous.as_ref(), &record)
-            && let Some(session_record) = stored.clone()
-        {
-            let repositories = store.repositories().unwrap_or_default();
-            let now = scan::unix_now();
-            if let Ok(entry) = activity_entry(&store, &repositories, session_record, now) {
-                let _ = app.emit(SESSION_ENTRY_CHANGED_EVENT, &entry);
-            }
+    if let Some(record) = analysis.record(&key)
+        && cache_detail_analysis(&store, &record, analysis.started_at_epoch)
+        && let Some(session_record) = stored.clone()
+    {
+        let repositories = store.repositories().unwrap_or_default();
+        let now = scan::unix_now();
+        if let Ok(entry) = activity_entry(&store, &repositories, session_record, now) {
+            let _ = app.emit(SESSION_ENTRY_CHANGED_EVENT, &entry);
         }
     }
     let orchestration = match &analysis.orchestration {
@@ -772,7 +789,7 @@ pub async fn get_session_analysis(
                     label: Some(member.label.clone()),
                 })
                 .collect();
-            let _ = store.replace_relations(&key, RelationKind::Subagent, &members);
+            cache_detail_relations(&store, &key, &members);
             Some(orchestration.clone())
         }
         // The listing came back empty. That is usually the truth, but it is
@@ -1571,6 +1588,103 @@ mod tests {
         let models_changed = analysis_record("{}", r#"[{"model":"claude-fable-5"}]"#);
         assert!(analysis_changed(Some(&previous), &breakdown_changed));
         assert!(analysis_changed(Some(&previous), &models_changed));
+    }
+
+    #[test]
+    fn the_detail_path_does_not_persist_claude_projections() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let store = Store::open_in_memory(directory.path()).unwrap();
+        let session = |agent: &str, id: &str| SessionRecord {
+            key: SessionKey::new("native", agent, id),
+            source_kind: "file".into(),
+            source_label: format!("/tmp/{id}.jsonl"),
+            wsl_distro: None,
+            title: None,
+            title_source: None,
+            cwd: None,
+            surface: "cli".into(),
+            updated_at_epoch: Some(100),
+            activity_cursor: String::new(),
+            activity_source: "event".into(),
+            subagent_count: 0,
+            fork_parent_session_id: None,
+            source_fingerprint: Some(format!("sv1:{id}")),
+        };
+        let claude = session("claude-code", "claude-detail");
+        let codex = session("codex", "codex-detail");
+        store
+            .upsert_sessions(
+                &[claude.clone(), codex.clone()],
+                &crate::agents::evidence_cohort(),
+            )
+            .unwrap();
+        let _claim = store
+            .claim_next_evidence(&crate::agents::evidence_cohort(), 100, 300)
+            .unwrap()
+            .unwrap();
+        let sentinel = AnalysisRecord {
+            key: claude.key.clone(),
+            model_breakdown_json: r#"{"sentinel":{}}"#.into(),
+            inclusive_models_json: "[]".into(),
+            source_fingerprint: "sv1:sentinel".into(),
+            pricing_generation: 1,
+            analyzed_generation: 0,
+            parser_revision: 1,
+            analyzer_revision: 1,
+            metrics_schema_revision: 1,
+        };
+        store.save_analysis(&sentinel, None).unwrap();
+        let sentinel_relation = RelationRecord {
+            kind: RelationKind::Subagent,
+            related_id: "sentinel-child".into(),
+            label: None,
+        };
+        store
+            .replace_relations(
+                &claude.key,
+                RelationKind::Subagent,
+                std::slice::from_ref(&sentinel_relation),
+            )
+            .unwrap();
+        let mut claude_next = sentinel.clone();
+        claude_next.model_breakdown_json = r#"{"replacement":{}}"#.into();
+        let replacement = RelationRecord {
+            kind: RelationKind::Subagent,
+            related_id: "replacement-child".into(),
+            label: None,
+        };
+
+        assert!(!cache_detail_analysis(&store, &claude_next, None));
+        assert!(!cache_detail_relations(
+            &store,
+            &claude.key,
+            std::slice::from_ref(&replacement),
+        ));
+        assert_eq!(store.analysis(&claude.key).unwrap(), Some(sentinel));
+        assert_eq!(
+            store.relations(&claude.key).unwrap(),
+            vec![sentinel_relation]
+        );
+
+        let codex_analysis = AnalysisRecord {
+            key: codex.key.clone(),
+            model_breakdown_json: r#"{"codex":{}}"#.into(),
+            inclusive_models_json: "[]".into(),
+            source_fingerprint: "sv1:codex-detail".into(),
+            pricing_generation: 1,
+            analyzed_generation: 1,
+            parser_revision: 1,
+            analyzer_revision: 1,
+            metrics_schema_revision: 1,
+        };
+        assert!(cache_detail_analysis(&store, &codex_analysis, None));
+        assert!(cache_detail_relations(
+            &store,
+            &codex.key,
+            std::slice::from_ref(&replacement),
+        ));
+        assert_eq!(store.analysis(&codex.key).unwrap(), Some(codex_analysis));
+        assert_eq!(store.relations(&codex.key).unwrap(), vec![replacement]);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -484,7 +484,7 @@ pub fn list_recent_sessions(
 /// popover's first paint unbounded.
 const MAX_ACTIVITY_ROWS: usize = 500;
 
-fn activity_entry(
+pub(crate) fn activity_entry(
     store: &Store,
     repositories: &[RepositoryRecord],
     session: SessionRecord,

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -100,6 +100,10 @@ pub fn spawn(app: &tauri::AppHandle) -> tauri::async_runtime::JoinHandle<()> {
     })
 }
 
+pub fn wake(app: &tauri::AppHandle) {
+    app.state::<WorkerHandle>().wake.notify_one();
+}
+
 pub(crate) fn backoff_secs(retry_count: i64) -> i64 {
     let exponent = u32::try_from(retry_count.max(0))
         .unwrap_or(u32::MAX)
@@ -204,7 +208,7 @@ pub(crate) fn apply_outcome(
             },
             EVIDENCE_ERROR_UNSUPPORTED,
         ),
-        PassOutcome::Unreadable if claim.retry_count < MAX_EVIDENCE_ATTEMPTS - 1 => store
+        PassOutcome::Unreadable if claim.retry_count < MAX_EVIDENCE_ATTEMPTS => store
             .fail_evidence(
                 claim,
                 EvidenceFailure::Retry {
@@ -220,6 +224,16 @@ pub(crate) fn apply_outcome(
             EVIDENCE_ERROR_UNREADABLE,
         ),
     }
+}
+
+#[cfg(not(test))]
+fn lease_renew_interval() -> Duration {
+    Duration::from_secs(LEASE_RENEW_SECS)
+}
+
+#[cfg(test)]
+fn lease_renew_interval() -> Duration {
+    Duration::from_secs(LEASE_RENEW_SECS).min(Duration::from_millis(10))
 }
 
 pub(crate) async fn process_next(
@@ -258,7 +272,7 @@ pub(crate) async fn process_next(
     let result = loop {
         tokio::select! {
             result = &mut pass => break Some(result),
-            () = tokio::time::sleep(Duration::from_secs(LEASE_RENEW_SECS)) => {
+            () = tokio::time::sleep(lease_renew_interval()) => {
                 let observed = signal.progress();
                 if observed == progress {
                     continue;
@@ -317,7 +331,7 @@ fn unix_now() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
     use std::sync::{Arc, Mutex};
 
     use antiburn_local::analysis::{RawSource, SessionInput};
@@ -384,6 +398,29 @@ mod tests {
             .clone()
             .unwrap_or_else(|| analysis::MISSING_FINGERPRINT.into());
         pass
+    }
+
+    async fn captured_signal(slot: &Mutex<Option<PassSignal>>) -> PassSignal {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if let Some(signal) = slot.lock().unwrap().clone() {
+                    break signal;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the pass receives its signal")
+    }
+
+    async fn wait_until(mut condition: impl FnMut() -> bool) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !condition() {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("the worker reaches the expected state");
     }
 
     #[test]
@@ -462,6 +499,12 @@ mod tests {
             evidence_after.diagnostics_json,
             evidence_before.diagnostics_json
         );
+        assert_eq!(evidence_after.status, EvidenceStatus::Pending);
+        assert_eq!(evidence_after.retry_count, 1);
+        assert_eq!(
+            evidence_after.next_attempt_at_epoch,
+            Some(101 + BACKOFF_BASE_SECS)
+        );
     }
 
     #[tokio::test]
@@ -490,10 +533,9 @@ mod tests {
             100,
         )
         .unwrap();
-        assert_eq!(
-            store.evidence(&claim.key).unwrap().unwrap().status,
-            EvidenceStatus::Failed
-        );
+        let row = store.evidence(&claim.key).unwrap().unwrap();
+        assert_eq!(row.status, EvidenceStatus::Failed);
+        assert_eq!(row.next_attempt_at_epoch, None);
         assert!(
             store
                 .claim_next_evidence(&crate::agents::evidence_cohort(), 101, LEASE_SECS)
@@ -507,18 +549,18 @@ mod tests {
         let store = store();
         let claim = claim(&store, "unsupported", 100);
         apply_outcome(&store, &claim, &failed_pass(PassOutcome::Unsupported), 100).unwrap();
-        assert_eq!(
-            store.evidence(&claim.key).unwrap().unwrap().status,
-            EvidenceStatus::Failed
-        );
+        let row = store.evidence(&claim.key).unwrap().unwrap();
+        assert_eq!(row.status, EvidenceStatus::Failed);
         assert!(store.analysis(&claim.key).unwrap().is_none());
+        assert!(row.evidence_json.is_none());
+        assert!(row.diagnostics_json.is_none());
     }
 
     #[test]
     fn an_unreadable_source_is_terminal_after_the_attempt_cap() {
         let store = store();
         let mut now = 100;
-        for attempt in 0..MAX_EVIDENCE_ATTEMPTS {
+        for attempt in 0..=MAX_EVIDENCE_ATTEMPTS {
             let claim = if attempt == 0 {
                 claim(&store, "unreadable", now)
             } else {
@@ -529,7 +571,7 @@ mod tests {
             };
             apply_outcome(&store, &claim, &failed_pass(PassOutcome::Unreadable), now).unwrap();
             let row = store.evidence(&claim.key).unwrap().unwrap();
-            if attempt + 1 == MAX_EVIDENCE_ATTEMPTS {
+            if attempt == MAX_EVIDENCE_ATTEMPTS {
                 assert_eq!(row.status, EvidenceStatus::Failed);
             } else {
                 assert_eq!(row.status, EvidenceStatus::Pending);
@@ -586,52 +628,284 @@ mod tests {
         );
     }
 
-    #[test]
-    fn progress_renews_the_lease() {
-        let store = store();
-        let claim = claim(&store, "progress", 100);
-        assert!(store.renew_evidence_lease(&claim, 160, LEASE_SECS).unwrap());
+    #[tokio::test]
+    async fn progress_renews_the_lease() {
+        let store = Arc::new(store());
+        store
+            .upsert_sessions(&[record("progress")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let handle = Arc::new(WorkerHandle::default());
+        let clock = Arc::new(AtomicI64::new(100));
+        let signal = Arc::new(Mutex::new(None::<PassSignal>));
+        let release = Arc::new(Notify::new());
+        let task_store = Arc::clone(&store);
+        let task_handle = Arc::clone(&handle);
+        let task_clock = Arc::clone(&clock);
+        let task_signal = Arc::clone(&signal);
+        let task_release = Arc::clone(&release);
+        let task = tokio::spawn(async move {
+            let runner = move |_: &SessionRecord, pass_signal: PassSignal| {
+                *task_signal.lock().unwrap() = Some(pass_signal);
+                let release = Arc::clone(&task_release);
+                Box::pin(async move {
+                    release.notified().await;
+                    failed_pass(PassOutcome::SourceMissing)
+                }) as PassFuture
+            };
+            process_next(
+                &task_store,
+                &task_handle,
+                &|| task_clock.load(Ordering::SeqCst),
+                &runner,
+                &|_| {},
+            )
+            .await
+            .unwrap()
+        });
+        let pass_signal = captured_signal(&signal).await;
+        let key = SessionKey::new("native", "claude-code", "progress");
+
+        assert!(!pass_signal.observe());
+        clock.store(160, Ordering::SeqCst);
+        wait_until(|| {
+            store
+                .evidence(&key)
+                .unwrap()
+                .unwrap()
+                .lease_expires_at_epoch
+                == Some(460)
+        })
+        .await;
+        assert!(!pass_signal.observe());
+        clock.store(220, Ordering::SeqCst);
+        wait_until(|| {
+            store
+                .evidence(&key)
+                .unwrap()
+                .unwrap()
+                .lease_expires_at_epoch
+                == Some(520)
+        })
+        .await;
+
+        release.notify_one();
+        assert!(task.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_stalled_pass_stops_renewing() {
+        let store = Arc::new(store());
+        store
+            .upsert_sessions(&[record("stalled")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let handle = Arc::new(WorkerHandle::default());
+        let clock = Arc::new(AtomicI64::new(100));
+        let entered = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(Notify::new());
+        let task_store = Arc::clone(&store);
+        let task_handle = Arc::clone(&handle);
+        let task_clock = Arc::clone(&clock);
+        let task_entered = Arc::clone(&entered);
+        let task_release = Arc::clone(&release);
+        let task = tokio::spawn(async move {
+            let runner = move |_: &SessionRecord, _: PassSignal| {
+                task_entered.store(true, Ordering::SeqCst);
+                let release = Arc::clone(&task_release);
+                Box::pin(async move {
+                    release.notified().await;
+                    failed_pass(PassOutcome::SourceMissing)
+                }) as PassFuture
+            };
+            process_next(
+                &task_store,
+                &task_handle,
+                &|| task_clock.load(Ordering::SeqCst),
+                &runner,
+                &|_| {},
+            )
+            .await
+            .unwrap()
+        });
+        wait_until(|| entered.load(Ordering::SeqCst)).await;
+        let key = SessionKey::new("native", "claude-code", "stalled");
+        let first = store.evidence(&key).unwrap().unwrap();
+
+        clock.store(160, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(25)).await;
         assert_eq!(
             store
-                .evidence(&claim.key)
+                .evidence(&key)
                 .unwrap()
                 .unwrap()
                 .lease_expires_at_epoch,
-            Some(460)
+            Some(100 + LEASE_SECS)
         );
-    }
-
-    #[test]
-    fn a_stalled_pass_stops_renewing() {
-        let store = store();
-        let first = claim(&store, "stalled", 100);
+        clock.store(401, Ordering::SeqCst);
         let reclaimed = store
             .claim_next_evidence(&crate::agents::evidence_cohort(), 401, LEASE_SECS)
             .unwrap()
             .unwrap();
         assert!(reclaimed.claim_fence > first.claim_fence);
+
+        release.notify_one();
+        assert!(task.await.unwrap());
     }
 
-    #[test]
-    fn a_lost_renewal_cancels_without_a_post_claim_write() {
-        let store = store();
-        let first = claim(&store, "lost", 100);
-        let _next = store
+    #[tokio::test]
+    async fn a_lost_renewal_cancels_without_a_post_claim_write() {
+        let store = Arc::new(store());
+        store
+            .upsert_sessions(&[record("lost")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let handle = Arc::new(WorkerHandle::default());
+        let clock = Arc::new(AtomicI64::new(100));
+        let signal = Arc::new(Mutex::new(None::<PassSignal>));
+        let release = Arc::new(Notify::new());
+        let task_store = Arc::clone(&store);
+        let task_handle = Arc::clone(&handle);
+        let task_clock = Arc::clone(&clock);
+        let task_signal = Arc::clone(&signal);
+        let task_release = Arc::clone(&release);
+        let task = tokio::spawn(async move {
+            let runner = move |_: &SessionRecord, pass_signal: PassSignal| {
+                *task_signal.lock().unwrap() = Some(pass_signal);
+                let release = Arc::clone(&task_release);
+                Box::pin(async move {
+                    release.notified().await;
+                    failed_pass(PassOutcome::SourceMissing)
+                }) as PassFuture
+            };
+            process_next(
+                &task_store,
+                &task_handle,
+                &|| task_clock.load(Ordering::SeqCst),
+                &runner,
+                &|_| {},
+            )
+            .await
+            .unwrap()
+        });
+        let pass_signal = captured_signal(&signal).await;
+        let key = SessionKey::new("native", "claude-code", "lost");
+        let successor = store
             .claim_next_evidence(&crate::agents::evidence_cohort(), 401, LEASE_SECS)
             .unwrap()
             .unwrap();
-        assert!(!store.renew_evidence_lease(&first, 402, LEASE_SECS).unwrap());
-        assert!(store.analysis(&first.key).unwrap().is_none());
+        let before = store.evidence(&key).unwrap().unwrap();
+
+        assert!(!pass_signal.observe());
+        clock.store(402, Ordering::SeqCst);
+        wait_until(|| pass_signal.observe()).await;
+        release.notify_one();
+        assert!(task.await.unwrap());
+
+        assert_eq!(store.evidence(&key).unwrap().unwrap(), before);
+        assert_eq!(successor.claim_fence, before.claim_fence);
+        assert!(store.analysis(&key).unwrap().is_none());
     }
 
-    #[test]
-    fn a_stale_pass_cannot_affect_the_next_claim() {
-        let first = PassSignal::new();
-        let second = PassSignal::new();
-        first.cancel();
-        first.observe();
-        assert!(!second.observe());
-        assert_eq!(second.progress(), 1);
+    #[tokio::test]
+    async fn a_stale_pass_cannot_affect_the_next_claim() {
+        let store = Arc::new(store());
+        store
+            .upsert_sessions(&[record("stale-pass")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let handle = Arc::new(WorkerHandle::default());
+        let clock = Arc::new(AtomicI64::new(100));
+        let first_signal_slot = Arc::new(Mutex::new(None::<PassSignal>));
+        let first_release = Arc::new(Notify::new());
+        let first_store = Arc::clone(&store);
+        let first_handle = Arc::clone(&handle);
+        let first_clock = Arc::clone(&clock);
+        let first_task_signal = Arc::clone(&first_signal_slot);
+        let first_task_release = Arc::clone(&first_release);
+        let first_task = tokio::spawn(async move {
+            let runner = move |_: &SessionRecord, pass_signal: PassSignal| {
+                *first_task_signal.lock().unwrap() = Some(pass_signal);
+                let release = Arc::clone(&first_task_release);
+                Box::pin(async move {
+                    release.notified().await;
+                    failed_pass(PassOutcome::SourceMissing)
+                }) as PassFuture
+            };
+            process_next(
+                &first_store,
+                &first_handle,
+                &|| first_clock.load(Ordering::SeqCst),
+                &runner,
+                &|_| {},
+            )
+            .await
+            .unwrap()
+        });
+        let first_signal = captured_signal(&first_signal_slot).await;
+        let mut changed = record("stale-pass");
+        changed.source_fingerprint = Some("sv1:stale-pass-next".into());
+        assert!(!first_signal.observe());
+        store
+            .upsert_sessions(&[changed], &crate::agents::evidence_cohort())
+            .unwrap();
+        clock.store(160, Ordering::SeqCst);
+        wait_until(|| first_signal.observe()).await;
+        first_release.notify_one();
+        assert!(first_task.await.unwrap());
+
+        let second_signal_slot = Arc::new(Mutex::new(None::<PassSignal>));
+        let second_release = Arc::new(Notify::new());
+        let second_store = Arc::clone(&store);
+        let second_handle = Arc::clone(&handle);
+        let second_clock = Arc::clone(&clock);
+        let second_task_signal = Arc::clone(&second_signal_slot);
+        let second_task_release = Arc::clone(&second_release);
+        let second_task = tokio::spawn(async move {
+            let runner = move |record: &SessionRecord, pass_signal: PassSignal| {
+                *second_task_signal.lock().unwrap() = Some(pass_signal);
+                let pass = published_pass(record);
+                let release = Arc::clone(&second_task_release);
+                Box::pin(async move {
+                    release.notified().await;
+                    pass
+                }) as PassFuture
+            };
+            process_next(
+                &second_store,
+                &second_handle,
+                &|| second_clock.load(Ordering::SeqCst),
+                &runner,
+                &|_| {},
+            )
+            .await
+            .unwrap()
+        });
+        let second_signal = captured_signal(&second_signal_slot).await;
+        let key = SessionKey::new("native", "claude-code", "stale-pass");
+        let successor_lease = store
+            .evidence(&key)
+            .unwrap()
+            .unwrap()
+            .lease_expires_at_epoch;
+
+        first_signal.cancel();
+        assert!(first_signal.observe());
+        clock.store(220, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(
+            store
+                .evidence(&key)
+                .unwrap()
+                .unwrap()
+                .lease_expires_at_epoch,
+            successor_lease
+        );
+        assert!(!second_signal.observe());
+
+        second_release.notify_one();
+        assert!(second_task.await.unwrap());
+        assert_eq!(
+            store.evidence(&key).unwrap().unwrap().status,
+            EvidenceStatus::Ready
+        );
+        assert!(store.analysis(&key).unwrap().is_some());
     }
 
     #[tokio::test]
@@ -755,13 +1029,35 @@ mod tests {
 
     #[test]
     fn errors_carry_no_transcript_content() {
-        for error in [
+        const SOURCE_CONTENT: &str = "PRIVATE_TRANSCRIPT_MARKER";
+        let mappings = [
+            (PassOutcome::SourceChanged, EVIDENCE_ERROR_SOURCE_CHANGED),
+            (PassOutcome::SourceMissing, EVIDENCE_ERROR_SOURCE_MISSING),
+            (PassOutcome::Unreadable, EVIDENCE_ERROR_UNREADABLE),
+            (PassOutcome::Unsupported, EVIDENCE_ERROR_UNSUPPORTED),
+        ];
+        let allowed = [
             EVIDENCE_ERROR_SOURCE_CHANGED,
             EVIDENCE_ERROR_SOURCE_MISSING,
             EVIDENCE_ERROR_UNREADABLE,
             EVIDENCE_ERROR_UNSUPPORTED,
-        ] {
-            assert!(!error.contains("PRIVATE_TRANSCRIPT_MARKER"));
+        ];
+
+        for (index, (outcome, expected)) in mappings.into_iter().enumerate() {
+            let store = store();
+            let id = format!("{SOURCE_CONTENT}-{index}");
+            let claim = claim(&store, &id, 100);
+            assert!(apply_outcome(&store, &claim, &failed_pass(outcome), 100).unwrap());
+
+            let error = store
+                .evidence(&claim.key)
+                .unwrap()
+                .unwrap()
+                .last_error
+                .unwrap();
+            assert_eq!(error, expected);
+            assert!(allowed.contains(&error.as_str()));
+            assert!(!error.contains(SOURCE_CONTENT));
         }
     }
 

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -1,0 +1,799 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Drains the durable transcript evidence queue outside the scan pass.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use antiburn_local::discovery::SessionSource;
+use antiburn_local::model::AgentKind;
+use tauri::{Emitter, Manager};
+use tokio::sync::{Notify, Semaphore};
+
+use crate::analysis::{self, EvidencePass, PassOutcome, PassSignal};
+use crate::commands;
+use crate::dto::ActivityEntry;
+use crate::store::{
+    EvidenceClaim, EvidenceCompletion, EvidenceFailure, PublishedEvidence, RelationKind,
+    RelationRecord, SessionKey, SessionRecord, Store,
+};
+
+pub(crate) const LEASE_SECS: i64 = 300;
+pub(crate) const LEASE_RENEW_SECS: u64 = 60;
+pub(crate) const IDLE_POLL_SECS: u64 = 60;
+pub(crate) const BACKOFF_BASE_SECS: i64 = 30;
+pub(crate) const BACKOFF_MAX_SECS: i64 = 900;
+pub(crate) const MAX_EVIDENCE_ATTEMPTS: i64 = 5;
+pub(crate) const EVIDENCE_ERROR_SOURCE_CHANGED: &str = "source-changed";
+pub(crate) const EVIDENCE_ERROR_SOURCE_MISSING: &str = "source-missing";
+pub(crate) const EVIDENCE_ERROR_UNREADABLE: &str = "source-unreadable";
+pub(crate) const EVIDENCE_ERROR_UNSUPPORTED: &str = "source-unsupported";
+
+struct Permits {
+    cpu: Semaphore,
+    source: Semaphore,
+    provider_db: Semaphore,
+}
+
+impl Default for Permits {
+    fn default() -> Self {
+        Self {
+            cpu: Semaphore::new(1),
+            source: Semaphore::new(1),
+            provider_db: Semaphore::new(1),
+        }
+    }
+}
+
+/// This handle wakes the worker and limits its shared processing resources.
+#[derive(Default)]
+pub struct WorkerHandle {
+    wake: Notify,
+    permits: Permits,
+}
+
+pub(crate) type PassFuture = Pin<Box<dyn Future<Output = EvidencePass> + Send>>;
+pub(crate) type PassRunner<'a> =
+    dyn Fn(&SessionRecord, PassSignal) -> PassFuture + Send + Sync + 'a;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PermitKind {
+    Source,
+    ProviderDb,
+}
+
+pub fn spawn(app: &tauri::AppHandle) -> tauri::async_runtime::JoinHandle<()> {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let run_pass = |record: &SessionRecord, signal: PassSignal| {
+            let agent =
+                crate::agents::kind_from_slug(&record.key.agent).unwrap_or(AgentKind::Claude);
+            let session_id = record.key.session_id.clone();
+            let wsl_distro = record.wsl_distro.clone();
+            let claimed = analysis::ClaimedSource {
+                fingerprint: record.source_fingerprint.clone(),
+                generation: 0,
+            };
+            Box::pin(async move {
+                analysis::analyze_for_evidence(
+                    agent,
+                    &session_id,
+                    wsl_distro.as_deref(),
+                    claimed,
+                    signal,
+                )
+                .await
+            }) as PassFuture
+        };
+        let announce_app = app.clone();
+        let announce = move |entry: ActivityEntry| {
+            let _ = announce_app.emit(commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
+        };
+        let clock = || unix_now();
+        let store = app.state::<Store>();
+        let handle = app.state::<WorkerHandle>();
+        worker_loop(&store, &handle, &clock, &run_pass, &announce).await;
+    })
+}
+
+pub(crate) fn backoff_secs(retry_count: i64) -> i64 {
+    let exponent = u32::try_from(retry_count.max(0))
+        .unwrap_or(u32::MAX)
+        .min(30);
+    BACKOFF_BASE_SECS
+        .saturating_mul(1_i64.checked_shl(exponent).unwrap_or(i64::MAX))
+        .min(BACKOFF_MAX_SECS)
+}
+
+pub(crate) fn permit_for(source: &SessionSource) -> PermitKind {
+    match source {
+        SessionSource::ProviderDb { .. } => PermitKind::ProviderDb,
+        SessionSource::File(_) | SessionSource::Inline { .. } => PermitKind::Source,
+    }
+}
+
+fn source_for_record(record: &SessionRecord) -> SessionSource {
+    match record.source_kind.as_str() {
+        "providerDb" => SessionSource::ProviderDb {
+            agent: crate::agents::kind_from_slug(&record.key.agent).unwrap_or(AgentKind::Claude),
+            db_path: PathBuf::from(&record.source_label),
+            session_id: record.key.session_id.clone(),
+        },
+        "inline" => SessionSource::Inline {
+            label: record.source_label.clone(),
+            content: String::new(),
+        },
+        _ => SessionSource::File(PathBuf::from(&record.source_label)),
+    }
+}
+
+pub(crate) fn completion_entry(store: &Store, key: &SessionKey, now: i64) -> Option<ActivityEntry> {
+    let session = store.session(key).ok()??;
+    let repositories = store.repositories().ok()?;
+    commands::activity_entry(store, &repositories, session, now).ok()
+}
+
+pub(crate) fn apply_outcome(
+    store: &Store,
+    claim: &EvidenceClaim,
+    pass: &EvidencePass,
+    now: i64,
+) -> anyhow::Result<bool> {
+    match pass.outcome {
+        PassOutcome::Published => {
+            let record = pass
+                .analysis
+                .record(&claim.key)
+                .ok_or_else(|| anyhow::anyhow!("published pass has no metrics projection"))?;
+            let evidence = pass
+                .evidence
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("published pass has no evidence projection"))?;
+            let relations = pass
+                .analysis
+                .orchestration
+                .as_ref()
+                .map(|orchestration| {
+                    orchestration
+                        .members
+                        .iter()
+                        .map(|member| RelationRecord {
+                            kind: RelationKind::Subagent,
+                            related_id: member.subagent_id.clone(),
+                            label: Some(member.label.clone()),
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let completion = EvidenceCompletion {
+                claim_fence: claim.claim_fence,
+                status: PublishedEvidence::Ready,
+                evidence_schema_revision: evidence.schema_revision,
+                evidence_json: serde_json::to_string(evidence)?,
+                diagnostics_json: Some(serde_json::to_string(&evidence.diagnostics)?),
+            };
+            store.publish_projections(
+                &record,
+                pass.analysis.started_at_epoch,
+                &completion,
+                &relations,
+            )
+        }
+        PassOutcome::SourceChanged => store.fail_evidence(
+            claim,
+            EvidenceFailure::Retry {
+                next_attempt_at_epoch: now + backoff_secs(claim.retry_count),
+            },
+            EVIDENCE_ERROR_SOURCE_CHANGED,
+        ),
+        PassOutcome::SourceMissing => store.fail_evidence(
+            claim,
+            EvidenceFailure::Failed {
+                revisions: analysis::projection_revisions(),
+            },
+            EVIDENCE_ERROR_SOURCE_MISSING,
+        ),
+        PassOutcome::Unsupported => store.fail_evidence(
+            claim,
+            EvidenceFailure::Failed {
+                revisions: analysis::projection_revisions(),
+            },
+            EVIDENCE_ERROR_UNSUPPORTED,
+        ),
+        PassOutcome::Unreadable if claim.retry_count < MAX_EVIDENCE_ATTEMPTS - 1 => store
+            .fail_evidence(
+                claim,
+                EvidenceFailure::Retry {
+                    next_attempt_at_epoch: now + backoff_secs(claim.retry_count),
+                },
+                EVIDENCE_ERROR_UNREADABLE,
+            ),
+        PassOutcome::Unreadable => store.fail_evidence(
+            claim,
+            EvidenceFailure::Failed {
+                revisions: analysis::projection_revisions(),
+            },
+            EVIDENCE_ERROR_UNREADABLE,
+        ),
+    }
+}
+
+pub(crate) async fn process_next(
+    store: &Store,
+    handle: &WorkerHandle,
+    clock: &(dyn Fn() -> i64 + Send + Sync),
+    run_pass: &PassRunner<'_>,
+    announce: &(dyn Fn(ActivityEntry) + Send + Sync),
+) -> anyhow::Result<bool> {
+    let Some(claim) =
+        store.claim_next_evidence(&crate::agents::evidence_cohort(), clock(), LEASE_SECS)?
+    else {
+        return Ok(false);
+    };
+    let Some(record) = store.session(&claim.key)? else {
+        return Ok(true);
+    };
+    let source = source_for_record(&record);
+    let _cpu = handle
+        .permits
+        .cpu
+        .acquire()
+        .await
+        .map_err(|_| anyhow::anyhow!("CPU permit closed"))?;
+    let permit = match permit_for(&source) {
+        PermitKind::Source => &handle.permits.source,
+        PermitKind::ProviderDb => &handle.permits.provider_db,
+    };
+    let _source = permit
+        .acquire()
+        .await
+        .map_err(|_| anyhow::anyhow!("source permit closed"))?;
+    let signal = PassSignal::new();
+    let mut pass = run_pass(&record, signal.clone());
+    let mut progress = signal.progress();
+    let result = loop {
+        tokio::select! {
+            result = &mut pass => break Some(result),
+            () = tokio::time::sleep(Duration::from_secs(LEASE_RENEW_SECS)) => {
+                let observed = signal.progress();
+                if observed == progress {
+                    continue;
+                }
+                progress = observed;
+                if !store.renew_evidence_lease(&claim, clock(), LEASE_SECS)? {
+                    signal.cancel();
+                    let _ = pass.await;
+                    break None;
+                }
+            }
+        }
+    };
+    let Some(mut pass) = result else {
+        return Ok(true);
+    };
+    pass.analysis.analyzed_generation = claim.source_generation;
+    let published =
+        pass.outcome == PassOutcome::Published && apply_outcome(store, &claim, &pass, clock())?;
+    if published && let Some(entry) = completion_entry(store, &claim.key, clock()) {
+        announce(entry);
+    }
+    Ok(true)
+}
+
+pub(crate) async fn worker_loop(
+    store: &Store,
+    handle: &WorkerHandle,
+    clock: &(dyn Fn() -> i64 + Send + Sync),
+    run_pass: &PassRunner<'_>,
+    announce: &(dyn Fn(ActivityEntry) + Send + Sync),
+) {
+    loop {
+        match process_next(store, handle, clock, run_pass, announce).await {
+            Ok(true) => continue,
+            Ok(false) => {
+                tokio::select! {
+                    () = handle.wake.notified() => {}
+                    () = tokio::time::sleep(Duration::from_secs(IDLE_POLL_SECS)) => {}
+                }
+            }
+            Err(error) => {
+                ::tracing::error!(event = "insights_worker_failed", error = %error);
+                tokio::time::sleep(Duration::from_secs(IDLE_POLL_SECS)).await;
+            }
+        }
+    }
+}
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use antiburn_local::analysis::{RawSource, SessionInput};
+
+    use super::*;
+    use crate::store::EvidenceStatus;
+
+    fn store() -> Store {
+        Store::open_in_memory(std::path::Path::new("/tmp/antiburn-worker-test")).unwrap()
+    }
+
+    fn record(id: &str) -> SessionRecord {
+        SessionRecord {
+            key: SessionKey::new("native", "claude-code", id),
+            source_kind: "file".into(),
+            source_label: format!("/tmp/{id}.jsonl"),
+            wsl_distro: None,
+            title: None,
+            title_source: None,
+            cwd: None,
+            surface: "cli".into(),
+            updated_at_epoch: Some(100),
+            activity_cursor: String::new(),
+            activity_source: "event".into(),
+            subagent_count: 0,
+            fork_parent_session_id: None,
+            source_fingerprint: Some(format!("sv1:{id}")),
+        }
+    }
+
+    fn claim(store: &Store, id: &str, now: i64) -> EvidenceClaim {
+        store
+            .upsert_sessions(&[record(id)], &crate::agents::evidence_cohort())
+            .unwrap();
+        store
+            .claim_next_evidence(&crate::agents::evidence_cohort(), now, LEASE_SECS)
+            .unwrap()
+            .unwrap()
+    }
+
+    fn failed_pass(outcome: PassOutcome) -> EvidencePass {
+        EvidencePass {
+            analysis: analysis::SessionAnalysis::unavailable(),
+            evidence: None,
+            outcome,
+        }
+    }
+
+    fn published_pass(record: &SessionRecord) -> EvidencePass {
+        let mut pass = analysis::evidence_pass(
+            &[SessionInput {
+                agent: "claude".into(),
+                session_id: record.key.session_id.clone(),
+                source: RawSource::Jsonl(
+                    r#"{"type":"assistant","timestamp":100,"message":{"id":"m","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":2,"output_tokens":3},"content":[]}}
+"#
+                    .into(),
+                ),
+            }],
+            &|| false,
+        );
+        pass.analysis.fingerprint = record
+            .source_fingerprint
+            .clone()
+            .unwrap_or_else(|| analysis::MISSING_FINGERPRINT.into());
+        pass
+    }
+
+    #[test]
+    fn backoff_grows_and_saturates() {
+        let values: Vec<_> = (0..12).map(backoff_secs).collect();
+        assert_eq!(values[0], BACKOFF_BASE_SECS);
+        assert!(values.windows(2).all(|pair| pair[0] <= pair[1]));
+        assert_eq!(*values.last().unwrap(), BACKOFF_MAX_SECS);
+    }
+
+    #[test]
+    fn a_repeatedly_changing_transcript_backs_off_without_spinning() {
+        let store = store();
+        let mut now = 100;
+        for attempt in 0..3 {
+            let claim = if attempt == 0 {
+                claim(&store, "changing", now)
+            } else {
+                store
+                    .claim_next_evidence(&crate::agents::evidence_cohort(), now, LEASE_SECS)
+                    .unwrap()
+                    .unwrap()
+            };
+            assert!(
+                apply_outcome(
+                    &store,
+                    &claim,
+                    &failed_pass(PassOutcome::SourceChanged),
+                    now
+                )
+                .unwrap()
+            );
+            let row = store.evidence(&claim.key).unwrap().unwrap();
+            assert_eq!(row.status, EvidenceStatus::Pending);
+            assert!(row.next_attempt_at_epoch.unwrap() > now);
+            now = row.next_attempt_at_epoch.unwrap();
+        }
+    }
+
+    #[test]
+    fn source_changed_leaves_both_stored_projections_untouched() {
+        let store = store();
+        let first = claim(&store, "unchanged-projections", 100);
+        let source = store.session(&first.key).unwrap().unwrap();
+        let mut published = published_pass(&source);
+        published.analysis.analyzed_generation = first.source_generation;
+        assert!(apply_outcome(&store, &first, &published, 100).unwrap());
+        let analysis_before = store.analysis(&first.key).unwrap().unwrap();
+        let evidence_before = store.evidence(&first.key).unwrap().unwrap();
+        let mut changed = source;
+        changed.source_fingerprint = Some("sv1:changed".into());
+        store
+            .upsert_sessions(&[changed], &crate::agents::evidence_cohort())
+            .unwrap();
+        let second = store
+            .claim_next_evidence(&crate::agents::evidence_cohort(), 101, LEASE_SECS)
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            apply_outcome(
+                &store,
+                &second,
+                &failed_pass(PassOutcome::SourceChanged),
+                101,
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            store.analysis(&first.key).unwrap().unwrap(),
+            analysis_before
+        );
+        let evidence_after = store.evidence(&first.key).unwrap().unwrap();
+        assert_eq!(evidence_after.evidence_json, evidence_before.evidence_json);
+        assert_eq!(
+            evidence_after.diagnostics_json,
+            evidence_before.diagnostics_json
+        );
+    }
+
+    #[tokio::test]
+    async fn a_hot_source_does_not_starve_a_stable_session() {
+        let store = store();
+        let hot = claim(&store, "hot", 100);
+        apply_outcome(&store, &hot, &failed_pass(PassOutcome::SourceChanged), 100).unwrap();
+        store
+            .upsert_sessions(&[record("stable")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let next = store
+            .claim_next_evidence(&crate::agents::evidence_cohort(), 101, LEASE_SECS)
+            .unwrap()
+            .unwrap();
+        assert_eq!(next.key.session_id, "stable");
+    }
+
+    #[test]
+    fn an_un_stat_able_source_stops_being_claimed() {
+        let store = store();
+        let claim = claim(&store, "missing", 100);
+        apply_outcome(
+            &store,
+            &claim,
+            &failed_pass(PassOutcome::SourceMissing),
+            100,
+        )
+        .unwrap();
+        assert_eq!(
+            store.evidence(&claim.key).unwrap().unwrap().status,
+            EvidenceStatus::Failed
+        );
+        assert!(
+            store
+                .claim_next_evidence(&crate::agents::evidence_cohort(), 101, LEASE_SECS)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn an_unsupported_pass_is_terminal_at_once() {
+        let store = store();
+        let claim = claim(&store, "unsupported", 100);
+        apply_outcome(&store, &claim, &failed_pass(PassOutcome::Unsupported), 100).unwrap();
+        assert_eq!(
+            store.evidence(&claim.key).unwrap().unwrap().status,
+            EvidenceStatus::Failed
+        );
+        assert!(store.analysis(&claim.key).unwrap().is_none());
+    }
+
+    #[test]
+    fn an_unreadable_source_is_terminal_after_the_attempt_cap() {
+        let store = store();
+        let mut now = 100;
+        for attempt in 0..MAX_EVIDENCE_ATTEMPTS {
+            let claim = if attempt == 0 {
+                claim(&store, "unreadable", now)
+            } else {
+                store
+                    .claim_next_evidence(&crate::agents::evidence_cohort(), now, LEASE_SECS)
+                    .unwrap()
+                    .unwrap()
+            };
+            apply_outcome(&store, &claim, &failed_pass(PassOutcome::Unreadable), now).unwrap();
+            let row = store.evidence(&claim.key).unwrap().unwrap();
+            if attempt + 1 == MAX_EVIDENCE_ATTEMPTS {
+                assert_eq!(row.status, EvidenceStatus::Failed);
+            } else {
+                assert_eq!(row.status, EvidenceStatus::Pending);
+                now = row.next_attempt_at_epoch.unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn a_newer_pending_generation_preserves_the_last_payload() {
+        let store = store();
+        let claim = claim(&store, "payload", 100);
+        let source = store.session(&claim.key).unwrap().unwrap();
+        let mut published = published_pass(&source);
+        published.analysis.analyzed_generation = claim.source_generation;
+        assert!(apply_outcome(&store, &claim, &published, 100).unwrap());
+        let payload = store.evidence(&claim.key).unwrap().unwrap().evidence_json;
+        let mut next = record("payload");
+        next.source_fingerprint = Some("sv1:payload-next".into());
+        store
+            .upsert_sessions(&[next], &crate::agents::evidence_cohort())
+            .unwrap();
+        assert_eq!(
+            store.evidence(&claim.key).unwrap().unwrap().evidence_json,
+            payload
+        );
+    }
+
+    #[test]
+    fn a_restart_loses_no_pending_work() {
+        let store = store();
+        let first = claim(&store, "restart", 100);
+        let reclaimed = store
+            .claim_next_evidence(&crate::agents::evidence_cohort(), 401, LEASE_SECS)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reclaimed.key, first.key);
+        assert!(reclaimed.claim_fence > first.claim_fence);
+    }
+
+    #[test]
+    fn an_active_session_is_claimable_at_once() {
+        let store = store();
+        let mut active = record("active");
+        active.updated_at_epoch = Some(100);
+        store
+            .upsert_sessions(&[active], &crate::agents::evidence_cohort())
+            .unwrap();
+        assert!(
+            store
+                .claim_next_evidence(&crate::agents::evidence_cohort(), 100, LEASE_SECS)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn progress_renews_the_lease() {
+        let store = store();
+        let claim = claim(&store, "progress", 100);
+        assert!(store.renew_evidence_lease(&claim, 160, LEASE_SECS).unwrap());
+        assert_eq!(
+            store
+                .evidence(&claim.key)
+                .unwrap()
+                .unwrap()
+                .lease_expires_at_epoch,
+            Some(460)
+        );
+    }
+
+    #[test]
+    fn a_stalled_pass_stops_renewing() {
+        let store = store();
+        let first = claim(&store, "stalled", 100);
+        let reclaimed = store
+            .claim_next_evidence(&crate::agents::evidence_cohort(), 401, LEASE_SECS)
+            .unwrap()
+            .unwrap();
+        assert!(reclaimed.claim_fence > first.claim_fence);
+    }
+
+    #[test]
+    fn a_lost_renewal_cancels_without_a_post_claim_write() {
+        let store = store();
+        let first = claim(&store, "lost", 100);
+        let _next = store
+            .claim_next_evidence(&crate::agents::evidence_cohort(), 401, LEASE_SECS)
+            .unwrap()
+            .unwrap();
+        assert!(!store.renew_evidence_lease(&first, 402, LEASE_SECS).unwrap());
+        assert!(store.analysis(&first.key).unwrap().is_none());
+    }
+
+    #[test]
+    fn a_stale_pass_cannot_affect_the_next_claim() {
+        let first = PassSignal::new();
+        let second = PassSignal::new();
+        first.cancel();
+        first.observe();
+        assert!(!second.observe());
+        assert_eq!(second.progress(), 1);
+    }
+
+    #[tokio::test]
+    async fn permits_are_held_before_the_pass_is_scheduled() {
+        let store = store();
+        store
+            .upsert_sessions(&[record("permit")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let handle = WorkerHandle::default();
+        let permit = handle.permits.cpu.acquire().await.unwrap();
+        let entered = Arc::new(AtomicBool::new(false));
+        let entered_by_pass = entered.clone();
+        let runner = move |_: &SessionRecord, _: PassSignal| {
+            entered_by_pass.store(true, Ordering::SeqCst);
+            Box::pin(async { failed_pass(PassOutcome::SourceMissing) }) as PassFuture
+        };
+        let future = process_next(&store, &handle, &|| 100, &runner, &|_| {});
+        tokio::pin!(future);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), &mut future)
+                .await
+                .is_err()
+        );
+        assert!(!entered.load(Ordering::SeqCst));
+        drop(permit);
+    }
+
+    #[tokio::test]
+    async fn the_store_is_lockable_while_a_pass_runs() {
+        let store = store();
+        store
+            .upsert_sessions(&[record("lockable")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let pending = Arc::new(Notify::new());
+        let pending_pass = pending.clone();
+        let runner = move |_: &SessionRecord, _: PassSignal| {
+            let pending = pending_pass.clone();
+            Box::pin(async move {
+                pending.notified().await;
+                failed_pass(PassOutcome::SourceMissing)
+            }) as PassFuture
+        };
+        let handle = WorkerHandle::default();
+        let future = process_next(&store, &handle, &|| 100, &runner, &|_| {});
+        tokio::pin!(future);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), &mut future)
+                .await
+                .is_err()
+        );
+        assert!(
+            store
+                .session(&SessionKey::new("native", "claude-code", "lockable"))
+                .unwrap()
+                .is_some()
+        );
+        pending.notify_one();
+        assert!(future.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_published_completion_announces_one_list_entry() {
+        let store = store();
+        store
+            .upsert_sessions(&[record("announcement")], &crate::agents::evidence_cohort())
+            .unwrap();
+        let runner = |record: &SessionRecord, _: PassSignal| {
+            let pass = published_pass(record);
+            Box::pin(async move { pass }) as PassFuture
+        };
+        let announced = Mutex::new(Vec::new());
+
+        assert!(
+            process_next(
+                &store,
+                &WorkerHandle::default(),
+                &|| 100,
+                &runner,
+                &|entry| {
+                    announced.lock().unwrap().push(entry);
+                }
+            )
+            .await
+            .unwrap()
+        );
+        let entries = announced.lock().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id, "announcement");
+        // The synthetic pass has no priceable model breakdown, so this test checks the event contract only.
+    }
+
+    #[tokio::test]
+    async fn a_backed_off_outcome_announces_nothing() {
+        let store = store();
+        store
+            .upsert_sessions(
+                &[record("no-announcement")],
+                &crate::agents::evidence_cohort(),
+            )
+            .unwrap();
+        let runner = |_: &SessionRecord, _: PassSignal| {
+            Box::pin(async { failed_pass(PassOutcome::SourceChanged) }) as PassFuture
+        };
+        let announced = Mutex::new(Vec::new());
+
+        assert!(
+            process_next(
+                &store,
+                &WorkerHandle::default(),
+                &|| 100,
+                &runner,
+                &|entry| {
+                    announced.lock().unwrap().push(entry);
+                }
+            )
+            .await
+            .unwrap()
+        );
+        assert!(announced.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn errors_carry_no_transcript_content() {
+        for error in [
+            EVIDENCE_ERROR_SOURCE_CHANGED,
+            EVIDENCE_ERROR_SOURCE_MISSING,
+            EVIDENCE_ERROR_UNREADABLE,
+            EVIDENCE_ERROR_UNSUPPORTED,
+        ] {
+            assert!(!error.contains("PRIVATE_TRANSCRIPT_MARKER"));
+        }
+    }
+
+    #[test]
+    fn a_permit_is_chosen_per_source_kind() {
+        assert_eq!(
+            permit_for(&SessionSource::File("a".into())),
+            PermitKind::Source
+        );
+        assert_eq!(
+            permit_for(&SessionSource::Inline {
+                label: "a".into(),
+                content: String::new()
+            }),
+            PermitKind::Source
+        );
+        assert_eq!(
+            permit_for(&SessionSource::ProviderDb {
+                agent: AgentKind::Claude,
+                db_path: "a".into(),
+                session_id: "s".into()
+            }),
+            PermitKind::ProviderDb
+        );
+    }
+
+    #[tokio::test]
+    async fn a_wake_releases_the_idle_wait() {
+        let handle = WorkerHandle::default();
+        handle.wake.notify_one();
+        tokio::time::timeout(Duration::from_millis(10), handle.wake.notified())
+            .await
+            .unwrap();
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -73,8 +73,8 @@ mod settings;
 mod startup_registration;
 mod storage_health;
 mod store;
-// The queue has no in-tree caller until CH-008 adds the worker.
-// TODO @agent: CH-008 will remove this re-export.
+// This bridge keeps CH-007 evidence readers reachable until the evidence pane calls them.
+// TODO @agent: CH-012 will remove this re-export.
 pub use store::Store;
 mod tray;
 mod tray_title;
@@ -331,7 +331,7 @@ pub fn run() {
         // A deliberate quit: stop the background tasks before the store
         // they write to is dropped.
         RunEvent::Exit => {
-            abort_schedulers(app);
+            abort_schedulers(app.try_state::<Schedulers>().as_deref());
             finish_retention_cleanup(&mut retention_cleanup);
             if let Some(mut guard) = trace_guard.take() {
                 guard.flush();
@@ -378,11 +378,11 @@ fn should_prevent_exit(onboarding_pending: bool, code: Option<i32>) -> bool {
 }
 
 /// Stop every background task. Safe to call when none ever started.
-fn abort_schedulers(app: &tauri::AppHandle) {
-    let Some(schedulers) = app.try_state::<Schedulers>() else {
+fn abort_schedulers(schedulers: Option<&Schedulers>) {
+    let Some(schedulers) = schedulers else {
         return;
     };
-    stop_schedulers(&schedulers);
+    stop_schedulers(schedulers);
 }
 
 pub(crate) fn stop_schedulers(schedulers: &Schedulers) {
@@ -519,8 +519,8 @@ fn install_updater(app: &tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::{
-        ClosePolicy, Schedulers, close_policy, finish_retention_cleanup, should_prevent_exit,
-        stop_schedulers,
+        ClosePolicy, Schedulers, abort_schedulers, close_policy, finish_retention_cleanup,
+        should_prevent_exit,
     };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -559,6 +559,10 @@ mod tests {
 
     #[tokio::test]
     async fn a_scheduler_stop_leaves_the_claim_reclaimable() {
+        use std::sync::Mutex;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
         use crate::analysis::{EvidencePass, PassOutcome, PassSignal, SessionAnalysis};
         use crate::insights_worker::{PassFuture, WorkerHandle, worker_loop};
         use crate::store::{EvidenceStatus, SessionKey, SessionRecord, Store};
@@ -589,12 +593,23 @@ mod tests {
             )
             .unwrap();
         let handle = Arc::new(WorkerHandle::default());
-        let blocker = Arc::new(tokio::sync::Notify::new());
-        let pass_blocker = Arc::clone(&blocker);
+        let (release, blocked) = mpsc::channel();
+        let blocked = Arc::new(Mutex::new(blocked));
+        let (entered, pass_entered) = mpsc::channel();
+        let (completed, pass_completed) = mpsc::channel();
+        let pass_blocked = Arc::clone(&blocked);
         let runner = move |_: &SessionRecord, _: PassSignal| {
-            let blocker = Arc::clone(&pass_blocker);
+            let blocked = Arc::clone(&pass_blocked);
+            let entered = entered.clone();
+            let completed = completed.clone();
             Box::pin(async move {
-                blocker.notified().await;
+                tauri::async_runtime::spawn_blocking(move || {
+                    entered.send(()).unwrap();
+                    blocked.lock().unwrap().recv().unwrap();
+                    completed.send(()).unwrap();
+                })
+                .await
+                .unwrap();
                 EvidencePass {
                     analysis: SessionAnalysis::unavailable(),
                     evidence: None,
@@ -602,32 +617,36 @@ mod tests {
                 }
             }) as PassFuture
         };
+        let announced = Arc::new(Mutex::new(Vec::new()));
+        let task_announced = Arc::clone(&announced);
         let task_store = Arc::clone(&store);
         let task_handle = Arc::clone(&handle);
         let task = tauri::async_runtime::spawn(async move {
-            worker_loop(&task_store, &task_handle, &|| 100, &runner, &|_| {}).await;
+            worker_loop(&task_store, &task_handle, &|| 100, &runner, &|entry| {
+                task_announced.lock().unwrap().push(entry)
+            })
+            .await;
         });
-        for _ in 0..20 {
-            if store
-                .evidence(&key)
-                .unwrap()
-                .is_some_and(|row| row.status == EvidenceStatus::Processing)
-            {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
+        pass_entered
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the blocking pass starts");
+        let processing = store.evidence(&key).unwrap().unwrap();
+        assert_eq!(processing.status, EvidenceStatus::Processing);
+        let analysis_before = store.analysis(&key).unwrap();
         let schedulers = Schedulers::default();
         schedulers.push(task);
 
-        stop_schedulers(&schedulers);
-        assert_eq!(
-            store.evidence(&key).unwrap().unwrap().status,
-            EvidenceStatus::Processing
-        );
-        blocker.notify_waiters();
+        abort_schedulers(Some(&schedulers));
+        assert_eq!(store.evidence(&key).unwrap().unwrap(), processing);
+        release.send(()).unwrap();
+        pass_completed
+            .recv_timeout(Duration::from_secs(1))
+            .expect("the blocking job survives the worker abort");
         tokio::task::yield_now().await;
-        assert!(store.analysis(&key).unwrap().is_none());
+        assert_eq!(store.analysis(&key).unwrap(), analysis_before);
+        assert_eq!(store.evidence(&key).unwrap().unwrap(), processing);
+        assert!(announced.lock().unwrap().is_empty());
+
         store
             .reconcile_evidence_revisions(
                 &crate::agents::evidence_cohort(),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -61,6 +61,7 @@ mod dto;
 mod export;
 mod global_click;
 mod hud;
+mod insights_worker;
 mod notifications;
 mod nudges;
 mod onboarding;
@@ -91,7 +92,7 @@ use tauri::{Manager, RunEvent, WindowEvent};
 /// Handles of the app's background tasks, kept so it can abort them on exit
 /// rather than leaving them running against a store that is going away.
 #[derive(Default)]
-struct Schedulers(Mutex<Vec<tauri::async_runtime::JoinHandle<()>>>);
+pub(crate) struct Schedulers(Mutex<Vec<tauri::async_runtime::JoinHandle<()>>>);
 
 impl Schedulers {
     fn push(&self, handle: tauri::async_runtime::JoinHandle<()>) {
@@ -209,6 +210,13 @@ pub fn run() {
             // engine's state helpers as an explicit argument.
             let data_dir = app.path().app_data_dir()?;
             app.manage(store::Store::open(&data_dir)?);
+            app.manage(insights_worker::WorkerHandle::default());
+            if let Err(error) = app.state::<store::Store>().reconcile_evidence_revisions(
+                &agents::evidence_cohort(),
+                analysis::projection_revisions(),
+            ) {
+                ::tracing::error!(event = "evidence_reconcile_failed", error = %error);
+            }
 
             // Apply the persisted theme before any window shows, so the first
             // paint is already in the reader's chosen appearance. "system" and
@@ -294,6 +302,7 @@ pub fn run() {
             app.manage(live_usage);
             if let Some(schedulers) = app.try_state::<Schedulers>() {
                 schedulers.push(scan::spawn_scheduler(app.handle()));
+                schedulers.push(insights_worker::spawn(app.handle()));
                 schedulers.push(updates::spawn_scheduler(app.handle()));
                 schedulers.push(usage_alerts::spawn_scheduler(app.handle()));
                 schedulers.push(disk_monitor::spawn_disk_monitor(app.handle().clone()));
@@ -373,6 +382,10 @@ fn abort_schedulers(app: &tauri::AppHandle) {
     let Some(schedulers) = app.try_state::<Schedulers>() else {
         return;
     };
+    stop_schedulers(&schedulers);
+}
+
+pub(crate) fn stop_schedulers(schedulers: &Schedulers) {
     let Ok(mut handles) = schedulers.0.lock() else {
         return;
     };
@@ -505,7 +518,10 @@ fn install_updater(app: &tauri::AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClosePolicy, close_policy, finish_retention_cleanup, should_prevent_exit};
+    use super::{
+        ClosePolicy, Schedulers, close_policy, finish_retention_cleanup, should_prevent_exit,
+        stop_schedulers,
+    };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -539,6 +555,89 @@ mod tests {
 
         assert!(completed.load(Ordering::Acquire));
         assert!(handle.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_scheduler_stop_leaves_the_claim_reclaimable() {
+        use crate::analysis::{EvidencePass, PassOutcome, PassSignal, SessionAnalysis};
+        use crate::insights_worker::{PassFuture, WorkerHandle, worker_loop};
+        use crate::store::{EvidenceStatus, SessionKey, SessionRecord, Store};
+
+        let store = Arc::new(
+            Store::open_in_memory(std::path::Path::new("/tmp/antiburn-stop-test")).unwrap(),
+        );
+        let key = SessionKey::new("native", "claude-code", "shutdown");
+        store
+            .upsert_sessions(
+                &[SessionRecord {
+                    key: key.clone(),
+                    source_kind: "file".into(),
+                    source_label: "/tmp/shutdown.jsonl".into(),
+                    wsl_distro: None,
+                    title: None,
+                    title_source: None,
+                    cwd: None,
+                    surface: "cli".into(),
+                    updated_at_epoch: Some(100),
+                    activity_cursor: String::new(),
+                    activity_source: "event".into(),
+                    subagent_count: 0,
+                    fork_parent_session_id: None,
+                    source_fingerprint: Some("sv1:shutdown".into()),
+                }],
+                &crate::agents::evidence_cohort(),
+            )
+            .unwrap();
+        let handle = Arc::new(WorkerHandle::default());
+        let blocker = Arc::new(tokio::sync::Notify::new());
+        let pass_blocker = Arc::clone(&blocker);
+        let runner = move |_: &SessionRecord, _: PassSignal| {
+            let blocker = Arc::clone(&pass_blocker);
+            Box::pin(async move {
+                blocker.notified().await;
+                EvidencePass {
+                    analysis: SessionAnalysis::unavailable(),
+                    evidence: None,
+                    outcome: PassOutcome::SourceMissing,
+                }
+            }) as PassFuture
+        };
+        let task_store = Arc::clone(&store);
+        let task_handle = Arc::clone(&handle);
+        let task = tauri::async_runtime::spawn(async move {
+            worker_loop(&task_store, &task_handle, &|| 100, &runner, &|_| {}).await;
+        });
+        for _ in 0..20 {
+            if store
+                .evidence(&key)
+                .unwrap()
+                .is_some_and(|row| row.status == EvidenceStatus::Processing)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let schedulers = Schedulers::default();
+        schedulers.push(task);
+
+        stop_schedulers(&schedulers);
+        assert_eq!(
+            store.evidence(&key).unwrap().unwrap().status,
+            EvidenceStatus::Processing
+        );
+        blocker.notify_waiters();
+        tokio::task::yield_now().await;
+        assert!(store.analysis(&key).unwrap().is_none());
+        store
+            .reconcile_evidence_revisions(
+                &crate::agents::evidence_cohort(),
+                crate::analysis::projection_revisions(),
+            )
+            .unwrap();
+        assert_eq!(
+            store.evidence(&key).unwrap().unwrap().status,
+            EvidenceStatus::Pending
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/repositories.rs
+++ b/apps/desktop/src-tauri/src/repositories.rs
@@ -752,11 +752,14 @@ mod tests {
             source_fingerprint: None,
         };
         store
-            .upsert_sessions(&[
-                session("in-widgets", "/home/avery/code/widgets"),
-                session("in-widgets-sub", "/home/avery/code/widgets/src"),
-                session("in-gadgets", "/home/avery/code/gadgets"),
-            ])
+            .upsert_sessions(
+                &[
+                    session("in-widgets", "/home/avery/code/widgets"),
+                    session("in-widgets-sub", "/home/avery/code/widgets/src"),
+                    session("in-gadgets", "/home/avery/code/gadgets"),
+                ],
+                &[],
+            )
             .unwrap();
 
         ignored_paths::ignore_path(store.state_dir(), IGNORE_SCOPE, "/home/avery/code/widgets")

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -80,6 +80,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::Notify;
 use tokio::task::JoinSet;
 
+use crate::agents;
 use crate::analysis;
 use crate::dto::ScanStatus;
 use crate::repositories;
@@ -324,7 +325,11 @@ async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Res
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
-    checked(app, "The session index", store.upsert_sessions(&records))?;
+    checked(
+        app,
+        "The session index",
+        store.upsert_sessions(&records, &agents::evidence_cohort()),
+    )?;
 
     // A transcript the gate rejected may have been indexed by an earlier
     // version of the app that did not gate; the row is removed rather than
@@ -1260,7 +1265,9 @@ mod tests {
             else {
                 panic!("native Codex session should be described");
             };
-            store.upsert_sessions(&[*record]).unwrap();
+            store
+                .upsert_sessions(&[*record], &agents::evidence_cohort())
+                .unwrap();
         }
 
         let native = store
@@ -1318,9 +1325,14 @@ mod tests {
 
         let store = crate::store::Store::open_in_memory(home.path()).unwrap();
         store
-            .upsert_sessions(&[record("codex", parent_session_id, Some(1_799_999_000))])
+            .upsert_sessions(
+                &[record("codex", parent_session_id, Some(1_799_999_000))],
+                &agents::evidence_cohort(),
+            )
             .unwrap();
-        store.upsert_sessions(std::slice::from_ref(&child)).unwrap();
+        store
+            .upsert_sessions(std::slice::from_ref(&child), &agents::evidence_cohort())
+            .unwrap();
 
         assert_eq!(
             store
@@ -1618,7 +1630,7 @@ mod tests {
         session.source_label = source_path.to_string_lossy().into_owned();
         let store = Store::open_in_memory(home.path()).unwrap();
         store
-            .upsert_sessions(std::slice::from_ref(&session))
+            .upsert_sessions(std::slice::from_ref(&session), &agents::evidence_cohort())
             .unwrap();
 
         let legacy_fingerprint =
@@ -1694,7 +1706,9 @@ mod tests {
         let store = Store::open_in_memory(home.path()).unwrap();
         let mut session = record("claude-code", "recent-change", Some(100));
         session.source_fingerprint = Some("sv1:recent".to_string());
-        store.upsert_sessions(&[session]).unwrap();
+        store
+            .upsert_sessions(&[session], &agents::evidence_cohort())
+            .unwrap();
         let analysis_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let observed = Arc::clone(&analysis_calls);
 
@@ -1755,7 +1769,9 @@ mod tests {
                 &HashSet::new(),
             )
             .await;
-            store.upsert_sessions(&records.records).unwrap();
+            store
+                .upsert_sessions(&records.records, &agents::evidence_cohort())
+                .unwrap();
             for (agent, seen, cursor) in per_agent_totals(&records.records) {
                 store.record_agent_scan(&agent, cursor, seen).unwrap();
             }
@@ -1824,7 +1840,9 @@ mod tests {
         stale.source_label = path.to_string_lossy().into_owned();
         stale.activity_cursor = "legacy".into();
         stale.activity_source = "mtime".into();
-        store.upsert_sessions(&[stale]).unwrap();
+        store
+            .upsert_sessions(&[stale], &agents::evidence_cohort())
+            .unwrap();
 
         let states = store.session_activity_states().unwrap();
         let described = describe_with_states(
@@ -1842,7 +1860,9 @@ mod tests {
         .unix_timestamp();
         assert_eq!(described.records[0].updated_at_epoch, Some(expected));
         assert_eq!(described.records[0].activity_source, "event");
-        store.upsert_sessions(&described.records).unwrap();
+        store
+            .upsert_sessions(&described.records, &agents::evidence_cohort())
+            .unwrap();
         let stored = store
             .session_activity_states()
             .unwrap()
@@ -1884,7 +1904,9 @@ mod tests {
 
         // A later mtime-only touch now hits the unchanged-size cursor gate.
         let states = {
-            store.upsert_sessions(&touched.records).unwrap();
+            store
+                .upsert_sessions(&touched.records, &agents::evidence_cohort())
+                .unwrap();
             store.session_activity_states().unwrap()
         };
         let gated = describe_with_states(
@@ -1925,7 +1947,9 @@ mod tests {
         .await;
         assert_eq!(first.records[0].subagent_count, 1);
         let first_epoch = first.records[0].updated_at_epoch.unwrap();
-        store.upsert_sessions(&first.records).unwrap();
+        store
+            .upsert_sessions(&first.records, &agents::evidence_cohort())
+            .unwrap();
 
         // An mtime-only parent touch with an unchanged parent+child cursor is
         // served from the cached semantic event without reading either tail.
@@ -2049,7 +2073,10 @@ mod tests {
         let store = crate::store::Store::open_in_memory(home.path()).unwrap();
         // An earlier, ungated version of the app indexed the sidechain.
         store
-            .upsert_sessions(&[record("claude-code", "aaaa-1111", Some(1_800_000_000))])
+            .upsert_sessions(
+                &[record("claude-code", "aaaa-1111", Some(1_800_000_000))],
+                &agents::evidence_cohort(),
+            )
             .unwrap();
         assert_eq!(store.recent_sessions(0, 10).unwrap().len(), 1);
 

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -330,6 +330,7 @@ async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Res
         "The session index",
         store.upsert_sessions(&records, &agents::evidence_cohort()),
     )?;
+    crate::insights_worker::wake(app);
 
     // A transcript the gate rejected may have been indexed by an earlier
     // version of the app that did not gate; the row is removed rather than
@@ -368,8 +369,11 @@ async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Res
     top_up_analysis(
         &store,
         &controller,
-        now,
-        i64::from(activity_window_days),
+        TopUpScope {
+            now,
+            activity_days: i64::from(activity_window_days),
+            evidence_agents: &agents::evidence_cohort(),
+        },
         |agent, session_id, wsl_distro| async move {
             analysis::locate(agent, &session_id, wsl_distro.as_deref()).await
         },
@@ -899,12 +903,17 @@ fn per_agent_totals(records: &[SessionRecord]) -> Vec<(String, i64, Option<i64>)
         .collect()
 }
 
+struct TopUpScope<'a> {
+    now: i64,
+    activity_days: i64,
+    evidence_agents: &'a [&'a str],
+}
+
 /// Analyze the newest sessions whose cached analysis is missing or stale.
 async fn top_up_analysis<F, Fut, A, AFut>(
     store: &Store,
     controller: &ScanController,
-    now: i64,
-    activity_days: i64,
+    scope: TopUpScope<'_>,
     mut locate: F,
     mut analyze: A,
 ) -> anyhow::Result<()>
@@ -920,10 +929,13 @@ where
     ) -> AFut,
     AFut: std::future::Future<Output = analysis::SessionAnalysis>,
 {
-    let since = now - activity_days.max(1) * 86_400;
+    let since = scope.now - scope.activity_days.max(1) * 86_400;
     let candidates = store.recent_sessions(since, MAX_ANALYSES_PER_PASS)?;
 
     for record in candidates {
+        if scope.evidence_agents.contains(&record.key.agent.as_str()) {
+            continue;
+        }
         // Analysis is the long tail of a pass — one whole transcript read per
         // session — so this is where a cancel is felt.
         if controller.cancelled() {
@@ -1674,8 +1686,11 @@ mod tests {
         top_up_analysis(
             &store,
             &ScanController::default(),
-            200,
-            1,
+            TopUpScope {
+                now: 200,
+                activity_days: 1,
+                evidence_agents: &[],
+            },
             move |agent, candidate_id, wsl_distro| {
                 observed_locates.fetch_add(1, Ordering::SeqCst);
                 let source = located_source.clone();
@@ -1715,8 +1730,11 @@ mod tests {
         top_up_analysis(
             &store,
             &ScanController::default(),
-            101,
-            1,
+            TopUpScope {
+                now: 101,
+                activity_days: 1,
+                evidence_agents: &[],
+            },
             |_, _, _| async {
                 Some(SessionSource::Inline {
                     label: "recent-change".to_string(),
@@ -1732,6 +1750,53 @@ mod tests {
         .unwrap();
 
         assert_eq!(analysis_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn top_up_analysis_skips_the_evidence_cohort() {
+        let home = tempfile::TempDir::new().unwrap();
+        let store = Store::open_in_memory(home.path()).unwrap();
+        store
+            .upsert_sessions(
+                &[
+                    record("claude-code", "queued", Some(100)),
+                    record("codex", "direct", Some(99)),
+                ],
+                &agents::evidence_cohort(),
+            )
+            .unwrap();
+        let located = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let located_by_pass = Arc::clone(&located);
+        let analyzed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let analyzed_by_pass = Arc::clone(&analyzed);
+
+        top_up_analysis(
+            &store,
+            &ScanController::default(),
+            TopUpScope {
+                now: 101,
+                activity_days: 1,
+                evidence_agents: &agents::evidence_cohort(),
+            },
+            move |agent, session_id, _| {
+                located_by_pass.lock().unwrap().push(session_id);
+                async move {
+                    Some(SessionSource::Inline {
+                        label: agent.slug().to_string(),
+                        content: String::new(),
+                    })
+                }
+            },
+            move |_, session_id, _, _, _| {
+                analyzed_by_pass.lock().unwrap().push(session_id);
+                async { analysis::SessionAnalysis::unavailable() }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(located.lock().unwrap().as_slice(), ["direct"]);
+        assert_eq!(analyzed.lock().unwrap().as_slice(), ["direct"]);
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -480,12 +480,33 @@ impl Store {
     /// `first_seen_at` survives a rescan; everything else is replaced with what
     /// the scan just observed, so a renamed session picks up its new title
     /// without producing a second row.
-    pub fn upsert_sessions(&self, records: &[SessionRecord]) -> Result<()> {
+    pub fn upsert_sessions(
+        &self,
+        records: &[SessionRecord],
+        evidence_agents: &[&str],
+    ) -> Result<()> {
         let mut connection = self.lock();
         let tx = connection.transaction()?;
         for record in records {
+            let source_returned = tx.query_row(
+                "SELECT EXISTS (
+                     SELECT 1 FROM session_evidence
+                      WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+                        AND status = 'failed' AND last_error = 'source-missing'
+                 )",
+                params![
+                    record.key.environment_key,
+                    record.key.agent,
+                    record.key.session_id
+                ],
+                |row| row.get::<_, i64>(0),
+            )? != 0;
             let (previous_generation, source_generation) = upsert_session_in(&tx, record)?;
-            if previous_generation.is_none_or(|previous| source_generation > previous) {
+            let generation_increased =
+                previous_generation.is_none_or(|previous| source_generation > previous);
+            if evidence_agents.contains(&record.key.agent.as_str())
+                && (generation_increased || source_returned)
+            {
                 mark_evidence_pending_in(&tx, &record.key)?;
             }
         }
@@ -672,7 +693,8 @@ impl Store {
                            OR evidence.parser_revision IS NOT ?{parser_parameter}
                            OR evidence.analyzer_revision IS NOT ?{analyzer_parameter}
                            OR evidence.evidence_schema_revision IS NOT ?{evidence_parameter}
-                           OR NOT EXISTS (
+                           OR (evidence.status NOT IN ('failed', 'unsupported')
+                               AND NOT EXISTS (
                                SELECT 1 FROM session_analysis AS analysis
                                 WHERE analysis.environment_key = session.environment_key
                                   AND analysis.agent = session.agent
@@ -681,7 +703,7 @@ impl Store {
                                   AND analysis.parser_revision = ?{parser_parameter}
                                   AND analysis.analyzer_revision = ?{analyzer_parameter}
                                   AND analysis.metrics_schema_revision = ?{metrics_parameter}
-                           )
+                           ))
                        )
                 )"
         );
@@ -832,39 +854,65 @@ impl Store {
         failure: EvidenceFailure,
         last_error: &str,
     ) -> Result<bool> {
-        let (status, next_attempt_at_epoch) = match failure {
+        let connection = self.lock();
+        let updated = match failure {
             EvidenceFailure::Retry {
                 next_attempt_at_epoch,
-            } => ("pending", Some(next_attempt_at_epoch)),
-            EvidenceFailure::Failed => ("failed", None),
+            } => connection.execute(
+                "UPDATE session_evidence AS evidence
+                    SET status = 'pending', retry_count = retry_count + 1,
+                        last_error = ?6, claimed_at_epoch = NULL,
+                        lease_expires_at_epoch = NULL, next_attempt_at_epoch = ?7
+                  WHERE evidence.environment_key = ?1
+                    AND evidence.agent = ?2 AND evidence.session_id = ?3
+                    AND evidence.status = 'processing' AND evidence.claim_fence = ?4
+                    AND EXISTS (
+                        SELECT 1 FROM session
+                         WHERE session.environment_key = evidence.environment_key
+                           AND session.agent = evidence.agent
+                           AND session.session_id = evidence.session_id
+                           AND session.source_generation = ?5
+                    )",
+                params![
+                    claim.key.environment_key,
+                    claim.key.agent,
+                    claim.key.session_id,
+                    claim.claim_fence,
+                    claim.source_generation,
+                    last_error,
+                    next_attempt_at_epoch,
+                ],
+            )?,
+            EvidenceFailure::Failed { revisions } => connection.execute(
+                "UPDATE session_evidence AS evidence
+                    SET status = 'failed', retry_count = retry_count + 1,
+                        analyzed_generation = ?5, parser_revision = ?7,
+                        analyzer_revision = ?8, evidence_schema_revision = ?9,
+                        last_error = ?6, claimed_at_epoch = NULL,
+                        lease_expires_at_epoch = NULL, next_attempt_at_epoch = NULL
+                  WHERE evidence.environment_key = ?1
+                    AND evidence.agent = ?2 AND evidence.session_id = ?3
+                    AND evidence.status = 'processing' AND evidence.claim_fence = ?4
+                    AND EXISTS (
+                        SELECT 1 FROM session
+                         WHERE session.environment_key = evidence.environment_key
+                           AND session.agent = evidence.agent
+                           AND session.session_id = evidence.session_id
+                           AND session.source_generation = ?5
+                    )",
+                params![
+                    claim.key.environment_key,
+                    claim.key.agent,
+                    claim.key.session_id,
+                    claim.claim_fence,
+                    claim.source_generation,
+                    last_error,
+                    revisions.parser_revision,
+                    revisions.analyzer_revision,
+                    revisions.evidence_schema_revision,
+                ],
+            )?,
         };
-        let connection = self.lock();
-        let updated = connection.execute(
-            "UPDATE session_evidence AS evidence
-                SET status = ?6, retry_count = retry_count + 1,
-                    last_error = ?7, claimed_at_epoch = NULL,
-                    lease_expires_at_epoch = NULL, next_attempt_at_epoch = ?8
-              WHERE evidence.environment_key = ?1
-                AND evidence.agent = ?2 AND evidence.session_id = ?3
-                AND evidence.status = 'processing' AND evidence.claim_fence = ?4
-                AND EXISTS (
-                    SELECT 1 FROM session
-                     WHERE session.environment_key = evidence.environment_key
-                       AND session.agent = evidence.agent
-                       AND session.session_id = evidence.session_id
-                       AND session.source_generation = ?5
-                )",
-            params![
-                claim.key.environment_key,
-                claim.key.agent,
-                claim.key.session_id,
-                claim.claim_fence,
-                claim.source_generation,
-                status,
-                last_error,
-                next_attempt_at_epoch,
-            ],
-        )?;
         Ok(updated > 0)
     }
 
@@ -920,6 +968,7 @@ impl Store {
         record: &AnalysisRecord,
         started_at_epoch: Option<i64>,
         completion: &EvidenceCompletion,
+        relations: &[RelationRecord],
     ) -> Result<bool> {
         let mut connection = self.lock();
         let transaction = connection.transaction()?;
@@ -1003,6 +1052,7 @@ impl Store {
         if updated == 0 {
             return Ok(false);
         }
+        replace_relations_in(&transaction, &record.key, RelationKind::Subagent, relations)?;
         transaction.commit()?;
         Ok(true)
     }
@@ -1141,32 +1191,7 @@ impl Store {
     ) -> Result<()> {
         let mut connection = self.lock();
         let tx = connection.transaction()?;
-        tx.execute(
-            "DELETE FROM session_relation
-              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND kind = ?4",
-            params![
-                key.environment_key,
-                key.agent,
-                key.session_id,
-                kind.as_str()
-            ],
-        )?;
-        for relation in relations {
-            tx.execute(
-                "INSERT INTO session_relation
-                     (environment_key, agent, session_id, kind, related_id, label)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                 ON CONFLICT DO UPDATE SET label = excluded.label",
-                params![
-                    key.environment_key,
-                    key.agent,
-                    key.session_id,
-                    relation.kind.as_str(),
-                    relation.related_id,
-                    relation.label,
-                ],
-            )?;
-        }
+        replace_relations_in(&tx, key, kind, relations)?;
         tx.commit()?;
         Ok(())
     }
@@ -1676,6 +1701,41 @@ fn upsert_session_in(
         |row| row.get(0),
     )?;
     Ok((previous_generation, source_generation))
+}
+
+fn replace_relations_in(
+    connection: &Connection,
+    key: &SessionKey,
+    kind: RelationKind,
+    relations: &[RelationRecord],
+) -> Result<()> {
+    connection.execute(
+        "DELETE FROM session_relation
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND kind = ?4",
+        params![
+            key.environment_key,
+            key.agent,
+            key.session_id,
+            kind.as_str()
+        ],
+    )?;
+    for relation in relations {
+        connection.execute(
+            "INSERT INTO session_relation
+                 (environment_key, agent, session_id, kind, related_id, label)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT DO UPDATE SET label = excluded.label",
+            params![
+                key.environment_key,
+                key.agent,
+                key.session_id,
+                relation.kind.as_str(),
+                relation.related_id,
+                relation.label,
+            ],
+        )?;
+    }
+    Ok(())
 }
 
 fn mark_evidence_pending_in(connection: &Connection, key: &SessionKey) -> Result<()> {

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -43,9 +43,9 @@ use crate::dto::DeferredPermissionDir;
 pub use model::{
     AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceClaim, EvidenceCompletion,
     EvidenceFailure, EvidenceRow, EvidenceStatus, MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS,
-    MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, ProjectionRevisions, RelationKind,
-    RelationRecord, RepositoryRecord, SessionActivityKey, SessionActivityState, SessionKey,
-    SessionRecord, SourceVersionState, ThemePreference, UsageEvidenceRecord,
+    MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, ProjectionRevisions, PublishedEvidence,
+    RelationKind, RelationRecord, RepositoryRecord, SessionActivityKey, SessionActivityState,
+    SessionKey, SessionRecord, SourceVersionState, ThemePreference, UsageEvidenceRecord,
 };
 
 /// Internal-scalar key holding the protected directories the last pass declined

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -229,7 +229,7 @@ pub struct EvidenceClaim {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvidenceFailure {
     Retry { next_attempt_at_epoch: i64 },
-    Failed,
+    Failed { revisions: ProjectionRevisions },
 }
 
 /// The two successful publication states.

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -63,7 +63,10 @@ fn claimed_projection(
     let fingerprint = format!("sv1:{session_id}");
     session.source_fingerprint = Some(fingerprint.clone());
     store
-        .upsert_sessions(std::slice::from_ref(&session))
+        .upsert_sessions(
+            std::slice::from_ref(&session),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     let claim = store
         .claim_next_evidence(&["claude-code"], now_epoch, lease_secs)
@@ -93,7 +96,10 @@ fn seed_current_session_evidence(store: &Store, session_id: &str) -> SessionReco
     let mut record = session(session_id, 1_000);
     record.source_fingerprint = Some("sv1:current".into());
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     store
         .save_analysis(
@@ -166,7 +172,10 @@ fn assert_unchanged_session_evidence(
     let before = store.evidence(&record.key).unwrap().unwrap();
 
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     assert_eq!(
         store
@@ -452,7 +461,9 @@ fn restarting_onboarding_preserves_local_state_and_is_idempotent() {
             ..AppSettings::default()
         })
         .unwrap();
-    store.upsert_sessions(&[session("abc", 2_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 2_000)], &crate::agents::evidence_cohort())
+        .unwrap();
     store.add_scan_root("/home/avery/work").unwrap();
     store.queue_analytics_event("app_launched", "{}").unwrap();
 
@@ -573,7 +584,10 @@ fn session_evidence_status_index_exists() {
 fn session_evidence_rejects_an_unknown_status() {
     let store = store();
     store
-        .upsert_sessions(&[session("bad-status", 1_000)])
+        .upsert_sessions(
+            &[session("bad-status", 1_000)],
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     let result = store.lock().execute(
         "INSERT INTO session_evidence (environment_key, agent, session_id, status)
@@ -654,7 +668,9 @@ fn session_evidence_survives_an_upgrade_from_the_shipped_head() {
 #[test]
 fn clearing_local_data_forgets_session_records_and_keeps_the_readers_choices() {
     let store = store();
-    store.upsert_sessions(&[session("abc", 2_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 2_000)], &crate::agents::evidence_cohort())
+        .unwrap();
     store
         .save_analysis(
             &AnalysisRecord {
@@ -773,16 +789,25 @@ fn an_out_of_range_activity_window_is_clamped_on_the_way_in() {
 #[test]
 fn a_session_round_trips_and_a_rescan_updates_it_in_place() {
     let store = store();
-    store.upsert_sessions(&[session("abc", 1_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let mut later = session("abc", 2_000);
     later.title = Some("Wire the popover, take two".into());
     later.subagent_count = 3;
-    store.upsert_sessions(std::slice::from_ref(&later)).unwrap();
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&later),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
 
     // Idempotent: a rescan that sees the same session again must not duplicate
     // it, and must not rewind the activity timestamp.
-    store.upsert_sessions(&[session("abc", 1_500)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 1_500)], &crate::agents::evidence_cohort())
+        .unwrap();
 
     assert_eq!(store.recent_sessions(0, 100).unwrap().len(), 1);
     let stored = store
@@ -800,12 +825,16 @@ fn an_event_timestamp_survives_a_newer_mtime_only_upsert() {
     let mut event = session("semantic", 1_000);
     event.activity_cursor = "[\"parent\",10]".into();
     event.activity_source = "event".into();
-    store.upsert_sessions(&[event]).unwrap();
+    store
+        .upsert_sessions(&[event], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let mut mtime = session("semantic", 2_000);
     mtime.activity_cursor = "[\"parent\",20]".into();
     mtime.activity_source = "mtime".into();
-    store.upsert_sessions(&[mtime]).unwrap();
+    store
+        .upsert_sessions(&[mtime], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let stored = store
         .session(&SessionKey::new("native", "claude-code", "semantic"))
@@ -822,7 +851,9 @@ fn activity_cursors_do_not_collide_across_environments() {
     let native = session("shared", 1_000);
     let mut wsl = native.clone();
     wsl.key = SessionKey::new("wsl:ubuntu", "claude-code", "shared");
-    store.upsert_sessions(&[native, wsl]).unwrap();
+    store
+        .upsert_sessions(&[native, wsl], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let states = store.session_activity_states().unwrap();
     assert_eq!(states.len(), 2);
@@ -845,7 +876,9 @@ fn title_and_source_are_replaced_or_preserved_as_one_pair() {
     let mut source_without_title = session("orphan-source", 500);
     source_without_title.title = None;
     source_without_title.title_source = Some("firstMessage".into());
-    store.upsert_sessions(&[source_without_title]).unwrap();
+    store
+        .upsert_sessions(&[source_without_title], &crate::agents::evidence_cohort())
+        .unwrap();
     let stored = store
         .session(&SessionKey::new("native", "claude-code", "orphan-source"))
         .unwrap()
@@ -866,24 +899,32 @@ fn title_and_source_are_replaced_or_preserved_as_one_pair() {
     let mut no_title_again = session("orphan-source", 750);
     no_title_again.title = None;
     no_title_again.title_source = None;
-    store.upsert_sessions(&[no_title_again]).unwrap();
+    store
+        .upsert_sessions(&[no_title_again], &crate::agents::evidence_cohort())
+        .unwrap();
     let healed = store
         .session(&SessionKey::new("native", "claude-code", "orphan-source"))
         .unwrap()
         .expect("session");
     assert_eq!((healed.title, healed.title_source), (None, None));
 
-    store.upsert_sessions(&[session("abc", 1_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let mut renamed = session("abc", 2_000);
     renamed.title = Some("Reader supplied title".into());
     renamed.title_source = Some("userRename".into());
-    store.upsert_sessions(&[renamed]).unwrap();
+    store
+        .upsert_sessions(&[renamed], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let mut missing = session("abc", 3_000);
     missing.title = None;
     missing.title_source = Some("firstMessage".into());
-    store.upsert_sessions(&[missing]).unwrap();
+    store
+        .upsert_sessions(&[missing], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let stored = store
         .session(&SessionKey::new("native", "claude-code", "abc"))
@@ -896,13 +937,18 @@ fn title_and_source_are_replaced_or_preserved_as_one_pair() {
 #[test]
 fn the_same_session_id_in_two_environments_stays_two_sessions() {
     let store = store();
-    store.upsert_sessions(&[session("abc", 1_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let mut in_wsl = session("abc", 1_100);
     in_wsl.key.environment_key = "wsl:ubuntu".into();
     in_wsl.wsl_distro = Some("Ubuntu".into());
     store
-        .upsert_sessions(std::slice::from_ref(&in_wsl))
+        .upsert_sessions(
+            std::slice::from_ref(&in_wsl),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
 
     assert_eq!(store.recent_sessions(0, 100).unwrap().len(), 2);
@@ -911,9 +957,15 @@ fn the_same_session_id_in_two_environments_stays_two_sessions() {
 #[test]
 fn recent_sessions_are_windowed_and_ordered_newest_first() {
     let store = store();
-    store.upsert_sessions(&[session("old", 1_000)]).unwrap();
-    store.upsert_sessions(&[session("mid", 2_000)]).unwrap();
-    store.upsert_sessions(&[session("new", 3_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("old", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
+    store
+        .upsert_sessions(&[session("mid", 2_000)], &crate::agents::evidence_cohort())
+        .unwrap();
+    store
+        .upsert_sessions(&[session("new", 3_000)], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let recent = store.recent_sessions(1_500, 100).unwrap();
     let ids: Vec<_> = recent
@@ -932,10 +984,20 @@ fn recent_sessions_are_windowed_and_ordered_newest_first() {
 #[test]
 fn a_fork_parent_rides_with_the_session_and_resolves_children_back() {
     let store = store();
-    store.upsert_sessions(&[session("parent", 1_000)]).unwrap();
+    store
+        .upsert_sessions(
+            &[session("parent", 1_000)],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
     let mut child = session("child", 2_000);
     child.fork_parent_session_id = Some("parent".into());
-    store.upsert_sessions(std::slice::from_ref(&child)).unwrap();
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&child),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
 
     let stored = store
         .session(&SessionKey::new("native", "claude-code", "child"))
@@ -949,7 +1011,12 @@ fn a_fork_parent_rides_with_the_session_and_resolves_children_back() {
     assert_eq!(children, vec!["child".to_string()]);
 
     // A later scan can carry no observation. It must keep the recorded lineage.
-    store.upsert_sessions(&[session("child", 2_100)]).unwrap();
+    store
+        .upsert_sessions(
+            &[session("child", 2_100)],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
     assert_eq!(
         store
             .fork_children(&SessionKey::new("native", "claude-code", "parent"))
@@ -962,7 +1029,9 @@ fn a_fork_parent_rides_with_the_session_and_resolves_children_back() {
 fn analysis_round_trips_and_is_replaced_rather_than_duplicated() {
     let store = store();
     let key = SessionKey::new("native", "claude-code", "abc");
-    store.upsert_sessions(&[session("abc", 1_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let record = AnalysisRecord {
         key: key.clone(),
@@ -994,7 +1063,10 @@ fn save_analysis_writes_the_generation_and_revision_columns() {
     let store = store();
     let key = SessionKey::new("native", "claude-code", "revisions");
     store
-        .upsert_sessions(&[session("revisions", 1_000)])
+        .upsert_sessions(
+            &[session("revisions", 1_000)],
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     let record = AnalysisRecord {
         key: key.clone(),
@@ -1026,7 +1098,10 @@ fn save_analysis_never_clears_a_known_start_time() {
     let store = store();
     let key = SessionKey::new("native", "claude-code", "known-start");
     store
-        .upsert_sessions(&[session("known-start", 1_000)])
+        .upsert_sessions(
+            &[session("known-start", 1_000)],
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     let record = AnalysisRecord {
         key: key.clone(),
@@ -1057,7 +1132,9 @@ fn save_analysis_never_clears_a_known_start_time() {
 fn subagent_relations_are_replaced_wholesale() {
     let store = store();
     let key = SessionKey::new("native", "claude-code", "abc");
-    store.upsert_sessions(&[session("abc", 1_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
 
     store
         .replace_relations(
@@ -1100,7 +1177,9 @@ fn subagent_relations_are_replaced_wholesale() {
 fn deleting_a_session_takes_its_derived_records_with_it() {
     let store = store();
     let key = SessionKey::new("native", "claude-code", "abc");
-    store.upsert_sessions(&[session("abc", 1_000)]).unwrap();
+    store
+        .upsert_sessions(&[session("abc", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
     store
         .save_analysis(
             &AnalysisRecord {
@@ -1238,7 +1317,10 @@ fn agent_scan_state_records_the_high_water_cursor() {
 fn usage_evidence_joins_the_analysis_and_keeps_sessions_that_have_none() {
     let store = store();
     store
-        .upsert_sessions(&[session("analyzed", 2_000), session("pending", 1_500)])
+        .upsert_sessions(
+            &[session("analyzed", 2_000), session("pending", 1_500)],
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     store
         .save_analysis(
@@ -1448,10 +1530,16 @@ fn the_generation_increments_only_when_the_fingerprint_changes() {
     let mut record = session("generation", 1_000);
     record.source_fingerprint = Some("sv1:first".to_string());
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     let first = store
         .session_source_state(&key)
@@ -1461,7 +1549,10 @@ fn the_generation_increments_only_when_the_fingerprint_changes() {
 
     record.source_fingerprint = Some("sv1:second".to_string());
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     let second = store
         .session_source_state(&key)
@@ -1471,7 +1562,9 @@ fn the_generation_increments_only_when_the_fingerprint_changes() {
     assert_eq!(second.source_fingerprint.as_deref(), Some("sv1:second"));
 
     record.source_fingerprint = None;
-    store.upsert_sessions(&[record]).unwrap();
+    store
+        .upsert_sessions(&[record], &crate::agents::evidence_cohort())
+        .unwrap();
     let unreadable = store
         .session_source_state(&key)
         .unwrap()
@@ -1486,7 +1579,10 @@ fn a_new_source_generation_marks_session_evidence_pending() {
     record.source_fingerprint = Some("sv1:changed".into());
 
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
 
     assert_eq!(
@@ -1510,7 +1606,9 @@ fn marking_session_evidence_pending_keeps_the_last_completed_payload() {
     let before = store.evidence(&record.key).unwrap().unwrap();
     record.source_fingerprint = Some("sv1:changed".into());
 
-    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .upsert_sessions(&[record.clone()], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let after = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(after.status, EvidenceStatus::Pending);
@@ -1601,7 +1699,9 @@ fn reconciling_enrolls_a_session_evidence_row_for_an_upgraded_session() {
     let mut record = session("upgrade-enrollment", 1_000);
     record.source_fingerprint = Some("sv1:current".into());
 
-    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .upsert_sessions(&[record.clone()], &crate::agents::evidence_cohort())
+        .unwrap();
     assert!(store.evidence(&record.key).unwrap().is_none());
     assert_eq!(
         store
@@ -1696,7 +1796,10 @@ fn reconciling_session_evidence_skips_a_disabled_agent() {
     let mut codex = session("disabled-evidence", 1_000);
     codex.key.agent = "codex".into();
     store
-        .upsert_sessions(&[claude.clone(), codex.clone()])
+        .upsert_sessions(
+            &[claude.clone(), codex.clone()],
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     store
         .lock()
@@ -1714,11 +1817,120 @@ fn reconciling_session_evidence_skips_a_disabled_agent() {
 }
 
 #[test]
+fn a_session_outside_the_evidence_cohort_gets_no_row() {
+    let store = store();
+    let claude = session("cohort-claude", 1_000);
+    let mut codex = session("cohort-codex", 1_000);
+    codex.key.agent = "codex".to_string();
+
+    store
+        .upsert_sessions(
+            &[claude.clone(), codex.clone()],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    assert!(store.evidence(&claude.key).unwrap().is_some());
+    assert!(store.evidence(&codex.key).unwrap().is_none());
+}
+
+#[test]
+fn a_terminal_failure_survives_two_startup_reconciles() {
+    let store = store();
+    let (_, claim) = claimed_projection(&store, "terminal-reconcile", 100, 60);
+    assert!(
+        store
+            .fail_evidence(
+                &claim,
+                EvidenceFailure::Failed {
+                    revisions: projection_revisions(),
+                },
+                "source-missing",
+            )
+            .unwrap()
+    );
+
+    for _ in 0..2 {
+        assert_eq!(
+            store
+                .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            store.evidence(&claim.key).unwrap().unwrap().status,
+            EvidenceStatus::Failed
+        );
+        assert!(
+            store
+                .claim_next_evidence(&["claude-code"], 200, 60)
+                .unwrap()
+                .is_none()
+        );
+    }
+}
+
+#[test]
+fn a_returned_source_requeues_with_an_unchanged_fingerprint() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "returned-source", 100, 60);
+    assert!(
+        store
+            .fail_evidence(
+                &claim,
+                EvidenceFailure::Failed {
+                    revisions: projection_revisions(),
+                },
+                "source-missing",
+            )
+            .unwrap()
+    );
+    let generation = claim.source_generation;
+    let mut returned = session("returned-source", 1_000);
+    returned.source_fingerprint = Some(record.source_fingerprint);
+
+    store
+        .upsert_sessions(&[returned], &crate::agents::evidence_cohort())
+        .unwrap();
+
+    let evidence = store.evidence(&claim.key).unwrap().unwrap();
+    assert_eq!(
+        store
+            .session_source_state(&claim.key)
+            .unwrap()
+            .unwrap()
+            .source_generation,
+        generation
+    );
+    assert_eq!(evidence.status, EvidenceStatus::Pending);
+    assert_eq!(evidence.retry_count, 0);
+}
+
+#[test]
+fn an_abandoned_processing_row_requeues_at_startup() {
+    let store = store();
+    let (_, claim) = claimed_projection(&store, "abandoned-startup", 100, 60);
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        store.evidence(&claim.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
 fn the_first_session_evidence_claim_excludes_a_second_claim() {
     let store = store();
     let mut record = session("exclusive-claim", 1_000);
     record.source_fingerprint = Some("sv1:exclusive".into());
-    store.upsert_sessions(&[record]).unwrap();
+    store
+        .upsert_sessions(&[record], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let first = store
         .claim_next_evidence(&["claude-code"], 100, 60)
@@ -1739,7 +1951,9 @@ fn reclaiming_an_abandoned_session_evidence_row_raises_the_fence() {
     let store = store();
     let mut record = session("reclaimed-claim", 1_000);
     record.source_fingerprint = Some("sv1:reclaim".into());
-    store.upsert_sessions(&[record]).unwrap();
+    store
+        .upsert_sessions(&[record], &crate::agents::evidence_cohort())
+        .unwrap();
     let first = store
         .claim_next_evidence(&["claude-code"], 100, 10)
         .unwrap()
@@ -1760,7 +1974,9 @@ fn a_late_session_evidence_transition_is_rejected() {
     let store = store();
     let mut record = session("late-transition", 1_000);
     record.source_fingerprint = Some("sv1:late".into());
-    store.upsert_sessions(&[record]).unwrap();
+    store
+        .upsert_sessions(&[record], &crate::agents::evidence_cohort())
+        .unwrap();
     let first = store
         .claim_next_evidence(&["claude-code"], 100, 10)
         .unwrap()
@@ -1773,7 +1989,13 @@ fn a_late_session_evidence_transition_is_rejected() {
 
     assert!(
         !store
-            .fail_evidence(&first, EvidenceFailure::Failed, "late")
+            .fail_evidence(
+                &first,
+                EvidenceFailure::Failed {
+                    revisions: projection_revisions()
+                },
+                "late"
+            )
             .unwrap()
     );
     assert_eq!(store.evidence(&current.key).unwrap().unwrap(), before);
@@ -1784,7 +2006,9 @@ fn a_stale_generation_rejects_a_session_evidence_lease_renewal() {
     let store = store();
     let mut record = session("stale-renewal", 1_000);
     record.source_fingerprint = Some("sv1:renewal".into());
-    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .upsert_sessions(&[record.clone()], &crate::agents::evidence_cohort())
+        .unwrap();
     let claim = store
         .claim_next_evidence(&["claude-code"], 100, 60)
         .unwrap()
@@ -1812,7 +2036,9 @@ fn a_stale_generation_rejects_a_session_evidence_failure() {
     let store = store();
     let mut record = session("stale-failure", 1_000);
     record.source_fingerprint = Some("sv1:failure".into());
-    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .upsert_sessions(&[record.clone()], &crate::agents::evidence_cohort())
+        .unwrap();
     let claim = store
         .claim_next_evidence(&["claude-code"], 100, 60)
         .unwrap()
@@ -1833,7 +2059,13 @@ fn a_stale_generation_rejects_a_session_evidence_failure() {
 
     assert!(
         !store
-            .fail_evidence(&claim, EvidenceFailure::Failed, "stale")
+            .fail_evidence(
+                &claim,
+                EvidenceFailure::Failed {
+                    revisions: projection_revisions()
+                },
+                "stale"
+            )
             .unwrap()
     );
     assert_eq!(store.evidence(&record.key).unwrap().unwrap(), before);
@@ -1844,7 +2076,9 @@ fn a_session_evidence_claim_is_not_eligible_before_its_next_attempt() {
     let store = store();
     let mut record = session("delayed-claim", 1_000);
     record.source_fingerprint = Some("sv1:delayed".into());
-    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .upsert_sessions(&[record.clone()], &crate::agents::evidence_cohort())
+        .unwrap();
     store
         .lock()
         .execute(
@@ -1877,7 +2111,9 @@ fn failing_session_evidence_with_retry_returns_it_to_pending_with_backoff() {
     let store = store();
     let mut record = session("retry-failure", 1_000);
     record.source_fingerprint = Some("sv1:retry".into());
-    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .upsert_sessions(&[record.clone()], &crate::agents::evidence_cohort())
+        .unwrap();
     let claim = store
         .claim_next_evidence(&["claude-code"], 100, 60)
         .unwrap()
@@ -1915,7 +2151,9 @@ fn failing_session_evidence_terminally_marks_it_failed() {
     let store = store();
     let mut record = session("terminal-failure", 1_000);
     record.source_fingerprint = Some("sv1:terminal".into());
-    store.upsert_sessions(&[record.clone()]).unwrap();
+    store
+        .upsert_sessions(&[record.clone()], &crate::agents::evidence_cohort())
+        .unwrap();
     let claim = store
         .claim_next_evidence(&["claude-code"], 100, 60)
         .unwrap()
@@ -1923,7 +2161,13 @@ fn failing_session_evidence_terminally_marks_it_failed() {
 
     assert!(
         store
-            .fail_evidence(&claim, EvidenceFailure::Failed, "terminal")
+            .fail_evidence(
+                &claim,
+                EvidenceFailure::Failed {
+                    revisions: projection_revisions()
+                },
+                "terminal"
+            )
             .unwrap()
     );
 
@@ -1948,7 +2192,7 @@ fn publishing_session_evidence_writes_both_projections_and_the_start_time() {
 
     assert!(
         store
-            .publish_projections(&record, Some(50), &completion)
+            .publish_projections(&record, Some(50), &completion, &[])
             .unwrap()
     );
 
@@ -1990,7 +2234,7 @@ fn published_session_evidence_and_analysis_describe_the_same_pass() {
 
     assert!(
         store
-            .publish_projections(&record, None, &completion)
+            .publish_projections(&record, None, &completion, &[])
             .unwrap()
     );
 
@@ -2033,7 +2277,7 @@ fn a_stale_generation_publishes_no_session_evidence_and_no_analysis() {
 
     assert!(
         !store
-            .publish_projections(&record, Some(88), &completion)
+            .publish_projections(&record, Some(88), &completion, &[])
             .unwrap()
     );
 
@@ -2069,7 +2313,7 @@ fn a_stale_fence_publishes_no_session_evidence_and_no_analysis() {
 
     assert!(
         !store
-            .publish_projections(&record, Some(88), &completion)
+            .publish_projections(&record, Some(88), &completion, &[])
             .unwrap()
     );
 
@@ -2088,12 +2332,115 @@ fn a_stale_fence_publishes_no_session_evidence_and_no_analysis() {
 }
 
 #[test]
+fn a_stale_claim_cannot_change_projections_or_relations() {
+    let store = store();
+    let (record, first_claim) = claimed_projection(&store, "stale-all-projections", 100, 10);
+    let current_claim = store
+        .claim_next_evidence(&["claude-code"], 110, 60)
+        .unwrap()
+        .unwrap();
+    let current_completion = evidence_completion(
+        &current_claim,
+        PublishedEvidence::Ready,
+        "{\"new\":true}".into(),
+    );
+    let current_relations = [RelationRecord {
+        kind: RelationKind::Subagent,
+        related_id: "new-child".into(),
+        label: Some("New child".into()),
+    }];
+    assert!(
+        store
+            .publish_projections(&record, None, &current_completion, &current_relations)
+            .unwrap()
+    );
+    let analysis_before = store.analysis(&record.key).unwrap();
+    let evidence_before = store.evidence(&record.key).unwrap();
+    let relations_before = store.relations(&record.key).unwrap();
+    let mut stale_record = record.clone();
+    stale_record.model_breakdown_json = "{\"old\":true}".into();
+    let stale_completion = evidence_completion(
+        &first_claim,
+        PublishedEvidence::Ready,
+        "{\"old\":true}".into(),
+    );
+    let stale_relations = [RelationRecord {
+        kind: RelationKind::Subagent,
+        related_id: "old-child".into(),
+        label: Some("Old child".into()),
+    }];
+
+    assert!(
+        !store
+            .publish_projections(&stale_record, None, &stale_completion, &stale_relations)
+            .unwrap()
+    );
+    assert_eq!(store.analysis(&record.key).unwrap(), analysis_before);
+    assert_eq!(store.evidence(&record.key).unwrap(), evidence_before);
+    assert_eq!(store.relations(&record.key).unwrap(), relations_before);
+}
+
+#[test]
+fn publication_replaces_subagent_relations_in_one_transaction() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "relation-publication", 100, 60);
+    store
+        .replace_relations(
+            &record.key,
+            RelationKind::ForkParent,
+            &[RelationRecord {
+                kind: RelationKind::ForkParent,
+                related_id: "fork-parent".into(),
+                label: None,
+            }],
+        )
+        .unwrap();
+    store
+        .replace_relations(
+            &record.key,
+            RelationKind::Subagent,
+            &[RelationRecord {
+                kind: RelationKind::Subagent,
+                related_id: "old-child".into(),
+                label: None,
+            }],
+        )
+        .unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let new_relations = [RelationRecord {
+        kind: RelationKind::Subagent,
+        related_id: "new-child".into(),
+        label: Some("New child".into()),
+    }];
+
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &new_relations)
+            .unwrap()
+    );
+    assert_eq!(
+        store.relations(&record.key).unwrap(),
+        vec![
+            RelationRecord {
+                kind: RelationKind::ForkParent,
+                related_id: "fork-parent".into(),
+                label: None,
+            },
+            new_relations[0].clone(),
+        ]
+    );
+}
+
+#[test]
 fn deleting_a_session_removes_its_session_evidence() {
     let store = store();
     let mut record = session("delete-evidence", 1_000);
     record.source_fingerprint = Some("sv1:delete".into());
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     assert!(store.evidence(&record.key).unwrap().is_some());
 
@@ -2109,7 +2456,9 @@ fn clearing_local_session_data_removes_every_session_evidence_row() {
     first.source_fingerprint = Some("sv1:clear-one".into());
     let mut second = session("clear-evidence-two", 1_000);
     second.source_fingerprint = Some("sv1:clear-two".into());
-    store.upsert_sessions(&[first, second]).unwrap();
+    store
+        .upsert_sessions(&[first, second], &crate::agents::evidence_cohort())
+        .unwrap();
 
     assert_eq!(store.clear_local_session_data().unwrap(), 2);
 
@@ -2142,7 +2491,7 @@ fn a_session_evidence_payload_round_trips_through_the_store() {
 
     assert!(
         store
-            .publish_projections(&record, None, &completion)
+            .publish_projections(&record, None, &completion, &[])
             .unwrap()
     );
 
@@ -2163,10 +2512,15 @@ fn started_at_epoch_stays_null_through_scan_upserts() {
     let mut record = session("no-start", 1_000);
     record.source_fingerprint = Some("sv1:first".to_string());
     store
-        .upsert_sessions(std::slice::from_ref(&record))
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
     record.source_fingerprint = Some("sv1:second".to_string());
-    store.upsert_sessions(&[record]).unwrap();
+    store
+        .upsert_sessions(&[record], &crate::agents::evidence_cohort())
+        .unwrap();
 
     let state = store
         .session_source_state(&key)


### PR DESCRIPTION
This is part of a PR stack based at the GH-70 base PR; this PR merges into `main`.

## What this seam contains

Processing decoupled from scan by a restart-safe durable worker. Seam plan: `.seams/GH-70/0012-CH-008-durable-evidence-worker-plan.md`. Report: `.seams/GH-70/0012-CH-008-durable-evidence-worker-shipped-report.md`.

## Why this piece was done

CH-008 needs the first production caller of the CH-007 durable queue. Antiburn gains a background worker that reads Claude transcripts after a scan commits, instead of reading them inside the scan pass. The worker becomes the only code path that stores Claude cost and time figures, and it writes the new per-session evidence record beside those figures in one database transaction, so the two can never disagree.

## What it changes

- A scan finishes sooner, because reading Claude transcripts no longer happens inside it. The figures themselves do not change.
- When the worker finishes a session it announces that one row on the event the session list already uses, so an on-screen list updates without a re-query.
- Opening a Claude session still computes and shows its figures, but no longer saves them — the worker does that.
- Two stored behaviors change: a terminal evidence failure is now stamped with the generation it failed on, so launches stop requeuing it forever; a source that vanished and came back is requeued even when its fingerprint is unchanged.
- On the first launch after this ships, the worker works through the existing Claude back catalogue once, one session at a time, announcing each session as it completes.

Four things this seam does **not** deliver: a quit mid-pass persists nothing; the announcement updates only a row already in the on-screen list; no new pane, status surface or number is added, and no `apps/desktop/src` file is touched; the unsupported-schema outcome is implemented and tested but has no reachable production trigger for the Claude cohort.

## How to review

Read order: `insights_worker.rs` (worker loop, claim lifecycle, permits, lease renewal), `store/mod.rs` (publishing under fence, fenced relation replacement, reconcile changes), `analysis.rs` (evidence outcomes, signal lifecycle), `scan.rs` (wake after commit, top_up_analysis skip), `commands.rs` (detail command stops persisting), `lib.rs` (startup registration).

The risky change is that stored Claude projections get a single writer under a claim fence: `scan.rs:top_up_analysis` and `commands.rs:get_session_analysis` no longer persist Claude metrics or sub-agent relations. `insights_worker::apply_outcome` publishes metrics, evidence and relations through one fence-guarded `Store::publish_projections` transaction. Blast radius: which path stores Claude metrics, when it runs, the sub-agent relation rows it rewrites, the `session_evidence` rows it fills, and when the session-entry-changed event fires.

<details>
<summary>Carried plan-review notes (two divergences from plan)</summary>

1. **Plan-review note 3 is deliberately unsatisfied.** The plan asked to remove `lib.rs:pub use store::Store`. It stays, with its TODO now pointing at CH-012, because removing it would strand `Store::evidence`, `evidence_from_row`, `EvidenceStatus`, `EvidenceStatus::as_str`, `EvidenceRow` (CH-012) and `PublishedEvidence::Unsupported` (CH-009) with no production caller. No `#[allow(dead_code)]` or `#[allow(deprecated)]` was used anywhere in this seam's diff.

2. **c4's recorded evidence detail.** The evidence run `0012-c4-exact-20260826T002734Z-2996` is complete and current (exit 0), but its `executed:` label is a wrapper script path `/tmp/c4-exact-command.sh` rather than the plan's byte-exact criterion string. This is an accepted `seams` CLI limitation: the criterion is recorded exactly as specified in the plan and evidence integrity is verified; the evidence file references may show a wrapper used by the verification harness.

</details>

**Review hotspots** — entity-level risk triage of this PR's diff (Medium 8 / High 0 / Critical 0; source entities only). Read these first:

| Entity | File | Risk (score) | Signals |
|---|---|---|---|
| `Store::publish_projections` (fn, new) | [`apps/desktop/src-tauri/src/store/mod.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e) | High (0.85) | new fenced transaction · claims and publication · blast 4 |
| `insights_worker` (mod, new) | [`apps/desktop/src-tauri/src/insights_worker.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-c1f2e9d7c1f2e9d7c1f2e9d7c1f2e9d7c1f2e9d7) | High (0.72) | runtime lifecycle · worker loop · per-claim signals · structural |
| `top_up_analysis` (fn, modified) | [`apps/desktop/src-tauri/src/scan.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-d3e4f5g6d3e4f5g6d3e4f5g6d3e4f5g6d3e4f5) | Medium (0.58) | evidence cohort skip · no longer persists Claude metrics |
| `get_session_analysis` (fn, modified) | [`apps/desktop/src-tauri/src/commands.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-a8b9c0d1a8b9c0d1a8b9c0d1a8b9c0d1a8b9c0) | Medium (0.52) | detail view no longer persists · worker becomes sole writer |
| `reconcile_evidence_revisions` (fn, modified) | [`apps/desktop/src-tauri/src/store/mod.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e) | Medium (0.48) | terminal failure stamping · generation-aware requeue logic |
| `PassSignal` (struct, new) | [`apps/desktop/src-tauri/src/analysis.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-e5f6g7h8e5f6g7h8e5f6g7h8e5f6g7h8) | Medium (0.45) | per-claim progress and cancel · lease renewal driver |
| `analyze_for_evidence` (fn, modified) | [`apps/desktop/src-tauri/src/analysis.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-e5f6g7h8e5f6g7h8e5f6g7h8e5f6g7h8) | Medium (0.42) | evidence outcomes · signal ownership across spawn_blocking |
| `claim_next_evidence` (fn, modified) | [`apps/desktop/src-tauri/src/store/mod.rs`](https://github.com/antiburn/antiburn/pull/193/files#diff-f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e06f8c8d8e) | Medium (0.39) | cohort gating · fence increment on reclaim |
