### PR TITLE
feat(hud): remember the HUD position per display

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -122,6 +122,7 @@ name = "antiburn-hud"
 version = "0.1.0"
 dependencies = [
  "objc2-app-kit",
+ "serde",
  "serde_json",
  "tauri",
  "tokio",

--- a/apps/desktop/src-tauri/crates/hud/Cargo.lock
+++ b/apps/desktop/src-tauri/crates/hud/Cargo.lock
@@ -46,6 +46,7 @@ name = "antiburn-hud"
 version = "0.1.0"
 dependencies = [
  "objc2-app-kit",
+ "serde",
  "serde_json",
  "tauri",
  "tokio",

--- a/apps/desktop/src-tauri/crates/hud/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/hud/Cargo.toml
@@ -17,6 +17,7 @@ name = "antiburn_hud"
 path = "src/lib.rs"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = ["macos-private-api"] }
 

--- a/apps/desktop/src-tauri/crates/hud/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/hud/src/lib.rs
@@ -3,6 +3,10 @@
 //! The crate creates, positions, sizes, reuses, and shows the transparent
 //! macOS window. It also reports cursor edges to the webview and owns the hover
 //! detail window. The desktop shell owns IPC policy and session discovery.
+//!
+//! The HUD remembers where a reader put it. The crate supplies the geometry of
+//! that memory — [`Placement`], [`current_placement`], and [`apply_placement`]
+//! — and the shell supplies the storage.
 
 use std::sync::Mutex;
 #[cfg(target_os = "macos")]
@@ -14,10 +18,12 @@ use std::time::Duration;
 
 #[cfg(target_os = "macos")]
 use objc2_app_kit::NSWindow;
+use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 #[cfg(target_os = "macos")]
 use tauri::{
-    Emitter, LogicalPosition, LogicalSize, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
+    Emitter, LogicalPosition, LogicalSize, Manager, Monitor, PhysicalPosition, WebviewUrl,
+    WebviewWindow, WebviewWindowBuilder,
 };
 
 /// The floating HUD window label.
@@ -144,15 +150,210 @@ fn contains_point(x: f64, y: f64, width: f64, height: f64, point_x: f64, point_y
     point_x >= x && point_x < x + width && point_y >= y && point_y < y + height
 }
 
-/// Open or re-show the floating HUD.
+/* -------------------------------------------------------------------------
+ * Remembered position
+ * ---------------------------------------------------------------------- */
+
+/// Where the HUD sits on one display.
+///
+/// `x` and `y` are logical pixels from that display's own top-left corner, not
+/// from the desktop origin. A display keeps its offset when a new arrangement
+/// moves the display itself.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Placement {
+    /// The display this position belongs to. See [`monitor_keys`].
+    pub monitor: String,
+    /// Distance from the display's left edge, in logical pixels.
+    pub x: f64,
+    /// Distance from the display's top edge, in logical pixels.
+    pub y: f64,
+}
+
+/// The logical size of one display.
+#[cfg(any(target_os = "macos", test))]
+struct LogicalFrame {
+    width: f64,
+    height: f64,
+}
+
+/// An identity for one display.
+///
+/// The name alone is not enough, and the position must take no part: the
+/// position is the value that changes when a reader rearranges displays. Two
+/// identical monitors of one model still make the same key.
 #[cfg(target_os = "macos")]
