### PR TITLE
chore(release): prepare antiburn 0.1.0-rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,50 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.1.0-rc.9] - 2026-08-27
+
+A release-candidate rehearsal build, not a supported release. The macOS app is
+Developer ID signed and notarized. The Windows installer is **unsigned**, so
+Windows can show a SmartScreen warning.
+
+### Added
+
+- **Updates can now be installed from Settings.** Settings → About shows
+  download progress, verifies the signed update, and offers a restart when the
+  new version is ready. Failed or interrupted updates stay visible and can be
+  retried safely.
+
+- **One-command installers are available for macOS, Linux, and Windows.** The
+  release includes `install.sh` and `install.ps1`; each selects the correct
+  package, verifies its SHA-256 checksum, and upgrades the existing
+  installation without leaving a partial replacement on failure.
+
+- **Session detail shows the cost of skills, MCP servers, built-in tools, and
+  sub-agents.** The Skills, MCPs and tools table identifies loaded, used,
+  unused, and deferred context sources. Expand the sub-agent cost row to see
+  each agent's model, tokens, cost, timing, and share of the session total.
+
+- Automated notifications now respect Focus and Do Not Disturb where the
+  operating system exposes that state. Suppressed notifications are dropped
+  instead of appearing later as a stale backlog.
+
+### Changed
+
+- Provider usage headings now show the detected subscription plan, such as
+  Claude Max 5x or Codex Pro.
+
+- Session-analysis cards explain their context, cost, and efficiency measures
+  more clearly. Cache misses during a fast tool burst no longer appear as
+  avoidable cache rehydration.
+
+### Fixed
+
+- The Context chart appears fully drawn when it first opens while retaining
+  transitions for later live updates.
+
+- Collapsed provider-limit rings show their percentage again, or an em dash
+  when the provider reports no percentage.
+
 ## [0.1.0-rc.8] - 2026-08-25
 
 A release-candidate rehearsal build, not a supported release. The macOS and

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.8",
+  "version": "0.1.0-rc.9",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 dependencies = [
  "antiburn-hud",
  "antiburn-local",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/hud", "crates/nudge", "crates/sound", "crates/trace"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.8",
+  "version": "0.1.0-rc.9",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary

- bump all four desktop version declarations to 0.1.0-rc.9
- add reader-facing release notes for updates, installers, Focus-aware notifications, and richer session analysis
- state the current macOS notarization and unsigned Windows signing modes

## Validation

- `node scripts/verify-release-version.mjs app antiburn-v0.1.0-rc.9`
- `node scripts/verify-app-engine-release.mjs`
- locked Cargo metadata resolves for the desktop manifest
- `pnpm run slop` (100/100)
- `git diff --check`