### PR TITLE
chore(release): prepare antiburn-local 0.1.8

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -21,6 +21,41 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-08-27
+
+### Added
+
+- `analysis::SessionEvidence`, `SessionEvidenceAccumulator`, and
+  `CompositeSink` collect bounded, versioned evidence about context depth,
+  tools, loaded skills and MCP servers, models, delegation, cache behavior,
+  compactions, source coverage, and parse diagnostics in the same streaming
+  pass that produces session metrics.
+- `insights::EfficiencyReportAccumulator` reduces ready session evidence into
+  a bounded report with explicit cohort, coverage, capability-gap, and
+  per-detector counts. The API includes the nine detector identifiers and the
+  evidence requirements for each detector; it does not yet implement detector
+  policy.
+- `analysis::tool_catalog` resolves the built-in tools and definition-token
+  costs for a recorded harness version and model. Initial-context rows now
+  include built-in tools, use counts, deferred-tool state, and known skill
+  origins.
+
+### Changed
+
+- **Breaking:** `InitialContextTokenSource` now represents `Skill`, `Mcp`, and
+  `BuiltinTool`; it no longer exposes agent-instruction, system-instruction, or
+  unattributed variants. `InitialContextBreakdown` no longer has
+  `tracking_status` or `total_tokens`, and each `InitialContextSourceCount` now
+  includes `use_count`, `origin`, and `deferred`.
+- **Breaking:** `SessionMetrics` no longer exposes the categorical `tool_mix`
+  totals. `NormalizedRecord` no longer carries `grep_count`, and
+  `SessionSummary` no longer carries `grep_total`. Callers can use the new
+  per-tool evidence and `tool_calls_by_name` data instead.
+- Claude metrics and evidence now share one record-by-record pass. The engine
+  records cache-routing misses, per-tool calls, MCP calls, model and effort
+  changes, delegation, compaction boundaries, and bounded context evidence
+  without rereading the transcript.
+
 ## [0.1.7] - 2026-08-25
 
 ### Changed

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MPL-2.0"


### PR DESCRIPTION
## Summary

- bump `antiburn-local` and both lockfile entries to 0.1.8
- add consumer-facing release notes for the evidence, insights, and built-in tool APIs
- record the breaking initial-context and tool-metric surface changes

## Validation

- `node scripts/verify-release-version.mjs engine antiburn-local-v0.1.8`
- locked Cargo metadata resolves for the engine and desktop manifests
- `pnpm run slop` (100/100)
- `git diff --check`