### PR TITLE
feat(desktop): add the hotspot block to the activity popover

### DIFF
--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -22,6 +22,7 @@ import {
   type ProviderUsageSummaryPayload,
 } from "../lib/ipc"
 import type { PopoverSurface } from "../lib/popoverHeight"
+import { HotspotBlock } from "./popover/HotspotBlock"
 import { PopoverSession, sessionKey } from "./popover/PopoverSession"
 import { UsageView } from "./popover/UsageView"
 import type { SessionSubject } from "./popover/SessionPane"
@@ -369,6 +370,13 @@ export function PopoverView() {
             />
           )}
         </div>
+
+        {/* The hotspot block sits between the list and the footer, and shows
+            nothing until the local insights report exists
+            (docs/plans/hotspot-popover-block.md). The list above it scrolls,
+            so a block that opens takes rows off the list and the window keeps
+            its height. */}
+        <HotspotBlock finding={null} />
 
         <PopoverFooter
           appVersion={state.appVersion}

--- a/apps/desktop/src/views/popover/HotspotBlock.test.tsx
+++ b/apps/desktop/src/views/popover/HotspotBlock.test.tsx
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DEFAULT_POPOVER_HEIGHT, POPOVER_HEIGHTS } from "../../lib/popoverHeight"
+import { HotspotBlock } from "./HotspotBlock"
+import {
+  HOTSPOT_CATEGORIES,
+  HOTSPOT_COPY,
+  hotspotCountLabel,
+  type HotspotFinding,
+} from "./hotspot"
+
+const FINDING: HotspotFinding = {
+  category: "unusedMcpServers",
+  sessions: 34,
+  saving: "≈ 210k tokens",
+  fix: "claude mcp remove playwright",
+  evidence: [
+    { label: "Tokens over the window", value: "210,400" },
+    { label: "Servers loaded, never called", value: "3" },
+  ],
+}
+
+describe("HotspotBlock", () => {
+  it("renders nothing when the report has no finding", () => {
+    const { container } = render(<HotspotBlock finding={null} />)
+
+    // FR-14: a cohort that is only half read must never render as clean. An
+    // empty shell or an "all clear" line could be misread; nothing cannot.
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("names the count, the category and the saving on the claim line", () => {
+    render(<HotspotBlock finding={FINDING} />)
+
+    // The default normalizer collapses the hair space in `34 ×`, which is the
+    // one character this label exists to add.
+    expect(screen.getByText(hotspotCountLabel(34), { normalizer: (text) => text })).toBeTruthy()
+    expect(screen.getByText(HOTSPOT_COPY.unusedMcpServers.name)).toBeTruthy()
+    expect(screen.getByText("≈ 210k tokens")).toBeTruthy()
+  })
+
+  it("shows the fix line whether the detail is open or closed", () => {
+    render(<HotspotBlock finding={FINDING} />)
+    expect(screen.getByText("claude mcp remove playwright")).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: /Unused MCP servers/ }))
+    expect(screen.getByText("claude mcp remove playwright")).toBeTruthy()
+  })
+
+  it("keeps the evidence out of the tree until the claim line is opened", () => {
+    render(<HotspotBlock finding={FINDING} />)
+    const claim = screen.getByRole("button", { name: /Unused MCP servers/ })
+
+    expect(claim.getAttribute("aria-expanded")).toBe("false")
+    expect(screen.queryByText("Tokens over the window")).toBeNull()
+
+    fireEvent.click(claim)
+    expect(claim.getAttribute("aria-expanded")).toBe("true")
+    expect(screen.getByText(HOTSPOT_COPY.unusedMcpServers.mechanism)).toBeTruthy()
+    expect(screen.getByText("Tokens over the window")).toBeTruthy()
+    expect(screen.getByText("Servers loaded, never called")).toBeTruthy()
+
+    fireEvent.click(claim)
+    expect(claim.getAttribute("aria-expanded")).toBe("false")
+    expect(screen.queryByText("Tokens over the window")).toBeNull()
+  })
+
+  it("points aria-controls at the evidence it reveals", () => {
+    render(<HotspotBlock finding={FINDING} />)
+    const claim = screen.getByRole("button", { name: /Unused MCP servers/ })
+
+    fireEvent.click(claim)
+    const controls = claim.getAttribute("aria-controls")
+    expect(controls).toBeTruthy()
+    expect(document.getElementById(controls as string)?.textContent).toContain(
+      "Servers loaded, never called",
+    )
+  })
+
+  it("leaves the saving out when pricing cannot value the category", () => {
+    render(<HotspotBlock finding={{ ...FINDING, saving: null }} />)
+
+    expect(screen.queryByText(/≈/)).toBeNull()
+  })
+
+  describe("copy", () => {
+    let written: string[]
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      written = []
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: (text: string) => {
+            written.push(text)
+            return Promise.resolve()
+          },
+        },
+      })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it("writes the fix verbatim and reverts the check without an effect", async () => {
+      render(<HotspotBlock finding={FINDING} />)
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy claude mcp remove playwright" }))
+      await act(async () => {})
+      expect(written).toEqual(["claude mcp remove playwright"])
+      expect(
+        screen.getByRole("button", { name: "Copied claude mcp remove playwright" }),
+      ).toBeTruthy()
+
+      // The revert is a timer the click starts, not a subscription a render
+      // sets up. It has to fire on its own.
+      await act(async () => {
+        vi.advanceTimersByTime(2000)
+      })
+      expect(
+        screen.getByRole("button", { name: "Copy claude mcp remove playwright" }),
+      ).toBeTruthy()
+    })
+
+    it("stays quiet when the webview refuses the write", async () => {
+      // A webview with no user activation or no focus rejects `writeText`.
+      // Seen for real in `pnpm dev:web` as `NotAllowedError`.
+      //
+      // The assertion below only covers the visible half: no check, because
+      // nothing was copied. The other half — that the rejection is handled —
+      // is enforced by vitest, which reports an unhandled rejection raised
+      // during a test and exits non-zero. Drop the `.catch` in `onCopy` and
+      // this file fails on that route, not on an `expect`.
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText: () => Promise.reject(new Error("Write permission denied.")) },
+      })
+
+      render(<HotspotBlock finding={FINDING} />)
+      fireEvent.click(screen.getByRole("button", { name: "Copy claude mcp remove playwright" }))
+      await act(async () => {})
+
+      expect(
+        screen.getByRole("button", { name: "Copy claude mcp remove playwright" }),
+      ).toBeTruthy()
+    })
+  })
+
+  it("makes the whole fix field the copy target, not just the icon", () => {
+    render(<HotspotBlock finding={FINDING} />)
+
+    // The command text has to sit inside the button. A 13px icon beside a wide
+    // command is the smaller of the two things a reader aims at.
+    const field = screen.getByRole("button", { name: "Copy claude mcp remove playwright" })
+    expect(field.textContent).toBe("claude mcp remove playwright")
+  })
+
+  it("shows every evidence row the finding carries", () => {
+    const rows = [
+      { label: "Tokens over the window", value: "210,400" },
+      { label: "Servers loaded, never called", value: "3" },
+      { label: "Tool definitions loaded", value: "41" },
+      { label: "Sessions in the cohort", value: "61" },
+      { label: "Longest run without a call", value: "12 days" },
+    ]
+    render(<HotspotBlock finding={{ ...FINDING, evidence: rows }} />)
+    fireEvent.click(screen.getByRole("button", { name: /Unused MCP servers/ }))
+
+    // No cap on the count. Past the detail's max height the rows scroll, so a
+    // long finding never pushes the session list out of the window.
+    for (const row of rows) expect(screen.getByText(row.label)).toBeTruthy()
+  })
+
+  it("has copy for every category the report can send", () => {
+    for (const category of HOTSPOT_CATEGORIES) {
+      expect(HOTSPOT_COPY[category].name.length).toBeGreaterThan(0)
+      expect(HOTSPOT_COPY[category].mechanism.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("never asks the shell for a taller activity window", () => {
+    // The block earns its height from the session list, which already scrolls.
+    // A later change that grows the window instead would move the tray popover
+    // under the cursor, so pin the contract here.
+    expect(POPOVER_HEIGHTS.activity).toBe(DEFAULT_POPOVER_HEIGHT)
+  })
+})

--- a/apps/desktop/src/views/popover/HotspotBlock.tsx
+++ b/apps/desktop/src/views/popover/HotspotBlock.tsx
@@ -1,0 +1,178 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { Check, Copy, Info } from "lucide-react"
+import { useId, useState } from "react"
+
+import { cn } from "../../lib/cn"
+import { HOTSPOT_COPY, hotspotCountLabel, type HotspotFinding } from "./hotspot"
+
+/**
+ * The block at the foot of the activity surface.
+ *
+ * It names the most common Hygiene & Efficiency finding across the assessed
+ * 30-day cohort, says how many sessions carry it, and hands over one pasteable
+ * fix. The info icon on the claim line opens the evidence behind the count.
+ *
+ * Four things about it are decided rather than incidental:
+ *
+ * - **No finding, no block.** With nothing to say this renders `null`, and the
+ *   session list takes the space back. Not an empty shell and not an "all
+ *   clear" message: a cohort that is half-read must never render as clean
+ *   (FR-14), and nothing at all cannot be misread.
+ * - **The window never resizes.** The activity surface stays at
+ *   `DEFAULT_POPOVER_HEIGHT`. Opening the detail takes its height out of the
+ *   session list, which already scrolls. A finding with many evidence rows
+ *   scrolls inside the detail instead of pushing the list out of the window.
+ * - **The detail opens below the fix field.** The pasteable line sits in the
+ *   same place open or closed, so the reader can copy without waiting for a
+ *   reflow to settle.
+ * - **One orange mark, and it is the rule across the top.** The fix field is a
+ *   plain stroked field and the count is ordinary label text. The brand carries
+ *   further when it marks one thing than when it fills three.
+ */
+
+/** How long the field shows a check after a successful write. */
+const COPIED_FEEDBACK_MS = 2000
+
+/**
+ * How tall the opened detail may grow before it scrolls.
+ *
+ * The block earns its height from the session list. Past this the list would
+ * have no rows left to give, so the evidence scrolls in place instead.
+ */
+const DETAIL_MAX_HEIGHT = "max-h-56"
+
+export interface HotspotBlockProps {
+  /** The winning finding, or null when the report has nothing to say. */
+  finding: HotspotFinding | null
+}
+
+export function HotspotBlock({ finding }: HotspotBlockProps) {
+  const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const detailId = useId()
+
+  // Reading `finding` before the hooks would change the hook count between a
+  // report with a finding and one without.
+  if (!finding) return null
+
+  const copy = HOTSPOT_COPY[finding.category]
+
+  // The revert is work the click causes, so the click owns it. A timer that
+  // outlives the block sets state on an unmounted component, which React
+  // ignores; an effect here would only exist to cancel a timer nobody is
+  // waiting on.
+  const onCopy = () => {
+    void navigator.clipboard
+      .writeText(finding.fix)
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS)
+      })
+      .catch(() => {
+        // The webview can refuse the write — no user activation, or no focus.
+        // The check never appears, which is the honest report: the reader can
+        // select the line and copy it. A 26px field has no room to say more,
+        // and an unhandled rejection would only shout in the console.
+      })
+  }
+
+  return (
+    <div className="shrink-0 border-t border-brand-tint">
+      <div className="flex flex-col gap-1.5 px-4 pt-2.5 pb-3">
+        {/* The whole claim line is the disclosure control, not just the icon:
+            a 12px glyph is a poor target for the one gesture this block
+            offers. */}
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={detailId}
+          onClick={() => setOpen((value) => !value)}
+          // Same reason as `ui/Disclosure`: the global button:active rule
+          // (styles/controls.css) makes a heading twitch.
+          className="-mx-1 flex items-baseline gap-1.5 rounded-control px-1 text-left active:transform-none active:opacity-100"
+        >
+          <Info
+            size={12}
+            strokeWidth={2}
+            aria-hidden="true"
+            className={cn(
+              "shrink-0 self-center transition-colors duration-[var(--duration-fast)]",
+              open ? "text-label" : "text-label-tertiary",
+            )}
+          />
+          <span className="type-body whitespace-nowrap text-label tabular-nums">
+            {hotspotCountLabel(finding.sessions)}
+          </span>
+          <span className="type-body min-w-0 truncate text-label">{copy.name}</span>
+          {finding.saving && (
+            <span className="type-body ml-auto whitespace-nowrap text-label-tertiary tabular-nums">
+              {finding.saving}
+            </span>
+          )}
+        </button>
+
+        {/* The field itself copies. A 13px icon target beside a wide, obviously
+            selectable command is the smaller of the two things a reader aims
+            at, so the whole field takes the click and the icon only reports
+            what happened. */}
+        <button
+          type="button"
+          onClick={onCopy}
+          aria-label={copied ? `Copied ${finding.fix}` : `Copy ${finding.fix}`}
+          className="flex h-[26px] items-center gap-2 rounded-control border border-separator px-2 text-left active:transform-none active:opacity-100"
+        >
+          <code className="type-footnote min-w-0 flex-1 truncate font-mono text-label">
+            {finding.fix}
+          </code>
+          {copied ? (
+            <Check
+              size={13}
+              strokeWidth={2.5}
+              aria-hidden="true"
+              className="shrink-0 text-system-green"
+            />
+          ) : (
+            <Copy
+              size={13}
+              strokeWidth={2}
+              aria-hidden="true"
+              className="shrink-0 text-label"
+            />
+          )}
+        </button>
+
+        {/* Unmounted rather than hidden, so closed evidence stays out of the
+            accessibility tree and out of find-in-page. */}
+        {open && (
+          <div
+            id={detailId}
+            className={cn(
+              "mt-1 flex flex-col gap-2 overflow-y-auto border-t border-separator pt-2",
+              DETAIL_MAX_HEIGHT,
+            )}
+          >
+            <p className="type-footnote m-0 text-pretty text-label-secondary">
+              {copy.mechanism}
+            </p>
+            <dl className="m-0 flex flex-col">
+              {finding.evidence.map((row) => (
+                <div
+                  key={row.label}
+                  className="flex items-baseline gap-2 border-b border-separator py-1 first:border-t"
+                >
+                  <dt className="type-caption truncate text-label-tertiary">{row.label}</dt>
+                  <dd className="type-caption m-0 ml-auto whitespace-nowrap text-label tabular-nums">
+                    {row.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/views/popover/hotspot.ts
+++ b/apps/desktop/src/views/popover/hotspot.ts
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The contract between the local insights report and the popover's hotspot
+ * block.
+ *
+ * A hotspot is the single most common Hygiene & Efficiency finding across the
+ * assessed 30-day cohort. The report ranks its findings and hands over one
+ * winner; this module says what that winner looks like on the way in.
+ *
+ * The report does not exist yet (`docs/plans/hotspot-popover-block.md`), so
+ * nothing produces a `HotspotFinding` today. The types are here first because
+ * the presentation is what is under design review, and freezing the shape is
+ * what lets the two halves land in either order.
+ */
+
+/**
+ * The nine canonical Hygiene & Efficiency categories.
+ *
+ * These are fixed identifiers from
+ * `docs/plans/local-insights-architecture.md`, not generated strings. The order
+ * is the tie-break order for two findings with equal session counts and equal
+ * token estimates.
+ */
+export const HOTSPOT_CATEGORIES = [
+  "sessionsOverDepth",
+  "modelOverthinking",
+  "overpoweredSubagents",
+  "unusedMcpServers",
+  "unusedBuiltInTools",
+  "unusedSkills",
+  "oldModelUsage",
+  "overuseOfFastMode",
+  "cacheChurn",
+] as const
+
+export type HotspotCategory = (typeof HOTSPOT_CATEGORIES)[number]
+
+/**
+ * One counted row in the opened evidence table.
+ *
+ * `HotspotFinding` is the only name that leaves this module, so this stays
+ * local until a second reader of the report needs it.
+ */
+interface HotspotEvidenceRow {
+  /** What was counted. Fixed copy, never a repository or a path. */
+  label: string
+  /** The count, already formatted for display. */
+  value: string
+}
+
+/**
+ * The winning finding, ready to render.
+ *
+ * Every number arrives preformatted. The report owns locale and rounding
+ * because it also owns the pricing catalog and the token arithmetic, and a
+ * second rounding rule in the view would let the same figure print two ways.
+ */
+export interface HotspotFinding {
+  category: HotspotCategory
+  /** Sessions in the assessed cohort that carry this finding. */
+  sessions: number
+  /**
+   * What acting on it is worth, already prefixed with `≈` because it is an
+   * estimate. Null when the pricing catalog cannot value the category.
+   */
+  saving: string | null
+  /**
+   * The one pasteable line: a CLI command, a settings key, or a model id.
+   * Never prose, because the block gives it one line and copies it verbatim.
+   */
+  fix: string
+  /**
+   * The counters the detector already recorded, in the order to show them:
+   * the size of the problem first, then the proof it is real.
+   *
+   * The block puts no ceiling on how many. A long list scrolls inside the
+   * opened detail rather than pushing the session list out of the window.
+   */
+  evidence: readonly HotspotEvidenceRow[]
+}
+
+/**
+ * What each category's display name is, and the one sentence that says why it
+ * costs anything.
+ *
+ * This copy lives in the view rather than in the report payload. It names no
+ * repository, no path and no number, so sending it across the IPC boundary
+ * would move a constant between processes for nothing — and the privacy rule
+ * in `local-insights-architecture.md` is easiest to hold when the boundary
+ * carries only counts and slots.
+ */
+export const HOTSPOT_COPY: Record<HotspotCategory, { name: string; mechanism: string }> = {
+  sessionsOverDepth: {
+    name: "Sessions over depth",
+    mechanism:
+      "Past this depth every turn resends the whole conversation, so the cache read grows with each message.",
+  },
+  modelOverthinking: {
+    name: "Model overthinking",
+    mechanism:
+      "These sessions ran a higher reasoning tier than the work needed, and the extra thinking is billed.",
+  },
+  overpoweredSubagents: {
+    name: "Overpowered subagents",
+    mechanism:
+      "Subagents inherit the main model unless a cheaper one is set. Most of these runs were searches and file reads.",
+  },
+  unusedMcpServers: {
+    name: "Unused MCP servers",
+    mechanism:
+      "Their tool definitions load into every session they are configured for, even when nothing calls them.",
+  },
+  unusedBuiltInTools: {
+    name: "Unused built-in tools",
+    mechanism:
+      "Every enabled tool adds its definition to the prompt, whether or not the session ever calls it.",
+  },
+  unusedSkills: {
+    name: "Unused skills",
+    mechanism:
+      "A loaded skill puts its description in the prompt for every session, and these were never invoked.",
+  },
+  oldModelUsage: {
+    name: "Old model usage",
+    mechanism: "These sessions ran a model that a newer one now beats on both price and speed.",
+  },
+  overuseOfFastMode: {
+    name: "Overuse of fast mode",
+    mechanism:
+      "Fast mode is priced above the standard tier, and these sessions did not need the speed.",
+  },
+  cacheChurn: {
+    name: "Cache churn",
+    mechanism:
+      "Switching models or leaving a session idle drops the cached prefix, so the next turn pays to rebuild it.",
+  },
+}
+
+/**
+ * The count as the claim line prints it: `34×`, with a hair space so the
+ * multiplication sign does not crowd the digits.
+ */
+export function hotspotCountLabel(sessions: number): string {
+  return `${sessions.toLocaleString()}\u200a×`
+}

--- a/docs/plans/hotspot-popover-block.md
+++ b/docs/plans/hotspot-popover-block.md
@@ -1,0 +1,276 @@
+# Hotspot block on the activity popover
+
+The block at the foot of the activity surface. It names the single most common
+Hygiene & Efficiency finding across the last 30 days, says how many sessions
+carry it, hands over one pasteable fix, and opens to show the evidence behind
+the count.
+
+Design is settled. This plan covers what has to be built, in what order, and
+the one thing that blocks the useful half of it.
+
+## What is settled
+
+From the Figma file _antiburn bottom section_, the HTML proto, and the review of
+the built block on 2026-08-26:
+
+- **An orange rule across the top of the block, and nothing else is orange.**
+  Not a left spine, not a hairline. `border-t border-brand-tint`. The first
+  build also filled the fix field with the brand colour and set the count in
+  `text-brand`; both were too loud. The brand carries further when it marks one
+  thing than when it fills three.
+- **One type style and one colour across the claim line.** The count, the
+  category name and the saving are all `type-body`. Only the saving steps back,
+  to `text-label-tertiary`, because it is an estimate.
+- **No section label.** No "TIPS", no "Issues", no eyebrow of any kind.
+- **The fix field is a plain stroked field.** `border-separator`, `text-label`
+  ink, `font-mono`. No fill and no brand colour, so it needs no new token and it
+  reads the same in both themes. This replaces the `brand-field` token an
+  earlier draft of this plan added: with no theme-varying ground there is
+  nothing for a token to hold.
+
+  Contrast is why the field never went white-on-orange. White on `brand-tint`
+  measures 2.86:1 and fails AA at 11px, and it also fails the 3:1 a graphic
+  needs, so the copied-state check could not have gone white either. On the
+  stroked field `label` measures 6.34:1 and the check is `system-green`.
+
+- **The whole field is the copy target.** A 13px icon beside a wide, obviously
+  selectable command is the smaller of the two things a reader aims at. The
+  field takes the click; the icon only reports what happened.
+- **Activity surface only.** Not session, not usage. `34×` is a claim about the
+  whole 30-day cohort; sitting under one session's analysis it would read as a
+  claim about _that_ session, and no wording fixes a placement that lies. The
+  usage surface is also already at 780px, the one recorded deviation from the
+  700 contract.
+- **The detail carries as many evidence rows as the detector recorded.** One
+  mechanism sentence, then the counters. No alternative line. An earlier draft
+  fixed the count at two; the block now takes a list and scrolls past
+  `max-h-56` rather than capping what a detector may prove.
+- **An info icon at the leading edge of the claim line**, and the whole claim
+  line is the hit target. Not a disclosure triangle: what opens is evidence for
+  a claim, not a section of the document.
+- **The detail opens below the fix field.** The pasteable line never moves, open
+  or closed, so the reader can hit copy without waiting for a reflow.
+- **The window never resizes.** See _Layout rule_ below.
+- **No finding, no block.** Rule, claim, fix and icon go together.
+
+## The blocker: nothing can populate this yet
+
+Checked against live code on this branch:
+
+- There is no `crates/antiburn-local/src/insights/` module. No report
+  accumulator, no detectors, no status module.
+- There is no `get_local_insights_report` IPC command, and nothing in
+  `apps/desktop/src` references an efficiency report.
+- In `crates/antiburn-local/src/analysis/evidence.rs:186`, `SessionEvidence`
+  carries exactly one real group — `context`. The groups every detector needs
+  (`tools`, `models`, `subagents`, `cache`, `compactions`, `quota_incidents`)
+  are `EvidenceValue<UnfinishedGroup>` behind `#[cfg(debug_assertions)]`.
+
+So **zero detectors can produce a finding today**, and Unused MCP Servers — the
+category the design is drawn around — needs the `tools` group specifically.
+
+This does not block the UI. It blocks the UI being _lit_. The carve below builds
+the presentation against a frozen contract and lets it render nothing until the
+report exists, which is exactly what it must do on a cold install anyway.
+
+## Layout rule
+
+`POPOVER_HEIGHTS.activity` stays at `DEFAULT_POPOVER_HEIGHT` (700). **Do not
+touch `apps/desktop/src/lib/popoverHeight.ts`.** Opening the detail must not
+ask the shell for a taller window.
+
+This works for free. In `PopoverView.tsx:345`, the list already sits in
+`<div className="min-h-0 flex-1">` above `PopoverFooter`, and `SessionList` owns
+a scrolling viewport inside it. A taller block takes its height out of the list,
+and the list shows fewer rows. Nothing moves; less is visible.
+
+The cost, measured off the built component in the running app, not the proto —
+the proto's padding was looser and its numbers (116px / 190px) were wrong:
+
+| State                    | Block height | List gives up                 |
+| ------------------------ | ------------ | ----------------------------- |
+| Closed                   | 68px         | —                             |
+| Open, five evidence rows | 236px        | 168px, about two session rows |
+
+The open figure grows with the row count until the detail hits `max-h-56`
+(224px), which lands at roughly eight rows. Past that the detail scrolls and the
+block stops growing, so the list never gives up more than 236px.
+
+The block goes between the list `div` and `<PopoverFooter>`, inside the same
+flex column. The footer keeps its own `border-t border-separator` when the block
+is absent; when the block is present the block owns the top edge and the footer's
+hairline is not drawn twice.
+
+## Component
+
+New file: `apps/desktop/src/views/popover/HotspotBlock.tsx`.
+
+Follow the conventions already set by `components/ui/Disclosure.tsx`:
+uncontrolled open state via `useState`, `aria-expanded` + `aria-controls`, and
+the body **unmounted** when collapsed so closed evidence stays out of the
+accessibility tree and out of find-in-page.
+
+It is a separate component rather than a use of `Disclosure`, because
+`Disclosure` is a full-width label button with a trailing chevron for prose in
+Settings. This is a three-part claim line with a leading info icon and a fixed
+action field that lives outside the collapsible region.
+
+**No `useEffect`.** The one place it would be reached for is reverting the copy
+icon from a check back to the clipboard glyph after 2s. That is work caused by
+the click, so it belongs in the click handler: set state, `setTimeout`, done. A
+timer that fires after unmount sets state on a dead component, which is a no-op
+in React 18 and not a warning. If review disagrees, the fallback is to drop the
+timed revert and leave the check until the block re-renders — not to add an
+effect.
+
+### Contract
+
+```ts
+/** One of the nine canonical Hygiene & Efficiency categories. */
+type HotspotCategory =
+  | "unusedMcpServers"
+  | "overpoweredSubagents"
+  | "sessionsOverDepth"
+  // … and the remaining six. `hotspot.ts` holds the full list, in tie-break
+  // order.
+  | "oldModelUsage";
+
+type HotspotFinding = {
+  category: HotspotCategory;
+  /** Sessions in the assessed cohort carrying this finding. */
+  sessions: number;
+  /** Preformatted, already `≈`-prefixed. Null when pricing is unknown. */
+  saving: string | null;
+  /** The one pasteable line. Never prose. */
+  fix: string;
+  /**
+   * The counters the detector recorded, preformatted, in the order to show
+   * them: the size of the problem first, then the proof it is real. For
+   * Unused MCP Servers that is tokens over the window, then the servers that
+   * were loaded and never invoked.
+   *
+   * No ceiling on the count. A long list scrolls inside the opened detail.
+   */
+  evidence: readonly HotspotEvidenceRow[];
+};
+```
+
+There is no `cohort` field. An earlier draft carried one for a `34 of 61`
+denominator, but the claim line prints `34×` and the denominator, where a
+detector records it, is just another evidence row.
+
+**Prose is not in the payload.** The mechanism sentence is a fixed string per
+category, held in a TS constant keyed by `HotspotCategory`. It never names a
+repo, a path or a number, so shipping it through IPC would be moving a constant
+across a process boundary for nothing.
+The IPC payload carries counts, slots and the assembled fix line only.
+
+This also keeps the privacy rule in `local-insights-architecture.md` easy to
+hold: no raw prompts, tool inputs, transcript content or local paths cross the
+boundary.
+
+### Rendering rules
+
+- `finding == null` → return `null`. Not an empty shell, not an "all clear"
+  message. This is what satisfies **FR-14**: a half-read cohort renders as
+  nothing, so it cannot be misread as clean.
+- The claim line is a `<button>` spanning the full width.
+- The info icon does not rotate. It steps from `text-label-tertiary` to
+  `text-label` over `duration-fast` while the detail is open.
+- The fix line is `font-mono`, truncates with an ellipsis, never wraps.
+- The fix field is itself a `<button>`. Copy writes `finding.fix` to the
+  clipboard and swaps the icon to a check for 2s — the same shape as Cadence's
+  `copyText`. A rejected write is caught and shows nothing: the reader can still
+  select the line, and a 26px field has no room to say more.
+
+## Selection
+
+One winner, chosen deterministically:
+
+1. Rank by session count, descending.
+2. Ties broken by estimated tokens, descending.
+3. Ties broken by fixed category order.
+
+Open state is **not persisted**. Every time the popover opens, the block is
+closed. Reopening on the same finding does not restore an expansion, because a
+tray popover is glanced at, and a reader who left it open a week ago did not ask
+for a 236px block on next launch.
+
+## Sequence
+
+**Seam 1 — presentation, wired but dark. Done.**
+`HotspotBlock.tsx`, the category prose constants, the contract types, unit
+tests. Rendered from `PopoverView` with a hard-coded `null` finding, so the call
+site exists and nothing is dead code. Ships invisible. No Rust.
+
+| File                                                   | State                                                      |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| `apps/desktop/src/views/popover/hotspot.ts`            | new — types, nine categories, per-category copy            |
+| `apps/desktop/src/views/popover/HotspotBlock.tsx`      | new — the block                                            |
+| `apps/desktop/src/views/popover/HotspotBlock.test.tsx` | new — 12 tests                                             |
+| `apps/desktop/src/views/PopoverView.tsx`               | renders `<HotspotBlock finding={null} />` above the footer |
+
+No stylesheet changes and no new tokens. The block uses `brand-tint`,
+`separator`, `label`, `label-secondary`, `label-tertiary` and `system-green`,
+all of which the contract already carries.
+
+Green on `origin/main` at `684b0a4`: `type-check`, `lint`, `format`, `knip`,
+849 unit tests, `check-design-drift.mjs`, `pnpm run slop`.
+
+**Seam 2 — the report reducer and detectors.**
+Blocked on the `tools` evidence group landing for real. Owned by GH-70's CH
+ladder, not by this plan. This plan's only requirement is that the reducer emits
+enough to fill `HotspotFinding`.
+
+**Seam 3 — IPC and go-live.**
+`get_local_insights_report`, the winner selection, and swapping the hard-coded
+`null` for the real value.
+
+Seam 1 is worth doing now and on its own: it is the part under design review,
+it needs no Rust, and it is the part that would otherwise be rewritten twice.
+
+## Verification
+
+- `HotspotBlock.test.tsx`: a null finding renders nothing at all; the claim line
+  exposes `aria-expanded` and toggles it; the evidence body is absent from the
+  DOM when closed; copy writes the fix string to the clipboard; the command text
+  sits inside the copy button, so the whole field is the target; every evidence
+  row a finding carries is rendered.
+- A test asserting `POPOVER_HEIGHTS.activity === DEFAULT_POPOVER_HEIGHT`, so a
+  later change cannot quietly make the block resize the window.
+- A rejected clipboard write leaves the block in its uncopied state. The other
+  half of that test — that the rejection is _handled_ — is enforced by vitest,
+  which reports an unhandled rejection and exits non-zero. Drop the `.catch` in
+  `onCopy` and the file fails on that route, not on an `expect`.
+- `scripts/check-design-drift.mjs` — no new tokens are needed, so this passes
+  untouched. If it does not, the block is hard-coding something.
+- `pnpm run slop` before finishing.
+
+## Decisions taken
+
+All three open questions were settled at review on 2026-08-26 and are folded
+into _What is settled_ above: no alternative line, `label` ink, and activity
+surface only.
+
+Reviewing the built block the same day settled five more, also folded in above:
+drop the brand fill for a plain stroked field, make the whole field the copy
+target, drop `text-brand` from the count, use an info icon rather than a
+disclosure triangle, and let the detail carry as many evidence rows as the
+detector recorded.
+
+One consequence of dropping the alternative line is worth recording rather than
+rediscovering. It means the block offers exactly one route. That is right for
+Unused MCP Servers, where `claude mcp remove` covers the common case. It is
+thinner for Sessions Over Depth, where the honest advice is often "hand off"
+rather than a threshold change, and for a claude.ai connector, which
+`claude mcp remove` cannot touch at all. Those still get a correct fix line;
+they just lose the caveat beside it. The caveat belongs in Settings → Insights,
+which reads the same report and has room for it.
+
+## Out of scope
+
+- The nine detectors and the evidence groups they need (GH-70).
+- The report accumulator and its read-only snapshot connection.
+- Settings → Insights, which the architecture plan names as the first insights
+  surface. This block is a second, smaller reader of the same report.
+- Any second finding, a list of findings, or a way to page between them.

--- a/docs/plans/hotspot-popover-block.md
+++ b/docs/plans/hotspot-popover-block.md
@@ -179,9 +179,9 @@ boundary.
   `text-label` over `duration-fast` while the detail is open.
 - The fix line is `font-mono`, truncates with an ellipsis, never wraps.
 - The fix field is itself a `<button>`. Copy writes `finding.fix` to the
-  clipboard and swaps the icon to a check for 2s — the same shape as Cadence's
-  `copyText`. A rejected write is caught and shows nothing: the reader can still
-  select the line, and a 26px field has no room to say more.
+  clipboard and swaps the icon to a check for 2s. A rejected write is caught and
+  shows nothing: the reader can still select the line, and a 26px field has no
+  room to say more.
 
 ## Selection
 


### PR DESCRIPTION
## What

Adds the hotspot block at the foot of the activity popover. It names the most
common Hygiene & Efficiency finding across the assessed 30-day cohort, says how
many sessions carry it, hands over one pasteable fix, and opens to show the
evidence behind the count.

Presentation only. No detector can produce a finding yet, so `PopoverView`
passes `null` and **the block renders nothing on this branch**. The contract in
`hotspot.ts` is frozen first because the presentation is the part under design
review, and freezing the shape lets the two halves land in either order.

## Screenshots

Both shots are the real component at the popover's 380px, rendered against a
temporary sample finding that is **not** in the commit.

<!-- drag hotspot-closed.png here -->

<!-- drag hotspot-open.png here -->

Closed the block is 68px. Open with five evidence rows it is 236px, taken out
of the session list, which already scrolls. Past `max-h-56` (about eight rows)
the detail scrolls in place, so the block never grows further and the window
never resizes.

Dark mode was checked in the running app at 400x700 and is not pictured. The
block adds no colour of its own, so both themes come from tokens the contract
already carries.

## Three rules the block keeps

- **No finding, no block.** With nothing to say it renders `null` and the
  session list takes the space back. Not an empty shell and not an "all clear"
  message: a cohort that is only half read must never render as clean (FR-14),
  and nothing at all cannot be misread.
- **The window never resizes.** The activity surface stays at
  `DEFAULT_POPOVER_HEIGHT`. A test pins `POPOVER_HEIGHTS.activity` so a later
  change cannot quietly make the block ask the shell for a taller window and
  move the tray popover under the cursor.
- **One orange mark, and it is the rule across the top.** The fix field is a
  plain stroked field and the count is ordinary label text. An earlier build
  filled the field with the brand colour and set the count in `text-brand`;
  both were too loud. No new token, and `check-design-drift.mjs` passes
  untouched.

## Notes for review

- **No `useEffect`.** The copy check reverts on a `setTimeout` the click starts,
  which is work the click owns. A timer that outlives the block sets state on an
  unmounted component, which React ignores.
- **A rejected clipboard write is caught and shows nothing.** A webview with no
  user activation rejects `writeText`; this was hit for real in `pnpm dev:web`.
  The reader can still select the line, and a 26px field has no room to say
  more. The test for it asserts only the visible half — that the rejection is
  *handled* is enforced by vitest, which reports an unhandled rejection and
  exits non-zero. Drop the `.catch` and the file fails on that route.
- **The whole fix field is the copy target**, not the 13px icon beside it.

## Checks

Green on `main` at `684b0a4`: `type-check`, `lint`, `format`, `knip`,
`check-design-drift.mjs`, `pnpm run slop` (0 errors, 0 warnings), and 849 unit
tests in 84 files. `HotspotBlock.test.tsx` adds 12 of those.

## Follow-ups, not in this PR

- The nine detectors and the evidence groups they need (GH-70).
- `get_local_insights_report`, the winner selection, and swapping the `null`.

Plan: `docs/plans/hotspot-popover-block.md`

>
<img width="2044" height="447" alt="Screenshot 2026-08-26 at 14-18-00" src="https://github.com/user-attachments/assets/1e0ff760-643e-4bdc-b077-7285ea452003" />