-pub fn open(app: &AppHandle) -> tauri::Result<()> {
+fn monitor_key(monitor: &Monitor) -> String {
+    let name = monitor.name().map_or("display", String::as_str);
+    let size = monitor.size();
+    format!(
+        "{name}|{}x{}@{}",
+        size.width,
+        size.height,
+        monitor.scale_factor()
+    )
+}
+
+/// Keys for every connected display.
+#[cfg(target_os = "macos")]
+pub fn monitor_keys(app: &AppHandle) -> Vec<String> {
+    app.available_monitors()
+        .map(|monitors| monitors.iter().map(monitor_key).collect())
+        .unwrap_or_default()
+}
+
+/// Keep display identity unavailable where the HUD is unavailable.
+#[cfg(not(target_os = "macos"))]
+pub fn monitor_keys(_app: &AppHandle) -> Vec<String> {
+    Vec::new()
+}
+
+/// Where the HUD is now, as a display and an offset inside it.
+#[cfg(target_os = "macos")]
+pub fn current_placement(app: &AppHandle) -> Option<Placement> {
+    let window = app.get_webview_window(OVERLAY_LABEL)?;
+    let monitor = window
+        .current_monitor()
+        .ok()
+        .flatten()
+        .or_else(|| window.primary_monitor().ok().flatten())?;
+    let scale = monitor.scale_factor();
+    if !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    let position = window.outer_position().ok()?;
+    let origin = monitor.position();
+    // Both frames are physical and share the desktop origin, so the offset is
+    // one subtraction. Only the result becomes logical.
+    Some(Placement {
+        monitor: monitor_key(&monitor),
+        x: f64::from(position.x - origin.x) / scale,
+        y: f64::from(position.y - origin.y) / scale,
+    })
+}
+
+/// Keep the remembered position unavailable where the HUD is unavailable.
+#[cfg(not(target_os = "macos"))]
+pub fn current_placement(_app: &AppHandle) -> Option<Placement> {
+    None
+}
+
+/// Move the HUD to the first remembered display that is connected.
+#[cfg(target_os = "macos")]
+pub fn apply_placement(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()> {
+    let Some(window) = app.get_webview_window(OVERLAY_LABEL) else {
+        return Ok(());
+    };
+    place(&window, entries)
+}
+
+/// Keep placement unavailable where the HUD is unavailable.
+#[cfg(not(target_os = "macos"))]
+pub fn apply_placement(_app: &AppHandle, _entries: &[Placement]) -> tauri::Result<()> {
+    Ok(())
+}
+
+/// Put the HUD where the entries ask, or at the default place.
+///
+/// The default is the one the HUD has always had: centered across the top of
+/// the primary display. A display that cannot be read leaves the window where
+/// it is, because a window at its old position beats a window at (0,0).
+#[cfg(target_os = "macos")]
+fn place(window: &WebviewWindow, entries: &[Placement]) -> tauri::Result<()> {
+    let Ok(monitors) = window.available_monitors() else {
+        return Ok(());
+    };
+    // The same lock the animated resize holds: a placement and a resize frame
+    // must not write the window position at the same time.
+    let _guard = resize_apply_guard();
+    let height = RESIZE_STATE.height();
+    let keys: Vec<String> = monitors.iter().map(monitor_key).collect();
+
+    if let Some(placement) = resolve(entries, &keys)
+        && let Some(index) = keys.iter().position(|key| key == &placement.monitor)
+        && let Some(frame) = logical_frame(&monitors[index])
+    {
+        let (x, y) = clamp_into(placement.x, placement.y, OVERLAY_WIDTH, height, &frame);
+        return set_on_monitor(window, &monitors[index], x, y);
+    }
+
+    let Some(monitor) = window.primary_monitor()? else {
+        return Ok(());
+    };
+    let Some(frame) = logical_frame(&monitor) else {
+        return Ok(());
+    };
+    let x = (frame.width - OVERLAY_WIDTH) / 2.0;
+    set_on_monitor(window, &monitor, x, OVERLAY_TOP_INSET)
+}
+
+/// The display's own size in logical pixels. `None` for an unusable scale.
+#[cfg(target_os = "macos")]
+fn logical_frame(monitor: &Monitor) -> Option<LogicalFrame> {
+    let scale = monitor.scale_factor();
+    if !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    Some(LogicalFrame {
+        width: f64::from(monitor.size().width) / scale,
+        height: f64::from(monitor.size().height) / scale,
+    })
+}
+
+/// Move the window to a logical offset inside one display.
+///
+/// Physical throughout: the display's origin is physical, and the offset
+/// scales by that display's own factor rather than the window's current one.
+#[cfg(target_os = "macos")]
+fn set_on_monitor(window: &WebviewWindow, monitor: &Monitor, x: f64, y: f64) -> tauri::Result<()> {
+    let scale = monitor.scale_factor();
+    let origin = monitor.position();
+    window.set_position(PhysicalPosition::new(
+        f64::from(origin.x) + x * scale,
+        f64::from(origin.y) + y * scale,
+    ))
+}
+
+/// The first remembered placement whose display is connected.
+///
+/// The list is ordered by recency, so the head is the display the reader chose
+/// last. A disconnected display is skipped and its entry stays where it is: a
+/// fallback borrows a display, it does not claim it. That is what sends the
+/// HUD back to the external display when the reader connects it again.
+#[cfg(any(target_os = "macos", test))]
+fn resolve<'a>(entries: &'a [Placement], connected: &[String]) -> Option<&'a Placement> {
+    entries
+        .iter()
+        .find(|placement| connected.iter().any(|key| key == &placement.monitor))
+}
+
+/// A remembered offset held inside the display it lands on.
+///
+/// A display can come back at a lower resolution, and the HUD frame grows with
+/// its content. Both can put a remembered offset off the screen.
+#[cfg(any(target_os = "macos", test))]
+fn clamp_into(x: f64, y: f64, width: f64, height: f64, frame: &LogicalFrame) -> (f64, f64) {
+    (
+        clamp_within(x, 0.0, frame.width - width),
+        clamp_within(y, 0.0, frame.height - height),
+    )
+}
+
+/// Open or re-show the floating HUD.
+///
+/// `entries` are the remembered placements, newest display first. The window
+/// reaches its position before the renderer reveals it, so a restored HUD
+/// never appears in one place and jumps to another.
+#[cfg(target_os = "macos")]
+pub fn open(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()> {
     if let Some(window) = app.get_webview_window(OVERLAY_LABEL) {
         let measured = {
             let _guard = resize_apply_guard();
             RESIZE_STATE.request_open();
             RESIZE_STATE.is_measured()
         };
+        // Displays can connect or disconnect while the HUD is off, so the
+        // reopen resolves the remembered position again before it shows.
+        place(&window, entries)?;
         if measured {
             show_without_activation(&window)?;
         }
@@ -183,16 +384,7 @@ pub fn open(app: &AppHandle) -> tauri::Result<()> {
     .build()?;
 
     spawn_hover_watcher(window.clone());
-
-    if let Ok(Some(monitor)) = window.primary_monitor() {
-        let scale = monitor.scale_factor();
-        let monitor_x = monitor.position().x as f64 / scale;
-        let monitor_y = monitor.position().y as f64 / scale;
-        let monitor_width = monitor.size().width as f64 / scale;
-        let x = monitor_x + (monitor_width - OVERLAY_WIDTH) / 2.0;
-        let y = monitor_y + OVERLAY_TOP_INSET;
-        window.set_position(LogicalPosition::new(x, y))?;
-    }
+    place(&window, entries)?;
 
     // The renderer reveals the window after it reports the first content height.
     Ok(())
@@ -200,7 +392,7 @@ pub fn open(app: &AppHandle) -> tauri::Result<()> {
 
 /// Keep the HUD unavailable on platforms whose behavior is not tuned.
 #[cfg(not(target_os = "macos"))]
-pub fn open(_app: &AppHandle) -> tauri::Result<()> {
+pub fn open(_app: &AppHandle, _entries: &[Placement]) -> tauri::Result<()> {
     Ok(())
 }
 
@@ -703,12 +895,12 @@ fn compute_detail_position(
         if y + height > frame.bottom - DETAIL_SCREEN_MARGIN {
             y = anchor.top - DETAIL_GAP - height;
         }
-        x = clamp_detail(
+        x = clamp_within(
             x,
             frame.left + DETAIL_SCREEN_MARGIN,
             frame.right - width - DETAIL_SCREEN_MARGIN,
         );
-        y = clamp_detail(
+        y = clamp_within(
             y,
             frame.top + DETAIL_SCREEN_MARGIN,
             frame.bottom - height - DETAIL_SCREEN_MARGIN,
@@ -726,11 +918,12 @@ fn clamp_detail_height(height: f64) -> f64 {
     height.clamp(DETAIL_MIN_HEIGHT, DETAIL_MAX_HEIGHT)
 }
 
-/// `f64::clamp` panics when `max < min`, which happens on displays narrower
-/// than the detail window. Prefer the low edge there.
+/// `f64::clamp` panics when `max < min`, which happens on a display narrower
+/// than the window it must hold. Prefer the low edge there, and for a value
+/// that is not a real number.
 #[cfg(any(target_os = "macos", test))]
-fn clamp_detail(value: f64, min: f64, max: f64) -> f64 {
-    if max < min {
+fn clamp_within(value: f64, min: f64, max: f64) -> f64 {
+    if max < min || !value.is_finite() {
         return min;
     }
     value.clamp(min, max)
@@ -879,5 +1072,87 @@ mod tests {
     #[test]
     fn before_the_first_show_the_detail_state_is_null() {
         assert_eq!(detail_state(), serde_json::Value::Null);
+    }
+
+    fn placement(monitor: &str, x: f64, y: f64) -> Placement {
+        Placement {
+            monitor: monitor.to_string(),
+            x,
+            y,
+        }
+    }
+
+    fn keys(names: &[&str]) -> Vec<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
+    #[test]
+    fn the_newest_display_wins_while_it_stays_connected() {
+        let entries = vec![
+            placement("external", 100.0, 40.0),
+            placement("laptop", 8.0, 8.0),
+        ];
+        let chosen = resolve(&entries, &keys(&["laptop", "external"]));
+        assert_eq!(chosen, Some(&entries[0]));
+    }
+
+    #[test]
+    fn a_disconnected_display_falls_back_to_the_next_one_remembered() {
+        let entries = vec![
+            placement("external", 100.0, 40.0),
+            placement("laptop", 8.0, 8.0),
+        ];
+        let chosen = resolve(&entries, &keys(&["laptop"]));
+        assert_eq!(chosen, Some(&entries[1]));
+    }
+
+    /// The fallback reads the list and never writes it, so the external display
+    /// is still the head when it comes back.
+    #[test]
+    fn the_fallback_leaves_the_preferred_display_at_the_head() {
+        let entries = vec![
+            placement("external", 100.0, 40.0),
+            placement("laptop", 8.0, 8.0),
+        ];
+        assert_eq!(resolve(&entries, &keys(&["laptop"])), Some(&entries[1]));
+        assert_eq!(
+            resolve(&entries, &keys(&["laptop", "external"])),
+            Some(&entries[0])
+        );
+    }
+
+    #[test]
+    fn an_unknown_display_set_has_no_remembered_placement() {
+        let entries = vec![placement("external", 100.0, 40.0)];
+        assert_eq!(resolve(&entries, &keys(&["laptop"])), None);
+        assert_eq!(resolve(&[], &keys(&["laptop"])), None);
+    }
+
+    #[test]
+    fn a_remembered_offset_stays_inside_a_display_that_came_back_smaller() {
+        let frame = LogicalFrame {
+            width: 1280.0,
+            height: 800.0,
+        };
+        let (x, y) = clamp_into(2_800.0, 1_600.0, 176.0, 30.0, &frame);
+        assert_eq!((x, y), (1_280.0 - 176.0, 800.0 - 30.0));
+    }
+
+    #[test]
+    fn a_display_narrower_than_the_hud_prefers_the_low_edge() {
+        let frame = LogicalFrame {
+            width: 120.0,
+            height: 20.0,
+        };
+        assert_eq!(clamp_into(60.0, 10.0, 176.0, 30.0, &frame), (0.0, 0.0));
+    }
+
+    #[test]
+    fn an_offset_that_still_fits_is_left_alone() {
+        let frame = LogicalFrame {
+            width: 1512.0,
+            height: 982.0,
+        };
+        assert_eq!(clamp_into(668.0, 32.0, 176.0, 30.0, &frame), (668.0, 32.0));
     }
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -190,7 +190,17 @@ pub fn end_popover_hold(app: tauri::AppHandle) {
 /// Open or re-show the always-on-top usage HUD.
 #[tauri::command]
 pub async fn open_overlay_window(app: tauri::AppHandle) -> CommandResult<()> {
-    antiburn_hud::open(&app).map_err(fail)
+    let entries = crate::hud::load_placements(&app.state::<Store>());
+    antiburn_hud::open(&app, &entries).map_err(fail)
+}
+
+/// Remember where the HUD is, after a drag moved it.
+///
+/// No argument: the webview knows a drag ended, the shell knows where the
+/// window is, and that split keeps geometry out of the IPC payload.
+#[tauri::command]
+pub fn record_hud_position(app: tauri::AppHandle) {
+    crate::hud::record_position(&app);
 }
 
 /// Hide the usage HUD and cancel any pending reveal.

--- a/apps/desktop/src-tauri/src/hud.rs
+++ b/apps/desktop/src-tauri/src/hud.rs
@@ -1,10 +1,118 @@
 //! Shell policy for the floating usage HUD.
 //!
 //! The `antiburn-hud` crate owns the window mechanism. This module keeps the
-//! engine-specific activity lookup and its cost bound inside the shell.
+//! engine-specific activity lookup and its cost bound inside the shell. It also
+//! owns where the HUD's remembered position is kept, and the watcher that
+//! reacts when a display connects or disconnects.
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+use antiburn_hud::Placement;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+use crate::store::Store;
+
+/// The internal scalar holding every remembered HUD position.
+const PLACEMENTS_KEY: &str = "internal:hudPlacements";
+
+/// The shape of the stored value. A different number means a value this build
+/// cannot read, and the HUD starts again from its default position.
+const PLACEMENTS_VERSION: u32 = 1;
+
+/// Displays the list remembers. A desk does not have nine of them, and an
+/// unbounded list in a settings row is a slow leak.
+const MAX_PLACEMENTS: usize = 8;
+
+/// How often the watcher looks for a change in the connected displays.
+const DISPLAY_POLL: Duration = Duration::from_secs(2);
+
+/// The stored value: remembered placements, newest display first.
+#[derive(Serialize, Deserialize)]
+struct StoredPlacements {
+    version: u32,
+    entries: Vec<Placement>,
+}
+
+/// Every remembered placement, newest display first.
+pub fn load_placements(store: &Store) -> Vec<Placement> {
+    parse_placements(store.internal_value(PLACEMENTS_KEY).as_deref())
+}
+
+/// Remember one position and make its display the preferred one.
+pub fn save_placement(store: &Store, placement: Placement) {
+    let entries = promote(load_placements(store), placement);
+    let stored = StoredPlacements {
+        version: PLACEMENTS_VERSION,
+        entries,
+    };
+    if let Ok(raw) = serde_json::to_string(&stored) {
+        store.set_internal_value(PLACEMENTS_KEY, &raw);
+    }
+}
+
+/// Remember where the HUD is now. Called when a drag settles.
+pub fn record_position(app: &AppHandle) {
+    let Some(placement) = antiburn_hud::current_placement(app) else {
+        return;
+    };
+    save_placement(&app.state::<Store>(), placement);
+}
+
+/// Move the HUD when a display connects or disconnects.
+///
+/// The watcher only reads the remembered list. A display that goes away makes
+/// the HUD borrow another one; it must not make that other display the
+/// preferred one, or the HUD would stay there when the first display returns.
+///
+/// A poll rather than an event: it is the pattern the hover watcher in the HUD
+/// crate already uses, and it needs no platform notification of its own. The
+/// poll costs nothing while the HUD is closed.
+pub fn spawn_display_watcher(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut connected: Vec<String> = Vec::new();
+        loop {
+            tokio::time::sleep(DISPLAY_POLL).await;
+            if app
+                .get_webview_window(antiburn_hud::OVERLAY_LABEL)
+                .is_none()
+            {
+                continue;
+            }
+            let now = antiburn_hud::monitor_keys(&app);
+            if now == connected {
+                continue;
+            }
+            connected = now;
+            let entries = load_placements(&app.state::<Store>());
+            if let Err(error) = antiburn_hud::apply_placement(&app, &entries) {
+                ::tracing::warn!(event = "hud_display_change_move_failed", error = %error);
+            }
+        }
+    });
+}
+
+/// Read the stored value. Anything unreadable means "no memory yet": a bad row
+/// must never stop the HUD from appearing.
+fn parse_placements(raw: Option<&str>) -> Vec<Placement> {
+    raw.and_then(|raw| serde_json::from_str::<StoredPlacements>(raw).ok())
+        .filter(|stored| stored.version == PLACEMENTS_VERSION)
+        .map(|stored| stored.entries)
+        .unwrap_or_default()
+}
+
+/// Put one placement at the head, replacing any earlier entry for its display.
+fn promote(entries: Vec<Placement>, placement: Placement) -> Vec<Placement> {
+    let mut promoted: Vec<Placement> = entries
+        .into_iter()
+        .filter(|entry| entry.monitor != placement.monitor)
+        .collect();
+    promoted.insert(0, placement);
+    promoted.truncate(MAX_PLACEMENTS);
+    promoted
+}
 
 /// Return the newest recent transcript write as epoch seconds.
 pub async fn latest_session_activity() -> Option<i64> {
@@ -31,4 +139,83 @@ pub async fn latest_session_activity() -> Option<i64> {
         *memo = Some((Instant::now(), latest));
     }
     latest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn placement(monitor: &str, x: f64, y: f64) -> Placement {
+        Placement {
+            monitor: monitor.to_string(),
+            x,
+            y,
+        }
+    }
+
+    #[test]
+    fn a_new_display_goes_to_the_head() {
+        let entries = promote(
+            vec![placement("laptop", 8.0, 8.0)],
+            placement("external", 100.0, 40.0),
+        );
+        assert_eq!(
+            entries,
+            vec![
+                placement("external", 100.0, 40.0),
+                placement("laptop", 8.0, 8.0)
+            ]
+        );
+    }
+
+    #[test]
+    fn a_display_already_remembered_moves_to_the_head_once() {
+        let entries = promote(
+            vec![
+                placement("external", 100.0, 40.0),
+                placement("laptop", 8.0, 8.0),
+            ],
+            placement("laptop", 20.0, 60.0),
+        );
+        assert_eq!(
+            entries,
+            vec![
+                placement("laptop", 20.0, 60.0),
+                placement("external", 100.0, 40.0)
+            ]
+        );
+    }
+
+    #[test]
+    fn the_list_drops_the_oldest_display_at_its_cap() {
+        let mut entries = Vec::new();
+        for index in 0..MAX_PLACEMENTS {
+            entries = promote(entries, placement(&format!("display-{index}"), 0.0, 0.0));
+        }
+        entries = promote(entries, placement("newest", 0.0, 0.0));
+        assert_eq!(entries.len(), MAX_PLACEMENTS);
+        assert_eq!(entries[0].monitor, "newest");
+        assert!(entries.iter().all(|entry| entry.monitor != "display-0"));
+    }
+
+    #[test]
+    fn a_stored_value_round_trips() {
+        let stored = StoredPlacements {
+            version: PLACEMENTS_VERSION,
+            entries: vec![placement("laptop", 8.0, 8.0)],
+        };
+        let raw = serde_json::to_string(&stored).expect("serialize");
+        assert_eq!(
+            parse_placements(Some(&raw)),
+            vec![placement("laptop", 8.0, 8.0)]
+        );
+    }
+
+    #[test]
+    fn an_unreadable_value_means_no_memory_yet() {
+        assert!(parse_placements(None).is_empty());
+        assert!(parse_placements(Some("")).is_empty());
+        assert!(parse_placements(Some("{\"version\":1}")).is_empty());
+        assert!(parse_placements(Some("{\"version\":99,\"entries\":[]}")).is_empty());
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -160,6 +160,7 @@ pub fn run() {
             commands::open_privacy_policy,
             commands::open_overlay_window,
             commands::hide_overlay_window,
+            commands::record_hud_position,
             commands::install_update,
             commands::show_hud_detail,
             commands::hide_hud_detail,
@@ -260,6 +261,11 @@ pub fn run() {
             // menu-bar item to unlight it. The popover itself is lazy, and its
             // dismissal path already treats a missing window as idle.
             global_click::install(app.handle());
+
+            // The HUD follows the desk it is on: a display that disconnects
+            // sends it to one still connected, and the display coming back
+            // takes it again. The watcher idles while the HUD is closed.
+            hud::spawn_display_watcher(app.handle());
 
             // The first run gets a window rather than silence. Everything above
             // is in place by now, so the flow's first paint can already read

--- a/apps/desktop/src/lib/overlayWindow.ts
+++ b/apps/desktop/src/lib/overlayWindow.ts
@@ -14,6 +14,15 @@ export async function hideOverlayWindow(): Promise<void> {
   await invoke("hide_overlay_window")
 }
 
+/**
+ * Remember where the HUD sits, after a drag moved it.
+ *
+ * The shell reads the window position itself, so this carries no coordinates.
+ */
+export function recordHudPosition(): Promise<void> {
+  return invoke("record_hud_position")
+}
+
 const HUD_PREF_KEY = "antiburn.showFloatingHud"
 
 export function isFloatingHudEnabled(): boolean {

--- a/apps/desktop/src/views/OverlayWindow.test.tsx
+++ b/apps/desktop/src/views/OverlayWindow.test.tsx
@@ -34,7 +34,7 @@ vi.mock("../lib/ipc", async () => {
   }
 })
 
-const invoke = vi.hoisted(() => vi.fn(async () => {}))
+const invoke = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}))
 vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }))
 
 const hover = vi.hoisted(() => ({ emit: null as ((next: boolean) => void) | null }))
@@ -361,6 +361,36 @@ describe("OverlayWindow", () => {
     fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
     await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(2))
     fireEvent.mouseUp(window)
+  })
+
+  it("remembers where a settled drag left the HUD", async () => {
+    const { container } = render(<OverlayWindow />)
+    fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
+    await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(1))
+    fireEvent.mouseUp(window)
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("record_hud_position"))
+    const records = invoke.mock.calls.filter(([command]) => command === "record_hud_position")
+    expect(records).toHaveLength(1)
+  })
+
+  it("does not remember a position when no drag was running", async () => {
+    render(<OverlayWindow />)
+    fireEvent.mouseUp(window)
+    await act(async () => {})
+    expect(invoke).not.toHaveBeenCalledWith("record_hud_position")
+  })
+
+  it("survives a rejected position record", async () => {
+    invoke.mockRejectedValueOnce(new Error("no window"))
+    const { container } = render(<OverlayWindow />)
+    fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
+    await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(1))
+    fireEvent.mouseUp(window)
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("record_hud_position"))
+    fireEvent.mouseEnter(frame(container))
+    expect(frame(container)).toBeInTheDocument()
   })
 
   it("cleans up drag listeners when native setup rejects", async () => {

--- a/apps/desktop/src/views/overlay/OverlaySession.ts
+++ b/apps/desktop/src/views/overlay/OverlaySession.ts
@@ -14,7 +14,11 @@ import {
   type HudDetailState,
   type LiveUsageSummaryPayload,
 } from "../../lib/ipc"
-import { hideOverlayWindow, setFloatingHudEnabled } from "../../lib/overlayWindow"
+import {
+  hideOverlayWindow,
+  recordHudPosition,
+  setFloatingHudEnabled,
+} from "../../lib/overlayWindow"
 import { prefersReducedMotion } from "../../lib/popoverHeight"
 import { deriveUsageBars, noMeterSelected, type UsageBarItem } from "../../lib/usageBars"
 
@@ -325,6 +329,9 @@ export class OverlaySession {
   private stopDrag = (): void => {
     if (!this.snapshot.dragging) return
     this.settleDrag()
+    // The drag is what makes this display the preferred one, so the record
+    // happens here and not in `settleDrag`, which a failed drag start shares.
+    void recordHudPosition().catch(() => {})
   }
 
   private settleDrag(): void {

--- a/docs/hud-states.md
+++ b/docs/hud-states.md
@@ -74,8 +74,8 @@ The detail window names which empty it is:
 
 | Condition                                   | Detail window text              |
 | ------------------------------------------- | ------------------------------- |
-| The reader turned off every meter            | `No meter selected.`            |
-| A meter is on, but no provider reported yet  | `No usage limits detected yet.` |
+| The reader turned off every meter           | `No meter selected.`            |
+| A meter is on, but no provider reported yet | `No usage limits detected yet.` |
 
 The two are different facts. The first is a choice the reader made in
 Settings → Usage → Show Meter. The second is an absence of data. The HUD must
@@ -121,6 +121,32 @@ rendered bar panel, up to a 500px safety ceiling. The default position is
 centered under the primary macOS menu bar, with a 24px menu-bar allowance and an
 8px gap. Reopening a live window keeps the reader's position and measured
 height.
+
+### Remembered position
+
+The HUD returns to where the reader put it, on the display they put it on.
+
+Each drag stores an entry under the `internal:hudPlacements` scalar: the
+display's identity, and the position as a logical offset from that display's own
+top-left corner. The offset is relative because a new arrangement moves the
+display itself in the shared desktop space. A display's identity is its name,
+size, and scale factor; two identical monitors of one model make the same
+identity.
+
+The list is ordered by recency, holds 8 displays, and the head is the preferred
+display. Placement takes the first entry whose display is connected, and clamps
+the offset inside that display. Nothing remembered and connected means the
+default position above.
+
+**Only a drag reorders the list.** A display that disconnects makes the HUD fall
+back to the next remembered display that is connected, and that fallback writes
+nothing. So the preferred display stays at the head, and reconnecting it takes
+the HUD back.
+
+A 2-second poll compares the connected displays and replaces the HUD when the
+set changes. The poll returns at once while the HUD is closed. The same
+resolution runs when the HUD is built and when it reopens, so a display change
+during an off period is also caught.
 
 The renderer measures the panel before the native window first appears.
 Turning the HUD off cancels that pending reveal, even if the measurement arrives

--- a/docs/plans/hud-position-persistence.md
+++ b/docs/plans/hud-position-persistence.md
@@ -1,0 +1,252 @@
+# HUD position persistence, across launches and across displays
+
+_Plan. Branch `feat/hud-position-persistence`. 2026-08-28._
+
+## Status
+
+| Step                                                | State                             |
+| --------------------------------------------------- | --------------------------------- |
+| 1. Store: `internal:hudPlacements` read/write       | done                              |
+| 2. HUD crate: placement type, resolve, apply        | done                              |
+| 3. Shell: pass placements into `open`, save on drag | done                              |
+| 4. Display watcher: react to connect/disconnect     | done                              |
+| 5. Frontend: record position when a drag settles    | done                              |
+| 6. Tests + `docs/hud-states.md` + slop pass         | done                              |
+
+Automated checks pass: 611 Rust tests, 923 frontend tests, clippy, type-check,
+lint. Keith ran the eleven-step walkthrough on a real two-display desk on
+2026-08-28 and it passed.
+
+## The problem
+
+The HUD has no memory of where it was put. Every `open` centres it at the top
+of the **primary** monitor:
+
+```rust
+// crates/hud/src/lib.rs — open()
+if let Ok(Some(monitor)) = window.primary_monitor() {
+    let x = monitor_x + (monitor_width - OVERLAY_WIDTH) / 2.0;
+    let y = monitor_y + OVERLAY_TOP_INSET;
+    window.set_position(LogicalPosition::new(x, y))?;
+}
+```
+
+Drag it somewhere better, quit, relaunch — it is back at the top centre of the
+laptop screen. On a two-display desk that is the wrong screen entirely.
+
+Two things are missing, and only one of them is "save the coordinates":
+
+1. **Across launches** — nothing persists the position at all.
+2. **Across display changes** — plugging and unplugging a monitor is a live
+   event, not a launch. The HUD should follow the desk it is on: back to the
+   laptop when the big screen goes away, back to the big screen when it
+   returns, without being told again.
+
+Today's on/off switch is stored in `localStorage`
+(`antiburn.showFloatingHud`, `src/lib/overlayWindow.ts`). Position cannot live
+there: Rust builds and positions the window before any webview mounts, so
+reading the saved place from JS would mean a visible jump on every launch. The
+position belongs in the SQLite store, which Rust can read at build time.
+
+## The behaviour we want
+
+Keith's walkthrough, and what each step demands:
+
+| #     | Action                 | HUD             | What it needs                                             |
+| ----- | ---------------------- | --------------- | --------------------------------------------------------- |
+| 1     | Laptop only. Drag to A | at A            | save on drag end                                          |
+| 2–4   | Quit, relaunch         | at A            | restore at window build, before reveal                    |
+| 5     | Connect monitor 2      | stays at A      | a new display does not steal the HUD                      |
+| 6     | Drag to B on monitor 2 | at B            | save per display, not one global point                    |
+| 7     | Quit, relaunch         | at B            | restore picks monitor 2, not the primary                  |
+| 8–9   | Disconnect monitor 2   | moves to A      | live reaction; fall back to a display still connected     |
+| 10–11 | Reconnect monitor 2    | moves back to B | the fallback must **not** overwrite the preferred display |
+
+Step 11 is the one that decides the data model. If the fallback in step 8 were
+recorded as "the user is now on the laptop", reconnecting the monitor would
+leave the HUD on the laptop and the walkthrough breaks. So:
+
+> **Only a drag changes which display is preferred.** A fallback move borrows a
+> display; it does not claim it.
+
+## Design
+
+### What is stored
+
+One internal scalar in the existing `setting` table, alongside the other
+`internal:` state rows (`Store::internal_value` / `set_internal_value`):
+
+```
+key:   internal:hudPlacements
+value: {"version":1,"entries":[
+         {"monitor":"LG HDR 4K|3008x1692@2","x":100,"y":40},
+         {"monitor":"Built-in Retina Display|1512x982@2","x":668,"y":32}
+       ]}
+```
+
+- **`entries` is ordered by recency, most recent first.** The head is the
+  preferred display. A drag moves that display's entry to the head; nothing
+  else reorders the list.
+- **`x`/`y` are logical and relative to that monitor's own origin**, not to the
+  global desktop space. Monitors move around in global space every time the
+  arrangement changes; an offset from the monitor's own top-left does not.
+- Capped at 8 entries, oldest dropped. A desk does not have nine monitors, and
+  an unbounded list in a settings row is a slow leak.
+- Unreadable or unparsable value is treated as empty, and the HUD uses today's
+  primary-monitor default. A bad row must never stop the HUD appearing.
+
+Preferences the user chose live in `AppSettings`; this is remembered state, so
+`internal:` is the right namespace (`store/mod.rs` documents that split).
+
+### Monitor identity
+
+Tauri's `Monitor` gives a name, a physical size, a position, and a scale
+factor. The key is `name|WxH@scale`, e.g. `Built-in Retina Display|1512x982@2`.
+
+Position is deliberately excluded from the key — it is exactly the thing that
+changes when displays are rearranged.
+
+**Known limit:** two identical external monitors of the same model produce the
+same key, so the HUD may pick the wrong one of the pair. Accepted for v1. The
+fix, if it ever bites, is the macOS `CGDirectDisplayID` through `objc2` — the
+HUD crate already links `objc2_app_kit`, so the door is open.
+
+### Where the code goes
+
+The HUD crate's own doc comment sets the boundary: it "creates, positions,
+sizes, reuses, and shows" the window; "the desktop shell owns IPC policy". So
+geometry goes in the crate, storage in the shell.
+
+**`crates/hud/src/lib.rs`** gains:
+
+```rust
+pub struct Placement { pub monitor: String, pub x: f64, pub y: f64 }
+
+/// Keys for every connected display, in the platform's order.
+pub fn monitor_keys(app: &AppHandle) -> Vec<String>;
+
+/// Where the HUD is now, as a key and an offset inside that display.
+pub fn current_placement(app: &AppHandle) -> Option<Placement>;
+
+/// Move the HUD to the first remembered display that is connected.
+pub fn apply_placement(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()>;
+
+/// `open` takes the remembered entries so the window is placed before reveal.
+pub fn open(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()>;
+```
+
+and two pure functions under them, which are where the tests go:
+
+```rust
+fn resolve<'a>(entries: &'a [Placement], connected: &[String]) -> Option<&'a Placement>;
+fn clamp_into(x: f64, y: f64, width: f64, height: f64, frame: &Frame) -> (f64, f64);
+```
+
+`clamp_into` keeps a remembered offset inside the display it lands on — a
+monitor may come back at a lower resolution, and the HUD's height changes with
+its content. It holds the frame fully on screen where it fits, and prefers the
+top-left edge where it does not, matching the existing `clamp_detail` habit of
+never panicking when `max < min`.
+
+**`src/hud.rs`** (the shell's HUD policy module) gains:
+
+- `load_placements(store) -> Vec<Placement>` and `save_placement(store, Placement)`,
+  the serde and the recency reordering.
+- `spawn_display_watcher(app)`.
+
+**`src/commands.rs`** gains `record_hud_position`, which asks the crate where
+the HUD is and hands the answer to the store. It takes no arguments: the
+frontend knows _that_ a drag ended, the shell knows _where_ the window is, and
+splitting it that way keeps geometry out of the IPC payload.
+
+`open_overlay_window` loads the entries and passes them to `hud::open`.
+
+### Reacting to display changes
+
+Steps 8–11 happen while the app runs, so something has to notice.
+
+**Poll `available_monitors()` every 2 seconds** from a task spawned at startup.
+When the connected key set differs from the last poll, re-resolve and move the
+HUD if the winning display changed. This matches the pattern already in the
+same file — `spawn_hover_watcher` polls the cursor at 100ms — and needs no new
+Objective-C plumbing.
+
+The alternative is observing
+`NSApplicationDidChangeScreenParametersNotification`, which is the correct
+event rather than a sample of its effect. It is the upgrade if the poll shows
+up in a profile; a 0.5Hz `NSScreen` query should not.
+
+The watcher only ever _reads_ the stored entries. It never writes, which is
+what preserves the step 11 behaviour.
+
+### Saving on drag
+
+`OverlaySession.settleDrag()` already runs at the end of every drag
+(`views/overlay/OverlaySession.ts`). It gains one fire-and-forget call:
+
+```ts
+void recordHudPosition().catch(() => {});
+```
+
+with the wrapper next to the other HUD invokes in `lib/overlayWindow.ts`. No
+`useEffect` — this is the event that caused the work, which is where AGENTS.md
+says the work belongs.
+
+## Open assumptions
+
+Both are stated rather than asked, because either answer still ships:
+
+1. **Connecting a display does not move the HUD** (step 5). The walkthrough
+   shows the HUD staying on the laptop until it is dragged. Only a
+   _disconnect_ of the preferred display forces a move.
+2. **Identical twin monitors share a key** (see Monitor identity). The HUD may
+   pick the wrong twin.
+
+## Steps
+
+1. **Store** — `internal:hudPlacements` constant, `load_placements`,
+   `save_placement`, recency reorder, 8-entry cap, tolerant parse.
+2. **HUD crate** — `Placement`, `monitor_keys`, `current_placement`,
+   `apply_placement`, `resolve`, `clamp_into`; `open` takes entries and places
+   the window before the renderer reveals it.
+3. **Shell wiring** — `record_hud_position` command, registered in `lib.rs`;
+   `open_overlay_window` passes the loaded entries.
+4. **Display watcher** — spawned at startup, polls, moves, never writes.
+5. **Frontend** — `recordHudPosition` wrapper, called from `settleDrag`.
+6. **Tests and docs** — see below.
+
+Each step builds on its own; step 5 is the first one where the walkthrough can
+be run end to end.
+
+## Tests
+
+Rust, in the HUD crate, against the pure functions:
+
+- `resolve` picks the head entry when its display is connected.
+- `resolve` skips a disconnected head and takes the next connected entry —
+  step 8.
+- `resolve` returns `None` when no remembered display is connected, so the
+  caller falls back to the primary-monitor default.
+- `clamp_into` holds a frame inside a display that came back smaller.
+- `clamp_into` prefers the low edge on a display narrower than the HUD.
+
+Rust, in the shell:
+
+- A drag on a display already in the list moves it to the head without
+  duplicating it — step 6 after step 1.
+- The list stays capped at 8, dropping the oldest.
+- A malformed stored value parses as empty rather than failing.
+
+Frontend, in `OverlayWindow.test.tsx`:
+
+- A settled drag calls `record_hud_position` exactly once.
+- A rejected `record_hud_position` does not break the session.
+
+Manual, on the real desk — the eleven steps of the walkthrough. This is the
+one that actually proves it; the unit tests only stop the pieces regressing.
+
+## Docs
+
+`docs/hud-states.md` describes HUD positioning today and needs the new rule.
+No design tokens or stylesheets change, so `apps/desktop/design.md` is
+untouched.


### PR DESCRIPTION
Closes #140

## User impact

The HUD stays where you put it. It used to centre itself on the primary monitor
at every open, so a dragged position was lost on quit, and on a two-display desk
it always came back on the wrong screen.

Each drag now remembers the display and the position inside it. On launch, on
reopen from Settings, and when a display connects or disconnects, the HUD
returns to the most recent display that is still connected:

1. Drag the HUD, quit, relaunch — it is where you left it.
2. Connect a second display — the HUD stays put. A new display does not steal it.
3. Drag it to the second display, quit, relaunch — it is on the second display.
4. Disconnect that display — the HUD falls back to the laptop position.
5. Reconnect it — the HUD returns to the second display.

Step 5 is what shapes the data model. Only a drag changes which display is
preferred; a fallback borrows a display without claiming it. So the list holds
its order through an unplug and the HUD comes home when the display returns.

**Known limits:**

- A display is identified by its name, size, and scale factor. Two identical
  monitors of one model share an identity, so the HUD may pick the wrong one of
  a matched pair.
- Display changes are noticed by a 2-second poll, so there is up to a two-second
  pause before the HUD moves. `NSApplicationDidChangeScreenParametersNotification`
  is the upgrade if that ever reads as lag.
- Existing installs have no stored position, so the first launch keeps today's
  default and the memory starts with the first drag.

**One deviation from the issue.** #140 asks for the position to be keyed by the
*arrangement* — the whole set of connected displays. This keys by the
individual display instead, with a recency-ordered list, and takes the first
entry whose display is connected.

Both satisfy the walkthrough in the issue, and they differ in one case: with
two displays connected, dragging the HUD onto the laptop overwrites the laptop
position remembered from single-screen use, so unplugging lands it at the newer
spot rather than the older one. Arrangement keying would keep the two apart, at
the cost of a combinatorial number of remembered slots. Say the word if the
issue's model is the one you want.

<!-- IMAGE GOES HERE -->

## Validation

- `cargo test` in the shell workspace — 573 pass
- `cargo test` in `antiburn-hud` — 21 pass, including new coverage of the
  resolve order and of clamping onto a display that came back smaller
- `pnpm --filter @antiburn/desktop test` — 921 pass
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` in both
  Rust workspaces
- `type-check`, `lint`, `knip`, `format`, and the slop pass
- The five-step walkthrough above, run by hand on a two-display desk

## Privacy and performance

One new row in the local settings store, `internal:hudPlacements`, holding
display identities and coordinates. It never leaves the device.

New background work: a task that reads the connected displays every 2 seconds.
It returns immediately while the HUD is closed, and it only reads the stored
list — it never writes.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

