### PR TITLE
feat(desktop): show the subscription plan in the live-usage provider heading

### DIFF
--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -524,6 +524,23 @@ pub struct LiveProviderUsage {
     /// The provider reports manual rate-limit resets here.
     #[serde(default)]
     pub reset_credits: Option<LiveUsageResetCredits>,
+    /// The subscription plan, when the source stated one. `null` when it did
+    /// not. Defaulted on deserialize: a snapshot cached before this field
+    /// existed must still load.
+    #[serde(default)]
+    pub plan: Option<LiveProviderPlan>,
+}
+
+/// The provider's own plan label, raw. The frontend maps these strings to
+/// display text; nothing here is a display string already.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveProviderPlan {
+    /// The plan, for example `"max"` or `"plus"`.
+    pub name: String,
+    /// A finer-grained tier within `name`, when the source stated one, for
+    /// example `"default_claude_max_5x"`.
+    pub tier: Option<String>,
 }
 
 /// Provider credits that manually reset rate limits.

--- a/apps/desktop/src-tauri/src/provider_usage/live/history.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/history.rs
@@ -207,6 +207,7 @@ mod tests {
             provider: crate::provider_usage::providers::ANTHROPIC,
             account: Some("account-a".into()),
             plan: None,
+            plan_tier: None,
             observed_at: OffsetDateTime::from_unix_timestamp(observed).unwrap(),
             source: UsageSource {
                 id: "fixture",

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -65,7 +65,7 @@ pub use model::{
 };
 
 use crate::dto::{
-    LiveExtraUsage, LiveProviderUsage, LiveUsageForecast, LiveUsageFreshness,
+    LiveExtraUsage, LiveProviderPlan, LiveProviderUsage, LiveUsageForecast, LiveUsageFreshness,
     LiveUsageResetCredits, LiveUsageSourceError, LiveUsageSummary, LiveUsageSupport,
     LiveUsageWindow,
 };
@@ -249,6 +249,10 @@ pub fn summarize_collected(
             }),
             reset_credits: snapshot.reset_credits.map(|credits| LiveUsageResetCredits {
                 available_count: credits.available_count,
+            }),
+            plan: snapshot.plan.map(|name| LiveProviderPlan {
+                name,
+                tier: snapshot.plan_tier,
             }),
         })
         .collect();

--- a/apps/desktop/src-tauri/src/provider_usage/live/model.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/model.rs
@@ -213,6 +213,9 @@ pub struct ProviderUsageSnapshot {
     pub account: Option<String>,
     /// The plan, when the source stated one. Never inferred.
     pub plan: Option<String>,
+    /// A finer-grained tier within `plan`, when the source stated one. For
+    /// example Claude's `rateLimitTier`. Never inferred.
+    pub plan_tier: Option<String>,
     /// When the underlying fact was observed — not when it was read.
     pub observed_at: OffsetDateTime,
     /// Provenance, confidence, and freshness.

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -87,6 +87,9 @@ struct ClaudeCredentials {
     access_token: String,
     expires_at_ms: i64,
     subscription_type: Option<String>,
+    /// The finer-grained tier within `subscriptionType`, for example
+    /// `default_claude_max_5x`.
+    rate_limit_tier: Option<String>,
 }
 
 /// Read and parse the credentials file. `None` covers both "no file" and "a
@@ -113,6 +116,11 @@ fn parse_credentials_json(contents: &str) -> Option<ClaudeCredentials> {
         expires_at_ms: oauth.get("expiresAt")?.as_i64()?,
         subscription_type: oauth
             .get("subscriptionType")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned),
+        rate_limit_tier: oauth
+            .get("rateLimitTier")
             .and_then(Value::as_str)
             .filter(|value| !value.is_empty())
             .map(str::to_owned),
@@ -322,6 +330,7 @@ fn fetch_live(
         // between.
         account: None,
         plan: credentials.subscription_type.clone(),
+        plan_tier: credentials.rate_limit_tier.clone(),
         observed_at: now,
         source: UsageSource {
             id: SOURCE_ID,
@@ -352,7 +361,8 @@ mod tests {
         format!(
             r#"{{"claudeAiOauth": {{"accessToken": "synthetic-token",
               "refreshToken": "synthetic-refresh", "expiresAt": {expires_at_ms},
-              "subscriptionType": "{subscription_type}"}}}}"#
+              "subscriptionType": "{subscription_type}",
+              "rateLimitTier": "default_claude_max_5x"}}}}"#
         )
     }
 
