### PR TITLE
feat: add release install scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,75 @@ jobs:
           require_success desktop-backend-checks "$CHECKS_RESULT"
           exit "$failed"
 
+  installer-tests:
+    name: installer scripts (${{ matrix.name }})
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: POSIX
+            os: ubuntu-24.04
+          - name: Windows
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Node
+        if: runner.os == 'Linux'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Test the POSIX installer
+        if: runner.os == 'Linux'
+        run: node --test scripts/install-sh.test.mjs
+
+      - name: Check the POSIX installer
+        if: runner.os == 'Linux'
+        run: shellcheck --shell=sh install.sh
+
+      - name: Install PowerShell test tools
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force
+          Install-Module PSScriptAnalyzer -RequiredVersion 1.24.0 -Scope CurrentUser -Force
+
+      - name: Test the PowerShell installer with PowerShell 7
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Import-Module Pester -RequiredVersion 5.7.1
+          Invoke-Pester scripts/install-ps1.test.ps1 -CI
+
+      - name: Install the Windows PowerShell test tool
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force
+
+      - name: Test the PowerShell installer with Windows PowerShell 5.1
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Import-Module Pester -RequiredVersion 5.7.1
+          Invoke-Pester scripts/install-ps1.test.ps1 -CI
+
+      - name: Check the PowerShell installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Import-Module PSScriptAnalyzer -RequiredVersion 1.24.0
+          $findings = @(Invoke-ScriptAnalyzer -Path install.ps1 -Severity Error,Warning)
+          if ($findings.Count -gt 0) {
+            $findings | Format-Table -AutoSize
+            throw "PSScriptAnalyzer found $($findings.Count) issue(s)."
+          }
+
   release-metadata:
     name: release metadata
     needs: classify
@@ -539,6 +608,7 @@ jobs:
       - engine
       - desktop-frontend
       - desktop-backend
+      - installer-tests
       - release-metadata
       - warm-release-cache
       - boundary
@@ -551,6 +621,7 @@ jobs:
       ENGINE_RESULT: ${{ needs.engine.result }}
       FRONTEND_RESULT: ${{ needs.desktop-frontend.result }}
       BACKEND_RESULT: ${{ needs.desktop-backend.result }}
+      INSTALLER_TESTS_RESULT: ${{ needs.installer-tests.result }}
       RELEASE_METADATA_RESULT: ${{ needs.release-metadata.result }}
       WARM_RELEASE_RESULT: ${{ needs.warm-release-cache.result }}
       BOUNDARY_RESULT: ${{ needs.boundary.result }}
@@ -561,6 +632,7 @@ jobs:
       ENGINE_SELECTED: ${{ needs.classify.outputs.engine }}
       FRONTEND_SELECTED: ${{ needs.classify.outputs.frontend }}
       BACKEND_SELECTED: ${{ needs.classify.outputs.desktop_backend }}
+      INSTALLERS_SELECTED: ${{ needs.classify.outputs.full }}
       RELEASE_APP_SELECTED: ${{ needs.classify.outputs.release_app }}
       RELEASE_ENGINE_SELECTED: ${{ needs.classify.outputs.release_engine }}
     steps:
@@ -597,6 +669,7 @@ jobs:
           require_if_selected engine "$ENGINE_SELECTED" "$ENGINE_RESULT"
           require_if_selected desktop-frontend "$FRONTEND_SELECTED" "$FRONTEND_RESULT"
           require_if_selected desktop-backend "$BACKEND_SELECTED" "$BACKEND_RESULT"
+          require_if_selected installer-tests "$INSTALLERS_SELECTED" "$INSTALLER_TESTS_RESULT"
           if [[ "$RELEASE_APP_SELECTED" == "true" || "$RELEASE_ENGINE_SELECTED" == "true" ]]; then
             require_success release-metadata "$RELEASE_METADATA_RESULT"
           else

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -361,10 +361,10 @@ jobs:
       # are no detached signatures, and latest.json would point at downloads
       # nothing can verify.
       #
-      # Platform code signing can be waived, but only deliberately and only
-      # loudly: set the repository variable ALLOW_UNSIGNED_MACOS or
-      # ALLOW_UNSIGNED_WINDOWS to `true`, and the draft says so in its own
-      # first line. Nothing here ever fakes a signature.
+      # Windows platform signing can be waived, but only deliberately and only
+      # loudly: set ALLOW_UNSIGNED_WINDOWS to `true`, and the draft says so in
+      # its own first line. macOS releases always require Developer ID signing
+      # and notarization. Nothing here ever fakes a signature.
       - name: Check the signing credentials this build needs
         id: signing
         shell: bash
@@ -376,7 +376,6 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          ALLOW_UNSIGNED_MACOS: ${{ vars.ALLOW_UNSIGNED_MACOS }}
           ALLOW_UNSIGNED_WINDOWS: ${{ vars.ALLOW_UNSIGNED_WINDOWS }}
         run: |
           set -euo pipefail
@@ -392,19 +391,11 @@ jobs:
 
           case "${RUNNER_OS}" in
             macOS)
-              if [[ -n "${APPLE_CERTIFICATE:-}" ]]; then
-                if [[ -z "${APPLE_ID:-}" || -z "${APPLE_PASSWORD:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_PROVISIONING_PROFILE:-}" ]]; then
-                  echo "::error::APPLE_CERTIFICATE is set but APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID or APPLE_PROVISIONING_PROFILE is not. A Developer ID build needs notarization and the profile-backed Communication Notifications entitlement."
-                  exit 1
-                fi
-                platform_signing=developer-id
-              elif [[ "${ALLOW_UNSIGNED_MACOS:-}" == "true" ]]; then
-                echo "::warning::Building macOS artifacts WITHOUT Developer ID signing or notarization, because ALLOW_UNSIGNED_MACOS is true. They are sealed with an ad-hoc signature: Gatekeeper still warns, but right-click → Open works."
-                platform_signing=unsigned
-              else
-                echo "::error::No Apple signing credentials (APPLE_CERTIFICATE, APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID) are configured. Add them to the 'release' environment, or set the repository variable ALLOW_UNSIGNED_MACOS=true to deliberately ship an unsigned, clearly-labelled build."
+              if [[ -z "${APPLE_CERTIFICATE:-}" || -z "${APPLE_ID:-}" || -z "${APPLE_PASSWORD:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_PROVISIONING_PROFILE:-}" ]]; then
+                echo "::error::APPLE_CERTIFICATE, APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID and APPLE_PROVISIONING_PROFILE are required. Every macOS release uses Developer ID signing, notarization and the profile-backed Communication Notifications entitlement."
                 exit 1
               fi
+              platform_signing=developer-id
               ;;
             Windows)
               if [[ -n "${WINDOWS_CERTIFICATE:-}" ]]; then
@@ -507,19 +498,6 @@ jobs:
             exit 1
           fi
           echo "TAURI_SIGNING_CONFIG=apps/desktop/src-tauri/tauri.release.conf.json" >> "$GITHUB_ENV"
