### PR TITLE
Stack GH-70: 0016 (CH-010) Bounded thirty-day report reduction over database evidence

### DIFF
--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -394,7 +394,7 @@ mod tests {
             assert_eq!(coverage.unknown_start, 1);
             assert_eq!(report.assessed_sessions, 1);
             assert!(coverage.is_consistent());
-            
+
             // Verify the cohort contains only the "ready" session, not the unknown-start sessions.
             // The "ready" session has all required capabilities, so any examples in capability
             // gaps must come from the assessed session. Check that examples identify "ready".
@@ -408,7 +408,7 @@ mod tests {
                 let first_example = all_examples[0];
                 assert_eq!(first_example.session_id, "ready");
             }
-            
+
             assert_eq!(
                 report
                     .detectors

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -1,0 +1,327 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use antiburn_local::analysis::{
+    ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION, SessionEvidence,
+};
+use antiburn_local::insights::{
+    CoverageBucket, CoverageCounts, EfficiencyReport, EfficiencyReportAccumulator, ReportContext,
+    ReportWindow,
+};
+use anyhow::{Context, Result, ensure};
+use rusqlite::params;
+
+use crate::store::open_read_only;
+
+const REPORT_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+const CURRENT_EVIDENCE_PREDICATE: &str = "
+    e.status = 'ready'
+    AND NOT (e.analyzed_generation IS NOT s.source_generation)
+    AND NOT (e.parser_revision IS NOT ?4)
+    AND NOT (e.analyzer_revision IS NOT ?5)
+    AND NOT (e.evidence_schema_revision IS NOT ?6)";
+
+const DENOMINATOR_SQL: &str = "
+SELECT bucket, COUNT(*), SUM(awaiting_provider_support)
+  FROM (
+    SELECT CASE
+             WHEN s.started_at_epoch IS NULL THEN 'unknown_start'
+             WHEN e.status IS NULL OR e.status = 'pending' THEN 'pending'
+             WHEN e.status = 'processing' THEN 'processing'
+             WHEN e.status = 'failed' THEN 'failed'
+             WHEN e.status = 'unsupported' THEN 'unsupported'
+             WHEN NOT ({current}) THEN 'stale'
+             ELSE 'ready'
+           END AS bucket,
+           CASE WHEN s.started_at_epoch IS NOT NULL AND e.status IS NULL
+                THEN 1 ELSE 0 END AS awaiting_provider_support
+      FROM session s
+      LEFT JOIN session_evidence e
+        ON e.environment_key = s.environment_key
+       AND e.agent = s.agent
+       AND e.session_id = s.session_id
+     WHERE s.environment_key = ?1
+       AND ((s.started_at_epoch >= ?2 AND s.started_at_epoch < ?3)
+         OR (s.started_at_epoch IS NULL
+             AND s.updated_at_epoch >= ?2 AND s.updated_at_epoch < ?3))
+  )
+ GROUP BY bucket
+ ORDER BY bucket";
+
+const COHORT_SQL: &str = "
+SELECT e.evidence_json
+  FROM session s
+  JOIN session_evidence e
+    ON e.environment_key = s.environment_key
+   AND e.agent = s.agent
+   AND e.session_id = s.session_id
+ WHERE s.environment_key = ?1
+   AND s.started_at_epoch >= ?2
+   AND s.started_at_epoch < ?3
+   AND {current}
+ ORDER BY s.started_at_epoch, s.session_id";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportRequest {
+    pub environment_key: String,
+    pub window: ReportWindow,
+    pub computed_at_epoch: i64,
+}
+
+/// Reduces one report without blocking the async runtime.
+pub async fn reduce_report(data_dir: PathBuf, request: ReportRequest) -> Result<EfficiencyReport> {
+    tokio::task::spawn_blocking(move || reduce_on_snapshot(&data_dir, request, &mut || {}))
+        .await
+        .context("report reduction task failed")?
+}
+
+fn reduce_on_snapshot(
+    data_dir: &Path,
+    request: ReportRequest,
+    after_denominator: &mut dyn FnMut(),
+) -> Result<EfficiencyReport> {
+    let connection = open_read_only(data_dir, REPORT_BUSY_TIMEOUT)?;
+    let transaction = connection.unchecked_transaction()?;
+    let mut coverage = CoverageCounts::default();
+    let denominator_sql = DENOMINATOR_SQL.replace("{current}", CURRENT_EVIDENCE_PREDICATE);
+    {
+        let mut statement = transaction.prepare(&denominator_sql)?;
+        let mut rows = statement.query(params![
+            request.environment_key,
+            request.window.start_epoch,
+            request.window.end_epoch,
+            PARSER_REVISION,
+            ANALYZER_REVISION,
+            EVIDENCE_SCHEMA_REVISION,
+        ])?;
+        while let Some(row) = rows.next()? {
+            let bucket = coverage_bucket(row.get::<_, String>(0)?.as_str())?;
+            let count = u64::try_from(row.get::<_, i64>(1)?)?;
+            let awaiting_provider_support = u64::try_from(row.get::<_, i64>(2)?)?;
+            coverage.observe(bucket, count);
+            coverage.awaiting_provider_support += awaiting_provider_support;
+        }
+    }
+    ensure!(
+        coverage.is_consistent(),
+        "report coverage does not partition"
+    );
+
+    after_denominator();
+
+    let mut accumulator = EfficiencyReportAccumulator::new();
+    let cohort_sql = COHORT_SQL.replace("{current}", CURRENT_EVIDENCE_PREDICATE);
+    {
+        let mut statement = transaction.prepare(&cohort_sql)?;
+        let mut rows = statement.query(params![
+            request.environment_key,
+            request.window.start_epoch,
+            request.window.end_epoch,
+            PARSER_REVISION,
+            ANALYZER_REVISION,
+            EVIDENCE_SCHEMA_REVISION,
+        ])?;
+        while let Some(row) = rows.next()? {
+            let evidence_json: String = row.get(0)?;
+            let evidence: SessionEvidence = serde_json::from_str(&evidence_json)
+                .context("stored session evidence is invalid")?;
+            accumulator.observe_session(evidence);
+        }
+    }
+
+    let report = accumulator.finish(ReportContext {
+        environment_key: request.environment_key,
+        window: request.window,
+        computed_at_epoch: request.computed_at_epoch,
+        parser_revision: PARSER_REVISION,
+        analyzer_revision: ANALYZER_REVISION,
+        evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+        coverage,
+    });
+    ensure!(
+        report.context.coverage.actively_growing <= report.context.coverage.ready,
+        "actively growing coverage exceeds ready coverage"
+    );
+    drop(transaction);
+    drop(connection);
+    Ok(report)
+}
+
+fn coverage_bucket(value: &str) -> Result<CoverageBucket> {
+    match value {
+        "unknown_start" => Ok(CoverageBucket::UnknownStart),
+        "pending" => Ok(CoverageBucket::Pending),
+        "processing" => Ok(CoverageBucket::Processing),
+        "failed" => Ok(CoverageBucket::Failed),
+        "unsupported" => Ok(CoverageBucket::Unsupported),
+        "stale" => Ok(CoverageBucket::Stale),
+        "ready" => Ok(CoverageBucket::Ready),
+        _ => anyhow::bail!("unknown report coverage bucket: {value}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::thread;
+
+    use antiburn_local::analysis::{
+        EVIDENCE_SCHEMA_REVISION, EvidenceSource, METRICS_SCHEMA_REVISION,
+        SessionEvidenceAccumulator, SourceCapabilities, SourceKind,
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::store::{
+        AnalysisRecord, EvidenceCompletion, PublishedEvidence, SessionKey, SessionRecord, Store,
+    };
+
+    fn request() -> ReportRequest {
+        ReportRequest {
+            environment_key: "native".to_owned(),
+            window: ReportWindow {
+                start_epoch: 100,
+                end_epoch: 200,
+            },
+            computed_at_epoch: 200,
+        }
+    }
+
+    fn session(session_id: &str, updated_at_epoch: i64, fingerprint: &str) -> SessionRecord {
+        SessionRecord {
+            key: SessionKey::new("native", "claude-code", session_id),
+            source_kind: "file".to_owned(),
+            source_label: format!("/home/avery/.claude/{session_id}.jsonl"),
+            wsl_distro: None,
+            title: None,
+            title_source: None,
+            cwd: None,
+            surface: "cli".to_owned(),
+            updated_at_epoch: Some(updated_at_epoch),
+            activity_cursor: String::new(),
+            activity_source: "event".to_owned(),
+            subagent_count: 0,
+            fork_parent_session_id: None,
+            source_fingerprint: Some(fingerprint.to_owned()),
+        }
+    }
+
+    fn publish_ready(store: &Store, session_id: &str, started_at_epoch: i64) {
+        let fingerprint = format!("sv1:{session_id}");
+        let session = session(session_id, started_at_epoch, &fingerprint);
+        store
+            .upsert_sessions(std::slice::from_ref(&session), &["claude-code"])
+            .unwrap();
+        let claim = store
+            .claim_next_evidence(&["claude-code"], 10, 60)
+            .unwrap()
+            .unwrap();
+        assert_eq!(claim.key, session.key);
+        let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude-code".to_owned(),
+            session_id: session_id.to_owned(),
+            kind: SourceKind::File,
+            capabilities: SourceCapabilities::claude(),
+        })
+        .evidence();
+        let analysis = AnalysisRecord {
+            key: session.key,
+            model_breakdown_json: "{}".to_owned(),
+            inclusive_models_json: "[]".to_owned(),
+            source_fingerprint: fingerprint,
+            pricing_generation: 1,
+            analyzed_generation: claim.source_generation,
+            parser_revision: PARSER_REVISION,
+            analyzer_revision: ANALYZER_REVISION,
+            metrics_schema_revision: METRICS_SCHEMA_REVISION,
+        };
+        let completion = EvidenceCompletion {
+            claim_fence: claim.claim_fence,
+            status: PublishedEvidence::Ready,
+            evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+            evidence_json: serde_json::to_string(&evidence).unwrap(),
+            diagnostics_json: None,
+        };
+        assert!(
+            store
+                .publish_projections(&analysis, Some(started_at_epoch), &completion, &[])
+                .unwrap()
+        );
+    }
+
+    mod concurrency {
+        use super::*;
+
+        #[test]
+        fn report_pins_one_snapshot_without_blocking_the_writer() {
+            let data_dir = TempDir::new().unwrap();
+            let store = Store::open(data_dir.path()).unwrap();
+            publish_ready(&store, "before", 120);
+            let writer = Store::open(data_dir.path()).unwrap();
+            let (release_tx, release_rx) = mpsc::channel();
+            let (committed_tx, committed_rx) = mpsc::channel();
+            let writer_thread = thread::spawn(move || {
+                release_rx.recv().unwrap();
+                publish_ready(&writer, "during", 130);
+                committed_tx.send(()).unwrap();
+            });
+            let mut release_tx = Some(release_tx);
+
+            let first = reduce_on_snapshot(data_dir.path(), request(), &mut || {
+                release_tx.take().unwrap().send(()).unwrap();
+                committed_rx
+                    .recv_timeout(REPORT_BUSY_TIMEOUT)
+                    .expect("the writer must commit while the reader holds its snapshot");
+            })
+            .unwrap();
+            writer_thread.join().unwrap();
+
+            assert_eq!(first.context.coverage.discovered, 1);
+            assert_eq!(first.assessed_sessions, 1);
+            let second = reduce_on_snapshot(data_dir.path(), request(), &mut || {}).unwrap();
+            assert_eq!(second.context.coverage.discovered, 2);
+            assert_eq!(second.assessed_sessions, 2);
+        }
+
+        #[tokio::test]
+        async fn async_entry_point_reduces_inside_a_blocking_task() {
+            let data_dir = TempDir::new().unwrap();
+            let store = Store::open(data_dir.path()).unwrap();
+            publish_ready(&store, "ready", 120);
+
+            let report = reduce_report(data_dir.path().to_path_buf(), request())
+                .await
+                .unwrap();
+
+            assert_eq!(report.context.coverage.discovered, 1);
+            assert_eq!(report.assessed_sessions, 1);
+        }
+    }
+
+    #[test]
+    fn report_keeps_gap_maps_and_examples_bounded() {
+        let data_dir = TempDir::new().unwrap();
+        let store = Store::open(data_dir.path()).unwrap();
+        for index in 0..10 {
+            publish_ready(&store, &format!("ready-{index}"), 120 + index);
+        }
+
+        let report = reduce_on_snapshot(data_dir.path(), request(), &mut || {}).unwrap();
+
+        assert!(report.capability_gaps.len() <= 9);
+        assert!(report.capability_gap_examples.len() <= 9);
+        assert!(
+            report
+                .capability_gap_examples
+                .values()
+                .map(Vec::len)
+                .sum::<usize>()
+                <= 9 * antiburn_local::insights::MAX_EXAMPLES_PER_DETECTOR
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -395,18 +395,17 @@ mod tests {
             assert_eq!(report.assessed_sessions, 1);
             assert!(coverage.is_consistent());
 
-            // Verify the cohort contains only the "ready" session, not the unknown-start sessions.
-            // The "ready" session has all required capabilities, so any examples in capability
-            // gaps must come from the assessed session. Check that examples identify "ready".
+            // Only the "ready" session is in the cohort, so every capability gap
+            // example must name it. The Claude capability set blocks four detectors,
+            // so the example list cannot be empty.
             let all_examples: Vec<_> = report
                 .capability_gap_examples
                 .values()
                 .flat_map(|v| v.iter())
                 .collect();
-            if !all_examples.is_empty() {
-                // If there are gaps, they must be from the "ready" session (the cohort member).
-                let first_example = all_examples[0];
-                assert_eq!(first_example.session_id, "ready");
+            assert!(!all_examples.is_empty());
+            for example in all_examples {
+                assert_eq!(example.session_id, "ready");
             }
 
             assert_eq!(
@@ -424,6 +423,51 @@ mod tests {
                     .map(|counts| counts.assessed)
                     .sum::<u64>(),
                 5
+            );
+        }
+
+        #[test]
+        fn unknown_start_rows_split_on_in_window_activity() {
+            // Each case seeds one row alone, so a reversed activity predicate
+            // cannot pass by counting the other row.
+            let active_dir = TempDir::new().unwrap();
+            let active_store = Store::open(active_dir.path()).unwrap();
+            let active = session("unknown-active", 150, "sv1:unknown-active");
+            active_store.upsert_sessions(&[active], &[]).unwrap();
+
+            let report = reduce_on_snapshot(active_dir.path(), request(), &mut || {}).unwrap();
+            let coverage = &report.context.coverage;
+            assert_eq!(coverage.discovered, 1);
+            assert_eq!(coverage.unknown_start, 1);
+            assert_eq!(report.assessed_sessions, 0);
+            assert!(coverage.is_consistent());
+            assert_eq!(
+                report
+                    .detectors
+                    .iter()
+                    .map(|counts| counts.eligible + counts.assessed)
+                    .sum::<u64>(),
+                0
+            );
+
+            let inactive_dir = TempDir::new().unwrap();
+            let inactive_store = Store::open(inactive_dir.path()).unwrap();
+            let inactive = session("unknown-inactive", 99, "sv1:unknown-inactive");
+            inactive_store.upsert_sessions(&[inactive], &[]).unwrap();
+
+            let report = reduce_on_snapshot(inactive_dir.path(), request(), &mut || {}).unwrap();
+            let coverage = &report.context.coverage;
+            assert_eq!(coverage.discovered, 0);
+            assert_eq!(coverage.unknown_start, 0);
+            assert_eq!(report.assessed_sessions, 0);
+            assert!(coverage.is_consistent());
+            assert_eq!(
+                report
+                    .detectors
+                    .iter()
+                    .map(|counts| counts.eligible + counts.assessed)
+                    .sum::<u64>(),
+                0
             );
         }
 

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -178,7 +178,8 @@ mod tests {
 
     use super::*;
     use crate::store::{
-        AnalysisRecord, EvidenceCompletion, PublishedEvidence, SessionKey, SessionRecord, Store,
+        AnalysisRecord, EvidenceCompletion, EvidenceFailure, ProjectionRevisions,
+        PublishedEvidence, SessionKey, SessionRecord, Store,
     };
 
     fn request() -> ReportRequest {
@@ -211,7 +212,12 @@ mod tests {
         }
     }
 
-    fn publish_ready(store: &Store, session_id: &str, started_at_epoch: i64) {
+    fn publish_evidence(
+        store: &Store,
+        session_id: &str,
+        started_at_epoch: i64,
+        status: PublishedEvidence,
+    ) {
         let fingerprint = format!("sv1:{session_id}");
         let session = session(session_id, started_at_epoch, &fingerprint);
         store
@@ -242,7 +248,7 @@ mod tests {
         };
         let completion = EvidenceCompletion {
             claim_fence: claim.claim_fence,
-            status: PublishedEvidence::Ready,
+            status,
             evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
             evidence_json: serde_json::to_string(&evidence).unwrap(),
             diagnostics_json: None,
@@ -252,6 +258,22 @@ mod tests {
                 .publish_projections(&analysis, Some(started_at_epoch), &completion, &[])
                 .unwrap()
         );
+    }
+
+    fn publish_ready(store: &Store, session_id: &str, started_at_epoch: i64) {
+        publish_evidence(
+            store,
+            session_id,
+            started_at_epoch,
+            PublishedEvidence::Ready,
+        );
+    }
+
+    fn change_source(store: &Store, session_id: &str, evidence_agents: &[&str]) {
+        let changed = session(session_id, 150, &format!("sv2:{session_id}"));
+        store
+            .upsert_sessions(std::slice::from_ref(&changed), evidence_agents)
+            .unwrap();
     }
 
     mod concurrency {
@@ -300,6 +322,114 @@ mod tests {
 
             assert_eq!(report.context.coverage.discovered, 1);
             assert_eq!(report.assessed_sessions, 1);
+        }
+    }
+
+    mod population {
+        use super::*;
+
+        #[test]
+        fn denominator_partitions_non_cohort_rows_by_reason() {
+            let data_dir = TempDir::new().unwrap();
+            let store = Store::open(data_dir.path()).unwrap();
+
+            publish_ready(&store, "processing", 120);
+            change_source(&store, "processing", &["claude-code"]);
+            let processing_claim = store
+                .claim_next_evidence(&["claude-code"], 20, 600)
+                .unwrap()
+                .unwrap();
+            assert_eq!(processing_claim.key.session_id, "processing");
+
+            publish_ready(&store, "failed", 121);
+            change_source(&store, "failed", &["claude-code"]);
+            let failed_claim = store
+                .claim_next_evidence(&["claude-code"], 20, 600)
+                .unwrap()
+                .unwrap();
+            assert_eq!(failed_claim.key.session_id, "failed");
+            assert!(
+                store
+                    .fail_evidence(
+                        &failed_claim,
+                        EvidenceFailure::Failed {
+                            revisions: ProjectionRevisions {
+                                parser_revision: PARSER_REVISION,
+                                analyzer_revision: ANALYZER_REVISION,
+                                metrics_schema_revision: METRICS_SCHEMA_REVISION,
+                                evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+                            },
+                        },
+                        "synthetic terminal failure",
+                    )
+                    .unwrap()
+            );
+
+            publish_evidence(&store, "unsupported", 123, PublishedEvidence::Unsupported);
+
+            publish_ready(&store, "stale", 124);
+            change_source(&store, "stale", &[]);
+
+            let unknown_active = session("unknown-active", 150, "sv1:unknown-active");
+            let unknown_inactive = session("unknown-inactive", 99, "sv1:unknown-inactive");
+            store
+                .upsert_sessions(&[unknown_active, unknown_inactive], &[])
+                .unwrap();
+
+            publish_ready(&store, "ready", 125);
+
+            publish_ready(&store, "pending", 122);
+            change_source(&store, "pending", &["claude-code"]);
+
+            let report = reduce_on_snapshot(data_dir.path(), request(), &mut || {}).unwrap();
+            let coverage = &report.context.coverage;
+
+            assert_eq!(coverage.discovered, 7);
+            assert_eq!(coverage.ready, 1);
+            assert_eq!(coverage.pending, 1);
+            assert_eq!(coverage.processing, 1);
+            assert_eq!(coverage.failed, 1);
+            assert_eq!(coverage.unsupported, 1);
+            assert_eq!(coverage.stale, 1);
+            assert_eq!(coverage.unknown_start, 1);
+            assert_eq!(report.assessed_sessions, 1);
+            assert!(coverage.is_consistent());
+            assert_eq!(
+                report
+                    .detectors
+                    .iter()
+                    .map(|counts| counts.eligible)
+                    .sum::<u64>(),
+                5
+            );
+            assert_eq!(
+                report
+                    .detectors
+                    .iter()
+                    .map(|counts| counts.assessed)
+                    .sum::<u64>(),
+                5
+            );
+        }
+
+        #[test]
+        fn report_excludes_sessions_from_another_environment() {
+            let data_dir = TempDir::new().unwrap();
+            let store = Store::open(data_dir.path()).unwrap();
+            let mut other = session("other-environment", 150, "sv1:other-environment");
+            other.key.environment_key = "wsl:ubuntu".to_owned();
+            store.upsert_sessions(&[other], &[]).unwrap();
+
+            let report = reduce_on_snapshot(data_dir.path(), request(), &mut || {}).unwrap();
+
+            assert_eq!(report.context.coverage.discovered, 0);
+            assert_eq!(report.assessed_sessions, 0);
+            assert!(
+                report
+                    .detectors
+                    .iter()
+                    .all(|counts| { counts.eligible == 0 && counts.assessed == 0 })
+            );
         }
     }
 

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -394,6 +394,21 @@ mod tests {
             assert_eq!(coverage.unknown_start, 1);
             assert_eq!(report.assessed_sessions, 1);
             assert!(coverage.is_consistent());
+            
+            // Verify the cohort contains only the "ready" session, not the unknown-start sessions.
+            // The "ready" session has all required capabilities, so any examples in capability
+            // gaps must come from the assessed session. Check that examples identify "ready".
+            let all_examples: Vec<_> = report
+                .capability_gap_examples
+                .values()
+                .flat_map(|v| v.iter())
+                .collect();
+            if !all_examples.is_empty() {
+                // If there are gaps, they must be from the "ready" session (the cohort member).
+                let first_example = all_examples[0];
+                assert_eq!(first_example.session_id, "ready");
+            }
+            
             assert_eq!(
                 report
                     .detectors

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -61,6 +61,7 @@ mod dto;
 mod export;
 mod global_click;
 mod hud;
+mod insights_report;
 mod insights_worker;
 mod notifications;
 mod nudges;
@@ -76,6 +77,9 @@ mod store;
 // This bridge keeps CH-007 evidence readers reachable until the evidence pane calls them.
 // TODO @agent: CH-012 will remove this re-export.
 pub use store::Store;
+// This bridge keeps the CH-010 report reducer reachable until the Insights pane calls it.
+// TODO @agent: CH-012 will remove this re-export.
+pub use insights_report::{ReportRequest, reduce_report};
 mod tray;
 mod tray_title;
 mod updates;

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -34,9 +34,10 @@ mod tests;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 
 use crate::dto::DeferredPermissionDir;
 
@@ -78,6 +79,21 @@ fn database_file() -> &'static str {
 /// Path of the database inside `data_dir`.
 pub fn database_path(data_dir: &Path) -> PathBuf {
     data_dir.join(database_file())
+}
+
+/// Opens a second connection for reads only. It never writes.
+pub fn open_read_only(data_dir: &Path, busy_timeout: Duration) -> Result<Connection> {
+    let path = database_path(data_dir);
+    let connection = Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_URI
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("failed to open {} for reporting", path.display()))?;
+    connection.busy_timeout(busy_timeout)?;
+    connection.pragma_update(None, "query_only", true)?;
+    Ok(connection)
 }
 
 /// The app's local database.

--- a/crates/antiburn-local/src/insights/mod.rs
+++ b/crates/antiburn-local/src/insights/mod.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Provider-neutral local insights report contracts and reduction.
+
+mod report;
+mod status;
+
+pub use report::{
+    CapabilityFlag, CoverageCounts, DetectorCounts, DetectorRequirements, EfficiencyReport,
+    EfficiencyReportAccumulator, EvidenceGroup, GroupState, MAX_EXAMPLES_PER_DETECTOR,
+    ReportContext, ReportWindow, SessionExample, requirements,
+};
+pub use status::{CoverageBucket, DetectorId};

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -297,12 +297,8 @@ impl EfficiencyReportAccumulator {
             self.actively_growing += 1;
         }
 
-        // Clone identity strings once to avoid per-detector allocations. The bounded
-        // examples use the shared identity for every detector gap.
-        let bounded_example = SessionExample {
-            agent: evidence.identity.agent.clone(),
-            session_id: evidence.identity.session_id.clone(),
-        };
+        // Lazily allocate the identity example only if this session has a detector gap.
+        let mut bounded_example: Option<SessionExample> = None;
 
         for detector in DetectorId::ALL {
             let requirements = requirements(detector);
@@ -332,7 +328,11 @@ impl EfficiencyReportAccumulator {
             *self.capability_gaps.entry(detector).or_default() += 1;
             let examples = self.capability_gap_examples.entry(detector).or_default();
             if examples.len() < MAX_EXAMPLES_PER_DETECTOR {
-                examples.push(bounded_example.clone());
+                let example = bounded_example.get_or_insert_with(|| SessionExample {
+                    agent: evidence.identity.agent.clone(),
+                    session_id: evidence.identity.session_id.clone(),
+                });
+                examples.push(example.clone());
             }
         }
     }

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -297,6 +297,13 @@ impl EfficiencyReportAccumulator {
             self.actively_growing += 1;
         }
 
+        // Clone identity strings once to avoid per-detector allocations. The bounded
+        // examples use the shared identity for every detector gap.
+        let bounded_example = SessionExample {
+            agent: evidence.identity.agent.clone(),
+            session_id: evidence.identity.session_id.clone(),
+        };
+
         for detector in DetectorId::ALL {
             let requirements = requirements(detector);
             let capabilities_hold = requirements.capabilities.iter().all(|clause| {
@@ -325,10 +332,7 @@ impl EfficiencyReportAccumulator {
             *self.capability_gaps.entry(detector).or_default() += 1;
             let examples = self.capability_gap_examples.entry(detector).or_default();
             if examples.len() < MAX_EXAMPLES_PER_DETECTOR {
-                examples.push(SessionExample {
-                    agent: evidence.identity.agent.clone(),
-                    session_id: evidence.identity.session_id.clone(),
-                });
+                examples.push(bounded_example.clone());
             }
         }
     }

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -1,0 +1,519 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+
+use crate::analysis::{
+    CoverageReason, EvidenceCoverage, EvidenceValue, SessionEvidence, SourceAcceptance,
+    SourceCapabilities,
+};
+
+use super::{CoverageBucket, DetectorId};
+
+pub const MAX_EXAMPLES_PER_DETECTOR: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DetectorCounts {
+    pub eligible: u64,
+    pub assessed: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReportWindow {
+    pub start_epoch: i64,
+    pub end_epoch: i64,
+}
+
+/// Names one session without transcript content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionExample {
+    pub agent: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityFlag {
+    RequestContextTokens,
+    CacheWriteTokens,
+    TimestampsAndOrder,
+    ToolInvocations,
+    SkillMcpAttribution,
+    ToolDefinitions,
+    ModelIdentity,
+    TokenClasses,
+    ReasoningEffortTier,
+    FastTier,
+    ServiceTier,
+    SubagentRelationships,
+    SubagentModels,
+    CompactionBoundaries,
+    ThreadIdentity,
+}
+
+impl CapabilityFlag {
+    pub fn is_set(self, capabilities: &SourceCapabilities) -> bool {
+        match self {
+            Self::RequestContextTokens => capabilities.request_context_tokens,
+            Self::CacheWriteTokens => capabilities.cache_write_tokens,
+            Self::TimestampsAndOrder => capabilities.timestamps_and_order,
+            Self::ToolInvocations => capabilities.tool_invocations,
+            Self::SkillMcpAttribution => capabilities.skill_mcp_attribution,
+            Self::ToolDefinitions => capabilities.tool_definitions,
+            Self::ModelIdentity => capabilities.model_identity,
+            Self::TokenClasses => capabilities.token_classes,
+            Self::ReasoningEffortTier => capabilities.reasoning_effort_tier,
+            Self::FastTier => capabilities.fast_tier,
+            Self::ServiceTier => capabilities.service_tier,
+            Self::SubagentRelationships => capabilities.subagent_relationships,
+            Self::SubagentModels => capabilities.subagent_models,
+            Self::CompactionBoundaries => capabilities.compaction_boundaries,
+            Self::ThreadIdentity => capabilities.thread_identity,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceGroup {
+    Context,
+    Eligibility,
+    Tools,
+    ContextSources,
+    Models,
+    Subagents,
+    Cache,
+    Compactions,
+    TimeRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupState {
+    Unsupported,
+    Partial,
+    Complete,
+}
+
+impl EvidenceGroup {
+    pub fn state(self, evidence: &SessionEvidence) -> GroupState {
+        match self {
+            Self::Context => state(&evidence.context),
+            Self::Eligibility => state(&evidence.eligibility),
+            Self::Tools => state(&evidence.tools),
+            Self::ContextSources => state(&evidence.context_sources),
+            Self::Models => state(&evidence.models),
+            Self::Subagents => state(&evidence.subagents),
+            Self::Cache => state(&evidence.cache),
+            Self::Compactions => state(&evidence.compactions),
+            Self::TimeRange => state(&evidence.time_range),
+        }
+    }
+}
+
+fn state<T>(value: &EvidenceValue<T>) -> GroupState {
+    match value {
+        EvidenceValue::Unsupported => GroupState::Unsupported,
+        EvidenceValue::Partial { .. } => GroupState::Partial,
+        EvidenceValue::Complete(_) => GroupState::Complete,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DetectorRequirements {
+    pub capabilities: &'static [&'static [CapabilityFlag]],
+    pub groups: &'static [EvidenceGroup],
+}
+
+const REQUEST_CONTEXT_TOKENS: &[CapabilityFlag] = &[CapabilityFlag::RequestContextTokens];
+const CACHE_WRITE_TOKENS: &[CapabilityFlag] = &[CapabilityFlag::CacheWriteTokens];
+const TIMESTAMPS_AND_ORDER: &[CapabilityFlag] = &[CapabilityFlag::TimestampsAndOrder];
+const TOOL_INVOCATIONS: &[CapabilityFlag] = &[CapabilityFlag::ToolInvocations];
+const SKILL_MCP_ATTRIBUTION: &[CapabilityFlag] = &[CapabilityFlag::SkillMcpAttribution];
+const TOOL_DEFINITIONS: &[CapabilityFlag] = &[CapabilityFlag::ToolDefinitions];
+const MODEL_IDENTITY: &[CapabilityFlag] = &[CapabilityFlag::ModelIdentity];
+const TOKEN_CLASSES: &[CapabilityFlag] = &[CapabilityFlag::TokenClasses];
+const REASONING_EFFORT_TIER: &[CapabilityFlag] = &[CapabilityFlag::ReasoningEffortTier];
+const FAST_OR_SERVICE_TIER: &[CapabilityFlag] =
+    &[CapabilityFlag::FastTier, CapabilityFlag::ServiceTier];
+const SUBAGENT_RELATIONSHIPS: &[CapabilityFlag] = &[CapabilityFlag::SubagentRelationships];
+const SUBAGENT_MODELS: &[CapabilityFlag] = &[CapabilityFlag::SubagentModels];
+const COMPACTION_BOUNDARIES: &[CapabilityFlag] = &[CapabilityFlag::CompactionBoundaries];
+const THREAD_IDENTITY: &[CapabilityFlag] = &[CapabilityFlag::ThreadIdentity];
+
+pub fn requirements(detector: DetectorId) -> DetectorRequirements {
+    use EvidenceGroup as Group;
+
+    match detector {
+        DetectorId::SessionsOverDepth => DetectorRequirements {
+            capabilities: &[
+                REQUEST_CONTEXT_TOKENS,
+                MODEL_IDENTITY,
+                THREAD_IDENTITY,
+                TIMESTAMPS_AND_ORDER,
+            ],
+            groups: &[Group::Context],
+        },
+        DetectorId::ModelOverthinking => DetectorRequirements {
+            capabilities: &[REASONING_EFFORT_TIER, MODEL_IDENTITY],
+            groups: &[Group::Models, Group::Eligibility],
+        },
+        DetectorId::OverpoweredSubagents => DetectorRequirements {
+            capabilities: &[MODEL_IDENTITY, SUBAGENT_MODELS, SUBAGENT_RELATIONSHIPS],
+            groups: &[Group::Subagents, Group::Models],
+        },
+        DetectorId::UnusedMcpServers => DetectorRequirements {
+            capabilities: &[SKILL_MCP_ATTRIBUTION, TOOL_INVOCATIONS],
+            groups: &[Group::ContextSources, Group::Tools, Group::Eligibility],
+        },
+        DetectorId::UnusedBuiltInTools => DetectorRequirements {
+            capabilities: &[TOOL_DEFINITIONS, TOOL_INVOCATIONS],
+            groups: &[Group::ContextSources, Group::Tools],
+        },
+        DetectorId::UnusedSkills => DetectorRequirements {
+            capabilities: &[SKILL_MCP_ATTRIBUTION, TOOL_INVOCATIONS],
+            groups: &[Group::ContextSources, Group::Tools, Group::Eligibility],
+        },
+        DetectorId::OldModelUsage => DetectorRequirements {
+            capabilities: &[MODEL_IDENTITY, TIMESTAMPS_AND_ORDER, TOKEN_CLASSES],
+            groups: &[Group::Models, Group::TimeRange],
+        },
+        DetectorId::OveruseOfFastMode => DetectorRequirements {
+            capabilities: &[FAST_OR_SERVICE_TIER, SUBAGENT_RELATIONSHIPS],
+            groups: &[Group::Models, Group::Subagents],
+        },
+        DetectorId::CacheChurn => DetectorRequirements {
+            capabilities: &[
+                TIMESTAMPS_AND_ORDER,
+                THREAD_IDENTITY,
+                MODEL_IDENTITY,
+                CACHE_WRITE_TOKENS,
+                COMPACTION_BOUNDARIES,
+            ],
+            groups: &[Group::Cache, Group::Compactions, Group::Models],
+        },
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CoverageCounts {
+    pub discovered: u64,
+    pub unknown_start: u64,
+    pub pending: u64,
+    pub processing: u64,
+    pub failed: u64,
+    pub unsupported: u64,
+    pub stale: u64,
+    pub ready: u64,
+    pub actively_growing: u64,
+    pub awaiting_provider_support: u64,
+}
+
+impl CoverageCounts {
+    pub fn observe(&mut self, bucket: CoverageBucket, count: u64) {
+        self.discovered += count;
+        match bucket {
+            CoverageBucket::UnknownStart => self.unknown_start += count,
+            CoverageBucket::Pending => self.pending += count,
+            CoverageBucket::Processing => self.processing += count,
+            CoverageBucket::Failed => self.failed += count,
+            CoverageBucket::Unsupported => self.unsupported += count,
+            CoverageBucket::Stale => self.stale += count,
+            CoverageBucket::Ready => self.ready += count,
+        }
+    }
+
+    pub fn is_consistent(&self) -> bool {
+        self.discovered
+            == self.unknown_start
+                + self.pending
+                + self.processing
+                + self.failed
+                + self.unsupported
+                + self.stale
+                + self.ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportContext {
+    pub environment_key: String,
+    pub window: ReportWindow,
+    pub computed_at_epoch: i64,
+    pub parser_revision: i64,
+    pub analyzer_revision: i64,
+    pub evidence_schema_revision: i64,
+    pub coverage: CoverageCounts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EfficiencyReport {
+    pub context: ReportContext,
+    pub assessed_sessions: u64,
+    pub detectors: [DetectorCounts; 9],
+    pub coverage_reasons: BTreeMap<CoverageReason, u64>,
+    pub capability_gaps: BTreeMap<DetectorId, u64>,
+    pub capability_gap_examples: BTreeMap<DetectorId, Vec<SessionExample>>,
+}
+
+pub struct EfficiencyReportAccumulator {
+    assessed_sessions: u64,
+    detectors: [DetectorCounts; 9],
+    coverage_reasons: BTreeMap<CoverageReason, u64>,
+    capability_gaps: BTreeMap<DetectorId, u64>,
+    capability_gap_examples: BTreeMap<DetectorId, Vec<SessionExample>>,
+    actively_growing: u64,
+}
+
+impl Default for EfficiencyReportAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EfficiencyReportAccumulator {
+    pub fn new() -> Self {
+        Self {
+            assessed_sessions: 0,
+            detectors: [DetectorCounts {
+                eligible: 0,
+                assessed: 0,
+            }; 9],
+            coverage_reasons: BTreeMap::new(),
+            capability_gaps: BTreeMap::new(),
+            capability_gap_examples: BTreeMap::new(),
+            actively_growing: 0,
+        }
+    }
+
+    /// Observes one session from the ready-and-current cohort.
+    pub fn observe_session(&mut self, evidence: SessionEvidence) {
+        self.assessed_sessions += 1;
+        if let EvidenceCoverage::Partial(reason) = evidence.coverage {
+            *self.coverage_reasons.entry(reason).or_default() += 1;
+        }
+        if matches!(
+            evidence.provenance.source_acceptance,
+            SourceAcceptance::AcceptedPrefix { .. }
+        ) {
+            self.actively_growing += 1;
+        }
+
+        for detector in DetectorId::ALL {
+            let requirements = requirements(detector);
+            let capabilities_hold = requirements.capabilities.iter().all(|clause| {
+                clause
+                    .iter()
+                    .any(|flag| flag.is_set(&evidence.capabilities))
+            });
+            let groups_supported = requirements
+                .groups
+                .iter()
+                .all(|group| group.state(&evidence) != GroupState::Unsupported);
+            let eligible = capabilities_hold && groups_supported;
+            if eligible {
+                let counts = &mut self.detectors[detector.index()];
+                counts.eligible += 1;
+                if requirements
+                    .groups
+                    .iter()
+                    .all(|group| group.state(&evidence) == GroupState::Complete)
+                {
+                    counts.assessed += 1;
+                }
+                continue;
+            }
+
+            *self.capability_gaps.entry(detector).or_default() += 1;
+            let examples = self.capability_gap_examples.entry(detector).or_default();
+            if examples.len() < MAX_EXAMPLES_PER_DETECTOR {
+                examples.push(SessionExample {
+                    agent: evidence.identity.agent.clone(),
+                    session_id: evidence.identity.session_id.clone(),
+                });
+            }
+        }
+    }
+
+    pub fn finish(self, mut context: ReportContext) -> EfficiencyReport {
+        context.coverage.actively_growing = self.actively_growing;
+        EfficiencyReport {
+            context,
+            assessed_sessions: self.assessed_sessions,
+            detectors: self.detectors,
+            coverage_reasons: self.coverage_reasons,
+            capability_gaps: self.capability_gaps,
+            capability_gap_examples: self.capability_gap_examples,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{
+        ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, EvidenceSource, PARSER_REVISION,
+        SessionEvidenceAccumulator, SourceKind,
+    };
+
+    fn evidence(session_id: &str) -> SessionEvidence {
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: session_id.to_owned(),
+            kind: SourceKind::File,
+            capabilities: SourceCapabilities::claude(),
+        })
+        .evidence()
+    }
+
+    fn context(coverage: CoverageCounts) -> ReportContext {
+        ReportContext {
+            environment_key: "native".to_owned(),
+            window: ReportWindow {
+                start_epoch: 10,
+                end_epoch: 20,
+            },
+            computed_at_epoch: 20,
+            parser_revision: PARSER_REVISION,
+            analyzer_revision: ANALYZER_REVISION,
+            evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+            coverage,
+        }
+    }
+
+    #[test]
+    fn coverage_buckets_partition_discovered_without_overlays() {
+        let mut counts = CoverageCounts::default();
+        for bucket in [
+            CoverageBucket::UnknownStart,
+            CoverageBucket::Pending,
+            CoverageBucket::Processing,
+            CoverageBucket::Failed,
+            CoverageBucket::Unsupported,
+            CoverageBucket::Stale,
+            CoverageBucket::Ready,
+        ] {
+            counts.observe(bucket, 2);
+        }
+        counts.actively_growing = 4;
+        counts.awaiting_provider_support = 1;
+
+        assert_eq!(counts.discovered, 14);
+        assert!(counts.is_consistent());
+    }
+
+    #[test]
+    fn any_capability_clause_accepts_either_flag() {
+        for (fast_tier, service_tier) in [(true, false), (false, true)] {
+            let mut row = evidence("mode");
+            row.capabilities.fast_tier = fast_tier;
+            row.capabilities.service_tier = service_tier;
+            let mut accumulator = EfficiencyReportAccumulator::new();
+            accumulator.observe_session(row);
+            let report = accumulator.finish(context(CoverageCounts::default()));
+
+            assert_eq!(
+                report.detectors[DetectorId::OveruseOfFastMode.index()].eligible,
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn group_states_separate_eligibility_from_assessment() {
+        let mut unsupported = evidence("unsupported");
+        unsupported.models = EvidenceValue::Unsupported;
+        let mut partial = evidence("partial");
+        partial.models = match partial.models {
+            EvidenceValue::Complete(observed) => EvidenceValue::Partial {
+                observed,
+                reason: CoverageReason::AttributionIncomplete,
+            },
+            _ => unreachable!(),
+        };
+        let complete = evidence("complete");
+        let mut accumulator = EfficiencyReportAccumulator::new();
+        accumulator.observe_session(unsupported);
+        accumulator.observe_session(partial);
+        accumulator.observe_session(complete);
+        let report = accumulator.finish(context(CoverageCounts::default()));
+        let counts = report.detectors[DetectorId::ModelOverthinking.index()];
+
+        assert_eq!(counts.eligible, 2);
+        assert_eq!(counts.assessed, 1);
+    }
+
+    #[test]
+    fn claude_matrix_has_the_exact_eligible_detector_set() {
+        let mut accumulator = EfficiencyReportAccumulator::new();
+        accumulator.observe_session(evidence("matrix"));
+        let report = accumulator.finish(context(CoverageCounts::default()));
+        let eligible: Vec<_> = DetectorId::ALL
+            .into_iter()
+            .filter(|detector| report.detectors[detector.index()].eligible == 1)
+            .collect();
+
+        assert_eq!(
+            eligible,
+            vec![
+                DetectorId::ModelOverthinking,
+                DetectorId::UnusedMcpServers,
+                DetectorId::UnusedSkills,
+                DetectorId::OldModelUsage,
+                DetectorId::OveruseOfFastMode,
+            ]
+        );
+    }
+
+    #[test]
+    fn finish_replaces_only_the_actively_growing_overlay() {
+        let mut accumulator = EfficiencyReportAccumulator::new();
+        for index in 0..5 {
+            let mut row = evidence(&format!("session-{index}"));
+            row.provenance.source_acceptance = if index < 3 {
+                SourceAcceptance::AcceptedPrefix { boundary: 10 }
+            } else {
+                SourceAcceptance::AcceptedFull
+            };
+            accumulator.observe_session(row);
+        }
+        let mut coverage = CoverageCounts::default();
+        coverage.observe(CoverageBucket::Ready, 5);
+        coverage.actively_growing = 99;
+        coverage.awaiting_provider_support = 2;
+        let report = accumulator.finish(context(coverage));
+
+        assert_eq!(report.context.coverage.actively_growing, 3);
+        assert_eq!(report.context.coverage.ready, 5);
+        assert_eq!(report.context.coverage.awaiting_provider_support, 2);
+        assert!(report.context.coverage.actively_growing <= report.context.coverage.ready);
+        assert!(report.context.coverage.is_consistent());
+    }
+
+    #[test]
+    fn capability_gap_examples_keep_the_first_three_sessions() {
+        let mut accumulator = EfficiencyReportAccumulator::new();
+        for index in 0..5 {
+            accumulator.observe_session(evidence(&format!("session-{index}")));
+        }
+        let report = accumulator.finish(context(CoverageCounts::default()));
+        let detector = DetectorId::SessionsOverDepth;
+
+        assert_eq!(report.capability_gaps[&detector], 5);
+        assert_eq!(report.capability_gap_examples[&detector].len(), 3);
+        assert_eq!(
+            report.capability_gap_examples[&detector]
+                .iter()
+                .map(|example| example.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["session-0", "session-1", "session-2"]
+        );
+        assert!(report.capability_gap_examples.len() <= DetectorId::ALL.len());
+        assert!(
+            report
+                .capability_gap_examples
+                .values()
+                .map(Vec::len)
+                .sum::<usize>()
+                <= DetectorId::ALL.len() * MAX_EXAMPLES_PER_DETECTOR
+        );
+    }
+}

--- a/crates/antiburn-local/src/insights/status.rs
+++ b/crates/antiburn-local/src/insights/status.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Identifies one provider-neutral report detector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DetectorId {
+    SessionsOverDepth,
+    ModelOverthinking,
+    OverpoweredSubagents,
+    UnusedMcpServers,
+    UnusedBuiltInTools,
+    UnusedSkills,
+    OldModelUsage,
+    OveruseOfFastMode,
+    CacheChurn,
+}
+
+impl DetectorId {
+    pub const ALL: [Self; 9] = [
+        Self::SessionsOverDepth,
+        Self::ModelOverthinking,
+        Self::OverpoweredSubagents,
+        Self::UnusedMcpServers,
+        Self::UnusedBuiltInTools,
+        Self::UnusedSkills,
+        Self::OldModelUsage,
+        Self::OveruseOfFastMode,
+        Self::CacheChurn,
+    ];
+
+    pub const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Identifies one exclusive coverage bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageBucket {
+    UnknownStart,
+    Pending,
+    Processing,
+    Failed,
+    Unsupported,
+    Stale,
+    Ready,
+}

--- a/crates/antiburn-local/src/lib.rs
+++ b/crates/antiburn-local/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod analysis;
 pub mod discovery;
+pub mod insights;
 pub mod model;
 pub mod paths;
 pub mod platform;

--- a/docs/plans/local-insights-followups.md
+++ b/docs/plans/local-insights-followups.md
@@ -81,3 +81,19 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Why deferred:** The read occurs upstream of the CH-005 analysis boundary. Removing it requires a discovery source contract change.
 - **Kind:** `deferred`
 - **Disposition:** `file-issue` after CH-013 measures the affected source volume.
+
+## Unsupported evidence publication trigger
+
+- **What was found:** The first production writer of `PublishedEvidence::Unsupported` needs the detector prerequisite sets before it can classify a provider.
+- **Found by seam:** GH-70 seam 0016.
+- **Why deferred:** CH-010 reads unsupported rows but does not own evidence publication policy.
+- **Kind:** `deferred`
+- **Disposition:** `fold-into-later-seam` for CH-011.
+
+## Report scope for hosts with WSL sessions
+
+- **What was found:** The report entry point accepts one environment key, so CH-012 must decide whether a host report combines native and WSL scopes.
+- **Found by seam:** GH-70 seam 0016.
+- **Why deferred:** CH-012 owns the IPC request and the reader-facing scope.
+- **Kind:** `enhancement`
+- **Disposition:** `fold-into-later-seam` for CH-012.


### PR DESCRIPTION
## What this seam contains

The counting engine behind the thirty-day insights report: a provider-neutral bounded accumulator (`crates/antiburn-local/src/insights/`) fed by two bounded queries over one pinned read-only snapshot (`apps/desktop/src-tauri/src/insights_report.rs`). The report states two nested populations per FR-12 — the assessed cohort and the coverage denominator — so a pending, processing, failed, unsupported, stale, or unknown-start session is counted with its own reason and never reads as assessed.

Link: [seam plan (unregistered draft)](.seams/GH-70/.draft-0016-plan.md) · master plan item CH-010 (`docs/plans/local-insights-architecture.md:1158`)

Commit chain (slots): `2f561b6` accumulator → `03b8fed` pinned-snapshot reducer → `f065d3d` population + concurrency proofs → `26b67e9`/`f5db37f`/`1ffa846`/`8a288c7` verification-pass fixes.

## Why this piece was done

CH-010 is the read-path layer both the nine detectors (CH-011) and the Insights pane (CH-012) build on. It splits source Phase 9's population/concurrency semantics from detector policy so each reviews alone. No caller runs this code in a shipped build until CH-012; nothing user-visible changes.

## What it changes

- New `crates/antiburn-local/src/insights/`: `EfficiencyReportAccumulator` (bounded maps, ≤3 gap examples per detector, finalize after denominators known), `CoverageCounts` with a `denominator ⊇ cohort` consistency check, and a structural `DetectorRequirements` table derived from the master plan's per-detector evidence lists — prerequisites only, no detector rules or thresholds.
- New `apps/desktop/src-tauri/src/insights_report.rs`: `reduce_report` opens the DB inside `spawn_blocking`, pins one read transaction, runs `DENOMINATOR_SQL` then `COHORT_SQL` on the same snapshot, folds rows one at a time. Half-open window `[start, end)`; unknown-start rows join the denominator only with in-window `updated_at_epoch`.
- `store/mod.rs`: `open_read_only` — second connection with `SQLITE_OPEN_READ_ONLY`, `query_only` pragma, busy timeout.
- `docs/plans/local-insights-followups.md`: the `PublishedEvidence::Unsupported` production-writer deferral re-homed to CH-011.
- No schema migration, no IPC/DTO/pane work, no evidence-production changes.

## How to review

Read in this order: `EfficiencyReportAccumulator::observe_session`/`finish` (population counting, detector eligibility gating), then the two SQL constants and `reduce_on_snapshot` (FR-12 predicates, snapshot pinning, one-row fold), then the population tests (`insights_report.rs` `mod population`) and the concurrency test.

Verify by reading:
- No path lets a denominator-only row into the cohort or any detector eligible/assessed count (the false-clean failure mode).
- Both queries share the window/scope predicates and run inside the same read transaction.
- `crates/antiburn-local` carries no application-schema knowledge (Locked Decision 11) — the SQL and row mapping live in `src-tauri` only.
- The read transaction, statement, and connection drop after finalization; nothing awaits while the snapshot is open.

**Review hotspots** — entity-level risk triage of this PR's diff (manual triage; source entities only). Read these first:

| Entity | File | Risk | Signals |
|---|---|---|---|
| `EfficiencyReportAccumulator::observe_session` (fn, new) | [`crates/antiburn-local/src/insights/report.rs`](https://github.com/antiburn/antiburn/pull/208/files#diff-f83312682b5dc1d2d74ababa6eea60d043f893c1873e7267382c23d71e5b85ab) | High | population semantics · CH-011/CH-012 build on it · bounded-memory contract |
| `DENOMINATOR_SQL` / `COHORT_SQL` + `reduce_on_snapshot` (new) | [`apps/desktop/src-tauri/src/insights_report.rs`](https://github.com/antiburn/antiburn/pull/208/files#diff-2ac5496cc07fd343e990a9657a48f595a48bea79503597896b57a4cad96c2a62) | High | FR-12 predicates · snapshot pinning · second connection to live user DB |
| `requirements` + `DetectorRequirements` (fn/struct, new) | [`crates/antiburn-local/src/insights/report.rs`](https://github.com/antiburn/antiburn/pull/208/files#diff-f83312682b5dc1d2d74ababa6eea60d043f893c1873e7267382c23d71e5b85ab) | Medium | public API · encodes the CH-010/CH-011 boundary |
| `open_read_only` (fn, new) | [`apps/desktop/src-tauri/src/store/mod.rs`](https://github.com/antiburn/antiburn/pull/208/files#diff-3d36ec47b68bb411bc89dd840f4feaaa5483caa5103eba2a848b878dbe5d7c0f) | Medium | public API · read-only/query-only enforcement |
| `DetectorId` / `CoverageBucket` (enums, new) | [`crates/antiburn-local/src/insights/status.rs`](https://github.com/antiburn/antiburn/pull/208/files#diff-7f008bda847b71d360c586d9660d1e0d8bd503d0699deed08e091ed68b473a7e) | Low | public API · nine-detector and coverage vocabulary |

<details>
<summary>Gate results — full ci.yml gate set, final seams verify run-ids</summary>

18 non-excluded gates green against `1ffa846`; the follow-up commit `8a288c7` (single test file in src-tauri) re-ran its affected gates with fresh run-ids.

| Gate | Result | Run-id |
|------|--------|--------|
| ci-control-plane-tests | ✅ pass | `0016-regate-ci-control-plane-tests-20260826T094035Z-2511` |
| design-drift | ✅ pass | `0016-regate-design-drift-20260826T094047Z-3c1f` |
| classify | ✅ pass (`engine=true, desktop_backend=true, frontend=false, full=false`) | `0016-regate-classify-20260826T094047Z-3c1f` |
| boundary | ✅ pass | `0016-regate-boundary-20260826T094133Z-303d` |
| dco | ✅ pass (all commits signed) | `0016-regate-dco-20260826T094145Z-038c` |
| aislop | ✅ pass (0 findings) | `0016-regate-aislop-20260826T094155Z-3506` |
| engine-fmt | ✅ pass | `0016-regate-engine-fmt-20260826T094225Z-7f01` |
| engine-clippy | ✅ pass | `0016-regate-engine-clippy-20260826T094234Z-54e1` |
| engine-tests (nextest) | ✅ pass | `0016-regate-engine-tests-nextest-20260826T094245Z-7f42` |
| fmt src-tauri / trace / hud | ✅ pass | `0016-regate-desktop-backend-fmt-*-20260826T094303Z` |
| desktop clippy ×3 | ✅ pass | `0016-regate-desktop-backend-clippy-20260826T094313Z-2fc2` |
| desktop tests ×3 | ✅ pass | `0016-regate-desktop-backend-tests-20260826T094326Z-0d7d` |
| engine bans+licenses / advisories | ✅ pass | `0016-regate-licenses-engine-*-20260826T094344Z` |
| desktop licenses / advisories | ✅ pass | `0016-regate-licenses-desktop-*-20260826T094355Z` |

Rebound to `8a288c7` (test-only diff in src-tauri):

| Gate | Result | Run-id |
|------|--------|--------|
| desktop-backend fmt (src-tauri) | ✅ pass | `0016-regate2-desktop-backend-fmt-shell-20260826T094849Z-6b3f` |
| desktop-backend clippy (src-tauri) | ✅ pass | `0016-regate2-desktop-backend-clippy-20260826T094855Z-632e` |
| desktop-backend tests (nextest, 545 passed) | ✅ pass | `0016-regate2-desktop-backend-tests-20260826T094905Z-2adc` |
| aislop | ✅ pass | `0016-regate2-aislop-20260826T094921Z-1099` |

Notes: the boundary gate's first local run exited 1 on git-ignored local tooling absent from CI's checkout; the unmodified script passes against a pristine `git archive HEAD` export. Per-workspace cargo gates were wrapped as `bash -c 'cd <ws> && <cmd>'` to match ci.yml's `working-directory`; commands verbatim. No checks were edited.

**Gates excluded** (path-filter proven):
- Frontend format/lint/type-check/knip/test/build: ci.yml gates on `classify.outputs.frontend == 'true'`; classify outputs `frontend=false` — no changed file under `apps/desktop/` outside `src-tauri`.
- installer-tests: requires `full == 'true'`; classify outputs `full=false`.
- release-metadata / warm-release-cache: require `release_app`/`release_engine`; both `false`, and warm-release-cache runs only on push to main.

</details>

<details>
<summary>Verification pass — findings and fixes</summary>

Adversarial pass over `git diff origin/main...HEAD` (assume-competent-and-wrong):

- **Fixed** (`f5db37f`): commit `26b67e9` claimed per-session-only allocation but still cloned identity strings per stored gap example and allocated them unconditionally; now lazy via `Option::get_or_insert_with`.
- **Fixed** (`8a288c7`, post-PR audit): the unknown-start population test seeded the active and inactive rows together and asserted only aggregates, so a reversed activity predicate still passed; each case now seeds alone and asserts its exact coverage outcome, and the cohort example assertion is unconditional.
- Gate comparison: the implementation pass had skipped nextest and the per-crate desktop fmt/clippy/test gates without justification; all run green here.
- No existing test assertions weakened vs `origin/main`; no scope creep beyond CH-010's boundary.

**Deferred / noticed out of scope:**
- `PublishedEvidence::Unsupported` still has no production writer; the trigger is a write-path decision needing CH-011's capability sets — recorded in `docs/plans/local-insights-followups.md`.
- Per-detector eligible/assessed counts use structural prerequisites only; status policy (clean/finding rules) is CH-011.
- Report entry point stays test-reachable until CH-012 wires IPC.

</details>

---

This is part of a PR stack based at #91; this PR merges into main.
