### PR TITLE
feat(desktop): respect OS Focus and Do Not Disturb for automated notifications

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -150,14 +150,21 @@ dependencies = [
 name = "antiburn-nudge"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "core-foundation",
  "core-graphics",
+ "gio",
  "gtk",
+ "objc2",
+ "objc2-foundation",
+ "objc2-intents",
+ "objc2-user-notifications",
  "serde",
  "tauri",
  "tauri-nspanel",
  "tracing",
  "windows 0.62.2",
+ "zbus",
 ]
 
 [[package]]
@@ -2933,6 +2940,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-intents"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fac082e6de12282b24ea745e9707cd374363c7ae0b2f813bf1813cfc289325"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +3036,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
+ "bitflags 2.13.1",
+ "block2",
  "objc2",
  "objc2-foundation",
 ]

--- a/apps/desktop/src-tauri/Entitlements.plist
+++ b/apps/desktop/src-tauri/Entitlements.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Signed into the macOS bundle by tauri-bundler (bundle.macOS.entitlements).
+
+  The communication-notifications entitlement is what lets a signed antiburn
+  ask macOS whether Focus applies to it (INFocusStatusCenter). Without the
+  entitlement the query has no value, the notification gate reads Unknown,
+  and delivery fails open. Unbundled development builds skip the query
+  entirely; see the antiburn-nudge gate module.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -14,6 +14,10 @@
   each one says what antiburn looks for and what it does not do with it. They
   are deliberately narrow: antiburn asks for these folders only because a
   coding agent recorded a session in one.
+
+  The Focus status usage description follows the same rule. antiburn reads
+  the Focus status for one decision only: do not show an automated
+  notification while Focus or Do Not Disturb is on.
 -->
 <plist version="1.0">
   <dict>
@@ -25,5 +29,7 @@
     <string>antiburn looks for the git repositories your coding agents worked in. It reads repository names and locations only, and nothing leaves this Mac.</string>
     <key>NSDownloadsFolderUsageDescription</key>
     <string>antiburn looks for the git repositories your coding agents worked in. It reads repository names and locations only, and nothing leaves this Mac.</string>
+    <key>NSFocusStatusUsageDescription</key>
+    <string>antiburn uses this only to keep its notifications quiet while Focus is on. Nothing leaves this Mac.</string>
   </dict>
 </plist>

--- a/apps/desktop/src-tauri/crates/nudge/Cargo.lock
+++ b/apps/desktop/src-tauri/crates/nudge/Cargo.lock
@@ -45,15 +45,22 @@ dependencies = [
 name = "antiburn-nudge"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "core-foundation",
  "core-graphics",
+ "gio",
  "gtk",
+ "objc2",
+ "objc2-foundation",
+ "objc2-intents",
+ "objc2-user-notifications",
  "serde",
  "serde_json",
  "tauri",
  "tauri-nspanel",
  "tracing",
  "windows 0.62.2",
+ "zbus",
 ]
 
 [[package]]
@@ -61,6 +68,137 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "atk"
@@ -155,6 +293,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -344,6 +495,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -748,6 +908,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +949,36 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -884,6 +1101,19 @@ name = "futures-io"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1238,6 +1468,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1748,6 +1984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2302,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-intents"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fac082e6de12282b24ea745e9707cd374363c7ae0b2f813bf1813cfc289325"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2362,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
+ "bitflags 2.13.1",
+ "block2",
  "objc2",
  "objc2-foundation",
 ]
@@ -2140,6 +2395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2428,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2259,6 +2530,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2583,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2553,6 +2849,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2831,6 +3140,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3309,6 +3628,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,6 +4006,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4544,6 +4887,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,3 +5015,44 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
+]

--- a/apps/desktop/src-tauri/crates/nudge/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/nudge/Cargo.toml
@@ -39,19 +39,38 @@ tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "a3122e
 # rather than always on the primary display.
 core-foundation = "0.10"
 core-graphics = "0.25"
+# The Focus/DND gate reads `INFocusStatusCenter` before an automated nudge
+# shows, so a notification does not interrupt Focus. UserNotifications carries
+# the modern authorization request the Focus status depends on. The feature
+# lists name the exact types gate.rs touches. Versions match the shell's
+# objc2 family, so this adds no second copy.
+block2 = "0.6"
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = ["NSError"] }
+objc2-intents = { version = "0.3", default-features = false, features = ["INFocusStatus", "INFocusStatusCenter", "block2"] }
+objc2-user-notifications = { version = "0.3", default-features = false, features = ["UNUserNotificationCenter", "block2"] }
 
 [target.'cfg(windows)'.dependencies]
 # `ShowWindow(SW_SHOWNOACTIVATE)` on the notification's HWND, so revealing it
 # never activates the window or pulls key focus from the user's frontmost app.
 # Version matches what `tauri`'s own `hwnd()` returns (`windows::Win32::Foundation::HWND`),
 # so this doesn't add a second incompatible copy of the `windows` crate.
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+# Shell and Registry carry the Focus/DND gate's probes:
+# `SHQueryUserNotificationState` for fullscreen/presentation/locked states and
+# one registry read for the global toasts switch.
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_System_Registry", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # `gtk_window.set_focus_on_map(false)` before showing the notification, so it
 # never takes input focus from the user's frontmost app. Version matches what
 # `tauri` itself pulls in for `gtk_window()`, so this doesn't add a second copy.
 gtk = { version = "0.18", features = ["v3_24"] }
+# The Focus/DND gate reads GNOME's `show-banners` setting through gio (the
+# same GLib family as gtk 0.18) and Plasma's `Inhibited` property over a
+# bounded, no-auto-start D-Bus call through zbus. Both probes run on demand
+# and hold no connection at idle.
+gio = "0.18"
+zbus = "5"
 
 [dev-dependencies]
 serde_json = "1"

