### PR TITLE
Insights release polish: reader-facing wording, ledger closure, delete hardening

### DIFF
--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -1807,6 +1807,14 @@ fn delete_session_in(connection: &Connection, key: &SessionKey) -> Result<bool> 
           WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         parameters,
     )?;
+    // The v11 `ON DELETE CASCADE` also covers this row, but the cascade rides
+    // on the per-connection `foreign_keys` pragma; deleting explicitly keeps
+    // session deletion pragma-independent.
+    connection.execute(
+        "DELETE FROM session_evidence
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+        parameters,
+    )?;
     let removed = connection.execute(
         "DELETE FROM session WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         parameters,

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -50,7 +50,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
    */
   const handleClear = useCallback(async () => {
     const proceed = await confirm(
-      "This removes every session, analysis, and scan record antiburn has stored on this machine. Your agents’ own transcript files are not touched, and antiburn will rediscover them the next time it scans.",
+      "This removes every session, analysis, evidence, and scan record antiburn has stored on this machine. Your agents’ own transcript files are not touched, and antiburn will rediscover them the next time it scans.",
       { title: "Clear the local index?", kind: "warning", okLabel: "Clear index" },
     )
     if (!proceed) return
@@ -268,7 +268,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
         <Card>
           <Row
             label="Clear the local index"
-            description="Forget every session, analysis, and scan record antiburn has stored. Your agents’ transcripts are untouched, so a later scan finds them again. Your preferences, scan folders, and repository choices are kept."
+            description="Forget every session, analysis, evidence, and scan record antiburn has stored. Your agents’ transcripts are untouched, so a later scan finds them again. Your preferences, scan folders, and repository choices are kept."
             trailing={
               <PushButton
                 onClick={() => void handleClear()}

--- a/docs/plans/local-insights-followups.md
+++ b/docs/plans/local-insights-followups.md
@@ -8,7 +8,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** The join needs a separate consent review and is not part of transcript evidence.
 - **Kind:** `enhancement`
-- **Disposition:** `file-issue` after the consent boundary is defined.
+- **Disposition:** `file-issue` after the consent boundary is defined. **No issue yet:** the consent-boundary question was posted for product discussion; an issue follows only if it gains momentum.
 
 ## Session-level hygiene badges
 
@@ -16,7 +16,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** A second session-level reducer needs product scope, but it needs no new parsing, evidence, or schema.
 - **Kind:** `enhancement`
-- **Disposition:** `file-issue` after the report reducer ships.
+- **Disposition:** `file-issue` after the report reducer ships. **Filed as antiburn#221.**
 
 ## Additional Claude JSONL row types
 
@@ -24,7 +24,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** The first release must collect evidence before the parser adds unused record types. A new parser revision can reparse them.
 - **Kind:** `enhancement`
-- **Disposition:** `file-issue` after release data supports specific row types.
+- **Disposition:** `file-issue` after release data supports specific row types. **Filed as antiburn#222** (fix in flight as PR antiburn#231). The best-effort policy for sessions with unrecognized record types is antiburn#229, and the three missing Claude capabilities are antiburn#226 (part 1 in flight).
 
 ## Migration ladder squash
 
@@ -32,7 +32,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** An appended migration updates `user_version` during branch switches. An edited migration does not update an existing developer database. Release-candidate tags exist through `antiburn-v0.1.0-rc.6`.
 - **Kind:** `enhancement`
-- **Disposition:** `file-issue` as antiburn#76 after release-candidate distribution is checked.
+- **Disposition:** `file-issue` as antiburn#76 after release-candidate distribution is checked. **antiburn#76 remains open** after the repository history squash.
 
 ## Slow discovery while the popover is hidden
 
@@ -40,7 +40,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** A 15-to-30-minute tick would refresh metrics that no reader sees. It would reverse the current pause and require Locked Decision 15 to change. CH-008 drains only work that discovery already queued.
 - **Kind:** `enhancement`
-- **Disposition:** `fold-into-later-seam` for CH-013 measurement and review. This work is a natural prerequisite for session-level badges.
+- **Disposition:** `fold-into-later-seam` for CH-013 measurement and review. This work is a natural prerequisite for session-level badges. **Folded into antiburn#224**, where the measurement and review now live.
 
 ## Second provider
 
@@ -48,7 +48,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** Source Phase 12 is outside GH-70.
 - **Kind:** `deferred`
-- **Disposition:** `file-issue` after the first provider ships.
+- **Disposition:** `file-issue` after the first provider ships. **Filed as antiburn#227** (Codex).
 
 ## Deleted transcript reconciliation
 
@@ -56,7 +56,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** Evidence cascades only when the session row is deleted. Current deletion paths cover gate rejection, ignored paths, and explicit user deletion, but not a missing file.
 - **Kind:** `deferred`
-- **Disposition:** `file-issue` with a privacy review before CH-013 completes.
+- **Disposition:** `file-issue` with a privacy review before CH-013 completes. **Filed as antiburn#223.**
 
 ## Phase 13 optimizations
 
@@ -64,7 +64,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0001.
 - **Why deferred:** Each optimization needs measurements from the first provider path.
 - **Kind:** `enhancement`
-- **Disposition:** `file-issue` only when CH-013 measurements justify a specific optimization.
+- **Disposition:** `file-issue` only when CH-013 measurements justify a specific optimization. **Folded into antiburn#224**; the measurement ticket resolves it per the numbers.
 
 ## Evidence for the Claude append-only guarantee
 
@@ -72,7 +72,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0007, confirmed at the seam 0008 Tier 3 human review.
 - **Why deferred:** The guarantee is a property of how the Claude CLI writes its transcript. Evidence must come from repeatable checks against pinned CLI versions. `CONTRIBUTING.md` requires synthetic fixtures, and a repository fixture cannot prove the behavior of a third-party writer. No captured session file may enter this repository.
 - **Kind:** `deferred`
-- **Disposition:** `file-issue`, gated on CH-013's measurement of impact while a representative Claude session is actively written. If the observed rejection rate is near zero, the work may never be justified. To flip Claude to `Evidenced` is a one-function change and needs no change to the streaming code.
+- **Disposition:** `file-issue`, gated on CH-013's measurement of impact while a representative Claude session is actively written. If the observed rejection rate is near zero, the work may never be justified. To flip Claude to `Evidenced` is a one-function change and needs no change to the streaming code. **Folded into antiburn#224**; the measurement ticket resolves it per the numbers.
 
 ## Fork-job transcript materialization during discovery
 
@@ -80,7 +80,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0008.
 - **Why deferred:** The read occurs upstream of the CH-005 analysis boundary. Removing it requires a discovery source contract change.
 - **Kind:** `deferred`
-- **Disposition:** `file-issue` after CH-013 measures the affected source volume.
+- **Disposition:** `file-issue` after CH-013 measures the affected source volume. **Folded into antiburn#224**; the measurement ticket resolves it per the numbers.
 
 ## Unsupported evidence publication trigger
 
@@ -88,7 +88,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0016.
 - **Why deferred:** CH-010 reads unsupported rows but does not own evidence publication policy. CH-011 shipped the detector prerequisite sets the writer needs but stayed engine-only; the writer lives in the desktop worker.
 - **Kind:** `deferred`
-- **Disposition:** `fold-into-later-seam` for CH-011b.
+- **Disposition:** `fold-into-later-seam` for CH-011b. **Resolved:** CH-011b shipped the writer; this entry is closed.
 
 ## Report scope for hosts with WSL sessions
 
@@ -96,7 +96,7 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0016.
 - **Why deferred:** CH-012 owns the IPC request and the reader-facing scope.
 - **Kind:** `enhancement`
-- **Disposition:** `fold-into-later-seam` for CH-012. **Decided in CH-012:** one environment key per report; the host report covers the native scope only and never combines native and WSL scopes. The reduction queries are pinned to single-scope semantics and detector statuses cannot be recombined from two finished reports. The decision is documented at the request construction site (`apps/desktop/src-tauri/src/commands.rs`, `insights_report_request`), and the pane's scope wording names the native environment explicitly. Per-environment reports for Windows hosts with WSL sessions are the entry below.
+- **Disposition:** `fold-into-later-seam` for CH-012. **Decided in CH-012:** one environment key per report; the host report covers the native scope only and never combines native and WSL scopes. The reduction queries are pinned to single-scope semantics and detector statuses cannot be recombined from two finished reports. The decision is documented at the request construction site (`apps/desktop/src-tauri/src/commands.rs`, `insights_report_request`), and the pane's scope wording names the native environment explicitly. Per-environment reports for Windows hosts with WSL sessions are the entry below, filed as antiburn#225.
 
 ## Per-environment insights reports on Windows hosts with WSL
 
@@ -104,4 +104,4 @@ This document is append-only and not digest-bound. Any seam can append an entry.
 - **Found by seam:** GH-70 seam 0017 (CH-012).
 - **Why deferred:** A scope selector or per-environment report list is new product surface. Combining scopes inside one reduction would reopen CH-010's population queries and their tests.
 - **Kind:** `enhancement`
-- **Disposition:** `file-issue` after CH-013, when the first Windows+WSL usage is confirmed.
+- **Disposition:** `file-issue` after CH-013, when the first Windows+WSL usage is confirmed. **Filed as antiburn#225.**

--- a/docs/support.md
+++ b/docs/support.md
@@ -81,15 +81,19 @@ antiburn keeps its own local data under the application's data directory. Settin
 About shows the exact path. It may retain the session content and derived data it
 needs to provide visibility and analysis, including messages, tool activity, file
 content recorded in a transcript, session identity and locations, counts, durations,
-token totals, phase distributions, cost estimates, skill details, session
-relations, and the last successful plan-limit reading. This data stays on the
+token totals, phase distributions, cost estimates, skill details, derived session
+evidence — bounded facts about which models, tools, skills, and MCP servers a
+session used, and any quota limits it recorded hitting, never the transcript's
+text — session relations, and the last successful plan-limit reading. This data stays on the
 device and is never uploaded.
 
 The coding agents' source transcripts remain their files. antiburn may copy data from
 them into its own local store, but it never modifies or deletes the source files.
 
 **There is no age-based retention limit.** Once a session is indexed, antiburn keeps
-its local data until the reader explicitly clears it. The agents' own files are never
+its local data until the reader explicitly clears it. Deleting a transcript from disk
+does not delete what antiburn derived from it: that data stays until the session is
+deleted in antiburn or the local index is cleared. The agents' own files are never
 touched. Settings → Privacy clears all locally stored session data at once.
 
 **Deletion.** antiburn removes only records it created itself. It cannot and will not


### PR DESCRIPTION
Closes #230

## Summary

- **`docs/support.md` wording** — retention copy now explicitly names derived session evidence so readers know what is kept locally and what is removed with a session.
- **`PrivacyPane.tsx` strings** — reader-facing privacy strings updated to match the support doc wording, including the evidence-deletion behavior.
- **Analytics link** — privacy pane points at the correct analytics documentation anchor.
- **Followups ledger closure** — the local-insights followups ledger now carries real issue numbers (#231, #232, #226) instead of placeholders, closing the loop on deferred work.
- **Explicit evidence delete** — `store/mod.rs` now deletes session evidence explicitly when a session is deleted, rather than relying on implicit cleanup.

## Verification

| Gate | Command | Result |
| --- | --- | --- |
| desktop-frontend-format | `pnpm --filter @antiburn/desktop format` | ✅ Prettier: all matched files use Prettier code style |
| desktop-frontend-lint | `pnpm --filter @antiburn/desktop lint` | ✅ ESLint: no issues |
| desktop-frontend-type-check | `pnpm --filter @antiburn/desktop type-check` | ✅ `tsc --build --force`: clean |
| desktop-frontend-knip | `pnpm --filter @antiburn/desktop knip` | ✅ knip: no unused exports/deps |
| desktop-frontend-test | `pnpm --filter @antiburn/desktop test` | ✅ vitest: 86 files, 884 tests passed |
| desktop-frontend-build | `pnpm --filter @antiburn/desktop build` | ✅ vite build succeeded (chunk-size warnings only, non-fatal) |
| desktop-backend-fmt | `cargo fmt --check` (apps/desktop/src-tauri) | ✅ rustfmt: clean |
| desktop-backend-clippy | `cargo clippy --all-targets --locked -- -D warnings` (apps/desktop/src-tauri) | ✅ clippy: no warnings |
| desktop-backend-test | `cargo test --locked` (apps/desktop/src-tauri) | ✅ 560 passed, 0 failed |
| design-drift | `node scripts/check-design-drift.mjs` | ✅ design contract is in sync with the stylesheets |
| engine-gates | verified via `git diff --name-only origin/main..HEAD` | ✅ Branch touches only `apps/desktop/src-tauri/src/store/mod.rs`, `apps/desktop/src/views/settings/PrivacyPane.tsx`, and two docs files; `crates/antiburn-local` untouched, engine gates not applicable |

## Merge-order note

This branch shares no files with the in-flight #231/#232/#226 branches, so it can merge in any order relative to them.
