### PR TITLE
Measure the Claude insights pipeline and record a baseline (#224)

### DIFF
--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -15,11 +15,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "antiburn-local"
 version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-trait",
+ "criterion",
  "filetime",
  "futures-util",
  "libc",
@@ -53,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,10 +121,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "errno"
@@ -195,6 +324,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -291,10 +440,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot"
@@ -371,6 +535,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +595,15 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -571,6 +773,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +869,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +927,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -76,3 +76,7 @@ tempfile = "3"
 [[bench]]
 name = "pipeline_baseline"
 harness = false
+
+[[bench]]
+name = "memory_baseline"
+harness = false

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -65,7 +65,14 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+# Bench harness for the pipeline measurement baseline (issue #224). Kept
+# lean: no plotters/rayon, console output only.
+criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
 # Deterministic file mtimes for discovery's recency-window tests.
 filetime = "0.2"
 serial_test = "4"
 tempfile = "3"
+
+[[bench]]
+name = "pipeline_baseline"
+harness = false

--- a/crates/antiburn-local/benches/BASELINE.md
+++ b/crates/antiburn-local/benches/BASELINE.md
@@ -132,6 +132,26 @@ constant in ratio and growing in absolute bytes (57 MB saved at 50 MiB); the
 next memory win, if one is ever needed, is accumulator retention, not
 framing.
 
+### 500 MiB tier: which accumulator owns the peak
+
+The same binary runs a 500 MiB tier (generated on demand; the repository
+stores no large blob) and measures the metrics accumulator alone against the
+full composite:
+
+| Measurement | Value |
+|---|---|
+| Metrics-only peak | 797.0 MB (1.40× source) |
+| Composite (metrics + evidence) peak | 797.0 MB — evidence adds 5,825 bytes |
+| Metrics retained at end of stream | 525.6 MB over 1,722,451 turns (~305 bytes/turn, ≈0.92× source) |
+| Serialized evidence | 4,497 bytes — flat from 1 MiB to 500 MiB |
+
+The peak multiplier improves with scale (1.75–1.84× at 10–50 MiB, 1.40× at
+500 MiB): parse transients amortize and metrics retention is what remains.
+The evidence caps bound its memory the same way they bound its output, so
+the whole pipeline reduces to: peak ≈ metrics retention plus bounded
+transients; the reader and evidence are both effectively free. A 500 MiB
+session is ~10× the largest session in the issue #222 field cohort.
+
 ## Active-writer `SourceChanged` rates
 
 2 MiB source (~13 ms read window), full-reprocess claim, `Absent` guarantee,

--- a/crates/antiburn-local/benches/BASELINE.md
+++ b/crates/antiburn-local/benches/BASELINE.md
@@ -110,6 +110,28 @@ not milliseconds.
 | Metrics accumulator, 10 MiB source | 34,361 turns, 10.4 MB retained (~303 bytes/turn) | CH-005's "proportional growth" quantified: ≈ 1.0× source bytes for a dense transcript |
 | Serialized evidence per session (report query row proxy) | ~4.5 KB | a 500-session reduction reads ~2.2 MB of evidence rows; the accumulator itself holds only capped folds and examples |
 
+### Peak heap: streaming vs whole-file materialization
+
+Measured with a counting global allocator in `benches/memory_baseline.rs`
+(`cargo bench --bench memory_baseline`). Peak growth over the live baseline
+for the full pipeline (parse → metrics → evidence → serialize) on the same
+on-disk session, streamed vs `read_to_string` first:
+
+| Source | Streaming peak | Inline peak | Inline / streaming |
+|---|---|---|---|
+| 1 MiB | 1.66 MB (1.49× source) | 2.68 MB (2.40× source) | 1.61× |
+| 10 MiB | 20.7 MB (1.84× source) | 32.0 MB (2.84× source) | 1.54× |
+| 50 MiB | 98.9 MB (1.75× source) | 155.6 MB (2.75× source) | 1.57× |
+
+What this says: the streaming reader itself is nearly free (446-byte
+high-water above), so the streaming floor of ~1.5–1.8× source is the metrics
+accumulator's proportional retention plus parse transients — not the reader.
+Materializing first adds one full source copy on top, so inline peaks at
+~1.55× the streaming peak at every size. Streaming keeps its advantage
+constant in ratio and growing in absolute bytes (57 MB saved at 50 MiB); the
+next memory win, if one is ever needed, is accumulator retention, not
+framing.
+
 ## Active-writer `SourceChanged` rates
 
 2 MiB source (~13 ms read window), full-reprocess claim, `Absent` guarantee,

--- a/crates/antiburn-local/benches/BASELINE.md
+++ b/crates/antiburn-local/benches/BASELINE.md
@@ -18,11 +18,15 @@ content only; nothing reads a real transcript).
 ## Stage coverage
 
 In-crate stages measured: source reading, framing, parsing/normalization,
-metrics accumulation, evidence accumulation, report reduction. The remaining
-stages the master plan names (discovery, queue wait, persistence, report
-query, IPC) live in the desktop app (`apps/desktop/src-tauri`) and need a
-desktop-side harness — they are out of reach of this standalone crate and are
-left as the desktop-side half of the measurement follow-up.
+metrics accumulation, evidence accumulation, report reduction. Provider-DB-
+backed sources are also in-crate: a raw `RawSource::Sqlite` resolves to the
+generic schema-agnostic SQLite table walk (`vendors/sqlite.rs`, the OpenCode
+fallback), covered functionally in `tests/pipeline_corpus.rs` and timed
+below over a synthetic seeded database. The remaining stages the master plan
+names (discovery, queue wait, persistence, report query, IPC) live in the
+desktop app (`apps/desktop/src-tauri`) and need a desktop-side harness —
+those stages (not the provider-DB read path) are the desktop-side half of
+the measurement follow-up.
 
 ## Timing baseline
 
@@ -69,6 +73,21 @@ adapter); both accumulators together add only ~2–3 % on top.
 
 Materializing the whole transcript first costs ~6 % extra time plus one
 transient full-source allocation (10 MiB here).
+
+### Provider-DB-backed source (generic SQLite walk)
+
+Raw `RawSource::Sqlite` through the composite metrics+evidence sink. This
+path is batch, not streaming: the walk materializes every extracted event
+before the sink sees them, so retained memory here is proportional to the
+session, like the metrics accumulator itself.
+
+| Rows (records) | DB size | Time (median) | Throughput |
+|---|---|---|---|
+| 2,000 | ~0.6 MiB | 2.98 ms | ~214 MiB/s |
+| 20,000 | ~6.2 MiB | 30.7 ms | ~205 MiB/s |
+
+Linear, and slightly faster per byte than the JSONL path (SQLite hands the
+walk whole text cells; no newline scanning).
 
 ### Report reduction vs cohort size (`EfficiencyReportAccumulator`)
 

