### PR TITLE
feat(analysis): turn-row facts query (seam 3a)

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -21,7 +21,7 @@ use antiburn_local::analysis::{
     EfficiencyTotals, EvidenceSource, METRICS_SCHEMA_REVISION, ModelRun, NormalizedSession,
     PARSER_REVISION, RawSource, SessionCost, SessionEvidence, SessionEvidenceAccumulator,
     SessionInput, SessionMetrics, SessionMetricsAccumulator, SkillUse, SourceCapabilities,
-    SourceClaim, SourceKind, TurnRowSink, TurnRowWriter, VisitOutcome, adapter_for,
+    SourceClaim, SourceKind, TurnRowSink, TurnRowStore, TurnScope, VisitOutcome, adapter_for,
     aggregate_metrics, analyze_session, analyze_sources_with, append_only_guarantee, merge_metrics,
     merge_subagent_events, normalize_source, price_breakdown, pricing_generation,
 };
@@ -528,7 +528,7 @@ fn stream_vendor_with_hooks(
     cancelled: &dyn Fn() -> bool,
     after_claim: &dyn Fn(usize, &std::path::Path),
     database_claim: Option<&str>,
-    turn_row_writer: Option<&dyn TurnRowWriter>,
+    turn_row_store: Option<Arc<dyn TurnRowStore>>,
 ) -> StreamOutcome {
     let mut accumulators = Vec::with_capacity(inputs.len());
     let mut parent_fingerprint = None;
@@ -552,13 +552,19 @@ fn stream_vendor_with_hooks(
         });
         // The turn-row source key is the input's own session id: the parent
         // transcript's id for index 0, a child's own id for every other
