### PR TITLE
fix(desktop): skip initial context chart animation

### DIFF
--- a/apps/desktop/src/components/session/analysis/ContextTokensChart.test.tsx
+++ b/apps/desktop/src/components/session/analysis/ContextTokensChart.test.tsx
@@ -3,7 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { cleanup, render, screen } from "@testing-library/react"
-import { cloneElement, isValidElement, type ReactElement, type ReactNode } from "react"
+import {
+  cloneElement,
+  isValidElement,
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+} from "react"
 import type * as Recharts from "recharts"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -23,6 +29,11 @@ vi.mock("recharts", async (importOriginal) => {
   const actual = await importOriginal<typeof Recharts>()
   return {
     ...actual,
+    Area: (props: ComponentProps<typeof actual.Area>) => (
+      <g data-animation-active={String(props.isAnimationActive)}>
+        <actual.Area {...props} />
+      </g>
+    ),
     ResponsiveContainer: ({ children }: { children: ReactNode }) => (
       <div style={{ width: 600, height: 160 }}>
         {isValidElement(children)
@@ -63,6 +74,27 @@ function bucket(over: Partial<SessionBucket> = {}): SessionBucket {
 }
 
 describe("ContextTokensChart", () => {
+  it("renders the first bucket set without animation and animates a replacement set", () => {
+    const initialBuckets = [
+      bucket({ contextTokens: 100_000 }),
+      bucket({ contextTokens: 120_000 }),
+    ]
+    const { container, rerender } = render(
+      <ContextTokensChart buckets={initialBuckets} contextWindow={200_000} />,
+    )
+
+    expect(container.querySelectorAll('g[data-animation-active="false"]')).toHaveLength(4)
+
+    rerender(
+      <ContextTokensChart
+        buckets={[...initialBuckets, bucket({ contextTokens: 140_000 })]}
+        contextWindow={200_000}
+      />,
+    )
+
+    expect(container.querySelectorAll('g[data-animation-active="true"]')).toHaveLength(4)
+  })
+
   it("draws a wide red bar up to the context level for a cache-rehydration bucket", () => {
     const buckets = [
       bucket({ contextTokens: 200_000 }),

--- a/apps/desktop/src/components/session/analysis/ContextTokensChart.tsx
+++ b/apps/desktop/src/components/session/analysis/ContextTokensChart.tsx
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { useId, type ReactElement } from "react"
+import { useId, useState, type ReactElement } from "react"
 import {
   Area,
   AreaChart,
@@ -321,10 +321,9 @@ export function ContextTokensChart({
   const data = contextTokenSeries(buckets)
   const fillId = `context-tokens-fill-${useId().replace(/:/g, "")}`
   const hasContext = contextWindow != null
-  // A live poll can grow this chart's data mid-session, unlike the other
-  // analysis charts, which only ever draw once. The transition makes that
-  // arrival readable instead of a silent jump cut.
-  const animate = !prefersReducedMotion()
+  const [initialBuckets] = useState(() => buckets)
+  // The first bucket set renders without motion. A later set comes from the live poll.
+  const animate = buckets !== initialBuckets && !prefersReducedMotion()
   const animationDurationMs = slowAnimationDurationMs()
 
   const peak = data.reduce((m, d) => Math.max(m, d.contextTokens), 0)


### PR DESCRIPTION
## Summary

- render the Context chart fully on its first appearance
- retain the existing transition when live polling replaces its bucket data
- cover the initial and replacement data behavior with a regression test

## Verification

- `pnpm --dir apps/desktop exec vitest run src/components/session/analysis/ContextTokensChart.test.tsx`
- `pnpm --dir apps/desktop run type-check`
- `pnpm --dir apps/desktop exec eslint src/components/session/analysis/ContextTokensChart.tsx src/components/session/analysis/ContextTokensChart.test.tsx`
- `pnpm run slop`