### PR TITLE
fix(insights): stop false clean results in session hygiene checks

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -2139,8 +2139,18 @@ mod tests {
         let payload = session_hygiene_payload(Some(row));
         assert_eq!(payload.evidence_state, "activelyGrowing");
         assert!(payload.badges.iter().all(|badge| {
+            // Obsolete Model reports the empty-catalog contract gap, and
+            // Model Overthinking / Fast Mode Overuse report a missing
+            // signal, because the synthetic evidence carries zero
+            // eligible turns. Every other badge reports the session-
+            // wide partial coverage from the accepted-prefix outcome.
+            let expected_reason = match badge.id {
+                "obsoleteModel" => "evidenceContractIncomplete",
+                "modelOverthinking" | "fastModeOveruse" => "signalMissing",
+                _ => "incompleteEvidence",
+            };
             matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed)
-                && badge.not_assessed_reason == Some("incompleteEvidence")
+                && badge.not_assessed_reason == Some(expected_reason)
         }));
     }
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -621,6 +621,7 @@ fn not_assessed_reason_str(reason: NotAssessedReason) -> &'static str {
         NotAssessedReason::CapabilityMissing => "capabilityMissing",
         NotAssessedReason::IncompleteEvidence => "incompleteEvidence",
         NotAssessedReason::EvidenceContractIncomplete => "evidenceContractIncomplete",
+        NotAssessedReason::SignalMissing => "signalMissing",
     }
 }
 

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -2004,9 +2004,9 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
             parser_revision: 5,
-            analyzer_revision: 6,
+            analyzer_revision: 7,
             metrics_schema_revision: 1,
-            evidence_schema_revision: 3,
+            evidence_schema_revision: 4,
         }
     );
 }
@@ -2076,7 +2076,7 @@ async fn reprocessing_a_revision_one_row_leaves_no_placeholder_in_stored_evidenc
 
     let ready = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(ready.status, EvidenceStatus::Ready);
-    assert_eq!(ready.evidence_schema_revision, Some(3));
+    assert_eq!(ready.evidence_schema_revision, Some(4));
     assert!(!ready.evidence_json.unwrap().contains("unimplemented"));
 }
 
@@ -2117,7 +2117,7 @@ async fn a_terminal_failure_clears_an_outdated_placeholder_payload() {
 
     let failed = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(failed.status, EvidenceStatus::Failed);
-    assert_eq!(failed.evidence_schema_revision, Some(3));
+    assert_eq!(failed.evidence_schema_revision, Some(4));
     assert!(failed.evidence_json.is_none());
     assert!(failed.diagnostics_json.is_none());
 }

--- a/apps/desktop/src/lib/insightsIpc.ts
+++ b/apps/desktop/src/lib/insightsIpc.ts
@@ -31,6 +31,7 @@ export type InsightsNotAssessedReason =
   | "capabilityMissing"
   | "incompleteEvidence"
   | "evidenceContractIncomplete"