--- a/apps/desktop/src-tauri/crates/nudge/src/gate.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/gate.rs
@@ -1,0 +1,600 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Best-effort OS interruption gate for automated nudges.
+//!
+//! Each platform probe maps its failures to [`NotificationGateState::Unknown`].
+//! Delivery fails open in that state, with bounded diagnostics, so a broken
+//! desktop integration cannot silence notifications forever.
+//!
+//! The gate keeps no resident state between probes. Each query runs on demand,
+//! immediately before one automated nudge shows, and retains nothing after it
+//! returns. Do not replace this with an observer or a cached listener: the app
+//! idles in the menu bar, and its resting footprint must not grow.
+
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+const UNKNOWN_LOG_LIMIT: u8 = 3;
+
+/// The operating system's current willingness to accept an automated nudge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationGateState {
+    Allowed,
+    Suppressed,
+    Unknown,
+}
+
+/// Queries the current platform immediately before automated nudge delivery.
+pub struct NotificationGate {
+    authorization_initialized: AtomicBool,
+    unknown_logs: AtomicU8,
+}
+
+impl Default for NotificationGate {
+    fn default() -> Self {
+        Self {
+            authorization_initialized: AtomicBool::new(false),
+            unknown_logs: AtomicU8::new(0),
+        }
+    }
+}
+
+impl NotificationGate {
+    /// Query the platform's current notification-interruption state.
+    pub fn state(&self) -> NotificationGateState {
+        platform_state()
+    }
+
+    /// Whether an automated nudge may be delivered now.
+    ///
+    /// The unknown state permits delivery on purpose. Only the first few
+    /// unknown results write a log line, so an absent desktop service cannot
+    /// flood the log.
+    pub fn delivery_allowed(&self) -> bool {
+        self.delivery_allowed_for(self.state())
+    }
+
+    fn delivery_allowed_for(&self, state: NotificationGateState) -> bool {
+        match state {
+            NotificationGateState::Allowed => true,
+            NotificationGateState::Suppressed => false,
+            NotificationGateState::Unknown => {
+                if self
+                    .unknown_logs
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                        (count < UNKNOWN_LOG_LIMIT).then_some(count + 1)
+                    })
+                    .is_ok()
+                {
+                    tracing::debug!(
+                        event = "nudge_notification_gate_unknown",
+                        "OS notification state unavailable; allowing automated nudge"
+                    );
+                }
+                true
+            }
+        }
+    }
+
+    /// Start the platform authorization needed to query interruption state.
+    ///
+    /// macOS can show its Focus-status authorization prompt here. The request
+    /// runs at most once per process, and only when the app tells the gate
+    /// that the notification preference is enabled. Other platforms need no
+    /// authorization, so this is a no-op there.
+    pub fn initialize_authorization(&self) {
+        let first_request = self
+            .authorization_initialized
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok();
+
+        #[cfg(target_os = "macos")]
+        if first_request {
+            macos::initialize_authorization();
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        let _ = first_request;
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn platform_state() -> NotificationGateState {
+    macos::state()
+}
+
+#[cfg(windows)]
+fn platform_state() -> NotificationGateState {
+    windows::state()
+}
+
+#[cfg(target_os = "linux")]
+fn platform_state() -> NotificationGateState {
+    linux::state()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn platform_state() -> NotificationGateState {
+    NotificationGateState::Unknown
+}
+
+#[cfg(any(test, target_os = "macos"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MacAuthorization {
+    Authorized,
+    NotDetermined,
+    Restricted,
+    Denied,
+    Unknown,
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn macos_state(authorization: MacAuthorization, is_focused: Option<bool>) -> NotificationGateState {
+    match (authorization, is_focused) {
+        (MacAuthorization::Authorized, Some(true)) => NotificationGateState::Suppressed,
+        (MacAuthorization::Authorized, Some(false)) => NotificationGateState::Allowed,
+        _ => NotificationGateState::Unknown,
+    }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn macos_app_bundle_executable(path: &std::path::Path) -> bool {
+    let Some(mac_os_dir) = path.parent() else {
+        return false;
+    };
+    let Some(contents_dir) = mac_os_dir.parent() else {
+        return false;
+    };
+    let Some(app_bundle) = contents_dir.parent() else {
+        return false;
+    };
+    mac_os_dir.file_name() == Some(std::ffi::OsStr::new("MacOS"))
+        && contents_dir.file_name() == Some(std::ffi::OsStr::new("Contents"))
+        && app_bundle.extension() == Some(std::ffi::OsStr::new("app"))
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use block2::RcBlock;
+    use objc2::runtime::Bool;
+    use objc2_foundation::NSError;
+    use objc2_intents::{
+        INFocusStatusAuthorizationStatus as AuthorizationStatus, INFocusStatusCenter,
+    };
+    use objc2_user_notifications::{UNAuthorizationOptions, UNUserNotificationCenter};
+
+    use super::{
+        MacAuthorization, NotificationGateState, macos_app_bundle_executable, macos_state,
+    };
+
+    fn authorization(raw: AuthorizationStatus) -> MacAuthorization {
+        if raw == AuthorizationStatus::Authorized {
+            MacAuthorization::Authorized
+        } else if raw == AuthorizationStatus::NotDetermined {
+            MacAuthorization::NotDetermined
+        } else if raw == AuthorizationStatus::Restricted {
+            MacAuthorization::Restricted
+        } else if raw == AuthorizationStatus::Denied {
+            MacAuthorization::Denied
+        } else {
+            MacAuthorization::Unknown
+        }
+    }
+
+    pub(super) fn state() -> NotificationGateState {
+        // SAFETY: Intents.framework is available on the app's macOS 13 minimum.
+        // The generated bindings keep Objective-C ownership, and every returned
+        // object stays retained for the duration of this query.
+        unsafe {
+            let center = INFocusStatusCenter::defaultCenter();
+            let authorization = authorization(center.authorizationStatus());
+            let focused = (authorization == MacAuthorization::Authorized)
+                .then(|| center.focusStatus().isFocused())
+                .flatten()
+                .map(|value| value.boolValue());
+            macos_state(authorization, focused)
+        }
+    }
+
+    fn request_focus_authorization() {
+        // SAFETY: The completion block has an Objective-C-compatible signature,
+        // and Intents.framework copies it for the asynchronous request.
+        unsafe {
+            let center = INFocusStatusCenter::defaultCenter();
+            if center.authorizationStatus() != AuthorizationStatus::NotDetermined {
+                return;
+            }
+            let completion = RcBlock::new(move |status: AuthorizationStatus| {
+                tracing::debug!(
+                    event = "nudge_focus_authorization_completed",
+                    status = status.0
+                );
+            });
+            center.requestAuthorizationWithCompletionHandler(Some(&completion));
+        }
+    }
+
+    pub(super) fn initialize_authorization() {
+        // UserNotifications raises an Objective-C exception (which Rust cannot
+        // catch) when the unbundled binary from `tauri dev` calls
+        // `currentNotificationCenter`. Such a binary also lacks the signed
+        // communication entitlement, so skip the query and fail open.
+        let Ok(executable) = std::env::current_exe() else {
+            tracing::debug!(event = "nudge_authorization_executable_unknown");
+            return;
+        };
+        if !macos_app_bundle_executable(&executable) {
+            tracing::debug!(
+                event = "nudge_authorization_skipped_unbundled",
+                executable = %executable.display()
+            );
+            return;
+        }
+
+        // The Focus status has a value only after both User Notifications and
+        // Focus-status authorization. Ask for the modern notification
+        // authorization first, then request Focus authorization from its
+        // completion, so macOS never has to show two permission sheets at the
+        // same time.
+        let center = UNUserNotificationCenter::currentNotificationCenter();
+        let completion = RcBlock::new(move |granted: Bool, error: *mut NSError| {
+            tracing::debug!(
+                event = "nudge_notification_authorization_completed",
+                granted = granted.as_bool(),
+                error = !error.is_null()
+            );
+            request_focus_authorization();
+        });
+        center.requestAuthorizationWithOptions_completionHandler(
+            UNAuthorizationOptions::Alert,
+            &completion,
+        );
+    }
+}
+
+#[cfg(any(test, windows))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowsProbe<T> {
+    Value(T),
+    Missing,
+    Failed,
+}
+
+#[cfg(any(test, windows))]
+fn windows_state(
+    shell_state: WindowsProbe<i32>,
+    global_toasts: WindowsProbe<u32>,
+) -> NotificationGateState {
+    if matches!(global_toasts, WindowsProbe::Value(0)) {
+        return NotificationGateState::Suppressed;
+    }
+    match shell_state {
+        // QUNS_ACCEPTS_NOTIFICATIONS
+        WindowsProbe::Value(5) => NotificationGateState::Allowed,
+        WindowsProbe::Value(_) => NotificationGateState::Suppressed,
+        WindowsProbe::Missing | WindowsProbe::Failed => NotificationGateState::Unknown,
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_SUCCESS};
+    use windows::Win32::System::Registry::{HKEY_CURRENT_USER, RRF_RT_REG_DWORD, RegGetValueW};
+    use windows::Win32::UI::Shell::SHQueryUserNotificationState;
+    use windows::core::w;
+
+    use super::{NotificationGateState, WindowsProbe, windows_state};
+
+    fn global_toasts() -> WindowsProbe<u32> {
+        let mut value = 0_u32;
+        let mut size = std::mem::size_of::<u32>() as u32;
+        // SAFETY: Both strings are static UTF-16 values. `value` and `size`
+        // point to writable storage of the sizes passed to RegGetValueW.
+        let result = unsafe {
+            RegGetValueW(
+                HKEY_CURRENT_USER,
+                w!("Software\\Microsoft\\Windows\\CurrentVersion\\Notifications\\Settings"),
+                w!("NOC_GLOBAL_SETTING_TOASTS_ENABLED"),
+                RRF_RT_REG_DWORD,
+                None,
+                Some((&mut value as *mut u32).cast()),
+                Some(&mut size),
+            )
+        };
+        if result == ERROR_SUCCESS {
+            WindowsProbe::Value(value)
+        } else if result == ERROR_FILE_NOT_FOUND || result == ERROR_PATH_NOT_FOUND {
+            WindowsProbe::Missing
+        } else {
+            WindowsProbe::Failed
+        }
+    }
+
+    pub(super) fn state() -> NotificationGateState {
+        // SAFETY: SHQueryUserNotificationState takes no caller-owned pointers;
+        // the generated wrapper turns HRESULT failure into Result::Err.
+        let shell = unsafe { SHQueryUserNotificationState() }
+            .map(|state| WindowsProbe::Value(state.0))
+            .unwrap_or(WindowsProbe::Failed);
+        windows_state(shell, global_toasts())
+    }
+}
+
+#[cfg(any(test, target_os = "linux"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinuxProbe<T> {
+    Value(T),
+    Missing,
+    Malformed,
+    TimedOut,
+    Failed,
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn linux_state(
+    gnome_banners: LinuxProbe<bool>,
+    plasma_inhibited: LinuxProbe<bool>,
+) -> NotificationGateState {
+    if matches!(gnome_banners, LinuxProbe::Value(false))
+        || matches!(plasma_inhibited, LinuxProbe::Value(true))
+    {
+        NotificationGateState::Suppressed
+    } else if matches!(gnome_banners, LinuxProbe::Value(true))
+        || matches!(plasma_inhibited, LinuxProbe::Value(false))
+    {
+        NotificationGateState::Allowed
+    } else {
+        NotificationGateState::Unknown
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use gio::prelude::SettingsExt;
+    use zbus::blocking::{Proxy, connection};
+    use zbus::proxy::MethodFlags;
+    use zbus::zvariant::OwnedValue;
+
+    use super::{LinuxProbe, NotificationGateState, linux_state};
+
+    const PLASMA_TIMEOUT: Duration = Duration::from_millis(150);
+    static PLASMA_PROBE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+    fn gnome_banners() -> LinuxProbe<bool> {
+        let Some(source) = gio::SettingsSchemaSource::default() else {
+            return LinuxProbe::Missing;
+        };
+        let Some(schema) = source.lookup("org.gnome.desktop.notifications", true) else {
+            return LinuxProbe::Missing;
+        };
+        if !schema.has_key("show-banners") {
+            return LinuxProbe::Missing;
+        }
+        let settings = gio::Settings::new_full(&schema, None::<&gio::SettingsBackend>, None);
+        LinuxProbe::Value(settings.boolean("show-banners"))
+    }
+
+    fn classify_error(error: &zbus::Error) -> LinuxProbe<bool> {
+        let message = error.to_string().to_ascii_lowercase();
+        if message.contains("timed out") || message.contains("timeout") {
+            LinuxProbe::TimedOut
+        } else if message.contains("namehasnoowner")
+            || message.contains("serviceunknown")
+            || message.contains("no such")
+        {
+            LinuxProbe::Missing
+        } else {
+            LinuxProbe::Failed
+        }
+    }
+
+    fn plasma_inhibited_blocking() -> LinuxProbe<bool> {
+        let connection = match connection::Builder::session()
+            .map(|builder| builder.method_timeout(PLASMA_TIMEOUT))
+            .and_then(connection::Builder::build)
+        {
+            Ok(connection) => connection,
+            Err(error) => return classify_error(&error),
+        };
+        let proxy = match Proxy::new(
+            &connection,
+            "org.freedesktop.Notifications",
+            "/org/freedesktop/Notifications",
+            "org.freedesktop.DBus.Properties",
+        ) {
+            Ok(proxy) => proxy,
+            Err(error) => return classify_error(&error),
+        };
+        let reply: Option<OwnedValue> = match proxy.call_with_flags(
+            "Get",
+            MethodFlags::NoAutoStart.into(),
+            &("org.freedesktop.Notifications", "Inhibited"),
+        ) {
+            Ok(reply) => reply,
+            Err(error) => return classify_error(&error),
+        };
+        let Some(value) = reply else {
+            return LinuxProbe::Malformed;
+        };
+        bool::try_from(value)
+            .map(LinuxProbe::Value)
+            .unwrap_or(LinuxProbe::Malformed)
+    }
+
+    fn plasma_inhibited() -> LinuxProbe<bool> {
+        // `Proxy::call_with_flags` bypasses the connection-level method
+        // timeout in zbus, so a worker bounds the whole operation, including
+        // the bus connection. If a broken bus never returns, keep at most one
+        // worker and fail later probes open, so blocked threads do not
+        // accumulate.
+        if PLASMA_PROBE_IN_FLIGHT
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return LinuxProbe::TimedOut;
+        }
+
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let worker = std::thread::Builder::new()
+            .name("antiburn-plasma-notification-probe".to_string())
+            .spawn(move || {
+                let result = plasma_inhibited_blocking();
+                PLASMA_PROBE_IN_FLIGHT.store(false, Ordering::Release);
+                let _ = sender.send(result);
+            });
+        if worker.is_err() {
+            PLASMA_PROBE_IN_FLIGHT.store(false, Ordering::Release);
+            return LinuxProbe::Failed;
+        }
+
+        receiver
+            .recv_timeout(PLASMA_TIMEOUT)
+            .unwrap_or(LinuxProbe::TimedOut)
+    }
+
+    pub(super) fn state() -> NotificationGateState {
+        let desktop = std::env::var("XDG_CURRENT_DESKTOP")
+            .unwrap_or_default()
+            .to_ascii_uppercase();
+        if desktop.contains("GNOME") || desktop.contains("UNITY") {
+            linux_state(gnome_banners(), LinuxProbe::Missing)
+        } else if desktop.contains("KDE") || desktop.contains("PLASMA") {
+            linux_state(LinuxProbe::Missing, plasma_inhibited())
+        } else {
+            NotificationGateState::Unknown
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macos_active_inactive_and_unauthorized_states() {
+        assert_eq!(
+            macos_state(MacAuthorization::Authorized, Some(true)),
+            NotificationGateState::Suppressed
+        );
+        assert_eq!(
+            macos_state(MacAuthorization::Authorized, Some(false)),
+            NotificationGateState::Allowed
+        );
+        for authorization in [
+            MacAuthorization::NotDetermined,
+            MacAuthorization::Restricted,
+            MacAuthorization::Denied,
+            MacAuthorization::Unknown,
+        ] {
+            assert_eq!(
+                macos_state(authorization, None),
+                NotificationGateState::Unknown
+            );
+        }
+        assert_eq!(
+            macos_state(MacAuthorization::Authorized, None),
+            NotificationGateState::Unknown
+        );
+    }
+
+    #[test]
+    fn macos_authorization_requires_an_app_bundle_executable() {
+        assert!(macos_app_bundle_executable(std::path::Path::new(
+            "/Applications/antiburn.app/Contents/MacOS/antiburn"
+        )));
+        assert!(!macos_app_bundle_executable(std::path::Path::new(
+            "/work/apps/desktop/src-tauri/target/debug/antiburn"
+        )));
+        assert!(!macos_app_bundle_executable(std::path::Path::new(
+            "/Applications/antiburn.app/antiburn"
+        )));
+    }
+
+    #[test]
+    fn every_windows_notification_state_is_mapped() {
+        for raw in [1, 2, 3, 4, 6, 7] {
+            assert_eq!(
+                windows_state(WindowsProbe::Value(raw), WindowsProbe::Missing),
+                NotificationGateState::Suppressed,
+                "QUNS state {raw} must suppress"
+            );
+        }
+        assert_eq!(
+            windows_state(WindowsProbe::Value(5), WindowsProbe::Missing),
+            NotificationGateState::Allowed
+        );
+        assert_eq!(
+            windows_state(WindowsProbe::Failed, WindowsProbe::Missing),
+            NotificationGateState::Unknown
+        );
+    }
+
+    #[test]
+    fn windows_global_toast_setting_is_fail_open_except_explicit_zero() {
+        assert_eq!(
+            windows_state(WindowsProbe::Value(5), WindowsProbe::Value(0)),
+            NotificationGateState::Suppressed
+        );
+        assert_eq!(
+            windows_state(WindowsProbe::Value(5), WindowsProbe::Value(1)),
+            NotificationGateState::Allowed
+        );
+        assert_eq!(
+            windows_state(WindowsProbe::Value(5), WindowsProbe::Missing),
+            NotificationGateState::Allowed
+        );
+        assert_eq!(
+            windows_state(WindowsProbe::Failed, WindowsProbe::Failed),
+            NotificationGateState::Unknown
+        );
+    }
+
+    #[test]
+    fn linux_gnome_and_plasma_states_are_mapped() {
+        assert_eq!(
+            linux_state(LinuxProbe::Value(false), LinuxProbe::Missing),
+            NotificationGateState::Suppressed
+        );
+        assert_eq!(
+            linux_state(LinuxProbe::Value(true), LinuxProbe::Missing),
+            NotificationGateState::Allowed
+        );
+        assert_eq!(
+            linux_state(LinuxProbe::Missing, LinuxProbe::Value(true)),
+            NotificationGateState::Suppressed
+        );
+        assert_eq!(
+            linux_state(LinuxProbe::Missing, LinuxProbe::Value(false)),
+            NotificationGateState::Allowed
+        );
+    }
+
+    #[test]
+    fn linux_missing_malformed_timeout_and_failure_states_fail_open() {
+        for unavailable in [
+            LinuxProbe::Missing,
+            LinuxProbe::Malformed,
+            LinuxProbe::TimedOut,
+            LinuxProbe::Failed,
+        ] {
+            assert_eq!(
+                linux_state(unavailable, unavailable),
+                NotificationGateState::Unknown
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_state_allows_delivery() {
+        let gate = NotificationGate::default();
+        for _ in 0..(UNKNOWN_LOG_LIMIT + 2) {
+            assert!(gate.delivery_allowed_for(NotificationGateState::Unknown));
+        }
+        assert_eq!(gate.unknown_logs.load(Ordering::Relaxed), UNKNOWN_LOG_LIMIT);
+    }
+}

--- a/apps/desktop/src-tauri/crates/nudge/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/lib.rs
@@ -26,6 +26,7 @@
 //! antiburn app, so there's no need to be generic over the runtime.
 
 pub mod commands;
+mod gate;
 mod geometry;
 #[cfg(target_os = "linux")]
 mod linux;
@@ -42,6 +43,7 @@ use std::time::Duration;
 
 use tauri::{AppHandle, Emitter, Manager};
 
+pub use gate::{NotificationGate, NotificationGateState};
 pub use model::{Nudge, NudgeAction, NudgeActionEvent, NudgeActionTarget, NudgeKind, NudgeTone};
 
 /// Register the platform support this crate needs while building the Tauri app.

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -401,6 +401,12 @@ fn apply_settings_transition(app: &tauri::AppHandle, previous: &AppSettings, sav
         crate::disk_monitor::refresh_title(app);
     }
 
+    // On macOS, the Focus-status authorization waits for a completed setup
+    // and the master notification switch. The function checks both itself,
+    // and repeat calls are free (the gate keeps a once-flag), so no
+    // transition edge needs to be computed here.
+    crate::notifications::maybe_initialize_authorization(app);
+
     // Consent changing is the queue's business: turning it off withdraws
     // whatever is already queued rather than merely pausing it, and destroys
     // the installation identifier so a later opt-in cannot be joined to this

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -233,6 +233,7 @@ pub fn run() {
             app.manage(settings::SettingsWindowState::default());
             app.manage(onboarding::OnboardingWindowState::default());
             app.manage(nudges::AnchorOverride::default());
+            app.manage(antiburn_nudge::NotificationGate::default());
 
             tray::create(app.handle())?;
             // After the tray, and on the main thread: the monitor reaches the
@@ -283,6 +284,10 @@ pub fn run() {
             // The notification window's manager and the chime player. The
             // webview itself is created only when policy delivers a nudge.
             nudges::init(app.handle())?;
+            // On macOS, ask for the Focus-status authorization when a
+            // completed setup already permits notifications. First runs wait:
+            // apply_settings_transition asks again when onboarding finishes.
+            notifications::maybe_initialize_authorization(app.handle());
             // The live-usage registry: the sources that can prove a
             // provider's own limit figures, and the milestone ledger they
             // feed. Registered before the schedulers so the first pass sees

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -28,6 +28,16 @@
 //! - **Only the shell posts one.** The webview is granted no notification
 //!   permission (`capabilities/default.json`), so "what is worth interrupting
 //!   someone for" is decided in one place, in this file.
+//! - **The operating system gets the last word** for automated kinds.
+//!   Immediately before an automated notification shows, [`deliver`] asks the
+//!   OS whether interruptions are welcome right now — Focus and Do Not Disturb
+//!   on macOS, fullscreen/presentation/toasts-off states on Windows, DND on
+//!   GNOME and Plasma ([`antiburn_nudge::NotificationGate`]). A suppressed
+//!   notification is dropped and its trigger stays consumed, so ending Focus
+//!   does not release a backlog of stale notifications. Unknown OS state fails
+//!   open. Preview kinds bypass the gate for the same reason they bypass the
+//!   master switch: the reader just asked to see them. See
+//!   `docs/os-notification-gating.md`.
 //!
 //! Delivery goes to antiburn's own notification window (the `antiburn-nudge`
 //! crate, via [`crate::nudges`]): the decisions above are ordinary functions
@@ -181,7 +191,34 @@ impl NotificationState {
     }
 }
 
+/// Who asked for this notification.
+///
+/// The OS interruption gate applies only to [`Delivery::Automated`]. A preview
+/// is the direct result of a button the reader pressed a moment earlier, so
+/// Focus or Do Not Disturb must not hide it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Delivery {
+    /// antiburn decided to speak. The OS gate can drop it.
+    Automated,
+    /// The reader asked to see it. The OS gate does not apply.
+    Preview,
+}
+
+/// Ask the OS whether an automated notification may interrupt right now.
+///
+/// A missing gate fails open: the gate is managed at setup, so its absence
+/// means a test harness, not a policy answer.
+fn os_gate_allows(app: &AppHandle) -> bool {
+    app.try_state::<antiburn_nudge::NotificationGate>()
+        .is_none_or(|gate| gate.delivery_allowed())
+}
+
 /// Build and hand off one approved nudge.
+///
+/// For [`Delivery::Automated`], the OS interruption gate runs here, last,
+/// after every preference and claim has already passed — so a suppressed
+/// notification is dropped with its bookkeeping consumed, and ending Focus
+/// cannot release it later.
 ///
 /// The id is unique per delivery — the view de-duplicates re-emitted events
 /// by id, so reusing one would make a genuinely new nudge look like an echo.
@@ -190,10 +227,15 @@ impl NotificationState {
 fn deliver(
     app: &AppHandle,
     kind: Kind,
+    delivery: Delivery,
     copy: NotificationCopy,
     extra_action: Option<(&str, &str)>,
     tone_override: Option<NudgeTone>,
 ) {
+    if delivery == Delivery::Automated && !os_gate_allows(app) {
+        tracing::debug!(event = "nudge_os_suppressed", ?kind);
+        return;
+    }
     static SEQUENCE: AtomicU64 = AtomicU64::new(0);
     let (nudge_kind, default_tone) = match kind {
         Kind::UpdateAvailable => (NudgeKind::UpdateAvailable, NudgeTone::Info),
@@ -365,6 +407,7 @@ pub fn note_scan_outcome(app: &AppHandle, status: &ScanStatus) {
     deliver(
         app,
         Kind::ScanFailure,
+        Delivery::Automated,
         scan_failure_message(error),
         Some(("review_sources", "Review sources")),
         None,
@@ -395,6 +438,7 @@ pub fn note_update_status(app: &AppHandle, status: &UpdateStatus) {
     deliver(
         app,
         Kind::UpdateAvailable,
+        Delivery::Automated,
         update_message(version),
         Some(("view", "View")),
         None,
@@ -402,8 +446,10 @@ pub fn note_update_status(app: &AppHandle, status: &UpdateStatus) {
 }
 
 /// Report low disk space. Returns whether the episode was consumed: `true`
-/// when delivered, `false` when suppressed by preference so the caller's
-/// trigger retries on its next tick (see [`crate::disk_monitor`]).
+/// when delivered — or when Focus/DND suppressed it, because a stale disk
+/// warning must not appear when Focus ends; the trigger re-arms only after
+/// free space recovers. `false` means suppressed by preference, so the
+/// caller's trigger retries on its next tick (see [`crate::disk_monitor`]).
 pub fn note_disk_space_low(app: &AppHandle, free_gb: u64, threshold_gb: u32) -> bool {
     if !enabled(app, Kind::DiskSpaceLow) {
         return false;
@@ -411,6 +457,7 @@ pub fn note_disk_space_low(app: &AppHandle, free_gb: u64, threshold_gb: u32) -> 
     deliver(
         app,
         Kind::DiskSpaceLow,
+        Delivery::Automated,
         disk_space_low_message(free_gb, threshold_gb),
         None,
         None,
@@ -420,6 +467,8 @@ pub fn note_disk_space_low(app: &AppHandle, free_gb: u64, threshold_gb: u32) -> 
 
 /// Report crossed milestones. Selection and dedup happen in the engine
 /// ([`crate::provider_usage::live`]); this only applies the preference gate.
+/// A crossing that Focus/DND suppresses stays consumed (`true`): the moment
+/// it described has passed, and it must not surface when Focus ends.
 pub fn note_usage_milestone(
     app: &AppHandle,
     content: &crate::provider_usage::live::MilestoneContent,
@@ -430,6 +479,7 @@ pub fn note_usage_milestone(
     deliver(
         app,
         Kind::UsageMilestone,
+        Delivery::Automated,
         usage_milestone_message(content),
         None,
         Some(usage_milestone_tone(content)),
@@ -449,6 +499,7 @@ pub fn note_menu_bar_home(app: &AppHandle) {
     deliver(
         app,
         Kind::MenuBarHome,
+        Delivery::Preview,
         menu_bar_home_message(),
         Some(("show", "Show me")),
         None,
@@ -459,7 +510,14 @@ pub fn note_menu_bar_home(app: &AppHandle) {
 /// the reader pressed the button — but is otherwise the same delivery path as
 /// every real kind, so what they see is what they will get.
 pub fn note_test(app: &AppHandle) {
-    deliver(app, Kind::Test, test_message(), None, None);
+    deliver(
+        app,
+        Kind::Test,
+        Delivery::Preview,
+        test_message(),
+        None,
+        None,
+    );
 }
 
 /// Post a sample of `kind` with representative figures, for copy work.
@@ -499,7 +557,32 @@ pub fn note_sample(app: &AppHandle, kind: Kind) {
         }
         Kind::Test => (test_message(), None, None),
     };
-    deliver(app, kind, copy, extra_action, tone);
+    deliver(app, kind, Delivery::Preview, copy, extra_action, tone);
+}
+
+/// Request the macOS Focus-status authorization, at most once per process.
+///
+/// The request runs only when setup is complete and the master notification
+/// preference is on, so the permission sheet cannot appear over the first-run
+/// window. Repeat calls are free: the gate keeps a once-flag. The other
+/// platforms need no authorization. The gate self-skips for unbundled dev
+/// binaries, which cannot hold the signed entitlement.
+pub fn maybe_initialize_authorization(app: &AppHandle) {
+    let ready = app
+        .try_state::<Store>()
+        .and_then(|store| store.settings().ok())
+        .is_some_and(|settings| settings.onboarding_completed && settings.notifications_enabled);
+    if !ready {
+        return;
+    }
+    let init_app = app.clone();
+    if let Err(error) = app.run_on_main_thread(move || {
+        if let Some(gate) = init_app.try_state::<antiburn_nudge::NotificationGate>() {
+            gate.initialize_authorization();
+        }
+    }) {
+        tracing::debug!(event = "nudge_authorization_dispatch_failed", %error);
+    }
 }
 
 /// The reader's preferences, read fresh, defaulting to *silence* when the store

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -36,6 +36,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
+      "entitlements": "Entitlements.plist",
       "minimumSystemVersion": "13.0",
       "dmg": {
         "background": "dmg/background.tiff",

--- a/docs/os-notification-gating.md
+++ b/docs/os-notification-gating.md
@@ -1,0 +1,126 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+# OS notification gating
+
+How antiburn decides not to show an automated notification while the operating
+system says interruptions are unwelcome — Focus and Do Not Disturb on macOS,
+fullscreen and presentation states on Windows, Do Not Disturb on GNOME and
+Plasma. Written for whoever next touches notification policy, because the two
+rules that matter most — *drop, never queue* and *fail open* — are invisible in
+any single function signature.
+
+The policy home is `apps/desktop/src-tauri/src/notifications.rs`; the OS probes
+live in the `antiburn-nudge` crate's gate module
+(`apps/desktop/src-tauri/crates/nudge/src/gate.rs`).
+
+## The problem this exists to solve
+
+antiburn's notification window is its own — not the system notification center —
+so Focus and Do Not Disturb do not apply to it automatically. Without a gate, a
+disk warning or a usage milestone can float over a presentation, a screen share,
+or a Focus session the reader set up precisely to avoid being interrupted.
+
+The obvious fix — defer suppressed notifications and release them when Focus
+ends — creates a second problem: a pile of stale notifications arriving the
+moment the reader turns Focus off, describing moments that have passed.
+
+So the two rules the whole design serves:
+
+1. **The OS gets the last word, and a suppressed notification is dropped.** The
+   gate runs last, after every preference and once-per-run claim has already
+   passed, so the trigger's bookkeeping stays consumed. Ending Focus releases
+   nothing.
+2. **Unknown state fails open.** A missing desktop service, a denied
+   authorization, or an API failure must never silently disable notifications
+   forever. When the OS cannot answer, antiburn delivers, and logs the fact at
+   most three times per run.
+
+## Who is gated
+
+Automated kinds — update available, scan failure, low disk space, usage
+milestone — ask the gate. Preview kinds bypass it for the same reason they
+bypass the master notification switch: they are the direct result of a button
+the reader pressed a moment earlier. That is the settings pane's test
+notification, the debug-only sample row, and the one-shot first-run
+menu-bar pointer.
+
+Consequences of drop semantics, per kind:
+
+- **Low disk space** — the episode is consumed. The warning returns only after
+  free space recovers past the re-arm threshold and then crosses below the
+  limit again (`disk_monitor.rs` hysteresis).
+- **Usage milestone** — the crossing stays recorded as delivered. The next
+  milestone step notifies as usual.
+- **Scan failure** — the once-per-run claim stays spent; the next run of the
+  app reports again if scans still fail.
+- **Update available** — the once-per-version claim stays spent; a *newer*
+  version still notifies.
+
+## Platform matrix
+
+| Platform | Suppresses when | Fails open when |
+|---|---|---|
+| macOS 13+ | `INFocusStatusCenter` is authorized and reports that Focus applies to antiburn | Authorization denied, restricted, or not determined; a `nil` Focus value; an unbundled dev binary (see below) |
+| Windows | `SHQueryUserNotificationState` reports anything other than `QUNS_ACCEPTS_NOTIFICATIONS`, or the `NOC_GLOBAL_SETTING_TOASTS_ENABLED` registry value is exactly zero | Missing registry value; API failure. Windows 11's own DND switch is not exposed by the supported API and is not detected |
+| GNOME | `org.gnome.desktop.notifications show-banners` is false | Missing schema or key |
+| Plasma | `org.freedesktop.Notifications` reports `Inhibited` = true | Missing service, malformed reply, or a 150 ms timeout on the bounded, no-auto-start D-Bus call |
+| Other desktops | never | always |
+
+If the reader adds antiburn to a Focus's Allowed Apps list, macOS reports that
+Focus does not apply to antiburn, and notifications behave as if Focus were
+off. That is the OS's answer, not a gap.
+
+## Idle cost: none
+
+Every probe runs on demand, immediately before one automated notification would
+show, and retains nothing afterward. There is no polling loop, no Focus-change
+observer, no cached D-Bus connection, and no worker thread at idle (the Plasma
+probe's bounded worker exists only for the duration of one query, at most one
+in flight). Do not "improve" this into a subscription model: antiburn idles in
+the menu bar, and its resting footprint must not grow.
+
+## Authorization (macOS)
+
+Reading the Focus status needs two authorizations — User Notifications, then
+Focus status — and the second prompt only means something after the first.
+antiburn requests them once per process, chained so macOS never shows two
+sheets at once, and only when setup is complete and the master notification
+preference is on. First runs never see the prompt over the onboarding window;
+`apply_settings_transition` asks again when onboarding finishes or the master
+switch turns on, and the gate's once-flag makes repeat calls free.
+
+A denied prompt is a fail-open state, not an error: notifications keep
+working, they just stop yielding to Focus. The reader can change their mind in
+System Settings → Focus.
+
+## The signed-bundle caveat
+
+Focus status is only available to a bundle with a stable identity, the
+communication-notifications entitlement (`Entitlements.plist`, wired through
+`bundle.macOS.entitlements`), and a signature macOS recognizes. Two
+consequences:
+
+- The unbundled binary `tauri dev` produces cannot even ask: UserNotifications
+  raises an Objective-C exception (which Rust cannot catch) for unbundled
+  callers, so the gate detects the layout and skips the query entirely.
+- A local ad-hoc-signed `.app` may show the permission dialog, but its answers
+  are not reliable evidence. **Test Focus behavior only with the signed CI
+  release artifact**, and use an automated trigger (low disk, a milestone) —
+  the test button bypasses the gate by design and proves nothing about
+  suppression.
+
+## Manual test recipe (signed build)
+
+1. Enable notifications, complete onboarding, and accept both authorization
+   prompts. Confirm the prompts appear once and never again.
+2. Turn on Do Not Disturb. Fire an automated trigger (lower the disk threshold
+   above current free space, or wait for a milestone). Nothing appears, and
+   nothing appears later when DND ends.
+3. Press the test button during DND. The test notification appears — previews
+   bypass the gate.
+4. Add antiburn to the Focus's Allowed Apps. Automated notifications appear
+   during that Focus.
+5. Deny the Focus authorization on a fresh install. Automated notifications
+   keep working (fail open).

--- a/docs/oss/source-allowlist.toml
+++ b/docs/oss/source-allowlist.toml
@@ -21,7 +21,7 @@ source_commit = "54c4a3bceda80558760a9ff6fc8bf7d04873b43f"
 # later authorized platform migration makes it canonical, version this manifest at the next source
 # review to record its exact reviewed commit while retaining Cadence provenance.
 intended_future_private_repository = "antiburn/antiburn-cloud"
-governance_decisions = ["D-001", "D-002", "D-003", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-014", "D-020", "D-021", "D-022", "D-023", "D-024", "D-026", "D-028", "D-029"]
+governance_decisions = ["D-001", "D-002", "D-003", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-014", "D-020", "D-021", "D-022", "D-023", "D-024", "D-026", "D-028", "D-029", "D-030"]
 default_action = "deny"
 publication_authorization = "authorized MPL-2.0 repository commit or merge; unresolved rights remain denied"
 third_party_resolution = "deferred until the public local-crate manifest and lockfile exist"
@@ -733,7 +733,7 @@ current_license = "Proprietary"
 intended_license = "MPL-2.0"
 notes = [
   "Keep the poll cadence, binary-GB arithmetic, edge trigger with re-arm hysteresis, launch seeding, and the rationale comments.",
-  "Rewrite the delivery function against the public notifications pipeline; do not copy popover parking, DeferredNudge, NotificationGate, or NudgeAccess entitlement gating.",
+  "Rewrite the delivery function against the public notifications pipeline; do not copy popover parking, DeferredNudge, or NudgeAccess entitlement gating. The NotificationGate check is separately authorized by rule focus-dnd-gate under D-030.",
   "Strip Cadence names, analytics calls, and private state types; add MPL-2.0 headers.",
 ]
 
@@ -788,8 +788,30 @@ current_license = "Proprietary"
 intended_license = "MPL-2.0"
 notes = [
   "Extract only the slim subset: window construction, placement geometry, show/replace/dismiss, auto-dismiss timing, and the view's tone/title/body/dismiss presentation.",
-  "Do not copy gate.rs (Focus/DND gate), popover parking, DeferredNudge, NudgeAccess entitlement, ambience/radar/tune-up kinds, cooldown telemetry, or analytics.",
+  "Do not copy popover parking, DeferredNudge, NudgeAccess entitlement, ambience/radar/tune-up kinds, cooldown telemetry, or analytics. gate.rs (Focus/DND gate) is separately authorized by rule focus-dnd-gate under D-030.",
   "Strip Cadence names and event names; add MPL-2.0 headers; route delivery through the public notifications module's gating.",
+]
+
+[[rule]]
+id = "focus-dnd-gate"
+source_paths = [
+  "desktop/src-tauri/crates/nudge/src/gate.rs",
+  "desktop/src-tauri/src/nudges.rs",
+  "desktop/src-tauri/src/lib.rs",
+  "desktop/src-tauri/src/commands.rs",
+  "desktop/src-tauri/src/disk_monitor.rs",
+]
+path_kind = "file-sections"
+disposition = "adapt"
+destination = "apps/desktop/src-tauri/crates/nudge/src/gate.rs and the notification policy seams in apps/desktop/src-tauri/src"
+provenance = "Cadence company-authored OS interruption gate; D-030 maintainer decision authorizes the adapt port; reviewed at private merge commit 7b7d54f49b3200aed78dd075c685822d46da08e3"
+current_license = "Proprietary"
+intended_license = "MPL-2.0"
+notes = [
+  "Extract the NotificationGate states, the fail-open policy, the bounded unknown logging, the one-shot authorization, and the macOS/Windows/GNOME/Plasma probes with their unit tests.",
+  "Do not copy popover parking, DeferredNudge, delivery-class park/drain machinery, NudgeAccess entitlement gating, or the provider-usage, ambience, radar, and tray call sites.",
+  "Route the gate through the public notifications module's single delivery seam; explicit previews bypass it there.",
+  "Strip private names; add MPL-2.0 headers; keep every probe on-demand with no resident observers.",
 ]
 
 [[rule]]

--- a/docs/oss/source-denylist.toml
+++ b/docs/oss/source-denylist.toml
@@ -23,7 +23,7 @@ source_commit = "54c4a3bceda80558760a9ff6fc8bf7d04873b43f"
 # later authorized platform migration makes it canonical, version this manifest at the next source
 # review to record its exact reviewed commit while retaining Cadence provenance.
 intended_future_private_repository = "antiburn/antiburn-cloud"
-governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-015", "D-016", "D-017", "D-018", "D-019", "D-020", "D-021", "D-022", "D-023", "D-024", "D-025", "D-026", "D-027", "D-028", "D-029"]
+governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D-009", "D-010", "D-011", "D-012", "D-015", "D-016", "D-017", "D-018", "D-019", "D-020", "D-021", "D-022", "D-023", "D-024", "D-025", "D-026", "D-027", "D-028", "D-029", "D-030"]
 # D-025 (maintainer decision, 2026-08-18; definition of "local" in docs/deviations.md D-27):
 # fixes the boundary this manifest draws around what the installed app may DO.
 # antiburn is local in that it needs no service of antiburn's; as the reader's
@@ -104,6 +104,26 @@ governance_decisions = ["D-001", "D-003", "D-004", "D-005", "D-007", "D-008", "D
 # The macos-private-api feature this needs is already in the build, resolved
 # through tauri-nspanel. The manifest now asks for it directly so the popover
 # does not depend on another crate's feature by accident.
+# D-030 (maintainer decision, ratified 2026-08-26): authorizes the adapt port
+# named by allowlist rule focus-dnd-gate — the best-effort OS interruption gate
+# that keeps automated notifications from appearing while Focus, Do Not
+# Disturb, presentation mode, or an equivalent desktop inhibition state is
+# active.
+# D-023's nudge-window-mechanics and disk-space-monitor rules excluded this
+# gate to bound that port's scope; this decision lifts exactly that exclusion
+# and no other. Popover parking, deferred-nudge machinery, delivery-class
+# park/drain state, entitlement-based access gating, and the private app's
+# provider-usage, ambience, radar, and tray call sites remain denied — the
+# public app has none of those surfaces.
+# The gate adds no data flow and no resident state. Every platform probe runs
+# on demand, immediately before one automated notification would show, and
+# retains nothing between probes. Suppression drops the notification and
+# consumes its trigger, so nothing queues while Focus is on. Unknown or
+# unavailable OS state fails open with bounded logging.
+# Reviewed at private merge commit 7b7d54f49b3200aed78dd075c685822d46da08e3
+# (the OS-aware delivery change). The macOS usage description, entitlement
+# plist, and bundle wiring are configuration authored for this tree; they
+# carry ordinary Git/DCO provenance.
 # D-023 (maintainer decision): authorizes the adapt ports named by allowlist rules
 # startup-registration, disk-space-monitor, tray-title-attributed-string,
 # notification-sound-crate, nudge-window-mechanics, and usage-milestone-engine.

--- a/docs/support.md
+++ b/docs/support.md
@@ -175,6 +175,19 @@ select-all and clear-all controls. antiburn constructs each notification on this
 machine, and nothing about it leaves the machine. The test and first-run
 location ignore the master switch because both follow a direct action.
 
+**Notifications respect Focus and Do Not Disturb.** Immediately before an
+automated notification appears, antiburn asks your operating system whether
+interruptions are welcome — Focus and Do Not Disturb on macOS, fullscreen and
+presentation states on Windows, Do Not Disturb on GNOME and KDE Plasma. A
+suppressed notification is dropped, not saved: turning Focus off never releases
+a backlog of stale alerts. The test button still works during Focus, because
+you pressed it. On macOS this needs your permission once — antiburn asks after
+setup, reads only whether Focus is on, and nothing about it leaves this Mac; if
+you decline, notifications simply stop yielding to Focus. If antiburn is in a
+Focus's Allowed Apps list, macOS lets its notifications through, and antiburn
+follows that answer. When the system cannot say either way, antiburn delivers
+rather than staying silent.
+
 ## Reporting a gap
 
 If an agent on this list is not discovered on a supported platform, that is a bug —


### PR DESCRIPTION
## Summary

Automated notifications now check the operating system interruption state immediately before display. A notification blocked by Focus or Do Not Disturb is dropped instead of queued, so stale alerts do not appear when Focus ends. User-requested previews bypass this check.

- Use native interruption signals on macOS, Windows, GNOME, and KDE Plasma.
- Fail open when the operating system state cannot be read.
- Query only at delivery time, with no background polling or persistent connection.
- Keep platform checks bounded and logged.

## Validation

- Rust tests, Clippy, formatting, plist validation, and code-quality checks passed.
- Local development builds were smoke-tested.
- Full suppression testing requires a signed artifact because development builds lack the required operating system authorization.