### PR TITLE
chore(release): antiburn 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-28
+
 ### Added
 
 - OpenCode sessions now receive dedicated local analysis and Insights without

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "antiburn-hud",
  "antiburn-local",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/hud", "crates/nudge", "crates/sound", "crates/trace"]
 
 [package]
 name = "antiburn"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary

- release the accumulated reader-facing desktop changes as `antiburn-v0.2.0`
- update all four application version manifests
- promote the existing Unreleased notes for 2026-08-28

## User impact

The release adds dedicated OpenCode and Pi analysis, reassesses safely skipped unknown records, improves large-session memory use, refreshes Codex sub-agent analysis, and corrects delegated-token attribution.

## Verification

- frontend lint, type-check, 923 tests, and production build
- shell formatting, Clippy with warnings denied, and 568 tests
- release version, engine-tag, locked metadata, and release-script checks
- full slop and secret scans

## Privacy and performance

The promoted notes include the bounded anonymised unknown-record event. Session content and unknown type names remain local. The release reduces retained memory for large sessions. No new release-time limit is known.