### PR TITLE
fix(discovery): admit only Claude desktop manifests that name a transcript

### DIFF
--- a/crates/antiburn-local/src/discovery/agents/claude.rs
+++ b/crates/antiburn-local/src/discovery/agents/claude.rs
@@ -507,10 +507,12 @@ async fn discover_recent_including_subagent_parents(
 
     let manifest_dirs = desktop_manifest_dirs_in(home).await;
     for manifest in recent_files_with_exts(&manifest_dirs, now, since_secs, &["json"]).await {
-        let log =
+        if let Some(log) =
             desktop_manifest_session_log(home, &project_dirs, manifest.path, manifest.mtime_epoch)
-                .await;
-        merge_session_log(&mut discovered, log);
+                .await
+        {
+            merge_session_log(&mut discovered, log);
+        }
     }
 
     for log in interactive_fork_job_logs(home, &project_dirs, now - since_secs).await {
@@ -632,25 +634,36 @@ async fn interactive_fork_job_logs(
     logs
 }
 
+/// Build a session from one Claude desktop session manifest.
+///
+/// The manifest must be a JSON object that names a CLI transcript in
+/// `cliSessionId`. The `claude-code-sessions` tree also holds sidecar files
+/// that are not sessions, such as the `scheduled-tasks.json` task
+/// configuration. A manifest without `cliSessionId` has no transcript and
+/// therefore no token records. Both give a session that analysis can never
+/// assess, so this function returns `None` for them.
 async fn desktop_manifest_session_log(
     home: &Path,
     project_dirs: &[PathBuf],
     manifest_path: PathBuf,
     manifest_mtime_epoch: i64,
-) -> SessionLog {
-    let content = tokio::fs::read_to_string(&manifest_path)
-        .await
-        .unwrap_or_default();
-    if let Some(cli_session_id) = parse_cli_session_id(&content)
-        && let Some(transcript_path) =
-            resolve_cli_transcript_path(project_dirs, &cli_session_id).await
+) -> Option<SessionLog> {
+    let content = tokio::fs::read_to_string(&manifest_path).await.ok()?;
+    let mut manifest = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+    let cli_session_id = manifest
+        .get("cliSessionId")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+
+    if let Some(transcript_path) = resolve_cli_transcript_path(project_dirs, &cli_session_id).await
     {
-        return SessionLog {
+        return Some(SessionLog {
             environment: Default::default(),
             agent_type: AgentKind::Claude,
             source: SessionSource::File(transcript_path),
             updated_at: Some(manifest_mtime_epoch),
-        };
+        });
     }
 
     let label = format!(
@@ -660,15 +673,23 @@ async fn desktop_manifest_session_log(
             .unwrap_or(&manifest_path)
             .display()
     );
-    SessionLog {
+    // The transcript is not on disk yet. Name the session by the CLI session
+    // id so a later scan that finds the transcript maps to the same session.
+    if let Some(object) = manifest.as_object_mut() {
+        object.insert(
+            "sessionId".to_string(),
+            serde_json::Value::String(cli_session_id),
+        );
+    }
+    Some(SessionLog {
         environment: Default::default(),
         agent_type: AgentKind::Claude,
         source: SessionSource::Inline {
             label,
-            content: fallback_manifest_content(&content),
+            content: manifest.to_string(),
         },
         updated_at: Some(manifest_mtime_epoch),
-    }
+    })
 }
 
 /// Resolve the on-disk path for a Claude CLI transcript by `(project_dirs,
@@ -700,37 +721,6 @@ async fn resolve_cli_transcript_path(
     .await
     .ok()
     .flatten()
-}
-
-fn parse_cli_session_id(content: &str) -> Option<String> {
-    serde_json::from_str::<serde_json::Value>(content)
-        .ok()?
-        .get("cliSessionId")?
-        .as_str()
-        .map(ToOwned::to_owned)
-}
-
-fn fallback_manifest_content(content: &str) -> String {
-    let mut value = match serde_json::from_str::<serde_json::Value>(content) {
-        Ok(value) => value,
-        Err(_) => return content.to_string(),
-    };
-
-    let cli_session_id = value
-        .get("cliSessionId")
-        .and_then(|candidate| candidate.as_str())
-        .map(ToOwned::to_owned);
-
-    if let Some(cli_session_id) = cli_session_id
-        && let Some(object) = value.as_object_mut()
-    {
-        object.insert(
-            "sessionId".to_string(),
-            serde_json::Value::String(cli_session_id),
-        );
-    }
-
-    value.to_string()
 }
 
 fn merge_session_log(discovered: &mut HashMap<String, SessionLog>, incoming: SessionLog) {
@@ -977,6 +967,57 @@ mod tests {
                 assert!(content.contains("\"sessionId\":\"cli-session\""));
             }
             SessionSource::File(path) => panic!("unexpected file source: {}", path.display()),
+            SessionSource::ProviderDb { .. } => panic!("unexpected provider db source"),
+        }
+        assert_eq!(logs[0].updated_at, Some(now - 5));
+    }
+
+    #[tokio::test]
+    async fn test_discover_recent_skips_desktop_session_sidecar_files() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "tests/fixtures/claude-desktop-session-sidecars.json"
+        ))
+        .unwrap();
+        let home = TempDir::new().unwrap();
+        let now: i64 = 1_700_000_000;
+        let since_secs: i64 = 86_400;
+
+        let project_dir = home
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-home-avery-projects-demo-app");
+        tokio::fs::create_dir_all(&project_dir).await.unwrap();
+
+        // The transcript is older than the cutoff. Only the manifest can
+        // promote it, so this also proves the manifest scan still works.
+        let cli_session_id = fixture["manifest"]["cliSessionId"].as_str().unwrap();
+        let transcript = project_dir.join(format!("{cli_session_id}.jsonl"));
+        tokio::fs::write(&transcript, "{}\n").await.unwrap();
+        set_file_mtime(&transcript, now - (since_secs + 10));
+
+        let manifest_dir = app_config_dir_in("Claude", home.path())
+            .join("claude-code-sessions")
+            .join("workspace")
+            .join("window");
+        tokio::fs::create_dir_all(&manifest_dir).await.unwrap();
+        for (file_name, fixture_key) in [
+            ("local_session.json", "manifest"),
+            ("local_no_cli_session.json", "manifest_without_cli_session"),
+            ("scheduled-tasks.json", "scheduled_tasks_sidecar"),
+        ] {
+            let path = manifest_dir.join(file_name);
+            tokio::fs::write(&path, fixture[fixture_key].to_string())
+                .await
+                .unwrap();
+            set_file_mtime(&path, now - 5);
+        }
+
+        let logs = discover_recent_in(home.path(), now, since_secs).await;
+        assert_eq!(logs.len(), 1);
+        match &logs[0].source {
+            SessionSource::File(path) => assert_eq!(path, &transcript),
+            SessionSource::Inline { label, .. } => panic!("unexpected inline source: {label}"),
             SessionSource::ProviderDb { .. } => panic!("unexpected provider db source"),
         }
         assert_eq!(logs[0].updated_at, Some(now - 5));

