### PR TITLE
feat(analysis): capture message content into turn_content

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use antiburn_local::analysis::{TurnScope, count_turn_rows};
+use antiburn_local::analysis::{
+    ContentKind, ContentPart, TurnScope, count_turn_content_rows, count_turn_rows,
+};
 
 use super::model::PublishedEvidence;
 use super::*;
@@ -2985,6 +2987,7 @@ fn turn_row(turn_index: u64) -> TurnRow {
         message_id: None,
         uuid: None,
         parent_uuid: None,
+        content: Vec::new(),
     }
 }
 
@@ -3216,4 +3219,68 @@ fn deleting_the_session_row_directly_cascades_to_its_turn_rows() {
         count_turn_rows(&connection, &turn_session_key(&key), 1).unwrap(),
         0
     );
+}
+
+fn turn_row_with_content(turn_index: u64, text: &str) -> TurnRow {
+    TurnRow {
+        content: vec![ContentPart::new(ContentKind::AssistantText, text)],
+        ..turn_row(turn_index)
+    }
+}
+
+#[test]
+fn deleting_a_session_removes_turn_content_written_through_the_fenced_writer() {
+    let store = store();
+    let key = SessionKey::new("native", "claude-code", "turn-content-delete-session");
+    store
+        .upsert_sessions(
+            &[session("turn-content-delete-session", 1_000)],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), 1);
+    writer
+        .write_turn_rows(&[turn_row_with_content(0, "PRIVATE_TURN_CONTENT")])
+        .unwrap();
+    assert_eq!(
+        count_turn_content_rows(&store.lock(), &turn_session_key(&key), 1).unwrap(),
+        1
+    );
+
+    assert!(store.delete_session(&key).unwrap());
+
+    assert_eq!(
+        count_turn_content_rows(&store.lock(), &turn_session_key(&key), 1).unwrap(),
+        0
+    );
+}
+
+#[test]
+fn clearing_local_session_data_removes_turn_content_written_through_the_fenced_writer() {
+    let store = store();
+    let mut record = session("turn-content-clear", 1_000);
+    record.source_fingerprint = Some("sv1:turn-content-clear".into());
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    let key = record.key.clone();
+    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), 1);
+    writer
+        .write_turn_rows(&[turn_row_with_content(0, "PRIVATE_TURN_CONTENT")])
+        .unwrap();
+    assert_eq!(
+        count_turn_content_rows(&store.lock(), &turn_session_key(&key), 1).unwrap(),
+        1
+    );
+
+    store.clear_local_session_data().unwrap();
+
+    let remaining: i64 = store
+        .lock()
+        .query_row("SELECT COUNT(*) FROM turn_content", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(remaining, 0);
 }

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -155,6 +155,7 @@ impl SessionEvidenceAccumulator {
                 self.observe_event(event);
             }
             NormalizedRecord::Observation(observation) => self.observe_observation(observation),