-
-      # An unsigned macOS build still needs a *sealed* bundle. Without any
-      # bundle signature the .app carries only the linker's per-binary ad-hoc
-      # stubs (no Info.plist binding, no sealed resources), and macOS reports
-      # a quarantined download as "damaged" instead of offering the
-      # right-click → Open path for an unidentified developer — the rc.2
-      # rehearsal shipped exactly that. `-` is codesign's ad-hoc identity: no
-      # certificate and no identity claim, but the bundler runs its full
-      # signing pass — nested binaries, sealed resources — so Gatekeeper can
-      # at least read what it is refusing.
-      - name: Use the ad-hoc signing identity
-        if: runner.os == 'macOS' && steps.signing.outputs.platform_signing == 'unsigned'
-        run: echo "APPLE_SIGNING_IDENTITY=-" >> "$GITHUB_ENV"
 
       - name: Import the Authenticode signing certificate
         if: runner.os == 'Windows' && steps.signing.outputs.platform_signing == 'authenticode'
@@ -659,25 +637,6 @@ jobs:
           spctl --assess --type execute --verbose=4 "$app"
           xcrun stapler validate "$app"
 
-      # The ad-hoc seal is verified with codesign only: Gatekeeper is
-      # *supposed* to refuse an ad-hoc build, so `spctl` would fail by design.
-      # The assertion is that the seal exists and is intact — the thing rc.2
-      # lacked, which turned "unidentified developer" into "damaged".
-      - name: Verify the ad-hoc seal
-        if: runner.os == 'macOS' && steps.signing.outputs.platform_signing == 'unsigned'
-        env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          set -euo pipefail
-          app="apps/desktop/src-tauri/target/${TARGET}/release/bundle/macos/antiburn.app"
-          test -d "$app"
-          test ! -e "$app/Contents/embedded.provisionprofile"
-          codesign --verify --deep --strict --verbose=2 "$app"
-          details=$(codesign -dv "$app" 2>&1)
-          printf '%s\n' "$details"
-          grep -q '^Signature=adhoc$' <<<"$details"
-          grep -q '^Sealed Resources version=' <<<"$details"
-
       - name: Verify the Authenticode signature
         if: runner.os == 'Windows' && steps.signing.outputs.platform_signing == 'authenticode'
         shell: pwsh
@@ -816,6 +775,9 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
       - name: Download the built artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -845,6 +807,7 @@ jobs:
           find incoming -type f ! -name 'updater-*.json' ! -name 'evidence-*.json' \
             -exec cp {} dist/ \;
           cp notes/RELEASE-NOTES.md dist/
+          cp install.sh install.ps1 dist/
 
           mapfile -t manifests < <(find incoming -type f -name 'updater-*.json' | sort)
           if [[ "${#manifests[@]}" -ne 4 ]]; then
@@ -862,7 +825,6 @@ jobs:
               ["darwin-aarch64", "darwin-x86_64", "linux-x86_64-appimage", "windows-x86_64"] and
             all(.[]; (.signing | length) > 0 and (.files | length) >= 2)
           ' "${evidence[@]}" > /dev/null
