### PR TITLE
fix(release): resolve the macOS signing config

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -528,7 +528,7 @@ jobs:
             echo "::error::Provisioning profile expired at ${expiration}."
             exit 1
           fi
-          echo "TAURI_SIGNING_CONFIG=apps/desktop/src-tauri/tauri.release.conf.json" >> "$GITHUB_ENV"
+          echo "TAURI_SIGNING_CONFIG=${GITHUB_WORKSPACE}/apps/desktop/src-tauri/tauri.release.conf.json" >> "$GITHUB_ENV"
 
       - name: Import the Authenticode signing certificate
         if: runner.os == 'Windows' && steps.signing.outputs.platform_signing == 'authenticode'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,50 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.1.0-rc.10] - 2026-08-27
+
+A release-candidate rehearsal build, not a supported release. The macOS app is
+Developer ID signed and notarized. The Windows installer is **unsigned**, so
+Windows can show a SmartScreen warning.
+
+### Added
+
+- **Updates can now be installed from Settings.** Settings → About shows
+  download progress, verifies the signed update, and offers a restart when the
+  new version is ready. Failed or interrupted updates stay visible and can be
+  retried safely.
+
+- **One-command installers are available for macOS, Linux, and Windows.** The
+  release includes `install.sh` and `install.ps1`; each selects the correct
+  package, verifies its SHA-256 checksum, and upgrades the existing
+  installation without leaving a partial replacement on failure.
+
+- **Session detail shows the cost of skills, MCP servers, built-in tools, and
+  sub-agents.** The Skills, MCPs and tools table identifies loaded, used,
+  unused, and deferred context sources. Expand the sub-agent cost row to see
+  each agent's model, tokens, cost, timing, and share of the session total.
+
+- Automated notifications now respect Focus and Do Not Disturb where the
+  operating system exposes that state. Suppressed notifications are dropped
+  instead of appearing later as a stale backlog.
+
+### Changed
+
+- Provider usage headings now show the detected subscription plan, such as
+  Claude Max 5x or Codex Pro.
+
+- Session-analysis cards explain their context, cost, and efficiency measures
+  more clearly. Cache misses during a fast tool burst no longer appear as
+  avoidable cache rehydration.
+
+### Fixed
+
+- The Context chart appears fully drawn when it first opens while retaining
+  transitions for later live updates.
+
+- Collapsed provider-limit rings show their percentage again, or an em dash
+  when the provider reports no percentage.
+
 ## [0.1.0-rc.9] - 2026-08-27
 
 A release-candidate rehearsal build, not a supported release. The macOS app is

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0-rc.9",
+  "version": "0.1.0-rc.10",
   "private": true,
   "type": "module",
   "license": "MPL-2.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0-rc.9"
+version = "0.1.0-rc.10"
 dependencies = [
  "antiburn-hud",
  "antiburn-local",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/hud", "crates/nudge", "crates/sound", "crates/trace"]
 
 [package]
 name = "antiburn"
-version = "0.1.0-rc.9"
+version = "0.1.0-rc.10"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0-rc.9",
+  "version": "0.1.0-rc.10",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/scripts/verify-release-provisioning.test.mjs
+++ b/scripts/verify-release-provisioning.test.mjs
@@ -63,7 +63,7 @@ test("the release workflow validates and verifies the profile-backed entitlement
   assert.match(workflow, /ExpirationDate/);
   assert.match(
     workflow,
-    /TAURI_SIGNING_CONFIG=apps\/desktop\/src-tauri\/tauri\.release\.conf\.json/,
+    /TAURI_SIGNING_CONFIG=\$\{GITHUB_WORKSPACE\}\/apps\/desktop\/src-tauri\/tauri\.release\.conf\.json/,
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- resolve the macOS Tauri release overlay from an absolute workspace path
- assert the path invariant in the provisioning workflow test
- prepare `0.1.0-rc.10` because the immutable `rc.9` tag cannot contain the correction

The `rc.9` release workflow passed its signing credential and provisioning-profile checks, then both macOS jobs failed because `pnpm --filter ... exec` runs from `apps/desktop` while the workflow supplied a repository-root-relative config path. Linux and Windows built, but the failed workflow created no release draft.

## Verification

- `node --test scripts/verify-release-provisioning.test.mjs`
- `node scripts/verify-release-version.mjs app antiburn-v0.1.0-rc.10`
- `node scripts/verify-app-engine-release.mjs`
- `cargo metadata --locked --no-deps --format-version 1 --manifest-path apps/desktop/src-tauri/Cargo.toml`
- direct pnpm working-directory and config-path assertion
- `actionlint .github/workflows/release-app.yml`
- `pnpm run slop` (100)
- `git diff --check`