+            NormalizedRecord::TurnContent(_) => {}
             NormalizedRecord::Unusable(reason) => {
                 self.diagnostics.records_observed =
                     self.diagnostics.records_observed.saturating_add(1);

--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -40,7 +40,77 @@ pub struct SessionInput {
 pub enum NormalizedRecord {
     MetricsEvent(Box<NormalizedEvent>),
     Observation(Box<EvidenceObservation>),
+    /// One turn's captured message content. An adapter emits this
+    /// immediately after the `MetricsEvent` it belongs to, and only when it
+    /// has at least one part. The metrics and evidence sinks ignore it; only
+    /// [`crate::analysis::rows::TurnRowSink`] reads it.
+    TurnContent(Box<TurnContent>),
     Unusable(PartialReason),
+}
+
+/// Cap on one [`ContentPart`]'s byte length. [`ContentPart::new`] truncates
+/// longer text on a char boundary. This bounds the row sink's per-batch
+/// memory no matter how long a single message part is.
+pub const MAX_CONTENT_PART_BYTES: usize = 256 * 1024;
+
+/// One turn's captured message content, ready to become `turn_content` rows.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TurnContent {
+    pub parts: Vec<ContentPart>,
+}
+
+/// One piece of a turn's captured text: one text block, one thinking block,
+/// one tool call's input, or one tool call's result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentPart {
+    pub kind: ContentKind,
+    pub text: String,
+    /// True when `text` was cut short at [`MAX_CONTENT_PART_BYTES`].
+    pub truncated: bool,
+}
+
+impl ContentPart {
+    /// Builds a part, capping `text` at [`MAX_CONTENT_PART_BYTES`] bytes on a
+    /// char boundary.
+    pub fn new(kind: ContentKind, text: impl Into<String>) -> Self {
+        let mut text = text.into();
+        let mut truncated = false;
+        if text.len() > MAX_CONTENT_PART_BYTES {
+            let mut boundary = MAX_CONTENT_PART_BYTES;
+            while boundary > 0 && !text.is_char_boundary(boundary) {
+                boundary -= 1;
+            }
+            text.truncate(boundary);
+            truncated = true;
+        }
+        Self {
+            kind,
+            text,
+            truncated,
+        }
+    }
+}
+
+/// The kind of text one [`ContentPart`] carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentKind {
+    UserText,
+    AssistantText,
+    Thinking,
+    ToolInput,
+    ToolResult,
+}
+
+impl ContentKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ContentKind::UserText => "user",
+            ContentKind::AssistantText => "assistant",
+            ContentKind::Thinking => "thinking",
+            ContentKind::ToolInput => "tool_input",
+            ContentKind::ToolResult => "tool_result",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -183,6 +253,7 @@ impl RecordSink for SessionCollector {
         match record {
             NormalizedRecord::MetricsEvent(event) => self.events.push(*event),
             NormalizedRecord::Observation(_) => {}
+            NormalizedRecord::TurnContent(_) => {}
             NormalizedRecord::Unusable(reason) => {
                 self.partial_reasons.insert(reason);
             }

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -65,9 +65,9 @@ pub use framing::{
 };
 pub use initial_context::{InitialContextBreakdown, InitialContextSourceCount, SourceOrigin};
 pub use interface::{
-    ContextSourceKind, EvidenceObservation, NormalizedRecord, RawSource, RecordCoverage,
-    RecordSink, RelationProvenance, SessionCollector, SessionInput, SessionSummary,
-    SourceChangedReason, VendorAdapter, VisitOutcome,
+    ContentKind, ContentPart, ContextSourceKind, EvidenceObservation, MAX_CONTENT_PART_BYTES,
+    NormalizedRecord, RawSource, RecordCoverage, RecordSink, RelationProvenance, SessionCollector,
+    SessionInput, SessionSummary, SourceChangedReason, TurnContent, VendorAdapter, VisitOutcome,
 };
 pub use merge::merge_subagent_events;
 pub use metrics_sink::{RETAINED_METRICS_BYTES_BOUND, SessionMetricsAccumulator, merge_metrics};
@@ -77,8 +77,9 @@ pub use model::{
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
 pub use rows::{
     TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TurnRow, TurnRowSink, TurnRowWriteError, TurnRowWriter,
-    TurnScope, TurnSessionKey, count_turn_rows, delete_turn_rows, delete_turn_rows_except_fence,
-    delete_turn_rows_for_fence, insert_turn_rows, turn_row_from_event,
+    TurnScope, TurnSessionKey, count_turn_content_rows, count_turn_rows, delete_turn_rows,
+    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
+    turn_row_from_event,
 };
 pub use source_validity::{
     AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -10,7 +10,7 @@
 
 use rusqlite::{Connection, params};
 
-use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary};
+use crate::analysis::interface::{ContentPart, NormalizedRecord, RecordSink, SessionSummary};
 use crate::analysis::model::{EventSource, NormalizedEvent, Role};
 
 /// DDL for the `turn` and `turn_content` tables.
@@ -24,6 +24,11 @@ use crate::analysis::model::{EventSource, NormalizedEvent, Role};
 ///
 /// The caller applies this DDL after its own `session` table exists — the
 /// foreign key references `session (environment_key, agent, session_id)`.
+///
+/// `turn_content` is the only place transcript text is persisted. Evidence
+/// JSON, metrics JSON, and every other projection never join to it — see
+/// `docs/plans/session-evidence-harness-parity.md`, "Privacy with content
+/// stored".
 pub const TURN_SCHEMA_SQL: &str = r#"
 CREATE TABLE turn (
     rowid INTEGER PRIMARY KEY,
@@ -61,6 +66,7 @@ CREATE TABLE turn_content (
     part_index INTEGER NOT NULL,
     kind TEXT NOT NULL,
     content BLOB NOT NULL,
+    truncated INTEGER NOT NULL,
     PRIMARY KEY (turn_rowid, part_index)
 ) WITHOUT ROWID, STRICT;
 "#;
@@ -110,6 +116,10 @@ pub struct TurnRow {
     pub message_id: Option<String>,
     pub uuid: Option<String>,
     pub parent_uuid: Option<String>,
+    /// This turn's captured message content, when the source adapter emitted
+    /// a `TurnContent` record for it. Attached by [`TurnRowSink`] after
+    /// [`turn_row_from_event`] builds the row — an event alone carries none.
+    pub content: Vec<ContentPart>,
 }
 
 fn role_key(role: Role) -> &'static str {
@@ -154,6 +164,7 @@ pub fn turn_row_from_event(event: &NormalizedEvent, source_key: &str, turn_index
         message_id: event.message_id.clone(),
         uuid: event.uuid.clone(),
         parent_uuid: event.parent_uuid.clone(),
+        content: Vec::new(),
     }
 }
 
@@ -193,14 +204,19 @@ pub trait TurnRowWriter: Send + Sync {
     fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError>;
 }
 
-/// A [`RecordSink`] that turns `MetricsEvent` records into [`TurnRow`]s and
-/// writes them through a [`TurnRowWriter`] in bounded batches.
+/// A [`RecordSink`] that turns `MetricsEvent` records into [`TurnRow`]s,
+/// attaches each row's `TurnContent` record (when one arrives), and writes
+/// the rows through a [`TurnRowWriter`] in bounded batches.
 ///
-/// `turn_index` is monotonic per `source_key`, starting at zero. The buffer
-/// never exceeds `batch_size`: [`Self::observe`] flushes as soon as it
-/// reaches that size, so memory stays bounded no matter how long the source
-/// runs. The first write error is kept and stops further writes;
-/// [`Self::into_error`] lets the caller surface it.
+/// `turn_index` is monotonic per `source_key`, starting at zero. After each
+/// call to [`Self::observe`] the buffer holds at most `batch_size` rows: once
+/// a pushed `MetricsEvent` row takes it over that size, every row except the
+/// one just pushed is flushed immediately, so memory stays bounded no matter
+/// how long the source runs. The most recently pushed row stays buffered
+/// (unwritten) so its `TurnContent` record — which the adapter contract
+/// promises arrives right after the `MetricsEvent` it belongs to — can still
+/// attach before that row is written. The first write error is kept and
+/// stops further writes; [`Self::into_error`] lets the caller surface it.
 pub struct TurnRowSink<'a> {
     writer: &'a dyn TurnRowWriter,
     source_key: String,
@@ -242,20 +258,29 @@ impl<'a> TurnRowSink<'a> {
         self.error
     }
 
-    /// Folds one record without taking it. Only a `MetricsEvent` becomes a
-    /// row; `Observation` and `Unusable` records are not turns.
+    /// Folds one record without taking it. A `MetricsEvent` becomes a
+    /// buffered row; a `TurnContent` record attaches its parts to the most
+    /// recently buffered row. `Observation` and `Unusable` records are not
+    /// turns.
     pub fn observe(&mut self, record: &NormalizedRecord) {
         if self.error.is_some() {
             return;
         }
-        let NormalizedRecord::MetricsEvent(event) = record else {
-            return;
-        };
-        let row = turn_row_from_event(event, &self.source_key, self.next_index);
-        self.next_index += 1;
-        self.buffer.push(row);
-        if self.buffer.len() >= self.batch_size {
-            self.flush();
+        match record {
+            NormalizedRecord::MetricsEvent(event) => {
+                let row = turn_row_from_event(event, &self.source_key, self.next_index);
+                self.next_index += 1;
+                self.buffer.push(row);
+                if self.buffer.len() > self.batch_size {
+                    self.flush_except_last();
+                }
+            }
+            NormalizedRecord::TurnContent(content) => {
+                if let Some(row) = self.buffer.last_mut() {
+                    row.content.clone_from(&content.parts);
+                }
+            }
+            NormalizedRecord::Observation(_) | NormalizedRecord::Unusable(_) => {}
         }
     }
 
@@ -268,6 +293,24 @@ impl<'a> TurnRowSink<'a> {
             self.error = Some(error);
         }
         self.buffer.clear();
+    }
+
+    /// Writes every buffered row except the last, keeping that last row
+    /// buffered so a `TurnContent` record for it can still attach before it
+    /// is written. Keeps the buffer at `batch_size` rows or fewer once this
+    /// returns.
+    fn flush_except_last(&mut self) {
+        if self.error.is_some() {
+            return;
+        }
+        let Some(last) = self.buffer.pop() else {
+            return;
+        };
+        if let Err(error) = self.writer.write_turn_rows(&self.buffer) {
+            self.error = Some(error);
+        }
+        self.buffer.clear();
+        self.buffer.push(last);
     }
 }
 
@@ -291,11 +334,16 @@ const INSERT_TURN_SQL: &str = "INSERT INTO turn (
     ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
 )";
 
-/// Inserts one batch of rows for `key`, all stamped with `claim_fence`.
+const INSERT_TURN_CONTENT_SQL: &str = "INSERT INTO turn_content (
+    turn_rowid, part_index, kind, content, truncated
+) VALUES (?1, ?2, ?3, ?4, ?5)";
+
+/// Inserts one batch of rows for `key`, all stamped with `claim_fence`, and
+/// each row's captured content (if any) into `turn_content`.
 ///
-/// One prepared statement executed once per row. The caller supplies the
-/// transaction (pass a [`rusqlite::Transaction`], which derefs to
-/// `Connection`).
+/// One prepared statement executed once per row, plus one per content part.
+/// The caller supplies the transaction (pass a [`rusqlite::Transaction`],
+/// which derefs to `Connection`).
 pub fn insert_turn_rows(
     conn: &Connection,
     key: &TurnSessionKey<'_>,
@@ -303,6 +351,7 @@ pub fn insert_turn_rows(
     rows: &[TurnRow],
 ) -> rusqlite::Result<()> {
     let mut statement = conn.prepare(INSERT_TURN_SQL)?;
+    let mut content_statement = conn.prepare(INSERT_TURN_CONTENT_SQL)?;
     for row in rows {
         statement.execute(params![
             key.environment_key,
@@ -328,6 +377,18 @@ pub fn insert_turn_rows(
             row.uuid,
             row.parent_uuid,
         ])?;
+        if !row.content.is_empty() {
+            let turn_rowid = conn.last_insert_rowid();
+            for (part_index, part) in row.content.iter().enumerate() {
+                content_statement.execute(params![
+                    turn_rowid,
+                    part_index as i64,
+                    part.kind.as_str(),
+                    part.text.as_bytes(),
+                    i64::from(part.truncated),
+                ])?;
+            }
+        }
     }
     Ok(())
 }
@@ -418,6 +479,26 @@ pub fn count_turn_rows(
     Ok(count.max(0) as u64)
 }
 
+/// Counts the `turn_content` rows for `key`'s turns stamped with
+/// `claim_fence`.
+pub fn count_turn_content_rows(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<u64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM turn_content
+          WHERE turn_rowid IN (
+              SELECT rowid FROM turn
+               WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+                 AND claim_fence = ?4
+          )",
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+        |row| row.get(0),
+    )?;
+    Ok(count.max(0) as u64)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -471,6 +552,7 @@ mod tests {
             message_id: None,
             uuid: None,
             parent_uuid: None,
+            content: Vec::new(),
         }
     }
 
@@ -625,6 +707,20 @@ mod tests {
             )
             .expect("count")
         }