--- a/crates/antiburn-local/src/discovery/agents/tests/fixtures/README.md
+++ b/crates/antiburn-local/src/discovery/agents/tests/fixtures/README.md
@@ -10,6 +10,7 @@ from the test that consumes it, so it must stay inside this crate.
 | `cursor-cli-store-fork.json` | **Synthetic**, authored from the contract |
 | `cursor-cli-agent-fork.json` | **Synthetic**, authored from the contract |
 | `claude-cli-job-fork.json` | **Synthetic**, authored from the contract |
+| `claude-desktop-session-sidecars.json` | **Synthetic**, authored from the contract |
 | `opencode-cli-production-db.json` | Re-homed from `crates/analysis`, explicitly authorized |
 
 "Authored from the contract" means the values were derived from the parser code
@@ -70,6 +71,22 @@ Consumed by `claude::tests::interactive_fork_job_enriches_waiting_child_with_par
 - `child_transcript` — the child's `~/.claude/projects/-repo/<child>.jsonl`
   records, which discovery appends to the synthesized header. They repeat the
   state's `cwd` so the scanner's last-cwd-wins rule agrees with the header.
+
+### `claude-desktop-session-sidecars.json`
+
+Consumed by `claude::tests::test_discover_recent_skips_desktop_session_sidecar_files`.
+
+Three files that all sit in one `claude-code-sessions/<workspace>/<window>/`
+directory, covering each arm of `desktop_manifest_session_log`:
+
+- `manifest` — a desktop session manifest with `cliSessionId`. This is the only
+  admitted file, and it promotes the CLI transcript named by that id.
+- `manifest_without_cli_session` — a manifest with `sessionId` but no
+  `cliSessionId`. It names no transcript, so it holds no token records and must
+  be skipped.
+- `scheduled_tasks_sidecar` — the `scheduled-tasks.json` task configuration that
+  the desktop app writes beside the manifests. It is not a session at all and
+  must be skipped.
 
 ### `opencode-cli-production-db.json`
 

--- a/crates/antiburn-local/src/discovery/agents/tests/fixtures/claude-desktop-session-sidecars.json
+++ b/crates/antiburn-local/src/discovery/agents/tests/fixtures/claude-desktop-session-sidecars.json
@@ -1,0 +1,29 @@
+{
+  "manifest": {
+    "sessionId": "local_00000000-0000-4000-8000-0000000000a1",
+    "cliSessionId": "00000000-0000-4000-8000-0000000000b1",
+    "cwd": "/home/avery/projects/demo-app",
+    "title": "Add the retry banner",
+    "isArchived": false,
+    "lastActivityAt": 1700000000000
+  },
+  "manifest_without_cli_session": {
+    "sessionId": "local_00000000-0000-4000-8000-0000000000a2",
+    "cwd": "/home/avery/projects/demo-app",
+    "title": "Sketch the release notes",
+    "isArchived": false,
+    "lastActivityAt": 1700000000000
+  },
+  "scheduled_tasks_sidecar": {
+    "scheduledTasks": [
+      {
+        "id": "demo-app-nightly-check",
+        "enabled": false,
+        "cwd": "/home/avery/projects/demo-app",
+        "filePath": "/home/avery/.claude/scheduled-tasks/demo-app-nightly-check/SKILL.md",
+        "notifySessionId": "local_00000000-0000-4000-8000-0000000000a2"
+      }
+    ],
+    "recordedSkips": {}
+  }
+}


### PR DESCRIPTION
## What this is, and what it is not

This is **not** a filter on the kind of work in a session. Nothing is excluded
for being "not coding", and no file in this change is a transcript.

The Claude desktop layout is two-tier:

- `~/.claude/projects/**/*.jsonl` — the actual transcripts. The conversation, and
  the token records.
- `<app-config>/Claude/claude-code-sessions/**/*.json` — manifests. Small
  metadata records (title, cwd, model) whose job is to *point* at a transcript
  via `cliSessionId`. That directory holds no transcripts at all.

Discovery scans the manifest tree so a desktop session's recency reflects when it
was last used, then follows the pointer to the real transcript. The bug is that
it treated every `.json` in there as a session even when there was no pointer to
follow.

The rule this PR adds is "does this file lead to token records?", not "was this
coding work?". A non-coding conversation in Claude Desktop still counts exactly
as before, as long as a real session sits behind it.

## Problem

Discovery walked **every** `.json` file under the manifest tree and turned each
one into a session:

```rust
let manifest_dirs = desktop_manifest_dirs_in(home).await;
for manifest in recent_files_with_exts(&manifest_dirs, now, since_secs, &["json"]).await {
```

`desktop_manifest_session_log` then returned a `SessionLog` unconditionally. If
`cliSessionId` resolved to a transcript it used that file; otherwise it fell back
to an inline session whose entire content was the JSON object.

Two kinds of file slipped through. Neither carries any token records, so both
analyse to partial coverage and sit in the popover as permanently "not assessed"
sessions:

| File | What it is | Conversation content |
| --- | --- | --- |
| `scheduled-tasks.json` | Scheduled-task configuration. Top-level keys are `scheduledTasks` / `recordedSkips` — no session id at all | None. It is a config file |
| A manifest with `sessionId` but no `cliSessionId` | Session metadata with no pointer to a transcript | None. Verified no transcript exists under those ids |

## Fix

A desktop manifest earns a session only if it is a JSON object with a non-empty
`cliSessionId`. Both classes above are skipped.

The already-tested fallback is preserved: a manifest that *does* name a
transcript which is not on disk yet still produces its inline session, so a live
desktop session that has not written its transcript is unaffected.

The manifest is now parsed once instead of twice, which removes
`parse_cli_session_id` and `fallback_manifest_content`.

## Is the rule too broad?

Checked against one local install of 1225 `.json` files in that tree:

- 1190 carry `cliSessionId` — kept
- 34 carry only `sessionId` — dropped
- 1 (`scheduled-tasks.json`) carries neither — dropped

The 34 were real sessions once, but their transcripts are gone: a search of the
transcript tree finds no `.jsonl` under any of those ids. Their tokens were never
countable, which is exactly why they could only ever render as "not assessed".
Nothing measurable is lost — the placeholder row stops appearing.

## Test

New synthetic fixture `claude-desktop-session-sidecars.json` holds all three
arms — a valid manifest, a manifest without `cliSessionId`, and the
scheduled-tasks sidecar. The test drops all three into one manifest directory and
asserts only the transcript comes back. The transcript's mtime is deliberately
older than the cutoff, so the test also proves the manifest still promotes
recency rather than just proving the sidecars vanish.

No real transcripts, home paths, or repository names — the fixture follows the
existing `avery` / `/home/avery/projects/demo-app` convention, and its provenance
is recorded in the fixtures README.

## Checks

Run from `crates/antiburn-local`:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 883 + 63 + 17 + 8 + 8 + 1 + 1 passed, 0 failed

Both pre-existing desktop-manifest tests still pass.

No screenshot: engine-only change with no UI surface of its own, and the natural
screenshot would be a real session list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)