-
           require_count() {
             local pattern="$1" expected="$2" found
             found=$(find dist -maxdepth 1 -type f -name "$pattern" | wc -l | tr -d ' ')
@@ -878,6 +840,8 @@ jobs:
           require_count '*.app.tar.gz' 2
           require_count '*.sig' 4
           require_count '*.cdx.json' 2
+          require_count 'install.sh' 1
+          require_count 'install.ps1' 1
 
           platforms=$(jq -s 'add' "${manifests[@]}")
           jq -n \
@@ -1033,6 +997,7 @@ jobs:
             echo "### Manual acceptance"
             echo
             echo "- Install and launch on every reachable platform."
+            echo "- Run install.sh on macOS and Linux, and install.ps1 on Windows."
             echo "- Confirm Gatekeeper or SmartScreen behavior matches the signing mode above."
             echo "- Confirm a previous version can discover this update."
             echo "- Read the release notes and confirm the Latest/prerelease setting before publishing."

--- a/README.md
+++ b/README.md
@@ -21,6 +21,36 @@ Supported platforms are macOS 13 or later, Windows 11, and mainstream x86-64 Lin
 desktops. See [`docs/support.md`](docs/support.md) for the full matrix and for what
 antiburn stores.
 
+## Install
+
+On macOS or Linux:
+
+```sh
+curl -fsSL https://github.com/antiburn/antiburn/releases/latest/download/install.sh | sh
+```
+
+On Windows 11 in PowerShell:
+
+```powershell
+irm https://github.com/antiburn/antiburn/releases/latest/download/install.ps1 | iex
+```
+
+The scripts resolve one release, download its package from an immutable tag URL,
+and require the package's entry in `SHA256SUMS`. macOS also verifies the application
+signature with Gatekeeper. Windows releases are not required to have an Authenticode
+signature yet, so SmartScreen can warn. Rerunning a script upgrades the existing
+installation.
+
+To inspect a script before it runs, download it first and read it. For a reproducible
+install, pass `--version <version>` to `install.sh` or `-Version <version>` to
+`install.ps1`. Set `ANTIBURN_VERIFY_ATTESTATION=1` to also require GitHub release
+attestation verification with `gh`. Manual packages remain available on the
+[latest release](https://github.com/antiburn/antiburn/releases/latest).
+
+The GitHub release URLs remain the canonical public URLs when this repository opens.
+A future short URL can redirect to them without changing the installer or release
+trust model.
+
 **Local boundary:** antiburn needs no connection to any service of ours — no antiburn
 account, server, or backend, ever. Everything runs on this machine, as you. The
 connections it makes beyond that are yours: it can read your provider's own current

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -14,7 +14,7 @@ There are two release trains, tagged separately and released separately:
 
 | Train               | Tag                         | Workflow                                                           | What it produces                                                                           |
 | ------------------- | --------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| Desktop application | `antiburn-v<version>`       | [`release-app.yml`](../../.github/workflows/release-app.yml)       | Installers, updater bundles, signatures, checksums, inventories, provenance, `latest.json` |
+| Desktop application | `antiburn-v<version>`       | [`release-app.yml`](../../.github/workflows/release-app.yml)       | Installers, bootstrap scripts, updater bundles, signatures, checksums, inventories, provenance, `latest.json` |
 | Engine crate        | `antiburn-local-v<version>` | [`release-engine.yml`](../../.github/workflows/release-engine.yml) | A source tarball, checksums, an inventory, provenance                                      |
 
 Both are **draft-first**. The workflow builds, signs, hashes, attests, and
@@ -111,14 +111,34 @@ Variables (Settings → Secrets and variables → Actions → Variables), not se
 
 | Variable                 | Default when unset                              | Effect                                                                                                                                                                                                                                                                                                                                           |
 | ------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ALLOW_UNSIGNED_MACOS`   | unset (= build fails without Apple credentials) | `true` builds macOS artifacts **without** Developer ID signing or notarization; the app is sealed with an ad-hoc signature instead. Gatekeeper still warns on first launch — right-click → Open accepts it, or clear quarantine with `xattr -dr com.apple.quarantine /Applications/antiburn.app`. Only for a deliberate, clearly-labelled build. |
 | `ALLOW_UNSIGNED_WINDOWS` | unset (= build fails without a certificate)     | `true` builds the Windows installer **without** an Authenticode signature. SmartScreen warns on download.                                                                                                                                                                                                                                        |
 | `WINDOWS_TIMESTAMP_URL`  | `http://timestamp.digicert.com`                 | RFC 3161 timestamp authority used when signing the installer, so signatures outlive the certificate.                                                                                                                                                                                                                                             |
 
-`ALLOW_UNSIGNED_MACOS` is an emergency escape hatch and must remain unset while
-the Apple credentials are available. `ALLOW_UNSIGNED_WINDOWS` remains set under
-D-16 until an Authenticode certificate exists. These variables produce builds
-that say they are unsigned; they never fake a platform signature.
+macOS releases always require Developer ID signing and notarization.
+`ALLOW_UNSIGNED_WINDOWS` remains set under D-16 until an Authenticode certificate
+exists. It produces a build that says it is unsigned; it never fakes a platform
+signature.
+
+#### Enabling Windows installer signature enforcement
+
+The PowerShell bootstrap installer requires SHA-256 verification today but permits
+the unsigned Windows mode recorded in D-16. When an Authenticode certificate is
+available:
+
+1. Configure `WINDOWS_CERTIFICATE` and `WINDOWS_CERTIFICATE_PASSWORD` in the
+   `release` environment.
+2. Remove `ALLOW_UNSIGNED_WINDOWS` and require the `authenticode` signing mode in
+   `release-app.yml`.
+3. Extend `Assert-InstallerIntegrity` in the root `install.ps1` with
+   `Get-AuthenticodeSignature`. Require `Valid` status and the expected antiburn
+   publisher identity.
+4. Add tests for a missing signature, a wrong publisher, an invalid chain, and an
+   expired certificate to `scripts/install-ps1.test.ps1`.
+5. Remove the unsigned-installer warning from `install.ps1` and the README only
+   after a signed release passes the Windows acceptance check.
+
+Do not add inactive signature code before these credentials exist. The checksum
+and the unsigned warning must continue to state the current release behavior.
 
 ### 1.4 Tag protection
 
@@ -260,7 +280,8 @@ tag only after the commit is on `main`.
    updater bundle, a detached signature, and a fragment of `latest.json`. These
    are the only jobs that can see a signing credential, and none may save a
    cache after doing so.
-5. **draft** — merges the fragments into `latest.json` with immutable
+5. **draft** — adds the root `install.sh` and `install.ps1`, then merges the
+   fragments into `latest.json` with immutable
    tag-specific URLs; verifies all four platform keys, asset presence, detached
    signatures, reported signing modes, and `SHA256SUMS`; attests provenance over
    every asset; and creates the draft.
@@ -288,10 +309,7 @@ work, but it does not replace these signed-artifact checks.
       downloaded installer, launch it, confirm the tray item appears, open the
       popover, and check that Settings → About shows the new version. On macOS,
       confirm it opens without a Gatekeeper prompt (which is what notarization
-      buys); on Windows, note whether SmartScreen warns. For a deliberate
-      unsigned rehearsal build, the macOS expectation is different: the ad-hoc
-      seal produces the "unidentified developer" prompt and right-click → Open
-      accepts it — "damaged and can't be opened" means the seal regressed.
+      buys); on Windows, note whether SmartScreen warns.
 - [ ] **The previous version can update to this one.** The real test of a
       release: install the previous version, point it at the draft only after
       publishing (drafts are not reachable), or rehearse with a pre-release tag.
@@ -310,6 +328,10 @@ work, but it does not replace these signed-artifact checks.
       confirm it survived.
 - [ ] **The release notes and signing modes tell the truth.** Read the notes and
       compare any Gatekeeper or SmartScreen behavior with the workflow summary.
+- [ ] **The bootstrap scripts install this release.** Run `install.sh` on macOS
+      and Linux and `install.ps1` on Windows. Run each script twice and confirm
+      the second run replaces or upgrades the same installation. Interrupt one
+      package download and confirm the installed version does not change.
 - [ ] **Provenance verifies where available:**
       `gh attestation verify <asset> --repo antiburn/antiburn`.
 
@@ -322,6 +344,8 @@ deliberately a person's action.
 
 ```bash
 curl -sSL https://github.com/antiburn/antiburn/releases/latest/download/latest.json | jq .
+curl -fsSL https://github.com/antiburn/antiburn/releases/latest/download/install.sh | sh -s -- --help
+curl -fsSL https://github.com/antiburn/antiburn/releases/latest/download/install.ps1 > /dev/null
 ```
 
 The `version` must be the one just published and the URLs must point at its tag.
@@ -440,8 +464,6 @@ published one.
 - Publishing by hand from a local build. Every published artifact comes from a
   tagged run of these workflows, which is what the provenance attestation
   actually attests to.
-- Signing with anything but the credentials in the `release` environment. (The
-  deliberate `ALLOW_UNSIGNED_*` builds are sealed with codesign's ad-hoc
-  identity, which asserts no identity and uses no credential — a seal, not a
-  signature. The rule forbids any _identity-claiming_ signature from outside
-  the environment.)
+- Signing with anything but the credentials in the `release` environment.
+  `ALLOW_UNSIGNED_WINDOWS` uses no signing identity; it does not make an
+  identity claim from outside the environment.

--- a/install.ps1
+++ b/install.ps1
@@ -15,7 +15,7 @@ $script:GitHubUrl = "https://github.com/$script:Repository"
 
 function Write-InstallerInfo {
     param([Parameter(Mandatory)][string] $Message)
-    Write-Host "antiburn: $Message"
+    Write-Information "antiburn: $Message" -InformationAction Continue
 }
 
 function Get-AntiburnRelease {
@@ -87,15 +87,15 @@ function Get-ExpectedChecksum {
         [Parameter(Mandatory)][string] $AssetName
     )
 
-    $matches = foreach ($line in Get-Content -LiteralPath $ChecksumFile) {
+    $checksumMatches = foreach ($line in Get-Content -LiteralPath $ChecksumFile) {
         if ($line -match '^([0-9A-Fa-f]{64})\s+\*?(.+)$' -and $Matches[2] -ceq $AssetName) {
             $Matches[1].ToLowerInvariant()
         }
     }
-    if (@($matches).Count -ne 1) {
+    if (@($checksumMatches).Count -ne 1) {
         throw "SHA256SUMS must contain exactly one valid entry for $AssetName."
     }
-    return $matches
+    return $checksumMatches
 }
 
 function Assert-InstallerIntegrity {

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,182 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [ValidatePattern('^[0-9A-Za-z.-]+$')]
+    [string] $Version = $env:ANTIBURN_VERSION
+)
+
+$ErrorActionPreference = 'Stop'
+$script:Repository = 'antiburn/antiburn'
+$script:GitHubUrl = "https://github.com/$script:Repository"
+
+function Write-InstallerInfo {
+    param([Parameter(Mandatory)][string] $Message)
+    Write-Host "antiburn: $Message"
+}
+
+function Get-AntiburnRelease {
+    param([string] $RequestedVersion)
+
+    if ($RequestedVersion) {
+        return [PSCustomObject]@{
+            Version = $RequestedVersion
+            Tag = "antiburn-v$RequestedVersion"
+        }
+    }
+
+    Write-InstallerInfo 'Resolving the latest release'
+    $request = @{
+        Uri = "https://api.github.com/repos/$script:Repository/releases/latest"
+        Headers = @{ Accept = 'application/vnd.github+json' }
+        UseBasicParsing = $true
+    }
+    $release = Invoke-RestMethod @request
+    $tag = [string] $release.tag_name
+    if ($tag -notmatch '^antiburn-v([0-9A-Za-z.-]+)$') {
+        throw "GitHub returned an invalid release tag: $tag"
+    }
+    return [PSCustomObject]@{
+        Version = $Matches[1]
+        Tag = $tag
+    }
+}
+
+function Invoke-InstallerDownload {
+    param(
+        [Parameter(Mandatory)][uri] $Uri,
+        [Parameter(Mandatory)][string] $OutFile
+    )
+
+    $request = @{
+        Uri = $Uri
+        UseBasicParsing = $true
+    }
+    if ($Uri.Scheme -cne 'https') {
+        throw "Refusing a non-HTTPS download: $Uri"
+    }
+    $response = Invoke-WebRequest @request
+    $finalUri = if ($response.BaseResponse.ResponseUri) {
+        $response.BaseResponse.ResponseUri
+    }
+    else {
+        $response.BaseResponse.RequestMessage.RequestUri
+    }
+    if ($finalUri.Scheme -cne 'https') {
+        throw "Refusing a download that redirected to $finalUri"
+    }
+    $outputStream = $null
+    try {
+        $outputStream = [System.IO.File]::Create($OutFile)
+        $response.RawContentStream.CopyTo($outputStream)
+    }
+    finally {
+        if ($null -ne $outputStream) {
+            $outputStream.Dispose()
+        }
+        $response.RawContentStream.Dispose()
+    }
+}
+
+function Get-ExpectedChecksum {
+    param(
+        [Parameter(Mandatory)][string] $ChecksumFile,
+        [Parameter(Mandatory)][string] $AssetName
+    )
+
+    $matches = foreach ($line in Get-Content -LiteralPath $ChecksumFile) {
+        if ($line -match '^([0-9A-Fa-f]{64})\s+\*?(.+)$' -and $Matches[2] -ceq $AssetName) {
+            $Matches[1].ToLowerInvariant()
+        }
+    }
+    if (@($matches).Count -ne 1) {
+        throw "SHA256SUMS must contain exactly one valid entry for $AssetName."
+    }
+    return $matches
+}
+
+function Assert-InstallerIntegrity {
+    param(
+        [Parameter(Mandatory)][string] $InstallerPath,
+        [Parameter(Mandatory)][string] $ChecksumFile
+    )
+
+    $assetName = Split-Path -Leaf $InstallerPath
+    $expected = Get-ExpectedChecksum -ChecksumFile $ChecksumFile -AssetName $assetName
+    $actual = (Get-FileHash -LiteralPath $InstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -cne $expected) {
+        throw "Checksum verification failed for $assetName."
+    }
+    Write-InstallerInfo "Verified SHA-256 for $assetName"
+}
+
+function Test-WindowsArchitecture {
+    $architecture = if ($env:PROCESSOR_ARCHITEW6432) {
+        $env:PROCESSOR_ARCHITEW6432
+    }
+    else {
+        $env:PROCESSOR_ARCHITECTURE
+    }
+    if ($architecture -notin @('AMD64', 'x86_64')) {
+        throw "Unsupported Windows architecture: $architecture"
+    }
+}
+
+function Invoke-AntiburnInstall {
+    param([string] $RequestedVersion)
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $protocol = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = $protocol -bor [Net.SecurityProtocolType]::Tls12
+    }
+
+    Test-WindowsArchitecture
+    $release = Get-AntiburnRelease -RequestedVersion $RequestedVersion
+    $assetName = "antiburn_$($release.Version)_x64-setup.exe"
+    $baseUrl = "$script:GitHubUrl/releases/download/$($release.Tag)"
+    $temporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("antiburn-install-" + [guid]::NewGuid())
+    $installerPath = Join-Path $temporaryDirectory $assetName
+    $checksumPath = Join-Path $temporaryDirectory 'SHA256SUMS'
+
+    New-Item -ItemType Directory -Path $temporaryDirectory | Out-Null
+    try {
+        Write-InstallerInfo "Downloading $assetName"
+        Invoke-InstallerDownload -Uri "$baseUrl/SHA256SUMS" -OutFile $checksumPath
+        Invoke-InstallerDownload -Uri "$baseUrl/$assetName" -OutFile $installerPath
+        Assert-InstallerIntegrity -InstallerPath $installerPath -ChecksumFile $checksumPath
+
+        if ($env:ANTIBURN_VERIFY_ATTESTATION -eq '1') {
+            if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+                throw 'gh is required when ANTIBURN_VERIFY_ATTESTATION=1.'
+            }
+            & gh release verify-asset $release.Tag $installerPath --repo $script:Repository | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "GitHub could not verify the release attestation for $assetName."
+            }
+            Write-InstallerInfo 'Verified the GitHub release attestation'
+        }
+
+        Write-Warning 'The Windows installer is not required to have an Authenticode signature yet. Windows SmartScreen can warn.'
+        Write-InstallerInfo 'Starting the passive installer'
+        $process = Start-Process -FilePath $installerPath -ArgumentList '/P /R' -Wait -PassThru
+        if ($process.ExitCode -ne 0) {
+            throw "The Windows installer failed with exit code $($process.ExitCode)."
+        }
+
+        $installedApplication = Join-Path $env:LOCALAPPDATA 'antiburn\antiburn.exe'
+        if (-not (Test-Path -LiteralPath $installedApplication)) {
+            throw "The installer completed, but antiburn was not found at $installedApplication."
+        }
+        Write-InstallerInfo "Installed antiburn $($release.Version)"
+    }
+    finally {
+        Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-AntiburnInstall -RequestedVersion $Version
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,366 @@
+#!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -eu
+
+REPOSITORY="antiburn/antiburn"
+GITHUB_URL="https://github.com/${REPOSITORY}"
+TMP_DIR=""
+MOUNT_POINT=""
+MACOS_STAGING_ROOT=""
+MACOS_BACKUP=""
+MACOS_DESTINATION=""
+APPIMAGE_STAGED=""
+APPIMAGE_BACKUP=""
+APPIMAGE_DESTINATION=""
+APPIMAGE_NEW_INSTALLED="0"
+APPIMAGE_SWAP_COMPLETE="0"
+
+info() {
+  printf '%s\n' "antiburn: $*"
+}
+
+fail() {
+  printf '%s\n' "antiburn: error: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "$MACOS_BACKUP" ] && [ -e "$MACOS_BACKUP" ] && [ ! -e "$MACOS_DESTINATION" ]; then
+    as_root mv "$MACOS_BACKUP" "$MACOS_DESTINATION" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$MACOS_STAGING_ROOT" ]; then
+    as_root rm -rf "$MACOS_STAGING_ROOT" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$APPIMAGE_STAGED" ]; then
+    rm -f "$APPIMAGE_STAGED"
+  fi
+  if [ "$APPIMAGE_SWAP_COMPLETE" != "1" ]; then
+    if [ "$APPIMAGE_NEW_INSTALLED" = "1" ]; then
+      rm -f "$APPIMAGE_DESTINATION"
+    fi
+    if [ -n "$APPIMAGE_BACKUP" ] && [ -e "$APPIMAGE_BACKUP" ]; then
+      mv "$APPIMAGE_BACKUP" "$APPIMAGE_DESTINATION" >/dev/null 2>&1 || true
+      APPIMAGE_BACKUP=""
+    fi
+  fi
+  if [ -n "$APPIMAGE_BACKUP" ]; then
+    rm -f "$APPIMAGE_BACKUP"
+  fi
+  if [ -n "$MOUNT_POINT" ]; then
+    hdiutil detach "$MOUNT_POINT" -quiet >/dev/null 2>&1 || true
+  fi
+  if [ -n "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required but was not found in PATH."
+}
+
+as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  else
+    require_command sudo
+    sudo "$@"
+  fi
+}
+
+download() {
+  url="$1"
+  output="$2"
+  curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' \
+    --retry 3 --retry-delay 1 \
+    --output "$output" "$url"
+}
+
+validate_version() {
+  case "$1" in
+    '' | *[!0-9A-Za-z.-]*) fail "Invalid version: $1" ;;
+  esac
+}
+
+resolve_release() {
+  requested_version="$1"
+  if [ -n "$requested_version" ]; then
+    validate_version "$requested_version"
+    VERSION="$requested_version"
+    TAG="antiburn-v${VERSION}"
+    return
+  fi
+
+  info "Resolving the latest release"
+  effective_url=$(curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' \
+    --retry 3 --retry-delay 1 \
+    --output /dev/null --write-out '%{url_effective}' \
+    "${GITHUB_URL}/releases/latest") || fail "Could not resolve the latest release."
+  TAG=${effective_url##*/}
+  case "$TAG" in
+    antiburn-v*) VERSION=${TAG#antiburn-v} ;;
+    *) fail "GitHub returned an invalid release tag: $TAG" ;;
+  esac
+  validate_version "$VERSION"
+  [ "$TAG" = "antiburn-v${VERSION}" ] || fail "GitHub returned an invalid release tag: $TAG"
+}
+
+expected_checksum() {
+  checksum_file="$1"
+  asset_name="$2"
+  matches=$(awk -v name="$asset_name" '
+    $2 == name || $2 == "*" name {
+      if ($1 ~ /^[0-9A-Fa-f]{64}$/) print tolower($1)
+    }
+  ' "$checksum_file")
+  count=$(printf '%s\n' "$matches" | awk 'NF { count++ } END { print count + 0 }')
+  [ "$count" -eq 1 ] || fail "SHA256SUMS must contain exactly one valid entry for ${asset_name}."
+  printf '%s\n' "$matches"
+}
+
+actual_checksum() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{ print tolower($1) }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{ print tolower($1) }'
+  else
+    fail "sha256sum or shasum is required to verify the download."
+  fi
+}
+
+verify_checksum() {
+  file="$1"
+  checksum_file="$2"
+  asset_name=${file##*/}
+  expected=$(expected_checksum "$checksum_file" "$asset_name")
+  actual=$(actual_checksum "$file")
+  [ "$actual" = "$expected" ] || fail "Checksum verification failed for ${asset_name}."
+  info "Verified SHA-256 for ${asset_name}"
+}
+
+verify_attestation_if_requested() {
+  file="$1"
+  if [ "${ANTIBURN_VERIFY_ATTESTATION:-0}" != "1" ]; then
+    return
+  fi
+  require_command gh
+  gh release verify-asset "$TAG" "$file" --repo "$REPOSITORY" >/dev/null \
+    || fail "GitHub could not verify the release attestation for ${file##*/}."
+  info "Verified the GitHub release attestation"
+}
+
+verify_macos_app() {
+  app="$1"
+  [ -d "$app" ] || fail "The DMG does not contain antiburn.app."
+  codesign --verify --deep --strict "$app" >/dev/null 2>&1 \
+    || fail "The antiburn application signature is invalid."
+  spctl --assess --type execute "$app" >/dev/null 2>&1 \
+    || fail "Gatekeeper did not accept antiburn.app."
+  bundle_id=$(defaults read "$app/Contents/Info" CFBundleIdentifier 2>/dev/null || true)
+  [ "$bundle_id" = "ai.antiburn.desktop" ] \
+    || fail "The application has an unexpected bundle identifier: ${bundle_id:-missing}."
+}
+
+install_macos() {
+  arch="$1"
+  require_command hdiutil
+  require_command codesign
+  require_command spctl
+  require_command defaults
+  require_command ditto
+  require_command id
+  require_command sw_vers
+
+  macos_major=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+  case "$macos_major" in
+    '' | *[!0-9]*) fail "Could not determine the macOS version." ;;
+  esac
+  [ "$macos_major" -ge 13 ] || fail "antiburn requires macOS 13 or later."
+
+  case "$arch" in
+    arm64) arch_label="aarch64" ;;
+    x86_64) arch_label="x64" ;;
+    *) fail "Unsupported macOS architecture: $arch" ;;
+  esac
+
+  asset_name="antiburn_${VERSION}_${arch_label}.dmg"
+  asset_path="${TMP_DIR}/${asset_name}"
+  download_release_asset "$asset_name" "$asset_path"
+  hdiutil verify "$asset_path" >/dev/null || fail "The DMG failed its internal verification."
+
+  MOUNT_POINT="${TMP_DIR}/mount"
+  mkdir "$MOUNT_POINT"
+  hdiutil attach "$asset_path" -readonly -nobrowse -mountpoint "$MOUNT_POINT" >/dev/null \
+    || fail "Could not mount the DMG."
+  source_app="${MOUNT_POINT}/antiburn.app"
+  verify_macos_app "$source_app"
+
+  MACOS_DESTINATION="/Applications/antiburn.app"
+  MACOS_STAGING_ROOT=$(as_root mktemp -d "/Applications/.antiburn-install.XXXXXX") \
+    || fail "Could not create a staging directory in /Applications."
+  as_root chmod 755 "$MACOS_STAGING_ROOT"
+  staged="${MACOS_STAGING_ROOT}/antiburn.app"
+  MACOS_BACKUP="${MACOS_STAGING_ROOT}/previous.app"
+  info "Installing to ${MACOS_DESTINATION}"
+  as_root ditto "$source_app" "$staged"
+  verify_macos_app "$staged"
+  if [ -e "$MACOS_DESTINATION" ]; then
+    as_root mv "$MACOS_DESTINATION" "$MACOS_BACKUP"
+  fi
+  if ! as_root mv "$staged" "$MACOS_DESTINATION"; then
+    if [ -e "$MACOS_BACKUP" ]; then
+      as_root mv "$MACOS_BACKUP" "$MACOS_DESTINATION" || true
+    fi
+    fail "Could not replace ${MACOS_DESTINATION}."
+  fi
+  as_root rm -rf "$MACOS_BACKUP"
+  MACOS_BACKUP=""
+  as_root rm -rf "$MACOS_STAGING_ROOT"
+  MACOS_STAGING_ROOT=""
+  info "Installed antiburn ${VERSION} to ${MACOS_DESTINATION}"
+}
+
+install_deb() {
+  require_command id
+  asset_name="antiburn_${VERSION}_amd64.deb"
+  asset_path="${TMP_DIR}/${asset_name}"
+  download_release_asset "$asset_name" "$asset_path"
+
+  package_name=$(dpkg-deb -f "$asset_path" Package)
+  package_arch=$(dpkg-deb -f "$asset_path" Architecture)
+  package_version=$(dpkg-deb -f "$asset_path" Version)
+  [ "$package_name" = "antiburn" ] || fail "The Debian package has an unexpected name: $package_name."
+  [ "$package_arch" = "amd64" ] || fail "The Debian package has an unexpected architecture: $package_arch."
+  [ "$package_version" = "$VERSION" ] || fail "The Debian package has an unexpected version: $package_version."
+
+  info "Installing the Debian package"
+  # Debian compares a hyphenated prerelease as newer than the stable version.
+  # The selected local package is already pinned to the requested release and verified.
+  as_root apt-get install --yes --allow-downgrades "$asset_path"
+  info "Installed antiburn ${VERSION} with APT"
+}
+
+install_appimage() {
+  [ -n "${HOME:-}" ] || fail "HOME is required for an AppImage installation."
+  asset_name="antiburn_${VERSION}_amd64.AppImage"
+  asset_path="${TMP_DIR}/${asset_name}"
+  download_release_asset "$asset_name" "$asset_path"
+
+  applications_dir="${HOME}/Applications"
+  bin_dir="${HOME}/.local/bin"
+  destination="${applications_dir}/antiburn.AppImage"
+  APPIMAGE_DESTINATION="$destination"
+  APPIMAGE_STAGED="${applications_dir}/.antiburn.AppImage.$$"
+  APPIMAGE_BACKUP="${applications_dir}/.antiburn-backup.$$"
+  mkdir -p "$applications_dir" "$bin_dir"
+  chmod 755 "$asset_path"
+  mv "$asset_path" "$APPIMAGE_STAGED"
+  if [ -e "$destination" ]; then
+    mv "$destination" "$APPIMAGE_BACKUP"
+  else
+    APPIMAGE_BACKUP=""
+  fi
+  APPIMAGE_NEW_INSTALLED="1"
+  mv -f "$APPIMAGE_STAGED" "$destination"
+  APPIMAGE_STAGED=""
+  APPIMAGE_SWAP_COMPLETE="1"
+  if [ -n "$APPIMAGE_BACKUP" ]; then
+    rm -f "$APPIMAGE_BACKUP"
+    APPIMAGE_BACKUP=""
+  fi
+  link_path="${bin_dir}/antiburn"
+  if [ -L "$link_path" ]; then
+    require_command readlink
+    if [ "$(readlink "$link_path")" != "$destination" ]; then
+      info "Not replacing the existing link at ${link_path}."
+    fi
+  elif [ -e "$link_path" ]; then
+    info "Not replacing the existing path at ${link_path}."
+  elif ! ln -s "$destination" "$link_path"; then
+    info "Could not create the optional command link at ${link_path}."
+  fi
+  info "Installed antiburn ${VERSION} to ${destination}"
+  case ":${PATH:-}:" in
+    *":${bin_dir}:"*) ;;
+    *) info "Add ${bin_dir} to PATH to run antiburn from a terminal." ;;
+  esac
+}
+
+install_linux() {
+  arch="$1"
+  case "$arch" in
+    x86_64 | amd64) ;;
+    *) fail "Unsupported Linux architecture: $arch" ;;
+  esac
+
+  if command -v apt-get >/dev/null 2>&1 && command -v dpkg-deb >/dev/null 2>&1; then
+    install_deb
+  else
+    install_appimage
+  fi
+}
+
+download_release_asset() {
+  asset_name="$1"
+  asset_path="$2"
+  release_url="${GITHUB_URL}/releases/download/${TAG}"
+  checksum_path="${TMP_DIR}/SHA256SUMS"
+  if [ ! -f "$checksum_path" ]; then
+    download "${release_url}/SHA256SUMS" "$checksum_path" \
+      || fail "Could not download SHA256SUMS for ${TAG}."
+  fi
+  info "Downloading ${asset_name}"
+  download "${release_url}/${asset_name}" "$asset_path" \
+    || fail "Could not download ${asset_name}."
+  verify_checksum "$asset_path" "$checksum_path"
+  verify_attestation_if_requested "$asset_path"
+}
+
+parse_args() {
+  VERSION_REQUESTED="${ANTIBURN_VERSION:-}"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --version)
+        [ "$#" -ge 2 ] || fail "--version requires a value."
+        VERSION_REQUESTED="$2"
+        shift 2
+        ;;
+      --help)
+        printf '%s\n' "Usage: install.sh [--version VERSION]"
+        exit 0
+        ;;
+      *) fail "Unknown argument: $1" ;;
+    esac
+  done
+}
+
+install_antiburn() {
+  parse_args "$@"
+  require_command curl
+  require_command awk
+  require_command mktemp
+  require_command uname
+  TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/antiburn-install.XXXXXX") \
+    || fail "Could not create a temporary directory."
+  trap cleanup EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  resolve_release "$VERSION_REQUESTED"
+  os=$(uname -s)
+  arch=$(uname -m)
+  info "Installing antiburn ${VERSION} for ${os}/${arch}"
+  case "$os" in
+    Darwin) install_macos "$arch" ;;
+    Linux) install_linux "$arch" ;;
+    *) fail "Unsupported operating system: $os" ;;
+  esac
+}
+
+install_antiburn "$@"