+
+        fn content_count(&self, claim_fence: i64) -> u64 {
+            let conn = self.conn.lock().expect("lock");
+            count_turn_content_rows(
+                &conn,
+                &TurnSessionKey {
+                    environment_key: "native",
+                    agent: "claude",
+                    session_id: &self.key,
+                },
+                claim_fence,
+            )
+            .expect("count")
+        }
     }
 
     impl TurnRowWriter for RecordingWriter {
@@ -675,9 +771,12 @@ mod tests {
         let writer = FailingWriter;
         let mut sink = TurnRowSink::with_batch_size(&writer, "s1", 1);
 
+        // A row stays buffered, unflushed, until a later row pushes the
+        // buffer over `batch_size` — so the first write attempt (and the
+        // failure) happens on the second `observe` call, not the first.
+        sink.observe(&metric_record(Role::Assistant));
         sink.observe(&metric_record(Role::Assistant));
         assert!(sink.has_error());
-        sink.observe(&metric_record(Role::Assistant));
         sink.observe(&metric_record(Role::Assistant));
 
         let error = sink.into_error().expect("error must surface");
@@ -703,5 +802,60 @@ mod tests {
         sink.finish(SessionSummary::default());
 
         assert_eq!(writer.count(1), 1);
+    }
+
+    fn content_record(text: &str) -> NormalizedRecord {
+        NormalizedRecord::TurnContent(Box::new(crate::analysis::interface::TurnContent {
+            parts: vec![crate::analysis::interface::ContentPart::new(
+                crate::analysis::interface::ContentKind::AssistantText,
+                text,
+            )],
+        }))
+    }
+
+    #[test]
+    fn a_turn_content_record_attaches_to_the_row_it_follows() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        let writer = RecordingWriter::new(conn);
+        let mut sink = TurnRowSink::new(&writer, "s1");
+
+        sink.observe(&metric_record(Role::User));
+        sink.observe(&content_record("hello"));
+        sink.observe(&metric_record(Role::Assistant));
+        sink.finish(SessionSummary::default());
+
+        assert_eq!(writer.count(1), 2);
+        assert_eq!(writer.content_count(1), 1);
+    }
+
+    #[test]
+    fn content_still_attaches_after_the_batch_boundary_flushes_earlier_rows() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        let writer = RecordingWriter::new(conn);
+        let mut sink = TurnRowSink::with_batch_size(&writer, "s1", 2);
+
+        sink.observe(&metric_record(Role::Assistant));
+        sink.observe(&metric_record(Role::Assistant));
+        // Pushing a third row over `batch_size` flushes the first two,
+        // keeping only this one buffered for its content to attach to.
+        sink.observe(&metric_record(Role::Assistant));
+        assert_eq!(sink.buffer.len(), 1);
+        sink.observe(&content_record("hello"));
+        sink.finish(SessionSummary::default());
+
+        assert_eq!(writer.count(1), 3);
+        assert_eq!(writer.content_count(1), 1);
     }
 }

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -15,15 +15,15 @@ use serde_json::Value;
 
 use super::jsonl::{
     SKILL_BASE_MARKER, collect_skill_base_names_from_text, command_names_in_text,
-    command_skill_name, evidence_observations, is_inert_recognized_eventless,
-    is_inert_unrecognized, is_recognized_eventless, parse_record, record_discriminator,
-    record_text,
+    command_skill_name, evidence_observations, extract_content_parts,
+    is_inert_recognized_eventless, is_inert_unrecognized, is_recognized_eventless, parse_record,
+    record_discriminator, record_text,
 };
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, RecordSkip};
 use crate::analysis::initial_context::ClaudeContextAccumulator;
 use crate::analysis::interface::{
     NormalizedRecord, RawSource, RecordSink, SessionCollector, SessionInput, SessionSummary,
-    VendorAdapter, VisitOutcome,
+    TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, ToolCall, Usage};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
@@ -212,7 +212,13 @@ impl ClaudeAdapter {
                             });
                         state.pending_commands.push((state.ordinal, commands));
                     }
+                    let content_parts = extract_content_parts(&value, event.role);
                     sink.record(NormalizedRecord::MetricsEvent(Box::new(event)));
+                    if !content_parts.is_empty() {
+                        sink.record(NormalizedRecord::TurnContent(Box::new(TurnContent {
+                            parts: content_parts,
+                        })));
+                    }
                     state.ordinal += 1;
                 }
             }
@@ -583,6 +589,57 @@ mod tests {
     }
 
     #[test]