--- a/crates/antiburn-local/benches/BASELINE.md
+++ b/crates/antiburn-local/benches/BASELINE.md
@@ -1,0 +1,152 @@
+# Pipeline measurement baseline (issue #224)
+
+Indicative local baseline from one machine — **not CI-enforced thresholds**.
+Collected with `cargo bench --bench pipeline_baseline` over the deterministic
+synthetic corpus generator in `tests/support/corpus.rs` (seeded, fictional
+content only; nothing reads a real transcript).
+
+## Machine context
+
+| | |
+|---|---|
+| CPU | Apple M3 Pro (11 cores, arm64) |
+| RAM | 18 GiB |
+| OS | macOS 26.2 |
+| Toolchain | rustc 1.97.0, bench profile (optimized) |
+| Date | 2026-02 baseline run |
+
+## Stage coverage
+
+In-crate stages measured: source reading, framing, parsing/normalization,
+metrics accumulation, evidence accumulation, report reduction. The remaining
+stages the master plan names (discovery, queue wait, persistence, report
+query, IPC) live in the desktop app (`apps/desktop/src-tauri`) and need a
+desktop-side harness — they are out of reach of this standalone crate and are
+left as the desktop-side half of the measurement follow-up.
+
+## Timing baseline
+
+### Framing throughput (`BoundedJsonlReader`)
+
+| Scenario | Time (median) | Throughput |
+|---|---|---|
+| 6 MiB of small lines (~22k records) | 3.05 ms | ~2.07 GiB/s |
+| One near-8 MiB line (just under the bound) | 4.04 ms | ~1.92 GiB/s |
+| One oversized line (> 8 MiB, skipped) | 3.42 ms | ~2.30 GiB/s |
+
+### Full reparse cost vs session size (the append-only question)
+
+Claimed path with `AppendOnlyGuarantee::Absent`: pin → stream through the
+composite metrics+evidence sink → full recheck. This is what the worker pays
+for every source change today.
+
+| File size | Time (median) | Throughput |
+|---|---|---|
+| 1 MiB | 7.38 ms | ~146 MiB/s |
+| 10 MiB | 72.5 ms | ~149 MiB/s |
+| 50 MiB | 351 ms | ~154 MiB/s |
+
+The cost curve is linear at ~150 MiB/s end to end.
+
+### Per-stage split at 10 MiB (in-memory source)
+
+| Stage composition | Time (median) | Share |
+|---|---|---|
+| Framing only | 4.64 ms | ~7 % |
+| + parse/normalize (no-op sink) | 67.0 ms | ~98 % |
+| + metrics accumulation | 66.4 ms | within noise of no-op |
+| + metrics and evidence together | 68.4 ms | +~2 ms |
+
+The pipeline is dominated by JSON parsing (serde deserialization inside the
+adapter); both accumulators together add only ~2–3 % on top.
+
+### Fork-job `Inline` materialization proxy at 10 MiB
+
+| Path | Time (median) |
+|---|---|
+| Stream from file | 68.8 ms |
+| `read_to_string` then inline visit | 73.2 ms |
+
+Materializing the whole transcript first costs ~6 % extra time plus one
+transient full-source allocation (10 MiB here).
+
+### Report reduction vs cohort size (`EfficiencyReportAccumulator`)
+
+| Sessions | Time (median) | Per session |
+|---|---|---|
+| 10 | 8.98 µs | ~0.9 µs |
+| 65 (field cohort, issue #222) | 49.2 µs | ~0.76 µs |
+| 100 | 75.4 µs | ~0.75 µs |
+| 500 | 367 µs | ~0.73 µs |
+
+Linear at ~0.75 µs/session — reduction over a 30-day window is microseconds,
+not milliseconds.
+
+## Memory figures
+
+| Figure | Value | Bound / note |
+|---|---|---|
+| Framing high-water, 10 MiB of small lines | 446 bytes | ≤ `SCAN_QUANTUM_BYTES × 4` |
+| Framing high-water, one near-8 MiB line | 8,323,291 bytes | ≤ `MAX_RECORD_BYTES` (8,388,608) — bound respected |
+| Metrics accumulator, 10 MiB source | 34,361 turns, 10.4 MB retained (~303 bytes/turn) | CH-005's "proportional growth" quantified: ≈ 1.0× source bytes for a dense transcript |
+| Serialized evidence per session (report query row proxy) | ~4.5 KB | a 500-session reduction reads ~2.2 MB of evidence rows; the accumulator itself holds only capped folds and examples |
+
+## Active-writer `SourceChanged` rates
+
+2 MiB source (~13 ms read window), full-reprocess claim, `Absent` guarantee,
+15 attempts per row; a synthetic writer appends one ~300-byte record per
+interval:
+
+| Append interval | Rejected (SourceChanged) | Accepted |
+|---|---|---|
+| 2 ms | 15/15 | 0 |
+| 20 ms | 0/15 | 15 |
+| 200 ms | 0/15 | 15 |
+| quiescent control | 0/15 | 15 |
+
+A rejection needs a write to land inside the read window. Once the append
+interval exceeds the read duration, the observed rate drops to zero; the
+steady-state rejection probability is approximately
+`read_window / write_interval`. Real agent sessions write on the order of
+seconds apart, and the read window for typical session sizes is milliseconds.
+
+## What the numbers say — the four folded questions
+
+1. **Phase-13 optimizations (report caching, relational evidence
+   projections, read pooling)** — *dismiss with the number.* Report
+   reduction costs ~0.75 µs/session (367 µs for a 500-session cohort, 49 µs
+   for the 65-session field cohort). No stage shows a bottleneck that
+   caching or projections would relieve; the only material cost is serde
+   parsing at ~150 MiB/s, and even a 50 MiB session completes in 0.35 s.
+
+2. **Claude append-only guarantee evidence** — *defer with evidence; likely
+   never justified.* A full reprocess is 7 ms at 1 MiB, 73 ms at 10 MiB,
+   351 ms at 50 MiB — linear and cheap. The rejection rate is bounded by
+   read-window/write-interval and reached zero in every measured scenario
+   with realistic write spacing. The followups entry's own words apply:
+   "the work may never be justified." Incremental (byte-offset) parsing
+   would save at most a fraction of ~0.35 s per pathological session.
+
+3. **Fork-job `Inline` materialization** — *defer.* Materializing costs
+   ~6 % extra time and one transient full-source buffer per fork job. With
+   the worker's single source permit, peak transient memory equals the
+   largest single session. The metrics accumulator already retains ≈ source
+   size for dense transcripts, so inlining changes the constant, not the
+   order of magnitude. Revisit only if field sessions well beyond 50 MiB
+   appear in the affected-source volume.
+
+4. **Popover-hidden staleness (Locked Decision 15 review)** — *reaffirm; no
+   change proposed.* Catch-up drain time once the popover opens is
+   N × per-session full-pipeline cost: the 65-session field cohort at
+   typical sizes (≤ a few hundred KB) drains in well under one second on
+   one permit; even a pathological 65 × 10 MiB backlog drains in ~5 s.
+   Staleness while hidden is therefore bounded by the pause itself, and
+   recovery is fast enough that no scheduling change is warranted.
+
+**Worker concurrency and leases (Part 3 tuning clause):** keep 1 CPU /
+1 source / 1 provider-DB permit and `LEASE_SECS = 300`,
+`LEASE_RENEW_SECS = 60` — now a measured outcome. The worst measured
+per-session cost (0.35 s at 50 MiB) is two orders of magnitude below the
+lease renewal interval, and single-permit throughput (~150 MiB/s) clears
+realistic backlogs in seconds, so extra permits would only add contention
+with the reader's live agent sessions.

--- a/crates/antiburn-local/benches/memory_baseline.rs
+++ b/crates/antiburn-local/benches/memory_baseline.rs
@@ -119,6 +119,44 @@ fn normalized(serialized: &str) -> serde_json::Value {
     value
 }
 
+/// Measures the 500 MiB tier and splits the peak between the accumulators.
+///
+/// The generator materializes the source on demand. The repository does not
+/// store a large transcript-shaped blob.
+fn large_session_split() {
+    println!("\n== 500 MiB tier: accumulator split ==");
+    let directory = TempDir::new().expect("tempdir");
+    let session = generate_session_of_bytes(211, 0, 500 * MIB);
+    let source_bytes = session.jsonl.len();
+    let path = write_session(&directory, &session);
+    let session_id = session.session_id.clone();
+    drop(session);
+
+    let input = file_input(&session_id, &path);
+
+    let (metrics_peak, (retained_turns, retained_bytes)) = measure_peak(|| {
+        let mut metrics =
+            SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+        adapter_for("claude")
+            .visit(&input, &mut metrics)
+            .expect("synthetic source must stream");
+        (metrics.retained_turns(), metrics.retained_bytes())
+    });
+
+    let (composite_peak, evidence) = measure_peak(|| run_pipeline(&input));
+
+    println!(
+        "source {source_bytes} bytes | metrics-only peak {metrics_peak} bytes ({:.2}x source), \
+         retained {retained_bytes} bytes over {retained_turns} turns | composite peak \
+         {composite_peak} bytes ({:.2}x source) | evidence adds {} bytes to the peak | \
+         serialized evidence {} bytes",
+        metrics_peak as f64 / source_bytes as f64,
+        composite_peak as f64 / source_bytes as f64,
+        composite_peak as i64 - metrics_peak as i64,
+        evidence.len()
+    );
+}
+
 fn main() {
     println!("== peak heap: streaming vs whole-file materialization ==");
     println!("(peak growth over the live baseline; the source file stays on disk)");
@@ -160,4 +198,6 @@ fn main() {
             inline_peak as f64 / streaming_peak.max(1) as f64,
         );
     }
+
+    large_session_split();
 }

--- a/crates/antiburn-local/benches/memory_baseline.rs
+++ b/crates/antiburn-local/benches/memory_baseline.rs
@@ -1,0 +1,163 @@
+//! Peak-heap comparison: streaming a transcript vs whole-file materialization
+//! (issue #224).
+//!
+//! A counting global allocator records the heap high-water mark for the full
+//! pipeline over the same synthetic session, once streamed from a file and
+//! once materialized with `read_to_string` first. This binary is separate
+//! from `pipeline_baseline` so the allocator counters do not perturb the
+//! timing numbers. Results are recorded in `benches/BASELINE.md`.
+
+#[path = "../tests/support/corpus.rs"]
+mod corpus;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use antiburn_local::analysis::{
+    CompositeSink, EvidenceSource, RawSource, SessionEvidenceAccumulator, SessionInput,
+    SessionMetricsAccumulator, SourceCapabilities, SourceKind, adapter_for,
+};
+use corpus::{GeneratedSession, generate_session_of_bytes};
+use tempfile::TempDir;
+
+/// Wraps the system allocator and tracks live bytes and the peak.
+struct CountingAllocator;
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            let live = LIVE_BYTES.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            PEAK_BYTES.fetch_max(live, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) };
+        LIVE_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !new_pointer.is_null() {
+            if new_size >= layout.size() {
+                let grown = new_size - layout.size();
+                let live = LIVE_BYTES.fetch_add(grown, Ordering::Relaxed) + grown;
+                PEAK_BYTES.fetch_max(live, Ordering::Relaxed);
+            } else {
+                LIVE_BYTES.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        new_pointer
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Runs `work` and returns its peak heap growth over the starting live bytes.
+fn measure_peak<T>(work: impl FnOnce() -> T) -> (usize, T) {
+    let live_before = LIVE_BYTES.load(Ordering::Relaxed);
+    PEAK_BYTES.store(live_before, Ordering::Relaxed);
+    let value = work();
+    let peak = PEAK_BYTES.load(Ordering::Relaxed);
+    (peak.saturating_sub(live_before), value)
+}
+
+fn composite_for(input: &SessionInput) -> CompositeSink {
+    CompositeSink::new(
+        SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone()),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: input.agent.clone(),
+            session_id: input.session_id.clone(),
+            kind: SourceKind::from(&input.source),
+            capabilities: SourceCapabilities::claude(),
+        }),
+    )
+}
+
+fn run_pipeline(input: &SessionInput) -> String {
+    let mut composite = composite_for(input);
+    let outcome = adapter_for("claude")
+        .visit(input, &mut composite)
+        .expect("synthetic source must stream");
+    composite.observe_source_outcome(outcome);
+    let evidence = composite.evidence().expect("clean session must publish");
+    serde_json::to_string(&evidence).expect("evidence serializes")
+}
+
+fn write_session(directory: &TempDir, session: &GeneratedSession) -> PathBuf {
+    let path = directory
+        .path()
+        .join(format!("{}.jsonl", session.session_id));
+    std::fs::write(&path, session.jsonl.as_bytes()).expect("write synthetic session");
+    path
+}
+
+fn file_input(session_id: &str, path: &Path) -> SessionInput {
+    SessionInput {
+        agent: "claude".to_string(),
+        session_id: session_id.to_string(),
+        source: RawSource::File(path.to_path_buf()),
+    }
+}
+
+const MIB: usize = 1024 * 1024;
+
+/// Parses serialized evidence and blanks the source kind, which is the one
+/// expected difference between the file path and the inline path.
+fn normalized(serialized: &str) -> serde_json::Value {
+    let mut value: serde_json::Value =
+        serde_json::from_str(serialized).expect("evidence parses back");
+    value["provenance"]["sourceKind"] = serde_json::Value::Null;
+    value
+}
+
+fn main() {
+    println!("== peak heap: streaming vs whole-file materialization ==");
+    println!("(peak growth over the live baseline; the source file stays on disk)");
+
+    for &size_mib in &[1_usize, 10, 50] {
+        let directory = TempDir::new().expect("tempdir");
+        let session = generate_session_of_bytes(163, 0, size_mib * MIB);
+        let source_bytes = session.jsonl.len();
+        let path = write_session(&directory, &session);
+        let session_id = session.session_id.clone();
+        // Drop the in-memory copy so only the on-disk file remains.
+        drop(session);
+
+        let streamed = file_input(&session_id, &path);
+        let (streaming_peak, streamed_evidence) = measure_peak(|| run_pipeline(&streamed));
+        black_box(&streamed_evidence);
+
+        let (inline_peak, inline_evidence) = measure_peak(|| {
+            let content = std::fs::read_to_string(&path).expect("materialize transcript");
+            let inline = SessionInput {
+                agent: "claude".to_string(),
+                session_id: session_id.clone(),
+                source: RawSource::Jsonl(content),
+            };
+            run_pipeline(&inline)
+        });
+        assert_eq!(
+            normalized(&streamed_evidence),
+            normalized(&inline_evidence),
+            "both paths must publish identical evidence apart from the source kind"
+        );
+
+        println!(
+            "{size_mib} MiB source ({source_bytes} bytes): streaming peak {streaming_peak} bytes \
+             ({:.2}x source), inline peak {inline_peak} bytes ({:.2}x source), \
+             inline/streaming {:.2}x",
+            streaming_peak as f64 / source_bytes as f64,
+            inline_peak as f64 / source_bytes as f64,
+            inline_peak as f64 / streaming_peak.max(1) as f64,
+        );
+    }
+}