@@ -391,6 +401,7 @@ mod tests {
             access_token: "synthetic-token".into(),
             expires_at_ms: (NOW - 3_600) * 1_000,
             subscription_type: Some("max".into()),
+            rate_limit_tier: None,
         };
         assert_eq!(
             fetch_live(&credentials, now),
@@ -421,14 +432,19 @@ mod tests {
         assert_eq!(credentials.access_token, "synthetic-token");
         assert_eq!(credentials.expires_at_ms, NOW * 1_000);
         assert_eq!(credentials.subscription_type.as_deref(), Some("max"));
+        assert_eq!(
+            credentials.rate_limit_tier.as_deref(),
+            Some("default_claude_max_5x")
+        );
     }
 
     /// The Keychain and the file carrier hold the identical JSON shape, so
     /// this exercises `parse_credentials_json` directly against a synthetic
     /// value shaped exactly like what `security find-generic-password -w`
     /// prints — including the fields this source never reads
-    /// (`refreshTokenExpiresAt`, `scopes`, `rateLimitTier`), to confirm they
-    /// are ignored rather than tripping the parser.
+    /// (`refreshTokenExpiresAt`, `scopes`), to confirm they are ignored
+    /// rather than tripping the parser. `rateLimitTier` is read, into
+    /// `plan_tier` on the resulting snapshot.
     #[test]
     fn keychain_shaped_json_parses_through_the_same_function_as_the_file() {
         let keychain_value = format!(
@@ -443,6 +459,10 @@ mod tests {
         assert_eq!(credentials.access_token, "synthetic-token");
         assert_eq!(credentials.expires_at_ms, NOW * 1_000);
         assert_eq!(credentials.subscription_type.as_deref(), Some("max"));
+        assert_eq!(
+            credentials.rate_limit_tier.as_deref(),
+            Some("default_claude_max_5x")
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_app_server.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_app_server.rs
@@ -126,6 +126,9 @@ pub fn fetch(now: OffsetDateTime) -> Result<Option<ProviderUsageSnapshot>, Provi
         provider: crate::provider_usage::providers::OPENAI,
         account: None,
         plan,
+        // The app-server does not report a finer-grained tier below the
+        // plan itself.
+        plan_tier: None,
         observed_at: now,
         source: UsageSource {
             id: CODEX_SOURCE_ID,
@@ -266,7 +269,7 @@ fn rpc_result(response: &Value) -> Result<&Value, ProviderUsageError> {
 /// ask about rate limits, and how.
 #[derive(Debug, PartialEq)]
 enum AccountVerdict {
-    /// An OAuth ChatGPT sign-in: proceed, with the plan label the account
+    /// An OAuth ChatGPT sign-in: proceed, with the raw `planType` slug the account
     /// stated, if it stated one.
     HasRateLimits(Option<String>),
     /// A real answer, but this account type has no plan allowance to report.
@@ -293,25 +296,8 @@ fn classify_account(account: &Value) -> Result<AccountVerdict, ProviderUsageErro
         .get("planType")
         .and_then(Value::as_str)
         .filter(|plan| !plan.is_empty())
-        .map(plan_label);
+        .map(str::to_string);
     Ok(AccountVerdict::HasRateLimits(plan))
-}
-
-/// The label a `planType` slug is shown under. An unrecognized slug keeps its
-/// own spelling rather than being dropped — the provider stated a plan, and
-/// showing it verbatim is more honest than showing nothing.
-fn plan_label(plan_type: &str) -> String {
-    match plan_type {
-        "free" => "ChatGPT Free".to_string(),
-        "plus" => "ChatGPT Plus".to_string(),
-        "pro" => "ChatGPT Pro".to_string(),
-        "team" => "ChatGPT Team".to_string(),
-        "business" => "ChatGPT Business".to_string(),
-        "enterprise" => "ChatGPT Enterprise".to_string(),
-        "edu" => "ChatGPT Edu".to_string(),
-        "go" => "ChatGPT Go".to_string(),
-        other => other.to_string(),
-    }
 }
 
 /// `account/rateLimits/read`'s result: `rateLimits` (the "default" bucket)
@@ -660,9 +646,7 @@ mod tests {
         let account = serde_json::json!({"type": "chatgpt", "planType": "plus"});
         assert_eq!(
             classify_account(&account),
-            Ok(AccountVerdict::HasRateLimits(Some(
-                "ChatGPT Plus".to_string()
-            )))
+            Ok(AccountVerdict::HasRateLimits(Some("plus".to_string())))
         );
     }
 
@@ -710,16 +694,5 @@ mod tests {
             rpc_result(&response),
             Err(ProviderUsageError::Schema(SchemaReason::MissingEnvelope))
         );
-    }
-
-    #[test]
-    fn plan_type_slugs_map_to_their_display_names() {
-        assert_eq!(plan_label("plus"), "ChatGPT Plus");
-        assert_eq!(plan_label("enterprise"), "ChatGPT Enterprise");
-    }
-
-    #[test]
-    fn an_unrecognized_plan_type_keeps_its_own_spelling() {
-        assert_eq!(plan_label("mystery-tier"), "mystery-tier");
     }
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -92,6 +92,10 @@ const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 /// state one directly.
 const ACCOUNT_CLAIM: &str = "https://api.openai.com/auth/chatgpt_account_id";
 
+/// The unsigned JWT claim that names the plan, used only when the usage
+/// response itself does not state one.
+const PLAN_CLAIM: &str = "https://api.openai.com/auth/chatgpt_plan_type";
+
 /// The credential file, at the one documented place it lives.
 pub fn default_auth_path() -> Option<PathBuf> {
     let dir = antiburn_local::paths::non_empty_env_path("CODEX_HOME")
@@ -104,6 +108,10 @@ struct CodexAuth {
     access_token: String,
     refresh_token: String,
     account_id: Option<String>,
+    /// The `chatgpt_plan_type` claim, decoded ahead of time so a later
+    /// missing `plan_type` in the usage response has something to fall back
+    /// to — see [`PLAN_CLAIM`].
+    plan_claim: Option<String>,
 }
 
 /// Read and parse `auth.json`. `None` covers both "no file" and "a file that
@@ -118,23 +126,27 @@ fn read_auth(path: &Path) -> Option<CodexAuth> {
     let tokens = value.get("tokens")?;
     let access_token = tokens.get("access_token")?.as_str()?.to_owned();
     let refresh_token = tokens.get("refresh_token")?.as_str()?.to_owned();
+    let id_token = tokens.get("id_token").and_then(Value::as_str);
     let account_id = tokens
         .get("account_id")
         .and_then(Value::as_str)
         .filter(|id| !id.is_empty())
         .map(str::to_owned)
-        .or_else(|| decode_jwt_claim(&access_token, ACCOUNT_CLAIM))
-        .or_else(|| {
-            tokens
-                .get("id_token")
-                .and_then(Value::as_str)
-                .and_then(|token| decode_jwt_claim(token, ACCOUNT_CLAIM))
-        });
+        .or_else(|| claim_from_tokens(&access_token, id_token, ACCOUNT_CLAIM));
+    let plan_claim = claim_from_tokens(&access_token, id_token, PLAN_CLAIM);
     Some(CodexAuth {
         access_token,
         refresh_token,
         account_id,
+        plan_claim,
     })
+}
+
+/// Read one claim from the access token, falling back to the id token —
+/// the order every unsigned-JWT fallback in this source uses.
+fn claim_from_tokens(access_token: &str, id_token: Option<&str>, claim: &str) -> Option<String> {
+    decode_jwt_claim(access_token, claim)
+        .or_else(|| id_token.and_then(|token| decode_jwt_claim(token, claim)))
 }
 
 /// Read one claim out of a JWT's payload segment, without checking its
@@ -332,7 +344,7 @@ fn fetch_direct(
 ) -> Result<ProviderUsageSnapshot, ProviderUsageError> {
     let primary = effective_access_token(cached_refresh, auth);
     if let Ok(body) = transport.usage(&primary, auth.account_id.as_deref()) {
-        return build_snapshot(&body, auth.account_id.clone(), now);
+        return build_snapshot(&body, auth.account_id.clone(), auth.plan_claim.clone(), now);
     }
 
     let refreshed = transport.refresh(&auth.refresh_token)?;
@@ -346,7 +358,7 @@ fn fetch_direct(
         });
     }
     let body = transport.usage(&refreshed, auth.account_id.as_deref())?;
-    build_snapshot(&body, auth.account_id.clone(), now)
+    build_snapshot(&body, auth.account_id.clone(), auth.plan_claim.clone(), now)
 }
 
 /// The access token to try first: a still-applicable cached refresh, or
@@ -367,13 +379,18 @@ fn effective_access_token(
 fn build_snapshot(
     body: &str,
     account_id: Option<String>,
+    plan_claim: Option<String>,
     now: OffsetDateTime,
 ) -> Result<ProviderUsageSnapshot, ProviderUsageError> {
     let usage = codex::parse_wham_usage(body, now)?;
     Ok(ProviderUsageSnapshot {
         provider: crate::provider_usage::providers::OPENAI,
         account: account_id,
-        plan: usage.plan,
+        // The usage response's own `plan_type` wins; the JWT claim is only a
+        // fallback for a response shape that omits it.
+        plan: usage.plan.or(plan_claim),
+        // Codex does not report a finer-grained tier below the plan itself.
+        plan_tier: None,
         observed_at: now,
         source: UsageSource {
             id: super::CODEX_SOURCE_ID,
@@ -415,6 +432,7 @@ mod tests {
             access_token: "stale-token".into(),
             refresh_token: refresh_token.into(),
             account_id: Some("acct-123".into()),
+            plan_claim: None,
         }
     }
 
@@ -576,6 +594,61 @@ mod tests {
 
         let auth = read_auth(&path).expect("parses");
         assert_eq!(auth.account_id.as_deref(), Some("acct-from-jwt"));
+    }
+
+    /// Builds a JWT-shaped string carrying exactly the claims given, in the
+    /// `header.payload.signature` form this source's decoder expects.
+    fn jwt_with_claims(claims: serde_json::Value) -> String {
+        use base64::Engine as _;
+        let payload_b64 =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string());
+        format!("header.{payload_b64}.signature")
+    }
+
+    #[test]
+    fn read_auth_decodes_the_plan_claim_off_the_access_token() {
+        let token = jwt_with_claims(serde_json::json!({
+            "https://api.openai.com/auth/chatgpt_plan_type": "pro"
+        }));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("auth.json");
+        fs::write(
+            &path,
+            format!(r#"{{"tokens": {{"access_token": "{token}", "refresh_token": "r"}}}}"#),
+        )
+        .expect("write");
+
+        let auth = read_auth(&path).expect("parses");
+        assert_eq!(auth.plan_claim.as_deref(), Some("pro"));
+    }
+
+    #[test]
+    fn a_snapshots_plan_falls_back_to_the_jwt_claim_when_the_usage_body_has_none() {
+        const WHAM_BODY_WITHOUT_PLAN: &str = r#"{"rate_limit": {
+          "primary_window": {"used_percent": 20, "limit_window_seconds": 18000},
+          "secondary_window": {"used_percent": 55, "limit_window_seconds": 604800}
+        }}"#;
+
+        struct WorksFirstTry;
+        impl CodexTransport for WorksFirstTry {
+            fn usage(&self, _: &str, _: Option<&str>) -> Result<String, ProviderUsageError> {
+                Ok(WHAM_BODY_WITHOUT_PLAN.to_string())
+            }
+            fn refresh(&self, _: &str) -> Result<String, ProviderUsageError> {
+                unreachable!("a successful first attempt never refreshes")
+            }
+        }
+
+        let token = jwt_with_claims(serde_json::json!({
+            "https://api.openai.com/auth/chatgpt_plan_type": "team"
+        }));
+        let mut auth = auth("refresh-a");
+        auth.access_token = token;
+        auth.plan_claim = Some("team".into());
+
+        let cache = Mutex::new(None);
+        let snapshot = fetch_direct(&WorksFirstTry, &cache, &auth, now()).expect("ok");
+        assert_eq!(snapshot.plan.as_deref(), Some("team"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -201,6 +201,7 @@ mod tests {
             provider: crate::provider_usage::providers::ANTHROPIC,
             account: None,
             plan: None,
+            plan_tier: None,
             observed_at,
             source: UsageSource {
                 id: "fixture",

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -303,6 +303,7 @@ fn snapshot(freshness: Freshness, observed: i64, percent: f64) -> ProviderUsageS
         provider: crate::provider_usage::providers::ANTHROPIC,
         account: Some("account-a".into()),
         plan: None,
+        plan_tier: None,
         observed_at: at(observed),
         source: UsageSource {
             id: "fixture",
@@ -441,6 +442,30 @@ fn the_live_payload_carries_manual_reset_credits() {
     );
 }
 
+#[test]
+fn the_live_payload_carries_the_plan_and_its_tier_through() {
+    let mut reading = snapshot(Freshness::Fresh, NOW, 81.0);
+    reading.plan = Some("max".into());
+    reading.plan_tier = Some("default_claude_max_5x".into());
+    let sources: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed("fixture", vec![reading]))];
+
+    let summary = summarize(&sources, None, NOW, 0, MAX_AGE);
+    let plan = summary.providers[0].plan.as_ref().expect("plan present");
+    assert_eq!(plan.name, "max");
+    assert_eq!(plan.tier.as_deref(), Some("default_claude_max_5x"));
+}
+
+#[test]
+fn the_live_payload_has_no_plan_when_the_snapshot_stated_none() {
+    let sources: Vec<Box<dyn LiveUsageSource>> = vec![Box::new(Fixed(
+        "fixture",
+        vec![snapshot(Freshness::Fresh, NOW, 81.0)],
+    ))];
+
+    let summary = summarize(&sources, None, NOW, 0, MAX_AGE);
+    assert_eq!(summary.providers[0].plan, None);
+}
+
 fn required_present(json: &str, field: &str) -> bool {
     json.contains(&format!("\"{field}\":"))
 }
@@ -571,6 +596,7 @@ fn weekly_scoped_snapshot(
         provider: crate::provider_usage::providers::ANTHROPIC,
         account: Some("account-a".into()),
         plan: None,
+        plan_tier: None,
         observed_at: at(observed),
         source: UsageSource {
             id: "fixture",

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -404,6 +404,7 @@ mod tests {
                 windows: vec![],
                 extra_usage: None,
                 reset_credits: None,
+                plan: None,
             }],
             errors: vec![LiveUsageSourceError {
                 source: "fixture".into(),

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
@@ -54,6 +54,7 @@ function liveProvider(
     windows: [liveWindow()],
     extraUsage: null,
     resetCredits: null,
+    plan: null,
     ...overrides,
   }
 }
@@ -219,6 +220,32 @@ describe("UsageLimitsBar — the disclosure", () => {
     const codex = screen.getByRole("group", { name: "Codex" })
     expect(within(claude).getByText("5-hour limit")).toBeInTheDocument()
     expect(within(codex).getByText("5-hour limit")).toBeInTheDocument()
+  })
+
+  it("shows the plan as a muted suffix on the provider heading", () => {
+    bar({
+      live: liveSummary({
+        providers: [liveProvider({ plan: { name: "max", tier: "default_claude_max_5x" } })],
+      }),
+      expanded: true,
+    })
+    // The group's own aria-label carries the plan for a reader with no
+    // sight of the heading, and the heading itself carries it visibly.
+    const group = screen.getByRole("group", { name: "Claude, Max 5x plan" })
+    const heading = within(group).getByRole("heading")
+    expect(heading).toHaveTextContent("Claude · Max 5x")
+    const suffix = within(heading).getByText("· Max 5x")
+    expect(suffix.className).toContain("text-label-secondary")
+  })
+
+  it("omits the separator and suffix entirely when the source reports no plan", () => {
+    // The default fixture carries no plan. The heading stays the bare
+    // provider name, with no trailing separator left dangling.
+    bar({ live: liveSummary({ providers: [liveProvider({ plan: null })] }), expanded: true })
+    const group = screen.getByRole("group", { name: "Claude" })
+    const heading = within(group).getByRole("heading")
+    expect(heading).toHaveTextContent("Claude")
+    expect(heading.textContent).not.toContain("·")
   })
 })
 

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
@@ -15,6 +15,7 @@ import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
 import type { UnavailableLiveProvider } from "../../lib/presentation/liveUsage"
 import {
   liveErrorNote,
+  livePlanLabel,
   liveResetLabel,
   liveUnavailableProviders,
   liveUnavailableReason,
@@ -224,17 +225,21 @@ function ProviderGroup({
   /** The disclosure, on the topmost group only. */
   action?: ReactNode
 }) {
+  const plan = livePlanLabel(provider)
   return (
     <div
       role="group"
-      aria-label={provider.displayName}
+      aria-label={plan ? `${provider.displayName}, ${plan} plan` : provider.displayName}
       className="rounded-md px-2 py-2 transition-colors duration-[var(--duration-fast)] hover:bg-brand-tint/[0.08]"
     >
       {/* The same type size and color as the window labels and figures
-          below; the uppercase alone marks the grouping. */}
+          below; the uppercase alone marks the grouping. The plan, when the
+          source reports one, is a muted suffix on the same line rather than
+          a second line — it is context for the name, not its own fact. */}
       <div className="flex items-center justify-between gap-2 pb-1.5">
-        <h3 className="type-footnote font-medium tracking-wide uppercase text-label">
-          {provider.displayName}
+        <h3 className="type-footnote font-medium tracking-wide text-label">
+          <span className="uppercase">{provider.displayName}</span>
+          {plan && <span className="text-label-secondary"> · {plan}</span>}
         </h3>
         {action}
       </div>

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -421,6 +421,12 @@ export interface LiveUsageResetCreditsPayload {
   availableCount: number
 }
 
+/** The account's subscription plan, in the provider's own raw strings. */
+export interface LiveUsagePlanPayload {
+  name: string
+  tier: string | null
+}
+
 /** One provider account's live usage. Mirrors Rust `LiveProviderUsage`. */
 export interface LiveProviderUsagePayload {
   /** Canonical id, matching `ProviderUsagePayload.provider` so the two join. */
@@ -435,6 +441,8 @@ export interface LiveProviderUsagePayload {
   windows: LiveUsageWindowPayload[]
   extraUsage: LiveExtraUsagePayload | null
   resetCredits: LiveUsageResetCreditsPayload | null
+  /** The subscription plan, in the provider's own raw strings. Null when the source does not report one. */
+  plan: LiveUsagePlanPayload | null
 }
 
 /** A source that failed, in terms a reader can act on. */

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -23,6 +23,7 @@ import {
   liveUnavailableReason,
   liveWindowElapsed,
   liveWindowLabel,
+  livePlanLabel,
   liveMetricRows,
   liveWindowValueLabel,
   liveWindows,
@@ -84,6 +85,7 @@ function provider(overrides: Partial<LiveProviderUsagePayload> = {}): LiveProvid
     windows: [window()],
     extraUsage: null,
     resetCredits: null,
+    plan: null,
     ...overrides,
   }
 }
@@ -114,6 +116,65 @@ describe("window labels", () => {
     expect(liveWindowValueLabel(window({ usedPercent: null }))).toBe("Unknown")
     expect(liveWindowValueLabel(window({ usedPercent: 0 }))).toBe("0%")
     expect(liveWindowValueLabel(window({ usedPercent: 80.6 }))).toBe("81%")
+  })
+})
+
+describe("plan labels", () => {
+  it("reads Claude's max tiers by the substring they carry", () => {
+    expect(
+      livePlanLabel(
+        provider({
+          provider: "anthropic",
+          plan: { name: "max", tier: "default_claude_max_5x" },
+        }),
+      ),
+    ).toBe("Max 5x")
+    expect(
+      livePlanLabel(
+        provider({
+          provider: "anthropic",
+          plan: { name: "max", tier: "default_claude_max_20x" },
+        }),
+      ),
+    ).toBe("Max 20x")
+  })
+
+  it("names a Claude max plan with no tier, and a plain pro plan", () => {
+    expect(
+      livePlanLabel(provider({ provider: "anthropic", plan: { name: "max", tier: null } })),
+    ).toBe("Max")
+    expect(
+      livePlanLabel(provider({ provider: "anthropic", plan: { name: "pro", tier: null } })),
+    ).toBe("Pro")
+  })
+
+  it("names Codex's plans, including the multi-word and business variants", () => {
+    expect(
+      livePlanLabel(provider({ provider: "openai", plan: { name: "prolite", tier: null } })),
+    ).toBe("Pro Lite")
+    expect(
+      livePlanLabel(
+        provider({
+          provider: "openai",
+          plan: { name: "self_serve_business_usage_based", tier: null },
+        }),
+      ),
+    ).toBe("Business")
+  })
+
+  it("passes an unrecognised name through rather than hiding it", () => {
+    expect(
+      livePlanLabel(provider({ provider: "openai", plan: { name: "unknown", tier: null } })),
+    ).toBe("unknown")
+    expect(
+      livePlanLabel(
+        provider({ provider: "openai", plan: { name: "some_future_plan", tier: null } }),
+      ),
+    ).toBe("some_future_plan")
+  })
+
+  it("reads a missing plan as null, not as a guess", () => {
+    expect(livePlanLabel(provider({ plan: null }))).toBeNull()
   })
 })
 

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -26,6 +26,7 @@
 import type {
   LiveProviderUsagePayload,
   LiveUsageFreshness,
+  LiveUsagePlanPayload,
   LiveUsageSummaryPayload,
   LiveUsageWindowPayload,
 } from "../ipc"
@@ -39,6 +40,84 @@ export interface UnavailableLiveProvider {
   category: string
 }
 import { relativeTime } from "./relativeTime"
+
+/** Canonical provider ids, matching the Rust `provider_usage::providers` constants. */
+const ANTHROPIC = "anthropic"
+const OPENAI = "openai"
+
+/** Claude plan names that resolve to a fixed label with no tier to read. */
+const CLAUDE_PLAN_NAME_LABELS: Readonly<Record<string, string>> = {
+  pro: "Pro",
+  team: "Team",
+  enterprise: "Enterprise",
+}
+
+/**
+ * Claude's `max` tiers, matched by substring because the raw values carry
+ * extra prefixes (for example `default_claude_max_5x`) that this label does
+ * not repeat.
+ */
+const CLAUDE_MAX_TIER_LABELS: ReadonlyArray<{ substring: string; label: string }> = [
+  { substring: "max_5x", label: "Max 5x" },
+  { substring: "max_20x", label: "Max 20x" },
+]
+
+/** Codex plan names, mapped to the words this app shows for them. */
+const CODEX_PLAN_NAME_LABELS: Readonly<Record<string, string>> = {
+  free: "Free",
+  go: "Go",
+  plus: "Plus",
+  pro: "Pro",
+  prolite: "Pro Lite",
+  team: "Team",
+  business: "Business",
+  self_serve_business_prolite: "Business",
+  self_serve_business_usage_based: "Business",
+  enterprise: "Enterprise",
+  ent26: "Enterprise",
+  enterprise_cbp_automation: "Enterprise",
+  enterprise_cbp_usage_based: "Enterprise",
+  edu: "Edu",
+  edu_plus: "Edu Plus",
+  edu_pro: "Edu Pro",
+}
+
+/** Claude's plan label, reading the tier only for the `max` name. */
+function claudePlanLabel(plan: LiveUsagePlanPayload): string {
+  if (plan.name === "max") {
+    const tier = plan.tier ?? ""
+    const matched = CLAUDE_MAX_TIER_LABELS.find((entry) => tier.includes(entry.substring))
+    return matched?.label ?? "Max"
+  }
+  return CLAUDE_PLAN_NAME_LABELS[plan.name] ?? plan.name
+}
+
+/** Codex's plan label. Codex never reports a tier, so only the name matters. */
+function codexPlanLabel(plan: LiveUsagePlanPayload): string {
+  return CODEX_PLAN_NAME_LABELS[plan.name] ?? plan.name
+}
+
+/** How to read a plan, keyed by the provider's canonical id. */
+const PLAN_LABEL_BY_PROVIDER: Readonly<Record<string, (plan: LiveUsagePlanPayload) => string>> =
+  {
+    [ANTHROPIC]: claudePlanLabel,
+    [OPENAI]: codexPlanLabel,
+  }
+
+/**
+ * The plan a provider reports, in words, or null when nothing was reported.
+ *
+ * A provider with no entry in the table below falls back to the raw name
+ * rather than hiding it: the rule this module lives by is "never fill a
+ * gap", and swallowing a real value the app has not learned to word yet
+ * would be exactly that, in the other direction.
+ */
+export function livePlanLabel(provider: LiveProviderUsagePayload): string | null {
+  const { plan } = provider
+  if (!plan) return null
+  const label = PLAN_LABEL_BY_PROVIDER[provider.provider]
+  return label ? label(plan) : plan.name
+}
 
 /**
  * The full name of one window.

--- a/apps/desktop/src/lib/usageBars.test.ts
+++ b/apps/desktop/src/lib/usageBars.test.ts
@@ -47,6 +47,7 @@ function provider(overrides: Partial<LiveProviderUsagePayload> = {}): LiveProvid
     windows: [usageWindow()],
     extraUsage: null,
     resetCredits: null,
+    plan: null,
     ...overrides,
   }
 }

--- a/apps/desktop/src/views/OverlayWindow.test.tsx
+++ b/apps/desktop/src/views/OverlayWindow.test.tsx
@@ -103,6 +103,7 @@ function summary(): LiveUsageSummaryPayload {
         ],
         extraUsage: null,
         resetCredits: null,
+        plan: null,
       },
     ],
     errors: [],

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -189,6 +189,7 @@ const LIVE_USAGE = {
       ],
       extraUsage: null,
       resetCredits: null,
+      plan: null,
     },
   ],
   errors: [],

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -235,6 +235,7 @@ function liveProvider(): LiveProviderUsagePayload {
     ],
     extraUsage: null,
     resetCredits: null,
+    plan: null,
   }
 }
 
@@ -287,6 +288,32 @@ describe("UsageView — plan limits layered over local estimates", () => {
     expect(within(card).getByText("1 usage limit reset available.")).toBeInTheDocument()
     expect(within(card).getByText("/usage")).toBeInTheDocument()
     expect(within(card).getByText(/in Codex to use one/)).toBeInTheDocument()
+  })
+
+  it("shows the plan as a muted suffix on the provider card heading", () => {
+    // Anthropic is the only provider in "Recently used" for this fixture, so
+    // its region carries exactly one provider card and one h3.
+    const pro = live({
+      providers: [{ ...liveProvider(), plan: { name: "pro", tier: null } }],
+    })
+    render(<UsageView summary={summary()} live={pro} now={NOW} onBack={vi.fn()} />)
+
+    const recent = within(screen.getByRole("region", { name: "Recently used" }))
+    const heading = recent.getByRole("heading", { level: 3 })
+    expect(heading).toHaveTextContent("Anthropic · Pro")
+    const suffix = within(heading).getByText("· Pro")
+    expect(suffix.className).toContain("text-label-secondary")
+  })
+
+  it("omits the separator and suffix entirely when the source reports no plan", () => {
+    // liveProvider()'s default carries no plan. The heading stays the bare
+    // provider name, with no trailing separator left dangling.
+    render(<UsageView summary={summary()} live={live()} now={NOW} onBack={vi.fn()} />)
+
+    const recent = within(screen.getByRole("region", { name: "Recently used" }))
+    const heading = recent.getByRole("heading", { level: 3 })
+    expect(heading).toHaveTextContent("Anthropic")
+    expect(heading.textContent).not.toContain("·")
   })
 
   it("marks how far through the period the clock has travelled", () => {

--- a/apps/desktop/src/views/popover/UsageView.tsx
+++ b/apps/desktop/src/views/popover/UsageView.tsx
@@ -21,7 +21,7 @@ import type {
 import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
 import { HudVisibilitySession } from "../../lib/overlayWindow"
 import { isMacOS } from "../../lib/platform"
-import { liveAuthNote, liveForProvider } from "../../lib/presentation/liveUsage"
+import { liveAuthNote, liveForProvider, livePlanLabel } from "../../lib/presentation/liveUsage"
 import {
   providerWindow,
   rankByWindow,
@@ -216,6 +216,7 @@ function ProviderCard({
   const stale = stalenessNote(provider)
   const updated = updatedNote(provider)
   const usedToday = windowHasEvidence(providerWindow(provider, "today"))
+  const plan = live ? livePlanLabel(live) : null
 
   return (
     <li className="space-y-2.5 rounded-control bg-surface-card px-3 py-2.5">
@@ -230,6 +231,7 @@ function ProviderCard({
           <div className="flex items-center gap-1.5">
             <h3 className="truncate type-footnote font-medium text-label">
               {provider.displayName}
+              {plan && <span className="text-label-secondary"> · {plan}</span>}
             </h3>
             {usedToday && (
               <span className="shrink-0 rounded-full bg-system-green/15 px-1.5 py-px type-caption text-system-green">

--- a/apps/desktop/src/views/settings/UsagePane.test.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.test.tsx
@@ -150,6 +150,7 @@ describe("UsagePane", () => {
             windows: [],
             extraUsage: null,
             resetCredits: null,
+            plan: null,
           },
         ],
       }),


### PR DESCRIPTION
## Summary
- Rust reads the Claude `rateLimitTier` and falls back to the Codex `chatgpt_plan_type` JWT claim for the subscription plan; the app-server path passes the raw slug through.
- `LiveProviderUsage.plan { name, tier }` rides the IPC payload; `livePlanLabel()` maps raw values to display text.
- The provider heading in `UsageLimitsBar` and `UsageView` now shows a plan suffix, e.g. "CLAUDE · MAX 5X", "CODEX · PRO".

## Test plan
- [x] `cd apps/desktop/src-tauri && cargo test` — 539 passed
- [x] `cd apps/desktop && pnpm run type-check` — clean
- [x] `cd apps/desktop && pnpm test` — 846 passed (83 files)
- [x] `cd apps/desktop && pnpm run lint` — clean
- [x] `pnpm run slop` (from root) — 0 issues
- [x] Manual UAT on the popover (already done by the user prior to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)