+    fn content_capture_maps_text_thinking_tool_use_and_tool_result() {
+        use crate::analysis::interface::ContentKind;
+
+        let assistant_record = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "hello there"},
+                    {"type": "thinking", "thinking": "pondering"},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                ]
+            }
+        })
+        .to_string();
+        let tool_result_record = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+            }
+        })
+        .to_string();
+        let input = SessionInput {
+            agent: "claude".to_string(),
+            session_id: "content-session".to_string(),
+            source: RawSource::Jsonl(format!("{assistant_record}\n{tool_result_record}\n")),
+        };
+        let mut sink = ContentCapturingSink::default();
+
+        ClaudeAdapter
+            .visit(&input, &mut sink)
+            .expect("visit content session");
+
+        assert_eq!(sink.contents.len(), 2, "one TurnContent per turn");
+        let assistant_parts = &sink.contents[0].parts;
+        assert_eq!(assistant_parts.len(), 3);
+        assert_eq!(assistant_parts[0].kind, ContentKind::AssistantText);
+        assert_eq!(assistant_parts[0].text, "hello there");
+        assert_eq!(assistant_parts[1].kind, ContentKind::Thinking);
+        assert_eq!(assistant_parts[1].text, "pondering");
+        assert_eq!(assistant_parts[2].kind, ContentKind::ToolInput);
+        assert_eq!(assistant_parts[2].text, r#"{"command":"ls"}"#);
+
+        let tool_result_parts = &sink.contents[1].parts;
+        assert_eq!(tool_result_parts.len(), 1);
+        assert_eq!(tool_result_parts[0].kind, ContentKind::ToolResult);
+        assert_eq!(tool_result_parts[0].text, "ok");
+    }
+
+    #[test]
     fn a_mid_stream_read_failure_omits_the_whole_session() {
         let source = b"{\"type\":\"assistant\",\"message\":{\"id\":\"first\",\"role\":\"assistant\",\"content\":[]}}\n";
         let reader = BufReader::new(DataThenError::new(source));
@@ -638,6 +695,22 @@ mod tests {
         fn finish(&mut self, _summary: SessionSummary) {
             self.finishes += 1;
         }
+    }
+
+    /// Collects every `TurnContent` record a visit emits, in order.
+    #[derive(Default)]
+    struct ContentCapturingSink {
+        contents: Vec<TurnContent>,
+    }
+
+    impl RecordSink for ContentCapturingSink {
+        fn record(&mut self, record: NormalizedRecord) {
+            if let NormalizedRecord::TurnContent(content) = record {
+                self.contents.push(*content);
+            }
+        }
+
+        fn finish(&mut self, _summary: SessionSummary) {}
     }
 
     struct DataThenError {

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -34,13 +34,16 @@ use std::io::{BufRead, BufReader, Cursor, Read};
 use anyhow::Context;
 use serde_json::{Map, Value};
 
-use super::jsonl::{parse_ts, tool_call_from_input};
+use super::jsonl::{
+    compact_json_text, concatenated_text, extract_content_parts_from_container, parse_ts,
+    tool_call_from_input,
+};
 use super::read_source;
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::initial_context::CodexContextAccumulator;
 use crate::analysis::interface::{
-    EvidenceObservation, NormalizedRecord, RawSource, RecordSink, SessionInput, SessionSummary,
-    VendorAdapter, VisitOutcome,
+    ContentKind, ContentPart, EvidenceObservation, NormalizedRecord, RawSource, RecordSink,
+    SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role, ToolCall, Usage};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
@@ -358,7 +361,13 @@ impl CodexStreamState {
             if self.is_duplicate_boundary(&event) {
                 return;
             }
+            let content_parts = content_parts_for_record(&value);
             sink.record(NormalizedRecord::MetricsEvent(Box::new(event)));
+            if !content_parts.is_empty() {
+                sink.record(NormalizedRecord::TurnContent(Box::new(TurnContent {
+                    parts: content_parts,
+                })));
+            }
         } else if !is_recognized_eventless(record_type, payload_type) {
             sink.record(NormalizedRecord::Observation(Box::new(
                 EvidenceObservation::UnrecognizedType {
@@ -694,6 +703,99 @@ fn record_to_event(record: &Value) -> Option<NormalizedEvent> {
         ("compacted", _) => Some(compaction_event(ts)),
         _ => None,
     }
+}
+
+/// Extract one rollout envelope record's message content as
+/// [`ContentPart`]s, for the `turn_content` capture. Mirrors the
+/// `(rec_type, payload_type)` dispatch [`record_to_event`] uses, but the
+/// tool-call shapes [`record_to_event`] does not turn into a `NormalizedEvent`
+/// on their own (`local_shell_call`, `tool_search_call`, `web_search_call`,
+/// `image_generation_call`) are not captured here.
+fn content_parts_for_record(record: &Value) -> Vec<ContentPart> {
+    let Some(obj) = record.as_object() else {
+        return Vec::new();
+    };
+    let rec_type = obj.get("type").and_then(Value::as_str).unwrap_or("");
+    let Some(payload) = obj.get("payload").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    let payload_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
+    match (rec_type, payload_type) {
+        ("response_item", "message") => message_content_parts(payload),
+        ("response_item", "reasoning") => reasoning_content_parts(payload),
+        ("response_item", "function_call_output")
+        | ("response_item", "custom_tool_call_output")
+        | ("response_item", "tool_search_output")
+        | ("response_item", "mcp_tool_call_output") => tool_output_content_parts(payload),
+        ("response_item", "custom_tool_call") => function_call_content_parts(payload),
+        ("response_item", _) if payload.contains_key("name") => {
+            function_call_content_parts(payload)
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// A `message` response_item's `content[]` (Codex's OpenAI-shaped
+/// `input_text` / `output_text` blocks), captured through the shared JSONL
+/// content extractor.
+fn message_content_parts(payload: &Map<String, Value>) -> Vec<ContentPart> {
+    let role = match payload.get("role").and_then(Value::as_str) {
+        Some("assistant") => Role::Assistant,
+        // `user`, `system`, and `developer` all capture as user-side text —
+        // `ContentKind` has no separate system kind.
+        _ => Role::User,
+    };
+    extract_content_parts_from_container(payload, role)
+}
+
+/// A `reasoning` response_item's `summary[]` text, concatenated into one
+/// `Thinking` part. Empty when the transcript carries no summary text (Codex
+/// often logs reasoning with an empty summary and encrypted content only).
+fn reasoning_content_parts(payload: &Map<String, Value>) -> Vec<ContentPart> {
+    let Some(summary) = payload.get("summary").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut text = String::new();
+    for item in summary {
+        if let Some(part) = item.get("text").and_then(Value::as_str) {
+            if !text.is_empty() {
+                text.push('\n');
+            }
+            text.push_str(part);
+        }
+    }
+    if text.is_empty() {
+        Vec::new()
+    } else {
+        vec![ContentPart::new(ContentKind::Thinking, text)]
+    }
+}
+
+/// A tool call's `name` + `arguments`/`input`, as one `ToolInput` part.
+/// Covers both `function_call`-shaped records and `custom_tool_call` (whose
+/// `exec` wrapper input is a JavaScript string, kept as-is).
+fn function_call_content_parts(payload: &Map<String, Value>) -> Vec<ContentPart> {
+    let input = payload.get("arguments").or_else(|| payload.get("input"));
+    input
+        .and_then(compact_json_text)
+        .into_iter()
+        .map(|text| ContentPart::new(ContentKind::ToolInput, text))
+        .collect()
+}
+
+/// A tool call output's plain `output` string (`function_call_output` and
+/// its siblings), or the concatenated text of a `content[]` array when the
+/// output is block-shaped instead.
+fn tool_output_content_parts(payload: &Map<String, Value>) -> Vec<ContentPart> {
+    let text = payload
+        .get("output")
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .map(str::to_owned)
+        .or_else(|| concatenated_text(payload.get("content")));
+    text.into_iter()
+        .map(|text| ContentPart::new(ContentKind::ToolResult, text))
+        .collect()
 }
 
 fn message_event(payload: &Map<String, Value>, ts: Option<i64>) -> Option<NormalizedEvent> {
@@ -1114,5 +1216,79 @@ mod tests {
             sink.partial_reasons(),
             &std::collections::BTreeSet::from([PartialReason::AttributionIncomplete])
         );
+    }
+
+    /// Collects every `TurnContent` record a visit emits, in order.
+    #[derive(Default)]
+    struct ContentCapturingSink {
+        contents: Vec<TurnContent>,
+    }
+
+    impl RecordSink for ContentCapturingSink {
+        fn record(&mut self, record: NormalizedRecord) {
+            if let NormalizedRecord::TurnContent(content) = record {
+                self.contents.push(*content);
+            }
+        }
+
+        fn finish(&mut self, _summary: SessionSummary) {}
+    }
+
+    #[test]
+    fn content_capture_maps_message_reasoning_tool_call_and_output() {
+        let message_record = serde_json::json!({
+            "timestamp": "2026-08-01T10:00:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hello there"}]
+            }
+        })
+        .to_string();
+        let reasoning_record = serde_json::json!({
+            "timestamp": "2026-08-01T10:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "pondering"}]
+            }
+        })
+        .to_string();
+        let function_call_record = serde_json::json!({
+            "timestamp": "2026-08-01T10:00:02Z",
+            "type": "response_item",
+            "payload": {"type": "function_call", "name": "bash", "arguments": "{\"command\":\"ls\"}"}
+        })
+        .to_string();
+        let function_output_record = serde_json::json!({
+            "timestamp": "2026-08-01T10:00:03Z",
+            "type": "response_item",
+            "payload": {"type": "function_call_output", "call_id": "c1", "output": "ok"}
+        })
+        .to_string();
+        let jsonl = format!(
+            "{message_record}\n{reasoning_record}\n{function_call_record}\n{function_output_record}\n"
+        );
+        let input = SessionInput {
+            agent: "codex".to_string(),
+            session_id: "content-session".to_string(),
+            source: RawSource::Jsonl(jsonl),
+        };
+        let mut sink = ContentCapturingSink::default();
+
+        CodexAdapter
+            .visit(&input, &mut sink)
+            .expect("visit content session");
+
+        assert_eq!(sink.contents.len(), 4, "one TurnContent per turn");
+        assert_eq!(sink.contents[0].parts[0].kind, ContentKind::AssistantText);
+        assert_eq!(sink.contents[0].parts[0].text, "hello there");
+        assert_eq!(sink.contents[1].parts[0].kind, ContentKind::Thinking);
+        assert_eq!(sink.contents[1].parts[0].text, "pondering");
+        assert_eq!(sink.contents[2].parts[0].kind, ContentKind::ToolInput);
+        assert_eq!(sink.contents[2].parts[0].text, r#"{"command":"ls"}"#);
+        assert_eq!(sink.contents[3].parts[0].kind, ContentKind::ToolResult);
+        assert_eq!(sink.contents[3].parts[0].text, "ok");
     }
 }

--- a/crates/antiburn-local/src/analysis/vendors/jsonl.rs
+++ b/crates/antiburn-local/src/analysis/vendors/jsonl.rs
@@ -14,7 +14,9 @@ use serde_json::Value;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
-use crate::analysis::interface::{ContextSourceKind, EvidenceObservation, RelationProvenance};
+use crate::analysis::interface::{
+    ContentKind, ContentPart, ContextSourceKind, EvidenceObservation, RelationProvenance,
+};
 use crate::analysis::model::{
     CompactionTrigger, EventSource, NormalizedEvent, Role, ToolCall, Usage,
 };
@@ -474,6 +476,175 @@ pub(super) fn record_discriminator(value: &Value) -> String {
         .and_then(Value::as_str)
         .unwrap_or("<missing>")
         .to_owned()
+}
+
+/// Extract this record's message content as [`ContentPart`]s, for the
+/// `turn_content` capture. Reads the same `message.content[]` / top-level
+/// `content` shape [`parse_record`] reads, but never retains it on
+/// `NormalizedEvent` — the caller emits the result as a separate
+/// `TurnContent` record, right after the record's `MetricsEvent`.
+///
+/// `role` is the event's *resolved* role (after the Claude tool-result
+/// reclassification from `User` to `Tool`), so a `tool_result` block is
+/// captured as `ToolResult` even though the record's JSON role is `user`.
+pub(super) fn extract_content_parts(value: &Value, role: Role) -> Vec<ContentPart> {
+    let Some(obj) = value.as_object() else {
+        return Vec::new();
+    };
+    extract_content_parts_from_container(obj, role)
+}
+
+/// Like [`extract_content_parts`], reading a `message`-shaped JSON object
+/// directly rather than a whole transcript record. Lets a caller that only
+/// has the inner object (Codex's `payload`) skip re-wrapping it into a full
+/// record [`Value`].
+pub(super) fn extract_content_parts_from_container(
+    container: &serde_json::Map<String, Value>,
+    role: Role,
+) -> Vec<ContentPart> {
+    let content = container
+        .get("message")
+        .and_then(Value::as_object)
+        .and_then(|m| m.get("content"))
+        .or_else(|| container.get("content"));
+    if role == Role::Tool {
+        return tool_result_parts(content);
+    }
+    let mut parts = Vec::new();
+    match content {
+        Some(Value::String(text)) => push_text(text, role, &mut parts),
+        Some(Value::Array(items)) => {
+            for item in items {
+                push_content_block(item, role, &mut parts);
+            }
+        }
+        _ => {}
+    }
+    parts
+}
+
+fn text_kind(role: Role) -> ContentKind {
+    if role == Role::Assistant {
+        ContentKind::AssistantText
+    } else {
+        ContentKind::UserText
+    }
+}
+
+fn push_text(text: &str, role: Role, parts: &mut Vec<ContentPart>) {
+    if !text.is_empty() {
+        parts.push(ContentPart::new(text_kind(role), text));
+    }
+}
+
+fn push_content_block(item: &Value, role: Role, parts: &mut Vec<ContentPart>) {
+    let kind = item.get("type").and_then(Value::as_str).unwrap_or("");
+    match kind {
+        // "input_text" / "output_text" are Codex's (OpenAI-shaped) content
+        // block types, captured through this same helper.
+        "text" | "input_text" | "output_text" => {
+            if let Some(text) = item.get("text").and_then(Value::as_str) {
+                push_text(text, role, parts);
+            }
+        }
+        "thinking" => {
+            if let Some(text) = item
+                .get("thinking")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            {
+                parts.push(ContentPart::new(ContentKind::Thinking, text));
+            }
+        }
+        "tool_use" | "toolCall" => {
+            let input = item.get("input").or_else(|| item.get("arguments"));
+            if let Some(text) = input.and_then(compact_json_text) {
+                parts.push(ContentPart::new(ContentKind::ToolInput, text));
+            }
+        }
+        "tool_result" | "toolResult" | "function_call_output" => {
+            if let Some(text) = tool_result_text(item) {
+                parts.push(ContentPart::new(ContentKind::ToolResult, text));
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A tool-result-shaped item's own content: a plain string, or the
+/// concatenated text of a content-block array (non-text parts skipped).
+fn tool_result_text(item: &Value) -> Option<String> {
+    concatenated_text(item.get("content"))
+}
+
+/// A content value's text: a plain string, or the concatenated `text` field
+/// of each item in a content-block array (non-text items skipped).
+pub(super) fn concatenated_text(content: Option<&Value>) -> Option<String> {
+    match content? {
+        Value::String(text) => (!text.is_empty()).then(|| text.clone()),
+        Value::Array(items) => {
+            let mut out = String::new();
+            for item in items {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str(text);
+                }
+            }
+            (!out.is_empty()).then_some(out)
+        }
+        _ => None,
+    }
+}
+
+/// A tool-role record's whole content as one `ToolResult` part: the
+/// top-level content string or array (Pi's `toolResult` message shape), or
+/// the nested tool-result items within a mixed array (Claude's `tool_result`
+/// content block, embedded in an otherwise `user`-shaped message). Non-text
+/// items are skipped.
+fn tool_result_parts(content: Option<&Value>) -> Vec<ContentPart> {
+    let text = match content {
+        Some(Value::Array(items)) => {
+            let mut out = String::new();
+            for item in items {
+                let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
+                let text = if matches!(
+                    item_type,
+                    "tool_result" | "toolResult" | "function_call_output"
+                ) {
+                    tool_result_text(item)
+                } else {
+                    item.get("text").and_then(Value::as_str).map(str::to_owned)
+                };
+                if let Some(text) = text {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str(&text);
+                }
+            }
+            (!out.is_empty()).then_some(out)
+        }
+        _ => concatenated_text(content),
+    };
+    text.into_iter()
+        .map(|text| ContentPart::new(ContentKind::ToolResult, text))
+        .collect()
+}
+
+/// A tool call's input, JSON-serialized compactly. A JSON-encoded string
+/// (OpenAI-style `function.arguments`) is parsed and re-serialized so the
+/// stored text is canonical JSON either way; a non-JSON string (Codex's raw
+/// `exec` script) is kept as-is.
+pub(super) fn compact_json_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(raw) => match serde_json::from_str::<Value>(raw) {
+            Ok(parsed) => serde_json::to_string(&parsed).ok(),
+            Err(_) => Some(raw.clone()),
+        },
+        other => serde_json::to_string(other).ok(),
+    }
 }
 
 /// Parse a single JSON record into a normalized event, or `None` if the record

--- a/crates/antiburn-local/src/analysis/vendors/opencode.rs
+++ b/crates/antiburn-local/src/analysis/vendors/opencode.rs
@@ -14,15 +14,15 @@ use anyhow::Context;
 use rusqlite::{Connection, OpenFlags, Statement, params};
 use serde_json::{Map, Value};
 
-use super::jsonl::{parse_ts, tool_call_from_input};
+use super::jsonl::{compact_json_text, parse_ts, tool_call_from_input};
 use crate::analysis::EVIDENCE_STRING_CAP;
 use crate::analysis::SourceChangedReason;
 use crate::analysis::framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,
 };
 use crate::analysis::interface::{
-    EvidenceObservation, NormalizedRecord, RawSource, RecordSink, SessionCollector, SessionInput,
-    SessionSummary, VendorAdapter, VisitOutcome,
+    ContentKind, ContentPart, EvidenceObservation, NormalizedRecord, RawSource, RecordSink,
+    SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{
     CompactionTrigger, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
@@ -217,11 +217,17 @@ fn visit_database_connection(
         let mut pending = PendingMessage {
             id: message_id,
             event,
+            content: Vec::new(),
             part_bytes: 0,
             parts_oversized: false,
         };
         visit_db_parts(&mut parts, &mut pending, cancel, sink)?;
         sink.record(NormalizedRecord::MetricsEvent(Box::new(pending.event)));
+        if !pending.content.is_empty() {
+            sink.record(NormalizedRecord::TurnContent(Box::new(TurnContent {
+                parts: pending.content,
+            })));
+        }
     }
     Ok(state.finish())
 }
@@ -282,7 +288,7 @@ fn visit_db_parts(
         apply_part(
             &value,
             created.or(updated).and_then(parse_db_ts),
-            &mut pending.event,
+            pending,
             sink,
         );
     }
@@ -298,6 +304,7 @@ fn drain_message_parts(
     let mut pending = PendingMessage {
         id: message_id.to_owned(),
         event: NormalizedEvent::new(Role::Assistant),
+        content: Vec::new(),
         part_bytes: 0,
         parts_oversized: false,
     };
@@ -313,6 +320,10 @@ struct OpenCodeStreamState {
 struct PendingMessage {
     id: String,
     event: NormalizedEvent,
+    /// Content captured from this message's `text`, `reasoning`, and `tool`
+    /// parts, in part order. Emitted as one `TurnContent` record right after
+    /// this message's `MetricsEvent`.
+    content: Vec<ContentPart>,
     part_bytes: usize,
     parts_oversized: bool,
 }
@@ -337,6 +348,7 @@ impl OpenCodeStreamState {
                 self.pending = Some(PendingMessage {
                     id: id.to_owned(),
                     event,
+                    content: Vec::new(),
                     part_bytes: 0,
                     parts_oversized: false,
                 });
@@ -361,7 +373,7 @@ impl OpenCodeStreamState {
                 }
                 let payload = value.get("payload").unwrap_or(&value);
                 let fallback_ts = value.pointer("/time/created").and_then(parse_ts);
-                apply_part(payload, fallback_ts, &mut pending.event, sink);
+                apply_part(payload, fallback_ts, pending, sink);
             }
             Some("session_meta" | "session_member") => {
                 self.flush(sink);
@@ -395,6 +407,11 @@ impl OpenCodeStreamState {
     fn flush(&mut self, sink: &mut dyn RecordSink) {
         if let Some(pending) = self.pending.take() {
             sink.record(NormalizedRecord::MetricsEvent(Box::new(pending.event)));
+            if !pending.content.is_empty() {
+                sink.record(NormalizedRecord::TurnContent(Box::new(TurnContent {
+                    parts: pending.content,
+                })));
+            }
         }
     }
 
@@ -435,15 +452,15 @@ fn message_event(value: &Value, fallback_ts: Option<i64>) -> Option<NormalizedEv
 fn apply_part(
     value: &Value,
     fallback_ts: Option<i64>,
-    event: &mut NormalizedEvent,
+    pending: &mut PendingMessage,
     sink: &mut dyn RecordSink,
 ) {
     let Some(object) = value.as_object() else {
         sink.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
         return;
     };
-    if event.ts_ms.is_none() {
-        event.ts_ms = object
+    if pending.event.ts_ms.is_none() {
+        pending.event.ts_ms = object
             .get("time")
             .and_then(|time| time.get("created"))
             .and_then(parse_ts)
@@ -451,38 +468,79 @@ fn apply_part(
     }
     let part_type = object.get("type").and_then(Value::as_str).unwrap_or("");
     match part_type {
-        "text" | "file" | "snapshot" | "step-start" | "step-finish" | "agent" | "retry" => {}
-        "reasoning" => event.has_thinking = true,
-        "tool" => apply_tool_part(object, event),
-        "patch" => event.tools.push(ToolCall {
+        "text" => {
+            if let Some(text) = object
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            {
+                let kind = if pending.event.role == Role::Assistant {
+                    ContentKind::AssistantText
+                } else {
+                    ContentKind::UserText
+                };
+                pending.content.push(ContentPart::new(kind, text));
+            }
+        }
+        "file" | "snapshot" | "step-start" | "step-finish" | "agent" | "retry" => {}
+        "reasoning" => {
+            pending.event.has_thinking = true;
+            if let Some(text) = object
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            {
+                pending
+                    .content
+                    .push(ContentPart::new(ContentKind::Thinking, text));
+            }
+        }
+        "tool" => apply_tool_part(object, pending),
+        "patch" => pending.event.tools.push(ToolCall {
             name: "patch".to_owned(),
             category: ToolCategory::Edit,
             detail: None,
         }),
         "compaction" => {
-            event.is_compaction_boundary = true;
-            event.compaction_trigger = object.get("auto").and_then(Value::as_bool).map(|auto| {
-                if auto {
-                    CompactionTrigger::Auto
-                } else {
-                    CompactionTrigger::Manual
-                }
-            });
+            pending.event.is_compaction_boundary = true;
+            pending.event.compaction_trigger =
+                object.get("auto").and_then(Value::as_bool).map(|auto| {
+                    if auto {
+                        CompactionTrigger::Auto
+                    } else {
+                        CompactionTrigger::Manual
+                    }
+                });
         }
         discriminator if !discriminator.is_empty() => unrecognized(discriminator, sink),
         _ => unrecognized("<missing_part_type>", sink),
     }
 }
 
-fn apply_tool_part(part: &Map<String, Value>, event: &mut NormalizedEvent) {
+fn apply_tool_part(part: &Map<String, Value>, pending: &mut PendingMessage) {
     let name = part
         .get("tool")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .unwrap_or("tool");
-    let input = part.get("state").and_then(|state| state.get("input"));
-    event.tools.push(tool_call_from_input(name, input));
+    let state = part.get("state");
+    let input = state.and_then(|state| state.get("input"));
+    pending.event.tools.push(tool_call_from_input(name, input));
+    if let Some(text) = input.and_then(compact_json_text) {
+        pending
+            .content
+            .push(ContentPart::new(ContentKind::ToolInput, text));
+    }
+    if let Some(output) = state
+        .and_then(|state| state.get("output"))
+        .and_then(Value::as_str)
+        .filter(|output| !output.is_empty())
+    {
+        pending
+            .content
+            .push(ContentPart::new(ContentKind::ToolResult, output));
+    }
 }
 
 fn unrecognized(discriminator: &str, sink: &mut dyn RecordSink) {
@@ -596,5 +654,86 @@ mod tests {
 
         assert!(state.pending.is_none());
         assert_eq!(sink.0, 10_000);
+    }
+
+    /// Collects every `TurnContent` record a visit emits, in order.
+    #[derive(Default)]
+    struct ContentCapturingSink {
+        contents: Vec<TurnContent>,
+    }
+
+    impl RecordSink for ContentCapturingSink {
+        fn record(&mut self, record: NormalizedRecord) {
+            if let NormalizedRecord::TurnContent(content) = record {
+                self.contents.push(*content);
+            }
+        }
+
+        fn finish(&mut self, _summary: SessionSummary) {}
+    }
+
+    #[test]
+    fn content_capture_maps_text_reasoning_and_tool_parts() {
+        let mut state = OpenCodeStreamState::default();
+        let mut sink = ContentCapturingSink::default();
+
+        state.observe_export(
+            serde_json::json!({
+                "type": "message",
+                "messageID": "m1",
+                "time": {"created": 1000},
+                "payload": {"role": "assistant", "modelID": "model-a"}
+            }),
+            64,
+            &mut sink,
+        );
+        state.observe_export(
+            serde_json::json!({
+                "type": "part",
+                "messageID": "m1",
+                "payload": {"type": "text", "text": "hello there"}
+            }),
+            64,
+            &mut sink,
+        );
+        state.observe_export(
+            serde_json::json!({
+                "type": "part",
+                "messageID": "m1",
+                "payload": {"type": "reasoning", "text": "pondering"}
+            }),
+            64,
+            &mut sink,
+        );
+        state.observe_export(
+            serde_json::json!({
+                "type": "part",
+                "messageID": "m1",
+                "payload": {
+                    "type": "tool",
+                    "tool": "bash",
+                    "state": {"input": {"command": "ls"}, "output": "ok"}
+                }
+            }),
+            64,
+            &mut sink,
+        );
+        state.flush(&mut sink);
+
+        assert_eq!(
+            sink.contents.len(),
+            1,
+            "one TurnContent for the one message"
+        );
+        let parts = &sink.contents[0].parts;
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0].kind, ContentKind::AssistantText);
+        assert_eq!(parts[0].text, "hello there");
+        assert_eq!(parts[1].kind, ContentKind::Thinking);
+        assert_eq!(parts[1].text, "pondering");
+        assert_eq!(parts[2].kind, ContentKind::ToolInput);
+        assert_eq!(parts[2].text, r#"{"command":"ls"}"#);
+        assert_eq!(parts[3].kind, ContentKind::ToolResult);
+        assert_eq!(parts[3].text, "ok");
     }
 }

--- a/crates/antiburn-local/src/analysis/vendors/pi.rs
+++ b/crates/antiburn-local/src/analysis/vendors/pi.rs
@@ -20,11 +20,11 @@ use std::io::{BufRead, BufReader, Cursor, Read};
 use anyhow::Context;
 use serde_json::Value;
 
-use super::jsonl::{parse_record, parse_ts};
+use super::jsonl::{extract_content_parts, parse_record, parse_ts};
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::interface::{
-    EvidenceObservation, NormalizedRecord, RawSource, RecordSink, SessionCollector, SessionInput,
-    SessionSummary, VendorAdapter, VisitOutcome,
+    ContentPart, EvidenceObservation, NormalizedRecord, RawSource, RecordSink, SessionCollector,
+    SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
@@ -290,7 +290,8 @@ impl PiStreamState {
         }
 
         let unknown_blocks = unknown_content_blocks(value);
-        self.emit_event(event, sink);
+        let content_parts = extract_content_parts(value, event.role);
+        self.emit_event(event, content_parts, sink);
         for discriminator in &unknown_blocks {
             sink.record(NormalizedRecord::Observation(Box::new(
                 EvidenceObservation::UnrecognizedType {
@@ -372,11 +373,21 @@ impl PiStreamState {
         event.compaction_pre_tokens = value.get("tokensBefore").and_then(Value::as_u64);
         event.model = self.current_model.clone();
         event.thinking_mode = self.current_thinking_mode.clone();
-        self.emit_event(event, sink);
+        self.emit_event(event, Vec::new(), sink);
     }
 
-    fn emit_event(&mut self, event: NormalizedEvent, sink: &mut dyn RecordSink) {
+    fn emit_event(
+        &mut self,
+        event: NormalizedEvent,
+        content_parts: Vec<ContentPart>,
+        sink: &mut dyn RecordSink,
+    ) {
         sink.record(NormalizedRecord::MetricsEvent(Box::new(event)));
+        if !content_parts.is_empty() {
+            sink.record(NormalizedRecord::TurnContent(Box::new(TurnContent {
+                parts: content_parts,
+            })));
+        }
     }
 
     fn finish(self) -> SessionSummary {
@@ -516,7 +527,77 @@ fn unknown_content_blocks(value: &Value) -> Vec<String> {
 mod tests {
     use serde_json::json;
 
-    use super::is_inert_shape;
+    use super::*;
+    use crate::analysis::interface::ContentKind;
+
+    /// Collects every `TurnContent` record a visit emits, in order.
+    #[derive(Default)]
+    struct ContentCapturingSink {
+        contents: Vec<TurnContent>,
+    }
+
+    impl RecordSink for ContentCapturingSink {
+        fn record(&mut self, record: NormalizedRecord) {
+            if let NormalizedRecord::TurnContent(content) = record {
+                self.contents.push(*content);
+            }
+        }
+
+        fn finish(&mut self, _summary: SessionSummary) {}
+    }
+
+    #[test]
+    fn content_capture_maps_text_thinking_tool_call_and_tool_result() {
+        let assistant_record = json!({
+            "type": "message",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "hello there"},
+                    {"type": "thinking", "thinking": "pondering"},
+                    {"type": "toolCall", "id": "call-1", "name": "bash", "arguments": {"command": "ls"}},
+                ]
+            }
+        })
+        .to_string();
+        let tool_result_record = json!({
+            "type": "message",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "call-1",
+                "toolName": "bash",
+                "content": [{"type": "text", "text": "ok"}]
+            }
+        })
+        .to_string();
+        let input = SessionInput {
+            agent: "pi".to_string(),
+            session_id: "content-session".to_string(),
+            source: RawSource::Jsonl(format!("{assistant_record}\n{tool_result_record}\n")),
+        };
+        let mut sink = ContentCapturingSink::default();
+
+        PiAdapter
+            .visit(&input, &mut sink)
+            .expect("visit content session");
+
+        assert_eq!(sink.contents.len(), 2, "one TurnContent per turn");
+        let assistant_parts = &sink.contents[0].parts;
+        assert_eq!(assistant_parts.len(), 3);
+        assert_eq!(assistant_parts[0].kind, ContentKind::AssistantText);
+        assert_eq!(assistant_parts[0].text, "hello there");
+        assert_eq!(assistant_parts[1].kind, ContentKind::Thinking);
+        assert_eq!(assistant_parts[1].text, "pondering");
+        assert_eq!(assistant_parts[2].kind, ContentKind::ToolInput);
+        assert_eq!(assistant_parts[2].text, r#"{"command":"ls"}"#);
+
+        let tool_result_parts = &sink.contents[1].parts;
+        assert_eq!(tool_result_parts.len(), 1);
+        assert_eq!(tool_result_parts[0].kind, ContentKind::ToolResult);
+        assert_eq!(tool_result_parts[0].text, "ok");
+    }
 
     #[test]
     fn inert_shape_checks_only_shared_parser_locations() {

--- a/crates/antiburn-local/tests/turn_content_privacy.rs
+++ b/crates/antiburn-local/tests/turn_content_privacy.rs
@@ -1,0 +1,200 @@
+//! Turn-content capture must never leak transcript text into any other
+//! projection. Content lives only in `turn_content`: `NormalizedSession`,
+//! `SessionEvidence` (diagnostics included), and `SessionMetrics` must never
+//! carry it, and deleting a session's turn rows must remove it completely.
+//! See "Privacy with content stored" in
+//! `docs/plans/session-evidence-harness-parity.md`.
+
+use std::sync::Mutex;
+
+use antiburn_local::analysis::{
+    CompositeSink, EvidenceSource, RawSource, SessionEvidenceAccumulator, SessionInput,
+    SessionMetricsAccumulator, SourceCapabilities, SourceKind, TURN_SCHEMA_SQL, TurnRow,
+    TurnRowSink, TurnRowWriteError, TurnRowWriter, TurnSessionKey, adapter_for,
+    count_turn_content_rows, delete_turn_rows, insert_turn_rows, normalize_source,
+};
+use rusqlite::{Connection, params};
+
+const SENTINEL_USER: &str = "SENTINEL-USER-7f3a";
+const SENTINEL_THINK: &str = "SENTINEL-THINK-9c2b";
+const SENTINEL_TOOLIN: &str = "SENTINEL-TOOLIN-3d1e";
+const SENTINEL_RESULT: &str = "SENTINEL-RESULT-88aa";
+
+const SENTINELS: [&str; 4] = [
+    SENTINEL_USER,
+    SENTINEL_THINK,
+    SENTINEL_TOOLIN,
+    SENTINEL_RESULT,
+];
+
+const ENVIRONMENT_KEY: &str = "native";
+const AGENT: &str = "claude";
+const SESSION_ID: &str = "content-privacy-session";
+
+fn key() -> TurnSessionKey<'static> {
+    TurnSessionKey {
+        environment_key: ENVIRONMENT_KEY,
+        agent: AGENT,
+        session_id: SESSION_ID,
+    }
+}
+
+/// A small Claude transcript carrying one sentinel per captured content
+/// kind: a user prompt, an assistant thinking block, a tool call's input,
+/// and a tool result.
+fn fixture() -> String {
+    let user = serde_json::json!({
+        "type": "user",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": format!("{SENTINEL_USER} please investigate")}],
+        }
+    })
+    .to_string();
+    let assistant = serde_json::json!({
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:01Z",
+        "message": {
+            "id": "msg-1",
+            "role": "assistant",
+            "model": "claude-opus-4-6",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "content": [
+                {"type": "thinking", "thinking": format!("{SENTINEL_THINK} pondering")},
+                {
+                    "type": "tool_use",
+                    "name": "Bash",
+                    "input": {"command": format!("echo {SENTINEL_TOOLIN}")},
+                },
+            ],
+        }
+    })
+    .to_string();
+    let tool_result = serde_json::json!({
+        "type": "user",
+        "timestamp": "2026-01-01T00:00:02Z",
+        "message": {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": format!("{SENTINEL_RESULT} done")},
+            ],
+        }
+    })
+    .to_string();
+    format!("{user}\n{assistant}\n{tool_result}\n")
+}
+
+fn test_connection() -> Connection {
+    let conn = Connection::open_in_memory().expect("open in-memory connection");
+    conn.execute_batch(
+        "CREATE TABLE session (
+            environment_key TEXT NOT NULL,
+            agent TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            PRIMARY KEY (environment_key, agent, session_id)
+        ) STRICT;",
+    )
+    .expect("create session table");
+    conn.execute_batch(TURN_SCHEMA_SQL)
+        .expect("create turn schema");
+    conn.execute(
+        "INSERT INTO session (environment_key, agent, session_id) VALUES (?1, ?2, ?3)",
+        params![ENVIRONMENT_KEY, AGENT, SESSION_ID],
+    )
+    .expect("insert session");
+    conn
+}
+
+struct TestWriter(Mutex<Connection>);
+
+impl TurnRowWriter for TestWriter {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+        let conn = self.0.lock().expect("lock");
+        insert_turn_rows(&conn, &key(), 1, rows).map_err(TurnRowWriteError::from)
+    }
+}
+
+#[test]
+fn turn_content_captures_sentinels_while_every_other_projection_stays_clean() {
+    let input = SessionInput {
+        agent: AGENT.to_string(),
+        session_id: SESSION_ID.to_string(),
+        source: RawSource::Jsonl(fixture()),
+    };
+
+    // The normalized model never carries message text.
+    let normalized_session = normalize_source(&input).expect("fixture must normalize");
+    let normalized_json = serde_json::to_string(&normalized_session).expect("serialize session");
+    for sentinel in SENTINELS {
+        assert!(
+            !normalized_json.contains(sentinel),
+            "NormalizedSession leaked {sentinel}"
+        );
+    }
+
+    // Run the full pipeline: metrics, evidence, and turn rows in one pass,
+    // exactly as the durable analysis worker does.
+    let writer = TestWriter(Mutex::new(test_connection()));
+    let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::from(&input.source),
+        capabilities: SourceCapabilities::claude(),
+    });
+    let turn_rows = TurnRowSink::new(&writer, input.session_id.clone());
+    let mut composite = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
+    let outcome = adapter_for("claude")
+        .visit(&input, &mut composite)
+        .expect("claude source must be visited");
+    composite.observe_source_outcome(outcome);
+    assert!(!composite.turn_row_write_failed());
+
+    let evidence = composite.evidence().expect("evidence must publish");
+    let evidence_json = serde_json::to_string(&evidence).expect("serialize evidence");
+    let metrics = composite.metrics().expect("metrics must publish");
+    let metrics_json = serde_json::to_string(&metrics).expect("serialize metrics");
+    for sentinel in SENTINELS {
+        assert!(
+            !evidence_json.contains(sentinel),
+            "SessionEvidence (including diagnostics) leaked {sentinel}"
+        );
+        assert!(
+            !metrics_json.contains(sentinel),
+            "SessionMetrics leaked {sentinel}"
+        );
+    }
+
+    // Every sentinel reached `turn_content`.
+    {
+        let conn = writer.0.lock().expect("lock");
+        let stored: Vec<String> = conn
+            .prepare("SELECT content FROM turn_content")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, Vec<u8>>(0))
+            .expect("query")
+            .map(|blob| String::from_utf8(blob.expect("row content is valid UTF-8")).unwrap())
+            .collect();
+        let all_content = stored.join("\n");
+        for sentinel in SENTINELS {
+            assert!(
+                all_content.contains(sentinel),
+                "turn_content is missing {sentinel}"
+            );
+        }
+        assert!(count_turn_content_rows(&conn, &key(), 1).expect("count") >= 4);
+    }
+
+    // Deleting the session's turn rows removes every sentinel from the
+    // database — the mechanism `Store::delete_session` and
+    // `Store::clear_local_session_data` both rely on.
+    {
+        let conn = writer.0.lock().expect("lock");
+        delete_turn_rows(&conn, &key()).expect("delete turn rows");
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM turn_content", [], |row| row.get(0))
+            .expect("count remaining turn_content rows");
+        assert_eq!(remaining, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Seam 2b, stacked on #262 (retarget to `main` after it merges). Message content is persisted from day one, per the rev 2 plan.

- New `NormalizedRecord::TurnContent { parts: Vec<ContentPart> }` with kinds `user`, `assistant`, `thinking`, `tool_input`, `tool_result`. Adapters emit it immediately after the turn's `MetricsEvent`. Each part is capped at 256 KiB (`truncated` flag).
- `TurnRowSink` keeps a row buffered until the next row arrives so its content can attach; batch bound is now `batch_size + 1`. `insert_turn_rows` writes `turn_content` in the same batch transaction.
- `turn_content` DDL gains `truncated INTEGER NOT NULL` — amended in the unshipped V15 from #262, no new migration.
- Per adapter: Claude/Pi via shared `jsonl.rs` (`text`, `thinking`, `tool_use` input as compact JSON, `tool_result`); Codex (`input_text`/`output_text`, `reasoning.summary`, `function_call`/`custom_tool_call` args, `function_call_output`); OpenCode (`text`/`reasoning` parts, `tool.state.input`/`output`). Not captured yet: Codex `local_shell_call`/`web_search_call` structured args.
- Metrics, evidence, `SessionCollector`, and every characterization golden are unchanged.

## Privacy

`crates/antiburn-local/tests/turn_content_privacy.rs`: sentinel strings in a fixture reach `turn_content`, and never appear in serialized `NormalizedSession`, `SessionEvidence` (with diagnostics), or `SessionMetrics`; `delete_turn_rows` removes them. Store tests prove `delete_session` and `clear_local_session_data` remove content written through `FencedTurnRowWriter`.

## Measured cost (76 local Claude transcripts, 162 MB, 26,560 turns)

- Content stored: 26.3 MB, 16% of raw transcript bytes. 2 parts truncated at 256 KiB.
- Streaming pass wall time: +16% across the corpus, +25% on the largest 32 MB file (95 ms → 133 ms). Measured against in-memory SQLite, so on-disk fsync adds some.

## Validation

- `crates/antiburn-local`: fmt, clippy `-D warnings`, test (1004 unit + integration)
- `apps/desktop/src-tauri`: fmt, clippy `-D warnings`, test (579)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U7uVd1iQZBdWV2KdmSjSA