--- a/crates/antiburn-local/benches/pipeline_baseline.rs
+++ b/crates/antiburn-local/benches/pipeline_baseline.rs
@@ -33,7 +33,9 @@ use antiburn_local::discovery::source_version::{FingerprintInputs, SourceStat, h
 use antiburn_local::insights::{
     CoverageBucket, CoverageCounts, EfficiencyReportAccumulator, ReportContext, ReportWindow,
 };
-use corpus::{GeneratedSession, SessionSpec, generate_session, generate_session_of_bytes};
+use corpus::{
+    GeneratedSession, SessionSpec, generate_session, generate_session_of_bytes, write_provider_db,
+};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
 use tempfile::TempDir;
 
@@ -307,6 +309,43 @@ fn materialization(criterion: &mut Criterion) {
     group.finish();
 }
 
+/// Provider-DB-backed source: the generic schema-agnostic SQLite walk
+/// (the raw-`RawSource::Sqlite` fallback path), through the composite sink.
+fn provider_db(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("provider_db_walk");
+    group.sample_size(10);
+
+    let directory = TempDir::new().expect("tempdir");
+    for &records in &[2_000_usize, 20_000] {
+        let session = generate_session(&SessionSpec::tier_s(151, records, records));
+        let db_path = directory.path().join(format!("provider-{records}.db"));
+        write_provider_db(&db_path, &session).expect("write synthetic provider DB");
+        let db_bytes = std::fs::metadata(&db_path).expect("stat provider DB").len();
+        let input = SessionInput {
+            agent: "opencode".to_string(),
+            session_id: session.session_id.clone(),
+            source: RawSource::Sqlite(db_path),
+        };
+        group.throughput(Throughput::Bytes(db_bytes));
+        group.bench_with_input(
+            BenchmarkId::new("visit_composite", format!("{records}_rows")),
+            &records,
+            |bencher, _| {
+                bencher.iter(|| {
+                    let mut composite = composite_for(&input);
+                    let outcome = adapter_for(&input.agent)
+                        .visit(&input, &mut composite)
+                        .expect("synthetic provider DB must be readable");
+                    composite.observe_source_outcome(outcome);
+                    black_box(composite.evidence())
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 /// Report reduction cost against cohort size (the 30-day accumulator).
 fn report_reduction(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("report_reduction");
@@ -480,6 +519,7 @@ fn main() {
     full_reparse(&mut criterion);
     stage_split(&mut criterion);
     materialization(&mut criterion);
+    provider_db(&mut criterion);
     report_reduction(&mut criterion);
     criterion.final_summary();
     memory_probes();

--- a/crates/antiburn-local/benches/pipeline_baseline.rs
+++ b/crates/antiburn-local/benches/pipeline_baseline.rs
@@ -1,0 +1,487 @@
+//! Pipeline measurement baseline (issue #224).
+//!
+//! Criterion benches over the synthetic corpus generator shared with
+//! `tests/pipeline_corpus.rs`. All sources are generated in memory or into a
+//! tempdir; nothing reads a real transcript. The numbers are an indicative
+//! local baseline recorded in `benches/BASELINE.md` with machine context —
+//! they are not CI-enforced thresholds.
+//!
+//! Stage coverage (of the ten stages the master plan names): source reading,
+//! parsing/framing, normalization, metrics accumulation, evidence
+//! accumulation, and report reduction. Discovery, queue wait, persistence,
+//! report query, and IPC live in the desktop app and need a desktop-side
+//! harness.
+
+#[path = "../tests/support/corpus.rs"]
+mod corpus;
+
+use std::hint::black_box;
+use std::io::{Cursor, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use antiburn_local::analysis::{
+    ANALYZER_REVISION, AppendOnlyGuarantee, BoundedJsonlReader, ClaudeAdapter, CompositeSink,
+    EVIDENCE_SCHEMA_REVISION, EvidenceSource, MAX_RECORD_BYTES, NormalizedRecord, PARSER_REVISION,
+    RawSource, RecordSink, SessionEvidence, SessionEvidenceAccumulator, SessionInput,
+    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceClaim, SourceKind,
+    VisitOutcome, adapter_for,
+};
+use antiburn_local::discovery::source_version::{FingerprintInputs, SourceStat, head_hash_of};
+use antiburn_local::insights::{
+    CoverageBucket, CoverageCounts, EfficiencyReportAccumulator, ReportContext, ReportWindow,
+};
+use corpus::{GeneratedSession, SessionSpec, generate_session, generate_session_of_bytes};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
+use tempfile::TempDir;
+
+const MIB: usize = 1024 * 1024;
+
+struct NoopSink;
+
+impl RecordSink for NoopSink {
+    fn record(&mut self, _record: NormalizedRecord) {}
+    fn finish(&mut self, _summary: SessionSummary) {}
+}
+
+fn jsonl_input(session: &GeneratedSession) -> SessionInput {
+    SessionInput {
+        agent: "claude".to_string(),
+        session_id: session.session_id.clone(),
+        source: RawSource::Jsonl(session.jsonl.clone()),
+    }
+}
+
+fn file_input(session_id: &str, path: &Path) -> SessionInput {
+    SessionInput {
+        agent: "claude".to_string(),
+        session_id: session_id.to_string(),
+        source: RawSource::File(path.to_path_buf()),
+    }
+}
+
+fn composite_for(input: &SessionInput) -> CompositeSink {
+    CompositeSink::new(
+        SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone()),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: input.agent.clone(),
+            session_id: input.session_id.clone(),
+            kind: SourceKind::from(&input.source),
+            capabilities: SourceCapabilities::claude(),
+        }),
+    )
+}
+
+fn write_session(directory: &TempDir, session: &GeneratedSession) -> PathBuf {
+    let path = directory
+        .path()
+        .join(format!("{}.jsonl", session.session_id));
+    std::fs::write(&path, session.jsonl.as_bytes()).expect("write synthetic session");
+    path
+}
+
+fn claim_for_path(path: &Path) -> SourceClaim {
+    let file = std::fs::File::open(path).expect("open source for claim");
+    let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+    let bytes = std::fs::read(path).expect("read source for claim");
+    SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+        stat,
+        head_hash: Some(head_hash_of(&bytes)),
+    })
+}
+
+fn report_context(ready_sessions: u64) -> ReportContext {
+    let mut coverage = CoverageCounts::default();
+    coverage.observe(CoverageBucket::Ready, ready_sessions);
+    ReportContext {
+        environment_key: "synthetic".to_owned(),
+        window: ReportWindow {
+            start_epoch: 1_770_000_000,
+            end_epoch: 1_772_600_000,
+        },
+        computed_at_epoch: 1_772_600_000,
+        parser_revision: PARSER_REVISION,
+        analyzer_revision: ANALYZER_REVISION,
+        evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+        coverage,
+    }
+}
+
+/// Framing throughput: many small lines, and single near-bound / over-bound lines.
+fn framing(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("framing");
+    group.sample_size(20);
+
+    let many_lines = generate_session_of_bytes(101, 0, 6 * MIB);
+    group.throughput(Throughput::Bytes(many_lines.jsonl.len() as u64));
+    group.bench_function("many_small_lines_6MiB", |bencher| {
+        bencher.iter(|| {
+            let mut reader = BoundedJsonlReader::new(Cursor::new(many_lines.jsonl.as_bytes()));
+            let mut records = 0_u64;
+            while let Some(record) = reader.next_record(&|| false) {
+                black_box(&record);
+                records += 1;
+            }
+            records
+        });
+    });
+
+    let mut near_spec = SessionSpec::tier_s(103, 0, 24);
+    near_spec.oversized_at = Some(12);
+    near_spec.oversized_bytes = MAX_RECORD_BYTES - 64 * 1024;
+    let near_max = generate_session(&near_spec);
+    group.throughput(Throughput::Bytes(near_max.jsonl.len() as u64));
+    group.bench_function("one_near_8MiB_line", |bencher| {
+        bencher.iter(|| {
+            let mut reader = BoundedJsonlReader::new(Cursor::new(near_max.jsonl.as_bytes()));
+            let mut records = 0_u64;
+            while let Some(record) = reader.next_record(&|| false) {
+                black_box(&record);
+                records += 1;
+            }
+            records
+        });
+    });
+
+    let mut over_spec = SessionSpec::tier_s(107, 0, 24);
+    over_spec.oversized_at = Some(12);
+    over_spec.oversized_bytes = MAX_RECORD_BYTES + 64 * 1024;
+    let over_max = generate_session(&over_spec);
+    group.throughput(Throughput::Bytes(over_max.jsonl.len() as u64));
+    group.bench_function("one_oversized_line_skipped", |bencher| {
+        bencher.iter(|| {
+            let mut reader = BoundedJsonlReader::new(Cursor::new(over_max.jsonl.as_bytes()));
+            let mut records = 0_u64;
+            while let Some(record) = reader.next_record(&|| false) {
+                black_box(&record);
+                records += 1;
+            }
+            records
+        });
+    });
+
+    group.finish();
+}
+
+/// The append-only question: what a full reprocess costs as the file grows.
+/// Runs the claimed full-validation path (pin → stream through the composite
+/// sink → full recheck), exactly what the worker pays on every source change.
+fn full_reparse(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("full_reparse");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(12));
+
+    let directory = TempDir::new().expect("tempdir");
+    for &size in &[MIB, 10 * MIB, 50 * MIB] {
+        let session = generate_session_of_bytes(109, size / MIB, size);
+        let path = write_session(&directory, &session);
+        let input = file_input(&session.session_id, &path);
+        let claim = claim_for_path(&path);
+        group.throughput(Throughput::Bytes(session.jsonl.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("claimed_absent_guarantee", format!("{}MiB", size / MIB)),
+            &size,
+            |bencher, _| {
+                bencher.iter(|| {
+                    let mut composite = composite_for(&input);
+                    let outcome = ClaudeAdapter
+                        .visit_claimed(
+                            &input,
+                            &claim,
+                            AppendOnlyGuarantee::Absent,
+                            &|| false,
+                            &mut composite,
+                        )
+                        .expect("synthetic source must stream");
+                    assert!(matches!(outcome, VisitOutcome::AcceptedFull));
+                    composite.observe_source_outcome(outcome);
+                    black_box(composite.evidence())
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Per-stage attribution over one 10 MiB in-memory source: framing only,
+/// + parse/normalize, + metrics, + metrics and evidence together.
+fn stage_split(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("stage_split_10MiB");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(12));
+
+    let session = generate_session_of_bytes(113, 0, 10 * MIB);
+    let input = jsonl_input(&session);
+    group.throughput(Throughput::Bytes(session.jsonl.len() as u64));
+
+    group.bench_function("framing_only", |bencher| {
+        bencher.iter(|| {
+            let mut reader = BoundedJsonlReader::new(Cursor::new(session.jsonl.as_bytes()));
+            let mut records = 0_u64;
+            while let Some(record) = reader.next_record(&|| false) {
+                black_box(&record);
+                records += 1;
+            }
+            records
+        });
+    });
+
+    group.bench_function("normalize_noop_sink", |bencher| {
+        bencher.iter(|| {
+            let mut sink = NoopSink;
+            adapter_for("claude")
+                .visit(&input, &mut sink)
+                .expect("synthetic source must stream")
+        });
+    });
+
+    group.bench_function("normalize_plus_metrics", |bencher| {
+        bencher.iter(|| {
+            let mut sink =
+                SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+            adapter_for("claude")
+                .visit(&input, &mut sink)
+                .expect("synthetic source must stream");
+            black_box(sink.retained_turns())
+        });
+    });
+
+    group.bench_function("normalize_plus_metrics_and_evidence", |bencher| {
+        bencher.iter(|| {
+            let mut composite = composite_for(&input);
+            let outcome = adapter_for("claude")
+                .visit(&input, &mut composite)
+                .expect("synthetic source must stream");
+            composite.observe_source_outcome(outcome);
+            black_box(composite.evidence())
+        });
+    });
+
+    group.finish();
+}
+
+/// Fork-job `Inline` materialization proxy: streaming a file through the
+/// pipeline vs reading the whole transcript into memory first.
+fn materialization(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("materialization_10MiB");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(12));
+
+    let directory = TempDir::new().expect("tempdir");
+    let session = generate_session_of_bytes(127, 0, 10 * MIB);
+    let path = write_session(&directory, &session);
+    group.throughput(Throughput::Bytes(session.jsonl.len() as u64));
+
+    let streamed = file_input(&session.session_id, &path);
+    group.bench_function("stream_from_file", |bencher| {
+        bencher.iter(|| {
+            let mut composite = composite_for(&streamed);
+            let outcome = adapter_for("claude")
+                .visit(&streamed, &mut composite)
+                .expect("synthetic source must stream");
+            composite.observe_source_outcome(outcome);
+            black_box(composite.evidence())
+        });
+    });
+
+    group.bench_function("read_to_string_then_inline", |bencher| {
+        bencher.iter(|| {
+            let content = std::fs::read_to_string(&path).expect("materialize transcript");
+            let inline = SessionInput {
+                agent: "claude".to_string(),
+                session_id: session.session_id.clone(),
+                source: RawSource::Jsonl(content),
+            };
+            let mut composite = composite_for(&inline);
+            let outcome = adapter_for("claude")
+                .visit(&inline, &mut composite)
+                .expect("synthetic source must stream");
+            composite.observe_source_outcome(outcome);
+            black_box(composite.evidence())
+        });
+    });
+
+    group.finish();
+}
+
+/// Report reduction cost against cohort size (the 30-day accumulator).
+fn report_reduction(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("report_reduction");
+    group.sample_size(20);
+
+    // One evidence value per distinct session, from a representative S tier.
+    let evidence_of = |session_index: usize| -> SessionEvidence {
+        let session = generate_session(&SessionSpec::tier_s(131, session_index, 120));
+        let input = jsonl_input(&session);
+        let mut composite = composite_for(&input);
+        let outcome = adapter_for("claude")
+            .visit(&input, &mut composite)
+            .expect("synthetic source must stream");
+        composite.observe_source_outcome(outcome);
+        composite.evidence().expect("clean session must publish")
+    };
+
+    for &sessions in &[10_usize, 65, 100, 500] {
+        let cohort: Vec<SessionEvidence> = (0..sessions).map(evidence_of).collect();
+        group.throughput(Throughput::Elements(sessions as u64));
+        group.bench_with_input(
+            BenchmarkId::new("observe_and_finish", sessions),
+            &cohort,
+            |bencher, cohort| {
+                bencher.iter_batched(
+                    || cohort.clone(),
+                    |cohort| {
+                        let mut report = EfficiencyReportAccumulator::new();
+                        let count = cohort.len() as u64;
+                        for evidence in cohort {
+                            report.observe_session(evidence);
+                        }
+                        black_box(report.finish(report_context(count)))
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Memory figures printed alongside the timing baseline (recorded in
+/// BASELINE.md): framing high-water, metrics retained bytes, and a
+/// serialized-evidence size proxy for the report query loop.
+fn memory_probes() {
+    println!("\n== memory probes (recorded in benches/BASELINE.md) ==");
+
+    let large = generate_session_of_bytes(137, 0, 10 * MIB);
+    let mut reader = BoundedJsonlReader::new(Cursor::new(large.jsonl.as_bytes()));
+    while reader.next_record(&|| false).is_some() {}
+    println!(
+        "framing high-water, 10 MiB / {} records of small lines: {} bytes",
+        large.tallies.total_records,
+        reader.retained_record_bytes_high_water()
+    );
+
+    let mut near_spec = SessionSpec::tier_s(139, 0, 24);
+    near_spec.oversized_at = Some(12);
+    near_spec.oversized_bytes = MAX_RECORD_BYTES - 64 * 1024;
+    let near_max = generate_session(&near_spec);
+    let mut reader = BoundedJsonlReader::new(Cursor::new(near_max.jsonl.as_bytes()));
+    while reader.next_record(&|| false).is_some() {}
+    println!(
+        "framing high-water, one near-8 MiB line: {} bytes (bound {})",
+        reader.retained_record_bytes_high_water(),
+        MAX_RECORD_BYTES
+    );
+
+    let input = jsonl_input(&large);
+    let mut metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+    adapter_for("claude")
+        .visit(&input, &mut metrics)
+        .expect("synthetic source must stream");
+    println!(
+        "metrics accumulator, 10 MiB source: {} retained turns, {} retained bytes ({} bytes/turn)",
+        metrics.retained_turns(),
+        metrics.retained_bytes(),
+        metrics.retained_bytes() / metrics.retained_turns().max(1)
+    );
+
+    let mut composite = composite_for(&input);
+    let outcome = adapter_for("claude")
+        .visit(&input, &mut composite)
+        .expect("synthetic source must stream");
+    composite.observe_source_outcome(outcome);
+    let evidence = composite.evidence().expect("clean session must publish");
+    let serialized = serde_json::to_string(&evidence).expect("evidence serializes");
+    println!(
+        "serialized evidence for the 10 MiB session (report query row proxy): {} bytes",
+        serialized.len()
+    );
+}
+
+/// Active-writer figure: how often the full-reprocess claim is rejected with
+/// `SourceChanged` while a synthetic writer keeps appending, per append
+/// interval. Printed as a rate; recorded in BASELINE.md.
+fn active_writer_rates() {
+    println!("\n== active-writer SourceChanged rates (recorded in benches/BASELINE.md) ==");
+    const ATTEMPTS: usize = 15;
+
+    let directory = TempDir::new().expect("tempdir");
+    let session = generate_session_of_bytes(149, 0, 2 * MIB);
+    let path = write_session(&directory, &session);
+    let input = file_input(&session.session_id, &path);
+
+    let run_attempts = |writer_interval: Option<Duration>| -> (usize, usize) {
+        let mut rejected = 0;
+        let mut accepted = 0;
+        for _ in 0..ATTEMPTS {
+            let claim = claim_for_path(&path);
+            let stop = Arc::new(AtomicBool::new(false));
+            let writer = writer_interval.map(|interval| {
+                let stop = Arc::clone(&stop);
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        std::thread::sleep(interval);
+                        let mut file = std::fs::OpenOptions::new()
+                            .append(true)
+                            .open(&path)
+                            .expect("open source for append");
+                        file.write_all(
+                            b"{\"type\":\"assistant\",\"timestamp\":1770099999,\"message\":{\"id\":\"msg-writer\",\"role\":\"assistant\",\"model\":\"claude-3-5-haiku-20241022\",\"usage\":{\"input_tokens\":2,\"output_tokens\":3},\"content\":[{\"type\":\"text\",\"text\":\"Appended synthetic turn.\"}]}}\n",
+                        )
+                        .expect("append to source");
+                    }
+                })
+            });
+            let mut sink = NoopSink;
+            let outcome = ClaudeAdapter
+                .visit_claimed(
+                    &input,
+                    &claim,
+                    AppendOnlyGuarantee::Absent,
+                    &|| false,
+                    &mut sink,
+                )
+                .expect("synthetic source must stream");
+            stop.store(true, Ordering::Relaxed);
+            if let Some(writer) = writer {
+                writer.join().expect("writer thread joins");
+            }
+            match outcome {
+                VisitOutcome::SourceChanged(_) => rejected += 1,
+                VisitOutcome::AcceptedFull => accepted += 1,
+                other => panic!("unexpected outcome: {other:?}"),
+            }
+        }
+        (rejected, accepted)
+    };
+
+    for interval_ms in [2_u64, 20, 200] {
+        let (rejected, accepted) = run_attempts(Some(Duration::from_millis(interval_ms)));
+        println!(
+            "append every {interval_ms} ms: {rejected}/{} rejected (SourceChanged), {accepted} accepted",
+            rejected + accepted
+        );
+    }
+    let (rejected, accepted) = run_attempts(None);
+    println!(
+        "quiescent control: {rejected}/{} rejected, {accepted} accepted",
+        rejected + accepted
+    );
+}
+
+fn main() {
+    let mut criterion = Criterion::default().configure_from_args();
+    framing(&mut criterion);
+    full_reparse(&mut criterion);
+    stage_split(&mut criterion);
+    materialization(&mut criterion);
+    report_reduction(&mut criterion);
+    criterion.final_summary();
+    memory_probes();
+    active_writer_rates();
+}

--- a/crates/antiburn-local/tests/pipeline_corpus.rs
+++ b/crates/antiburn-local/tests/pipeline_corpus.rs
@@ -1,0 +1,379 @@
+//! End-to-end pipeline composition over the synthetic corpus tiers.
+//!
+//! Every scenario drives the full in-crate pipeline — framing → vendor
+//! normalization → metrics + evidence accumulation → report reduction — and
+//! asserts outcome shape (counts, coverage, bounded-memory contracts), never
+//! timing. Timing lives in `benches/pipeline_baseline.rs` over the same
+//! generator; keep the in-test tiers small so the suite stays fast.
+
+#[path = "support/corpus.rs"]
+mod corpus;
+
+use std::fs::OpenOptions;
+use std::io::{Cursor, Write};
+use std::path::{Path, PathBuf};
+
+use antiburn_local::analysis::{
+    ANALYZER_REVISION, AppendOnlyGuarantee, BoundedJsonlReader, ClaudeAdapter, CompositeSink,
+    CoverageReason, EVIDENCE_SCHEMA_REVISION, EvidenceCoverage, EvidenceSource, EvidenceValue,
+    MAX_RECORD_BYTES, NormalizedRecord, PARSER_REVISION, RawSource, RecordSink, SCAN_QUANTUM_BYTES,
+    SessionEvidence, SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator,
+    SessionSummary, SourceCapabilities, SourceChangedReason, SourceClaim, SourceKind, VisitOutcome,
+    adapter_for,
+};
+use antiburn_local::discovery::source_version::{FingerprintInputs, SourceStat, head_hash_of};
+use antiburn_local::insights::{
+    CoverageBucket, CoverageCounts, EfficiencyReportAccumulator, ReportContext, ReportWindow,
+};
+use corpus::{GeneratedSession, SessionSpec, generate_session, generate_session_of_bytes};
+use tempfile::TempDir;
+
+fn file_input(session_id: &str, path: &Path) -> SessionInput {
+    SessionInput {
+        agent: "claude".to_string(),
+        session_id: session_id.to_string(),
+        source: RawSource::File(path.to_path_buf()),
+    }
+}
+
+fn write_session(directory: &TempDir, session: &GeneratedSession) -> PathBuf {
+    let path = directory
+        .path()
+        .join(format!("{}.jsonl", session.session_id));
+    std::fs::write(&path, session.jsonl.as_bytes()).expect("write synthetic session");
+    path
+}
+
+fn composite_for(input: &SessionInput) -> CompositeSink {
+    let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::from(&input.source),
+        capabilities: SourceCapabilities::claude(),
+    });
+    CompositeSink::new(metrics, evidence)
+}
+
+/// Runs framing → normalization → metrics + evidence for one input.
+fn run_pipeline(input: &SessionInput) -> CompositeSink {
+    let mut composite = composite_for(input);
+    let outcome = adapter_for("claude")
+        .visit(input, &mut composite)
+        .expect("synthetic source must stream");
+    composite.observe_source_outcome(outcome);
+    composite
+}
+
+fn observed<T>(value: &EvidenceValue<T>) -> &T {
+    match value {
+        EvidenceValue::Complete(observed) | EvidenceValue::Partial { observed, .. } => observed,
+        EvidenceValue::Unsupported => panic!("evidence group must be observed"),
+    }
+}
+
+fn report_context(ready_sessions: u64) -> ReportContext {
+    let mut coverage = CoverageCounts::default();
+    coverage.observe(CoverageBucket::Ready, ready_sessions);
+    ReportContext {
+        environment_key: "synthetic".to_owned(),
+        window: ReportWindow {
+            start_epoch: 1_770_000_000,
+            end_epoch: 1_772_600_000,
+        },
+        computed_at_epoch: 1_772_600_000,
+        parser_revision: PARSER_REVISION,
+        analyzer_revision: ANALYZER_REVISION,
+        evidence_schema_revision: EVIDENCE_SCHEMA_REVISION,
+        coverage,
+    }
+}
+
+fn claim_for_path(path: &Path) -> SourceClaim {
+    let file = std::fs::File::open(path).expect("open source for claim");
+    let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+    let bytes = std::fs::read(path).expect("read source for claim");
+    SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+        stat,
+        head_hash: Some(head_hash_of(&bytes)),
+    })
+}
+
+#[test]
+fn s_tier_session_flows_end_to_end_into_a_report() {
+    let directory = TempDir::new().expect("tempdir");
+    let session = generate_session(&SessionSpec::tier_s(11, 0, 500));
+    assert_eq!(session.tallies.total_records, 500);
+    assert!(session.tallies.compaction_boundaries >= 2);
+    let path = write_session(&directory, &session);
+    let input = file_input(&session.session_id, &path);
+
+    let composite = run_pipeline(&input);
+    let evidence = composite.evidence().expect("clean session must publish");
+    let metrics = composite.metrics().expect("clean session must publish");
+
+    assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
+    assert_eq!(evidence.diagnostics.records_unusable, 0);
+    let eligibility = observed(&evidence.eligibility);
+    assert_eq!(
+        eligibility.assistant_turns,
+        session.tallies.assistant_records as u64
+    );
+    assert!(eligibility.turns >= eligibility.assistant_turns);
+    assert!(evidence.diagnostics.records_observed >= session.tallies.assistant_records as u64);
+    assert!(evidence.diagnostics.records_observed <= session.tallies.total_records as u64);
+    assert_eq!(metrics.session_id, session.session_id);
+    // Assistant and user records become events; so does each compaction
+    // boundary (it carries a compaction marker through the metrics path).
+    assert_eq!(
+        metrics.event_count,
+        session.tallies.assistant_records
+            + session.tallies.user_records
+            + session.tallies.compaction_boundaries
+    );
+    assert!(metrics.tokens_in > 0 && metrics.tokens_out > 0);
+
+    let mut report = EfficiencyReportAccumulator::new();
+    report.observe_session(evidence);
+    let report = report.finish(report_context(1));
+    assert_eq!(report.assessed_sessions, 1);
+    assert!(report.coverage_reasons.is_empty());
+    assert!(report.context.coverage.is_consistent());
+}
+
+#[test]
+fn oversized_line_is_bounded_and_neighbours_survive() {
+    let directory = TempDir::new().expect("tempdir");
+    let mut spec = SessionSpec::tier_s(13, 0, 120);
+    spec.oversized_at = Some(60);
+    spec.oversized_bytes = MAX_RECORD_BYTES + 4096;
+    let session = generate_session(&spec);
+    assert_eq!(session.tallies.oversized_records, 1);
+    let path = write_session(&directory, &session);
+    let input = file_input(&session.session_id, &path);
+
+    // The framing layer never retains more than the record bound.
+    let mut reader = BoundedJsonlReader::new(Cursor::new(session.jsonl.as_bytes()));
+    while reader.next_record(&|| false).is_some() {}
+    assert!(reader.retained_record_bytes_high_water() <= MAX_RECORD_BYTES);
+
+    let composite = run_pipeline(&input);
+    let evidence = composite
+        .evidence()
+        .expect("an oversized line degrades coverage, not publication");
+    assert_eq!(
+        evidence.coverage,
+        EvidenceCoverage::Partial(CoverageReason::Oversized)
+    );
+    assert_eq!(evidence.diagnostics.records_unusable, 1);
+    let eligibility = observed(&evidence.eligibility);
+    assert_eq!(
+        eligibility.assistant_turns,
+        session.tallies.assistant_records as u64
+    );
+}
+
+#[test]
+fn large_session_respects_bounded_memory_contracts() {
+    let directory = TempDir::new().expect("tempdir");
+    let session = generate_session_of_bytes(17, 0, 3 * 1024 * 1024);
+    assert!(session.jsonl.len() >= 3 * 1024 * 1024);
+    let path = write_session(&directory, &session);
+    let input = file_input(&session.session_id, &path);
+
+    let mut reader = BoundedJsonlReader::new(Cursor::new(session.jsonl.as_bytes()));
+    while reader.next_record(&|| false).is_some() {}
+    assert!(reader.retained_record_bytes_high_water() <= SCAN_QUANTUM_BYTES * 4);
+
+    let composite = run_pipeline(&input);
+    let (metrics, evidence) = composite
+        .into_parts()
+        .expect("large clean session must publish");
+    assert!(metrics.retained_turns() > 0);
+    assert!(
+        metrics.retained_bytes() < metrics.retained_turns() * 1024,
+        "retained {} bytes for {} turns",
+        metrics.retained_bytes(),
+        metrics.retained_turns()
+    );
+    assert_eq!(evidence.evidence().coverage, EvidenceCoverage::Complete);
+}
+
+#[test]
+fn m_tier_report_reduction_covers_every_session() {
+    let directory = TempDir::new().expect("tempdir");
+    const SESSIONS: usize = 24;
+    let mut report = EfficiencyReportAccumulator::new();
+    for session_index in 0..SESSIONS {
+        let session = generate_session(&SessionSpec::tier_s(19, session_index, 80));
+        let path = write_session(&directory, &session);
+        let input = file_input(&session.session_id, &path);
+        let composite = run_pipeline(&input);
+        let evidence = composite.evidence().expect("clean session must publish");
+        assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
+        report.observe_session(evidence);
+    }
+    let report = report.finish(report_context(SESSIONS as u64));
+    assert_eq!(report.assessed_sessions, SESSIONS as u64);
+    assert!(report.coverage_reasons.is_empty());
+    for counts in report.detectors {
+        assert!(counts.eligible <= SESSIONS as u64);
+        assert!(counts.assessed <= counts.eligible);
+    }
+}
+
+#[test]
+fn roster_parent_and_subagent_children_compose() {
+    let directory = TempDir::new().expect("tempdir");
+    let mut parent_spec = SessionSpec::tier_s(23, 0, 60);
+    parent_spec.task_spawns = 3;
+    let parent = generate_session(&parent_spec);
+    assert_eq!(parent.tallies.task_spawns, 3);
+
+    let mut evidences: Vec<SessionEvidence> = Vec::new();
+    let parent_path = write_session(&directory, &parent);
+    let parent_evidence = run_pipeline(&file_input(&parent.session_id, &parent_path))
+        .evidence()
+        .expect("parent must publish");
+    let subagents = observed(&parent_evidence.subagents).clone();
+    assert_eq!(subagents.spawn_count, 3);
+    evidences.push(parent_evidence);
+
+    for child_index in 1..=3 {
+        let mut child_spec = SessionSpec::tier_s(23, child_index, 30);
+        child_spec.delegated = true;
+        let child = generate_session(&child_spec);
+        let child_path = write_session(&directory, &child);
+        let child_evidence = run_pipeline(&file_input(&child.session_id, &child_path))
+            .evidence()
+            .expect("child must publish");
+        let child_subagents = observed(&child_evidence.subagents);
+        assert_eq!(
+            child_subagents.delegated_turns,
+            child.tallies.assistant_records as u64
+        );
+        evidences.push(child_evidence);
+    }
+
+    let mut report = EfficiencyReportAccumulator::new();
+    let cohort = evidences.len() as u64;
+    for evidence in evidences {
+        report.observe_session(evidence);
+    }
+    let report = report.finish(report_context(cohort));
+    assert_eq!(report.assessed_sessions, cohort);
+}
+
+#[test]
+fn housekeeping_tail_with_unrecognized_types_degrades_coverage_only() {
+    let directory = TempDir::new().expect("tempdir");
+    let mut spec = SessionSpec::tier_s(29, 0, 200);
+    spec.unrecognized_every = Some(25);
+    let session = generate_session(&spec);
+    assert!(session.tallies.unrecognized_records > 0);
+    let path = write_session(&directory, &session);
+
+    let composite = run_pipeline(&file_input(&session.session_id, &path));
+    let evidence = composite
+        .evidence()
+        .expect("unrecognized housekeeping degrades coverage, not publication");
+    assert_eq!(
+        evidence.coverage,
+        EvidenceCoverage::Partial(CoverageReason::UnrecognizedRecordType)
+    );
+    assert!(
+        evidence
+            .diagnostics
+            .unrecognized_types
+            .iter()
+            .any(|discriminator| discriminator == "relay_probe" || discriminator == "shelf_audit")
+    );
+    let eligibility = observed(&evidence.eligibility);
+    assert_eq!(
+        eligibility.assistant_turns,
+        session.tallies.assistant_records as u64
+    );
+}
+
+/// Forwards to a composite sink and appends to the source file mid-read,
+/// like an agent still writing its transcript.
+struct AppendingSink {
+    inner: CompositeSink,
+    path: PathBuf,
+    append_after_records: usize,
+    seen: usize,
+    appended: bool,
+}
+
+impl RecordSink for AppendingSink {
+    fn record(&mut self, record: NormalizedRecord) {
+        self.seen += 1;
+        if !self.appended && self.seen >= self.append_after_records {
+            self.appended = true;
+            let mut file = OpenOptions::new()
+                .append(true)
+                .open(&self.path)
+                .expect("open source for mid-read append");
+            file.write_all(
+                b"{\"type\":\"assistant\",\"timestamp\":1770009999,\"message\":{\"id\":\"msg-writer-1\",\"role\":\"assistant\",\"model\":\"claude-3-5-haiku-20241022\",\"usage\":{\"input_tokens\":2,\"output_tokens\":3},\"content\":[{\"type\":\"text\",\"text\":\"Appended synthetic turn.\"}]}}\n",
+            )
+            .expect("append to source");
+        }
+        self.inner.record(record);
+    }
+
+    fn finish(&mut self, summary: SessionSummary) {
+        self.inner.finish(summary);
+    }
+}
+
+#[test]
+fn an_active_writer_forces_source_changed_and_nothing_publishes() {
+    let directory = TempDir::new().expect("tempdir");
+    let session = generate_session(&SessionSpec::tier_s(31, 0, 400));
+    let path = write_session(&directory, &session);
+    let input = file_input(&session.session_id, &path);
+    let claim = claim_for_path(&path);
+
+    let mut sink = AppendingSink {
+        inner: composite_for(&input),
+        path: path.clone(),
+        append_after_records: 20,
+        seen: 0,
+        appended: false,
+    };
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &input,
+            &claim,
+            AppendOnlyGuarantee::Absent,
+            &|| false,
+            &mut sink,
+        )
+        .expect("actively-written source must stream");
+    assert!(sink.appended, "the synthetic writer must have appended");
+    assert_eq!(
+        outcome,
+        VisitOutcome::SourceChanged(SourceChangedReason::FingerprintMismatch)
+    );
+    sink.inner.observe_source_outcome(outcome);
+    assert!(sink.inner.metrics().is_none(), "no projection may publish");
+    assert!(sink.inner.evidence().is_none(), "no projection may publish");
+
+    // Control: once the writer is quiet, the same full-reprocess claim passes.
+    let claim = claim_for_path(&path);
+    let mut composite = composite_for(&input);
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &input,
+            &claim,
+            AppendOnlyGuarantee::Absent,
+            &|| false,
+            &mut composite,
+        )
+        .expect("quiescent source must stream");
+    assert_eq!(outcome, VisitOutcome::AcceptedFull);
+    composite.observe_source_outcome(outcome);
+    assert!(composite.metrics().is_some());
+    assert!(composite.evidence().is_some());
+}

--- a/crates/antiburn-local/tests/pipeline_corpus.rs
+++ b/crates/antiburn-local/tests/pipeline_corpus.rs
@@ -25,7 +25,9 @@ use antiburn_local::discovery::source_version::{FingerprintInputs, SourceStat, h
 use antiburn_local::insights::{
     CoverageBucket, CoverageCounts, EfficiencyReportAccumulator, ReportContext, ReportWindow,
 };
-use corpus::{GeneratedSession, SessionSpec, generate_session, generate_session_of_bytes};
+use corpus::{
+    GeneratedSession, SessionSpec, generate_session, generate_session_of_bytes, write_provider_db,
+};
 use tempfile::TempDir;
 
 fn file_input(session_id: &str, path: &Path) -> SessionInput {
@@ -293,6 +295,55 @@ fn housekeeping_tail_with_unrecognized_types_degrades_coverage_only() {
         eligibility.assistant_turns,
         session.tallies.assistant_records as u64
     );
+}
+
+#[test]
+fn provider_db_backed_source_flows_end_to_end_into_a_report() {
+    let directory = TempDir::new().expect("tempdir");
+    let session = generate_session(&SessionSpec::tier_s(37, 0, 300));
+    let db_path = directory.path().join("provider.db");
+    write_provider_db(&db_path, &session).expect("write synthetic provider DB");
+
+    // A raw provider DB handed straight in resolves to the generic
+    // schema-agnostic SQLite walk (the OpenCode fallback path).
+    let input = SessionInput {
+        agent: "opencode".to_string(),
+        session_id: session.session_id.clone(),
+        source: RawSource::Sqlite(db_path),
+    };
+    let mut composite = composite_for(&input);
+    let outcome = adapter_for(&input.agent)
+        .visit(&input, &mut composite)
+        .expect("synthetic provider DB must be readable");
+    assert_eq!(outcome, VisitOutcome::Unvalidated);
+    composite.observe_source_outcome(outcome);
+
+    let evidence = composite
+        .evidence()
+        .expect("provider-DB session must publish");
+    let metrics = composite
+        .metrics()
+        .expect("provider-DB session must publish");
+    assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
+    let eligibility = observed(&evidence.eligibility);
+    // The walk feeds every JSON text cell through the shared record parser:
+    // conversational records become events, the eventless housekeeping tail
+    // and the non-JSON housekeeping table are skipped without loss.
+    assert_eq!(
+        eligibility.assistant_turns,
+        session.tallies.assistant_records as u64
+    );
+    assert!(eligibility.turns >= eligibility.assistant_turns);
+    assert_eq!(evidence.diagnostics.records_unusable, 0);
+    assert_eq!(metrics.session_id, session.session_id);
+    assert!(metrics.event_count >= session.tallies.assistant_records);
+    assert!(metrics.tokens_in > 0 && metrics.tokens_out > 0);
+
+    let mut report = EfficiencyReportAccumulator::new();
+    report.observe_session(evidence);
+    let report = report.finish(report_context(1));
+    assert_eq!(report.assessed_sessions, 1);
+    assert!(report.coverage_reasons.is_empty());
 }
 
 /// Forwards to a composite sink and appends to the source file mid-read,

--- a/crates/antiburn-local/tests/support/corpus.rs
+++ b/crates/antiburn-local/tests/support/corpus.rs
@@ -1,0 +1,463 @@
+//! Deterministic synthetic Claude-shaped JSONL corpus generator.
+//!
+//! Shared by the integration tests and the bench targets (via `#[path]`
+//! inclusion), so both measure the same corpus tiers. Everything here is
+//! synthetic and fictional: no real project names, paths, prompts, or
+//! transcripts. The generator is seeded and deterministic — the same
+//! `SessionSpec` always yields byte-identical JSONL.
+//!
+//! The record-type mix follows the shape of a housekeeping frequency table
+//! (a few dominant conversational types plus a long tail of rare
+//! housekeeping/eventless types), with entirely fictional values.
+#![allow(dead_code)]
+
+use serde_json::{Value, json};
+
+/// Fictional models rotated at fixed session fractions (cap-safe at any scale).
+const MODELS: [&str; 3] = [
+    "claude-3-5-haiku-20241022",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+];
+
+const SKILLS: [&str; 3] = ["orbit-planner", "atlas-index", "tide-charter"];
+const MCP_SERVERS: [&str; 2] = ["nebula-docs", "lunar-data"];
+const FILE_TOOLS: [&str; 3] = ["Read", "Grep", "Edit"];
+const FICTIONAL_PATHS: [&str; 3] = [
+    "/home/avery/projects/demo-app/src/orbit.rs",
+    "/home/avery/projects/demo-app/src/atlas.rs",
+    "/home/avery/projects/demo-app/notes/tides.md",
+];
+/// Fictional long-tail housekeeping types the adapter does not recognize.
+const UNRECOGNIZED_TYPES: [&str; 2] = ["relay_probe", "shelf_audit"];
+
+/// splitmix64 — small, deterministic, dependency-free.
+pub struct CorpusRng(u64);
+
+impl CorpusRng {
+    pub fn new(seed: u64) -> Self {
+        Self(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform value in `0..bound` (bound > 0).
+    pub fn pick(&mut self, bound: u64) -> u64 {
+        self.next_u64() % bound
+    }
+}
+
+/// One synthetic session to generate.
+pub struct SessionSpec {
+    pub seed: u64,
+    pub session_index: usize,
+    pub records: usize,
+    /// Marks assistant turns as sidechain (a delegated/subagent transcript).
+    pub delegated: bool,
+    /// Number of `Task` tool_use spawns to plant near the session start.
+    pub task_spawns: usize,
+    /// Insert one fictional unrecognized housekeeping record every N records.
+    pub unrecognized_every: Option<usize>,
+    /// Replace the record at this index with a single oversized line of
+    /// roughly `oversized_bytes` bytes.
+    pub oversized_at: Option<usize>,
+    pub oversized_bytes: usize,
+}
+
+impl SessionSpec {
+    pub fn tier_s(seed: u64, session_index: usize, records: usize) -> Self {
+        Self {
+            seed,
+            session_index,
+            records,
+            delegated: false,
+            task_spawns: 0,
+            unrecognized_every: None,
+            oversized_at: None,
+            oversized_bytes: 0,
+        }
+    }
+}
+
+/// Expected record tallies, so tests can assert outcome shape exactly.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Tallies {
+    pub total_records: usize,
+    /// Assistant records; every one carries `message.usage`.
+    pub assistant_records: usize,
+    /// User records (plain prompts and tool_result carriers).
+    pub user_records: usize,
+    /// Recognized eventless housekeeping (attachments, summaries, snapshots,
+    /// compaction boundaries).
+    pub eventless_records: usize,
+    pub unrecognized_records: usize,
+    pub oversized_records: usize,
+    pub task_spawns: usize,
+    pub compaction_boundaries: usize,
+}
+
+pub struct GeneratedSession {
+    pub session_id: String,
+    pub jsonl: String,
+    pub tallies: Tallies,
+}
+
+/// Generates one Claude-shaped JSONL session, deterministically.
+pub fn generate_session(spec: &SessionSpec) -> GeneratedSession {
+    let mut rng = CorpusRng::new(
+        spec.seed
+            .wrapping_mul(0x0100_0000_01B3)
+            .wrapping_add(spec.session_index as u64),
+    );
+    let session_id = format!("synthetic-{:04}-{:08x}", spec.session_index, spec.seed);
+    let mut jsonl = String::with_capacity(spec.records * 320);
+    let mut tallies = Tallies::default();
+    let base_epoch: i64 = 1_770_000_000 + (spec.session_index as i64) * 86_400;
+
+    // Fixed-position structure: bounded regardless of scale, so evidence
+    // caps (models, compactions) are never exceeded by tier size alone.
+    let compaction_points = fixed_points(spec.records, &[2, 4], 5);
+    let model_switch_points = fixed_points(spec.records, &[1, 2], 3);
+    let mut model_index = 0usize;
+    let mut planted_spawns = 0usize;
+    let mut last_tool_id: Option<String> = None;
+
+    for index in 0..spec.records {
+        let ts = base_epoch + (index as i64) * 7;
+
+        if spec.oversized_at == Some(index) {
+            jsonl.push_str(&oversized_record(ts, index, spec.oversized_bytes));
+            jsonl.push('\n');
+            tallies.total_records += 1;
+            tallies.oversized_records += 1;
+            continue;
+        }
+        if let Some(every) = spec.unrecognized_every
+            && every > 0
+            && index > 0
+            && index.is_multiple_of(every)
+        {
+            let kind = UNRECOGNIZED_TYPES[index / every % UNRECOGNIZED_TYPES.len()];
+            push_record(
+                &mut jsonl,
+                &json!({"type": kind, "timestamp": ts, "payload": {"sweep": index}}),
+            );
+            tallies.total_records += 1;
+            tallies.unrecognized_records += 1;
+            continue;
+        }
+        if compaction_points.contains(&index) {
+            push_record(
+                &mut jsonl,
+                &json!({
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "timestamp": ts,
+                    "content": "The synthetic session was compacted."
+                }),
+            );
+            tallies.total_records += 1;
+            tallies.eventless_records += 1;
+            tallies.compaction_boundaries += 1;
+            continue;
+        }
+        if model_switch_points.contains(&index) {
+            model_index = (model_index + 1) % MODELS.len();
+        }
+
+        if planted_spawns < spec.task_spawns && index >= 1 {
+            push_record(
+                &mut jsonl,
+                &assistant_record(
+                    ts,
+                    &session_id,
+                    index,
+                    MODELS[model_index],
+                    spec.delegated,
+                    &mut rng,
+                    json!([{
+                        "type": "tool_use",
+                        "id": format!("tool-{session_id}-{index}"),
+                        "name": "Task",
+                        "input": {
+                            "description": "Inspect the fictional orbit module.",
+                            "prompt": "Read the fictional module and report its shape."
+                        }
+                    }]),
+                ),
+            );
+            tallies.total_records += 1;
+            tallies.assistant_records += 1;
+            tallies.task_spawns += 1;
+            planted_spawns += 1;
+            continue;
+        }
+
+        let roll = rng.pick(100);
+        match roll {
+            // Dominant band: assistant text turns with usage.
+            0..=54 => {
+                push_record(
+                    &mut jsonl,
+                    &assistant_record(
+                        ts,
+                        &session_id,
+                        index,
+                        MODELS[model_index],
+                        spec.delegated,
+                        &mut rng,
+                        json!([{
+                            "type": "text",
+                            "text": format!("Synthetic turn {index} for the fictional demo app.")
+                        }]),
+                    ),
+                );
+                tallies.assistant_records += 1;
+            }
+            // User prompts.
+            55..=69 => {
+                push_record(
+                    &mut jsonl,
+                    &json!({
+                        "type": "user",
+                        "timestamp": ts,
+                        "message": {
+                            "role": "user",
+                            "content": format!("Inspect the fictional module number {index}.")
+                        }
+                    }),
+                );
+                tallies.user_records += 1;
+            }
+            // Assistant tool_use turns.
+            70..=81 => {
+                let tool_id = format!("tool-{session_id}-{index}");
+                let content = match rng.pick(4) {
+                    0 => json!([{
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "Skill",
+                        "input": {"skill": SKILLS[index % SKILLS.len()]}
+                    }]),
+                    1 => json!([{
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": format!(
+                            "mcp__{}__search_docs",
+                            MCP_SERVERS[index % MCP_SERVERS.len()]
+                        ),
+                        "input": {"query": "synthetic orbit"}
+                    }]),
+                    _ => json!([{
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": FILE_TOOLS[index % FILE_TOOLS.len()],
+                        "input": {"file_path": FICTIONAL_PATHS[index % FICTIONAL_PATHS.len()]}
+                    }]),
+                };
+                last_tool_id = Some(format!("tool-{session_id}-{index}"));
+                push_record(
+                    &mut jsonl,
+                    &assistant_record(
+                        ts,
+                        &session_id,
+                        index,
+                        MODELS[model_index],
+                        spec.delegated,
+                        &mut rng,
+                        content,
+                    ),
+                );
+                tallies.assistant_records += 1;
+            }
+            // User tool_result carriers.
+            82..=86 => {
+                let tool_id = last_tool_id
+                    .clone()
+                    .unwrap_or_else(|| format!("tool-{session_id}-none"));
+                push_record(
+                    &mut jsonl,
+                    &json!({
+                        "type": "user",
+                        "timestamp": ts,
+                        "message": {
+                            "role": "user",
+                            "content": [{
+                                "type": "tool_result",
+                                "tool_use_id": tool_id,
+                                "is_error": rng.pick(4) == 0,
+                                "content": "The fictional module report is ready."
+                            }]
+                        }
+                    }),
+                );
+                tallies.user_records += 1;
+            }
+            // Assistant thinking turns.
+            87..=91 => {
+                push_record(
+                    &mut jsonl,
+                    &assistant_record(
+                        ts,
+                        &session_id,
+                        index,
+                        MODELS[model_index],
+                        spec.delegated,
+                        &mut rng,
+                        json!([
+                            {"type": "thinking", "thinking": "I will inspect the fictional module."},
+                            {"type": "text", "text": format!("Synthetic reasoned turn {index}.")}
+                        ]),
+                    ),
+                );
+                tallies.assistant_records += 1;
+            }
+            // Housekeeping tail: recognized eventless record types.
+            92..=94 => {
+                push_record(
+                    &mut jsonl,
+                    &json!({
+                        "type": "attachment",
+                        "timestamp": ts,
+                        "attachment": {
+                            "type": "skill_listing",
+                            "content": "- orbit-planner: Plans synthetic orbital work.\n- atlas-index: Indexes synthetic atlas notes."
+                        }
+                    }),
+                );
+                tallies.eventless_records += 1;
+            }
+            95..=96 => {
+                push_record(
+                    &mut jsonl,
+                    &json!({
+                        "type": "attachment",
+                        "timestamp": ts,
+                        "attachment": {
+                            "type": "mcp_instructions_delta",
+                            "addedNames": [MCP_SERVERS[index % MCP_SERVERS.len()]],
+                            "addedBlocks": ["Search synthetic nebula documentation."]
+                        }
+                    }),
+                );
+                tallies.eventless_records += 1;
+            }
+            97..=98 => {
+                push_record(
+                    &mut jsonl,
+                    &json!({
+                        "type": "summary",
+                        "summary": format!("Synthetic summary {index} of fictional work."),
+                        "leafUuid": format!("leaf-{session_id}-{index}")
+                    }),
+                );
+                tallies.eventless_records += 1;
+            }
+            _ => {
+                push_record(
+                    &mut jsonl,
+                    &json!({
+                        "type": "file-history-snapshot",
+                        "timestamp": ts,
+                        "snapshot": {"path": FICTIONAL_PATHS[index % FICTIONAL_PATHS.len()]}
+                    }),
+                );
+                tallies.eventless_records += 1;
+            }
+        }
+        tallies.total_records += 1;
+    }
+
+    GeneratedSession {
+        session_id,
+        jsonl,
+        tallies,
+    }
+}
+
+/// Grows a session until its JSONL is at least `target_bytes` long.
+pub fn generate_session_of_bytes(
+    seed: u64,
+    session_index: usize,
+    target_bytes: usize,
+) -> GeneratedSession {
+    // Average record size is ~300 bytes; overshoot the first guess, then top up.
+    let mut records = target_bytes / 280;
+    loop {
+        let session = generate_session(&SessionSpec::tier_s(seed, session_index, records));
+        if session.jsonl.len() >= target_bytes {
+            return session;
+        }
+        let deficit = target_bytes - session.jsonl.len();
+        records += deficit / 280 + 64;
+    }
+}
+
+fn assistant_record(
+    ts: i64,
+    session_id: &str,
+    index: usize,
+    model: &str,
+    delegated: bool,
+    rng: &mut CorpusRng,
+    content: Value,
+) -> Value {
+    let mut record = json!({
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "id": format!("msg-{session_id}-{index}"),
+            "role": "assistant",
+            "model": model,
+            "usage": {
+                "input_tokens": 20 + rng.pick(400),
+                "output_tokens": 5 + rng.pick(120),
+                "cache_read_input_tokens": rng.pick(30_000),
+                "cache_creation_input_tokens": rng.pick(2_000)
+            },
+            "content": content
+        }
+    });
+    if delegated {
+        record["isSidechain"] = json!(true);
+    }
+    // A sparse tail of effort/speed annotations, like a real mode mix.
+    if rng.pick(20) == 0 {
+        record["effort"] = json!("high");
+    }
+    if rng.pick(20) == 0 {
+        record["speed"] = json!("fast");
+    }
+    record
+}
+
+fn oversized_record(ts: i64, index: usize, bytes: usize) -> String {
+    // One well-formed record whose single line is roughly `bytes` long.
+    let filler = "orbit ".repeat(bytes / 6 + 1);
+    format!(
+        "{{\"type\":\"assistant\",\"timestamp\":{ts},\"message\":{{\"id\":\"msg-oversized-{index}\",\"role\":\"assistant\",\"model\":\"claude-3-5-haiku-20241022\",\"usage\":{{\"input_tokens\":2,\"output_tokens\":3}},\"content\":[{{\"type\":\"text\",\"text\":\"{filler}\"}}]}}}}"
+    )
+}
+
+fn push_record(jsonl: &mut String, value: &Value) {
+    jsonl.push_str(&value.to_string());
+    jsonl.push('\n');
+}
+
+/// Fixed session-fraction positions, e.g. `&[2, 4]` of denominator 5 →
+/// indices at 40% and 80%. Empty for very small sessions.
+fn fixed_points(records: usize, numerators: &[usize], denominator: usize) -> Vec<usize> {
+    if records < denominator * 2 {
+        return Vec::new();
+    }
+    numerators
+        .iter()
+        .map(|numerator| records * numerator / denominator)
+        .collect()
+}

--- a/crates/antiburn-local/tests/support/corpus.rs
+++ b/crates/antiburn-local/tests/support/corpus.rs
@@ -11,6 +11,8 @@
 //! housekeeping/eventless types), with entirely fictional values.
 #![allow(dead_code)]
 
+use std::path::Path;
+
 use serde_json::{Value, json};
 
 /// Fictional models rotated at fixed session fractions (cap-safe at any scale).
@@ -448,6 +450,30 @@ fn oversized_record(ts: i64, index: usize, bytes: usize) -> String {
 fn push_record(jsonl: &mut String, value: &Value) {
     jsonl.push_str(&value.to_string());
     jsonl.push('\n');
+}
+
+/// Writes one synthetic provider-DB (SQLite) session for the generic
+/// schema-agnostic table walk: one JSON record per row in a `turns` table,
+/// plus a non-JSON `housekeeping` table the walk must skip. Content comes
+/// from the same deterministic generator as the JSONL tiers.
+pub fn write_provider_db(path: &Path, session: &GeneratedSession) -> anyhow::Result<()> {
+    let mut connection = rusqlite::Connection::open(path)?;
+    connection.execute_batch(
+        "CREATE TABLE turns (id INTEGER PRIMARY KEY, recorded_at INTEGER, payload TEXT);\n         CREATE TABLE housekeeping (id INTEGER PRIMARY KEY, note TEXT);",
+    )?;
+    let transaction = connection.transaction()?;
+    {
+        let mut insert =
+            transaction.prepare("INSERT INTO turns (recorded_at, payload) VALUES (?1, ?2)")?;
+        for (index, line) in session.jsonl.lines().enumerate() {
+            insert.execute(rusqlite::params![index as i64, line])?;
+        }
+        let mut note = transaction.prepare("INSERT INTO housekeeping (note) VALUES (?1)")?;
+        note.execute(["vacuum sweep of the fictional shelf index"])?;
+        note.execute(["synthetic retention note for the demo app"])?;
+    }
+    transaction.commit()?;
+    Ok(())
 }
 
 /// Fixed session-fraction positions, e.g. `&[2, 4]` of denominator 5 →


### PR DESCRIPTION
Closes #224

## Summary

Measures the Claude insights pipeline end to end and records a baseline, using only synthetic, seeded, fictional content:

- **Synthetic corpus generator** (`tests/support/corpus.rs`) — deterministic, seeded generator for JSONL transcripts and provider-DB (SQLite) sources; nothing reads a real transcript.
- **Integration tests** — `tests/pipeline_corpus.rs` runs the full in-crate pipeline (source read → framing → parse/normalize → metrics + evidence accumulation → report reduction) over the corpus, including the provider-DB-backed `RawSource::Sqlite` path; `tests/claude_characterization.rs` pins vendor-format behavior against goldens.
- **Criterion bench targets** (`benches/pipeline_baseline.rs`) — timing and memory measurement of every in-crate stage, with results and analysis recorded in `benches/BASELINE.md`. Numbers are indicative local baselines, not CI-enforced thresholds.

Stages the master plan names that live in the desktop app (discovery, queue wait, persistence, report query, IPC) need a desktop-side harness and are the follow-up half of the measurement work.

## Headline baseline numbers

Machine context: Apple M3 Pro (11 cores, arm64), 18 GiB RAM, macOS 26.2, rustc 1.97.0, optimized bench profile, 2026-02 run.

| Measurement | Result |
|---|---|
| Framing throughput (`BoundedJsonlReader`, 6 MiB of small lines) | 3.05 ms (~2.07 GiB/s) |
| Full reparse, 1 MiB session | 7.38 ms (~146 MiB/s) |
| Full reparse, 10 MiB session | 72.5 ms (~149 MiB/s) |
| Full reparse, 50 MiB session | 351 ms (~154 MiB/s) — linear at ~150 MiB/s |
| Per-stage split at 10 MiB | serde parsing dominates (~98 %); metrics + evidence accumulators add only ~2–3 % |
| Provider-DB (SQLite) walk, 20k rows / ~6.2 MiB | 30.7 ms (~205 MiB/s) — linear, slightly faster per byte than JSONL |
| Report reduction | ~0.75 µs/session (65-session field cohort: 49.2 µs; 500 sessions: 367 µs) |
| Framing memory high-water (10 MiB of small lines) | 446 bytes; single near-8 MiB line stays under the `MAX_RECORD_BYTES` bound |
| Metrics accumulator retention, 10 MiB dense source | 10.4 MB (~303 bytes/turn, ≈ 1.0× source bytes) |
| Active-writer `SourceChanged` rejections | 15/15 at 2 ms append interval; 0/15 at ≥ 20 ms; rate ≈ read_window / write_interval, effectively zero for realistic write spacing |

## Recommendations on the four measurement questions

1. **Phase-13 optimizations (report caching, relational evidence projections, read pooling)** — *dismiss with the number.* Report reduction is ~0.75 µs/session; no stage shows a bottleneck those changes would relieve. The only material cost is serde parsing at ~150 MiB/s, and even a 50 MiB session completes in 0.35 s.
2. **Claude append-only guarantee evidence** — *defer with evidence; likely never justified.* Full reprocess is linear and cheap (7 ms / 73 ms / 351 ms at 1 / 10 / 50 MiB), and the `SourceChanged` rejection rate reached zero in every scenario with realistic write spacing. Incremental byte-offset parsing would save at most a fraction of ~0.35 s per pathological session.
3. **Fork-job `Inline` materialization** — *defer.* Materializing costs ~6 % extra time plus one transient full-source buffer per fork job; with the single source permit, peak transient memory equals the largest single session. Revisit only if field sessions well beyond 50 MiB appear.
4. **Popover-hidden staleness (Locked Decision 15 review)** — *reaffirm; no change proposed.* Catch-up drain once the popover opens is N × per-session cost: the 65-session field cohort drains in well under one second on one permit; even a pathological 65 × 10 MiB backlog drains in ~5 s.

Worker concurrency and leases (Part 3 tuning clause): keep 1 CPU / 1 source / 1 provider-DB permit and `LEASE_SECS = 300` / `LEASE_RENEW_SECS = 60` — now a measured outcome rather than a guess.

## Verification

| Gate | Command | Result |
|---|---|---|
| engine: cargo fmt --check | `cd crates/antiburn-local && cargo fmt --check` | ✅ No formatting diffs |
| engine: cargo clippy | `cargo clippy --all-targets --locked -- -D warnings` | ✅ Clean; no warnings |
| engine: cargo nextest | `cargo nextest run --locked --lib --tests` | ✅ 929 passed, 1 skipped; suite wall time 3.49s — new integration tests do not blow up duration |
| engine: bench compile | `cargo bench --no-run` | ✅ Both bench executables built (lib benches + `benches/pipeline_baseline.rs`) |
| desktop | applicability check via `git diff --name-only origin/main..HEAD` | N/A — no `apps/desktop` files in the diff; desktop CI jobs would not trigger |
| repo: CI control-plane tests | `node --test scripts/*.test.mjs` (6 suites) | ✅ 76/76 pass after `pnpm install --frozen-lockfile` |
| repo: design-contract drift | `node scripts/check-design-drift.mjs` | ✅ Design contract in sync with the stylesheets |

## Merge-order note

This branch avoids every file the open PRs #231, #232, and #234 touch, so it merges cleanly in any order relative to them.