+  | "signalMissing"
 
 /** One of the nine report categories, with its status and denominators. */
 export interface InsightsCategoryPayload {

--- a/apps/desktop/src/lib/presentation/sessionHygiene.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import type { SessionHygienePayload } from "../insightsIpc"
 import {
   INITIAL_SESSION_HYGIENE,
+  notAssessedReasonLabel,
   sessionHygieneChecks,
   sessionHygieneStateLabel,
 } from "./sessionHygiene"
@@ -43,13 +44,35 @@ describe("sessionHygieneChecks", () => {
 
   it("names every check without a verdict, whatever the status", () => {
     expect(sessionHygieneChecks(PAYLOAD).map((check) => check.name)).toEqual([
-      "Session overdepth detected",
-      "Model overthinking detected",
-      "Overpowered subagents detected",
-      "Obsolete model detected",
-      "Fast mode overuse detected",
-      "Excess cache rehydration detected",
+      "Session overdepth",
+      "Model overthinking",
+      "Overpowered subagents",
+      "Obsolete model",
+      "Fast-mode overuse",
+      "Excess context reprocessing",
     ])
+  })
+
+  it("keeps every name free of verdict wording, whatever the status", () => {
+    for (const check of sessionHygieneChecks(PAYLOAD)) {
+      expect(check.name.toLowerCase()).not.toContain("detected")
+      expect(check.name.toLowerCase()).not.toContain("not assessed")
+    }
+  })
+
+  it("names the not-assessed obsolete-model check without its verdict", () => {
+    const notAssessedPayload: SessionHygienePayload = {
+      ...PAYLOAD,
+      badges: PAYLOAD.badges.map((badge) =>
+        badge.id === "obsoleteModel"
+          ? { id: "obsoleteModel" as const, status: "notAssessed" as const, notAssessedReason: "incompleteEvidence" as const }
+          : badge,
+      ),
+    }
+    const obsoleteModel = sessionHygieneChecks(notAssessedPayload).find(
+      (check) => check.id === "obsoleteModel",
+    )
+    expect(obsoleteModel?.name).toBe("Obsolete model")
   })
 
   it("maps finding, clean, and not-assessed states to semantic ink", () => {
@@ -68,6 +91,12 @@ describe("sessionHygieneChecks", () => {
     expect(checks).toHaveLength(6)
     expect(checks.every((check) => check.status === "notAssessed")).toBe(true)
     expect(sessionHygieneStateLabel(INITIAL_SESSION_HYGIENE.evidenceState)).toBe("Computing")
+  })
+
+  it("names the signal-missing reason without claiming a clean result", () => {
+    expect(notAssessedReasonLabel("signalMissing")).toBe(
+      "this session did not record the setting this check needs",
+    )
   })
 
   it("names every non-ready state and leaves ready evidence unlabeled", () => {

--- a/apps/desktop/src/lib/presentation/sessionHygiene.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.test.ts
@@ -65,7 +65,11 @@ describe("sessionHygieneChecks", () => {
       ...PAYLOAD,
       badges: PAYLOAD.badges.map((badge) =>
         badge.id === "obsoleteModel"
-          ? { id: "obsoleteModel" as const, status: "notAssessed" as const, notAssessedReason: "incompleteEvidence" as const }
+          ? {
+              id: "obsoleteModel" as const,
+              status: "notAssessed" as const,
+              notAssessedReason: "incompleteEvidence" as const,
+            }
           : badge,
       ),
     }

--- a/apps/desktop/src/lib/presentation/sessionHygiene.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.ts
@@ -23,6 +23,8 @@ export interface SessionHygieneCheck {
 
 interface HygieneCheckDefinition {
   id: SessionHygieneBadgeId
+  /** The check name alone, with no verdict. Feeds `SessionHygieneCheck.name`. */
+  name: string
   cleanTitle: string
   findingTitle: string
   notAssessedTitle: string
@@ -31,36 +33,45 @@ interface HygieneCheckDefinition {
 const CHECKS: readonly HygieneCheckDefinition[] = [
   {
     id: "sessionOverdepth",
+    name: "Session overdepth",
     cleanTitle: "No session overdepth detected",
     findingTitle: "Session overdepth detected",
     notAssessedTitle: "Session overdepth not assessed",
   },
   {
     id: "modelOverthinking",
+    name: "Model overthinking",
     cleanTitle: "No model overthinking detected",
     findingTitle: "Model overthinking detected",
     notAssessedTitle: "Model overthinking not assessed",
   },
   {
     id: "overpoweredSubagents",
+    name: "Overpowered subagents",
     cleanTitle: "No overpowered subagents detected",
     findingTitle: "Overpowered subagents detected",
     notAssessedTitle: "Overpowered subagents not assessed",
   },
   {
     id: "obsoleteModel",
+    name: "Obsolete model",
     cleanTitle: "No obsolete model detected",
     findingTitle: "Obsolete model detected",
     notAssessedTitle: "Obsolete model not assessed",
   },
   {
     id: "fastModeOveruse",
+    name: "Fast-mode overuse",
     cleanTitle: "No fast mode overuse detected",
     findingTitle: "Fast mode overuse detected",
     notAssessedTitle: "Fast mode overuse not assessed",
   },
   {
     id: "excessCacheRehydration",
+    // This name diverges from the title wording on purpose. "Excess cache
+    // rehydration" names the mechanism; "Excess context reprocessing"
+    // names the check in reader terms.
+    name: "Excess context reprocessing",
     cleanTitle: "No excess cache rehydration detected",
     findingTitle: "Excess cache rehydration detected",
     notAssessedTitle: "Excess cache rehydration not assessed",
@@ -89,7 +100,7 @@ export function sessionHygieneChecks(payload: SessionHygienePayload): SessionHyg
       return {
         ...badge,
         title: definition.findingTitle,
-        name: definition.findingTitle,
+        name: definition.name,
         ink: "system-red-text" as const,
       }
     }
@@ -97,14 +108,14 @@ export function sessionHygieneChecks(payload: SessionHygienePayload): SessionHyg
       return {
         ...badge,
         title: definition.cleanTitle,
-        name: definition.findingTitle,
+        name: definition.name,
         ink: "system-green" as const,
       }
     }
     return {
       ...badge,
       title: definition.notAssessedTitle,
-      name: definition.findingTitle,
+      name: definition.name,
       ink: "label-tertiary" as const,
     }
   })
@@ -153,6 +164,8 @@ export function notAssessedReasonLabel(reason: InsightsNotAssessedReason): strin
       return "couldn't read the whole session log"
     case "evidenceContractIncomplete":
       return "the log is missing data this check needs"
+    case "signalMissing":
+      return "this session did not record the setting this check needs"
     case "noSessionsInWindow":
       return "no sessions in the window"
   }

--- a/apps/desktop/src/views/settings/InsightsPane.test.tsx
+++ b/apps/desktop/src/views/settings/InsightsPane.test.tsx
@@ -443,6 +443,25 @@ describe("InsightsPane categories", () => {
       screen.getAllByText("Not assessed — no processed sessions in this window").length,
     ).toBe(4)
   })
+
+  it("names a missing recorded setting without claiming a clean result", async () => {
+    const categories = notAssessedCategories()
+    categories[0] = { ...categories[0]!, notAssessedReason: "signalMissing" }
+    mockCommands({
+      get_insights_report: report({
+        coverage: coverage({ discovered: 4, ready: 4 }),
+        assessedSessions: 4,
+        categories,
+      }),
+    })
+    render(<InsightsPane />)
+
+    expect(
+      await screen.findByText(
+        "Not assessed — this session did not record the setting this check needs",
+      ),
+    ).toBeInTheDocument()
+  })
 })
 
 describe("InsightsPane quota pressure", () => {

--- a/apps/desktop/src/views/settings/InsightsPane.tsx
+++ b/apps/desktop/src/views/settings/InsightsPane.tsx
@@ -66,6 +66,7 @@ const NOT_ASSESSED_WORDING: Record<InsightsNotAssessedReason, string> = {
   incompleteEvidence:
     "Not assessed — evidence is incomplete, so a clean result cannot be claimed",
   evidenceContractIncomplete: "Not assessed — stored evidence cannot express this check yet",
+  signalMissing: "Not assessed — this session did not record the setting this check needs",
 }
 
 /** Reader-facing names for the quota limit-kind identifiers. */

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -142,6 +142,23 @@ pub struct TurnCounts {
     pub delegated: u64,
 }
 
+/// The `speed` label Claude's transcript uses for its fast-mode
+/// signal. `overuse_of_fast_mode` reads only this key from
+/// `ModelEvidence::fast_modes`; every other observed label (for
+/// example `"standard"`) never counts toward the finding.
+pub const FAST_SPEED_KEY: &str = "fast";
+
+/// Counts how many eligible turns carried one signal, and how many
+/// of those turns observed a value for it. `present_turns <
+/// eligible_turns` (including `0/0`) means the signal is missing,
+/// not that the session used it zero times.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignalCoverage {
+    pub eligible_turns: u64,
+    pub present_turns: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelEvidence {
@@ -150,6 +167,14 @@ pub struct ModelEvidence {
     pub effort_tiers: BTreeMap<String, TurnCounts>,
     pub fast_modes: BTreeMap<String, TurnCounts>,
     pub service_tiers: EvidenceValue<()>,
+    /// Reasoning-effort-tier coverage. Old persisted evidence has no
+    /// field here, so it deserializes as `0/0`, which reads as missing.
+    #[serde(default)]
+    pub effort_signal: SignalCoverage,
+    /// Fast-tier coverage. Old persisted evidence has no field here,
+    /// so it deserializes as `0/0`, which reads as missing.
+    #[serde(default)]
+    pub speed_signal: SignalCoverage,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -615,7 +640,7 @@ mod tests {
         truncated_strings: serde_json::Value,
     ) -> serde_json::Value {
         json!({
-            "schemaRevision": 3,
+            "schemaRevision": 4,
             "identity": {"agent": "claude", "sessionId": session_id},
             "context": {"state": "complete", "value": {"maxRequestContextTokens": 0, "topDepthExamples": []}},
             "capabilities": {
@@ -640,8 +665,8 @@ mod tests {
             "coverage": coverage,
             "provenance": {
                 "parserRevision": 5,
-                "analyzerRevision": 6,
-                "evidenceSchemaRevision": 3,
+                "analyzerRevision": 7,
+                "evidenceSchemaRevision": 4,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",
                 "ordering": "monotonic",
@@ -660,7 +685,7 @@ mod tests {
             "eligibility": {"state": "complete", "value": {"turns": 0, "assistantTurns": 0, "toolTurns": 0, "depthEligibleTurns": 0}},
             "tools": {"state": "complete", "value": {"byName": {}}},
             "contextSources": {"state": "complete", "value": {"skills": {}, "mcpServers": {}, "toolDefinitions": {"state": "unsupported"}}},
-            "models": {"state": "complete", "value": {"byModel": {}, "unattributedTurns": 0, "effortTiers": {}, "fastModes": {}, "serviceTiers": {"state": "unsupported"}}},
+            "models": {"state": "complete", "value": {"byModel": {}, "unattributedTurns": 0, "effortTiers": {}, "fastModes": {}, "serviceTiers": {"state": "unsupported"}, "effortSignal": {"eligibleTurns": 0, "presentTurns": 0}, "speedSignal": {"eligibleTurns": 0, "presentTurns": 0}}},
             "subagents": {"state": "complete", "value": {"spawnCount": 0, "delegatedTurns": 0, "delegatedModels": [], "children": [], "examples": []}},
             "cache": {"state": "complete", "value": {"cacheReadTokens": 0, "cacheCreationTokens": 0, "freshInputTokens": 0, "modelTransitions": [], "longestIdleGapMs": 0, "idleGapMsTotal": 0, "userControlledChurn": {"manualCompactions": 0}, "previousTurn": {"state": "complete", "value": null}, "providerEviction": {"state": "unsupported"}}},
             "compactions": {"state": "complete", "value": {"boundaries": []}},

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -268,15 +268,18 @@ impl SessionEvidenceAccumulator {
             } else {
                 self.unattributed_turns = self.unattributed_turns.saturating_add(1);
             }
-            // Every assistant turn (parent or delegated) is eligible to
-            // carry an effort or speed value, whether or not it does.
-            self.effort_eligible_turns = self.effort_eligible_turns.saturating_add(1);
-            self.speed_eligible_turns = self.speed_eligible_turns.saturating_add(1);
-            if event.thinking_mode.is_some() {
-                self.effort_present_turns = self.effort_present_turns.saturating_add(1);
-            }
-            if event.speed.is_some() {
-                self.speed_present_turns = self.speed_present_turns.saturating_add(1);
+            // Every model-attributed assistant turn (parent or delegated)
+            // is eligible to carry an effort or speed value. Synthetic
+            // records have no model and never carry a setting.
+            if event.model.is_some() {
+                self.effort_eligible_turns = self.effort_eligible_turns.saturating_add(1);
+                self.speed_eligible_turns = self.speed_eligible_turns.saturating_add(1);
+                if event.thinking_mode.is_some() {
+                    self.effort_present_turns = self.effort_present_turns.saturating_add(1);
+                }
+                if event.speed.is_some() {
+                    self.speed_present_turns = self.speed_present_turns.saturating_add(1);
+                }
             }
         }
         if let Some(tier) = event.thinking_mode.as_deref() {
@@ -1250,6 +1253,37 @@ mod tests {
             accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
         }
         accumulator.evidence()
+    }
+
+    #[test]
+    fn synthetic_assistant_turns_are_not_signal_eligible() {
+        // Claude writes zero-usage `<synthetic>` assistant records. The
+        // adapter blanks their model. They never carry effort or speed,
+        // so they must not count against signal coverage.
+        let mut accumulator = accumulator(true);
+        let mut real = assistant_event(0);
+        real.model = Some("model".to_owned());
+        real.thinking_mode = Some("high".to_owned());
+        real.speed = Some("standard".to_owned());
+        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(real)));
+        let mut synthetic = assistant_event(1);
+        synthetic.model = None;
+        synthetic.usage.input_tokens = 0;
+        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(synthetic)));
+
+        // The unattributed synthetic turn leaves the group partial. The
+        // coverage counts must still exclude it.
+        let EvidenceValue::Partial {
+            observed: models,
+            reason: CoverageReason::AttributionIncomplete,
+        } = accumulator.evidence().models
+        else {
+            panic!("expected attribution-incomplete model evidence");
+        };
+        assert_eq!(models.effort_signal.eligible_turns, 1);
+        assert_eq!(models.effort_signal.present_turns, 1);
+        assert_eq!(models.speed_signal.eligible_turns, 1);
+        assert_eq!(models.speed_signal.present_turns, 1);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -7,7 +7,7 @@ use crate::analysis::evidence::{
     MAX_EVIDENCE_EXAMPLES, MAX_MODEL_TRANSITIONS, MAX_MODELS, MAX_SUBAGENT_CHILDREN,
     MAX_SUBAGENT_MODELS, MAX_TIER_LABELS, MAX_TOOL_NAMES, MAX_UNRECOGNIZED_TYPES, ModelEvidence,
     ModelTokens, ModelTransition, OrderingObservation, ParseDiagnostics, RelationConfidence,
-    SessionEvidence, SessionEvidenceIdentity, SessionProvenance, SessionTimeRange,
+    SessionEvidence, SessionEvidenceIdentity, SessionProvenance, SessionTimeRange, SignalCoverage,
     SourceAcceptance, SourceCapabilities, SourceKind, SubagentChild, SubagentEvidence,
     SubagentExample, ToolClass, ToolEvidence, ToolUse, TurnCounts, cap_string,
     insert_diagnostic_field, record_diagnostic_set_cap,
@@ -50,6 +50,10 @@ pub struct SessionEvidenceAccumulator {
     unattributed_turns: u64,
     effort_tiers: BTreeMap<String, TurnCounts>,
     fast_modes: BTreeMap<String, TurnCounts>,
+    effort_eligible_turns: u64,
+    effort_present_turns: u64,
+    speed_eligible_turns: u64,
+    speed_present_turns: u64,
     models_cap_exceeded: bool,
     subagent_spawn_count: u64,
     delegated_turns: u64,
@@ -110,6 +114,10 @@ impl SessionEvidenceAccumulator {
             unattributed_turns: 0,
             effort_tiers: BTreeMap::new(),
             fast_modes: BTreeMap::new(),
+            effort_eligible_turns: 0,
+            effort_present_turns: 0,
+            speed_eligible_turns: 0,
+            speed_present_turns: 0,
             models_cap_exceeded: false,
             subagent_spawn_count: 0,
             delegated_turns: 0,
@@ -259,6 +267,16 @@ impl SessionEvidenceAccumulator {
                 }
             } else {
                 self.unattributed_turns = self.unattributed_turns.saturating_add(1);
+            }
+            // Every assistant turn (parent or delegated) is eligible to
+            // carry an effort or speed value, whether or not it does.
+            self.effort_eligible_turns = self.effort_eligible_turns.saturating_add(1);
+            self.speed_eligible_turns = self.speed_eligible_turns.saturating_add(1);
+            if event.thinking_mode.is_some() {
+                self.effort_present_turns = self.effort_present_turns.saturating_add(1);
+            }
+            if event.speed.is_some() {
+                self.speed_present_turns = self.speed_present_turns.saturating_add(1);
             }
         }
         if let Some(tier) = event.thinking_mode.as_deref() {
@@ -630,6 +648,14 @@ impl SessionEvidenceAccumulator {
             effort_tiers: self.effort_tiers.clone(),
             fast_modes: self.fast_modes.clone(),
             service_tiers: EvidenceValue::Unsupported,
+            effort_signal: SignalCoverage {
+                eligible_turns: self.effort_eligible_turns,
+                present_turns: self.effort_present_turns,
+            },
+            speed_signal: SignalCoverage {
+                eligible_turns: self.speed_eligible_turns,
+                present_turns: self.speed_present_turns,
+            },
         };
         let subagents = SubagentEvidence {
             spawn_count: self.subagent_spawn_count,

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -50,12 +50,12 @@ pub use engine::{
 pub use evidence::{
     CacheEvidence, ChurnCounts, CompactionBoundary, CompactionEvidence, ContextEvidence,
     ContextSourceEvidence, CoverageReason, DepthExample, EVIDENCE_STRING_CAP, EligibilityEvidence,
-    EvidenceCoverage, EvidenceSource, EvidenceValue, LoadedSource, ModelEvidence, ModelTokens,
-    ModelTransition, OrderingObservation, ParseDiagnostics, QuotaConfidence, QuotaHitSeverity,
-    QuotaIncident, QuotaLimitKind, RelationConfidence, SessionEvidence, SessionEvidenceIdentity,
-    SessionProvenance, SessionQuotaEvidence, SessionTimeRange, SourceAcceptance,
-    SourceCapabilities, SourceKind, SubagentChild, SubagentEvidence, SubagentExample, ToolClass,
-    ToolEvidence, ToolUse, TurnCounts,
+    EvidenceCoverage, EvidenceSource, EvidenceValue, FAST_SPEED_KEY, LoadedSource, ModelEvidence,
+    ModelTokens, ModelTransition, OrderingObservation, ParseDiagnostics, QuotaConfidence,
+    QuotaHitSeverity, QuotaIncident, QuotaLimitKind, RelationConfidence, SessionEvidence,
+    SessionEvidenceIdentity, SessionProvenance, SessionQuotaEvidence, SessionTimeRange,
+    SignalCoverage, SourceAcceptance, SourceCapabilities, SourceKind, SubagentChild,
+    SubagentEvidence, SubagentExample, ToolClass, ToolEvidence, ToolUse, TurnCounts,
 };
 pub use evidence_sink::{CompositeSink, SessionEvidenceAccumulator};
 pub use framing::{
@@ -82,9 +82,9 @@ pub use vendors::pi::PiAdapter;
 pub use vendors::{adapter_for, has_dedicated_adapter};
 
 pub const PARSER_REVISION: i64 = 5;
-pub const ANALYZER_REVISION: i64 = 6;
+pub const ANALYZER_REVISION: i64 = 7;
 pub const METRICS_SCHEMA_REVISION: i64 = 1;
-pub const EVIDENCE_SCHEMA_REVISION: i64 = 3;
+pub const EVIDENCE_SCHEMA_REVISION: i64 = 4;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/insights/badges.rs
+++ b/crates/antiburn-local/src/insights/badges.rs
@@ -84,6 +84,7 @@ fn badge_status(
         Observation::ContractIncomplete => {
             BadgeStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete)
         }
+        Observation::SignalMissing => BadgeStatus::NotAssessed(NotAssessedReason::SignalMissing),
         Observation::NoFinding => {
             let groups_complete = required
                 .groups
@@ -252,16 +253,41 @@ mod tests {
         }
     }
 
+    /// Three badges never carry the generic zero-turn expectation:
+    /// Obsolete Model reports the empty-catalog contract gap, and
+    /// Model Overthinking / Fast Mode Overuse report a missing signal,
+    /// because the synthetic evidence carries zero eligible turns.
+    fn zero_turn_override(id: BadgeId) -> Option<BadgeStatus> {
+        match id {
+            BadgeId::ObsoleteModel => Some(BadgeStatus::NotAssessed(
+                NotAssessedReason::EvidenceContractIncomplete,
+            )),
+            BadgeId::ModelOverthinking | BadgeId::FastModeOveruse => {
+                Some(BadgeStatus::NotAssessed(NotAssessedReason::SignalMissing))
+            }
+            _ => None,
+        }
+    }
+
+    fn zero_turn_override_detector(id: BadgeId) -> Option<DetectorStatus> {
+        match zero_turn_override(id)? {
+            BadgeStatus::NotAssessed(reason) => Some(DetectorStatus::NotAssessed(reason)),
+            BadgeStatus::Clean => Some(DetectorStatus::Clean),
+            BadgeStatus::Finding => None,
+        }
+    }
+
     #[test]
     fn partial_coverage_without_a_signal_never_reads_clean() {
         let mut evidence = claude_evidence("synthetic-partial");
         evidence.coverage = EvidenceCoverage::Partial(CoverageReason::MalformedRecord);
 
         for result in session_badges(&evidence, &ReportCatalogs::default()) {
-            assert_eq!(
-                result.status,
-                BadgeStatus::NotAssessed(NotAssessedReason::IncompleteEvidence)
-            );
+            // Every other badge reports the session-wide partial coverage.
+            let expected = zero_turn_override(result.id).unwrap_or(BadgeStatus::NotAssessed(
+                NotAssessedReason::IncompleteEvidence,
+            ));
+            assert_eq!(result.status, expected, "{:?}", result.id);
         }
     }
 
@@ -287,7 +313,8 @@ mod tests {
         let evidence = claude_evidence("synthetic-clean");
 
         for result in session_badges(&evidence, &ReportCatalogs::default()) {
-            assert_eq!(result.status, BadgeStatus::Clean);
+            let expected = zero_turn_override(result.id).unwrap_or(BadgeStatus::Clean);
+            assert_eq!(result.status, expected, "{:?}", result.id);
         }
     }
 
@@ -356,17 +383,20 @@ mod tests {
         evidence.coverage = EvidenceCoverage::Partial(CoverageReason::MalformedRecord);
 
         for badge in session_badges(&evidence, &ReportCatalogs::default()) {
-            assert_eq!(
-                badge.status,
-                BadgeStatus::NotAssessed(NotAssessedReason::IncompleteEvidence),
-                "{:?}",
-                badge.id
-            );
+            // Obsolete Model, Model Overthinking, and Fast Mode Overuse
+            // report their own not-assessed reason on both sides
+            // regardless of session-wide coverage, so they sit outside
+            // this test's badge-vs-report divergence claim.
+            let expected = zero_turn_override(badge.id).unwrap_or(BadgeStatus::NotAssessed(
+                NotAssessedReason::IncompleteEvidence,
+            ));
+            assert_eq!(badge.status, expected, "{:?}", badge.id);
         }
         for id in BadgeId::ALL {
+            let expected = zero_turn_override_detector(id).unwrap_or(DetectorStatus::Clean);
             assert_eq!(
                 report_status(evidence.clone(), id.detector(), &ReportCatalogs::default()),
-                DetectorStatus::Clean,
+                expected,
                 "{id:?}"
             );
         }

--- a/crates/antiburn-local/src/insights/detectors/mod.rs
+++ b/crates/antiburn-local/src/insights/detectors/mod.rs
@@ -48,6 +48,9 @@ pub enum NotAssessedReason {
     /// The evidence schema does not yet carry the payload the rule
     /// needs, so neither a finding nor clean is expressible.
     EvidenceContractIncomplete,
+    /// The source supports the signal, but too few turns in this
+    /// session carried it to trust an absence conclusion.
+    SignalMissing,
 }
 
 /// Bounded finding summary for one detector.
@@ -67,6 +70,9 @@ pub(crate) enum Observation {
     NoFinding,
     /// The evidence contract cannot express the fact the rule needs.
     ContractIncomplete,
+    /// The source supports the signal, but too few turns in this
+    /// session carried it to trust an absence conclusion.
+    SignalMissing,
 }
 
 /// Bounded per-detector fold state across the assessed cohort.
@@ -75,6 +81,7 @@ pub(crate) struct DetectorFold {
     pub finding_sessions: u64,
     pub examples: Vec<SessionExample>,
     pub contract_incomplete: u64,
+    pub signal_missing: u64,
 }
 
 impl DetectorFold {
@@ -91,6 +98,7 @@ impl DetectorFold {
             }
             Observation::NoFinding => {}
             Observation::ContractIncomplete => self.contract_incomplete += 1,
+            Observation::SignalMissing => self.signal_missing += 1,
         }
     }
 }
@@ -126,7 +134,7 @@ pub struct ReportCatalogs {
 impl Default for ReportCatalogs {
     fn default() -> Self {
         Self {
-            revision: 2,
+            revision: 3,
             depth_cap_tokens: 160_000,
             effort_tiers_above_cap: ["max", "ultrathink", "xhigh"]
                 .into_iter()
@@ -215,6 +223,9 @@ pub(crate) fn status(
     if fold.contract_incomplete > 0 {
         return DetectorStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete);
     }
+    if fold.signal_missing > 0 {
+        return DetectorStatus::NotAssessed(NotAssessedReason::SignalMissing);
+    }
     if counts.assessed == counts.eligible {
         return DetectorStatus::Clean;
     }
@@ -272,6 +283,7 @@ mod tests {
             finding_sessions: 2,
             examples: Vec::new(),
             contract_incomplete: 1,
+            signal_missing: 0,
         };
 
         assert!(matches!(
@@ -315,11 +327,27 @@ mod tests {
             finding_sessions: 0,
             examples: Vec::new(),
             contract_incomplete: 1,
+            signal_missing: 0,
         };
 
         assert_eq!(
             status(counts(2, 2), fold, 2),
             DetectorStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete)
+        );
+    }
+
+    #[test]
+    fn signal_missing_sessions_prevent_clean() {
+        let fold = DetectorFold {
+            finding_sessions: 0,
+            examples: Vec::new(),
+            contract_incomplete: 0,
+            signal_missing: 1,
+        };
+
+        assert_eq!(
+            status(counts(2, 2), fold, 2),
+            DetectorStatus::NotAssessed(NotAssessedReason::SignalMissing)
         );
     }
 

--- a/crates/antiburn-local/src/insights/detectors/model_overthinking.rs
+++ b/crates/antiburn-local/src/insights/detectors/model_overthinking.rs
@@ -9,6 +9,10 @@
 //!   above-cap tier with turns proves presence.
 //! - Partial model evidence prevents clean. A missed record may hide
 //!   an above-cap tier, so absence cannot be concluded.
+//! - A finding still wins on partial effort-signal coverage. Otherwise,
+//!   when fewer eligible turns carried an effort value than the source
+//!   saw (including zero eligible turns), the rule reports the signal
+//!   as missing instead of clean.
 
 use crate::analysis::SessionEvidence;
 
@@ -23,6 +27,10 @@ pub(crate) fn evaluate(evidence: &SessionEvidence, catalogs: &ReportCatalogs) ->
                 return Observation::Finding;
             }
         }
+        let coverage = models.effort_signal;
+        if coverage.eligible_turns == 0 || coverage.present_turns < coverage.eligible_turns {
+            return Observation::SignalMissing;
+        }
     }
     Observation::NoFinding
 }
@@ -31,8 +39,10 @@ pub(crate) fn evaluate(evidence: &SessionEvidence, catalogs: &ReportCatalogs) ->
 mod tests {
     use super::super::test_support::claude_evidence;
     use super::*;
-    use crate::analysis::{CoverageReason, EvidenceValue, TurnCounts};
+    use crate::analysis::{CoverageReason, EvidenceValue, SignalCoverage, TurnCounts};
 
+    /// Builds evidence with one effort-tier entry and full effort-
+    /// signal coverage: every eligible turn carried an effort value.
     fn with_tier(tier: &str, partial: bool) -> SessionEvidence {
         let mut evidence = claude_evidence("effort");
         let EvidenceValue::Complete(mut models) = evidence.models else {
@@ -45,6 +55,10 @@ mod tests {
                 delegated: 0,
             },
         );
+        models.effort_signal = SignalCoverage {
+            eligible_turns: 1,
+            present_turns: 1,
+        };
         evidence.models = if partial {
             EvidenceValue::Partial {
                 observed: models,
@@ -79,5 +93,46 @@ mod tests {
             evaluate(&with_tier("medium", false), &catalogs),
             Observation::NoFinding
         );
+    }
+
+    #[test]
+    fn zero_eligible_effort_turns_report_the_signal_as_missing() {
+        let catalogs = ReportCatalogs::default();
+        let evidence = claude_evidence("no-eligible-turns");
+
+        assert_eq!(evaluate(&evidence, &catalogs), Observation::SignalMissing);
+    }
+
+    #[test]
+    fn partial_effort_signal_coverage_without_a_finding_is_signal_missing() {
+        let catalogs = ReportCatalogs::default();
+        let mut evidence = claude_evidence("partial-effort-coverage");
+        let EvidenceValue::Complete(mut models) = evidence.models else {
+            unreachable!()
+        };
+        models.effort_signal = SignalCoverage {
+            eligible_turns: 3,
+            present_turns: 1,
+        };
+        evidence.models = EvidenceValue::Complete(models);
+
+        assert_eq!(evaluate(&evidence, &catalogs), Observation::SignalMissing);
+    }
+
+    #[test]
+    fn a_finding_wins_over_partial_effort_signal_coverage() {
+        let catalogs = ReportCatalogs::default();
+        let tier = catalogs.effort_tiers_above_cap.first().unwrap().clone();
+        let mut evidence = with_tier(&tier, false);
+        let EvidenceValue::Complete(mut models) = evidence.models else {
+            unreachable!()
+        };
+        models.effort_signal = SignalCoverage {
+            eligible_turns: 3,
+            present_turns: 1,
+        };
+        evidence.models = EvidenceValue::Complete(models);
+
+        assert_eq!(evaluate(&evidence, &catalogs), Observation::Finding);
     }
 }

--- a/crates/antiburn-local/src/insights/detectors/old_model_usage.rs
+++ b/crates/antiburn-local/src/insights/detectors/old_model_usage.rs
@@ -14,12 +14,17 @@
 //!   contract gap: the rule cannot place the usage relative to the
 //!   replacement's availability, so the session never supports clean.
 //!   An observed finding elsewhere in the session still wins.
+//! - An empty replacement catalog reports the contract gap. No entry
+//!   in the catalog can prove that no deprecated model ran.
 
 use crate::analysis::SessionEvidence;
 
 use super::{Observation, ReportCatalogs, observed};
 
 pub(crate) fn evaluate(evidence: &SessionEvidence, catalogs: &ReportCatalogs) -> Observation {
+    if catalogs.model_replacements.is_empty() {
+        return Observation::ContractIncomplete;
+    }
     let mut missing_timestamp = false;
     if let Some(models) = observed(&evidence.models) {
         for (model, tokens) in &models.by_model {
@@ -158,5 +163,18 @@ mod tests {
         insert_model(&mut evidence, "old-model-3", 200);
 
         assert_eq!(evaluate(&evidence, &catalogs()), Observation::Finding);
+    }
+
+    #[test]
+    fn an_empty_replacement_registry_reports_the_contract_gap() {
+        // Production ships with an empty catalog. An empty catalog can
+        // never prove absence of deprecated-model usage, so the rule
+        // must not read as no-finding.
+        let evidence = with_model("any-model", 200, false);
+
+        assert_eq!(
+            evaluate(&evidence, &ReportCatalogs::default()),
+            Observation::ContractIncomplete
+        );
     }
 }

--- a/crates/antiburn-local/src/insights/detectors/overuse_of_fast_mode.rs
+++ b/crates/antiburn-local/src/insights/detectors/overuse_of_fast_mode.rs
@@ -13,8 +13,15 @@
 //!   gap: the eligibility clause admits a session on service-tier
 //!   alone, but `ModelEvidence::service_tiers` is a bare marker the
 //!   rule cannot read, so neither a finding nor clean is expressible.
+//! - The rule counts only the `FAST_SPEED_KEY` entry. Any other
+//!   observed speed label (for example `"standard"`) never counts
+//!   toward the finding.
+//! - A finding still wins on partial speed-signal coverage. Otherwise,
+//!   when fewer eligible turns carried a speed value than the source
+//!   saw (including zero eligible turns), the rule reports the signal
+//!   as missing instead of clean.
 
-use crate::analysis::SessionEvidence;
+use crate::analysis::{FAST_SPEED_KEY, SessionEvidence};
 
 use super::{Observation, ReportCatalogs, observed};
 
@@ -28,13 +35,16 @@ pub(crate) fn evaluate(evidence: &SessionEvidence, catalogs: &ReportCatalogs) ->
         return Observation::ContractIncomplete;
     }
     if let Some(models) = observed(&evidence.models) {
-        let delegated: u64 = models
+        let delegated = models
             .fast_modes
-            .values()
-            .map(|turns| turns.delegated)
-            .sum();
+            .get(FAST_SPEED_KEY)
+            .map_or(0, |turns| turns.delegated);
         if delegated > 0 && delegated >= catalogs.fast_mode_delegated_turns_threshold {
             return Observation::Finding;
+        }
+        let coverage = models.speed_signal;
+        if coverage.eligible_turns == 0 || coverage.present_turns < coverage.eligible_turns {
+            return Observation::SignalMissing;
         }
     }
     Observation::NoFinding
@@ -44,20 +54,36 @@ pub(crate) fn evaluate(evidence: &SessionEvidence, catalogs: &ReportCatalogs) ->
 mod tests {
     use super::super::test_support::claude_evidence;
     use super::*;
-    use crate::analysis::{CoverageReason, EvidenceValue, TurnCounts};
+    use crate::analysis::{CoverageReason, EvidenceValue, SignalCoverage, TurnCounts};
 
+    /// Builds evidence with one `FAST_SPEED_KEY` entry and full speed-
+    /// signal coverage: every eligible turn carried a speed value.
     fn with_fast_turns(main_loop: u64, delegated: u64, partial: bool) -> SessionEvidence {
+        with_speed_entry(FAST_SPEED_KEY, main_loop, delegated, partial)
+    }
+
+    fn with_speed_entry(
+        label: &str,
+        main_loop: u64,
+        delegated: u64,
+        partial: bool,
+    ) -> SessionEvidence {
         let mut evidence = claude_evidence("fast");
         let EvidenceValue::Complete(mut models) = evidence.models else {
             unreachable!()
         };
         models.fast_modes.insert(
-            "fast".to_owned(),
+            label.to_owned(),
             TurnCounts {
                 main_loop,
                 delegated,
             },
         );
+        let turns = main_loop + delegated;
+        models.speed_signal = SignalCoverage {
+            eligible_turns: turns,
+            present_turns: turns,
+        };
         evidence.models = if partial {
             EvidenceValue::Partial {
                 observed: models,
@@ -94,6 +120,18 @@ mod tests {
     }
 
     #[test]
+    fn a_delegated_standard_turn_never_counts_as_fast_mode_overuse() {
+        // A delegated turn on the "standard" speed label must never
+        // produce a finding: only the FAST_SPEED_KEY entry counts.
+        let catalogs = ReportCatalogs::default();
+
+        assert_eq!(
+            evaluate(&with_speed_entry("standard", 0, 1, false), &catalogs),
+            Observation::NoFinding
+        );
+    }
+
+    #[test]
     fn a_service_tier_only_source_reports_the_contract_gap() {
         let catalogs = ReportCatalogs::default();
         let mut evidence = claude_evidence("service-tier-only");
@@ -104,5 +142,45 @@ mod tests {
             evaluate(&evidence, &catalogs),
             Observation::ContractIncomplete
         );
+    }
+
+    #[test]
+    fn zero_eligible_speed_turns_report_the_signal_as_missing() {
+        let catalogs = ReportCatalogs::default();
+        let evidence = claude_evidence("no-eligible-turns");
+
+        assert_eq!(evaluate(&evidence, &catalogs), Observation::SignalMissing);
+    }
+
+    #[test]
+    fn partial_speed_signal_coverage_without_a_finding_is_signal_missing() {
+        let catalogs = ReportCatalogs::default();
+        let mut evidence = claude_evidence("partial-speed-coverage");
+        let EvidenceValue::Complete(mut models) = evidence.models else {
+            unreachable!()
+        };
+        models.speed_signal = SignalCoverage {
+            eligible_turns: 3,
+            present_turns: 1,
+        };
+        evidence.models = EvidenceValue::Complete(models);
+
+        assert_eq!(evaluate(&evidence, &catalogs), Observation::SignalMissing);
+    }
+
+    #[test]
+    fn a_finding_wins_over_partial_speed_signal_coverage() {
+        let catalogs = ReportCatalogs::default();
+        let mut evidence = with_fast_turns(0, 1, false);
+        let EvidenceValue::Complete(mut models) = evidence.models else {
+            unreachable!()
+        };
+        models.speed_signal = SignalCoverage {
+            eligible_turns: 3,
+            present_turns: 1,
+        };
+        evidence.models = EvidenceValue::Complete(models);
+
+        assert_eq!(evaluate(&evidence, &catalogs), Observation::Finding);
     }
 }

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -448,7 +448,7 @@ mod tests {
     use crate::analysis::{
         ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, EvidenceSource, ModelTokens, PARSER_REVISION,
         QuotaConfidence, QuotaHitSeverity, QuotaIncident, QuotaLimitKind,
-        SessionEvidenceAccumulator, SessionQuotaEvidence, SourceKind, TurnCounts,
+        SessionEvidenceAccumulator, SessionQuotaEvidence, SignalCoverage, SourceKind, TurnCounts,
     };
     use crate::insights::detectors::{ModelReplacement, NotAssessedReason};
     use crate::insights::quota::QuotaPressureSection;
@@ -465,13 +465,26 @@ mod tests {
 
     /// The same claude evidence with one observed assistant turn, so
     /// the zero-work denominator exclusion does not remove the session
-    /// from the absence detectors' eligible denominators.
+    /// from the absence detectors' eligible denominators. The one turn
+    /// carries full effort and speed signal coverage, so Model
+    /// Overthinking and Overuse of Fast Mode can read clean from it.
     fn evidence_with_work(session_id: &str) -> SessionEvidence {
         let mut row = evidence(session_id);
         let EvidenceValue::Complete(eligibility) = &mut row.eligibility else {
             unreachable!()
         };
         eligibility.assistant_turns = 1;
+        let EvidenceValue::Complete(models) = &mut row.models else {
+            unreachable!()
+        };
+        models.effort_signal = SignalCoverage {
+            eligible_turns: 1,
+            present_turns: 1,
+        };
+        models.speed_signal = SignalCoverage {
+            eligible_turns: 1,
+            present_turns: 1,
+        };
         row
     }
 
@@ -644,7 +657,7 @@ mod tests {
             ),
         ];
         for (fast_tier, service_tier, expected_status) in cases {
-            let mut row = evidence("mode");
+            let mut row = evidence_with_work("mode");
             row.capabilities.fast_tier = fast_tier;
             row.capabilities.service_tier = service_tier;
             let mut accumulator = EfficiencyReportAccumulator::new();
@@ -837,7 +850,6 @@ mod tests {
             DetectorId::OverpoweredSubagents,
             DetectorId::UnusedMcpServers,
             DetectorId::UnusedSkills,
-            DetectorId::OldModelUsage,
             DetectorId::OveruseOfFastMode,
             DetectorId::CacheChurn,
         ] {
@@ -850,6 +862,12 @@ mod tests {
         assert_eq!(
             report.detector_statuses[DetectorId::UnusedBuiltInTools.index()],
             DetectorStatus::NotAssessed(NotAssessedReason::CapabilityMissing)
+        );
+        // The production catalog default carries no curated deprecated
+        // models, so the rule can never prove absence.
+        assert_eq!(
+            report.detector_statuses[DetectorId::OldModelUsage.index()],
+            DetectorStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete)
         );
     }
 
@@ -1023,6 +1041,15 @@ mod tests {
                     DetectorStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete),
                     "baseline for {detector:?}"
                 );
+            } else if detector == DetectorId::OldModelUsage {
+                // The production catalog default carries no curated
+                // deprecated models: even the undegraded baseline
+                // cannot read clean.
+                assert_eq!(
+                    baseline,
+                    DetectorStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete),
+                    "baseline for {detector:?}"
+                );
             } else {
                 assert_eq!(
                     baseline,
@@ -1049,7 +1076,7 @@ mod tests {
         // One of two eligible sessions carries only partial model
         // evidence and shows no finding. Overthinking must not read
         // clean from that incomplete absence.
-        let mut partial = evidence("partial");
+        let mut partial = evidence_with_work("partial");
         partial.models = match partial.models {
             EvidenceValue::Complete(observed) => EvidenceValue::Partial {
                 observed,
@@ -1058,7 +1085,7 @@ mod tests {
             _ => unreachable!(),
         };
         let mut accumulator = EfficiencyReportAccumulator::new();
-        accumulator.observe_session(evidence("complete"));
+        accumulator.observe_session(evidence_with_work("complete"));
         accumulator.observe_session(partial);
         let report = accumulator.finish(context(CoverageCounts::default()));
 

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -115,6 +115,10 @@
               "turns": 1
             }
           },
+          "effortSignal": {
+            "eligibleTurns": 1,
+            "presentTurns": 1
+          },
           "effortTiers": {
             "low": {
               "delegated": 0,
@@ -125,14 +129,18 @@
           "serviceTiers": {
             "state": "unsupported"
           },
+          "speedSignal": {
+            "eligibleTurns": 1,
+            "presentTurns": 0
+          },
           "unattributedTurns": 0
         },
         "reason": "malformed_record"
       }
     },
     "provenance": {
-      "analyzerRevision": 6,
-      "evidenceSchemaRevision": 3,
+      "analyzerRevision": 7,
+      "evidenceSchemaRevision": 4,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -144,7 +152,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 3,
+    "schemaRevision": 4,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -105,6 +105,10 @@
             "turns": 4
           }
         },
+        "effortSignal": {
+          "eligibleTurns": 4,
+          "presentTurns": 4
+        },
         "effortTiers": {
           "medium": {
             "delegated": 0,
@@ -115,12 +119,16 @@
         "serviceTiers": {
           "state": "unsupported"
         },
+        "speedSignal": {
+          "eligibleTurns": 4,
+          "presentTurns": 0
+        },
         "unattributedTurns": 0
       }
     },
     "provenance": {
-      "analyzerRevision": 6,
-      "evidenceSchemaRevision": 3,
+      "analyzerRevision": 7,
+      "evidenceSchemaRevision": 4,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -132,7 +140,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 3,
+    "schemaRevision": 4,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -101,10 +101,18 @@
       "value": {
         "observed": {
           "byModel": {},
+          "effortSignal": {
+            "eligibleTurns": 0,
+            "presentTurns": 0
+          },
           "effortTiers": {},
           "fastModes": {},
           "serviceTiers": {
             "state": "unsupported"
+          },
+          "speedSignal": {
+            "eligibleTurns": 0,
+            "presentTurns": 0
           },
           "unattributedTurns": 0
         },
@@ -112,8 +120,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 6,
-      "evidenceSchemaRevision": 3,
+      "analyzerRevision": 7,
+      "evidenceSchemaRevision": 4,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -125,7 +133,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 3,
+    "schemaRevision": 4,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -92,17 +92,25 @@
             "turns": 1
           }
         },
+        "effortSignal": {
+          "eligibleTurns": 1,
+          "presentTurns": 0
+        },
         "effortTiers": {},
         "fastModes": {},
         "serviceTiers": {
           "state": "unsupported"
         },
+        "speedSignal": {
+          "eligibleTurns": 1,
+          "presentTurns": 0
+        },
         "unattributedTurns": 0
       }
     },
     "provenance": {
-      "analyzerRevision": 6,
-      "evidenceSchemaRevision": 3,
+      "analyzerRevision": 7,
+      "evidenceSchemaRevision": 4,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -114,7 +122,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 3,
+    "schemaRevision": 4,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -119,10 +119,18 @@
               "turns": 1
             }
           },
+          "effortSignal": {
+            "eligibleTurns": 1,
+            "presentTurns": 0
+          },
           "effortTiers": {},
           "fastModes": {},
           "serviceTiers": {
             "state": "unsupported"
+          },
+          "speedSignal": {
+            "eligibleTurns": 1,
+            "presentTurns": 0
           },
           "unattributedTurns": 0
         },
@@ -130,8 +138,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 6,
-      "evidenceSchemaRevision": 3,
+      "analyzerRevision": 7,
+      "evidenceSchemaRevision": 4,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -143,7 +151,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 3,
+    "schemaRevision": 4,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -101,10 +101,18 @@
       "value": {
         "observed": {
           "byModel": {},
+          "effortSignal": {
+            "eligibleTurns": 0,
+            "presentTurns": 0
+          },
           "effortTiers": {},
           "fastModes": {},
           "serviceTiers": {
             "state": "unsupported"
+          },
+          "speedSignal": {
+            "eligibleTurns": 0,
+            "presentTurns": 0
           },
           "unattributedTurns": 0
         },
@@ -112,8 +120,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 6,
-      "evidenceSchemaRevision": 3,
+      "analyzerRevision": 7,
+      "evidenceSchemaRevision": 4,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -125,7 +133,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 3,
+    "schemaRevision": 4,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -103,17 +103,25 @@
             "turns": 2
           }
         },
+        "effortSignal": {
+          "eligibleTurns": 2,
+          "presentTurns": 0
+        },
         "effortTiers": {},
         "fastModes": {},
         "serviceTiers": {
           "state": "unsupported"
         },
+        "speedSignal": {
+          "eligibleTurns": 2,
+          "presentTurns": 0
+        },
         "unattributedTurns": 0
       }
     },
     "provenance": {
-      "analyzerRevision": 6,
-      "evidenceSchemaRevision": 3,
+      "analyzerRevision": 7,
+      "evidenceSchemaRevision": 4,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -125,7 +133,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 3,
+    "schemaRevision": 4,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/pi_characterization.rs
+++ b/crates/antiburn-local/tests/pi_characterization.rs
@@ -890,9 +890,13 @@ fn pi_badges_follow_the_merged_session_coverage_policy() {
         complete_badges.map(|badge| badge.status),
         [
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
-            BadgeStatus::Clean,
+            // The fixture's assistant turns carry no effort value, so
+            // zero eligible turns means the effort signal is missing.
+            BadgeStatus::NotAssessed(NotAssessedReason::SignalMissing),
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
-            BadgeStatus::Clean,
+            // The production catalog default carries no curated
+            // deprecated models, so the rule can never prove absence.
+            BadgeStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete),
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
         ]
@@ -905,9 +909,13 @@ fn pi_badges_follow_the_merged_session_coverage_policy() {
         partial_badges.map(|badge| badge.status),
         [
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
-            BadgeStatus::NotAssessed(NotAssessedReason::IncompleteEvidence),
+            // The fixture's assistant turns carry no effort value, so
+            // zero eligible turns means the effort signal is missing.
+            BadgeStatus::NotAssessed(NotAssessedReason::SignalMissing),
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
-            BadgeStatus::NotAssessed(NotAssessedReason::IncompleteEvidence),
+            // The production catalog default carries no curated
+            // deprecated models, so the rule can never prove absence.
+            BadgeStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete),
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
             BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing),
         ]

--- a/crates/antiburn-local/tests/unrecognized_records.rs
+++ b/crates/antiburn-local/tests/unrecognized_records.rs
@@ -44,9 +44,11 @@ fn an_inert_unknown_session_enters_the_denominator_and_is_assessed() {
     let counts = report.detectors[DetectorId::ModelOverthinking.index()];
     assert_eq!(counts.eligible, 1);
     assert_eq!(counts.assessed, 1);
+    // The session carries zero assistant turns, so zero turns are
+    // eligible to carry an effort value: the signal reads as missing.
     assert_eq!(
         report.detector_statuses[DetectorId::ModelOverthinking.index()],
-        DetectorStatus::Clean
+        DetectorStatus::NotAssessed(NotAssessedReason::SignalMissing)
     );
     assert_eq!(report.unrecognized_records.sessions_with_types, 1);
     assert_eq!(report.unrecognized_records.inert_sessions, 1);
@@ -92,9 +94,11 @@ fn an_unrecognized_role_with_usage_fails_closed_and_keeps_neighbours() {
     let counts = report.detectors[DetectorId::ModelOverthinking.index()];
     assert_eq!(counts.eligible, 1);
     assert_eq!(counts.assessed, 0);
+    // The session carries zero assistant turns, so zero turns are
+    // eligible to carry an effort value: the signal reads as missing.
     assert_eq!(
         report.detector_statuses[DetectorId::ModelOverthinking.index()],
-        DetectorStatus::NotAssessed(NotAssessedReason::IncompleteEvidence)
+        DetectorStatus::NotAssessed(NotAssessedReason::SignalMissing)
     );
 }
 
@@ -246,9 +250,11 @@ fn a_capped_unknown_session_is_eligible_but_not_assessed() {
     assert_eq!(report.unrecognized_records.capped_sessions, 1);
     assert_eq!(report.unrecognized_records.truncated_sessions, 0);
     assert!(report.unrecognized_records.types_truncated);
+    // The session carries zero assistant turns, so zero turns are
+    // eligible to carry an effort value: the signal reads as missing.
     assert_eq!(
         report.detector_statuses[DetectorId::ModelOverthinking.index()],
-        DetectorStatus::NotAssessed(NotAssessedReason::IncompleteEvidence)
+        DetectorStatus::NotAssessed(NotAssessedReason::SignalMissing)
     );
 }
 
@@ -273,9 +279,11 @@ fn an_overlong_type_is_truncated_without_claiming_set_overflow() {
     let counts = report.detectors[DetectorId::ModelOverthinking.index()];
     assert_eq!(counts.eligible, 1);
     assert_eq!(counts.assessed, 0);
+    // The session carries zero assistant turns, so zero turns are
+    // eligible to carry an effort value: the signal reads as missing.
     assert_eq!(
         report.detector_statuses[DetectorId::ModelOverthinking.index()],
-        DetectorStatus::NotAssessed(NotAssessedReason::IncompleteEvidence)
+        DetectorStatus::NotAssessed(NotAssessedReason::SignalMissing)
     );
 
     let summary = report.unrecognized_records;


### PR DESCRIPTION
## Summary

Seam 1 of the session evidence harness parity plan (#259, rev 2): the four confirmed honesty defects, each with a failing-then-passing test.

- **Empty replacement registry** reported Clean. `ReportCatalogs::default()` has no rules; `old_model_usage` now returns the contract gap, so the badge and report read `evidenceContractIncomplete`.
- **Fast-mode overuse summed every speed label.** A delegated `standard` turn fired a finding. The numerator now reads only `FAST_SPEED_KEY`.
- **Missing effort/speed signals read Clean.** `ModelEvidence` gains `effortSignal` / `speedSignal` `{eligibleTurns, presentTurns}`. New `NotAssessedReason::SignalMissing` (`signalMissing`) in the Rust DTO, the TS union, and both wording maps. A finding still wins on partial coverage; incomplete coverage never reads clean.
- **Not-assessed tooltip showed finding wording** ("Obsolete model detected"). Every presentation branch now carries a verdict-free `name`. The shared name for `excessCacheRehydration` becomes "Excess context reprocessing"; the ID is unchanged.

`ANALYZER_REVISION` 6→7, `EVIDENCE_SCHEMA_REVISION` 3→4, catalog revision 2→3, so stored evidence requeues through `reconcile_evidence_revisions`. Seven Codex/Pi goldens change only by the new fields and revision numbers.

## Behaviour note

A 30-day report category reads `signalMissing` if any session in the window lacks the signal, matching the existing `contract_incomplete` rule (FR-14). Checked against 72 local Claude transcripts: Claude Code 2.1.241 writes `effort` on every assistant turn, but at least one older harness version (2.1.185) writes none, so "Model overthinking" stays not-assessed in the report until the last such session leaves the window. Zero-usage `<synthetic>` assistant records are excluded from signal eligibility.

Pre-existing, out of scope here: a `<synthetic>` record is counted as an unattributed assistant turn, which already leaves the models group `Partial` (9 of 72 local sessions). Fixing that is an adapter change with a `PARSER_REVISION` bump.

## Validation

- `crates/antiburn-local`: fmt, clippy `-D warnings`, test
- `apps/desktop/src-tauri`: fmt, clippy `-D warnings`, test
- `@antiburn/desktop`: lint, type-check, test, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U7uVd1iQZBdWV2KdmSjSA