-        // input. `thread_id` equals `source_key` in this change.
-        let mut accumulator = match turn_row_writer {
-            Some(writer) => CompositeSink::with_turn_rows(
-                metrics,
-                evidence,
-                TurnRowSink::new(writer, input.session_id.clone()),
-            ),
+        // input. `thread_id` equals `source_key` in this change. Every
+        // input after the parent is a discovered child transcript, so its
+        // rows get `Delegated` scope from position. The adapter's own
+        // `EventSource` flag is not the only source of scope.
+        let mut accumulator = match turn_row_store.as_ref() {
+            Some(store) => {
+                let scope = (index > 0).then_some(TurnScope::Delegated);
+                CompositeSink::with_turn_rows(
+                    metrics,
+                    evidence,
+                    TurnRowSink::new(Arc::clone(store), input.session_id.clone(), scope),
+                )
+            }
             None => CompositeSink::new(metrics, evidence),
         };
         let result = match &input.source {
@@ -750,7 +756,7 @@ pub async fn analyze(
     pass.analysis
 }
 
-/// `turn_row_writer` is `Some` only for a pass the durable worker runs under
+/// `turn_row_store` is `Some` only for a pass the durable worker runs under
 /// a claimed evidence fence — see `insights_worker::run_record_pass`. Every
 /// other caller (an on-demand session view, a scan-triggered pass with no
 /// claim) passes `None`: without a claim fence, rows would have nothing to
@@ -761,7 +767,7 @@ pub async fn analyze_for_evidence(
     wsl_distro: Option<&str>,
     claimed: ClaimedSource,
     signal: PassSignal,
-    turn_row_writer: Option<Arc<dyn TurnRowWriter>>,
+    turn_row_store: Option<Arc<dyn TurnRowStore>>,
 ) -> EvidencePass {
     let Some(source) = locate(agent, session_id, wsl_distro).await else {
         return unavailable_evidence_pass(PassOutcome::SourceMissing, None, None);
@@ -845,13 +851,12 @@ pub async fn analyze_for_evidence(
     let computed = tauri::async_runtime::spawn_blocking(move || {
         if streams_evidence {
             let cancelled = || signal_for_pass.observe();
-            let turn_row_writer = turn_row_writer.as_deref();
             return match stream_vendor_with_hooks(
                 &inputs,
                 &cancelled,
                 &test_subagent_after_claim,
                 database_claim.as_deref(),
-                turn_row_writer,
+                turn_row_store,
             ) {
                 StreamOutcome::Published {
                     session,
@@ -1104,7 +1109,7 @@ pub(crate) fn evidence_pass(inputs: &[SessionInput], cancelled: &dyn Fn() -> boo
     evidence_pass_with_hook(inputs, cancelled, &test_subagent_after_claim, None)
 }
 
-/// Like [`evidence_pass`], with a [`TurnRowWriter`] fanned out through the
+/// Like [`evidence_pass`], with a [`TurnRowStore`] fanned out through the
 /// same real `stream_vendor_with_hooks` path the worker uses. Lets a test
 /// outside this module (`insights_worker`'s) assert on turn rows a published
 /// pass wrote, without a fake analyzer that skips the row sink entirely.
@@ -1112,13 +1117,13 @@ pub(crate) fn evidence_pass(inputs: &[SessionInput], cancelled: &dyn Fn() -> boo
 pub(crate) fn evidence_pass_with_turn_rows(
     inputs: &[SessionInput],
     cancelled: &dyn Fn() -> bool,
-    turn_row_writer: Option<&dyn TurnRowWriter>,
+    turn_row_store: Option<Arc<dyn TurnRowStore>>,
 ) -> EvidencePass {
     evidence_pass_with_hook(
         inputs,
         cancelled,
         &test_subagent_after_claim,
-        turn_row_writer,
+        turn_row_store,
     )
 }
 
@@ -1127,9 +1132,9 @@ fn evidence_pass_with_hook(
     inputs: &[SessionInput],
     cancelled: &dyn Fn() -> bool,
     after_claim: &dyn Fn(usize, &std::path::Path),
-    turn_row_writer: Option<&dyn TurnRowWriter>,
+    turn_row_store: Option<Arc<dyn TurnRowStore>>,
 ) -> EvidencePass {
-    match stream_vendor_with_hooks(inputs, cancelled, after_claim, None, turn_row_writer) {
+    match stream_vendor_with_hooks(inputs, cancelled, after_claim, None, turn_row_store) {
         StreamOutcome::Published { session, .. } => {
             let StreamedSession {
                 merged,

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use antiburn_local::analysis::{SessionEvidence, TurnRowWriter};
+use antiburn_local::analysis::{SessionEvidence, TurnRowStore};
 use antiburn_local::insights::{DetectorId, requirements};
 use antiburn_local::model::AgentKind;
 use tauri::{Emitter, Manager};
@@ -15,7 +15,7 @@ use crate::analysis::{self, EvidencePass, PassOutcome, PassSignal};
 use crate::commands;
 use crate::dto::ActivityEntry;
 use crate::store::{
-    EvidenceClaim, EvidenceCompletion, EvidenceFailure, FencedTurnRowWriter, PublishedEvidence,
+    EvidenceClaim, EvidenceCompletion, EvidenceFailure, FencedTurnRowStore, PublishedEvidence,
     RelationKind, RelationRecord, SessionKey, SessionRecord, Store,
 };
 
@@ -65,7 +65,7 @@ type RecordAnalyzer<'a> = dyn Fn(
         Option<String>,
         analysis::ClaimedSource,
         PassSignal,
-        Option<Arc<dyn TurnRowWriter>>,
+        Option<Arc<dyn TurnRowStore>>,
     ) -> PassFuture
     + Send
     + Sync
@@ -78,7 +78,7 @@ pub(crate) enum PermitKind {
 }
 
 /// `store` is a cheap handle (see [`Store`]'s doc comment): this clones it
-/// once per pass into a [`FencedTurnRowWriter`] stamped with `claim_fence`,
+/// once per pass into a [`FencedTurnRowStore`] stamped with `claim_fence`,
 /// so turn rows this pass writes are attributable and cleaned up correctly
 /// if the pass loses the claim race.
 fn run_record_pass(
@@ -92,7 +92,7 @@ fn run_record_pass(
         signal,
         claim_fence,
         store,
-        &|agent, session_id, wsl_distro, claimed, signal, turn_row_writer| {
+        &|agent, session_id, wsl_distro, claimed, signal, turn_row_store| {
             Box::pin(async move {
                 analysis::analyze_for_evidence(
                     agent,
@@ -100,7 +100,7 @@ fn run_record_pass(
                     wsl_distro.as_deref(),
                     claimed,
                     signal,
-                    turn_row_writer,
+                    turn_row_store,
                 )
                 .await
             })
@@ -118,7 +118,7 @@ fn run_record_pass_with(
     let Some(agent) = crate::agents::kind_from_slug(&record.key.agent) else {
         return Box::pin(async { analysis::unsupported_evidence_pass() });
     };
-    let writer: Arc<dyn TurnRowWriter> = Arc::new(FencedTurnRowWriter::new(
+    let writer: Arc<dyn TurnRowStore> = Arc::new(FencedTurnRowStore::new(
         store,
         record.key.clone(),
         claim_fence,
@@ -1295,7 +1295,7 @@ mod tests {
         // A custom analyzer, like the fixture-backed tests above: it
         // bypasses real filesystem discovery, but runs the real
         // `evidence_pass_with_turn_rows` -> `stream_vendor_with_hooks` ->
-        // `TurnRowSink` -> `FencedTurnRowWriter` path the worker uses in
+        // `TurnRowSink` -> `FencedTurnRowStore` path the worker uses in
         // production, so this test proves rows a published pass writes
         // actually land under the claim's fence.
         let analyzer = |_agent: AgentKind,
@@ -1303,7 +1303,7 @@ mod tests {
                         _wsl_distro: Option<String>,
                         claimed: analysis::ClaimedSource,
                         signal: PassSignal,
-                        turn_row_writer: Option<Arc<dyn TurnRowWriter>>| {
+                        turn_row_store: Option<Arc<dyn TurnRowStore>>| {
             Box::pin(async move {
                 let mut pass = analysis::evidence_pass_with_turn_rows(
                     &[SessionInput {
@@ -1318,7 +1318,7 @@ mod tests {
                         .into()),
                     }],
                     &|| signal.observe(),
-                    turn_row_writer.as_deref(),
+                    turn_row_store,
                 );
                 if let Some(fingerprint) = claimed.fingerprint {
                     pass.analysis.fingerprint = fingerprint;
@@ -1378,39 +1378,38 @@ mod tests {
             .upsert_sessions(std::slice::from_ref(&pi), &crate::agents::evidence_cohort())
             .unwrap();
         let pi_source = source_path.clone();
-        let analyzer =
-            move |agent: AgentKind,
-                  session_id: String,
-                  wsl_distro: Option<String>,
-                  claimed: analysis::ClaimedSource,
-                  signal: PassSignal,
-                  turn_row_writer: Option<Arc<dyn TurnRowWriter>>| {
-                if agent != AgentKind::Pi || session_id != "pi-worker-report" {
-                    return Box::pin(async move {
-                        analysis::analyze_for_evidence(
-                            agent,
-                            &session_id,
-                            wsl_distro.as_deref(),
-                            claimed,
-                            signal,
-                            turn_row_writer,
-                        )
-                        .await
-                    }) as PassFuture;
-                }
-                let input = antiburn_local::analysis::SessionInput {
-                    agent: crate::agents::vendor_label(agent).to_owned(),
-                    session_id,
-                    source: antiburn_local::analysis::RawSource::File(pi_source.clone()),
-                };
-                Box::pin(async move {
-                    let mut pass = analysis::evidence_pass(&[input], &|| signal.observe());
-                    if let Some(fingerprint) = claimed.fingerprint {
-                        pass.analysis.fingerprint = fingerprint;
-                    }
-                    pass
-                }) as PassFuture
+        let analyzer = move |agent: AgentKind,
+                             session_id: String,
+                             wsl_distro: Option<String>,
+                             claimed: analysis::ClaimedSource,
+                             signal: PassSignal,
+                             turn_row_store: Option<Arc<dyn TurnRowStore>>| {
+            if agent != AgentKind::Pi || session_id != "pi-worker-report" {
+                return Box::pin(async move {
+                    analysis::analyze_for_evidence(
+                        agent,
+                        &session_id,
+                        wsl_distro.as_deref(),
+                        claimed,
+                        signal,
+                        turn_row_store,
+                    )
+                    .await
+                }) as PassFuture;
+            }
+            let input = antiburn_local::analysis::SessionInput {
+                agent: crate::agents::vendor_label(agent).to_owned(),
+                session_id,
+                source: antiburn_local::analysis::RawSource::File(pi_source.clone()),
             };
+            Box::pin(async move {
+                let mut pass = analysis::evidence_pass(&[input], &|| signal.observe());
+                if let Some(fingerprint) = claimed.fingerprint {
+                    pass.analysis.fingerprint = fingerprint;
+                }
+                pass
+            }) as PassFuture
+        };
         let store_for_runner = store.clone();
         let runner = move |record: &SessionRecord, signal: PassSignal, claim_fence: i64| {
             run_record_pass_with(

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -33,8 +33,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use antiburn_local::analysis::{
-    TurnRow, TurnRowWriteError, TurnRowWriter, TurnSessionKey, count_turn_rows, delete_turn_rows,
-    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
+    TurnFacts, TurnRow, TurnRowError, TurnRowStore, TurnSessionKey, count_turn_rows,
+    delete_turn_rows, delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
+    query_turn_facts,
 };
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
@@ -117,7 +118,7 @@ pub fn open_read_only(data_dir: &Path, busy_timeout: Duration) -> Result<Connect
 ///
 /// `connection` is behind an `Arc` so a cheap [`Store::clone`] shares the
 /// same underlying connection rather than opening a second one. The worker
-/// uses this to hand a [`FencedTurnRowWriter`] a handle to the same database
+/// uses this to hand a [`FencedTurnRowStore`] a handle to the same database
 /// without threading `Store` state through every call site as `Arc<Store>`.
 #[derive(Clone)]
 pub struct Store {
@@ -1979,21 +1980,21 @@ fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> 
     })
 }
 
-/// Writes turn rows for one claimed evidence pass.
+/// Writes and reads turn rows for one claimed evidence pass.
 ///
 /// Holds an owned [`Store`] handle (cheap: it shares the app's one
 /// connection, see [`Store`]'s doc comment) plus the session key and claim
 /// fence the durable worker already knows for this pass. `Store` cannot
-/// implement [`TurnRowWriter`] directly — writing a row needs the session
-/// key and fence, and `Store` itself does not carry either.
+/// implement [`TurnRowStore`] directly — reading and writing rows needs the
+/// session key and fence, and `Store` itself does not carry either.
 #[derive(Clone)]
-pub struct FencedTurnRowWriter {
+pub struct FencedTurnRowStore {
     store: Store,
     key: SessionKey,
     claim_fence: i64,
 }
 
-impl FencedTurnRowWriter {
+impl FencedTurnRowStore {
     pub fn new(store: Store, key: SessionKey, claim_fence: i64) -> Self {
         Self {
             store,
@@ -2003,8 +2004,8 @@ impl FencedTurnRowWriter {
     }
 }
 
-impl TurnRowWriter for FencedTurnRowWriter {
-    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+impl TurnRowStore for FencedTurnRowStore {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowError> {
         // One transaction per batch: one fsync for the batch instead of
         // one for each row, and the lock is held only for the batch.
         let mut connection = self.store.lock();
@@ -2017,5 +2018,14 @@ impl TurnRowWriter for FencedTurnRowWriter {
         )?;
         transaction.commit()?;
         Ok(())
+    }
+
+    fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
+        let connection = self.store.lock();
+        Ok(query_turn_facts(
+            &connection,
+            &turn_session_key(&self.key),
+            self.claim_fence,
+        )?)
     }
 }

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -11,7 +11,7 @@
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
-    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15,
+    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -379,3 +379,11 @@ ON CONFLICT(environment_key, agent, session_id) DO NOTHING;
 /// the crate owns the DDL and the read/write functions over a borrowed
 /// connection, and never opens this database itself.
 const V15: &str = antiburn_local::analysis::TURN_SCHEMA_SQL;
+
+/// v16 adds the three compaction columns `query_turn_facts` reads:
+/// `compaction_trigger`, `compaction_pre_tokens`, `compaction_post_tokens`.
+///
+/// `antiburn_local::analysis::TURN_SCHEMA_V2_SQL` owns the column list, for
+/// the same reason [`V15`] re-exports `TURN_SCHEMA_SQL` instead of stating
+/// its own DDL.
+const V16: &str = antiburn_local::analysis::TURN_SCHEMA_V2_SQL;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -2987,6 +2987,9 @@ fn turn_row(turn_index: u64) -> TurnRow {
         message_id: None,
         uuid: None,
         parent_uuid: None,
+        compaction_trigger: None,
+        compaction_pre_tokens: None,
+        compaction_post_tokens: None,
         content: Vec::new(),
     }
 }
@@ -2996,10 +2999,10 @@ fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pinned so this test fails loudly if a future migration is appended
     // without also being counted here — the number is the whole point of
     // the assertion, not an incidental detail.
-    assert_eq!(super::schema::MIGRATIONS.len(), 15);
+    assert_eq!(super::schema::MIGRATIONS.len(), 16);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 15);
+    assert_eq!(store.schema_version().unwrap(), 16);
 }
 
 #[test]
@@ -3015,7 +3018,7 @@ fn a_fenced_turn_row_writer_inserts_rows_the_store_can_count() {
         .unwrap();
     let key = record.key.clone();
 
-    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), 7);
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), 7);
     writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
 
     let connection = store.lock();
@@ -3046,7 +3049,7 @@ fn publishing_evidence_keeps_only_the_current_fence_turn_rows() {
         )
         .unwrap();
     }
-    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), claim.claim_fence);
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
     let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
 
@@ -3084,7 +3087,7 @@ fn a_lost_publish_race_deletes_only_its_own_fences_turn_rows() {
         )
         .unwrap();
     }
-    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), claim.claim_fence);
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0)]).unwrap();
     // Bumping the source generation makes the fenced UPDATE inside
     // `publish_projections` affect zero rows — the same "lost the race"
@@ -3238,7 +3241,7 @@ fn deleting_a_session_removes_turn_content_written_through_the_fenced_writer() {
             &crate::agents::evidence_cohort(),
         )
         .unwrap();
-    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), 1);
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), 1);
     writer
         .write_turn_rows(&[turn_row_with_content(0, "PRIVATE_TURN_CONTENT")])
         .unwrap();
@@ -3267,7 +3270,7 @@ fn clearing_local_session_data_removes_turn_content_written_through_the_fenced_w
         )
         .unwrap();
     let key = record.key.clone();
-    let writer = FencedTurnRowWriter::new(store.clone(), key.clone(), 1);
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), 1);
     writer
         .write_turn_rows(&[turn_row_with_content(0, "PRIVATE_TURN_CONTENT")])
         .unwrap();

--- a/crates/antiburn-local/benches/memory_baseline.rs
+++ b/crates/antiburn-local/benches/memory_baseline.rs
@@ -74,7 +74,7 @@ fn measure_peak<T>(work: impl FnOnce() -> T) -> (usize, T) {
     (peak.saturating_sub(live_before), value)
 }
 
-fn composite_for(input: &SessionInput) -> CompositeSink<'static> {
+fn composite_for(input: &SessionInput) -> CompositeSink {
     CompositeSink::new(
         SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone()),
         SessionEvidenceAccumulator::new(EvidenceSource {

--- a/crates/antiburn-local/benches/pipeline_baseline.rs
+++ b/crates/antiburn-local/benches/pipeline_baseline.rs
@@ -64,7 +64,7 @@ fn file_input(session_id: &str, path: &Path) -> SessionInput {
     }
 }
 
-fn composite_for(input: &SessionInput) -> CompositeSink<'static> {
+fn composite_for(input: &SessionInput) -> CompositeSink {
     CompositeSink::new(
         SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone()),
         SessionEvidenceAccumulator::new(EvidenceSource {

--- a/crates/antiburn-local/src/analysis/evidence_query.rs
+++ b/crates/antiburn-local/src/analysis/evidence_query.rs
@@ -1,0 +1,945 @@
+//! Row-derived evidence facts: the read side of persisted turn rows.
+//!
+//! [`query_turn_facts`] reads the facts a later change uses to compute most
+//! of `SessionEvidence`, straight from the `turn` rows a pass already wrote
+//! — instead of by streaming an accumulator over the transcript again. See
+//! `docs/plans/session-evidence-harness-parity.md`.
+//!
+//! Every query here filters on the same four columns: `environment_key`,
+//! `agent`, `session_id`, and `claim_fence`.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rusqlite::{Connection, params};
+
+use crate::analysis::evidence::{
+    CompactionBoundary, DepthExample, EligibilityEvidence, MAX_COMPACTION_BOUNDARIES,
+    MAX_EVIDENCE_EXAMPLES, MAX_MODEL_TRANSITIONS, MAX_MODELS, MAX_SUBAGENT_MODELS, MAX_TIER_LABELS,
+    ModelTokens, ModelTransition, ParseDiagnostics, SessionTimeRange, SignalCoverage, TurnCounts,
+    cap_string, insert_diagnostic_field, record_diagnostic_set_cap,
+};
+use crate::analysis::model::CompactionTrigger;
+use crate::analysis::rows::TurnSessionKey;
+
+/// The row-derived facts for one session, at one claim fence.
+///
+/// A later change computes most of `SessionEvidence` from these instead of
+/// from `SessionEvidenceAccumulator`. The field-by-field rule each fact
+/// follows is documented next to the query that computes it, below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnFacts {
+    pub eligibility: EligibilityEvidence,
+    pub max_request_context_tokens: u64,
+    pub top_depth_examples: Vec<DepthExample>,
+    pub depth_examples_capped: bool,
+    pub time_range: SessionTimeRange,
+    pub by_model: BTreeMap<String, ModelTokens>,
+    pub models_capped: bool,
+    pub unattributed_turns: u64,
+    pub effort_tiers: BTreeMap<String, TurnCounts>,
+    pub fast_modes: BTreeMap<String, TurnCounts>,
+    pub tiers_capped: bool,
+    pub effort_signal: SignalCoverage,
+    pub speed_signal: SignalCoverage,
+    pub delegated_turns: u64,
+    pub delegated_models: BTreeSet<String>,
+    pub delegated_models_capped: bool,
+    pub delegated_model_missing: bool,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub fresh_input_tokens: u64,
+    pub model_transitions: Vec<ModelTransition>,
+    pub transitions_capped: bool,
+    pub longest_idle_gap_ms: i64,
+    pub idle_gap_ms_total: i64,
+    pub manual_compactions: u64,
+    pub compaction_boundaries: Vec<CompactionBoundary>,
+    pub compactions_capped: bool,
+    pub duplicate_turn_identities: u64,
+    pub thread_identity_missing: bool,
+    pub diagnostics: ParseDiagnostics,
+}
+
+/// Reads every [`TurnFacts`] field for the rows `key` and `claim_fence`
+/// select.
+pub fn query_turn_facts(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<TurnFacts> {
+    let mut diagnostics = ParseDiagnostics::new();
+
+    let core = query_core(conn, key, claim_fence)?;
+    let (top_depth_examples, depth_examples_capped) =
+        query_top_depth_examples(conn, key, claim_fence, &mut diagnostics)?;
+    let (by_model, models_capped) = query_by_model(conn, key, claim_fence, &mut diagnostics)?;
+    let (effort_tiers, effort_capped) = query_tier_map(
+        conn,
+        key,
+        claim_fence,
+        EFFORT_TIERS_SQL,
+        "models.effort_tiers",
+        &mut diagnostics,
+    )?;
+    let (fast_modes, fast_capped) = query_tier_map(
+        conn,
+        key,
+        claim_fence,
+        FAST_MODES_SQL,
+        "models.fast_modes",
+        &mut diagnostics,
+    )?;
+    let (effort_signal, speed_signal) = query_signal_coverage(conn, key, claim_fence)?;
+    let (delegated_models, delegated_models_capped) =
+        query_delegated_models(conn, key, claim_fence, &mut diagnostics)?;
+    let (model_transitions, transitions_capped, longest_idle_gap_ms, idle_gap_ms_total) =
+        query_transitions_and_idle_gaps(conn, key, claim_fence, &mut diagnostics)?;
+    let manual_compactions = query_manual_compactions(conn, key, claim_fence)?;
+    let (compaction_boundaries, compactions_capped) =
+        query_compaction_boundaries(conn, key, claim_fence, &mut diagnostics)?;
+    let duplicate_turn_identities = query_duplicate_turn_identities(conn, key, claim_fence)?;
+
+    Ok(TurnFacts {
+        eligibility: core.eligibility,
+        max_request_context_tokens: core.max_request_context_tokens,
+        top_depth_examples,
+        depth_examples_capped,
+        time_range: core.time_range,
+        by_model,
+        models_capped,
+        unattributed_turns: core.unattributed_turns,
+        effort_tiers,
+        fast_modes,
+        tiers_capped: effort_capped || fast_capped,
+        effort_signal,
+        speed_signal,
+        delegated_turns: core.delegated_turns,
+        delegated_models,
+        delegated_models_capped,
+        delegated_model_missing: core.delegated_model_missing,
+        cache_read_tokens: core.cache_read_tokens,
+        cache_creation_tokens: core.cache_creation_tokens,
+        fresh_input_tokens: core.fresh_input_tokens,
+        model_transitions,
+        transitions_capped,
+        longest_idle_gap_ms,
+        idle_gap_ms_total,
+        manual_compactions,
+        compaction_boundaries,
+        compactions_capped,
+        duplicate_turn_identities,
+        thread_identity_missing: core.thread_identity_missing,
+        diagnostics,
+    })
+}
+
+/// Clamps a SQLite `INTEGER` aggregate to a non-negative token or turn
+/// count. Every source column this module reads is a non-negative count,
+/// so a negative aggregate can only mean an empty `SUM`, which SQLite
+/// already reports as `0` through `COALESCE`; the clamp is a second
+/// guard, not the primary defense.
+fn as_u64(value: i64) -> u64 {
+    value.max(0) as u64
+}
+
+/// Records that one bounded collection overflowed, the same way
+/// `SessionEvidenceAccumulator::note_collection_cap` does.
+fn note_collection_cap(diagnostics: &mut ParseDiagnostics, field: &'static str) {
+    if insert_diagnostic_field(&mut diagnostics.capped_collections, field) {
+        record_diagnostic_set_cap(diagnostics, "diagnostics.capped_collections");
+    }
+}
+
+/* --------------------------------------------------------------------
+ * Core aggregate: eligibility, context depth, time range, cache sums,
+ * unattributed turns, delegated turns, and the two identity flags.
+ * ----------------------------------------------------------------- */
+
+struct Core {
+    eligibility: EligibilityEvidence,
+    max_request_context_tokens: u64,
+    time_range: SessionTimeRange,
+    cache_read_tokens: u64,
+    cache_creation_tokens: u64,
+    fresh_input_tokens: u64,
+    unattributed_turns: u64,
+    delegated_turns: u64,
+    delegated_model_missing: bool,
+    thread_identity_missing: bool,
+}
+
+/// "Depth" is `input_tokens + cache_read_tokens + cache_write_tokens` —
+/// this equals `Usage::context_tokens()`.
+const CORE_SQL: &str = "SELECT
+    COUNT(*),
+    COALESCE(SUM(role = 'assistant'), 0),
+    COALESCE(SUM(role = 'tool'), 0),
+    COALESCE(SUM((input_tokens + cache_read_tokens + cache_write_tokens) > 0), 0),
+    COALESCE(MAX(input_tokens + cache_read_tokens + cache_write_tokens), 0),
+    COALESCE(MIN(ts_ms), 0),
+    COALESCE(MAX(ts_ms), 0),
+    COALESCE(SUM(ts_ms IS NOT NULL), 0),
+    COALESCE(SUM(cache_read_tokens), 0),
+    COALESCE(SUM(cache_write_tokens), 0),
+    COALESCE(SUM(input_tokens), 0),
+    COALESCE(SUM(role = 'assistant' AND model IS NULL), 0),
+    COALESCE(SUM(scope = 'delegated'), 0),
+    COALESCE(SUM(scope = 'delegated' AND role = 'assistant' AND model IS NULL), 0),
+    COALESCE(SUM(uuid IS NULL), 0)
+  FROM turn
+ WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4";
+
+fn query_core(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<Core> {
+    conn.query_row(
+        CORE_SQL,
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+        |row| {
+            let turns: i64 = row.get(0)?;
+            let assistant_turns: i64 = row.get(1)?;
+            let tool_turns: i64 = row.get(2)?;
+            let depth_eligible_turns: i64 = row.get(3)?;
+            let max_request_context_tokens: i64 = row.get(4)?;
+            let first_ts_ms: i64 = row.get(5)?;
+            let last_ts_ms: i64 = row.get(6)?;
+            let timestamped_turns: i64 = row.get(7)?;
+            let cache_read_tokens: i64 = row.get(8)?;
+            let cache_creation_tokens: i64 = row.get(9)?;
+            let fresh_input_tokens: i64 = row.get(10)?;
+            let unattributed_turns: i64 = row.get(11)?;
+            let delegated_turns: i64 = row.get(12)?;
+            let delegated_model_missing: i64 = row.get(13)?;
+            let thread_identity_missing: i64 = row.get(14)?;
+            Ok(Core {
+                eligibility: EligibilityEvidence {
+                    turns: as_u64(turns),
+                    assistant_turns: as_u64(assistant_turns),
+                    tool_turns: as_u64(tool_turns),
+                    depth_eligible_turns: as_u64(depth_eligible_turns),
+                },
+                max_request_context_tokens: as_u64(max_request_context_tokens),
+                time_range: SessionTimeRange {
+                    first_ts_ms,
+                    last_ts_ms,
+                    timestamped_turns: as_u64(timestamped_turns),
+                },
+                cache_read_tokens: as_u64(cache_read_tokens),
+                cache_creation_tokens: as_u64(cache_creation_tokens),
+                fresh_input_tokens: as_u64(fresh_input_tokens),
+                unattributed_turns: as_u64(unattributed_turns),
+                delegated_turns: as_u64(delegated_turns),
+                delegated_model_missing: delegated_model_missing > 0,
+                thread_identity_missing: thread_identity_missing > 0,
+            })
+        },
+    )
+}
+
+/* --------------------------------------------------------------------
+ * Top depth examples.
+ * ----------------------------------------------------------------- */
+
+const TOP_DEPTH_EXAMPLES_SQL: &str = "SELECT ts_ms,
+        (input_tokens + cache_read_tokens + cache_write_tokens) AS depth, model
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND ts_ms IS NOT NULL
+    AND (input_tokens + cache_read_tokens + cache_write_tokens) > 0
+  ORDER BY depth DESC, ts_ms ASC
+  LIMIT ?5";
+
+fn query_top_depth_examples(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    diagnostics: &mut ParseDiagnostics,
+) -> rusqlite::Result<(Vec<DepthExample>, bool)> {
+    // One row past the cap tells us whether more qualifying rows exist,
+    // without a second COUNT query.
+    let limit = (MAX_EVIDENCE_EXAMPLES + 1) as i64;
+    let mut statement = conn.prepare(TOP_DEPTH_EXAMPLES_SQL)?;
+    let mut rows = statement.query(params![
+        key.environment_key,
+        key.agent,
+        key.session_id,
+        claim_fence,
+        limit
+    ])?;
+    let mut examples = Vec::new();
+    while let Some(row) = rows.next()? {
+        let ts_ms: i64 = row.get(0)?;
+        let depth: i64 = row.get(1)?;
+        let model: Option<String> = row.get(2)?;
+        let model =
+            model.map(|model| cap_string("context.top_depth_examples.model", &model, diagnostics));
+        examples.push(DepthExample {
+            ts_ms,
+            depth_tokens: as_u64(depth),
+            model,
+        });
+    }
+    let capped = examples.len() > MAX_EVIDENCE_EXAMPLES;
+    if capped {
+        examples.truncate(MAX_EVIDENCE_EXAMPLES);
+        note_collection_cap(diagnostics, "context.top_depth_examples");
+    }
+    Ok((examples, capped))
+}
+
+/* --------------------------------------------------------------------
+ * Per-model token totals.
+ * ----------------------------------------------------------------- */
+
+const BY_MODEL_SQL: &str = "SELECT model, input_tokens, output_tokens, cache_read_tokens,
+        cache_write_tokens, ts_ms
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND role = 'assistant' AND model IS NOT NULL
+  ORDER BY rowid";
+
+fn query_by_model(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    diagnostics: &mut ParseDiagnostics,
+) -> rusqlite::Result<(BTreeMap<String, ModelTokens>, bool)> {
+    let mut statement = conn.prepare(BY_MODEL_SQL)?;
+    let mut rows = statement.query(params![
+        key.environment_key,
+        key.agent,
+        key.session_id,
+        claim_fence
+    ])?;
+    let mut models: BTreeMap<String, ModelTokens> = BTreeMap::new();
+    let mut capped = false;
+    while let Some(row) = rows.next()? {
+        let model: String = row.get(0)?;
+        let input: i64 = row.get(1)?;
+        let output: i64 = row.get(2)?;
+        let cache_read: i64 = row.get(3)?;
+        let cache_creation: i64 = row.get(4)?;
+        let ts_ms: Option<i64> = row.get(5)?;
+        let capped_name = cap_string("models.by_model", &model, diagnostics);
+        if capped_name.len() != model.len() {
+            capped = true;
+        }
+        if let Some(tokens) = models.get_mut(&capped_name) {
+            add_model_tokens(tokens, input, output, cache_read, cache_creation, ts_ms);
+        } else if models.len() == MAX_MODELS {
+            capped = true;
+            note_collection_cap(diagnostics, "models.by_model");
+        } else {
+            let mut tokens = ModelTokens::default();
+            add_model_tokens(
+                &mut tokens,
+                input,
+                output,
+                cache_read,
+                cache_creation,
+                ts_ms,
+            );
+            models.insert(capped_name, tokens);
+        }
+    }
+    Ok((models, capped))
+}
+
+/// Mirrors `evidence_sink::add_model_tokens`'s exact semantics, including
+/// one quirk: while a model's `first_ts_ms` still holds its default of
+/// `0`, the next timestamped turn overwrites it outright instead of
+/// taking the minimum.
+fn add_model_tokens(
+    tokens: &mut ModelTokens,
+    input: i64,
+    output: i64,
+    cache_read: i64,
+    cache_creation: i64,
+    ts_ms: Option<i64>,
+) {
+    tokens.input = tokens.input.saturating_add(as_u64(input));
+    tokens.output = tokens.output.saturating_add(as_u64(output));
+    tokens.cache_read = tokens.cache_read.saturating_add(as_u64(cache_read));
+    tokens.cache_creation = tokens.cache_creation.saturating_add(as_u64(cache_creation));
+    tokens.turns = tokens.turns.saturating_add(1);
+    if let Some(ts_ms) = ts_ms {
+        if tokens.turns == 1 || tokens.first_ts_ms == 0 {
+            tokens.first_ts_ms = ts_ms;
+        } else {
+            tokens.first_ts_ms = tokens.first_ts_ms.min(ts_ms);
+        }
+        tokens.last_ts_ms = tokens.last_ts_ms.max(ts_ms);
+    }
+}
+
+/* --------------------------------------------------------------------
+ * Effort tiers and fast modes.
+ * ----------------------------------------------------------------- */
+
+const EFFORT_TIERS_SQL: &str = "SELECT effort, scope
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND effort IS NOT NULL
+  ORDER BY rowid";
+
+const FAST_MODES_SQL: &str = "SELECT speed, scope
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND speed IS NOT NULL
+  ORDER BY rowid";
+
+fn query_tier_map(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    sql: &str,
+    field: &'static str,
+    diagnostics: &mut ParseDiagnostics,
+) -> rusqlite::Result<(BTreeMap<String, TurnCounts>, bool)> {
+    let mut statement = conn.prepare(sql)?;
+    let mut rows = statement.query(params![
+        key.environment_key,
+        key.agent,
+        key.session_id,
+        claim_fence
+    ])?;
+    let mut map: BTreeMap<String, TurnCounts> = BTreeMap::new();
+    let mut capped = false;
+    while let Some(row) = rows.next()? {
+        let value: String = row.get(0)?;
+        let scope: String = row.get(1)?;
+        let delegated = scope == "delegated";
+        let capped_value = cap_string(field, &value, diagnostics);
+        if capped_value.len() != value.len() {
+            capped = true;
+        }
+        if let Some(counts) = map.get_mut(&capped_value) {
+            increment_turn_count(counts, delegated);
+        } else if map.len() == MAX_TIER_LABELS {
+            capped = true;
+            note_collection_cap(diagnostics, field);
+        } else {
+            let mut counts = TurnCounts::default();
+            increment_turn_count(&mut counts, delegated);
+            map.insert(capped_value, counts);
+        }
+    }
+    Ok((map, capped))
+}
+
+fn increment_turn_count(counts: &mut TurnCounts, delegated: bool) {
+    if delegated {
+        counts.delegated = counts.delegated.saturating_add(1);
+    } else {
+        counts.main_loop = counts.main_loop.saturating_add(1);
+    }
+}
+
+/* --------------------------------------------------------------------
+ * Effort/speed signal coverage.
+ * ----------------------------------------------------------------- */
+
+const SIGNAL_COVERAGE_SQL: &str = "SELECT
+    COALESCE(SUM(role = 'assistant' AND model IS NOT NULL), 0),
+    COALESCE(SUM(role = 'assistant' AND model IS NOT NULL AND effort IS NOT NULL), 0),
+    COALESCE(SUM(role = 'assistant' AND model IS NOT NULL AND speed IS NOT NULL), 0)
+  FROM turn
+ WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4";
+
+fn query_signal_coverage(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<(SignalCoverage, SignalCoverage)> {
+    conn.query_row(
+        SIGNAL_COVERAGE_SQL,
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+        |row| {
+            let eligible: i64 = row.get(0)?;
+            let effort_present: i64 = row.get(1)?;
+            let speed_present: i64 = row.get(2)?;
+            let eligible_turns = as_u64(eligible);
+            Ok((
+                SignalCoverage {
+                    eligible_turns,
+                    present_turns: as_u64(effort_present),
+                },
+                SignalCoverage {
+                    eligible_turns,
+                    present_turns: as_u64(speed_present),
+                },
+            ))
+        },
+    )
+}
+
+/* --------------------------------------------------------------------
+ * Delegated models.
+ * ----------------------------------------------------------------- */
+
+const DELEGATED_MODELS_SQL: &str = "SELECT model
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND scope = 'delegated' AND role = 'assistant' AND model IS NOT NULL
+  ORDER BY rowid";
+
+fn query_delegated_models(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    diagnostics: &mut ParseDiagnostics,
+) -> rusqlite::Result<(BTreeSet<String>, bool)> {
+    let mut statement = conn.prepare(DELEGATED_MODELS_SQL)?;
+    let mut rows = statement.query(params![
+        key.environment_key,
+        key.agent,
+        key.session_id,
+        claim_fence
+    ])?;
+    let mut models = BTreeSet::new();
+    let mut capped = false;
+    while let Some(row) = rows.next()? {
+        let model: String = row.get(0)?;
+        let capped_model = cap_string("subagents.delegated_models", &model, diagnostics);
+        if capped_model.len() != model.len() {
+            capped = true;
+        }
+        if models.contains(&capped_model) {
+            continue;
+        }
+        if models.len() == MAX_SUBAGENT_MODELS {
+            capped = true;
+            note_collection_cap(diagnostics, "subagents.delegated_models");
+        } else {
+            models.insert(capped_model);
+        }
+    }
+    Ok((models, capped))
+}
+
+/* --------------------------------------------------------------------
+ * Model transitions and idle gaps: one ordered scan of the main-loop
+ * rows, per thread.
+ * ----------------------------------------------------------------- */
+
+const MAIN_THREAD_SCAN_SQL: &str = "SELECT thread_id, ts_ms, model
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND scope = 'main'
+  ORDER BY thread_id, turn_index";
+
+/// Mirrors `evidence_sink::observe_cache_and_compaction`'s model-transition
+/// and idle-gap tracking exactly, with one difference: this scan resets
+/// the active model and the previous timestamp at each `thread_id`
+/// boundary, so a transition or a gap never crosses two threads.
+fn query_transitions_and_idle_gaps(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    diagnostics: &mut ParseDiagnostics,
+) -> rusqlite::Result<(Vec<ModelTransition>, bool, i64, i64)> {
+    let mut statement = conn.prepare(MAIN_THREAD_SCAN_SQL)?;
+    let mut rows = statement.query(params![
+        key.environment_key,
+        key.agent,
+        key.session_id,
+        claim_fence
+    ])?;
+    let mut transitions = Vec::new();
+    let mut capped = false;
+    let mut longest_idle_gap_ms: i64 = 0;
+    let mut idle_gap_ms_total: i64 = 0;
+    let mut current_thread: Option<String> = None;
+    let mut active_model: Option<String> = None;
+    let mut previous_ts: Option<i64> = None;
+    while let Some(row) = rows.next()? {
+        let thread_id: String = row.get(0)?;
+        let ts_ms: Option<i64> = row.get(1)?;
+        let model: Option<String> = row.get(2)?;
+        if current_thread.as_deref() != Some(thread_id.as_str()) {
+            current_thread = Some(thread_id);
+            active_model = None;
+            previous_ts = None;
+        }
+        if let Some(model) = model.as_deref() {
+            if let Some(previous) = active_model.as_deref()
+                && previous != model
+                && let Some(ts_ms) = ts_ms
+            {
+                let from_model =
+                    cap_string("cache.model_transitions.from_model", previous, diagnostics);
+                let to_model = cap_string("cache.model_transitions.to_model", model, diagnostics);
+                if transitions.len() == MAX_MODEL_TRANSITIONS {
+                    capped = true;
+                    note_collection_cap(diagnostics, "cache.model_transitions");
+                } else {
+                    transitions.push(ModelTransition {
+                        ts_ms,
+                        from_model,
+                        to_model,
+                    });
+                }
+            }
+            active_model = Some(model.to_owned());
+        }
+        if let Some(ts_ms) = ts_ms {
+            if let Some(previous) = previous_ts {
+                let gap = ts_ms.saturating_sub(previous).max(0);
+                longest_idle_gap_ms = longest_idle_gap_ms.max(gap);
+                idle_gap_ms_total = idle_gap_ms_total.saturating_add(gap);
+            }
+            previous_ts = Some(ts_ms);
+        }
+    }
+    Ok((transitions, capped, longest_idle_gap_ms, idle_gap_ms_total))
+}
+
+/* --------------------------------------------------------------------
+ * Compactions.
+ * ----------------------------------------------------------------- */
+
+const MANUAL_COMPACTIONS_SQL: &str = "SELECT COALESCE(
+        SUM(is_compaction_boundary = 1 AND compaction_trigger = ?5), 0)
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND scope = 'main'";
+
+fn query_manual_compactions(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<u64> {
+    let count: i64 = conn.query_row(
+        MANUAL_COMPACTIONS_SQL,
+        params![
+            key.environment_key,
+            key.agent,
+            key.session_id,
+            claim_fence,
+            CompactionTrigger::Manual.as_str()
+        ],
+        |row| row.get(0),
+    )?;
+    Ok(as_u64(count))
+}
+
+const COMPACTION_BOUNDARIES_SQL: &str = "SELECT ts_ms, compaction_trigger,
+        compaction_pre_tokens, compaction_post_tokens
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+    AND scope = 'main' AND is_compaction_boundary = 1
+  ORDER BY thread_id, turn_index
+  LIMIT ?5";
+
+fn query_compaction_boundaries(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    diagnostics: &mut ParseDiagnostics,
+) -> rusqlite::Result<(Vec<CompactionBoundary>, bool)> {
+    let limit = (MAX_COMPACTION_BOUNDARIES + 1) as i64;
+    let mut statement = conn.prepare(COMPACTION_BOUNDARIES_SQL)?;
+    let mut rows = statement.query(params![
+        key.environment_key,
+        key.agent,
+        key.session_id,
+        claim_fence,
+        limit
+    ])?;
+    let mut boundaries = Vec::new();
+    while let Some(row) = rows.next()? {
+        let ts_ms: Option<i64> = row.get(0)?;
+        let trigger: Option<String> = row.get(1)?;
+        let pre_tokens: Option<i64> = row.get(2)?;
+        let post_tokens: Option<i64> = row.get(3)?;
+        boundaries.push(CompactionBoundary {
+            ts_ms: ts_ms.unwrap_or(0),
+            trigger: trigger.as_deref().and_then(CompactionTrigger::parse),
+            pre_tokens: pre_tokens.map(as_u64),
+            post_tokens: post_tokens.map(as_u64),
+        });
+    }
+    let capped = boundaries.len() > MAX_COMPACTION_BOUNDARIES;
+    if capped {
+        boundaries.truncate(MAX_COMPACTION_BOUNDARIES);
+        note_collection_cap(diagnostics, "compactions.boundaries");
+    }
+    Ok((boundaries, capped))
+}
+
+/* --------------------------------------------------------------------
+ * Duplicate thread identities.
+ * ----------------------------------------------------------------- */
+
+const DUPLICATE_TURN_IDENTITIES_SQL: &str = "SELECT COUNT(*) FROM (
+        SELECT uuid FROM turn
+         WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+           AND uuid IS NOT NULL
+         GROUP BY uuid
+        HAVING COUNT(DISTINCT source_key) > 1
+    )";
+
+fn query_duplicate_turn_identities(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<u64> {
+    let count: i64 = conn.query_row(
+        DUPLICATE_TURN_IDENTITIES_SQL,
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+        |row| row.get(0),
+    )?;
+    Ok(as_u64(count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::rows::{TURN_MIGRATIONS, TurnRow, TurnScope, insert_turn_rows};
+
+    const KEY: TurnSessionKey<'static> = TurnSessionKey {
+        environment_key: "native",
+        agent: "claude",
+        session_id: "s1",
+    };
+
+    fn test_connection() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory connection");
+        conn.execute_batch(
+            "CREATE TABLE session (
+                environment_key TEXT NOT NULL,
+                agent TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                PRIMARY KEY (environment_key, agent, session_id)
+            ) STRICT;",
+        )
+        .expect("create session table");
+        for migration in TURN_MIGRATIONS {
+            conn.execute_batch(migration)
+                .expect("apply turn schema migration");
+        }
+        conn.execute(
+            "INSERT INTO session (environment_key, agent, session_id) VALUES (?1, ?2, ?3)",
+            params![KEY.environment_key, KEY.agent, KEY.session_id],
+        )
+        .expect("insert session");
+        conn
+    }
+
+    fn base_row(thread_id: &str, turn_index: u64) -> TurnRow {
+        TurnRow {
+            source_key: thread_id.to_owned(),
+            thread_id: thread_id.to_owned(),
+            turn_index,
+            scope: TurnScope::Main,
+            child_id: None,
+            role: "assistant",
+            ts_ms: Some(1_000 + turn_index as i64),
+            model: Some("model-a".to_owned()),
+            effort: None,
+            speed: None,
+            input_tokens: 10,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            output_tokens: 5,
+            is_compaction_boundary: false,
+            message_id: None,
+            uuid: None,
+            parent_uuid: None,
+            compaction_trigger: None,
+            compaction_pre_tokens: None,
+            compaction_post_tokens: None,
+            content: Vec::new(),
+        }
+    }
+
+    fn insert(conn: &Connection, rows: &[TurnRow]) {
+        insert_turn_rows(conn, &KEY, 1, rows).expect("insert rows");
+    }
+
+    #[test]
+    fn an_empty_session_reads_as_all_zero() {
+        let conn = test_connection();
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.eligibility.turns, 0);
+        assert_eq!(facts.max_request_context_tokens, 0);
+        assert_eq!(
+            facts.time_range,
+            SessionTimeRange {
+                first_ts_ms: 0,
+                last_ts_ms: 0,
+                timestamped_turns: 0,
+            }
+        );
+        assert!(facts.by_model.is_empty());
+        assert!(facts.model_transitions.is_empty());
+        assert!(facts.compaction_boundaries.is_empty());
+        assert_eq!(facts.duplicate_turn_identities, 0);
+        assert!(!facts.thread_identity_missing);
+    }
+
+    #[test]
+    fn fence_filtering_ignores_rows_under_another_fence() {
+        let conn = test_connection();
+        insert_turn_rows(&conn, &KEY, 2, &[base_row("s1", 0)]).expect("insert other fence");
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.eligibility.turns, 0);
+    }
+
+    #[test]
+    fn models_by_model_caps_at_max_models_and_flags_the_overflow() {
+        let conn = test_connection();
+        let rows: Vec<TurnRow> = (0..(MAX_MODELS * 2))
+            .map(|index| {
+                let mut row = base_row("s1", index as u64);
+                row.model = Some(format!("model-{index}"));
+                row
+            })
+            .collect();
+        insert(&conn, &rows);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.by_model.len(), MAX_MODELS);
+        assert!(facts.models_capped);
+        assert!(
+            facts
+                .diagnostics
+                .capped_collections
+                .contains("models.by_model")
+        );
+    }
+
+    #[test]
+    fn tier_labels_cap_at_max_tier_labels_and_flag_the_overflow() {
+        let conn = test_connection();
+        let rows: Vec<TurnRow> = (0..(MAX_TIER_LABELS * 2))
+            .map(|index| {
+                let mut row = base_row("s1", index as u64);
+                row.effort = Some(format!("tier-{index}"));
+                row
+            })
+            .collect();
+        insert(&conn, &rows);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.effort_tiers.len(), MAX_TIER_LABELS);
+        assert!(facts.tiers_capped);
+    }
+
+    #[test]
+    fn top_depth_examples_cap_at_max_evidence_examples_and_keep_the_deepest() {
+        let conn = test_connection();
+        let rows: Vec<TurnRow> = (0..(MAX_EVIDENCE_EXAMPLES * 2))
+            .map(|index| {
+                let mut row = base_row("s1", index as u64);
+                row.input_tokens = index as u64 + 1;
+                row
+            })
+            .collect();
+        insert(&conn, &rows);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.top_depth_examples.len(), MAX_EVIDENCE_EXAMPLES);
+        assert!(facts.depth_examples_capped);
+        // The deepest example is kept; depth is `input_tokens` here since
+        // every other component of depth is zero.
+        assert_eq!(
+            facts.top_depth_examples[0].depth_tokens,
+            (MAX_EVIDENCE_EXAMPLES * 2) as u64
+        );
+    }
+
+    #[test]
+    fn model_transitions_cap_at_max_model_transitions_and_flag_the_overflow() {
+        let conn = test_connection();
+        let rows: Vec<TurnRow> = (0..((MAX_MODEL_TRANSITIONS + 1) * 2))
+            .map(|index| {
+                let mut row = base_row("s1", index as u64);
+                row.model = Some(format!("model-{index}"));
+                row
+            })
+            .collect();
+        insert(&conn, &rows);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.model_transitions.len(), MAX_MODEL_TRANSITIONS);
+        assert!(facts.transitions_capped);
+    }
+
+    #[test]
+    fn compaction_boundaries_cap_at_max_compaction_boundaries_and_flag_the_overflow() {
+        let conn = test_connection();
+        let rows: Vec<TurnRow> = (0..(MAX_COMPACTION_BOUNDARIES * 2))
+            .map(|index| {
+                let mut row = base_row("s1", index as u64);
+                row.is_compaction_boundary = true;
+                row
+            })
+            .collect();
+        insert(&conn, &rows);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.compaction_boundaries.len(), MAX_COMPACTION_BOUNDARIES);
+        assert!(facts.compactions_capped);
+    }
+
+    #[test]
+    fn two_threads_with_different_models_produce_no_transition_between_them() {
+        let conn = test_connection();
+        let mut first = base_row("thread-a", 0);
+        first.model = Some("model-a".to_owned());
+        let mut second = base_row("thread-b", 0);
+        second.model = Some("model-b".to_owned());
+        insert(&conn, &[first, second]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert!(facts.model_transitions.is_empty());
+    }
+
+    #[test]
+    fn idle_gaps_reset_at_a_thread_boundary() {
+        let conn = test_connection();
+        let mut first_a = base_row("thread-a", 0);
+        first_a.ts_ms = Some(0);
+        let mut second_a = base_row("thread-a", 1);
+        second_a.ts_ms = Some(10_000);
+        let mut first_b = base_row("thread-b", 0);
+        first_b.ts_ms = Some(50_000);
+        insert(&conn, &[first_a, second_a, first_b]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        // A gap between the two threads' first rows must not appear: the
+        // scan resets `previous_ts` at the `thread-b` boundary.
+        assert_eq!(facts.longest_idle_gap_ms, 10_000);
+        assert_eq!(facts.idle_gap_ms_total, 10_000);
+    }
+
+    #[test]
+    fn delegated_rows_are_excluded_from_transitions_but_summed_into_tokens() {
+        let conn = test_connection();
+        let mut delegated = base_row("s1", 0);
+        delegated.scope = TurnScope::Delegated;
+        delegated.child_id = Some("s1".to_owned());
+        delegated.model = Some("model-b".to_owned());
+        delegated.input_tokens = 7;
+        let mut main = base_row("s1", 1);
+        main.model = Some("model-a".to_owned());
+        insert(&conn, &[delegated, main]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        // Only one main-loop model is ever observed, so there is no
+        // transition to record even though the session used two models.
+        assert!(facts.model_transitions.is_empty());
+        assert_eq!(facts.fresh_input_tokens, 17);
+        assert_eq!(facts.delegated_turns, 1);
+    }
+
+    #[test]
+    fn a_duplicate_uuid_across_two_source_keys_is_counted() {
+        let conn = test_connection();
+        let mut first = base_row("s1", 0);
+        first.uuid = Some("dup".to_owned());
+        let mut second = base_row("s1", 1);
+        second.source_key = "s2".to_owned();
+        second.uuid = Some("dup".to_owned());
+        let mut unique = base_row("s1", 2);
+        unique.uuid = Some("solo".to_owned());
+        insert(&conn, &[first, second, unique]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.duplicate_turn_identities, 1);
+    }
+}

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -974,13 +974,13 @@ impl RecordSink for SessionEvidenceAccumulator {
     }
 }
 
-pub struct CompositeSink<'a> {
+pub struct CompositeSink {
     metrics: SessionMetricsAccumulator,
     evidence: SessionEvidenceAccumulator,
-    turn_rows: Option<TurnRowSink<'a>>,
+    turn_rows: Option<TurnRowSink>,
 }
 
-impl<'a> CompositeSink<'a> {
+impl CompositeSink {
     pub fn new(metrics: SessionMetricsAccumulator, evidence: SessionEvidenceAccumulator) -> Self {
         Self {
             metrics,
@@ -995,7 +995,7 @@ impl<'a> CompositeSink<'a> {
     pub fn with_turn_rows(
         metrics: SessionMetricsAccumulator,
         evidence: SessionEvidenceAccumulator,
-        turn_rows: TurnRowSink<'a>,
+        turn_rows: TurnRowSink,
     ) -> Self {
         Self {
             metrics,
@@ -1032,7 +1032,7 @@ impl<'a> CompositeSink<'a> {
     }
 }
 
-impl RecordSink for CompositeSink<'_> {
+impl RecordSink for CompositeSink {
     fn record(&mut self, record: NormalizedRecord) {
         self.evidence.observe(&record);
         if let Some(turn_rows) = &mut self.turn_rows {

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -30,6 +30,7 @@
 mod efficiency;
 mod engine;
 mod evidence;
+mod evidence_query;
 mod evidence_sink;
 mod framing;
 mod initial_context;
@@ -58,6 +59,7 @@ pub use evidence::{
     SignalCoverage, SourceAcceptance, SourceCapabilities, SourceKind, SubagentChild,
     SubagentEvidence, SubagentExample, ToolClass, ToolEvidence, ToolUse, TurnCounts,
 };
+pub use evidence_query::{TurnFacts, query_turn_facts};
 pub use evidence_sink::{CompositeSink, SessionEvidenceAccumulator};
 pub use framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,
@@ -76,10 +78,10 @@ pub use model::{
 };
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
 pub use rows::{
-    TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TurnRow, TurnRowSink, TurnRowWriteError, TurnRowWriter,
-    TurnScope, TurnSessionKey, count_turn_content_rows, count_turn_rows, delete_turn_rows,
-    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
-    turn_row_from_event,
+    MemoryTurnRowStore, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL,
+    TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope, TurnSessionKey,
+    count_turn_content_rows, count_turn_rows, delete_turn_rows, delete_turn_rows_except_fence,
+    delete_turn_rows_for_fence, insert_turn_rows, turn_row_from_event,
 };
 pub use source_validity::{
     AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,

--- a/crates/antiburn-local/src/analysis/model.rs
+++ b/crates/antiburn-local/src/analysis/model.rs
@@ -227,6 +227,28 @@ pub enum CompactionTrigger {
     Auto,
 }
 
+impl CompactionTrigger {
+    /// The stable lowercase name a `turn` row stores in its
+    /// `compaction_trigger` column. Matches this type's serde form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CompactionTrigger::Manual => "manual",
+            CompactionTrigger::Auto => "auto",
+        }
+    }
+
+    /// Reads back a value [`Self::as_str`] wrote. Returns `None` for any
+    /// other text, so a row with an unrecognized trigger reads as no
+    /// trigger instead of failing the query.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "manual" => Some(CompactionTrigger::Manual),
+            "auto" => Some(CompactionTrigger::Auto),
+            _ => None,
+        }
+    }
+}
+
 /// Which transcript an event comes from, after [`crate::analysis::merge_subagent_events`]
 /// concatenates a parent session with its sub-agents into one stream.
 ///

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -8,10 +8,13 @@
 //! functions over a borrowed [`rusqlite::Connection`]. The crate does not open
 //! the app database and does not know any other app table.
 
+use std::sync::{Arc, Mutex};
+
 use rusqlite::{Connection, params};
 
+use crate::analysis::evidence_query::{TurnFacts, query_turn_facts};
 use crate::analysis::interface::{ContentPart, NormalizedRecord, RecordSink, SessionSummary};
-use crate::analysis::model::{EventSource, NormalizedEvent, Role};
+use crate::analysis::model::{CompactionTrigger, EventSource, NormalizedEvent, Role};
 
 /// DDL for the `turn` and `turn_content` tables.
 ///
@@ -71,6 +74,27 @@ CREATE TABLE turn_content (
 ) WITHOUT ROWID, STRICT;
 "#;
 
+/// DDL that adds the compaction columns [`TurnRow::compaction_trigger`],
+/// [`TurnRow::compaction_pre_tokens`], and [`TurnRow::compaction_post_tokens`]
+/// to an existing `turn` table.
+///
+/// [`TURN_SCHEMA_SQL`] is already applied as schema version 15 on user
+/// machines, so this change adds its three new columns through a migration
+/// instead of editing that constant. See [`TURN_MIGRATIONS`].
+pub const TURN_SCHEMA_V2_SQL: &str = r#"
+ALTER TABLE turn ADD COLUMN compaction_trigger TEXT;
+ALTER TABLE turn ADD COLUMN compaction_pre_tokens INTEGER;
+ALTER TABLE turn ADD COLUMN compaction_post_tokens INTEGER;
+"#;
+
+/// Every migration that builds the `turn` and `turn_content` schema, in
+/// order. A caller that creates this schema from scratch (a test, an
+/// in-memory store) applies every entry in order; the app applies
+/// [`TURN_SCHEMA_SQL`] and [`TURN_SCHEMA_V2_SQL`] as its own separately
+/// numbered migrations instead, since [`TURN_SCHEMA_SQL`] is already applied
+/// on user machines.
+pub const TURN_MIGRATIONS: &[&str] = &[TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL];
+
 /// Number of rows a [`TurnRowSink`] buffers before it writes them, unless the
 /// caller picks a different size with [`TurnRowSink::with_batch_size`].
 pub const TURN_ROW_BATCH_SIZE: usize = 512;
@@ -116,6 +140,9 @@ pub struct TurnRow {
     pub message_id: Option<String>,
     pub uuid: Option<String>,
     pub parent_uuid: Option<String>,
+    pub compaction_trigger: Option<CompactionTrigger>,
+    pub compaction_pre_tokens: Option<u64>,
+    pub compaction_post_tokens: Option<u64>,
     /// This turn's captured message content, when the source adapter emitted
     /// a `TurnContent` record for it. Attached by [`TurnRowSink`] after
     /// [`turn_row_from_event`] builds the row — an event alone carries none.
@@ -164,6 +191,9 @@ pub fn turn_row_from_event(event: &NormalizedEvent, source_key: &str, turn_index
         message_id: event.message_id.clone(),
         uuid: event.uuid.clone(),
         parent_uuid: event.parent_uuid.clone(),
+        compaction_trigger: event.compaction_trigger,
+        compaction_pre_tokens: event.compaction_pre_tokens,
+        compaction_post_tokens: event.compaction_post_tokens,
         content: Vec::new(),
     }
 }
@@ -177,36 +207,40 @@ pub struct TurnSessionKey<'a> {
     pub session_id: &'a str,
 }
 
-/// One `turn`-row write failed.
+/// One `turn`-row store operation failed.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TurnRowWriteError(pub String);
+pub struct TurnRowError(pub String);
 
-impl std::fmt::Display for TurnRowWriteError {
+impl std::fmt::Display for TurnRowError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "turn row write failed: {}", self.0)
+        write!(formatter, "turn row store failed: {}", self.0)
     }
 }
 
-impl std::error::Error for TurnRowWriteError {}
+impl std::error::Error for TurnRowError {}
 
-impl From<rusqlite::Error> for TurnRowWriteError {
+impl From<rusqlite::Error> for TurnRowError {
     fn from(error: rusqlite::Error) -> Self {
-        TurnRowWriteError(error.to_string())
+        TurnRowError(error.to_string())
     }
 }
 
-/// Writes a batch of turn rows for one session.
+/// Writes and reads a session's batch of turn rows.
 ///
 /// `&self` so a shared handle (an `Arc<Store>`, or an app type that wraps
 /// one) can implement this and move into the blocking thread that runs the
 /// analysis pass.
-pub trait TurnRowWriter: Send + Sync {
-    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError>;
+pub trait TurnRowStore: Send + Sync {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowError>;
+
+    /// Reads the facts for every row this store wrote under its own session
+    /// key and fence.
+    fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError>;
 }
 
 /// A [`RecordSink`] that turns `MetricsEvent` records into [`TurnRow`]s,
 /// attaches each row's `TurnContent` record (when one arrives), and writes
-/// the rows through a [`TurnRowWriter`] in bounded batches.
+/// the rows through a [`TurnRowStore`] in bounded batches.
 ///
 /// `turn_index` is monotonic per `source_key`, starting at zero. After each
 /// call to [`Self::observe`] the buffer holds at most `batch_size` rows: once
@@ -217,29 +251,40 @@ pub trait TurnRowWriter: Send + Sync {
 /// promises arrives right after the `MetricsEvent` it belongs to — can still
 /// attach before that row is written. The first write error is kept and
 /// stops further writes; [`Self::into_error`] lets the caller surface it.
-pub struct TurnRowSink<'a> {
-    writer: &'a dyn TurnRowWriter,
+pub struct TurnRowSink {
+    store: Arc<dyn TurnRowStore>,
     source_key: String,
+    forced_scope: Option<TurnScope>,
     next_index: u64,
     buffer: Vec<TurnRow>,
     batch_size: usize,
-    error: Option<TurnRowWriteError>,
+    error: Option<TurnRowError>,
 }
 
-impl<'a> TurnRowSink<'a> {
-    pub fn new(writer: &'a dyn TurnRowWriter, source_key: impl Into<String>) -> Self {
-        Self::with_batch_size(writer, source_key, TURN_ROW_BATCH_SIZE)
+impl TurnRowSink {
+    /// `scope` overrides the scope [`turn_row_from_event`] derives from each
+    /// event's [`EventSource`]. `Some(TurnScope::Delegated)` still sets
+    /// `child_id = Some(source_key)`, as if the event had come from a
+    /// sub-agent transcript. `None` keeps today's derived scope.
+    pub fn new(
+        store: Arc<dyn TurnRowStore>,
+        source_key: impl Into<String>,
+        scope: Option<TurnScope>,
+    ) -> Self {
+        Self::with_batch_size(store, source_key, scope, TURN_ROW_BATCH_SIZE)
     }
 
     pub fn with_batch_size(
-        writer: &'a dyn TurnRowWriter,
+        store: Arc<dyn TurnRowStore>,
         source_key: impl Into<String>,
+        scope: Option<TurnScope>,
         batch_size: usize,
     ) -> Self {
         let batch_size = batch_size.max(1);
         Self {
-            writer,
+            store,
             source_key: source_key.into(),
+            forced_scope: scope,
             next_index: 0,
             buffer: Vec::with_capacity(batch_size.min(TURN_ROW_BATCH_SIZE)),
             batch_size,
@@ -247,14 +292,14 @@ impl<'a> TurnRowSink<'a> {
         }
     }
 
-    /// True once a write has failed. No further row reaches the writer after
+    /// True once a write has failed. No further row reaches the store after
     /// this, but rows already accepted before the failure stay written.
     pub fn has_error(&self) -> bool {
         self.error.is_some()
     }
 
     /// Consumes the sink and returns the write error, if one occurred.
-    pub fn into_error(self) -> Option<TurnRowWriteError> {
+    pub fn into_error(self) -> Option<TurnRowError> {
         self.error
     }
 
@@ -268,7 +313,14 @@ impl<'a> TurnRowSink<'a> {
         }
         match record {
             NormalizedRecord::MetricsEvent(event) => {
-                let row = turn_row_from_event(event, &self.source_key, self.next_index);
+                let mut row = turn_row_from_event(event, &self.source_key, self.next_index);
+                if let Some(scope) = self.forced_scope {
+                    row.scope = scope;
+                    row.child_id = match scope {
+                        TurnScope::Delegated => Some(self.source_key.clone()),
+                        TurnScope::Main => None,
+                    };
+                }
                 self.next_index += 1;
                 self.buffer.push(row);
                 if self.buffer.len() > self.batch_size {
@@ -289,7 +341,7 @@ impl<'a> TurnRowSink<'a> {
         if self.error.is_some() || self.buffer.is_empty() {
             return;
         }
-        if let Err(error) = self.writer.write_turn_rows(&self.buffer) {
+        if let Err(error) = self.store.write_turn_rows(&self.buffer) {
             self.error = Some(error);
         }
         self.buffer.clear();
@@ -306,7 +358,7 @@ impl<'a> TurnRowSink<'a> {
         let Some(last) = self.buffer.pop() else {
             return;
         };
-        if let Err(error) = self.writer.write_turn_rows(&self.buffer) {
+        if let Err(error) = self.store.write_turn_rows(&self.buffer) {
             self.error = Some(error);
         }
         self.buffer.clear();
@@ -314,7 +366,7 @@ impl<'a> TurnRowSink<'a> {
     }
 }
 
-impl RecordSink for TurnRowSink<'_> {
+impl RecordSink for TurnRowSink {
     fn record(&mut self, record: NormalizedRecord) {
         self.observe(&record);
     }
@@ -328,10 +380,11 @@ const INSERT_TURN_SQL: &str = "INSERT INTO turn (
     environment_key, agent, session_id, claim_fence, source_key, thread_id,
     turn_index, scope, child_id, role, ts_ms, model, effort, speed,
     input_tokens, cache_read_tokens, cache_write_tokens, output_tokens,
-    is_compaction_boundary, message_id, uuid, parent_uuid
+    is_compaction_boundary, message_id, uuid, parent_uuid,
+    compaction_trigger, compaction_pre_tokens, compaction_post_tokens
 ) VALUES (
     ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-    ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+    ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25
 )";
 
 const INSERT_TURN_CONTENT_SQL: &str = "INSERT INTO turn_content (
@@ -376,6 +429,9 @@ pub fn insert_turn_rows(
             row.message_id,
             row.uuid,
             row.parent_uuid,
+            row.compaction_trigger.map(CompactionTrigger::as_str),
+            row.compaction_pre_tokens.map(|tokens| tokens as i64),
+            row.compaction_post_tokens.map(|tokens| tokens as i64),
         ])?;
         if !row.content.is_empty() {
             let turn_rowid = conn.last_insert_rowid();
@@ -499,28 +555,110 @@ pub fn count_turn_content_rows(
     Ok(count.max(0) as u64)
 }
 
+/// A minimal `session` table, just enough for the `turn` schema's foreign
+/// key to be valid. Shared by [`MemoryTurnRowStore`] and this module's own
+/// tests — neither owns the app's real `session` table.
+const MEMORY_SESSION_SQL: &str = "CREATE TABLE session (
+    environment_key TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    PRIMARY KEY (environment_key, agent, session_id)
+) STRICT;";
+
+/// An in-memory [`TurnRowStore`], for tests and tools.
+///
+/// Holds a private `rusqlite::Connection` with every [`TURN_MIGRATIONS`]
+/// entry applied, under one fixed [`TurnSessionKey`] and claim fence. The
+/// app writes through the fenced store in `apps/desktop/src-tauri`'s
+/// `store` module instead; this type lets a test stream a fixture through a
+/// [`TurnRowSink`] and then read the rows back — through
+/// [`Self::query_turn_facts`] or [`Self::with_connection`] — without a real
+/// database.
+pub struct MemoryTurnRowStore {
+    connection: Mutex<Connection>,
+    environment_key: String,
+    agent: String,
+    session_id: String,
+    claim_fence: i64,
+}
+
+impl MemoryTurnRowStore {
+    /// Builds a store scoped to one session, under claim fence `1`.
+    pub fn new(agent: impl Into<String>, session_id: impl Into<String>) -> Arc<Self> {
+        let agent = agent.into();
+        let session_id = session_id.into();
+        let environment_key = "native".to_owned();
+        let connection = Connection::open_in_memory().expect("open in-memory connection");
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .expect("enable foreign keys");
+        connection
+            .execute_batch(MEMORY_SESSION_SQL)
+            .expect("create session table");
+        for migration in TURN_MIGRATIONS {
+            connection
+                .execute_batch(migration)
+                .expect("apply turn schema migration");
+        }
+        connection
+            .execute(
+                "INSERT INTO session (environment_key, agent, session_id) VALUES (?1, ?2, ?3)",
+                params![environment_key, agent, session_id],
+            )
+            .expect("insert session");
+        Arc::new(Self {
+            connection: Mutex::new(connection),
+            environment_key,
+            agent,
+            session_id,
+            claim_fence: 1,
+        })
+    }
+
+    fn key(&self) -> TurnSessionKey<'_> {
+        TurnSessionKey {
+            environment_key: &self.environment_key,
+            agent: &self.agent,
+            session_id: &self.session_id,
+        }
+    }
+
+    /// Runs `f` against the underlying connection, for a test that reads
+    /// rows directly instead of through [`Self::query_turn_facts`].
+    pub fn with_connection<R>(&self, f: impl FnOnce(&Connection) -> R) -> R {
+        let connection = self.connection.lock().expect("lock");
+        f(&connection)
+    }
+}
+
+impl TurnRowStore for MemoryTurnRowStore {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowError> {
+        let connection = self.connection.lock().expect("lock");
+        insert_turn_rows(&connection, &self.key(), self.claim_fence, rows)
+            .map_err(TurnRowError::from)
+    }
+
+    fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
+        let connection = self.connection.lock().expect("lock");
+        query_turn_facts(&connection, &self.key(), self.claim_fence).map_err(TurnRowError::from)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use super::*;
     use crate::analysis::model::Usage;
-
-    const TEST_SESSION_SQL: &str = "CREATE TABLE session (
-        environment_key TEXT NOT NULL,
-        agent TEXT NOT NULL,
-        session_id TEXT NOT NULL,
-        PRIMARY KEY (environment_key, agent, session_id)
-    ) STRICT;";
 
     fn test_connection() -> Connection {
         let conn = Connection::open_in_memory().expect("open in-memory connection");
         conn.pragma_update(None, "foreign_keys", true)
             .expect("enable foreign keys");
-        conn.execute_batch(TEST_SESSION_SQL)
+        conn.execute_batch(MEMORY_SESSION_SQL)
             .expect("create session table");
-        conn.execute_batch(TURN_SCHEMA_SQL)
-            .expect("create turn schema");
+        for migration in TURN_MIGRATIONS {
+            conn.execute_batch(migration)
+                .expect("apply turn schema migration");
+        }
         conn
     }
 
@@ -552,6 +690,9 @@ mod tests {
             message_id: None,
             uuid: None,
             parent_uuid: None,
+            compaction_trigger: None,
+            compaction_pre_tokens: None,
+            compaction_post_tokens: None,
             content: Vec::new(),
         }
     }
@@ -669,18 +810,25 @@ mod tests {
         assert_eq!(row.child_id, None);
     }
 
-    /// A writer that always fails, so the sink's error path can be tested
-    /// without a real connection.
+    /// A store that always fails to write, so the sink's error path can be
+    /// tested without a real connection. Never read, so
+    /// [`TurnRowStore::query_turn_facts`] need not really work.
     struct FailingWriter;
 
-    impl TurnRowWriter for FailingWriter {
-        fn write_turn_rows(&self, _rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
-            Err(TurnRowWriteError("boom".to_owned()))
+    impl TurnRowStore for FailingWriter {
+        fn write_turn_rows(&self, _rows: &[TurnRow]) -> Result<(), TurnRowError> {
+            Err(TurnRowError("boom".to_owned()))
+        }
+
+        fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
+            Err(TurnRowError("not readable".to_owned()))
         }
     }
 
-    /// A writer over a real connection, so batching tests can assert on rows
-    /// actually reaching the table.
+    /// A store over a real connection, so batching tests can assert on rows
+    /// actually reaching the table. Never read through
+    /// [`TurnRowStore::query_turn_facts`] — the tests here inspect the
+    /// table directly.
     struct RecordingWriter {
         conn: Mutex<Connection>,
         key: String,
@@ -721,10 +869,34 @@ mod tests {
             )
             .expect("count")
         }
+
+        fn scopes(&self, claim_fence: i64) -> Vec<(TurnScope, Option<String>)> {
+            let conn = self.conn.lock().expect("lock");
+            let mut statement = conn
+                .prepare(
+                    "SELECT scope, child_id FROM turn
+                      WHERE environment_key = 'native' AND agent = 'claude'
+                        AND session_id = ?1 AND claim_fence = ?2
+                      ORDER BY turn_index",
+                )
+                .expect("prepare");
+            statement
+                .query_map(params![self.key, claim_fence], |row| {
+                    let scope: String = row.get(0)?;
+                    let scope = match scope.as_str() {
+                        "main" => TurnScope::Main,
+                        _ => TurnScope::Delegated,
+                    };
+                    Ok((scope, row.get(1)?))
+                })
+                .expect("query")
+                .map(|row| row.expect("row"))
+                .collect()
+        }
     }
 
-    impl TurnRowWriter for RecordingWriter {
-        fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+    impl TurnRowStore for RecordingWriter {
+        fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowError> {
             let conn = self.conn.lock().expect("lock");
             insert_turn_rows(
                 &conn,
@@ -736,7 +908,21 @@ mod tests {
                 1,
                 rows,
             )
-            .map_err(TurnRowWriteError::from)
+            .map_err(TurnRowError::from)
+        }
+
+        fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
+            let conn = self.conn.lock().expect("lock");
+            query_turn_facts(
+                &conn,
+                &TurnSessionKey {
+                    environment_key: "native",
+                    agent: "claude",
+                    session_id: &self.key,
+                },
+                1,
+            )
+            .map_err(TurnRowError::from)
         }
     }
 
@@ -753,8 +939,13 @@ mod tests {
             session_id: "s1",
         };
         insert_session(&conn, &key);
-        let writer = RecordingWriter::new(conn);
-        let mut sink = TurnRowSink::with_batch_size(&writer, "s1", 4);
+        let writer = Arc::new(RecordingWriter::new(conn));
+        let mut sink = TurnRowSink::with_batch_size(
+            Arc::clone(&writer) as Arc<dyn TurnRowStore>,
+            "s1",
+            None,
+            4,
+        );
 
         for _ in 0..10 {
             sink.observe(&metric_record(Role::Assistant));
@@ -768,8 +959,8 @@ mod tests {
 
     #[test]
     fn a_write_error_stops_further_writes_and_is_surfaced() {
-        let writer = FailingWriter;
-        let mut sink = TurnRowSink::with_batch_size(&writer, "s1", 1);
+        let writer = Arc::new(FailingWriter);
+        let mut sink = TurnRowSink::with_batch_size(writer, "s1", None, 1);
 
         // A row stays buffered, unflushed, until a later row pushes the
         // buffer over `batch_size` — so the first write attempt (and the
@@ -792,8 +983,8 @@ mod tests {
             session_id: "s1",
         };
         insert_session(&conn, &key);
-        let writer = RecordingWriter::new(conn);
-        let mut sink = TurnRowSink::new(&writer, "s1");
+        let writer = Arc::new(RecordingWriter::new(conn));
+        let mut sink = TurnRowSink::new(Arc::clone(&writer) as Arc<dyn TurnRowStore>, "s1", None);
 
         sink.observe(&metric_record(Role::Assistant));
         sink.observe(&NormalizedRecord::Unusable(
@@ -802,6 +993,34 @@ mod tests {
         sink.finish(SessionSummary::default());
 
         assert_eq!(writer.count(1), 1);
+    }
+
+    #[test]
+    fn a_forced_scope_overrides_the_event_derived_scope_and_sets_child_id() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        let writer = Arc::new(RecordingWriter::new(conn));
+        // Every event here is `EventSource::Parent`, which
+        // `turn_row_from_event` would otherwise map to `TurnScope::Main`
+        // with no `child_id`.
+        let mut sink = TurnRowSink::new(
+            Arc::clone(&writer) as Arc<dyn TurnRowStore>,
+            "s1",
+            Some(TurnScope::Delegated),
+        );
+
+        sink.observe(&metric_record(Role::Assistant));
+        sink.finish(SessionSummary::default());
+
+        assert_eq!(
+            writer.scopes(1),
+            vec![(TurnScope::Delegated, Some("s1".to_owned()))]
+        );
     }
 
     fn content_record(text: &str) -> NormalizedRecord {
@@ -822,8 +1041,8 @@ mod tests {
             session_id: "s1",
         };
         insert_session(&conn, &key);
-        let writer = RecordingWriter::new(conn);
-        let mut sink = TurnRowSink::new(&writer, "s1");
+        let writer = Arc::new(RecordingWriter::new(conn));
+        let mut sink = TurnRowSink::new(Arc::clone(&writer) as Arc<dyn TurnRowStore>, "s1", None);
 
         sink.observe(&metric_record(Role::User));
         sink.observe(&content_record("hello"));
@@ -843,8 +1062,13 @@ mod tests {
             session_id: "s1",
         };
         insert_session(&conn, &key);
-        let writer = RecordingWriter::new(conn);
-        let mut sink = TurnRowSink::with_batch_size(&writer, "s1", 2);
+        let writer = Arc::new(RecordingWriter::new(conn));
+        let mut sink = TurnRowSink::with_batch_size(
+            Arc::clone(&writer) as Arc<dyn TurnRowStore>,
+            "s1",
+            None,
+            2,
+        );
 
         sink.observe(&metric_record(Role::Assistant));
         sink.observe(&metric_record(Role::Assistant));

--- a/crates/antiburn-local/tests/claude_characterization.rs
+++ b/crates/antiburn-local/tests/claude_characterization.rs
@@ -226,7 +226,7 @@ fn stream_claude(input: &SessionInput) -> SessionMetricsAccumulator {
     accumulator
 }
 
-fn stream_composite(input: &SessionInput) -> CompositeSink<'static> {
+fn stream_composite(input: &SessionInput) -> CompositeSink {
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),

--- a/crates/antiburn-local/tests/pipeline_corpus.rs
+++ b/crates/antiburn-local/tests/pipeline_corpus.rs
@@ -64,7 +64,7 @@ fn write_session(directory: &TempDir, session: &GeneratedSession) -> PathBuf {
     path
 }
 
-fn composite_for(input: &SessionInput) -> CompositeSink<'static> {
+fn composite_for(input: &SessionInput) -> CompositeSink {
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),
@@ -76,7 +76,7 @@ fn composite_for(input: &SessionInput) -> CompositeSink<'static> {
 }
 
 /// Runs framing → normalization → metrics + evidence for one input.
-fn run_pipeline(input: &SessionInput) -> CompositeSink<'static> {
+fn run_pipeline(input: &SessionInput) -> CompositeSink {
     let mut composite = composite_for(input);
     let outcome = adapter_for("claude")
         .visit(input, &mut composite)
@@ -388,7 +388,7 @@ fn provider_db_backed_source_flows_end_to_end_into_a_report() {
 /// Forwards to a composite sink and appends to the source file mid-read,
 /// like an agent still writing its transcript.
 struct AppendingSink {
-    inner: CompositeSink<'static>,
+    inner: CompositeSink,
     path: PathBuf,
     append_after_records: usize,
     seen: usize,

--- a/crates/antiburn-local/tests/streaming_metrics_memory.rs
+++ b/crates/antiburn-local/tests/streaming_metrics_memory.rs
@@ -2,14 +2,15 @@
 mod corpus;
 
 use std::io::Cursor;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use antiburn_local::analysis::{
     BoundedJsonlReader, CompositeSink, EvidenceSource, NormalizedEvent, NormalizedRecord,
     RETAINED_METRICS_BYTES_BOUND, RawSource, RecordSink, Role, SCAN_QUANTUM_BYTES,
     SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SessionSummary,
-    SourceCapabilities, SourceKind, TURN_ROW_BATCH_SIZE, ToolCall, TurnRow, TurnRowSink,
-    TurnRowWriteError, TurnRowWriter, Usage, adapter_for,
+    SourceCapabilities, SourceKind, TURN_ROW_BATCH_SIZE, ToolCall, TurnFacts, TurnRow,
+    TurnRowError, TurnRowSink, TurnRowStore, Usage, adapter_for,
 };
 use corpus::generate_session_of_bytes;
 
@@ -134,11 +135,16 @@ struct CountingWriter {
     total_rows: AtomicUsize,
 }
 
-impl TurnRowWriter for CountingWriter {
-    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+impl TurnRowStore for CountingWriter {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowError> {
         self.max_batch.fetch_max(rows.len(), Ordering::SeqCst);
         self.total_rows.fetch_add(rows.len(), Ordering::SeqCst);
         Ok(())
+    }
+
+    // Never read: this test only asserts on the batches the sink wrote.
+    fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
+        Err(TurnRowError("not readable".to_owned()))
     }
 }
 
@@ -150,7 +156,7 @@ fn the_turn_row_sink_stays_bounded_over_a_streamed_corpus() {
         session_id: session.session_id.clone(),
         source: RawSource::Jsonl(session.jsonl.clone()),
     };
-    let writer = CountingWriter::default();
+    let writer = Arc::new(CountingWriter::default());
     let metrics = SessionMetricsAccumulator::new(&input.agent, &input.session_id);
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),
@@ -158,7 +164,11 @@ fn the_turn_row_sink_stays_bounded_over_a_streamed_corpus() {
         kind: SourceKind::Jsonl,
         capabilities: SourceCapabilities::claude(),
     });
-    let sink = TurnRowSink::new(&writer, input.session_id.clone());
+    let sink = TurnRowSink::new(
+        Arc::clone(&writer) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
     let mut composite = CompositeSink::with_turn_rows(metrics, evidence, sink);
     adapter_for("claude")
         .visit(&input, &mut composite)

--- a/crates/antiburn-local/tests/support/claude_fixture.rs
+++ b/crates/antiburn-local/tests/support/claude_fixture.rs
@@ -19,11 +19,11 @@ pub fn session_input(name: &str) -> SessionInput {
     }
 }
 
-pub fn stream_composite(name: &str) -> CompositeSink<'static> {
+pub fn stream_composite(name: &str) -> CompositeSink {
     stream_input(session_input(name))
 }
 
-pub fn stream_source(name: &str, source: String) -> CompositeSink<'static> {
+pub fn stream_source(name: &str, source: String) -> CompositeSink {
     stream_input(SessionInput {
         agent: "claude".to_owned(),
         session_id: name.to_owned(),
@@ -31,7 +31,7 @@ pub fn stream_source(name: &str, source: String) -> CompositeSink<'static> {
     })
 }
 
-fn stream_input(input: SessionInput) -> CompositeSink<'static> {
+fn stream_input(input: SessionInput) -> CompositeSink {
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),

--- a/crates/antiburn-local/tests/turn_content_privacy.rs
+++ b/crates/antiburn-local/tests/turn_content_privacy.rs
@@ -5,13 +5,13 @@
 //! See "Privacy with content stored" in
 //! `docs/plans/session-evidence-harness-parity.md`.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use antiburn_local::analysis::{
     CompositeSink, EvidenceSource, RawSource, SessionEvidenceAccumulator, SessionInput,
-    SessionMetricsAccumulator, SourceCapabilities, SourceKind, TURN_SCHEMA_SQL, TurnRow,
-    TurnRowSink, TurnRowWriteError, TurnRowWriter, TurnSessionKey, adapter_for,
-    count_turn_content_rows, delete_turn_rows, insert_turn_rows, normalize_source,
+    SessionMetricsAccumulator, SourceCapabilities, SourceKind, TURN_MIGRATIONS, TurnFacts, TurnRow,
+    TurnRowError, TurnRowSink, TurnRowStore, TurnSessionKey, adapter_for, count_turn_content_rows,
+    delete_turn_rows, insert_turn_rows, normalize_source,
 };
 use rusqlite::{Connection, params};
 
@@ -96,8 +96,10 @@ fn test_connection() -> Connection {
         ) STRICT;",
     )
     .expect("create session table");
-    conn.execute_batch(TURN_SCHEMA_SQL)
-        .expect("create turn schema");
+    for migration in TURN_MIGRATIONS {
+        conn.execute_batch(migration)
+            .expect("apply turn schema migration");
+    }
     conn.execute(
         "INSERT INTO session (environment_key, agent, session_id) VALUES (?1, ?2, ?3)",
         params![ENVIRONMENT_KEY, AGENT, SESSION_ID],
@@ -108,10 +110,16 @@ fn test_connection() -> Connection {
 
 struct TestWriter(Mutex<Connection>);
 
-impl TurnRowWriter for TestWriter {
-    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowWriteError> {
+impl TurnRowStore for TestWriter {
+    fn write_turn_rows(&self, rows: &[TurnRow]) -> Result<(), TurnRowError> {
         let conn = self.0.lock().expect("lock");
-        insert_turn_rows(&conn, &key(), 1, rows).map_err(TurnRowWriteError::from)
+        insert_turn_rows(&conn, &key(), 1, rows).map_err(TurnRowError::from)
+    }
+
+    // Never read: this test inspects `turn_content` through its own
+    // connection handle instead of through the store trait.
+    fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
+        Err(TurnRowError("not readable".to_owned()))
     }
 }
 
@@ -135,7 +143,7 @@ fn turn_content_captures_sentinels_while_every_other_projection_stays_clean() {
 
     // Run the full pipeline: metrics, evidence, and turn rows in one pass,
     // exactly as the durable analysis worker does.
-    let writer = TestWriter(Mutex::new(test_connection()));
+    let writer = Arc::new(TestWriter(Mutex::new(test_connection())));
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),
@@ -143,7 +151,11 @@ fn turn_content_captures_sentinels_while_every_other_projection_stays_clean() {
         kind: SourceKind::from(&input.source),
         capabilities: SourceCapabilities::claude(),
     });
-    let turn_rows = TurnRowSink::new(&writer, input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&writer) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
     let mut composite = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
     let outcome = adapter_for("claude")
         .visit(&input, &mut composite)

--- a/crates/antiburn-local/tests/turn_facts_parity.rs
+++ b/crates/antiburn-local/tests/turn_facts_parity.rs
@@ -1,0 +1,746 @@
+//! Parity check between `query_turn_facts` (the row-derived read side) and
+//! `SessionEvidenceAccumulator` (today's evidence source). See Phase 3 in
+//! `docs/plans/session-evidence-harness-parity.md`.
+//!
+//! Each vendor test streams every characterization fixture once, through a
+//! `CompositeSink` fanned out to a `MemoryTurnRowStore`, then compares the
+//! two projections field by field. The set of differences must equal the
+//! documented set in each test, exactly. A new difference is a bug in the
+//! query or a semantic change that needs a documented reason. A documented
+//! difference that no longer appears is a stale entry. Do not weaken a
+//! comparison to make a difference pass.
+//!
+//! The documented differences all come from three rules of the row query:
+//!
+//! - `time_range`: rows hold turns only. The accumulator also folds the
+//!   timestamps of eventless records (`RecordTimestamp` observations).
+//! - `delegated_turns`: rows count delegated turns only. The accumulator
+//!   counts every sidechain record, including inert ones.
+//! - `model_transitions` and idle gaps: rows use `scope='main'` only, per
+//!   thread. The accumulator runs one scan over every event, so an inline
+//!   sidechain event can form a transition or a gap with a main-loop event.
+
+use std::sync::Arc;
+
+use antiburn_local::analysis::{
+    CompositeSink, EvidenceSource, EvidenceValue, MemoryTurnRowStore, RawSource, SessionEvidence,
+    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SourceCapabilities,
+    SourceKind, TurnFacts, TurnRowSink, TurnRowStore, adapter_for,
+};
+
+/// Reads the value out of an `EvidenceValue`, for `Complete` and `Partial`
+/// alike. Returns `None` for `Unsupported`, so the caller skips a group the
+/// vendor never publishes.
+fn published<T: Clone>(value: &EvidenceValue<T>) -> Option<T> {
+    match value {
+        EvidenceValue::Complete(observed) => Some(observed.clone()),
+        EvidenceValue::Partial { observed, .. } => Some(observed.clone()),
+        EvidenceValue::Unsupported => None,
+    }
+}
+
+/// Records a mismatch when `accumulator` and `facts` differ for one field of
+/// one fixture.
+fn diff<T: std::fmt::Debug + PartialEq>(
+    mismatches: &mut Vec<Mismatch>,
+    fixture: &str,
+    field: &str,
+    accumulator: T,
+    facts: T,
+) {
+    if accumulator != facts {
+        mismatches.push(Mismatch {
+            fixture: fixture.to_owned(),
+            field: field.to_owned(),
+            detail: format!(
+                "fixture={fixture} field={field}\n  accumulator = {accumulator:?}\n  facts       = {facts:?}"
+            ),
+        });
+    }
+}
+
+struct Mismatch {
+    fixture: String,
+    field: String,
+    detail: String,
+}
+
+/// One documented difference: the fixture, the field, and the query rule
+/// that explains it.
+struct Documented {
+    fixture: &'static str,
+    field: &'static str,
+    rule: &'static str,
+}
+
+const TIME_RANGE_RULE: &str = "time_range comes from turn rows only";
+const DELEGATED_TURNS_RULE: &str = "delegated_turns counts turn rows only";
+const MAIN_SCOPE_RULE: &str = "transitions and idle gaps use scope='main' rows only";
+
+const fn documented(fixture: &'static str, field: &'static str, rule: &'static str) -> Documented {
+    Documented {
+        fixture,
+        field,
+        rule,
+    }
+}
+
+/// Streams `jsonl` through the named vendor's adapter into both an evidence
+/// accumulator and a `MemoryTurnRowStore`, and returns both projections.
+fn run_fixture(
+    agent: &str,
+    fixture: &str,
+    jsonl: &str,
+    capabilities: SourceCapabilities,
+) -> (SessionEvidence, TurnFacts) {
+    let input = SessionInput {
+        agent: agent.to_owned(),
+        session_id: fixture.to_owned(),
+        source: RawSource::Jsonl(jsonl.to_owned()),
+    };
+    let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::from(&input.source),
+        capabilities,
+    });
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut composite = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
+    let outcome = adapter_for(agent)
+        .visit(&input, &mut composite)
+        .expect("fixture must stream");
+    composite.observe_source_outcome(outcome);
+    assert!(
+        !composite.turn_row_write_failed(),
+        "fixture {fixture}: turn row write must not fail"
+    );
+
+    let evidence = composite
+        .evidence()
+        .expect("finished source must publish evidence");
+    let facts = store.query_turn_facts().expect("facts query must succeed");
+    (evidence, facts)
+}
+
+/// Compares every group both projections produce, for one fixture, pushing
+/// each field mismatch found into `mismatches`.
+fn compare_fixture(
+    mismatches: &mut Vec<Mismatch>,
+    fixture: &str,
+    evidence: &SessionEvidence,
+    facts: &TurnFacts,
+) {
+    if let Some(eligibility) = published(&evidence.eligibility) {
+        diff(
+            mismatches,
+            fixture,
+            "eligibility",
+            eligibility,
+            facts.eligibility.clone(),
+        );
+    }
+    if let Some(context) = published(&evidence.context) {
+        diff(
+            mismatches,
+            fixture,
+            "context.maxRequestContextTokens",
+            context.max_request_context_tokens,
+            facts.max_request_context_tokens,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "context.topDepthExamples",
+            context.top_depth_examples,
+            facts.top_depth_examples.clone(),
+        );
+    }
+    if let Some(time_range) = published(&evidence.time_range) {
+        diff(
+            mismatches,
+            fixture,
+            "timeRange",
+            time_range,
+            facts.time_range.clone(),
+        );
+    }
+    if let Some(models) = published(&evidence.models) {
+        diff(
+            mismatches,
+            fixture,
+            "models.byModel",
+            models.by_model,
+            facts.by_model.clone(),
+        );
+        diff(
+            mismatches,
+            fixture,
+            "models.unattributedTurns",
+            models.unattributed_turns,
+            facts.unattributed_turns,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "models.effortTiers",
+            models.effort_tiers,
+            facts.effort_tiers.clone(),
+        );
+        diff(
+            mismatches,
+            fixture,
+            "models.fastModes",
+            models.fast_modes,
+            facts.fast_modes.clone(),
+        );
+        diff(
+            mismatches,
+            fixture,
+            "models.effortSignal",
+            models.effort_signal,
+            facts.effort_signal,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "models.speedSignal",
+            models.speed_signal,
+            facts.speed_signal,
+        );
+    }
+    if let Some(subagents) = published(&evidence.subagents) {
+        diff(
+            mismatches,
+            fixture,
+            "subagents.delegatedTurns",
+            subagents.delegated_turns,
+            facts.delegated_turns,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "subagents.delegatedModels",
+            subagents.delegated_models,
+            facts.delegated_models.clone(),
+        );
+    }
+    if let Some(cache) = published(&evidence.cache) {
+        diff(
+            mismatches,
+            fixture,
+            "cache.cacheReadTokens",
+            cache.cache_read_tokens,
+            facts.cache_read_tokens,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "cache.cacheCreationTokens",
+            cache.cache_creation_tokens,
+            facts.cache_creation_tokens,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "cache.freshInputTokens",
+            cache.fresh_input_tokens,
+            facts.fresh_input_tokens,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "cache.modelTransitions",
+            cache.model_transitions,
+            facts.model_transitions.clone(),
+        );
+        diff(
+            mismatches,
+            fixture,
+            "cache.longestIdleGapMs",
+            cache.longest_idle_gap_ms,
+            facts.longest_idle_gap_ms,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "cache.idleGapMsTotal",
+            cache.idle_gap_ms_total,
+            facts.idle_gap_ms_total,
+        );
+        diff(
+            mismatches,
+            fixture,
+            "cache.userControlledChurn.manualCompactions",
+            cache.user_controlled_churn.manual_compactions,
+            facts.manual_compactions,
+        );
+    }
+    if let Some(compactions) = published(&evidence.compactions) {
+        diff(
+            mismatches,
+            fixture,
+            "compactions.boundaries",
+            compactions.boundaries,
+            facts.compaction_boundaries.clone(),
+        );
+    }
+}
+
+/// Asserts that the observed differences are exactly the documented ones.
+const CLAUDE_DIFFERENCES: &[Documented] = &[
+    documented(
+        "unrecognized_inert_sidechain",
+        "subagents.delegatedTurns",
+        DELEGATED_TURNS_RULE,
+    ),
+    documented(
+        "reasoning_and_fast_mode",
+        "cache.modelTransitions",
+        MAIN_SCOPE_RULE,
+    ),
+    documented(
+        "reasoning_and_fast_mode",
+        "cache.longestIdleGapMs",
+        MAIN_SCOPE_RULE,
+    ),
+    documented("delegated_turns", "cache.modelTransitions", MAIN_SCOPE_RULE),
+    documented("delegated_turns", "cache.longestIdleGapMs", MAIN_SCOPE_RULE),
+    documented("delegated_turns", "cache.idleGapMsTotal", MAIN_SCOPE_RULE),
+    documented(
+        "delegated_models",
+        "cache.modelTransitions",
+        MAIN_SCOPE_RULE,
+    ),
+    documented(
+        "delegated_models",
+        "cache.longestIdleGapMs",
+        MAIN_SCOPE_RULE,
+    ),
+    documented("delegated_models", "cache.idleGapMsTotal", MAIN_SCOPE_RULE),
+    documented(
+        "delegated_model_missing",
+        "cache.longestIdleGapMs",
+        MAIN_SCOPE_RULE,
+    ),
+    documented(
+        "delegated_model_missing",
+        "cache.idleGapMsTotal",
+        MAIN_SCOPE_RULE,
+    ),
+    documented(
+        "thread_identity_chain",
+        "cache.modelTransitions",
+        MAIN_SCOPE_RULE,
+    ),
+    documented(
+        "thread_identity_chain",
+        "cache.longestIdleGapMs",
+        MAIN_SCOPE_RULE,
+    ),
+    documented(
+        "sidechain_in_parent",
+        "cache.modelTransitions",
+        MAIN_SCOPE_RULE,
+    ),
+    documented(
+        "sidechain_in_parent",
+        "cache.longestIdleGapMs",
+        MAIN_SCOPE_RULE,
+    ),
+];
+
+const CODEX_DIFFERENCES: &[Documented] = &[];
+
+const PI_DIFFERENCES: &[Documented] = &[
+    documented("minimal_session", "timeRange", TIME_RANGE_RULE),
+    documented("model_change", "timeRange", TIME_RANGE_RULE),
+    documented("thinking_level_change", "timeRange", TIME_RANGE_RULE),
+    documented("compaction_and_inert", "timeRange", TIME_RANGE_RULE),
+    documented("unknown_row_type", "timeRange", TIME_RANGE_RULE),
+    documented("custom_rows", "timeRange", TIME_RANGE_RULE),
+    documented("header_only", "timeRange", TIME_RANGE_RULE),
+    documented("unsupported_version", "timeRange", TIME_RANGE_RULE),
+    documented("fork_hazard_parent", "timeRange", TIME_RANGE_RULE),
+    documented("fork_hazard_child", "timeRange", TIME_RANGE_RULE),
+    documented("fork_no_inherited", "timeRange", TIME_RANGE_RULE),
+    documented("bash_execution_role", "timeRange", TIME_RANGE_RULE),
+    documented("bash_execution_with_usage", "timeRange", TIME_RANGE_RULE),
+    documented("inert_signal_guard", "timeRange", TIME_RANGE_RULE),
+    documented("non_turn_timestamp_ordering", "timeRange", TIME_RANGE_RULE),
+    documented("session_start", "timeRange", TIME_RANGE_RULE),
+];
+
+/// Asserts that the observed differences are exactly the documented ones.
+fn assert_documented_differences(vendor: &str, mismatches: Vec<Mismatch>, expected: &[Documented]) {
+    let undocumented: Vec<&str> = mismatches
+        .iter()
+        .filter(|mismatch| {
+            !expected
+                .iter()
+                .any(|entry| entry.fixture == mismatch.fixture && entry.field == mismatch.field)
+        })
+        .map(|mismatch| mismatch.detail.as_str())
+        .collect();
+    assert!(
+        undocumented.is_empty(),
+        "{vendor}: {} undocumented difference(s) between query_turn_facts and SessionEvidenceAccumulator:\n\n{}",
+        undocumented.len(),
+        undocumented.join("\n\n")
+    );
+    let stale: Vec<String> = expected
+        .iter()
+        .filter(|entry| {
+            !mismatches
+                .iter()
+                .any(|mismatch| mismatch.fixture == entry.fixture && mismatch.field == entry.field)
+        })
+        .map(|entry| {
+            format!(
+                "fixture={} field={} ({})",
+                entry.fixture, entry.field, entry.rule
+            )
+        })
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "{vendor}: {} documented difference(s) no longer appear; remove them:\n{}",
+        stale.len(),
+        stale.join("\n")
+    );
+}
+
+/* --------------------------------------------------------------------
+ * Claude fixtures. Reuses the fixture set `evidence_fixture_names`
+ * exercises in `claude_characterization.rs` — every fixture that suite
+ * treats as evidence-bearing.
+ * ----------------------------------------------------------------- */
+
+fn claude_fixture(name: &str) -> &'static str {
+    match name {
+        "records_all_kinds" => {
+            include_str!("fixtures/claude_characterization/records_all_kinds.jsonl")
+        }
+        "timestamps_repeated_and_out_of_order" => include_str!(
+            "fixtures/claude_characterization/timestamps_repeated_and_out_of_order.jsonl"
+        ),
+        "malformed_between_valid" => {
+            include_str!("fixtures/claude_characterization/malformed_between_valid.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/claude_characterization/incomplete_final_record.jsonl")
+        }
+        "unrecognized_type" => {
+            include_str!("fixtures/claude_characterization/unrecognized_type.jsonl")
+        }
+        "unrecognized_role_with_usage" => {
+            include_str!("fixtures/claude_characterization/unrecognized_role_with_usage.jsonl")
+        }
+        "unrecognized_evidence_shapes" => {
+            include_str!("fixtures/claude_characterization/unrecognized_evidence_shapes.jsonl")
+        }
+        "unrecognized_inert_records" => {
+            include_str!("fixtures/claude_characterization/unrecognized_inert_records.jsonl")
+        }
+        "unrecognized_inert_sidechain" => {
+            include_str!("fixtures/claude_characterization/unrecognized_inert_sidechain.jsonl")
+        }
+        "parent_with_task_spawn" => {
+            include_str!("fixtures/claude_characterization/parent_with_task_spawn.jsonl")
+        }
+        "subagent_child" => include_str!("fixtures/claude_characterization/subagent_child.jsonl"),
+        "multi_model_session" => {
+            include_str!("fixtures/claude_characterization/multi_model_session.jsonl")
+        }
+        "compaction_with_cache_rehydration" => {
+            include_str!("fixtures/claude_characterization/compaction_with_cache_rehydration.jsonl")
+        }
+        "inferred_cache_rehydration" => {
+            include_str!("fixtures/claude_characterization/inferred_cache_rehydration.jsonl")
+        }
+        "mcp_and_skill_sources" => {
+            include_str!("fixtures/claude_characterization/mcp_and_skill_sources.jsonl")
+        }
+        "reasoning_and_fast_mode" => {
+            include_str!("fixtures/claude_characterization/reasoning_and_fast_mode.jsonl")
+        }
+        "delegated_turns" => {
+            include_str!("fixtures/claude_characterization/delegated_turns.jsonl")
+        }
+        "delegated_models" => {
+            include_str!("fixtures/claude_characterization/delegated_models.jsonl")
+        }
+        "delegated_model_missing" => {
+            include_str!("fixtures/claude_characterization/delegated_model_missing.jsonl")
+        }
+        "housekeeping_records" => {
+            include_str!("fixtures/claude_characterization/housekeeping_records.jsonl")
+        }
+        "thread_identity_chain" => {
+            include_str!("fixtures/claude_characterization/thread_identity_chain.jsonl")
+        }
+        "thread_identity_missing_uuid" => {
+            include_str!("fixtures/claude_characterization/thread_identity_missing_uuid.jsonl")
+        }
+        "sidechain_in_parent" => {
+            include_str!("fixtures/claude_characterization/sidechain_in_parent.jsonl")
+        }
+        "late_skill_metrics" => {
+            include_str!("fixtures/claude_characterization/late_skill_metrics.jsonl")
+        }
+        "two_compactions_second_without_metadata" => include_str!(
+            "fixtures/claude_characterization/two_compactions_second_without_metadata.jsonl"
+        ),
+        "rehydration_gap_none" => {
+            include_str!("fixtures/claude_characterization/rehydration_gap_none.jsonl")
+        }
+        "disorder_ladder" => {
+            include_str!("fixtures/claude_characterization/disorder_ladder.jsonl")
+        }
+        "subagent_single_timestamp" => {
+            include_str!("fixtures/claude_characterization/subagent_single_timestamp.jsonl")
+        }
+        _ => panic!("unknown Claude characterization fixture: {name}"),
+    }
+}
+
+fn claude_fixture_names() -> [&'static str; 28] {
+    [
+        "records_all_kinds",
+        "timestamps_repeated_and_out_of_order",
+        "malformed_between_valid",
+        "incomplete_final_record",
+        "unrecognized_type",
+        "unrecognized_role_with_usage",
+        "unrecognized_evidence_shapes",
+        "unrecognized_inert_records",
+        "unrecognized_inert_sidechain",
+        "parent_with_task_spawn",
+        "subagent_child",
+        "multi_model_session",
+        "compaction_with_cache_rehydration",
+        "inferred_cache_rehydration",
+        "mcp_and_skill_sources",
+        "reasoning_and_fast_mode",
+        "delegated_turns",
+        "delegated_models",
+        "delegated_model_missing",
+        "housekeeping_records",
+        "thread_identity_chain",
+        "thread_identity_missing_uuid",
+        "sidechain_in_parent",
+        "late_skill_metrics",
+        "two_compactions_second_without_metadata",
+        "rehydration_gap_none",
+        "disorder_ladder",
+        "subagent_single_timestamp",
+    ]
+}
+
+#[test]
+fn claude_facts_match_evidence_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in claude_fixture_names() {
+        let (evidence, facts) = run_fixture(
+            "claude",
+            name,
+            claude_fixture(name),
+            SourceCapabilities::claude(),
+        );
+        compare_fixture(&mut mismatches, name, &evidence, &facts);
+    }
+    assert_documented_differences("claude", mismatches, CLAUDE_DIFFERENCES);
+}
+
+/* --------------------------------------------------------------------
+ * Codex fixtures. Reuses the fixture set `codex_characterization.rs`
+ * streams through `composite`.
+ * ----------------------------------------------------------------- */
+
+fn codex_fixture(name: &str) -> &'static str {
+    match name {
+        "records_all_kinds" => {
+            include_str!("fixtures/codex_characterization/records_all_kinds.jsonl")
+        }
+        "malformed_between_valid" => {
+            include_str!("fixtures/codex_characterization/malformed_between_valid.jsonl")
+        }
+        "unrecognized_type" => {
+            include_str!("fixtures/codex_characterization/unrecognized_type.jsonl")
+        }
+        "absent_model_and_effort" => {
+            include_str!("fixtures/codex_characterization/absent_model_and_effort.jsonl")
+        }
+        "resolved_fork" => include_str!("fixtures/codex_characterization/resolved_fork.jsonl"),
+        "fork_developer_lookbehind" => {
+            include_str!("fixtures/codex_characterization/fork_developer_lookbehind.jsonl")
+        }
+        "fork_disputed_window" => {
+            include_str!("fixtures/codex_characterization/fork_disputed_window.jsonl")
+        }
+        "unresolved_fork" => {
+            include_str!("fixtures/codex_characterization/unresolved_fork.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/codex_characterization/incomplete_final_record.jsonl")
+        }
+        _ => panic!("unknown Codex characterization fixture: {name}"),
+    }
+}
+
+fn codex_fixture_names() -> [&'static str; 9] {
+    [
+        "records_all_kinds",
+        "malformed_between_valid",
+        "unrecognized_type",
+        "absent_model_and_effort",
+        "resolved_fork",
+        "fork_developer_lookbehind",
+        "fork_disputed_window",
+        "unresolved_fork",
+        "incomplete_final_record",
+    ]
+}
+
+#[test]
+fn codex_facts_match_evidence_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in codex_fixture_names() {
+        let (evidence, facts) = run_fixture(
+            "codex",
+            name,
+            codex_fixture(name),
+            SourceCapabilities::codex(),
+        );
+        compare_fixture(&mut mismatches, name, &evidence, &facts);
+    }
+    assert_documented_differences("codex", mismatches, CODEX_DIFFERENCES);
+}
+
+/* --------------------------------------------------------------------
+ * Pi fixtures. Reuses the fixture set `pi_characterization.rs` streams
+ * through `composite`.
+ * ----------------------------------------------------------------- */
+
+fn pi_fixture(name: &str) -> &'static str {
+    match name {
+        "minimal_session" => include_str!("fixtures/pi_characterization/minimal_session.jsonl"),
+        "role_ordering" => include_str!("fixtures/pi_characterization/role_ordering.jsonl"),
+        "content_blocks" => include_str!("fixtures/pi_characterization/content_blocks.jsonl"),
+        "usage_all_buckets" => {
+            include_str!("fixtures/pi_characterization/usage_all_buckets.jsonl")
+        }
+        "usage_subset_keys" => {
+            include_str!("fixtures/pi_characterization/usage_subset_keys.jsonl")
+        }
+        "model_change" => include_str!("fixtures/pi_characterization/model_change.jsonl"),
+        "thinking_level_change" => {
+            include_str!("fixtures/pi_characterization/thinking_level_change.jsonl")
+        }
+        "compaction_and_inert" => {
+            include_str!("fixtures/pi_characterization/compaction_and_inert.jsonl")
+        }
+        "unknown_row_type" => {
+            include_str!("fixtures/pi_characterization/unknown_row_type.jsonl")
+        }
+        "unknown_content_block" => {
+            include_str!("fixtures/pi_characterization/unknown_content_block.jsonl")
+        }
+        "custom_rows" => include_str!("fixtures/pi_characterization/custom_rows.jsonl"),
+        "malformed_middle" => {
+            include_str!("fixtures/pi_characterization/malformed_middle.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/pi_characterization/incomplete_final_record.jsonl")
+        }
+        "header_only" => include_str!("fixtures/pi_characterization/header_only.jsonl"),
+        "unsupported_version" => {
+            include_str!("fixtures/pi_characterization/unsupported_version.jsonl")
+        }
+        "fork_hazard_parent" => {
+            include_str!("fixtures/pi_characterization/fork_hazard_parent.jsonl")
+        }
+        "fork_hazard_child" => {
+            include_str!("fixtures/pi_characterization/fork_hazard_child.jsonl")
+        }
+        "fork_no_inherited" => {
+            include_str!("fixtures/pi_characterization/fork_no_inherited.jsonl")
+        }
+        "timestamp_disagreement" => {
+            include_str!("fixtures/pi_characterization/timestamp_disagreement.jsonl")
+        }
+        "image_block" => include_str!("fixtures/pi_characterization/image_block.jsonl"),
+        "bash_execution_role" => {
+            include_str!("fixtures/pi_characterization/bash_execution_role.jsonl")
+        }
+        "bash_execution_with_usage" => {
+            include_str!("fixtures/pi_characterization/bash_execution_with_usage.jsonl")
+        }
+        "mixed_api" => include_str!("fixtures/pi_characterization/mixed_api.jsonl"),
+        "skill_tool_privacy" => {
+            include_str!("fixtures/pi_characterization/skill_tool_privacy.jsonl")
+        }
+        "inert_signal_guard" => {
+            include_str!("fixtures/pi_characterization/inert_signal_guard.jsonl")
+        }
+        "non_turn_timestamp_ordering" => {
+            include_str!("fixtures/pi_characterization/non_turn_timestamp_ordering.jsonl")
+        }
+        "session_start" => include_str!("fixtures/pi_characterization/session_start.jsonl"),
+        "headerless_tools" => {
+            include_str!("fixtures/pi_characterization/headerless_tools.jsonl")
+        }
+        "headerless_usage" => {
+            include_str!("fixtures/pi_characterization/headerless_usage.jsonl")
+        }
+        _ => panic!("unknown Pi characterization fixture: {name}"),
+    }
+}
+
+fn pi_fixture_names() -> [&'static str; 28] {
+    [
+        "minimal_session",
+        "role_ordering",
+        "content_blocks",
+        "usage_all_buckets",
+        "usage_subset_keys",
+        "model_change",
+        "thinking_level_change",
+        "compaction_and_inert",
+        "unknown_row_type",
+        "unknown_content_block",
+        "custom_rows",
+        "malformed_middle",
+        "header_only",
+        "unsupported_version",
+        "fork_hazard_parent",
+        "fork_hazard_child",
+        "fork_no_inherited",
+        "timestamp_disagreement",
+        "image_block",
+        "bash_execution_role",
+        "bash_execution_with_usage",
+        "mixed_api",
+        "skill_tool_privacy",
+        "inert_signal_guard",
+        "non_turn_timestamp_ordering",
+        "session_start",
+        "headerless_tools",
+        "headerless_usage",
+    ]
+}
+
+#[test]
+fn pi_facts_match_evidence_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in pi_fixture_names() {
+        let (evidence, facts) = run_fixture("pi", name, pi_fixture(name), SourceCapabilities::pi());
+        compare_fixture(&mut mismatches, name, &evidence, &facts);
+    }
+    assert_documented_differences("pi", mismatches, PI_DIFFERENCES);
+}


### PR DESCRIPTION
Seam 3a of `docs/plans/session-evidence-harness-parity.md` (Phase 3, rev 4). Pure addition: the evidence the app publishes does not change in this PR. 3b switches evidence assembly onto these facts and shrinks the accumulator.

## What

- **Schema V16**: `turn` gains `compaction_trigger`, `compaction_pre_tokens`, `compaction_post_tokens` via `ALTER TABLE`. `TURN_SCHEMA_SQL` (V15) is untouched since it is already applied on user machines; the crate exports `TURN_MIGRATIONS` for anything that builds the schema from scratch.
- **`TurnRowWriter` → `TurnRowStore`** with a read side, `query_turn_facts()`, scoped to the store's own session key and claim fence. `TurnRowSink` owns an `Arc<dyn TurnRowStore>`, so `CompositeSink` loses its lifetime parameter.
- **Forced child scope**: every input after the parent writes `scope='delegated'` rows by position, not only by the adapter's `EventSource` flag.
- **`evidence_query.rs`**: `query_turn_facts` — SQL aggregates for counts/sums/groups, one ordered streaming scan for per-thread model transitions and idle gaps. Never loads a session's rows into a `Vec`.
- **`MemoryTurnRowStore`** for tests and tools.
- **Parity test** (`tests/turn_facts_parity.rs`): streams every Claude/Codex/Pi characterization fixture through both the accumulator and the query and compares the shared groups. The observed differences must equal a documented allowlist *exactly* — a new difference fails, and a stale entry fails.

## Scope rules the query encodes (the semantic decisions)

| Fact | Rows | Why |
|---|---|---|
| eligibility, depth, time range, token sums, models, tiers, signal coverage | all scopes | logical session = parent ∪ children |
| delegated turns / models | `scope='delegated'` | child facts reach parent hygiene |
| model transitions, idle gaps, compactions | `scope='main'`, per `thread_id` | a child model switch never reads as parent reprocessing; two child threads never form an adjacent pair |
| duplicate turn identities | all | same `uuid` under two `source_key`s = parent/child overlap; 3b degrades instead of double counting |

## Documented differences from today's accumulator

Codex: none. Claude (15) and Pi (16) fixtures differ for exactly three reasons, all intended:

1. `time_range` — the accumulator also folds timestamps of eventless records; rows hold turns only.
2. `delegated_turns` — the accumulator counts every `isSidechain` record including inert ones; rows count turns.
3. `model_transitions` / idle gaps — the accumulator runs one scan over every event, so an inline sidechain event can pair with a main-loop event; the query uses main-scope rows per thread.

Measured on 76 local Claude sessions before design: no parent file contains an inline `isSidechain` record; 61 have child files, every child record carries `isSidechain: true`. So (3) affects only the older inline layout, which is a Phase 4 reconciliation item.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — clean in both `crates/antiburn-local` (1016 + integration suites) and `apps/desktop/src-tauri` (579).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U7uVd1iQZBdWV2KdmSjSA