--- a/scripts/install-ps1.test.ps1
+++ b/scripts/install-ps1.test.ps1
@@ -1,0 +1,109 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+BeforeAll {
+    $script:RepositoryRoot = Split-Path -Parent $PSScriptRoot
+    $script:InstallerPath = Join-Path $script:RepositoryRoot 'install.ps1'
+    . $script:InstallerPath
+}
+
+Describe 'install.ps1' {
+    It 'selects one exact checksum entry' {
+        $checksums = Join-Path $TestDrive 'SHA256SUMS'
+        $hash = 'a' * 64
+        Set-Content -LiteralPath $checksums -Value "$hash  antiburn_1.2.3_x64-setup.exe"
+
+        Get-ExpectedChecksum -ChecksumFile $checksums -AssetName 'antiburn_1.2.3_x64-setup.exe' |
+            Should -Be $hash
+    }
+
+    It 'rejects duplicate checksum entries' {
+        $checksums = Join-Path $TestDrive 'SHA256SUMS'
+        $hash = 'a' * 64
+        Set-Content -LiteralPath $checksums -Value @(
+            "$hash  antiburn_1.2.3_x64-setup.exe"
+            "$hash  antiburn_1.2.3_x64-setup.exe"
+        )
+
+        {
+            Get-ExpectedChecksum -ChecksumFile $checksums -AssetName 'antiburn_1.2.3_x64-setup.exe'
+        } | Should -Throw '*exactly one valid entry*'
+    }
+
+    It 'verifies the installer SHA-256 value' {
+        $installerFile = Join-Path $TestDrive 'antiburn_1.2.3_x64-setup.exe'
+        $checksums = Join-Path $TestDrive 'SHA256SUMS'
+        Set-Content -LiteralPath $installerFile -Value 'synthetic installer'
+        $hash = (Get-FileHash -LiteralPath $installerFile -Algorithm SHA256).Hash.ToLowerInvariant()
+        Set-Content -LiteralPath $checksums -Value "$hash  antiburn_1.2.3_x64-setup.exe"
+
+        { Assert-InstallerIntegrity -InstallerPath $installerFile -ChecksumFile $checksums } |
+            Should -Not -Throw
+    }
+
+    It 'rejects a checksum mismatch' {
+        $installerFile = Join-Path $TestDrive 'antiburn_1.2.3_x64-setup.exe'
+        $checksums = Join-Path $TestDrive 'SHA256SUMS'
+        Set-Content -LiteralPath $installerFile -Value 'synthetic installer'
+        Set-Content -LiteralPath $checksums -Value "$('a' * 64)  antiburn_1.2.3_x64-setup.exe"
+
+        { Assert-InstallerIntegrity -InstallerPath $installerFile -ChecksumFile $checksums } |
+            Should -Throw '*Checksum verification failed*'
+    }
+
+    It 'rejects a non-HTTPS download before making a request' {
+        Mock Invoke-WebRequest { throw 'The request must not run.' }
+
+        {
+            Invoke-InstallerDownload -Uri 'http://example.test/installer.exe' -OutFile (Join-Path $TestDrive 'installer.exe')
+        } | Should -Throw '*Refusing a non-HTTPS download*'
+        Should -Invoke Invoke-WebRequest -Times 0 -Exactly
+    }
+
+    It 'rejects and removes a download redirected to HTTP' {
+        $output = Join-Path $TestDrive 'installer.exe'
+        Mock Invoke-WebRequest {
+            [PSCustomObject]@{
+                BaseResponse = [PSCustomObject]@{
+                    ResponseUri = [uri] 'http://example.test/installer.exe'
+                }
+            }
+        }
+
+        {
+            Invoke-InstallerDownload -Uri 'https://example.test/installer.exe' -OutFile $output
+        } | Should -Throw '*redirected to http://*'
+        Test-Path -LiteralPath $output | Should -BeFalse
+    }
+
+    It 'writes the response stream to the download path' {
+        $output = Join-Path $TestDrive 'installer.exe'
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes('synthetic installer')
+        Mock Invoke-WebRequest {
+            [PSCustomObject]@{
+                BaseResponse = [PSCustomObject]@{
+                    ResponseUri = [uri] 'https://example.test/installer.exe'
+                }
+                RawContentStream = [System.IO.MemoryStream]::new($bytes)
+            }
+        }
+
+        Invoke-InstallerDownload -Uri 'https://example.test/installer.exe' -OutFile $output
+        [System.Text.Encoding]::UTF8.GetString([System.IO.File]::ReadAllBytes($output)) |
+            Should -Be 'synthetic installer'
+    }
+
+    It 'uses safe web parsing and the passive NSIS mode' {
+        $source = Get-Content -LiteralPath $script:InstallerPath -Raw
+        $source | Should -Match 'UseBasicParsing = \$true'
+        $source | Should -Match "-ArgumentList '/P /R'"
+        $source | Should -Not -Match 'Invoke-Expression'
+    }
+
+    It 'documents the current unsigned installer state' {
+        $source = Get-Content -LiteralPath $script:InstallerPath -Raw
+        $source | Should -Match 'not required to have an Authenticode signature yet'
+        $source | Should -Match 'SmartScreen can warn'
+    }
+}

