### PR TITLE
fix(desktop): install updates automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+### Changed
+
+- Signed application updates now download, install, and restart antiburn
+  automatically. The automatic-update setting remains available as an opt-out.
+
 ## [0.2.0] - 2026-08-28
 
 ### Added

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -151,7 +151,7 @@ engine. Release and dependency checks run through the required CI gate.
   background work must be no more frequent or intensive than the visible
   feature requires. See the policy at the top of `src-tauri/src/scan.rs`.
 - **Notifications.** Six kinds, all posted by the shell and never by the webview
-  (which is granted no notification permission): an available update, a failed
+  (which is granted no notification permission): an automatic update, a failed
   scan, low disk space, a crossed usage milestone, the first-run menu-bar
   location, and the settings pane's own test. The test and first-run location
   bypass the master switch because both follow a direct reader action. Other

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -522,6 +522,7 @@ fn install_updater(app: &tauri::AppHandle) {
                 if let Some(state) = app.try_state::<updates::UpdaterState>() {
                     state.note_registered();
                 }
+                ::tracing::info!(event = "updater_registered");
             }
             Err(error) => ::tracing::warn!(
                 event = "updater_registration_failed",

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -5,11 +5,10 @@
 //! choose to look at. That makes it the surface where restraint matters most,
 //! so the whole policy is here rather than spread across the callers:
 //!
-//! - **Every kind is enumerated here.** A newer version, a failed scan, low
-//!   disk space, a crossed usage milestone, where the app went when the first
-//!   run finished, and the settings pane's own test. Each is
-//!   something a reader would act on (or, for the test, explicitly asked for);
-//!   none is a progress report. Nothing else in the app posts a notification.
+//! - **Every kind is enumerated here.** An automatic update, a failed scan,
+//!   low disk space, a crossed usage milestone, where the app went after setup,
+//!   and the settings pane's own test. Each is information the reader needs.
+//!   Nothing else in the app posts a notification.
 //! - **Every kind is gated twice** — once by the master preference and once by
 //!   its own ([`allowed`]). All default on, because a notification surface
 //!   that has to be discovered before it says anything is a surface nobody
@@ -60,7 +59,7 @@ pub(crate) const NOTIFICATION_SETTINGS_ACTION_ID: &str = "notification_settings"
 /// Something antiburn is willing to interrupt a reader for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
-    /// An update check found a newer version.
+    /// An automatic update found a newer version and will restart the app.
     UpdateAvailable,
     /// A scan pass ended in an error.
     ScanFailure,
@@ -171,9 +170,8 @@ impl NotificationState {
 
     /// Claim the right to report `version`, once per version.
     ///
-    /// The automatic check repeats every six hours and keeps finding the same
-    /// release until it is installed. Keying on the version rather than on a
-    /// flag means a *newer* release is still announced.
+    /// A failed automatic install can find the same release again. Keying on
+    /// the version prevents repeated notices during one run.
     pub fn claim_update(&self, version: &str) -> bool {
         let mut reported = self
             .update_version_reported
@@ -269,6 +267,15 @@ pub fn update_message(version: &str) -> NotificationCopy {
         "antiburn update released",
         format!("New version {version} is available."),
         "Select Install to download, verify, and install it. Open About to follow progress.",
+    )
+}
+
+/// Tell the reader that an automatic update will restart the app.
+pub fn automatic_update_message(version: &str) -> NotificationCopy {
+    NotificationCopy::new(
+        "antiburn is updating",
+        format!("Installing version {version}."),
+        "antiburn will restart when the signed update is ready.",
     )
 }
 
@@ -416,12 +423,8 @@ pub fn note_scan_outcome(app: &AppHandle, status: &ScanStatus) {
     );
 }
 
-/// Report the outcome of an update check, if it found a version worth naming.
-///
-/// Only the shell's own schedule reaches here (see [`crate::updates`]): a
-/// reader who pressed "Check for updates" is already looking at the answer, and
-/// notifying them about it would be telling them what they can see.
-pub fn note_update_status(app: &AppHandle, status: &UpdateStatus) {
+/// Report that the automatic updater will install and restart the app.
+pub fn note_automatic_update(app: &AppHandle, status: &UpdateStatus) {
     if status.kind != "available" {
         return;
     }
@@ -441,8 +444,8 @@ pub fn note_update_status(app: &AppHandle, status: &UpdateStatus) {
         app,
         Kind::UpdateAvailable,
         Delivery::Automated,
-        update_message(version),
-        Some(("install", "Install", Some(update_target(version)))),
+        automatic_update_message(version),
+        None,
         None,
     );
 }
@@ -636,6 +639,14 @@ mod tests {
         assert!(copy.subtitle.contains("0.2.0"));
         assert!(copy.description.contains("Select Install"));
         assert!(copy.description.contains("Open About"));
+    }
+
+    #[test]
+    fn automatic_update_copy_explains_the_restart() {
+        let copy = automatic_update_message("0.2.0");
+        assert!(copy.subtitle.contains("0.2.0"));
+        assert!(copy.description.contains("restart"));
+        assert!(copy.description.contains("signed update"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -557,7 +557,7 @@ pub struct AppSettings {
     pub onboarding_completed: bool,
     /// Whether the packaged app should register itself to start after sign-in.
     pub launch_at_login: bool,
-    /// Whether the updater may check on its own. Read by
+    /// Whether the updater may install and restart on its own. Read by
     /// [`crate::updates::spawn_scheduler`], which is what makes it real.
     pub auto_update: bool,
     /// Whether background discovery and indexing are paused.
@@ -568,7 +568,7 @@ pub struct AppSettings {
     /// The master switch for desktop notifications. Off means nothing is
     /// delivered, whatever the per-kind preferences below say.
     pub notifications_enabled: bool,
-    /// Notify when an automatic update check finds a newer version.
+    /// Notify before an automatic update installs and restarts the app.
     pub notify_update_available: bool,
     /// Notify the first time a scan fails in this run of the app.
     pub notify_scan_failure: bool,

--- a/apps/desktop/src-tauri/src/updates.rs
+++ b/apps/desktop/src-tauri/src/updates.rs
@@ -10,15 +10,14 @@
 //!   configuration. A compile-time `cfg!` would say "yes" in a release build
 //!   whose key was never configured, and every piece of copy downstream would
 //!   inherit that lie.
-//! - **When it speaks on its own.** [`spawn_scheduler`] checks once shortly
-//!   after launch and then every [`CHECK_INTERVAL`], and only while the reader's
-//!   "check automatically" preference is on. It is the thing that makes that
-//!   preference real; without it the switch would be decoration.
+//! - **When it updates on its own.** [`spawn_scheduler`] checks once shortly
+//!   after launch and then every [`CHECK_INTERVAL`]. When automatic updates are
+//!   enabled, it downloads, verifies, installs, and restarts without waiting
+//!   for approval. It defers while the popover is open.
 //! - **What it says afterwards.** Every check — automatic or not — ends in an
 //!   [`EVENT_UPDATE`] event carrying an [`UpdateStatus`], which is what the
-//!   Updates pane renders. Nothing is inferred from silence. An *automatic*
-//!   check that finds a version also asks [`crate::notifications`] to say so
-//!   once, since nobody is watching the pane when the schedule runs.
+//!   Updates pane renders. Nothing is inferred from silence. An automatic
+//!   install also tells the reader that the app will restart.
 //!
 //! Nothing here contacts a server in a development build: the plugin is never
 //! registered there, so [`supported`] is false and the scheduler does nothing.
@@ -59,15 +58,18 @@ use crate::store::Store;
 /// Event the shell emits as the update lifecycle changes.
 pub const EVENT_UPDATE: &str = "update:status";
 
-/// How long after launch the first automatic check runs.
+/// How long after launch the first automatic update check runs.
 ///
 /// Launch is the busiest moment in the app's life — the first scan, the store
 /// migration, the webview boot — and an update check is the least urgent thing
 /// competing for it.
 pub const STARTUP_DELAY: Duration = Duration::from_secs(30);
 
-/// How often the automatic check repeats.
+/// How often the automatic update check repeats.
 pub const CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// How soon to retry when the reader has the popover open.
+pub const DEFERRED_RETRY: Duration = Duration::from_secs(30);
 
 /// Fixed version used by the debug-only update simulator.
 pub const SIMULATED_VERSION: &str = "99.0.0";
@@ -242,9 +244,7 @@ pub struct UpdateStatus {
     pub message: Option<String>,
     /// ISO-8601 stamp for this update state.
     pub checked_at: String,
-    /// True when the check ran on the schedule rather than because a reader
-    /// pressed a button — so the pane can say "checked automatically" without
-    /// inventing the distinction.
+    /// True when the shell schedule started this operation.
     pub automatic: bool,
     /// Bytes received for an active or completed download.
     pub downloaded_bytes: Option<u64>,
@@ -286,12 +286,13 @@ impl UpdateStatus {
         version: String,
         downloaded_bytes: u64,
         total_bytes: Option<u64>,
+        automatic: bool,
     ) -> UpdateStatus {
         UpdateStatus {
             version: Some(version),
             downloaded_bytes: Some(downloaded_bytes),
             total_bytes,
-            ..UpdateStatus::new("downloading", false)
+            ..UpdateStatus::new("downloading", automatic)
         }
     }
 
@@ -299,19 +300,20 @@ impl UpdateStatus {
         version: String,
         downloaded_bytes: u64,
         total_bytes: Option<u64>,
+        automatic: bool,
     ) -> UpdateStatus {
         UpdateStatus {
             version: Some(version),
             downloaded_bytes: Some(downloaded_bytes),
             total_bytes,
-            ..UpdateStatus::new("installing", false)
+            ..UpdateStatus::new("installing", automatic)
         }
     }
 
-    fn installed(version: String) -> UpdateStatus {
+    fn installed(version: String, automatic: bool) -> UpdateStatus {
         UpdateStatus {
             version: Some(version),
-            ..UpdateStatus::new("installed", false)
+            ..UpdateStatus::new("installed", automatic)
         }
     }
 
@@ -330,7 +332,7 @@ impl UpdateStatus {
     }
 }
 
-/// Start the automatic check schedule. The returned handle is aborted on exit.
+/// Start the automatic update schedule. The returned handle is aborted on exit.
 ///
 /// The loop runs in every build; what it *does* is decided every pass by
 /// [`supported`] and the reader's preference, so there is no compile-time
@@ -340,25 +342,27 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(STARTUP_DELAY).await;
         loop {
-            if should_check(&app) {
-                let Some(status) = automatic_check(&app).await else {
-                    tokio::time::sleep(CHECK_INTERVAL).await;
-                    continue;
-                };
-                // The Updates pane learns from the event; someone who is not
-                // looking at antiburn learns from a notification, at most once
-                // per version. A *manual* check is deliberately not notified:
-                // the reader is already looking at the answer.
-                let status = emit_status(&app, status);
-                crate::notifications::note_update_status(&app, &status);
+            if popover_visible(&app) {
+                ::tracing::debug!(event = "auto_update_deferred_popover_visible");
+                tokio::time::sleep(DEFERRED_RETRY).await;
+                continue;
+            }
+            if should_update(&app) {
+                automatic_update(&app).await;
             }
             tokio::time::sleep(CHECK_INTERVAL).await;
         }
     })
 }
 
-/// Whether an automatic check should run right now.
-fn should_check(app: &AppHandle) -> bool {
+fn popover_visible(app: &AppHandle) -> bool {
+    app.get_webview_window(crate::popover::LABEL)
+        .and_then(|window| window.is_visible().ok())
+        .unwrap_or(false)
+}
+
+/// Whether an automatic update should run now.
+fn should_update(app: &AppHandle) -> bool {
     supported(app)
         && auto_update_enabled(app)
         && app
@@ -366,8 +370,9 @@ fn should_check(app: &AppHandle) -> bool {
             .is_some_and(|state| state.installed_version().is_none())
 }
 
-/// The reader's "check automatically" preference, defaulting to *not* checking
-/// when the store cannot be read: a failed read is not consent.
+/// Read the automatic-update preference.
+///
+/// A failed store read does not authorize an installation.
 fn auto_update_enabled(app: &AppHandle) -> bool {
     app.try_state::<Store>()
         .and_then(|store| store.settings().ok())
@@ -383,15 +388,29 @@ pub async fn check(app: &AppHandle, automatic: bool) -> UpdateStatus {
     if !supported(app) {
         return UpdateStatus::new("unsupported", automatic);
     }
+    ::tracing::info!(event = "updater_check_started", automatic);
     check_with_plugin(app, automatic).await
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 async fn check_with_plugin(app: &AppHandle, automatic: bool) -> UpdateStatus {
     match find_update(app).await {
-        Ok(Some(update)) => UpdateStatus::available(update.version.clone(), automatic),
-        Ok(None) => UpdateStatus::current(automatic),
-        Err(error) => UpdateStatus::failed(error, automatic, "check", None),
+        Ok(Some(update)) => {
+            ::tracing::info!(
+                event = "updater_update_found",
+                version = %update.version,
+                automatic
+            );
+            UpdateStatus::available(update.version.clone(), automatic)
+        }
+        Ok(None) => {
+            ::tracing::info!(event = "updater_current", automatic);
+            UpdateStatus::current(automatic)
+        }
+        Err(error) => {
+            ::tracing::warn!(event = "updater_check_failed", automatic, error = %error);
+            UpdateStatus::failed(error, automatic, "check", None)
+        }
     }
 }
 
@@ -407,7 +426,7 @@ pub async fn manual_check(app: &AppHandle) -> UpdateStatus {
     };
     let _operation = state.operation.lock().await;
     if let Some(version) = state.installed_version() {
-        let status = UpdateStatus::installed(version);
+        let status = UpdateStatus::installed(version, false);
         return emit_status(app, status);
     }
     let status = check(app, false).await;
@@ -436,7 +455,7 @@ pub async fn start_simulation(app: &AppHandle) -> Result<UpdateStatus, &'static 
     ))
 }
 
-/// Download, verify, and install the version the reader approved.
+/// Download, verify, and install the version the reader selected.
 pub async fn install(app: &AppHandle, expected_version: &str) -> UpdateStatus {
     let Some(state) = app.try_state::<UpdaterState>() else {
         return UpdateStatus::new("unsupported", false);
@@ -449,7 +468,7 @@ pub async fn install(app: &AppHandle, expected_version: &str) -> UpdateStatus {
         return UpdateStatus::new("unsupported", false);
     }
     if let Some(version) = state.installed_version() {
-        let status = UpdateStatus::installed(version);
+        let status = UpdateStatus::installed(version, false);
         return emit_status(app, status);
     }
     install_with_plugin(app, expected_version).await
@@ -486,12 +505,15 @@ async fn install_simulation(
         );
     }
     if phase == SimulationPhase::Installed {
-        return emit_status(app, UpdateStatus::installed(SIMULATED_VERSION.to_string()));
+        return emit_status(
+            app,
+            UpdateStatus::installed(SIMULATED_VERSION.to_string(), false),
+        );
     }
 
     emit_status(
         app,
-        UpdateStatus::downloading(SIMULATED_VERSION.to_string(), 0, None),
+        UpdateStatus::downloading(SIMULATED_VERSION.to_string(), 0, None, false),
     );
     tokio::time::sleep(SIMULATION_STEP_DELAY).await;
     emit_status(
@@ -500,6 +522,7 @@ async fn install_simulation(
             SIMULATED_VERSION.to_string(),
             SIMULATED_TOTAL_BYTES / 2,
             Some(SIMULATED_TOTAL_BYTES),
+            false,
         ),
     );
     tokio::time::sleep(SIMULATION_STEP_DELAY).await;
@@ -524,20 +547,59 @@ async fn install_simulation(
             SIMULATED_VERSION.to_string(),
             SIMULATED_TOTAL_BYTES,
             Some(SIMULATED_TOTAL_BYTES),
+            false,
         ),
     );
     tokio::time::sleep(SIMULATION_STEP_DELAY).await;
-    emit_status(app, UpdateStatus::installed(SIMULATED_VERSION.to_string()))
+    emit_status(
+        app,
+        UpdateStatus::installed(SIMULATED_VERSION.to_string(), false),
+    )
 }
 
-async fn automatic_check(app: &AppHandle) -> Option<UpdateStatus> {
-    let state = app.try_state::<UpdaterState>()?;
-    let _operation = state.operation.try_lock().ok()?;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+async fn automatic_update(app: &AppHandle) {
+    let Some(state) = app.try_state::<UpdaterState>() else {
+        ::tracing::warn!(event = "auto_update_state_unavailable");
+        return;
+    };
+    let Ok(_operation) = state.operation.try_lock() else {
+        ::tracing::debug!(event = "auto_update_skip_busy");
+        return;
+    };
     if state.installed_version().is_some() {
-        return None;
+        return;
     }
-    Some(check(app, true).await)
+
+    ::tracing::info!(event = "updater_check_started", automatic = true);
+    let update = match find_update(app).await {
+        Ok(Some(update)) => update,
+        Ok(None) => {
+            ::tracing::info!(event = "updater_current", automatic = true);
+            emit_status(app, UpdateStatus::current(true));
+            return;
+        }
+        Err(error) => {
+            ::tracing::warn!(event = "updater_check_failed", automatic = true, error = %error);
+            emit_status(app, UpdateStatus::failed(error, true, "check", None));
+            return;
+        }
+    };
+
+    let version = update.version.clone();
+    ::tracing::info!(event = "auto_update_found", version = %version);
+    let available = emit_status(app, UpdateStatus::available(version.clone(), true));
+    crate::notifications::note_automatic_update(app, &available);
+
+    let status = download_and_install(app, update, true).await;
+    if status.kind == "installed" {
+        ::tracing::info!(event = "auto_update_installed", version = %version);
+        app.restart();
+    }
 }
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+async fn automatic_update(_app: &AppHandle) {}
 
 fn emit_status(app: &AppHandle, mut status: UpdateStatus) -> UpdateStatus {
     if let Some(state) = app.try_state::<UpdaterState>() {
@@ -579,10 +641,23 @@ async fn install_with_plugin(app: &AppHandle, expected_version: &str) -> UpdateS
         }
     };
 
+    download_and_install(app, update, false).await
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+async fn download_and_install(
+    app: &AppHandle,
+    update: tauri_plugin_updater::Update,
+    automatic: bool,
+) -> UpdateStatus {
     let version = update.version.clone();
+    ::tracing::info!(event = "updater_download_started", version = %version, automatic);
     let downloaded = Arc::new(AtomicU64::new(0));
     let total = Arc::new(AtomicU64::new(u64::MAX));
-    emit_status(app, UpdateStatus::downloading(version.clone(), 0, None));
+    emit_status(
+        app,
+        UpdateStatus::downloading(version.clone(), 0, None, automatic),
+    );
 
     let progress_downloaded = Arc::clone(&downloaded);
     let progress_total = Arc::clone(&total);
@@ -611,6 +686,7 @@ async fn install_with_plugin(app: &AppHandle, expected_version: &str) -> UpdateS
                             progress_version.clone(),
                             current,
                             content_length,
+                            automatic,
                         ),
                     );
                 }
@@ -627,9 +703,14 @@ async fn install_with_plugin(app: &AppHandle, expected_version: &str) -> UpdateS
                 let status = UpdateStatus::failed(
                     "The update download stopped making progress. Check your connection and try again."
                         .to_string(),
-                    false,
+                    automatic,
                     "install",
                     Some(version.clone()),
+                );
+                ::tracing::warn!(
+                    event = "updater_download_stalled",
+                    version = %version,
+                    automatic
                 );
                 return emit_status(app, status);
             };
@@ -640,9 +721,15 @@ async fn install_with_plugin(app: &AppHandle, expected_version: &str) -> UpdateS
                     Err(error) => {
                         let status = UpdateStatus::failed(
                             error.to_string(),
-                            false,
+                            automatic,
                             "install",
                             Some(version.clone()),
+                        );
+                        ::tracing::warn!(
+                            event = "updater_download_failed",
+                            version = %version,
+                            automatic,
+                            error = %error
                         );
                         return emit_status(app, status);
                     }
@@ -659,16 +746,26 @@ async fn install_with_plugin(app: &AppHandle, expected_version: &str) -> UpdateS
     };
     emit_status(
         app,
-        UpdateStatus::installing(version.clone(), downloaded_bytes, total_bytes),
+        UpdateStatus::installing(version.clone(), downloaded_bytes, total_bytes, automatic),
     );
+    ::tracing::info!(event = "updater_install_started", version = %version, automatic);
     let status = match update.install(bytes) {
         Ok(()) => {
             if let Some(state) = app.try_state::<UpdaterState>() {
                 state.note_installed(&version);
             }
-            UpdateStatus::installed(version)
+            ::tracing::info!(event = "updater_install_succeeded", version = %version, automatic);
+            UpdateStatus::installed(version, automatic)
         }
-        Err(error) => UpdateStatus::failed(error.to_string(), false, "install", Some(version)),
+        Err(error) => {
+            ::tracing::warn!(
+                event = "updater_install_failed",
+                version = %version,
+                automatic,
+                error = %error
+            );
+            UpdateStatus::failed(error.to_string(), automatic, "install", Some(version))
+        }
     };
     emit_status(app, status)
 }
@@ -746,21 +843,30 @@ mod tests {
         assert_eq!(current["kind"], "current");
         assert!(current["version"].is_null());
 
-        let downloading =
-            serde_json::to_value(UpdateStatus::downloading("0.2.0".into(), 512, Some(1_024)))
-                .unwrap();
+        let downloading = serde_json::to_value(UpdateStatus::downloading(
+            "0.2.0".into(),
+            512,
+            Some(1_024),
+            true,
+        ))
+        .unwrap();
         assert_eq!(downloading["kind"], "downloading");
         assert_eq!(downloading["downloadedBytes"], 512);
         assert_eq!(downloading["totalBytes"], 1_024);
+        assert_eq!(downloading["automatic"], true);
 
         let installing =
-            serde_json::to_value(UpdateStatus::installing("0.2.0".into(), 1_024, None)).unwrap();
+            serde_json::to_value(UpdateStatus::installing("0.2.0".into(), 1_024, None, true))
+                .unwrap();
         assert_eq!(installing["kind"], "installing");
         assert!(installing["totalBytes"].is_null());
+        assert_eq!(installing["automatic"], true);
 
-        let installed = serde_json::to_value(UpdateStatus::installed("0.2.0".into())).unwrap();
+        let installed =
+            serde_json::to_value(UpdateStatus::installed("0.2.0".into(), true)).unwrap();
         assert_eq!(installed["kind"], "installed");
         assert_eq!(installed["version"], "0.2.0");
+        assert_eq!(installed["automatic"], true);
     }
 
     #[test]
@@ -840,9 +946,9 @@ mod tests {
 
     #[test]
     fn the_schedule_is_the_one_the_updates_pane_describes() {
-        // The pane tells the reader an automatic check happens a moment after
-        // launch and then every few hours; these are those numbers.
+        // The pane tells the reader when automatic updates run.
         assert_eq!(STARTUP_DELAY, Duration::from_secs(30));
         assert_eq!(CHECK_INTERVAL, Duration::from_secs(21_600));
+        assert_eq!(DEFERRED_RETRY, Duration::from_secs(30));
     }
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -51,7 +51,7 @@ export interface AppSettings {
   onboardingCompleted: boolean
   /** Recorded; applied by the platform at next launch. */
   launchAtLogin: boolean
-  /** Whether the shell may check the release feed on its own schedule. */
+  /** Whether the shell may install and restart for updates on its schedule. */
   autoUpdate: boolean
   /**
    * Whether background discovery and indexing are paused.
@@ -65,7 +65,7 @@ export interface AppSettings {
    * delivered, whatever the per-kind preferences say.
    */
   notificationsEnabled: boolean
-  /** Notify when an automatic update check finds a newer version. */
+  /** Notify before an automatic update installs and restarts the app. */
   notifyUpdateAvailable: boolean
   /** Notify the first time a scan fails in this run of the app. */
   notifyScanFailure: boolean
@@ -549,7 +549,7 @@ export interface UpdateStatusPayload {
   version: string | null
   message: string | null
   checkedAt: string
-  /** True when the shell's own schedule ran the check rather than a reader. */
+  /** True when the shell schedule started this operation. */
   automatic: boolean
   downloadedBytes: number | null
   totalBytes: number | null
@@ -1499,9 +1499,8 @@ export const UPDATE_EVENT = "update:status"
  * Subscribe to checks, download progress, installation, and failures. The
  * returned function unsubscribes.
  *
- * This is what makes the "check automatically" preference visible: the shell
- * does the checking, and the Updates pane reflects what it found rather than
- * inferring anything from silence.
+ * This makes automatic updates visible. The shell owns the operation, and the
+ * Updates pane reports its state instead of inferring from silence.
  */
 export async function onUpdateStatus(
   handler: (status: UpdateStatusPayload) => void,

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -304,7 +304,7 @@ describe("SettingsView", () => {
 
     // Not a disabled switch over a preference nothing reads — no switch.
     expect(
-      screen.queryByRole("switch", { name: "Check for updates automatically" }),
+      screen.queryByRole("switch", { name: "Install updates automatically" }),
     ).not.toBeInTheDocument()
     expect(screen.getByText(/never contacts the release feed/i)).toBeInTheDocument()
   })
@@ -361,16 +361,17 @@ describe("SettingsView", () => {
     expect(await screen.findByText("Up to date")).toBeInTheDocument()
   })
 
-  it("offers the automatic-check preference, and persists it, when updates work", async () => {
+  it("offers the automatic-install preference, and persists it, when updates work", async () => {
     mockCommands({ app_info: { ...INFO, updatesSupported: true } })
     render(<SettingsView />)
 
     fireEvent.click(screen.getByRole("tab", { name: "About" }))
     const toggle = await screen.findByRole("switch", {
-      name: "Check for updates automatically",
+      name: "Install updates automatically",
     })
-    // The copy describes the schedule the shell actually runs.
+    // The copy describes the complete scheduled update path.
     expect(screen.getByText(/every six hours/i)).toBeInTheDocument()
+    expect(screen.getByText(/downloads, verifies, installs, and restarts/i)).toBeInTheDocument()
 
     fireEvent.click(toggle)
     await waitFor(() =>
@@ -380,12 +381,12 @@ describe("SettingsView", () => {
     )
   })
 
-  it("reflects what an automatic check found", async () => {
+  it("reflects what an automatic update found", async () => {
     mockCommands({ app_info: { ...INFO, updatesSupported: true } })
     render(<SettingsView />)
 
     fireEvent.click(screen.getByRole("tab", { name: "About" }))
-    await screen.findByRole("switch", { name: "Check for updates automatically" })
+    await screen.findByRole("switch", { name: "Install updates automatically" })
 
     emit(
       "update:status",
@@ -396,8 +397,7 @@ describe("SettingsView", () => {
     )
 
     expect(await screen.findByText("Version 0.2.0 is available")).toBeInTheDocument()
-    // The switch says when the schedule last ran, so "automatic" is an
-    // observable fact rather than an assurance.
+    // The switch says when the scheduled update path last ran.
     expect(screen.getByText(/last checked/i)).toBeInTheDocument()
   })
 

--- a/apps/desktop/src/views/settings/UpdatesSection.tsx
+++ b/apps/desktop/src/views/settings/UpdatesSection.tsx
@@ -40,9 +40,8 @@ import type { AppSettingsController } from "./useAppSettings"
  * it actually registered — not a compile-time guess. Everything here hangs off
  * that one flag:
  *
- * - **Supported.** The automatic-check switch is shown and is real: the shell
- *   runs the schedule, and the results arrive here as events, so the line under
- *   the switch reports what the last automatic check actually found.
+ * - **Supported.** The automatic-update switch is real. The shell runs the
+ *   schedule, and progress arrives here as events.
  * - **Unsupported.** The switch is not rendered at all. A build that cannot
  *   check for updates has no automatic behaviour to configure, and a disabled
  *   switch over a preference nothing reads is the exact "control that does
@@ -186,7 +185,7 @@ type UpdatesSnapshot = {
   latestRevision: number
 }
 
-// Module-level: the shell's automatic-check schedule and a manual check both
+// Module-level: the shell's automatic-update schedule and manual actions both
 // land here regardless of how many settings windows are open to see them.
 const updateStatusStore = createExternalStore<UpdatesSnapshot>({
   initial: { state: { kind: "idle" }, lastAutomatic: null, latestRevision: 0 },
@@ -363,11 +362,11 @@ export function UpdatesSection({ settings, update, info }: UpdatesSectionProps) 
         )}
         {supported ? (
           <ToggleRow
-            label="Check for updates automatically"
+            label="Install updates automatically"
             description={
               lastAutomatic
-                ? `A moment after launch and every six hours. antiburn contacts the release feed for this check and nothing else; last checked ${relativeTime(lastAutomatic)}.`
-                : "A moment after launch and every six hours. antiburn contacts the release feed for this check and nothing else — nothing about your sessions is ever sent."
+                ? `antiburn checks a moment after launch and every six hours, then downloads, verifies, installs, and restarts when an update is available; last checked ${relativeTime(lastAutomatic)}.`
+                : "antiburn checks a moment after launch and every six hours, then downloads, verifies, installs, and restarts when an update is available. Nothing about your sessions is sent."
             }
             checked={settings.autoUpdate}
             onChange={(next) => void update({ autoUpdate: next })}

--- a/docs/os-notification-gating.md
+++ b/docs/os-notification-gating.md
@@ -35,7 +35,7 @@ So the two rules the whole design serves:
 
 ## Who is gated
 
-Automated kinds — update available, scan failure, low disk space, usage
+Automated kinds — automatic update, scan failure, low disk space, usage
 milestone — ask the gate. Preview kinds bypass it for the same reason they
 bypass the master notification switch: they are the direct result of a button
 the reader pressed a moment earlier. That is the settings pane's test
@@ -51,8 +51,8 @@ Consequences of drop semantics, per kind:
   milestone step notifies as usual.
 - **Scan failure** — the once-per-run claim stays spent; the next run of the
   app reports again if scans still fail.
-- **Update available** — the once-per-version claim stays spent; a *newer*
-  version still notifies.
+- **Automatic update** — the once-per-version claim stays spent. The update still
+  installs and restarts antiburn when the notification is suppressed.
 
 ## Platform matrix
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -311,9 +311,9 @@ work, but it does not replace these signed-artifact checks.
 - [ ] **The previous version can update to this one.** The real test of a
       release: install the previous version, point it at the draft only after
       publishing (drafts are not reachable), or rehearse with a pre-release tag.
-      On macOS and Linux AppImage, confirm About shows download progress, changes
-      to the installed state, and offers Restart to update. Restart and confirm
-      About shows the new version. On Windows, confirm the passive NSIS installer
+      On macOS and Linux AppImage, leave the popover closed and confirm the app
+      downloads, installs, and restarts without approval. Confirm About shows the
+      new version after restart. On Windows, confirm the passive NSIS installer
       exits and relaunches the updated application. The Debian package is
       install-only and must report that in-app updates are unavailable.
 - [ ] **Updater failures stay safe and visible.** In a release rehearsal, interrupt

--- a/docs/support.md
+++ b/docs/support.md
@@ -121,13 +121,14 @@ beyond analytics and updates are yours, not ours: reading
 a provider's own figures with your own credentials is traffic between this machine
 and a provider you already use. The application's own connection to a service of
 ours are analytics and the updater. The updater asks GitHub Releases whether a newer
-version exists and downloads its signed bundle only after you select Install. The
-app never depends on either connection.
+version exists. When automatic updates are enabled, it downloads and installs the
+signed bundle and restarts antiburn. The app never depends on either connection.
 
 - The check sends nothing about you, your machine, or your sessions.
-- It runs on a schedule only while "check for updates automatically" is on, and can
+- It runs on a schedule only while "Install updates automatically" is on, and can
   always be run by hand from Settings → About.
-- Automatic checks never download or install an update.
+- An automatic update downloads, verifies, and installs the new version. antiburn
+  restarts as soon as installation succeeds.
 - An install verifies the downloaded bundle against the public key in the app before
   it changes the installed application.
 - Development builds carry no updater at all.


### PR DESCRIPTION
## Summary

- align the desktop updater with Cadence by downloading, verifying, installing, and immediately restarting after a scheduled update check
- defer automatic updates while the popover is visible and preserve the existing opt-out setting
- make update notifications informational and add lifecycle logs for updater diagnosis
- update settings copy, support documentation, release checks, and tests

## Validation

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (569 passed)
- pnpm --filter @antiburn/desktop format
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop test (923 passed)
- pnpm --filter @antiburn/desktop build
- pnpm run slop:all (score 100)
- pnpm run secrets

## User impact

Signed desktop releases now install without requiring the reader to notice and act on a short-lived notification. antiburn restarts as soon as installation succeeds. Automatic updates remain configurable in Settings.