### PR TITLE
Stack GH-70: 0014 (CH-002) Release test builds resolve the discovery instrumentation

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -149,6 +149,9 @@ objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSAttr
 winreg = "0.56"
 
 [dev-dependencies]
+# This dev-dependency resolves the engine counters for test builds only.
+# Release runtime builds exclude it.
+antiburn-local = { path = "../../../crates/antiburn-local", features = ["test-instrumentation"] }
 # Synthetic agent stores for the scan-pipeline tests.
 tempfile = "3"
 

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -14,6 +14,11 @@ repository = "https://github.com/antiburn/antiburn"
 name = "antiburn_local"
 path = "src/lib.rs"
 
+[features]
+# This feature compiles the discovery counters for tests.
+# A consumer's dev-dependency keeps them out of release runtime builds.
+test-instrumentation = []
+
 # Local-dependence contract: this crate needs no service of ours and depends
 # on no private workspace packages. It uses only the network a feature
 # actually needs — none, today. Every dependency added here must pass the

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -1006,7 +1006,7 @@ pub async fn session_source_content(source: &SessionSource) -> Option<String> {
             db_path,
             session_id,
         } => {
-            #[cfg(any(test, debug_assertions))]
+            #[cfg(any(test, feature = "test-instrumentation"))]
             record_tracked_provider_db_render(db_path);
             agents::opencode::render_db_session(db_path.clone(), session_id.clone()).await
         }
@@ -1229,18 +1229,18 @@ async fn read_file_source(path: &Path) -> Option<(Option<SourceStat>, u64, Optio
 }
 
 async fn open_file_for_head_read(path: &Path) -> Option<tokio::fs::File> {
-    #[cfg(any(test, debug_assertions))]
+    #[cfg(any(test, feature = "test-instrumentation"))]
     record_tracked_head_read(path);
     tokio::fs::File::open(path).await.ok()
 }
 
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 static TRACKED_PROVIDER_DB_RENDERS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<PathBuf, usize>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 #[doc(hidden)]
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 pub fn track_provider_db_renders(path: &Path) {
     TRACKED_PROVIDER_DB_RENDERS
         .lock()
@@ -1248,7 +1248,7 @@ pub fn track_provider_db_renders(path: &Path) {
         .insert(path.to_path_buf(), 0);
 }
 
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 fn record_tracked_provider_db_render(path: &Path) {
     let mut renders = TRACKED_PROVIDER_DB_RENDERS
         .lock()
@@ -1259,7 +1259,7 @@ fn record_tracked_provider_db_render(path: &Path) {
 }
 
 #[doc(hidden)]
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 pub fn take_tracked_provider_db_renders(path: &Path) -> usize {
     TRACKED_PROVIDER_DB_RENDERS
         .lock()
@@ -1268,13 +1268,13 @@ pub fn take_tracked_provider_db_renders(path: &Path) -> usize {
         .unwrap_or(0)
 }
 
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 static TRACKED_HEAD_READS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<PathBuf, usize>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 #[doc(hidden)]
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 pub fn track_head_reads(path: &Path) {
     TRACKED_HEAD_READS
         .lock()
@@ -1282,7 +1282,7 @@ pub fn track_head_reads(path: &Path) {
         .insert(path.to_path_buf(), 0);
 }
 
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 fn record_tracked_head_read(path: &Path) {
     let mut reads = TRACKED_HEAD_READS
         .lock()
@@ -1293,7 +1293,7 @@ fn record_tracked_head_read(path: &Path) {
 }
 
 #[doc(hidden)]
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-instrumentation"))]
 pub fn take_tracked_head_reads(path: &Path) -> usize {
     TRACKED_HEAD_READS
         .lock()


### PR DESCRIPTION
Stack GH-70: 0014 (CH-002) Release test builds resolve the discovery instrumentation

This is part of a PR stack based at #91; this PR merges into main.

## What this seam contains

Moves the discovery instrumentation (`track_head_reads`, `take_tracked_head_reads`, `track_provider_db_renders`, `take_tracked_provider_db_renders` symbols, their recorders, and two `LazyLock` statics) from a `#[cfg(any(test, debug_assertions))]` gate to `#[cfg(any(test, feature = "test-instrumentation"))]`.

The desktop test build turns the feature on via a `[dev-dependencies]` edge while the release build excludes it entirely, allowing `cargo test --release --locked` to compile and pass for the desktop app.

[Seam plan](/.seams/GH-70/0014-CH-002-release-test-instrumentation-gate-plan.md) | [Seam report](/.seams/GH-70/0014-CH-002-ch002-release-test-gates-report.md) | [Session artifacts](/.seams/GH-70)

## Why this piece was done

Release-mode test builds fail with missing-symbol errors today. The fix must not put instrumentation into the release binary. This seam unblocks CH-009's release-test gate verification.

## What it changes

- `crates/antiburn-local/Cargo.toml`: adds `[features]` section with `test-instrumentation = []`
- `crates/antiburn-local/src/discovery/mod.rs`: replaces all ten `#[cfg(any(test, debug_assertions))]` with `#[cfg(any(test, feature = "test-instrumentation"))]` on statics (lines 1237, 1271) and function items (lines 1243, 1251, 1262, 1277, 1285, 1296) and recorder call statement attributes (lines 1009, 1232); drops the `debug_assertions` gate entirely
- `apps/desktop/src-tauri/Cargo.toml`: adds `antiburn-local = { path = "../../../crates/antiburn-local", features = ["test-instrumentation"] }` to `[dev-dependencies]`

No function bodies changed. Neither lockfile changed.

<details>
<summary>Full file list</summary>

```
 apps/desktop/src-tauri/Cargo.toml          |  3 +++
 crates/antiburn-local/Cargo.toml           |  5 +++++
 crates/antiburn-local/src/discovery/mod.rs | 20 ++++++++++----------
 3 files changed, 18 insertions(+), 10 deletions(-)
```
</details>

## How to review

This is a small, mechanical change: one feature declaration, one cargo manifest edge, and ten gate sites (all defined in one file, used only by the desktop tests). Read the three files in order to verify the gate locations match the plan and no function bodies were altered.

The criteria prove two things: that release-mode tests compile and pass, and that the release binary's feature graph excludes the instrumentation while the test build's feature graph includes it.

**Review hotspots**: none — 0 source entities changed in a way that affects runtime behavior. The gates are compile-time-only, and the feature is test-only.