--- a/scripts/install-sh.test.mjs
+++ b/scripts/install-sh.test.mjs
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import test from "node:test";
+
+const root = resolve(import.meta.dirname, "..");
+const installer = join(root, "install.sh");
+
+function executable(path, contents) {
+  writeFileSync(path, contents, { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
+
+function linkCommands(bin, commands) {
+  for (const command of commands) {
+    const path = execFileSync("sh", ["-c", `command -v ${command}`], {
+      encoding: "utf8",
+    }).trim();
+    symlinkSync(path, join(bin, command));
+  }
+}
+
+function harness({
+  os = "Linux",
+  arch = "x86_64",
+  checksum = "a".repeat(64),
+  packageType = "appimage",
+} = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "antiburn-install-test-"));
+  const bin = join(directory, "bin");
+  const home = join(directory, "home");
+  const log = join(directory, "commands.log");
+  mkdirSync(bin);
+  mkdirSync(home);
+  linkCommands(bin, ["awk", "chmod", "id", "ln", "mkdir", "mktemp", "mv", "rm"]);
+
+  executable(
+    join(bin, "uname"),
+    `#!/bin/sh\n[ "\${1:-}" = "-m" ] && printf '%s\\n' '${arch}' || printf '%s\\n' '${os}'\n`,
+  );
+  executable(
+    join(bin, "curl"),
+    `#!/bin/sh
+output=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    --write-out) shift 2 ;;
+    --*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+if [ "$output" = "/dev/null" ]; then
+  printf '%s' 'https://github.com/antiburn/antiburn/releases/tag/antiburn-v1.2.3'
+elif [ "\${url##*/}" = "SHA256SUMS" ]; then
+  printf '%s  %s\\n' '${checksum}' '${packageType === "deb" ? "antiburn_1.2.3_amd64.deb" : "antiburn_1.2.3_amd64.AppImage"}' > "$output"
+else
+  printf '%s' 'release asset' > "$output"
+fi
+`,
+  );
+  executable(
+    join(bin, "sha256sum"),
+    `#!/bin/sh\nprintf '%s  %s\\n' '${checksum}' "$1"\n`,
+  );
+
+  if (packageType === "deb") {
+    executable(
+      join(bin, "apt-get"),
+      '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$TEST_COMMAND_LOG"\n',
+    );
+    executable(
+      join(bin, "dpkg-deb"),
+      `#!/bin/sh
+case "$3" in
+  Package) printf '%s\\n' antiburn ;;
+  Architecture) printf '%s\\n' amd64 ;;
+  Version) printf '%s\\n' 1.2.3 ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+    executable(join(bin, "sudo"), '#!/bin/sh\nexec "$@"\n');
+  }
+
+  return {
+    directory,
+    home,
+    log,
+    env: {
+      ...process.env,
+      ANTIBURN_VERSION: "1.2.3",
+      HOME: home,
+      PATH: bin,
+      TEST_COMMAND_LOG: log,
+      TMPDIR: directory,
+    },
+  };
+}
+
+test("install.sh has valid POSIX shell syntax", () => {
+  execFileSync("sh", ["-n", installer]);
+});
+
+test("install.sh keeps execution on its final line", () => {
+  const source = readFileSync(installer, "utf8");
+  assert.equal(source.trimEnd().split("\n").at(-1), 'install_antiburn "$@"');
+});
+
+test("install.sh rejects an unsupported operating system before downloading", () => {
+  const context = harness({ os: "Plan9" });
+  const result = spawnSync("/bin/sh", [installer], {
+    encoding: "utf8",
+    env: context.env,
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unsupported operating system: Plan9/);
+  assert.doesNotMatch(result.stdout, /Downloading antiburn_/);
+});
+
+test("install.sh installs the verified AppImage without root", () => {
+  const context = harness();
+  const result = spawnSync("/bin/sh", [installer], {
+    encoding: "utf8",
+    env: context.env,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Verified SHA-256/);
+  assert.ok(existsSync(join(context.home, "Applications", "antiburn.AppImage")));
+  assert.ok(existsSync(join(context.home, ".local", "bin", "antiburn")));
+});
+
+test("install.sh uses APT for a verified Debian package", () => {
+  const context = harness({ packageType: "deb" });
+  const result = spawnSync("/bin/sh", [installer], {
+    encoding: "utf8",
+    env: context.env,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    readFileSync(context.log, "utf8"),
+    /install --yes --allow-downgrades .*antiburn_1\.2\.3_amd64\.deb/,
+  );
+});
+
+test("install.sh stops before installation when the checksum differs", () => {
+  const context = harness({ checksum: "a".repeat(64) });
+  executable(
+    join(context.directory, "bin", "sha256sum"),
+    `#!/bin/sh\nprintf '%s  %s\\n' '${"b".repeat(64)}' "$1"\n`,
+  );
+  const result = spawnSync("/bin/sh", [installer], {
+    encoding: "utf8",
+    env: context.env,
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Checksum verification failed/);
+  assert.equal(existsSync(join(context.home, "Applications", "antiburn.AppImage")), false);
+});
+
+test("a truncated install.sh does not start installation", () => {
+  const context = harness();
+  const truncated = join(context.directory, basename(installer));
+  const lines = readFileSync(installer, "utf8").trimEnd().split("\n");
+  writeFileSync(truncated, `${lines.slice(0, -1).join("\n")}\n`);
+  const result = spawnSync("/bin/sh", [truncated], {
+    encoding: "utf8",
+    env: context.env,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(existsSync(join(context.home, "Applications", "antiburn.AppImage")), false);
+});
+
+test("install.sh contains the required macOS trust checks", () => {
+  const source = readFileSync(installer, "utf8");
+  assert.match(source, /hdiutil verify/);
+  assert.match(source, /codesign --verify --deep --strict/);
+  assert.match(source, /spctl --assess --type execute/);
+  assert.match(source, /ai\.antiburn\.desktop/);
+});
+
+test("the application release publishes both root installers before checksums", () => {
+  const workflow = readFileSync(join(root, ".github", "workflows", "release-app.yml"), "utf8");
+  const copyIndex = workflow.indexOf("cp install.sh install.ps1 dist/");
+  const checksumIndex = workflow.indexOf('mv "${RUNNER_TEMP}/SHA256SUMS" dist/SHA256SUMS');
+  assert.ok(copyIndex > 0);
+  assert.ok(checksumIndex > copyIndex);
+  assert.match(workflow, /require_count 'install\.sh' 1/);
+  assert.match(workflow, /require_count 'install\.ps1' 1/);
+});

--- a/scripts/verify-release-provisioning.test.mjs
+++ b/scripts/verify-release-provisioning.test.mjs
@@ -71,8 +71,6 @@ test("the release workflow validates and verifies the profile-backed entitlement
   );
   assert.match(workflow, /codesign -d --entitlements :- "\$executable"/);
   assert.match(workflow, /test "\$communication" = "true"/);
-  assert.match(
-    workflow,
-    /test ! -e "\$app\/Contents\/embedded\.provisionprofile"/,
-  );
+  assert.doesNotMatch(workflow, /ALLOW_UNSIGNED_MACOS/);
+  assert.doesNotMatch(workflow, /Signature=adhoc/);
 });

--- a/scripts/verify-workflow-portability.test.mjs
+++ b/scripts/verify-workflow-portability.test.mjs
@@ -231,6 +231,14 @@ test("ci-required fails closed on the aislop job", () => {
     1,
   );
   assert.equal(count(job, /^ {6}EVENT_NAME:/gm), 1);
+  assert.equal(count(job, /^ {6}- installer-tests$/gm), 1);
+  assert.equal(
+    count(
+      job,
+      /^ {6}INSTALLER_TESTS_RESULT: \$\{\{ needs\.installer-tests\.result \}\}$/gm,
+    ),
+    1,
+  );
 
   const steps = stepsIn(job);
   assert.equal(steps.length, 1);
@@ -269,6 +277,7 @@ require_success boundary "$BOUNDARY_RESULT"
 require_if_selected engine "$ENGINE_SELECTED" "$ENGINE_RESULT"
 require_if_selected desktop-frontend "$FRONTEND_SELECTED" "$FRONTEND_RESULT"
 require_if_selected desktop-backend "$BACKEND_SELECTED" "$BACKEND_RESULT"
+require_if_selected installer-tests "$INSTALLERS_SELECTED" "$INSTALLER_TESTS_RESULT"
 if [[ "$RELEASE_APP_SELECTED" == "true" || "$RELEASE_ENGINE_SELECTED" == "true" ]]; then
   require_success release-metadata "$RELEASE_METADATA_RESULT"
 else


### PR DESCRIPTION
## Summary

Add supported one-command installers for macOS, Linux, and Windows, and publish them with each application release.

- Select the latest release or a requested version.
- Detect the operating system and processor type.
- Download the matching package over HTTPS.
- Verify the SHA-256 checksum before installation.
- Stop with a clear error if download, verification, platform detection, or installation fails.
- Support exact-version installs and optional GitHub attestation verification.

macOS installs the verified application bundle, Linux selects a Debian package or AppImage, and Windows runs the NSIS installer in passive mode.

## Validation

- Node, Pester, shell, PowerShell, workflow, and release-contract tests passed.
- ShellCheck, PSScriptAnalyzer, actionlint, formatting, and the full platform CI matrix passed.

Closes #150.