### PR TITLE
feat(analysis): persist parsed turns as SQLite rows

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -21,9 +21,9 @@ use antiburn_local::analysis::{
     EfficiencyTotals, EvidenceSource, METRICS_SCHEMA_REVISION, ModelRun, NormalizedSession,
     PARSER_REVISION, RawSource, SessionCost, SessionEvidence, SessionEvidenceAccumulator,
     SessionInput, SessionMetrics, SessionMetricsAccumulator, SkillUse, SourceCapabilities,
-    SourceClaim, SourceKind, VisitOutcome, adapter_for, aggregate_metrics, analyze_session,
-    analyze_sources_with, append_only_guarantee, merge_metrics, merge_subagent_events,
-    normalize_source, price_breakdown, pricing_generation,
+    SourceClaim, SourceKind, TurnRowSink, TurnRowWriter, VisitOutcome, adapter_for,
+    aggregate_metrics, analyze_session, analyze_sources_with, append_only_guarantee, merge_metrics,
+    merge_subagent_events, normalize_source, price_breakdown, pricing_generation,
 };
 use antiburn_local::discovery::{
     ACTIVE_SESSION_WINDOW_SECS, Explorers, FORK_OBSERVATION_KEY, FingerprintInputs,
@@ -510,7 +510,7 @@ fn stream_vendor_with_claim_hook(
     cancel: &CancelFlag,
     after_claim: &dyn Fn(usize, &std::path::Path),
 ) -> StreamOutcome {
-    stream_vendor_with_hooks(inputs, &|| cancel.cancelled(), after_claim, None)
+    stream_vendor_with_hooks(inputs, &|| cancel.cancelled(), after_claim, None, None)
 }
 
 fn capabilities_for_vendor(agent: &str) -> Option<SourceCapabilities> {
@@ -528,6 +528,7 @@ fn stream_vendor_with_hooks(
     cancelled: &dyn Fn() -> bool,
     after_claim: &dyn Fn(usize, &std::path::Path),
     database_claim: Option<&str>,
+    turn_row_writer: Option<&dyn TurnRowWriter>,
 ) -> StreamOutcome {
     let mut accumulators = Vec::with_capacity(inputs.len());
     let mut parent_fingerprint = None;
@@ -549,7 +550,17 @@ fn stream_vendor_with_hooks(
             kind: SourceKind::from(&input.source),
             capabilities,
         });
-        let mut accumulator = CompositeSink::new(metrics, evidence);
+        // The turn-row source key is the input's own session id: the parent
+        // transcript's id for index 0, a child's own id for every other
+        // input. `thread_id` equals `source_key` in this change.
+        let mut accumulator = match turn_row_writer {
+            Some(writer) => CompositeSink::with_turn_rows(
+                metrics,
+                evidence,
+                TurnRowSink::new(writer, input.session_id.clone()),
+            ),
+            None => CompositeSink::new(metrics, evidence),
+        };
         let result = match &input.source {
             RawSource::File(path) => {
                 let claim = match claim_file(path) {
@@ -612,6 +623,12 @@ fn stream_vendor_with_hooks(
             Ok(outcome) => {
                 accumulator.observe_source_outcome(outcome);
                 if cancelled() {
+                    return StreamOutcome::ParentUnreadable;
+                }
+                // A turn-row write failure must fail the whole pass rather
+                // than publish metrics and evidence the rows disagree with.
+                // Retried like any other unreadable source.
+                if accumulator.turn_row_write_failed() {
                     return StreamOutcome::ParentUnreadable;
                 }
                 let Some(parts) = accumulator.into_parts() else {
@@ -722,6 +739,7 @@ pub async fn analyze(
         wsl_distro,
         claimed,
         PassSignal::from_cancel(cancel),
+        None,
     )
     .await;
     debug_assert!(
@@ -732,12 +750,18 @@ pub async fn analyze(
     pass.analysis
 }
 
+/// `turn_row_writer` is `Some` only for a pass the durable worker runs under
+/// a claimed evidence fence — see `insights_worker::run_record_pass`. Every
+/// other caller (an on-demand session view, a scan-triggered pass with no
+/// claim) passes `None`: without a claim fence, rows would have nothing to
+/// be stamped with and nothing to be cleaned up under.
 pub async fn analyze_for_evidence(
     agent: AgentKind,
     session_id: &str,
     wsl_distro: Option<&str>,
     claimed: ClaimedSource,
     signal: PassSignal,
+    turn_row_writer: Option<Arc<dyn TurnRowWriter>>,
 ) -> EvidencePass {
     let Some(source) = locate(agent, session_id, wsl_distro).await else {
         return unavailable_evidence_pass(PassOutcome::SourceMissing, None, None);
@@ -821,11 +845,13 @@ pub async fn analyze_for_evidence(
     let computed = tauri::async_runtime::spawn_blocking(move || {
         if streams_evidence {
             let cancelled = || signal_for_pass.observe();
+            let turn_row_writer = turn_row_writer.as_deref();
             return match stream_vendor_with_hooks(
                 &inputs,
                 &cancelled,
                 &test_subagent_after_claim,
                 database_claim.as_deref(),
+                turn_row_writer,
             ) {
                 StreamOutcome::Published {
                     session,
@@ -1075,7 +1101,25 @@ fn unavailable_evidence_pass(
 
 #[cfg(test)]
 pub(crate) fn evidence_pass(inputs: &[SessionInput], cancelled: &dyn Fn() -> bool) -> EvidencePass {
-    evidence_pass_with_hook(inputs, cancelled, &test_subagent_after_claim)
+    evidence_pass_with_hook(inputs, cancelled, &test_subagent_after_claim, None)
+}
+
+/// Like [`evidence_pass`], with a [`TurnRowWriter`] fanned out through the
+/// same real `stream_vendor_with_hooks` path the worker uses. Lets a test
+/// outside this module (`insights_worker`'s) assert on turn rows a published
+/// pass wrote, without a fake analyzer that skips the row sink entirely.
+#[cfg(test)]
+pub(crate) fn evidence_pass_with_turn_rows(
+    inputs: &[SessionInput],
+    cancelled: &dyn Fn() -> bool,
+    turn_row_writer: Option<&dyn TurnRowWriter>,
+) -> EvidencePass {
+    evidence_pass_with_hook(
+        inputs,
+        cancelled,
+        &test_subagent_after_claim,
+        turn_row_writer,
+    )
 }
 
 #[cfg(test)]
@@ -1083,8 +1127,9 @@ fn evidence_pass_with_hook(
     inputs: &[SessionInput],
     cancelled: &dyn Fn() -> bool,
     after_claim: &dyn Fn(usize, &std::path::Path),
+    turn_row_writer: Option<&dyn TurnRowWriter>,
 ) -> EvidencePass {
-    match stream_vendor_with_hooks(inputs, cancelled, after_claim, None) {
+    match stream_vendor_with_hooks(inputs, cancelled, after_claim, None, turn_row_writer) {
         StreamOutcome::Published { session, .. } => {
             let StreamedSession {
                 merged,
@@ -1569,7 +1614,8 @@ mod tests {
             source: RawSource::Sqlite(path),
         };
 
-        let outcome = stream_vendor_with_hooks(&[input], &|| false, &|_, _| {}, Some(&fingerprint));
+        let outcome =
+            stream_vendor_with_hooks(&[input], &|| false, &|_, _| {}, Some(&fingerprint), None);
 
         let StreamOutcome::Published {
             session,
@@ -1932,8 +1978,12 @@ mod tests {
                 .expect("change source");
         };
 
-        let pass =
-            evidence_pass_with_hook(&[file_input(&path, "changed")], &|| false, &change_source);
+        let pass = evidence_pass_with_hook(
+            &[file_input(&path, "changed")],
+            &|| false,
+            &change_source,
+            None,
+        );
 
         assert_eq!(pass.outcome, PassOutcome::SourceChanged);
         assert!(pass.analysis.metrics.is_none());
@@ -2126,6 +2176,7 @@ mod tests {
             &[file_input(&parent, "parent"), file_input(&child, "child")],
             &cancelled,
             &hook,
+            None,
             None,
         ) {
             StreamOutcome::ParentUnreadable => SessionAnalysis::unavailable(),

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -2,9 +2,10 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use antiburn_local::analysis::SessionEvidence;
+use antiburn_local::analysis::{SessionEvidence, TurnRowWriter};
 use antiburn_local::insights::{DetectorId, requirements};
 use antiburn_local::model::AgentKind;
 use tauri::{Emitter, Manager};
@@ -14,8 +15,8 @@ use crate::analysis::{self, EvidencePass, PassOutcome, PassSignal};
 use crate::commands;
 use crate::dto::ActivityEntry;
 use crate::store::{
-    EvidenceClaim, EvidenceCompletion, EvidenceFailure, PublishedEvidence, RelationKind,
-    RelationRecord, SessionKey, SessionRecord, Store,
+    EvidenceClaim, EvidenceCompletion, EvidenceFailure, FencedTurnRowWriter, PublishedEvidence,
+    RelationKind, RelationRecord, SessionKey, SessionRecord, Store,
 };
 
 pub(crate) const LEASE_SECS: i64 = 300;
@@ -53,9 +54,19 @@ pub struct WorkerHandle {
 }
 
 pub(crate) type PassFuture = Pin<Box<dyn Future<Output = EvidencePass> + Send>>;
+/// The `i64` is the claim's fence: [`process_next`] already holds the claim
+/// when it calls this, so it passes the fence through rather than the
+/// runner re-deriving it.
 pub(crate) type PassRunner<'a> =
-    dyn Fn(&SessionRecord, PassSignal) -> PassFuture + Send + Sync + 'a;
-type RecordAnalyzer<'a> = dyn Fn(AgentKind, String, Option<String>, analysis::ClaimedSource, PassSignal) -> PassFuture
+    dyn Fn(&SessionRecord, PassSignal, i64) -> PassFuture + Send + Sync + 'a;
+type RecordAnalyzer<'a> = dyn Fn(
+        AgentKind,
+        String,
+        Option<String>,
+        analysis::ClaimedSource,
+        PassSignal,
+        Option<Arc<dyn TurnRowWriter>>,
+    ) -> PassFuture
     + Send
     + Sync
     + 'a;
@@ -66,11 +77,22 @@ pub(crate) enum PermitKind {
     ProviderDb,
 }
 
-fn run_record_pass(record: &SessionRecord, signal: PassSignal) -> PassFuture {
+/// `store` is a cheap handle (see [`Store`]'s doc comment): this clones it
+/// once per pass into a [`FencedTurnRowWriter`] stamped with `claim_fence`,
+/// so turn rows this pass writes are attributable and cleaned up correctly
+/// if the pass loses the claim race.
+fn run_record_pass(
+    record: &SessionRecord,
+    signal: PassSignal,
+    claim_fence: i64,
+    store: Store,
+) -> PassFuture {
     run_record_pass_with(
         record,
         signal,
-        &|agent, session_id, wsl_distro, claimed, signal| {
+        claim_fence,
+        store,
+        &|agent, session_id, wsl_distro, claimed, signal, turn_row_writer| {
             Box::pin(async move {
                 analysis::analyze_for_evidence(
                     agent,
@@ -78,6 +100,7 @@ fn run_record_pass(record: &SessionRecord, signal: PassSignal) -> PassFuture {
                     wsl_distro.as_deref(),
                     claimed,
                     signal,
+                    turn_row_writer,
                 )
                 .await
             })
@@ -88,11 +111,18 @@ fn run_record_pass(record: &SessionRecord, signal: PassSignal) -> PassFuture {
 fn run_record_pass_with(
     record: &SessionRecord,
     signal: PassSignal,
+    claim_fence: i64,
+    store: Store,
     analyze: &RecordAnalyzer<'_>,
 ) -> PassFuture {
     let Some(agent) = crate::agents::kind_from_slug(&record.key.agent) else {
         return Box::pin(async { analysis::unsupported_evidence_pass() });
     };
+    let writer: Arc<dyn TurnRowWriter> = Arc::new(FencedTurnRowWriter::new(
+        store,
+        record.key.clone(),
+        claim_fence,
+    ));
     analyze(
         agent,
         record.key.session_id.clone(),
@@ -102,13 +132,17 @@ fn run_record_pass_with(
             generation: 0,
         },
         signal,
+        Some(writer),
     )
 }
 
 pub fn spawn(app: &tauri::AppHandle) -> tauri::async_runtime::JoinHandle<()> {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let run_pass = |record: &SessionRecord, signal: PassSignal| run_record_pass(record, signal);
+        let store_handle: Store = (*app.state::<Store>()).clone();
+        let run_pass = move |record: &SessionRecord, signal: PassSignal, claim_fence: i64| {
+            run_record_pass(record, signal, claim_fence, store_handle.clone())
+        };
         let announce_app = app.clone();
         let announce = move |entry: ActivityEntry| {
             let _ = announce_app.emit(commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
@@ -296,7 +330,7 @@ pub(crate) async fn process_next(
         .await
         .map_err(|_| anyhow::anyhow!("source permit closed"))?;
     let signal = PassSignal::new();
-    let mut pass = run_pass(&record, signal.clone());
+    let mut pass = run_pass(&record, signal.clone(), claim.claim_fence);
     let mut progress = signal.progress();
     let result = loop {
         tokio::select! {
@@ -492,7 +526,7 @@ mod tests {
         let mut unknown = record("unknown");
         unknown.key.agent = "unknown-agent".to_owned();
 
-        let pass = run_record_pass(&unknown, PassSignal::new()).await;
+        let pass = run_record_pass(&unknown, PassSignal::new(), 1, store()).await;
 
         assert_eq!(pass.outcome, PassOutcome::Unsupported);
         assert!(pass.evidence.is_none());
@@ -756,7 +790,7 @@ mod tests {
         let task_signal = Arc::clone(&signal);
         let task_release = Arc::clone(&release);
         let task = tokio::spawn(async move {
-            let runner = move |_: &SessionRecord, pass_signal: PassSignal| {
+            let runner = move |_: &SessionRecord, pass_signal: PassSignal, _: i64| {
                 *task_signal.lock().unwrap() = Some(pass_signal);
                 let release = Arc::clone(&task_release);
                 Box::pin(async move {
@@ -820,7 +854,7 @@ mod tests {
         let task_entered = Arc::clone(&entered);
         let task_release = Arc::clone(&release);
         let task = tokio::spawn(async move {
-            let runner = move |_: &SessionRecord, _: PassSignal| {
+            let runner = move |_: &SessionRecord, _: PassSignal, _: i64| {
                 task_entered.store(true, Ordering::SeqCst);
                 let release = Arc::clone(&task_release);
                 Box::pin(async move {
@@ -879,7 +913,7 @@ mod tests {
         let task_signal = Arc::clone(&signal);
         let task_release = Arc::clone(&release);
         let task = tokio::spawn(async move {
-            let runner = move |_: &SessionRecord, pass_signal: PassSignal| {
+            let runner = move |_: &SessionRecord, pass_signal: PassSignal, _: i64| {
                 *task_signal.lock().unwrap() = Some(pass_signal);
                 let release = Arc::clone(&task_release);
                 Box::pin(async move {
@@ -932,7 +966,7 @@ mod tests {
         let first_task_signal = Arc::clone(&first_signal_slot);
         let first_task_release = Arc::clone(&first_release);
         let first_task = tokio::spawn(async move {
-            let runner = move |_: &SessionRecord, pass_signal: PassSignal| {
+            let runner = move |_: &SessionRecord, pass_signal: PassSignal, _: i64| {
                 *first_task_signal.lock().unwrap() = Some(pass_signal);
                 let release = Arc::clone(&first_task_release);
                 Box::pin(async move {
@@ -970,7 +1004,7 @@ mod tests {
         let second_task_signal = Arc::clone(&second_signal_slot);
         let second_task_release = Arc::clone(&second_release);
         let second_task = tokio::spawn(async move {
-            let runner = move |record: &SessionRecord, pass_signal: PassSignal| {
+            let runner = move |record: &SessionRecord, pass_signal: PassSignal, _: i64| {
                 *second_task_signal.lock().unwrap() = Some(pass_signal);
                 let pass = published_pass(record);
                 let release = Arc::clone(&second_task_release);
@@ -1030,7 +1064,7 @@ mod tests {
         let permit = handle.permits.cpu.acquire().await.unwrap();
         let entered = Arc::new(AtomicBool::new(false));
         let entered_by_pass = entered.clone();
-        let runner = move |_: &SessionRecord, _: PassSignal| {
+        let runner = move |_: &SessionRecord, _: PassSignal, _: i64| {
             entered_by_pass.store(true, Ordering::SeqCst);
             Box::pin(async { failed_pass(PassOutcome::SourceMissing) }) as PassFuture
         };
@@ -1053,7 +1087,7 @@ mod tests {
             .unwrap();
         let pending = Arc::new(Notify::new());
         let pending_pass = pending.clone();
-        let runner = move |_: &SessionRecord, _: PassSignal| {
+        let runner = move |_: &SessionRecord, _: PassSignal, _: i64| {
             let pending = pending_pass.clone();
             Box::pin(async move {
                 pending.notified().await;
@@ -1084,7 +1118,7 @@ mod tests {
         store
             .upsert_sessions(&[record("announcement")], &crate::agents::evidence_cohort())
             .unwrap();
-        let runner = |record: &SessionRecord, _: PassSignal| {
+        let runner = |record: &SessionRecord, _: PassSignal, _: i64| {
             let pass = published_pass(record);
             Box::pin(async move { pass }) as PassFuture
         };
@@ -1118,7 +1152,7 @@ mod tests {
                 &crate::agents::evidence_cohort(),
             )
             .unwrap();
-        let runner = |_: &SessionRecord, _: PassSignal| {
+        let runner = |_: &SessionRecord, _: PassSignal, _: i64| {
             Box::pin(async { failed_pass(PassOutcome::SourceChanged) }) as PassFuture
         };
         let announced = Mutex::new(Vec::new());
@@ -1148,7 +1182,7 @@ mod tests {
                 &crate::agents::evidence_cohort(),
             )
             .unwrap();
-        let runner = |_: &SessionRecord, _: PassSignal| {
+        let runner = |_: &SessionRecord, _: PassSignal, _: i64| {
             Box::pin(async { failed_pass(PassOutcome::SourceChanged) }) as PassFuture
         };
 
@@ -1171,7 +1205,7 @@ mod tests {
                 &crate::agents::evidence_cohort(),
             )
             .unwrap();
-        let runner = |_: &SessionRecord, _: PassSignal| {
+        let runner = |_: &SessionRecord, _: PassSignal, _: i64| {
             Box::pin(async { failed_pass(PassOutcome::Unsupported) }) as PassFuture
         };
 
@@ -1193,7 +1227,7 @@ mod tests {
                 &crate::agents::evidence_cohort(),
             )
             .unwrap();
-        let runner = |_: &SessionRecord, _: PassSignal| {
+        let runner = |_: &SessionRecord, _: PassSignal, _: i64| {
             Box::pin(async { failed_pass(PassOutcome::SourceMissing) }) as PassFuture
         };
 
@@ -1221,7 +1255,7 @@ mod tests {
             )
             .unwrap();
         let clock = AtomicI64::new(100);
-        let runner = |_: &SessionRecord, _: PassSignal| {
+        let runner = |_: &SessionRecord, _: PassSignal, _: i64| {
             Box::pin(async { failed_pass(PassOutcome::Unreadable) }) as PassFuture
         };
         let key = SessionKey::new("native", "claude-code", "worker-unreadable");
@@ -1245,6 +1279,78 @@ mod tests {
                 clock.store(row.next_attempt_at_epoch.unwrap(), Ordering::SeqCst);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn a_published_pass_leaves_the_expected_turn_rows_under_its_claim_fence() {
+        let store = store();
+        let target = record("turn-rows-worker");
+        store
+            .upsert_sessions(
+                std::slice::from_ref(&target),
+                &crate::agents::evidence_cohort(),
+            )
+            .unwrap();
+
+        // A custom analyzer, like the fixture-backed tests above: it
+        // bypasses real filesystem discovery, but runs the real
+        // `evidence_pass_with_turn_rows` -> `stream_vendor_with_hooks` ->
+        // `TurnRowSink` -> `FencedTurnRowWriter` path the worker uses in
+        // production, so this test proves rows a published pass writes
+        // actually land under the claim's fence.
+        let analyzer = |_agent: AgentKind,
+                        session_id: String,
+                        _wsl_distro: Option<String>,
+                        claimed: analysis::ClaimedSource,
+                        signal: PassSignal,
+                        turn_row_writer: Option<Arc<dyn TurnRowWriter>>| {
+            Box::pin(async move {
+                let mut pass = analysis::evidence_pass_with_turn_rows(
+                    &[SessionInput {
+                        agent: "claude".into(),
+                        session_id,
+                        source: RawSource::Jsonl(concat!(
+                            r#"{"type":"assistant","timestamp":100,"message":{"id":"m1","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":2,"output_tokens":3},"content":[]}}"#,
+                            "\n",
+                            r#"{"type":"assistant","timestamp":200,"message":{"id":"m2","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":4,"output_tokens":6},"content":[]}}"#,
+                            "\n",
+                        )
+                        .into()),
+                    }],
+                    &|| signal.observe(),
+                    turn_row_writer.as_deref(),
+                );
+                if let Some(fingerprint) = claimed.fingerprint {
+                    pass.analysis.fingerprint = fingerprint;
+                }
+                pass
+            }) as PassFuture
+        };
+        let store_for_runner = store.clone();
+        let runner = move |record: &SessionRecord, signal: PassSignal, claim_fence: i64| {
+            run_record_pass_with(
+                record,
+                signal,
+                claim_fence,
+                store_for_runner.clone(),
+                &analyzer,
+            )
+        };
+
+        assert!(
+            process_next(&store, &WorkerHandle::default(), &|| 100, &runner, &|_| {})
+                .await
+                .unwrap()
+        );
+
+        let evidence = store.evidence(&target.key).unwrap().unwrap();
+        assert_eq!(evidence.status, EvidenceStatus::Ready);
+        assert_eq!(
+            store
+                .count_turn_rows_for_session(&target.key, evidence.claim_fence)
+                .unwrap(),
+            2
+        );
     }
 
     #[tokio::test]
@@ -1272,38 +1378,48 @@ mod tests {
             .upsert_sessions(std::slice::from_ref(&pi), &crate::agents::evidence_cohort())
             .unwrap();
         let pi_source = source_path.clone();
-        let analyzer = move |agent: AgentKind,
-                             session_id: String,
-                             wsl_distro: Option<String>,
-                             claimed: analysis::ClaimedSource,
-                             signal: PassSignal| {
-            if agent != AgentKind::Pi || session_id != "pi-worker-report" {
-                return Box::pin(async move {
-                    analysis::analyze_for_evidence(
-                        agent,
-                        &session_id,
-                        wsl_distro.as_deref(),
-                        claimed,
-                        signal,
-                    )
-                    .await
-                }) as PassFuture;
-            }
-            let input = antiburn_local::analysis::SessionInput {
-                agent: crate::agents::vendor_label(agent).to_owned(),
-                session_id,
-                source: antiburn_local::analysis::RawSource::File(pi_source.clone()),
-            };
-            Box::pin(async move {
-                let mut pass = analysis::evidence_pass(&[input], &|| signal.observe());
-                if let Some(fingerprint) = claimed.fingerprint {
-                    pass.analysis.fingerprint = fingerprint;
+        let analyzer =
+            move |agent: AgentKind,
+                  session_id: String,
+                  wsl_distro: Option<String>,
+                  claimed: analysis::ClaimedSource,
+                  signal: PassSignal,
+                  turn_row_writer: Option<Arc<dyn TurnRowWriter>>| {
+                if agent != AgentKind::Pi || session_id != "pi-worker-report" {
+                    return Box::pin(async move {
+                        analysis::analyze_for_evidence(
+                            agent,
+                            &session_id,
+                            wsl_distro.as_deref(),
+                            claimed,
+                            signal,
+                            turn_row_writer,
+                        )
+                        .await
+                    }) as PassFuture;
                 }
-                pass
-            }) as PassFuture
-        };
-        let runner = |record: &SessionRecord, signal: PassSignal| {
-            run_record_pass_with(record, signal, &analyzer)
+                let input = antiburn_local::analysis::SessionInput {
+                    agent: crate::agents::vendor_label(agent).to_owned(),
+                    session_id,
+                    source: antiburn_local::analysis::RawSource::File(pi_source.clone()),
+                };
+                Box::pin(async move {
+                    let mut pass = analysis::evidence_pass(&[input], &|| signal.observe());
+                    if let Some(fingerprint) = claimed.fingerprint {
+                        pass.analysis.fingerprint = fingerprint;
+                    }
+                    pass
+                }) as PassFuture
+            };
+        let store_for_runner = store.clone();
+        let runner = move |record: &SessionRecord, signal: PassSignal, claim_fence: i64| {
+            run_record_pass_with(
+                record,
+                signal,
+                claim_fence,
+                store_for_runner.clone(),
+                &analyzer,
+            )
         };
 
         assert!(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -620,7 +620,7 @@ mod tests {
         let (entered, pass_entered) = mpsc::channel();
         let (completed, pass_completed) = mpsc::channel();
         let pass_blocked = Arc::clone(&blocked);
-        let runner = move |_: &SessionRecord, _: PassSignal| {
+        let runner = move |_: &SessionRecord, _: PassSignal, _: i64| {
             let blocked = Arc::clone(&pass_blocked);
             let entered = entered.clone();
             let completed = completed.clone();

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -29,9 +29,13 @@ mod tests;
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use antiburn_local::analysis::{
+    TurnRow, TurnRowWriteError, TurnRowWriter, TurnSessionKey, count_turn_rows, delete_turn_rows,
+    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
+};
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 
@@ -110,8 +114,14 @@ pub fn open_read_only(data_dir: &Path, busy_timeout: Duration) -> Result<Connect
 }
 
 /// The app's local database.
+///
+/// `connection` is behind an `Arc` so a cheap [`Store::clone`] shares the
+/// same underlying connection rather than opening a second one. The worker
+/// uses this to hand a [`FencedTurnRowWriter`] a handle to the same database
+/// without threading `Store` state through every call site as `Arc<Store>`.
+#[derive(Clone)]
 pub struct Store {
-    connection: Mutex<Connection>,
+    connection: Arc<Mutex<Connection>>,
     /// The directory the engine's own state files (scan roots, ignored paths)
     /// live in. The engine never chooses this; the shell does.
     state_dir: PathBuf,
@@ -142,7 +152,7 @@ impl Store {
         connection.pragma_update(None, "synchronous", "NORMAL")?;
         connection.pragma_update(None, "foreign_keys", true)?;
         let store = Store {
-            connection: Mutex::new(connection),
+            connection: Arc::new(Mutex::new(connection)),
             state_dir,
         };
         store.migrate()?;
@@ -1005,6 +1015,8 @@ impl Store {
         tx.execute("DELETE FROM session_relation", [])?;
         tx.execute("DELETE FROM session_analysis", [])?;
         tx.execute("DELETE FROM session_evidence", [])?;
+        tx.execute("DELETE FROM turn_content", [])?;
+        tx.execute("DELETE FROM turn", [])?;
         let sessions = tx.execute("DELETE FROM session", [])?;
         tx.execute("DELETE FROM scan_state", [])?;
         tx.execute("UPDATE repository SET session_count = 0", [])?;
@@ -1116,11 +1128,52 @@ impl Store {
             ],
         )?;
         if updated == 0 {
+            // This pass lost the claim race (a newer claim, or a newer
+            // source generation, already moved past it). Dropping the
+            // transaction without a commit rolls back the session_analysis
+            // upsert above, exactly as before this pass wrote turn rows: a
+            // lost race must not publish anything this pass computed. Its
+            // rows were never published either, so they are cleaned up here
+            // under their own fence, in a separate statement, rather than
+            // left to accumulate.
+            drop(transaction);
+            delete_turn_rows_for_fence(
+                &connection,
+                &turn_session_key(&record.key),
+                completion.claim_fence,
+            )?;
             return Ok(false);
         }
+        // Every row from an earlier, superseded pass is dropped now that
+        // this pass's evidence is what published. Rows already carry this
+        // pass's fence — see `analysis::analyze_for_evidence` — so only
+        // stale fences are removed.
+        delete_turn_rows_except_fence(
+            &transaction,
+            &turn_session_key(&record.key),
+            completion.claim_fence,
+        )?;
         replace_relations_in(&transaction, &record.key, RelationKind::Subagent, relations)?;
         transaction.commit()?;
         Ok(true)
+    }
+
+    /// Deletes every turn row for one session. Used by delete paths that do
+    /// not go through [`Self::delete_session`] or
+    /// [`Self::clear_local_session_data`].
+    pub fn delete_turn_rows_for_session(&self, key: &SessionKey) -> Result<usize> {
+        let connection = self.lock();
+        Ok(delete_turn_rows(&connection, &turn_session_key(key))?)
+    }
+
+    /// Counts one session's turn rows stamped with `claim_fence`.
+    pub fn count_turn_rows_for_session(&self, key: &SessionKey, claim_fence: i64) -> Result<u64> {
+        let connection = self.lock();
+        Ok(count_turn_rows(
+            &connection,
+            &turn_session_key(key),
+            claim_fence,
+        )?)
     }
 
     /// Cache one session's derived analysis.
@@ -1850,11 +1903,28 @@ fn delete_session_in(connection: &Connection, key: &SessionKey) -> Result<bool> 
           WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         parameters,
     )?;
+    // Same reasoning as `session_evidence` above: the v15 cascades from
+    // `session` cover `turn` and `turn_content`, but this stays explicit and
+    // pragma-independent. `turn_content` has no direct session key, so it is
+    // deleted through `turn`'s rowid.
+    delete_turn_rows_in(connection, key)?;
     let removed = connection.execute(
         "DELETE FROM session WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         parameters,
     )?;
     Ok(removed > 0)
+}
+
+fn turn_session_key(key: &SessionKey) -> TurnSessionKey<'_> {
+    TurnSessionKey {
+        environment_key: &key.environment_key,
+        agent: &key.agent,
+        session_id: &key.session_id,
+    }
+}
+
+fn delete_turn_rows_in(connection: &Connection, key: &SessionKey) -> Result<usize> {
+    Ok(delete_turn_rows(connection, &turn_session_key(key))?)
 }
 
 fn evidence_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EvidenceRow> {
@@ -1907,4 +1977,45 @@ fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> 
         fork_parent_session_id: row.get(14)?,
         source_fingerprint: row.get(15)?,
     })
+}
+
+/// Writes turn rows for one claimed evidence pass.
+///
+/// Holds an owned [`Store`] handle (cheap: it shares the app's one
+/// connection, see [`Store`]'s doc comment) plus the session key and claim
+/// fence the durable worker already knows for this pass. `Store` cannot
+/// implement [`TurnRowWriter`] directly — writing a row needs the session
+/// key and fence, and `Store` itself does not carry either.
+#[derive(Clone)]
+pub struct FencedTurnRowWriter {
+    store: Store,
+    key: SessionKey,
+    claim_fence: i64,
+}
+
+impl FencedTurnRowWriter {
+    pub fn new(store: Store, key: SessionKey, claim_fence: i64) -> Self {
+        Self {
+            store,
+            key,
+            claim_fence,
+        }
+    }
+}
+
+impl TurnRowWriter for FencedTurnRowWriter {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+        // One transaction per batch: one fsync for the batch instead of
+        // one for each row, and the lock is held only for the batch.
+        let mut connection = self.store.lock();
+        let transaction = connection.transaction()?;
+        insert_turn_rows(
+            &transaction,
+            &turn_session_key(&self.key),
+            self.claim_fence,
+            rows,
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
 }

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -10,7 +10,9 @@
 
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
-pub const MIGRATIONS: &[&str] = &[V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14];
+pub const MIGRATIONS: &[&str] = &[
+    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15,
+];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
 ///
@@ -358,3 +360,22 @@ SELECT environment_key, agent, session_id
  WHERE agent = 'opencode'
 ON CONFLICT(environment_key, agent, session_id) DO NOTHING;
 "#;
+
+/// v15 — persisted turn rows.
+///
+/// # Data policy (schema-level contract)
+///
+/// `turn` stores one row per parsed turn: identity, thread and scope facts,
+/// and token accounting derived from a transcript. `turn_content` exists for
+/// a later change to store the turn's text; nothing writes to it yet.
+///
+/// Session deletion and clear-local-session-data remove these rows
+/// explicitly, the same way [`V11`]'s `session_evidence` does — the FK
+/// cascade is a backstop, not the mechanism.
+///
+/// `antiburn_local::analysis::TURN_SCHEMA_SQL` owns the column list; this is
+/// a re-export so [`MIGRATIONS`] stays a plain `&[&str]` of literals. See
+/// "Where the row logic lives" in the session-evidence-harness-parity plan:
+/// the crate owns the DDL and the read/write functions over a borrowed
+/// connection, and never opens this database itself.
+const V15: &str = antiburn_local::analysis::TURN_SCHEMA_SQL;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use antiburn_local::analysis::{TurnScope, count_turn_rows};
+
 use super::model::PublishedEvidence;
 use super::*;
 
@@ -2058,7 +2060,7 @@ async fn reprocessing_a_revision_one_row_leaves_no_placeholder_in_stored_evidenc
         Some("{\"state\":\"unimplemented\"}")
     );
 
-    let runner = |record: &SessionRecord, _signal: crate::analysis::PassSignal| {
+    let runner = |record: &SessionRecord, _signal: crate::analysis::PassSignal, _: i64| {
         let pass = published_evidence_pass(record);
         Box::pin(async move { pass }) as crate::insights_worker::PassFuture
     };
@@ -2094,7 +2096,7 @@ async fn a_terminal_failure_clears_an_outdated_placeholder_payload() {
             .unwrap(),
         1
     );
-    let runner = |_record: &SessionRecord, _signal: crate::analysis::PassSignal| {
+    let runner = |_record: &SessionRecord, _signal: crate::analysis::PassSignal, _: i64| {
         Box::pin(async {
             crate::analysis::EvidencePass {
                 analysis: crate::analysis::SessionAnalysis::unavailable(),
@@ -2957,4 +2959,261 @@ fn evidence_backlog_counts_split_pending_from_processing_within_one_environment(
     let wsl = store.evidence_backlog_counts("wsl:ubuntu").unwrap();
     assert_eq!(wsl.pending, 1);
     assert_eq!(wsl.processing, 0);
+}
+
+/* --------------------------------------------------------------------
+ * Turn rows
+ * ----------------------------------------------------------------- */
+
+fn turn_row(turn_index: u64) -> TurnRow {
+    TurnRow {
+        source_key: "s1".into(),
+        thread_id: "s1".into(),
+        turn_index,
+        scope: TurnScope::Main,
+        child_id: None,
+        role: "assistant",
+        ts_ms: Some(1_000 + turn_index as i64),
+        model: Some("claude-opus-4-6".into()),
+        effort: None,
+        speed: None,
+        input_tokens: 10,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        output_tokens: 5,
+        is_compaction_boundary: false,
+        message_id: None,
+        uuid: None,
+        parent_uuid: None,
+    }
+}
+
+#[test]
+fn the_migration_ladder_reaches_the_turn_row_schema() {
+    // Pinned so this test fails loudly if a future migration is appended
+    // without also being counted here — the number is the whole point of
+    // the assertion, not an incidental detail.
+    assert_eq!(super::schema::MIGRATIONS.len(), 15);
+
+    let store = store();
+    assert_eq!(store.schema_version().unwrap(), 15);
+}
+
+#[test]
+fn a_fenced_turn_row_writer_inserts_rows_the_store_can_count() {
+    let store = store();
+    let mut record = session("turn-rows-writer", 1_000);
+    record.source_fingerprint = Some("sv1:turn-rows-writer".into());
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    let key = record.key.clone();
+
+    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), 7);
+    writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
+
+    let connection = store.lock();
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), 7).unwrap(),
+        2
+    );
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), 8).unwrap(),
+        0
+    );
+}
+
+#[test]
+fn publishing_evidence_keeps_only_the_current_fence_turn_rows() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "publish-current-fence", 100, 60);
+    let key = record.key.clone();
+
+    // A row left over from an earlier, superseded pass under a stale fence.
+    {
+        let connection = store.lock();
+        insert_turn_rows(
+            &connection,
+            &turn_session_key(&key),
+            claim.claim_fence - 1,
+            &[turn_row(0)],
+        )
+        .unwrap();
+    }
+    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    let connection = store.lock();
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence - 1).unwrap(),
+        0
+    );
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence).unwrap(),
+        2
+    );
+}
+
+#[test]
+fn a_lost_publish_race_deletes_only_its_own_fences_turn_rows() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "lost-race-turn-rows", 100, 60);
+    let key = record.key.clone();
+    // A row from a still-current, earlier pass. A lost race must not touch
+    // rows it does not own.
+    {
+        let connection = store.lock();
+        insert_turn_rows(
+            &connection,
+            &turn_session_key(&key),
+            claim.claim_fence - 1,
+            &[turn_row(0)],
+        )
+        .unwrap();
+    }
+    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0)]).unwrap();
+    // Bumping the source generation makes the fenced UPDATE inside
+    // `publish_projections` affect zero rows — the same "lost the race"
+    // shape `a_stale_generation_publishes_no_session_evidence_and_no_analysis`
+    // exercises for the evidence and analysis projections.
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET source_generation = source_generation + 1
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        !store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    let connection = store.lock();
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence).unwrap(),
+        0
+    );
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence - 1).unwrap(),
+        1
+    );
+}
+
+#[test]
+fn deleting_a_session_removes_its_turn_rows() {
+    let store = store();
+    let key = SessionKey::new("native", "claude-code", "turn-rows-delete");
+    store
+        .upsert_sessions(
+            &[session("turn-rows-delete", 1_000)],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    {
+        let connection = store.lock();
+        insert_turn_rows(&connection, &turn_session_key(&key), 1, &[turn_row(0)]).unwrap();
+    }
+
+    assert!(store.delete_session(&key).unwrap());
+
+    let connection = store.lock();
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), 1).unwrap(),
+        0
+    );
+}
+
+#[test]
+fn clearing_local_session_data_removes_every_turn_row() {
+    let store = store();
+    let mut first = session("clear-turn-rows-one", 1_000);
+    first.source_fingerprint = Some("sv1:clear-turn-rows-one".into());
+    let mut second = session("clear-turn-rows-two", 1_000);
+    second.source_fingerprint = Some("sv1:clear-turn-rows-two".into());
+    store
+        .upsert_sessions(&[first, second], &crate::agents::evidence_cohort())
+        .unwrap();
+    {
+        let connection = store.lock();
+        insert_turn_rows(
+            &connection,
+            &TurnSessionKey {
+                environment_key: "native",
+                agent: "claude-code",
+                session_id: "clear-turn-rows-one",
+            },
+            1,
+            &[turn_row(0)],
+        )
+        .unwrap();
+        insert_turn_rows(
+            &connection,
+            &TurnSessionKey {
+                environment_key: "native",
+                agent: "claude-code",
+                session_id: "clear-turn-rows-two",
+            },
+            1,
+            &[turn_row(0)],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(store.clear_local_session_data().unwrap(), 2);
+
+    let count: i64 = store
+        .lock()
+        .query_row("SELECT COUNT(*) FROM turn", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn deleting_the_session_row_directly_cascades_to_its_turn_rows() {
+    // `delete_session` deletes `turn` rows explicitly (see its doc comment),
+    // matching how it already treats `session_evidence`. This test instead
+    // deletes the `session` row with raw SQL, bypassing that explicit
+    // delete, to prove the migrated schema's `ON DELETE CASCADE` also holds
+    // on its own — a backstop, not the primary mechanism.
+    let store = store();
+    let key = SessionKey::new("native", "claude-code", "turn-rows-cascade");
+    store
+        .upsert_sessions(
+            &[session("turn-rows-cascade", 1_000)],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    {
+        let connection = store.lock();
+        insert_turn_rows(&connection, &turn_session_key(&key), 1, &[turn_row(0)]).unwrap();
+    }
+
+    store
+        .lock()
+        .execute(
+            "DELETE FROM session WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .unwrap();
+
+    let connection = store.lock();
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), 1).unwrap(),
+        0
+    );
 }

--- a/crates/antiburn-local/benches/memory_baseline.rs
+++ b/crates/antiburn-local/benches/memory_baseline.rs
@@ -74,7 +74,7 @@ fn measure_peak<T>(work: impl FnOnce() -> T) -> (usize, T) {
     (peak.saturating_sub(live_before), value)
 }
 
-fn composite_for(input: &SessionInput) -> CompositeSink {
+fn composite_for(input: &SessionInput) -> CompositeSink<'static> {
     CompositeSink::new(
         SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone()),
         SessionEvidenceAccumulator::new(EvidenceSource {

--- a/crates/antiburn-local/benches/pipeline_baseline.rs
+++ b/crates/antiburn-local/benches/pipeline_baseline.rs
@@ -64,7 +64,7 @@ fn file_input(session_id: &str, path: &Path) -> SessionInput {
     }
 }
 
-fn composite_for(input: &SessionInput) -> CompositeSink {
+fn composite_for(input: &SessionInput) -> CompositeSink<'static> {
     CompositeSink::new(
         SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone()),
         SessionEvidenceAccumulator::new(EvidenceSource {

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -18,6 +18,7 @@ use crate::analysis::interface::{
 };
 use crate::analysis::metrics_sink::SessionMetricsAccumulator;
 use crate::analysis::model::{CompactionTrigger, EventSource, NormalizedEvent, Role};
+use crate::analysis::rows::TurnRowSink;
 use crate::analysis::{
     ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION, SessionMetrics,
 };
@@ -972,14 +973,34 @@ impl RecordSink for SessionEvidenceAccumulator {
     }
 }
 
-pub struct CompositeSink {
+pub struct CompositeSink<'a> {
     metrics: SessionMetricsAccumulator,
     evidence: SessionEvidenceAccumulator,
+    turn_rows: Option<TurnRowSink<'a>>,
 }
 
-impl CompositeSink {
+impl<'a> CompositeSink<'a> {
     pub fn new(metrics: SessionMetricsAccumulator, evidence: SessionEvidenceAccumulator) -> Self {
-        Self { metrics, evidence }
+        Self {
+            metrics,
+            evidence,
+            turn_rows: None,
+        }
+    }
+
+    /// Like [`Self::new`], with a [`TurnRowSink`] fanned out alongside
+    /// metrics and evidence. Every recorded `MetricsEvent` becomes a turn
+    /// row through it, in the same pass that builds metrics and evidence.
+    pub fn with_turn_rows(
+        metrics: SessionMetricsAccumulator,
+        evidence: SessionEvidenceAccumulator,
+        turn_rows: TurnRowSink<'a>,
+    ) -> Self {
+        Self {
+            metrics,
+            evidence,
+            turn_rows: Some(turn_rows),
+        }
     }
 
     pub fn metrics(&self) -> Option<SessionMetrics> {
@@ -996,6 +1017,13 @@ impl CompositeSink {
         self.evidence.observe_source_outcome(outcome);
     }
 
+    /// True once the fanned-out [`TurnRowSink`] (if any) has hit a write
+    /// error. The caller must not publish this pass's metrics or evidence
+    /// when this is true — rows and projections would disagree.
+    pub fn turn_row_write_failed(&self) -> bool {
+        self.turn_rows.as_ref().is_some_and(TurnRowSink::has_error)
+    }
+
     pub fn into_parts(self) -> Option<(SessionMetricsAccumulator, SessionEvidenceAccumulator)> {
         self.evidence
             .can_publish()
@@ -1003,14 +1031,20 @@ impl CompositeSink {
     }
 }
 
-impl RecordSink for CompositeSink {
+impl RecordSink for CompositeSink<'_> {
     fn record(&mut self, record: NormalizedRecord) {
         self.evidence.observe(&record);
+        if let Some(turn_rows) = &mut self.turn_rows {
+            turn_rows.observe(&record);
+        }
         self.metrics.record(record);
     }
 
     fn finish(&mut self, summary: SessionSummary) {
         self.evidence.observe_summary(&summary);
+        if let Some(turn_rows) = &mut self.turn_rows {
+            turn_rows.flush();
+        }
         self.metrics.finish(summary);
     }
 }

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -38,6 +38,7 @@ mod merge;
 mod metrics_sink;
 mod model;
 mod pricing;
+mod rows;
 mod source_validity;
 pub mod tool_catalog;
 mod vendors;
@@ -74,6 +75,11 @@ pub use model::{
     EventSource, ModelRun, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
 };
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
+pub use rows::{
+    TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TurnRow, TurnRowSink, TurnRowWriteError, TurnRowWriter,
+    TurnScope, TurnSessionKey, count_turn_rows, delete_turn_rows, delete_turn_rows_except_fence,
+    delete_turn_rows_for_fence, insert_turn_rows, turn_row_from_event,
+};
 pub use source_validity::{
     AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,
 };

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -1,0 +1,707 @@
+//! Persisted turn rows.
+//!
+//! Each parsed turn becomes one row in the `turn` table. This lets the app
+//! query the durable rows instead of streaming an accumulator, and lets a
+//! catalog or policy change requery rows instead of reparsing a transcript.
+//!
+//! This module owns only the `turn` and `turn_content` DDL and the read/write
+//! functions over a borrowed [`rusqlite::Connection`]. The crate does not open
+//! the app database and does not know any other app table.
+
+use rusqlite::{Connection, params};
+
+use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary};
+use crate::analysis::model::{EventSource, NormalizedEvent, Role};
+
+/// DDL for the `turn` and `turn_content` tables.
+///
+/// `turn` holds one row per parsed turn: identity, thread and scope facts,
+/// and token accounting. `turn_content` holds the turn's text, keyed by the
+/// `turn` rowid and part index (one turn has several parts: text,
+/// thinking, each tool input, each tool result), in a separate table so
+/// the hot `turn` table stays narrow.
+/// `turn_content` is created now; a later change writes to it.
+///
+/// The caller applies this DDL after its own `session` table exists — the
+/// foreign key references `session (environment_key, agent, session_id)`.
+pub const TURN_SCHEMA_SQL: &str = r#"
+CREATE TABLE turn (
+    rowid INTEGER PRIMARY KEY,
+    environment_key TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    claim_fence INTEGER NOT NULL,
+    source_key TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    turn_index INTEGER NOT NULL,
+    scope TEXT NOT NULL CHECK (scope IN ('main','delegated')),
+    child_id TEXT,
+    role TEXT NOT NULL,
+    ts_ms INTEGER,
+    model TEXT,
+    effort TEXT,
+    speed TEXT,
+    input_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL,
+    cache_write_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    is_compaction_boundary INTEGER NOT NULL,
+    message_id TEXT,
+    uuid TEXT,
+    parent_uuid TEXT,
+    FOREIGN KEY (environment_key, agent, session_id)
+      REFERENCES session (environment_key, agent, session_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX turn_session_thread
+    ON turn (environment_key, agent, session_id, thread_id, turn_index);
+
+CREATE TABLE turn_content (
+    turn_rowid INTEGER NOT NULL REFERENCES turn (rowid) ON DELETE CASCADE,
+    part_index INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    content BLOB NOT NULL,
+    PRIMARY KEY (turn_rowid, part_index)
+) WITHOUT ROWID, STRICT;
+"#;
+
+/// Number of rows a [`TurnRowSink`] buffers before it writes them, unless the
+/// caller picks a different size with [`TurnRowSink::with_batch_size`].
+pub const TURN_ROW_BATCH_SIZE: usize = 512;
+
+/// Whether a turn ran in the session's main loop or in a delegated child.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnScope {
+    Main,
+    Delegated,
+}
+
+impl TurnScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TurnScope::Main => "main",
+            TurnScope::Delegated => "delegated",
+        }
+    }
+}
+
+/// One parsed turn, ready to become a `turn` row.
+///
+/// Carries every column except the session key and the claim fence — the
+/// caller supplies those once, for the whole batch, in
+/// [`insert_turn_rows`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct TurnRow {
+    pub source_key: String,
+    pub thread_id: String,
+    pub turn_index: u64,
+    pub scope: TurnScope,
+    pub child_id: Option<String>,
+    pub role: &'static str,
+    pub ts_ms: Option<i64>,
+    pub model: Option<String>,
+    pub effort: Option<String>,
+    pub speed: Option<String>,
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub output_tokens: u64,
+    pub is_compaction_boundary: bool,
+    pub message_id: Option<String>,
+    pub uuid: Option<String>,
+    pub parent_uuid: Option<String>,
+}
+
+fn role_key(role: Role) -> &'static str {
+    match role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::System => "system",
+        Role::Tool => "tool",
+    }
+}
+
+/// Build one row from a normalized event.
+///
+/// `source_key` names the parent transcript or child file this event comes
+/// from. `thread_id` equals `source_key` in this change — a later change
+/// derives finer per-thread identity from provider record links.
+///
+/// Scope is `Delegated` with `child_id = Some(source_key)` when the event's
+/// [`EventSource`] is `Subagent`; otherwise scope is `Main` with no
+/// `child_id`.
+pub fn turn_row_from_event(event: &NormalizedEvent, source_key: &str, turn_index: u64) -> TurnRow {
+    let (scope, child_id) = match event.source {
+        EventSource::Subagent => (TurnScope::Delegated, Some(source_key.to_owned())),
+        EventSource::Parent => (TurnScope::Main, None),
+    };
+    TurnRow {
+        source_key: source_key.to_owned(),
+        thread_id: source_key.to_owned(),
+        turn_index,
+        scope,
+        child_id,
+        role: role_key(event.role),
+        ts_ms: event.ts_ms,
+        model: event.model.clone(),
+        effort: event.thinking_mode.clone(),
+        speed: event.speed.clone(),
+        input_tokens: event.usage.input_tokens,
+        cache_read_tokens: event.usage.cache_read_tokens,
+        cache_write_tokens: event.usage.cache_creation_tokens,
+        output_tokens: event.usage.output_tokens,
+        is_compaction_boundary: event.is_compaction_boundary,
+        message_id: event.message_id.clone(),
+        uuid: event.uuid.clone(),
+        parent_uuid: event.parent_uuid.clone(),
+    }
+}
+
+/// A session's identity for row queries. Distinct from the app's own session
+/// key type — this crate does not depend on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnSessionKey<'a> {
+    pub environment_key: &'a str,
+    pub agent: &'a str,
+    pub session_id: &'a str,
+}
+
+/// One `turn`-row write failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnRowWriteError(pub String);
+
+impl std::fmt::Display for TurnRowWriteError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "turn row write failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for TurnRowWriteError {}
+
+impl From<rusqlite::Error> for TurnRowWriteError {
+    fn from(error: rusqlite::Error) -> Self {
+        TurnRowWriteError(error.to_string())
+    }
+}
+
+/// Writes a batch of turn rows for one session.
+///
+/// `&self` so a shared handle (an `Arc<Store>`, or an app type that wraps
+/// one) can implement this and move into the blocking thread that runs the
+/// analysis pass.
+pub trait TurnRowWriter: Send + Sync {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError>;
+}
+
+/// A [`RecordSink`] that turns `MetricsEvent` records into [`TurnRow`]s and
+/// writes them through a [`TurnRowWriter`] in bounded batches.
+///
+/// `turn_index` is monotonic per `source_key`, starting at zero. The buffer
+/// never exceeds `batch_size`: [`Self::observe`] flushes as soon as it
+/// reaches that size, so memory stays bounded no matter how long the source
+/// runs. The first write error is kept and stops further writes;
+/// [`Self::into_error`] lets the caller surface it.
+pub struct TurnRowSink<'a> {
+    writer: &'a dyn TurnRowWriter,
+    source_key: String,
+    next_index: u64,
+    buffer: Vec<TurnRow>,
+    batch_size: usize,
+    error: Option<TurnRowWriteError>,
+}
+
+impl<'a> TurnRowSink<'a> {
+    pub fn new(writer: &'a dyn TurnRowWriter, source_key: impl Into<String>) -> Self {
+        Self::with_batch_size(writer, source_key, TURN_ROW_BATCH_SIZE)
+    }
+
+    pub fn with_batch_size(
+        writer: &'a dyn TurnRowWriter,
+        source_key: impl Into<String>,
+        batch_size: usize,
+    ) -> Self {
+        let batch_size = batch_size.max(1);
+        Self {
+            writer,
+            source_key: source_key.into(),
+            next_index: 0,
+            buffer: Vec::with_capacity(batch_size.min(TURN_ROW_BATCH_SIZE)),
+            batch_size,
+            error: None,
+        }
+    }
+
+    /// True once a write has failed. No further row reaches the writer after
+    /// this, but rows already accepted before the failure stay written.
+    pub fn has_error(&self) -> bool {
+        self.error.is_some()
+    }
+
+    /// Consumes the sink and returns the write error, if one occurred.
+    pub fn into_error(self) -> Option<TurnRowWriteError> {
+        self.error
+    }
+
+    /// Folds one record without taking it. Only a `MetricsEvent` becomes a
+    /// row; `Observation` and `Unusable` records are not turns.
+    pub fn observe(&mut self, record: &NormalizedRecord) {
+        if self.error.is_some() {
+            return;
+        }
+        let NormalizedRecord::MetricsEvent(event) = record else {
+            return;
+        };
+        let row = turn_row_from_event(event, &self.source_key, self.next_index);
+        self.next_index += 1;
+        self.buffer.push(row);
+        if self.buffer.len() >= self.batch_size {
+            self.flush();
+        }
+    }
+
+    /// Writes any buffered rows and clears the buffer.
+    pub fn flush(&mut self) {
+        if self.error.is_some() || self.buffer.is_empty() {
+            return;
+        }
+        if let Err(error) = self.writer.write_turn_rows(&self.buffer) {
+            self.error = Some(error);
+        }
+        self.buffer.clear();
+    }
+}
+
+impl RecordSink for TurnRowSink<'_> {
+    fn record(&mut self, record: NormalizedRecord) {
+        self.observe(&record);
+    }
+
+    fn finish(&mut self, _summary: SessionSummary) {
+        self.flush();
+    }
+}
+
+const INSERT_TURN_SQL: &str = "INSERT INTO turn (
+    environment_key, agent, session_id, claim_fence, source_key, thread_id,
+    turn_index, scope, child_id, role, ts_ms, model, effort, speed,
+    input_tokens, cache_read_tokens, cache_write_tokens, output_tokens,
+    is_compaction_boundary, message_id, uuid, parent_uuid
+) VALUES (
+    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+    ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+)";
+
+/// Inserts one batch of rows for `key`, all stamped with `claim_fence`.
+///
+/// One prepared statement executed once per row. The caller supplies the
+/// transaction (pass a [`rusqlite::Transaction`], which derefs to
+/// `Connection`).
+pub fn insert_turn_rows(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    rows: &[TurnRow],
+) -> rusqlite::Result<()> {
+    let mut statement = conn.prepare(INSERT_TURN_SQL)?;
+    for row in rows {
+        statement.execute(params![
+            key.environment_key,
+            key.agent,
+            key.session_id,
+            claim_fence,
+            row.source_key,
+            row.thread_id,
+            row.turn_index as i64,
+            row.scope.as_str(),
+            row.child_id,
+            row.role,
+            row.ts_ms,
+            row.model,
+            row.effort,
+            row.speed,
+            row.input_tokens as i64,
+            row.cache_read_tokens as i64,
+            row.cache_write_tokens as i64,
+            row.output_tokens as i64,
+            i64::from(row.is_compaction_boundary),
+            row.message_id,
+            row.uuid,
+            row.parent_uuid,
+        ])?;
+    }
+    Ok(())
+}
+
+/// Deletes every row for `key` whose `claim_fence` is not `keep_fence`.
+///
+/// Used after a pass publishes: rows from every earlier, superseded pass are
+/// dropped, keeping only the rows the just-published evidence was built
+/// from. Returns the number of `turn` rows removed.
+pub fn delete_turn_rows_except_fence(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    keep_fence: i64,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM turn_content WHERE turn_rowid IN (
+             SELECT rowid FROM turn
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+                AND claim_fence != ?4
+         )",
+        params![key.environment_key, key.agent, key.session_id, keep_fence],
+    )?;
+    conn.execute(
+        "DELETE FROM turn
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+            AND claim_fence != ?4",
+        params![key.environment_key, key.agent, key.session_id, keep_fence],
+    )
+}
+
+/// Deletes every row for `key` stamped with exactly `claim_fence`.
+///
+/// Used when a pass loses the publish race (its claim fence no longer
+/// matches): the rows it wrote never became part of any published evidence,
+/// so they are cleaned up under their own fence rather than left to
+/// accumulate. Returns the number of `turn` rows removed.
+pub fn delete_turn_rows_for_fence(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM turn_content WHERE turn_rowid IN (
+             SELECT rowid FROM turn
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+                AND claim_fence = ?4
+         )",
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+    )?;
+    conn.execute(
+        "DELETE FROM turn
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+            AND claim_fence = ?4",
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+    )
+}
+
+/// Deletes every row for `key`. Used by session delete and
+/// clear-local-session-data paths.
+pub fn delete_turn_rows(conn: &Connection, key: &TurnSessionKey<'_>) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM turn_content WHERE turn_rowid IN (
+             SELECT rowid FROM turn
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+         )",
+        params![key.environment_key, key.agent, key.session_id],
+    )?;
+    conn.execute(
+        "DELETE FROM turn
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+        params![key.environment_key, key.agent, key.session_id],
+    )
+}
+
+/// Counts the rows for `key` stamped with `claim_fence`.
+pub fn count_turn_rows(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<u64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM turn
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+            AND claim_fence = ?4",
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+        |row| row.get(0),
+    )?;
+    Ok(count.max(0) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::analysis::model::Usage;
+
+    const TEST_SESSION_SQL: &str = "CREATE TABLE session (
+        environment_key TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        PRIMARY KEY (environment_key, agent, session_id)
+    ) STRICT;";
+
+    fn test_connection() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory connection");
+        conn.pragma_update(None, "foreign_keys", true)
+            .expect("enable foreign keys");
+        conn.execute_batch(TEST_SESSION_SQL)
+            .expect("create session table");
+        conn.execute_batch(TURN_SCHEMA_SQL)
+            .expect("create turn schema");
+        conn
+    }
+
+    fn insert_session(conn: &Connection, key: &TurnSessionKey<'_>) {
+        conn.execute(
+            "INSERT INTO session (environment_key, agent, session_id) VALUES (?1, ?2, ?3)",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .expect("insert session");
+    }
+
+    fn sample_row(turn_index: u64) -> TurnRow {
+        TurnRow {
+            source_key: "s1".to_owned(),
+            thread_id: "s1".to_owned(),
+            turn_index,
+            scope: TurnScope::Main,
+            child_id: None,
+            role: "assistant",
+            ts_ms: Some(1_000 + turn_index as i64),
+            model: Some("claude-opus-4-6".to_owned()),
+            effort: None,
+            speed: None,
+            input_tokens: 10,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            output_tokens: 5,
+            is_compaction_boundary: false,
+            message_id: None,
+            uuid: None,
+            parent_uuid: None,
+        }
+    }
+
+    #[test]
+    fn insert_and_count_round_trip() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        let rows = vec![sample_row(0), sample_row(1)];
+        insert_turn_rows(&conn, &key, 7, &rows).expect("insert rows");
+
+        assert_eq!(count_turn_rows(&conn, &key, 7).expect("count"), 2);
+        assert_eq!(count_turn_rows(&conn, &key, 8).expect("count"), 0);
+    }
+
+    #[test]
+    fn delete_except_fence_keeps_only_the_current_pass() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        insert_turn_rows(&conn, &key, 1, &[sample_row(0)]).expect("insert pass 1");
+        insert_turn_rows(&conn, &key, 2, &[sample_row(0), sample_row(1)]).expect("insert pass 2");
+
+        let removed = delete_turn_rows_except_fence(&conn, &key, 2).expect("delete stale");
+        assert_eq!(removed, 1);
+        assert_eq!(count_turn_rows(&conn, &key, 1).expect("count"), 0);
+        assert_eq!(count_turn_rows(&conn, &key, 2).expect("count"), 2);
+    }
+
+    #[test]
+    fn delete_for_fence_removes_only_the_matching_pass() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        insert_turn_rows(&conn, &key, 1, &[sample_row(0)]).expect("insert pass 1");
+        insert_turn_rows(&conn, &key, 2, &[sample_row(0), sample_row(1)]).expect("insert pass 2");
+
+        let removed = delete_turn_rows_for_fence(&conn, &key, 1).expect("delete lost race");
+        assert_eq!(removed, 1);
+        assert_eq!(count_turn_rows(&conn, &key, 1).expect("count"), 0);
+        assert_eq!(count_turn_rows(&conn, &key, 2).expect("count"), 2);
+    }
+
+    #[test]
+    fn delete_turn_rows_removes_every_row_for_the_session() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        insert_turn_rows(&conn, &key, 1, &[sample_row(0), sample_row(1)]).expect("insert");
+
+        let removed = delete_turn_rows(&conn, &key).expect("delete all");
+        assert_eq!(removed, 2);
+        assert_eq!(count_turn_rows(&conn, &key, 1).expect("count"), 0);
+    }
+
+    #[test]
+    fn deleting_the_session_cascades_to_its_turn_rows() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        insert_turn_rows(&conn, &key, 1, &[sample_row(0)]).expect("insert");
+
+        conn.execute(
+            "DELETE FROM session WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .expect("delete session");
+
+        assert_eq!(count_turn_rows(&conn, &key, 1).expect("count"), 0);
+    }
+
+    #[test]
+    fn turn_row_from_event_maps_delegated_scope() {
+        let mut event = NormalizedEvent::new(Role::Assistant);
+        event.source = EventSource::Subagent;
+        event.usage = Usage {
+            input_tokens: 3,
+            ..Usage::default()
+        };
+
+        let row = turn_row_from_event(&event, "child-1", 2);
+        assert_eq!(row.scope, TurnScope::Delegated);
+        assert_eq!(row.child_id.as_deref(), Some("child-1"));
+        assert_eq!(row.thread_id, "child-1");
+        assert_eq!(row.turn_index, 2);
+        assert_eq!(row.input_tokens, 3);
+    }
+
+    #[test]
+    fn turn_row_from_event_maps_main_scope() {
+        let event = NormalizedEvent::new(Role::User);
+        let row = turn_row_from_event(&event, "parent-1", 0);
+        assert_eq!(row.scope, TurnScope::Main);
+        assert_eq!(row.child_id, None);
+    }
+
+    /// A writer that always fails, so the sink's error path can be tested
+    /// without a real connection.
+    struct FailingWriter;
+
+    impl TurnRowWriter for FailingWriter {
+        fn write_turn_rows(&self, _rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+            Err(TurnRowWriteError("boom".to_owned()))
+        }
+    }
+
+    /// A writer over a real connection, so batching tests can assert on rows
+    /// actually reaching the table.
+    struct RecordingWriter {
+        conn: Mutex<Connection>,
+        key: String,
+    }
+
+    impl RecordingWriter {
+        fn new(conn: Connection) -> Self {
+            Self {
+                conn: Mutex::new(conn),
+                key: "s1".to_owned(),
+            }
+        }
+
+        fn count(&self, claim_fence: i64) -> u64 {
+            let conn = self.conn.lock().expect("lock");
+            count_turn_rows(
+                &conn,
+                &TurnSessionKey {
+                    environment_key: "native",
+                    agent: "claude",
+                    session_id: &self.key,
+                },
+                claim_fence,
+            )
+            .expect("count")
+        }
+    }
+
+    impl TurnRowWriter for RecordingWriter {
+        fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+            let conn = self.conn.lock().expect("lock");
+            insert_turn_rows(
+                &conn,
+                &TurnSessionKey {
+                    environment_key: "native",
+                    agent: "claude",
+                    session_id: &self.key,
+                },
+                1,
+                rows,
+            )
+            .map_err(TurnRowWriteError::from)
+        }
+    }
+
+    fn metric_record(role: Role) -> NormalizedRecord {
+        NormalizedRecord::MetricsEvent(Box::new(NormalizedEvent::new(role)))
+    }
+
+    #[test]
+    fn the_buffer_never_exceeds_batch_size_and_index_stays_monotonic() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        let writer = RecordingWriter::new(conn);
+        let mut sink = TurnRowSink::with_batch_size(&writer, "s1", 4);
+
+        for _ in 0..10 {
+            sink.observe(&metric_record(Role::Assistant));
+            assert!(sink.buffer.len() <= 4);
+        }
+        sink.flush();
+
+        assert_eq!(writer.count(1), 10);
+        assert_eq!(sink.next_index, 10);
+    }
+
+    #[test]
+    fn a_write_error_stops_further_writes_and_is_surfaced() {
+        let writer = FailingWriter;
+        let mut sink = TurnRowSink::with_batch_size(&writer, "s1", 1);
+
+        sink.observe(&metric_record(Role::Assistant));
+        assert!(sink.has_error());
+        sink.observe(&metric_record(Role::Assistant));
+        sink.observe(&metric_record(Role::Assistant));
+
+        let error = sink.into_error().expect("error must surface");
+        assert_eq!(error.0, "boom");
+    }
+
+    #[test]
+    fn only_metrics_events_become_rows() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        let writer = RecordingWriter::new(conn);
+        let mut sink = TurnRowSink::new(&writer, "s1");
+
+        sink.observe(&metric_record(Role::Assistant));
+        sink.observe(&NormalizedRecord::Unusable(
+            crate::analysis::PartialReason::MalformedRecord,
+        ));
+        sink.finish(SessionSummary::default());
+
+        assert_eq!(writer.count(1), 1);
+    }
+}

--- a/crates/antiburn-local/tests/claude_characterization.rs
+++ b/crates/antiburn-local/tests/claude_characterization.rs
@@ -226,7 +226,7 @@ fn stream_claude(input: &SessionInput) -> SessionMetricsAccumulator {
     accumulator
 }
 
-fn stream_composite(input: &SessionInput) -> CompositeSink {
+fn stream_composite(input: &SessionInput) -> CompositeSink<'static> {
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),

--- a/crates/antiburn-local/tests/pipeline_corpus.rs
+++ b/crates/antiburn-local/tests/pipeline_corpus.rs
@@ -64,7 +64,7 @@ fn write_session(directory: &TempDir, session: &GeneratedSession) -> PathBuf {
     path
 }
 
-fn composite_for(input: &SessionInput) -> CompositeSink {
+fn composite_for(input: &SessionInput) -> CompositeSink<'static> {
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),
@@ -76,7 +76,7 @@ fn composite_for(input: &SessionInput) -> CompositeSink {
 }
 
 /// Runs framing → normalization → metrics + evidence for one input.
-fn run_pipeline(input: &SessionInput) -> CompositeSink {
+fn run_pipeline(input: &SessionInput) -> CompositeSink<'static> {
     let mut composite = composite_for(input);
     let outcome = adapter_for("claude")
         .visit(input, &mut composite)
@@ -388,7 +388,7 @@ fn provider_db_backed_source_flows_end_to_end_into_a_report() {
 /// Forwards to a composite sink and appends to the source file mid-read,
 /// like an agent still writing its transcript.
 struct AppendingSink {
-    inner: CompositeSink,
+    inner: CompositeSink<'static>,
     path: PathBuf,
     append_after_records: usize,
     seen: usize,

--- a/crates/antiburn-local/tests/streaming_metrics_memory.rs
+++ b/crates/antiburn-local/tests/streaming_metrics_memory.rs
@@ -2,11 +2,14 @@
 mod corpus;
 
 use std::io::Cursor;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use antiburn_local::analysis::{
-    BoundedJsonlReader, NormalizedEvent, NormalizedRecord, RETAINED_METRICS_BYTES_BOUND, RawSource,
-    RecordSink, Role, SCAN_QUANTUM_BYTES, SessionInput, SessionMetricsAccumulator, SessionSummary,
-    ToolCall, Usage, adapter_for,
+    BoundedJsonlReader, CompositeSink, EvidenceSource, NormalizedEvent, NormalizedRecord,
+    RETAINED_METRICS_BYTES_BOUND, RawSource, RecordSink, Role, SCAN_QUANTUM_BYTES,
+    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SessionSummary,
+    SourceCapabilities, SourceKind, TURN_ROW_BATCH_SIZE, ToolCall, TurnRow, TurnRowSink,
+    TurnRowWriteError, TurnRowWriter, Usage, adapter_for,
 };
 use corpus::generate_session_of_bytes;
 
@@ -121,4 +124,52 @@ fn retained_state_stays_small_for_a_small_session() {
     }
     accumulator.finish(SessionSummary::default());
     assert!(accumulator.retained_bytes() <= 32 * 1_024);
+}
+
+/// Records only the largest batch and the total row count it ever saw, so
+/// the assertions below need no real database.
+#[derive(Default)]
+struct CountingWriter {
+    max_batch: AtomicUsize,
+    total_rows: AtomicUsize,
+}
+
+impl TurnRowWriter for CountingWriter {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+        self.max_batch.fetch_max(rows.len(), Ordering::SeqCst);
+        self.total_rows.fetch_add(rows.len(), Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[test]
+fn the_turn_row_sink_stays_bounded_over_a_streamed_corpus() {
+    let session = generate_session_of_bytes(402, 0, 3 * 1024 * 1024);
+    let input = SessionInput {
+        agent: "claude".to_string(),
+        session_id: session.session_id.clone(),
+        source: RawSource::Jsonl(session.jsonl.clone()),
+    };
+    let writer = CountingWriter::default();
+    let metrics = SessionMetricsAccumulator::new(&input.agent, &input.session_id);
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::claude(),
+    });
+    let sink = TurnRowSink::new(&writer, input.session_id.clone());
+    let mut composite = CompositeSink::with_turn_rows(metrics, evidence, sink);
+    adapter_for("claude")
+        .visit(&input, &mut composite)
+        .expect("synthetic source streams");
+
+    assert!(!composite.turn_row_write_failed());
+    assert!(
+        writer.max_batch.load(Ordering::SeqCst) <= TURN_ROW_BATCH_SIZE,
+        "largest batch was {} rows, batch size is {}",
+        writer.max_batch.load(Ordering::SeqCst),
+        TURN_ROW_BATCH_SIZE
+    );
+    assert!(writer.total_rows.load(Ordering::SeqCst) > 0);
 }

--- a/crates/antiburn-local/tests/support/claude_fixture.rs
+++ b/crates/antiburn-local/tests/support/claude_fixture.rs
@@ -19,11 +19,11 @@ pub fn session_input(name: &str) -> SessionInput {
     }
 }
 
-pub fn stream_composite(name: &str) -> CompositeSink {
+pub fn stream_composite(name: &str) -> CompositeSink<'static> {
     stream_input(session_input(name))
 }
 
-pub fn stream_source(name: &str, source: String) -> CompositeSink {
+pub fn stream_source(name: &str, source: String) -> CompositeSink<'static> {
     stream_input(SessionInput {
         agent: "claude".to_owned(),
         session_id: name.to_owned(),
@@ -31,7 +31,7 @@ pub fn stream_source(name: &str, source: String) -> CompositeSink {
     })
 }
 
-fn stream_input(input: SessionInput) -> CompositeSink {
+fn stream_input(input: SessionInput) -> CompositeSink<'static> {
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),


### PR DESCRIPTION
## Summary

Seam 2a of the harness parity plan (#259 rev 2, "Turn rows are the source of truth"): every parsed turn becomes a row in a `turn` table in the app database. No message content yet — `turn_content` is created here (keyed `(turn_rowid, part_index)`) and written in the follow-up PR so that needs no migration.

- `antiburn-local` gains `analysis::rows`: `TURN_SCHEMA_SQL`, `TurnRow`/`TurnScope`, `turn_row_from_event`, `TurnRowWriter` trait, a batching `TurnRowSink` (`RecordSink`, ≤512 rows buffered), and insert/delete/count functions over a borrowed `rusqlite::Connection`. The crate never opens the app database.
- `CompositeSink` fans out to an optional `TurnRowSink`; metrics and evidence behaviour and all characterization goldens are unchanged.
- Desktop: migration V15 applies the crate DDL. `Store` becomes a cheap `Clone` handle (`Arc<Mutex<Connection>>`) so the worker can hand a `FencedTurnRowWriter` to the blocking analysis thread. Each batch is one transaction under the store lock.
- Fencing: rows carry the pass `claim_fence`. `publish_projections` deletes rows with any other fence inside its fenced transaction; a lost race deletes its own rows. A row-write error fails the pass (`Unreadable` → backoff retry).
- `delete_session` and `clear_local_session_data` delete `turn`/`turn_content` explicitly.
- `scope`/`child_id` derive from `EventSource` and the input's session id; `thread_id == source_key` until Phase 4 adapter enrichment.

## Tests

15 crate unit tests (round-trip, fence deletion, cascade, batching bound, scope mapping, error surfacing); store tests (migration head 15, fenced publish keep/lost-race, delete paths, cascade); a worker test through the real `stream_vendor_with_hooks → TurnRowSink → FencedTurnRowWriter` path; a streaming-memory test that the row buffer never exceeds the batch size.

## Validation

- `crates/antiburn-local`: fmt, clippy `-D warnings`, test (998 unit + integration)
- `apps/desktop/src-tauri`: fmt, clippy `-D warnings`, test (577), `cargo deny check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U7uVd1iQZBdWV2KdmSjSA