### PR TITLE
feat(analysis): build session evidence from turn rows (seam 3b)

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -33,7 +33,9 @@ use antiburn_local::model::AgentKind;
 use antiburn_local::pricing::ModelTokens;
 
 #[cfg(test)]
-use antiburn_local::analysis::{ClaudeAdapter, VendorAdapter};
+use antiburn_local::analysis::{
+    ClaudeAdapter, CoverageReason, EvidenceValue, FAST_SPEED_KEY, MemoryTurnRowStore, VendorAdapter,
+};
 
 use crate::agents::{supports_analysis, vendor_label};
 use crate::dto::{BillableTokens, OrchestrationStatus, SubagentMember};
@@ -523,6 +525,15 @@ fn capabilities_for_vendor(agent: &str) -> Option<SourceCapabilities> {
     }
 }
 
+/// Records one discovered child that this pass could not read. The parent
+/// streams at index 0, so the residual exists for every child path; the
+/// guard keeps a broken invariant from panicking the blocking thread.
+fn note_child_unreadable(parent_residual: &mut Option<SessionEvidenceAccumulator>) {
+    if let Some(parent) = parent_residual.as_mut() {
+        parent.observe_child_unreadable();
+    }
+}
+
 fn stream_vendor_with_hooks(
     inputs: &[SessionInput],
     cancelled: &dyn Fn() -> bool,
@@ -530,7 +541,14 @@ fn stream_vendor_with_hooks(
     database_claim: Option<&str>,
     turn_row_store: Option<Arc<dyn TurnRowStore>>,
 ) -> StreamOutcome {
-    let mut accumulators = Vec::with_capacity(inputs.len());
+    let mut metrics_accumulators = Vec::with_capacity(inputs.len());
+    // The parent's residual evidence accumulator. Set once index 0 streams
+    // successfully, then folded into by every child that streams after it —
+    // see `SessionEvidenceAccumulator::observe_child_coverage` and
+    // `observe_child_unreadable`. One document covers the parent and every
+    // child, so this must outlive the loop rather than live inside the
+    // per-index accumulator the loop below builds.
+    let mut parent_residual: Option<SessionEvidenceAccumulator> = None;
     let mut parent_fingerprint = None;
     for (index, input) in inputs.iter().enumerate() {
         if cancelled() {
@@ -581,7 +599,10 @@ fn stream_vendor_with_hooks(
                         return StreamOutcome::ParentMissing;
                     }
                     Err(_) if index == 0 => return StreamOutcome::ParentUnreadable,
-                    Err(_) => continue,
+                    Err(_) => {
+                        note_child_unreadable(&mut parent_residual);
+                        continue;
+                    }
                 };
                 let fingerprint = claim.fingerprint.clone();
                 after_claim(index, path);
@@ -637,25 +658,36 @@ fn stream_vendor_with_hooks(
                 if accumulator.turn_row_write_failed() {
                     return StreamOutcome::ParentUnreadable;
                 }
-                let Some(parts) = accumulator.into_parts() else {
-                    return StreamOutcome::ParentUnreadable;
+                let Some((metrics, residual)) = accumulator.into_parts() else {
+                    if index == 0 {
+                        return StreamOutcome::ParentUnreadable;
+                    }
+                    note_child_unreadable(&mut parent_residual);
+                    continue;
                 };
-                accumulators.push(parts);
+                if index == 0 {
+                    parent_residual = Some(residual);
+                } else if let Some(parent) = parent_residual.as_mut() {
+                    parent.observe_child_coverage(&residual);
+                }
+                metrics_accumulators.push(metrics);
             }
             Err(_) if cancelled() || index == 0 => {
                 return StreamOutcome::ParentUnreadable;
             }
-            Err(_) => continue,
+            Err(_) => {
+                note_child_unreadable(&mut parent_residual);
+                continue;
+            }
         }
     }
     if cancelled() {
         return StreamOutcome::ParentUnreadable;
     }
-    let (metrics, evidence): (Vec<_>, Vec<_>) = accumulators.into_iter().unzip();
-    let Some((parent, children)) = metrics.split_first() else {
+    let Some((parent, children)) = metrics_accumulators.split_first() else {
         return StreamOutcome::ParentUnreadable;
     };
-    let started_at_epoch = metrics
+    let started_at_epoch = metrics_accumulators
         .iter()
         .filter_map(SessionMetricsAccumulator::started_at_ms)
         .min()
@@ -666,13 +698,25 @@ fn stream_vendor_with_hooks(
         .map(|child| (child.metrics(), child.started_at_ms().map(|ts| ts / 1000)))
         .collect();
     let merged = merge_metrics(parent, children);
+    // A pass without a row store publishes no evidence: the residual alone
+    // cannot build a `SessionEvidence`, since every row-derived group comes
+    // from `TurnFacts`. A row query failure fails the whole pass, the same
+    // way a turn-row write failure does above — published metrics must
+    // never disagree with rows this pass could not read back.
+    let evidence = match turn_row_store {
+        Some(store) => match store.query_turn_facts() {
+            Ok(facts) => parent_residual.map(|residual| residual.evidence(&facts)),
+            Err(_) => return StreamOutcome::ParentUnreadable,
+        },
+        None => None,
+    };
     StreamOutcome::Published {
         session: Box::new(StreamedSession {
             parent: parent_metrics,
             merged,
             subagents,
             started_at_epoch,
-            evidence: evidence.first().map(SessionEvidenceAccumulator::evidence),
+            evidence,
         }),
         parent_fingerprint,
     }
@@ -1480,6 +1524,25 @@ pub fn price_cached_breakdown(model_breakdown_json: &str) -> (Option<SessionCost
 mod tests {
     use super::*;
 
+    /// A row store for a test pass that wants published evidence. A pass
+    /// without a row store publishes no evidence, so any test that reads
+    /// `session.evidence` or `pass.evidence` needs one of these.
+    fn turn_row_store(agent: &str, session_id: &str) -> Arc<dyn TurnRowStore> {
+        MemoryTurnRowStore::new(agent, session_id)
+    }
+
+    /// Reads the value out of an `EvidenceValue`, for `Complete` and
+    /// `Partial` alike. Panics on `Unsupported` — every group these tests
+    /// read is supported by the Claude capability set.
+    fn observed<T: Clone>(value: &EvidenceValue<T>) -> T {
+        match value {
+            EvidenceValue::Complete(observed) | EvidenceValue::Partial { observed, .. } => {
+                observed.clone()
+            }
+            EvidenceValue::Unsupported => panic!("evidence group must be supported"),
+        }
+    }
+
     #[tokio::test]
     async fn opencode_lineage_does_not_render_an_ordinary_database_session() {
         let directory = tempfile::TempDir::new().expect("tempdir");
@@ -1554,6 +1617,17 @@ mod tests {
         )
     }
 
+    /// Like [`claude_record`], with an explicit model and an optional
+    /// top-level `speed` signal.
+    fn claude_record_with(id: &str, timestamp: i64, model: &str, speed: Option<&str>) -> String {
+        let speed_field = speed
+            .map(|speed| format!(",\"speed\":\"{speed}\""))
+            .unwrap_or_default();
+        format!(
+            "{{\"type\":\"assistant\",\"timestamp\":{timestamp}{speed_field},\"message\":{{\"id\":\"{id}\",\"role\":\"assistant\",\"model\":\"{model}\",\"usage\":{{\"input_tokens\":2,\"output_tokens\":3}},\"content\":[{{\"type\":\"text\",\"text\":\"Synthetic output.\"}}]}}}}\n"
+        )
+    }
+
     fn file_input(path: &std::path::Path, id: &str) -> SessionInput {
         SessionInput {
             agent: "claude".to_string(),
@@ -1619,8 +1693,13 @@ mod tests {
             source: RawSource::Sqlite(path),
         };
 
-        let outcome =
-            stream_vendor_with_hooks(&[input], &|| false, &|_, _| {}, Some(&fingerprint), None);
+        let outcome = stream_vendor_with_hooks(
+            &[input],
+            &|| false,
+            &|_, _| {},
+            Some(&fingerprint),
+            Some(turn_row_store("opencode", "root")),
+        );
 
         let StreamOutcome::Published {
             session,
@@ -1704,12 +1783,15 @@ mod tests {
             panic!("Codex source must publish");
         };
         assert_eq!(session.started_at_epoch, Some(1_785_578_398));
-        assert_eq!(
-            session.evidence.unwrap().capabilities,
-            SourceCapabilities::codex()
-        );
+        // `stream_vendor` attaches no row store, so this pass alone
+        // publishes no evidence; the row-backed pass below does.
+        assert!(session.evidence.is_none());
 
-        let pass = evidence_pass(&[input], &|| false);
+        let pass = evidence_pass_with_turn_rows(
+            &[input],
+            &|| false,
+            Some(turn_row_store("codex", "codex-inline")),
+        );
         assert_eq!(pass.outcome, PassOutcome::Published);
         assert_eq!(
             pass.evidence.unwrap().capabilities,
@@ -1732,12 +1814,15 @@ mod tests {
         };
         assert_eq!(session.started_at_epoch, Some(1_785_578_398));
         assert_eq!(session.parent.peak_context_tokens, 14);
-        assert_eq!(
-            session.evidence.unwrap().capabilities,
-            SourceCapabilities::pi()
-        );
+        // `stream_vendor` attaches no row store, so this pass alone
+        // publishes no evidence; the row-backed pass below does.
+        assert!(session.evidence.is_none());
 
-        let pass = evidence_pass(&[input], &|| false);
+        let pass = evidence_pass_with_turn_rows(
+            &[input],
+            &|| false,
+            Some(turn_row_store("pi", "pi-inline")),
+        );
         assert_eq!(pass.outcome, PassOutcome::Published);
         assert_eq!(
             pass.evidence.unwrap().capabilities,
@@ -1955,17 +2040,168 @@ mod tests {
 
     #[test]
     fn a_published_claude_pass_carries_evidence() {
-        let pass = evidence_pass(
+        let pass = evidence_pass_with_turn_rows(
             &[inline_input(
                 claude_record("inline-evidence", 1_760_000_000),
                 "inline-evidence",
             )],
             &|| false,
+            Some(turn_row_store("claude", "inline-evidence")),
         );
 
         let evidence = pass.evidence.expect("published evidence");
         assert_eq!(pass.outcome, PassOutcome::Published);
         assert_eq!(evidence.schema_revision, EVIDENCE_SCHEMA_REVISION);
+    }
+
+    #[test]
+    fn a_child_only_fast_signal_reaches_the_parents_evidence() {
+        let directory = tempfile::TempDir::new().expect("tempdir");
+        let parent = directory.path().join("parent.jsonl");
+        let child = directory.path().join("child.jsonl");
+        std::fs::write(&parent, claude_record("fast-signal-parent", 1_760_000_000))
+            .expect("write parent");
+        std::fs::write(
+            &child,
+            claude_record_with(
+                "fast-signal-child",
+                1_760_000_001,
+                "claude-opus-4-6",
+                Some("fast"),
+            ),
+        )
+        .expect("write child");
+
+        let pass = evidence_pass_with_turn_rows(
+            &[
+                file_input(&parent, "fast-signal-parent"),
+                file_input(&child, "fast-signal-child"),
+            ],
+            &|| false,
+            Some(turn_row_store("claude", "fast-signal-parent")),
+        );
+        let evidence = pass.evidence.expect("published evidence");
+
+        let models = observed(&evidence.models);
+        let fast = models
+            .fast_modes
+            .get(FAST_SPEED_KEY)
+            .expect("the child's fast signal must reach the parent's evidence");
+        assert_eq!(fast.delegated, 1);
+        assert_eq!(fast.main_loop, 0);
+
+        let subagents = observed(&evidence.subagents);
+        assert!(subagents.delegated_models.contains("claude-opus-4-6"));
+    }
+
+    #[test]
+    fn a_model_switch_confined_to_one_child_produces_no_transition() {
+        let directory = tempfile::TempDir::new().expect("tempdir");
+        let parent = directory.path().join("parent.jsonl");
+        let child = directory.path().join("child.jsonl");
+        std::fs::write(&parent, claude_record("switch-parent", 1_760_000_000))
+            .expect("write parent");
+        std::fs::write(
+            &child,
+            claude_record_with("switch-child-1", 1_760_000_001, "model-a", None)
+                + &claude_record_with("switch-child-2", 1_760_000_002, "model-b", None),
+        )
+        .expect("write child");
+
+        let pass = evidence_pass_with_turn_rows(
+            &[
+                file_input(&parent, "switch-parent"),
+                file_input(&child, "switch-child"),
+            ],
+            &|| false,
+            Some(turn_row_store("claude", "switch-parent")),
+        );
+        let evidence = pass.evidence.expect("published evidence");
+
+        let cache = observed(&evidence.cache);
+        assert!(
+            cache.model_transitions.is_empty(),
+            "a model switch inside one child must not become a parent-thread transition"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_discovered_child_degrades_child_dependent_groups() {
+        let directory = tempfile::TempDir::new().expect("tempdir");
+        let parent = directory.path().join("parent.jsonl");
+        std::fs::write(&parent, claude_record("unreadable-parent", 1_760_000_000))
+            .expect("write parent");
+        let missing_child = directory.path().join("missing-child.jsonl");
+
+        let pass = evidence_pass_with_turn_rows(
+            &[
+                file_input(&parent, "unreadable-parent"),
+                file_input(&missing_child, "unreadable-child"),
+            ],
+            &|| false,
+            Some(turn_row_store("claude", "unreadable-parent")),
+        );
+        assert_eq!(pass.outcome, PassOutcome::Published);
+        let evidence = pass.evidence.expect("published evidence");
+
+        assert_eq!(evidence.diagnostics.children_unreadable, 1);
+        assert!(matches!(
+            evidence.subagents,
+            EvidenceValue::Partial {
+                reason: CoverageReason::ReadFailed,
+                ..
+            }
+        ));
+        assert!(matches!(
+            evidence.models,
+            EvidenceValue::Partial {
+                reason: CoverageReason::ReadFailed,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn two_children_with_different_models_share_no_transition_or_idle_gap() {
+        let directory = tempfile::TempDir::new().expect("tempdir");
+        let parent = directory.path().join("parent.jsonl");
+        let first_child = directory.path().join("first-child.jsonl");
+        let second_child = directory.path().join("second-child.jsonl");
+        std::fs::write(&parent, claude_record("siblings-parent", 1_760_000_000))
+            .expect("write parent");
+        std::fs::write(
+            &first_child,
+            claude_record_with("siblings-child-1", 1_760_000_001, "model-a", None),
+        )
+        .expect("write first child");
+        std::fs::write(
+            &second_child,
+            // Far enough past the first child's turn that a single shared
+            // clock would read as a long idle gap.
+            claude_record_with("siblings-child-2", 1_760_100_000, "model-b", None),
+        )
+        .expect("write second child");
+
+        let pass = evidence_pass_with_turn_rows(
+            &[
+                file_input(&parent, "siblings-parent"),
+                file_input(&first_child, "siblings-child-1"),
+                file_input(&second_child, "siblings-child-2"),
+            ],
+            &|| false,
+            Some(turn_row_store("claude", "siblings-parent")),
+        );
+        let evidence = pass.evidence.expect("published evidence");
+
+        let cache = observed(&evidence.cache);
+        assert!(
+            cache.model_transitions.is_empty(),
+            "two children never share a thread, so they form no transition"
+        );
+        assert_eq!(
+            cache.longest_idle_gap_ms, 0,
+            "two children never share a thread, so they form no idle gap"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -2063,7 +2063,7 @@ mod tests {
     }
 
     fn synthetic_evidence() -> SessionEvidence {
-        synthetic_evidence_accumulator().evidence()
+        synthetic_evidence_accumulator().evidence(&antiburn_local::analysis::TurnFacts::default())
     }
 
     #[test]
@@ -2127,7 +2127,7 @@ mod tests {
         accumulator.observe_source_outcome(
             antiburn_local::analysis::VisitOutcome::AcceptedPrefix { boundary: 1 },
         );
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&antiburn_local::analysis::TurnFacts::default());
         assert!(matches!(
             evidence.coverage,
             antiburn_local::analysis::EvidenceCoverage::Partial(

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -209,7 +209,7 @@ mod tests {
 
     use antiburn_local::analysis::{
         EVIDENCE_SCHEMA_REVISION, EvidenceSource, METRICS_SCHEMA_REVISION,
-        SessionEvidenceAccumulator, SourceCapabilities, SourceKind,
+        SessionEvidenceAccumulator, SourceCapabilities, SourceKind, TurnFacts,
     };
     use tempfile::TempDir;
 
@@ -271,7 +271,7 @@ mod tests {
             kind: SourceKind::File,
             capabilities: SourceCapabilities::claude(),
         })
-        .evidence();
+        .evidence(&TurnFacts::default());
         let analysis = AnalysisRecord {
             key: session.key,
             model_breakdown_json: "{}".to_owned(),

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -398,8 +398,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use antiburn_local::analysis::{
-        EvidenceSource, RawSource, SessionEvidenceAccumulator, SessionInput, SourceCapabilities,
-        SourceKind,
+        EvidenceSource, MemoryTurnRowStore, RawSource, SessionEvidenceAccumulator, SessionInput,
+        SourceCapabilities, SourceKind, TurnFacts, TurnRowStore,
     };
 
     use super::*;
@@ -447,7 +447,9 @@ mod tests {
     }
 
     fn published_pass(record: &SessionRecord) -> EvidencePass {
-        let mut pass = analysis::evidence_pass(
+        let store: Arc<dyn TurnRowStore> =
+            MemoryTurnRowStore::new("claude", record.key.session_id.clone());
+        let mut pass = analysis::evidence_pass_with_turn_rows(
             &[SessionInput {
                 agent: "claude".into(),
                 session_id: record.key.session_id.clone(),
@@ -458,6 +460,7 @@ mod tests {
                 ),
             }],
             &|| false,
+            Some(store),
         );
         pass.analysis.fingerprint = record
             .source_fingerprint
@@ -496,7 +499,7 @@ mod tests {
             kind: SourceKind::File,
             capabilities,
         })
-        .evidence()
+        .evidence(&TurnFacts::default())
     }
 
     fn no_capabilities() -> SourceCapabilities {
@@ -1403,7 +1406,11 @@ mod tests {
                 source: antiburn_local::analysis::RawSource::File(pi_source.clone()),
             };
             Box::pin(async move {
-                let mut pass = analysis::evidence_pass(&[input], &|| signal.observe());
+                let mut pass = analysis::evidence_pass_with_turn_rows(
+                    &[input],
+                    &|| signal.observe(),
+                    turn_row_store,
+                );
                 if let Some(fingerprint) = claimed.fingerprint {
                     pass.analysis.fingerprint = fingerprint;
                 }
@@ -1434,9 +1441,11 @@ mod tests {
         );
         let stored = store.evidence(&pi.key).unwrap().unwrap();
         assert_eq!(stored.status, EvidenceStatus::Ready);
-        let evidence: SessionEvidence =
-            serde_json::from_str(stored.evidence_json.as_deref().unwrap()).unwrap();
+        let evidence_json = stored.evidence_json.as_deref().unwrap();
+        assert!(evidence_json.contains("\"schemaRevision\":5"));
+        let evidence: SessionEvidence = serde_json::from_str(evidence_json).unwrap();
         assert_eq!(evidence.capabilities, SourceCapabilities::pi());
+        assert_eq!(evidence.schema_revision, 5);
 
         let report = crate::insights_report::reduce_report(
             data_dir.path().to_path_buf(),

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use antiburn_local::analysis::{
-    ContentKind, ContentPart, TurnScope, count_turn_content_rows, count_turn_rows,
+    ContentKind, ContentPart, MemoryTurnRowStore, TurnRowStore, TurnScope, count_turn_content_rows,
+    count_turn_rows,
 };
 
 use super::model::PublishedEvidence;
@@ -157,7 +158,9 @@ fn seed_revision_one_placeholder(store: &Store, session_id: &str) -> SessionReco
 }
 
 fn published_evidence_pass(record: &SessionRecord) -> crate::analysis::EvidencePass {
-    let mut pass = crate::analysis::evidence_pass(
+    let store: Arc<dyn TurnRowStore> =
+        MemoryTurnRowStore::new("claude", record.key.session_id.clone());
+    let mut pass = crate::analysis::evidence_pass_with_turn_rows(
         &[antiburn_local::analysis::SessionInput {
             agent: "claude".into(),
             session_id: record.key.session_id.clone(),
@@ -168,6 +171,7 @@ fn published_evidence_pass(record: &SessionRecord) -> crate::analysis::EvidenceP
             ),
         }],
         &|| false,
+        Some(store),
     );
     pass.analysis.fingerprint = record
         .source_fingerprint
@@ -2008,9 +2012,9 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
             parser_revision: 5,
-            analyzer_revision: 7,
+            analyzer_revision: 8,
             metrics_schema_revision: 1,
-            evidence_schema_revision: 4,
+            evidence_schema_revision: 5,
         }
     );
 }
@@ -2080,7 +2084,7 @@ async fn reprocessing_a_revision_one_row_leaves_no_placeholder_in_stored_evidenc
 
     let ready = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(ready.status, EvidenceStatus::Ready);
-    assert_eq!(ready.evidence_schema_revision, Some(4));
+    assert_eq!(ready.evidence_schema_revision, Some(5));
     assert!(!ready.evidence_json.unwrap().contains("unimplemented"));
 }
 
@@ -2121,7 +2125,7 @@ async fn a_terminal_failure_clears_an_outdated_placeholder_payload() {
 
     let failed = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(failed.status, EvidenceStatus::Failed);
-    assert_eq!(failed.evidence_schema_revision, Some(4));
+    assert_eq!(failed.evidence_schema_revision, Some(5));
     assert!(failed.evidence_json.is_none());
     assert!(failed.diagnostics_json.is_none());
 }
@@ -2842,7 +2846,8 @@ fn clearing_local_session_data_removes_every_session_evidence_row() {
 #[test]
 fn a_session_evidence_payload_round_trips_through_the_store() {
     use antiburn_local::analysis::{
-        EvidenceSource, SessionEvidence, SessionEvidenceAccumulator, SourceCapabilities, SourceKind,
+        EvidenceSource, SessionEvidence, SessionEvidenceAccumulator, SourceCapabilities,
+        SourceKind, TurnFacts,
     };
 
     let store = store();
@@ -2853,7 +2858,7 @@ fn a_session_evidence_payload_round_trips_through_the_store() {
         kind: SourceKind::Jsonl,
         capabilities: SourceCapabilities::claude(),
     })
-    .evidence();
+    .evidence(&TurnFacts::default());
     let payload_json = serde_json::to_string(&payload).unwrap();
     let completion = evidence_completion(&claim, PublishedEvidence::Ready, payload_json);
 

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -54,7 +54,7 @@ impl From<PartialReason> for CoverageReason {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionTimeRange {
     pub first_ts_ms: i64,
@@ -62,7 +62,7 @@ pub struct SessionTimeRange {
     pub timestamped_turns: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EligibilityEvidence {
     pub turns: u64,
@@ -500,7 +500,7 @@ pub struct SessionProvenance {
 ///
 /// `records_observed` counts metrics events, unusable records, and observed inert unknowns.
 /// It excludes known eventless records when their parser-readable shapes are inert.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ParseDiagnostics {
     pub records_observed: u64,
@@ -510,19 +510,24 @@ pub struct ParseDiagnostics {
     pub unrecognized_types: BTreeSet<String>,
     pub truncated_strings: BTreeSet<String>,
     pub capped_collections: BTreeSet<String>,
+    /// Discovered child transcripts, whether or not they streamed. Set by
+    /// [`super::evidence_sink::SessionEvidenceAccumulator::observe_child_unreadable`]
+    /// and
+    /// [`super::evidence_sink::SessionEvidenceAccumulator::observe_child_coverage`].
+    #[serde(default)]
+    pub children_discovered: u64,
+    /// Discovered child transcripts that could not be read.
+    #[serde(default)]
+    pub children_unreadable: u64,
+    /// Turn identities (`uuid`) the row store observed under more than one
+    /// `source_key` in this session. Copied from [`super::evidence_query::TurnFacts`].
+    #[serde(default)]
+    pub duplicate_turn_identities: u64,
 }
 
 impl ParseDiagnostics {
     pub(crate) fn new() -> Self {
-        Self {
-            records_observed: 0,
-            records_unusable: 0,
-            records_unrecognized_inert: 0,
-            unusable_reasons: BTreeMap::new(),
-            unrecognized_types: BTreeSet::new(),
-            truncated_strings: BTreeSet::new(),
-            capped_collections: BTreeSet::new(),
-        }
+        Self::default()
     }
 }
 
@@ -557,7 +562,10 @@ pub(crate) fn cap_string(
     value[..end].to_owned()
 }
 
-pub(crate) fn insert_diagnostic_field(set: &mut BTreeSet<String>, field: &'static str) -> bool {
+/// `field` need not be `'static`: a caller that merges an already-owned
+/// field name (for example one read back out of another session's
+/// diagnostics) can pass a borrowed `&str` too.
+pub(crate) fn insert_diagnostic_field(set: &mut BTreeSet<String>, field: &str) -> bool {
     if set.contains(field) {
         return false;
     }
@@ -623,6 +631,7 @@ mod tests {
 
     use super::*;
     use crate::analysis::SessionEvidenceAccumulator;
+    use crate::analysis::evidence_query::TurnFacts;
 
     fn empty_evidence(session_id: &str) -> SessionEvidence {
         SessionEvidenceAccumulator::new(EvidenceSource {
@@ -631,7 +640,7 @@ mod tests {
             kind: SourceKind::File,
             capabilities: SourceCapabilities::claude(),
         })
-        .evidence()
+        .evidence(&TurnFacts::default())
     }
 
     fn expected_empty_evidence(
@@ -640,7 +649,7 @@ mod tests {
         truncated_strings: serde_json::Value,
     ) -> serde_json::Value {
         json!({
-            "schemaRevision": 4,
+            "schemaRevision": 5,
             "identity": {"agent": "claude", "sessionId": session_id},
             "context": {"state": "complete", "value": {"maxRequestContextTokens": 0, "topDepthExamples": []}},
             "capabilities": {
@@ -665,8 +674,8 @@ mod tests {
             "coverage": coverage,
             "provenance": {
                 "parserRevision": 5,
-                "analyzerRevision": 7,
-                "evidenceSchemaRevision": 4,
+                "analyzerRevision": 8,
+                "evidenceSchemaRevision": 5,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",
                 "ordering": "monotonic",
@@ -679,7 +688,10 @@ mod tests {
                 "unusableReasons": {},
                 "unrecognizedTypes": [],
                 "truncatedStrings": truncated_strings,
-                "cappedCollections": []
+                "cappedCollections": [],
+                "childrenDiscovered": 0,
+                "childrenUnreadable": 0,
+                "duplicateTurnIdentities": 0
             },
             "timeRange": {"state": "complete", "value": {"firstTsMs": 0, "lastTsMs": 0, "timestampedTurns": 0}},
             "eligibility": {"state": "complete", "value": {"turns": 0, "assistantTurns": 0, "toolTurns": 0, "depthEligibleTurns": 0}},

--- a/crates/antiburn-local/src/analysis/evidence_query.rs
+++ b/crates/antiburn-local/src/analysis/evidence_query.rs
@@ -26,7 +26,7 @@ use crate::analysis::rows::TurnSessionKey;
 /// A later change computes most of `SessionEvidence` from these instead of
 /// from `SessionEvidenceAccumulator`. The field-by-field rule each fact
 /// follows is documented next to the query that computes it, below.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TurnFacts {
     pub eligibility: EligibilityEvidence,
     pub max_request_context_tokens: u64,
@@ -571,6 +571,9 @@ fn query_transitions_and_idle_gaps(
                 let from_model =
                     cap_string("cache.model_transitions.from_model", previous, diagnostics);
                 let to_model = cap_string("cache.model_transitions.to_model", model, diagnostics);
+                if from_model.len() != previous.len() || to_model.len() != model.len() {
+                    capped = true;
+                }
                 if transitions.len() == MAX_MODEL_TRANSITIONS {
                     capped = true;
                     note_collection_cap(diagnostics, "cache.model_transitions");
@@ -697,6 +700,7 @@ fn query_duplicate_turn_identities(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analysis::EVIDENCE_STRING_CAP;
     use crate::analysis::rows::{TURN_MIGRATIONS, TurnRow, TurnScope, insert_turn_rows};
 
     const KEY: TurnSessionKey<'static> = TurnSessionKey {
@@ -862,6 +866,130 @@ mod tests {
         let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
         assert_eq!(facts.model_transitions.len(), MAX_MODEL_TRANSITIONS);
         assert!(facts.transitions_capped);
+    }
+
+    #[test]
+    fn a_long_transition_model_name_flags_the_overflow_without_capping_the_count() {
+        let conn = test_connection();
+        let mut first = base_row("s1", 0);
+        first.model = Some("model-a".to_owned());
+        let mut second = base_row("s1", 1);
+        second.model = Some("x".repeat(EVIDENCE_STRING_CAP * 2));
+        insert(&conn, &[first, second]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.model_transitions.len(), 1);
+        assert_eq!(
+            facts.model_transitions[0].to_model.len(),
+            EVIDENCE_STRING_CAP
+        );
+        assert!(facts.transitions_capped);
+    }
+
+    #[test]
+    fn models_by_model_key_truncation_flags_the_overflow_without_capping_the_count() {
+        let conn = test_connection();
+        let mut row = base_row("s1", 0);
+        row.model = Some("x".repeat(EVIDENCE_STRING_CAP * 2));
+        insert(&conn, &[row]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.by_model.len(), 1);
+        assert_eq!(
+            facts.by_model.keys().next().unwrap().len(),
+            EVIDENCE_STRING_CAP
+        );
+        assert!(facts.models_capped);
+    }
+
+    fn tier_label_key_truncation(effort: bool) -> TurnFacts {
+        let conn = test_connection();
+        let mut row = base_row("s1", 0);
+        if effort {
+            row.effort = Some("x".repeat(EVIDENCE_STRING_CAP * 2));
+        } else {
+            row.speed = Some("x".repeat(EVIDENCE_STRING_CAP * 2));
+        }
+        insert(&conn, &[row]);
+        query_turn_facts(&conn, &KEY, 1).expect("query facts")
+    }
+
+    #[test]
+    fn effort_tier_key_truncation_flags_the_overflow() {
+        let facts = tier_label_key_truncation(true);
+        assert_eq!(facts.effort_tiers.len(), 1);
+        assert_eq!(
+            facts.effort_tiers.keys().next().unwrap().len(),
+            EVIDENCE_STRING_CAP
+        );
+        assert!(facts.tiers_capped);
+    }
+
+    #[test]
+    fn fast_mode_key_truncation_flags_the_overflow() {
+        let facts = tier_label_key_truncation(false);
+        assert_eq!(facts.fast_modes.len(), 1);
+        assert_eq!(
+            facts.fast_modes.keys().next().unwrap().len(),
+            EVIDENCE_STRING_CAP
+        );
+        assert!(facts.tiers_capped);
+    }
+
+    #[test]
+    fn delegated_models_cap_at_max_subagent_models_and_flag_the_overflow() {
+        let conn = test_connection();
+        let rows: Vec<TurnRow> = (0..(MAX_SUBAGENT_MODELS * 2))
+            .map(|index| {
+                let mut row = base_row("s1", index as u64);
+                row.scope = TurnScope::Delegated;
+                row.child_id = Some("s1".to_owned());
+                row.model = Some(format!("model-{index}"));
+                row
+            })
+            .collect();
+        insert(&conn, &rows);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.delegated_models.len(), MAX_SUBAGENT_MODELS);
+        assert!(facts.delegated_models_capped);
+    }
+
+    #[test]
+    fn a_long_delegated_model_name_flags_the_overflow_without_capping_the_count() {
+        let conn = test_connection();
+        let mut row = base_row("s1", 0);
+        row.scope = TurnScope::Delegated;
+        row.child_id = Some("s1".to_owned());
+        row.model = Some("x".repeat(EVIDENCE_STRING_CAP * 2));
+        insert(&conn, &[row]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.delegated_models.len(), 1);
+        assert_eq!(
+            facts.delegated_models.iter().next().unwrap().len(),
+            EVIDENCE_STRING_CAP
+        );
+        assert!(facts.delegated_models_capped);
+    }
+
+    #[test]
+    fn signal_coverage_counts_only_model_attributed_assistant_rows() {
+        // A row without a model (a synthetic `<synthetic>` assistant record,
+        // or any non-assistant row) is never signal-eligible: it can never
+        // carry an effort or speed value.
+        let conn = test_connection();
+        let mut with_signal = base_row("s1", 0);
+        with_signal.effort = Some("high".to_owned());
+        with_signal.speed = Some("standard".to_owned());
+        let mut unattributed = base_row("s1", 1);
+        unattributed.model = None;
+        let tool_row = TurnRow {
+            role: "tool",
+            ..base_row("s1", 2)
+        };
+        insert(&conn, &[with_signal, unattributed, tool_row]);
+        let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
+        assert_eq!(facts.effort_signal.eligible_turns, 1);
+        assert_eq!(facts.effort_signal.present_turns, 1);
+        assert_eq!(facts.speed_signal.eligible_turns, 1);
+        assert_eq!(facts.speed_signal.present_turns, 1);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -1,23 +1,23 @@
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use crate::analysis::evidence::{
-    CacheEvidence, ChurnCounts, CompactionBoundary, CompactionEvidence, ContextEvidence,
-    ContextSourceEvidence, CoverageReason, DepthExample, EligibilityEvidence, EvidenceCoverage,
-    EvidenceSource, EvidenceValue, LoadedSource, MAX_COMPACTION_BOUNDARIES, MAX_CONTEXT_SOURCES,
-    MAX_EVIDENCE_EXAMPLES, MAX_MODEL_TRANSITIONS, MAX_MODELS, MAX_SUBAGENT_CHILDREN,
-    MAX_SUBAGENT_MODELS, MAX_TIER_LABELS, MAX_TOOL_NAMES, MAX_UNRECOGNIZED_TYPES, ModelEvidence,
-    ModelTokens, ModelTransition, OrderingObservation, ParseDiagnostics, RelationConfidence,
-    SessionEvidence, SessionEvidenceIdentity, SessionProvenance, SessionTimeRange, SignalCoverage,
+    CacheEvidence, ChurnCounts, CompactionEvidence, ContextEvidence, ContextSourceEvidence,
+    CoverageReason, EvidenceCoverage, EvidenceSource, EvidenceValue, LoadedSource,
+    MAX_CONTEXT_SOURCES, MAX_EVIDENCE_EXAMPLES, MAX_SUBAGENT_CHILDREN, MAX_TOOL_NAMES,
+    MAX_UNRECOGNIZED_TYPES, ModelEvidence, OrderingObservation, ParseDiagnostics,
+    RelationConfidence, SessionEvidence, SessionEvidenceIdentity, SessionProvenance,
     SourceAcceptance, SourceCapabilities, SourceKind, SubagentChild, SubagentEvidence,
-    SubagentExample, ToolClass, ToolEvidence, ToolUse, TurnCounts, cap_string,
-    insert_diagnostic_field, record_diagnostic_set_cap,
+    SubagentExample, ToolClass, ToolEvidence, ToolUse, cap_string, insert_diagnostic_field,
+    record_diagnostic_set_cap,
 };
+use crate::analysis::evidence_query::TurnFacts;
 use crate::analysis::interface::{
     ContextSourceKind, EvidenceObservation, NormalizedRecord, RecordSink, SessionSummary,
     VisitOutcome,
 };
 use crate::analysis::metrics_sink::SessionMetricsAccumulator;
-use crate::analysis::model::{CompactionTrigger, EventSource, NormalizedEvent, Role};
+use crate::analysis::model::NormalizedEvent;
 use crate::analysis::rows::TurnRowSink;
 use crate::analysis::{
     ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION, SessionMetrics,
@@ -32,53 +32,27 @@ pub struct SessionEvidenceAccumulator {
     diagnostics: ParseDiagnostics,
     record_loss_reason: Option<CoverageReason>,
     session_cap_exceeded: bool,
+    /// The latest record timestamp seen so far, kept only to detect
+    /// out-of-order records. The published time range comes from the
+    /// row-derived [`TurnFacts`] instead.
     last_ts_ms: Option<i64>,
-    first_ts_ms: Option<i64>,
-    timestamped_turns: u64,
-    turns: u64,
-    assistant_turns: u64,
-    tool_turns: u64,
-    depth_eligible_turns: u64,
-    max_request_context_tokens: u64,
-    depth_examples: Vec<DepthExample>,
     tools: BTreeMap<String, ToolUse>,
     invoked_skills: BTreeSet<String>,
     tools_cap_exceeded: bool,
     skills: BTreeMap<String, LoadedSource>,
     mcp_servers: BTreeMap<String, LoadedSource>,
     context_sources_cap_exceeded: bool,
-    models: BTreeMap<String, ModelTokens>,
-    unattributed_turns: u64,
-    effort_tiers: BTreeMap<String, TurnCounts>,
-    fast_modes: BTreeMap<String, TurnCounts>,
-    effort_eligible_turns: u64,
-    effort_present_turns: u64,
-    speed_eligible_turns: u64,
-    speed_present_turns: u64,
-    models_cap_exceeded: bool,
     subagent_spawn_count: u64,
-    delegated_turns: u64,
-    delegated_models: BTreeSet<String>,
-    delegated_model_missing: bool,
     subagent_children: Vec<SubagentChild>,
     subagent_examples: Vec<SubagentExample>,
     subagents_cap_exceeded: bool,
-    cache_read_tokens: u64,
-    cache_creation_tokens: u64,
-    fresh_input_tokens: u64,
-    model_transitions: Vec<ModelTransition>,
-    active_model: Option<String>,
-    previous_turn_ts: Option<i64>,
-    longest_idle_gap_ms: i64,
-    idle_gap_ms_total: i64,
-    manual_compactions: u64,
-    cache_cap_exceeded: bool,
     seen_thread_uuids: HashSet<String>,
-    thread_identity_missing: bool,
     thread_parent_unresolved: bool,
-    compaction_boundaries: Vec<CompactionBoundary>,
-    compactions_cap_exceeded: bool,
     summary_observed: bool,
+    /// The worst [`CoverageReason`] any streamed child reported, folded in
+    /// by [`Self::observe_child_coverage`]. `None` when every streamed
+    /// child (if any) reported none.
+    child_loss_reason: Option<CoverageReason>,
 }
 
 impl SessionEvidenceAccumulator {
@@ -97,52 +71,20 @@ impl SessionEvidenceAccumulator {
             record_loss_reason: None,
             session_cap_exceeded,
             last_ts_ms: None,
-            first_ts_ms: None,
-            timestamped_turns: 0,
-            turns: 0,
-            assistant_turns: 0,
-            tool_turns: 0,
-            depth_eligible_turns: 0,
-            max_request_context_tokens: 0,
-            depth_examples: Vec::new(),
             tools: BTreeMap::new(),
             invoked_skills: BTreeSet::new(),
             tools_cap_exceeded: false,
             skills: BTreeMap::new(),
             mcp_servers: BTreeMap::new(),
             context_sources_cap_exceeded: false,
-            models: BTreeMap::new(),
-            unattributed_turns: 0,
-            effort_tiers: BTreeMap::new(),
-            fast_modes: BTreeMap::new(),
-            effort_eligible_turns: 0,
-            effort_present_turns: 0,
-            speed_eligible_turns: 0,
-            speed_present_turns: 0,
-            models_cap_exceeded: false,
             subagent_spawn_count: 0,
-            delegated_turns: 0,
-            delegated_models: BTreeSet::new(),
-            delegated_model_missing: false,
             subagent_children: Vec::new(),
             subagent_examples: Vec::new(),
             subagents_cap_exceeded: false,
-            cache_read_tokens: 0,
-            cache_creation_tokens: 0,
-            fresh_input_tokens: 0,
-            model_transitions: Vec::new(),
-            active_model: None,
-            previous_turn_ts: None,
-            longest_idle_gap_ms: 0,
-            idle_gap_ms_total: 0,
-            manual_compactions: 0,
-            cache_cap_exceeded: false,
             seen_thread_uuids: HashSet::new(),
-            thread_identity_missing: false,
             thread_parent_unresolved: false,
-            compaction_boundaries: Vec::new(),
-            compactions_cap_exceeded: false,
             summary_observed: false,
+            child_loss_reason: None,
         }
     }
 
@@ -170,54 +112,18 @@ impl SessionEvidenceAccumulator {
     }
 
     fn observe_event(&mut self, event: &NormalizedEvent) {
-        self.turns = self.turns.saturating_add(1);
-        self.assistant_turns = self
-            .assistant_turns
-            .saturating_add(u64::from(event.role == Role::Assistant));
-        self.tool_turns = self
-            .tool_turns
-            .saturating_add(u64::from(event.role == Role::Tool));
-        let depth = event.usage.context_tokens();
-        self.depth_eligible_turns = self
-            .depth_eligible_turns
-            .saturating_add(u64::from(depth > 0));
-        self.max_request_context_tokens = self.max_request_context_tokens.max(depth);
-
+        // Turn counts, context depth, per-model tokens, cache accounting,
+        // and compaction boundaries all come from the row-derived
+        // `TurnFacts` now. This only tracks ordering (from the timestamp)
+        // and tool usage — neither of which a row query can give back,
+        // since a tool call is not its own row and ordering must be seen
+        // live to catch an out-of-order record.
         if let Some(timestamp) = event.ts_ms {
             if self.last_ts_ms.is_some_and(|last| timestamp < last) {
                 self.ordering = OrderingObservation::OutOfOrder;
             }
             self.last_ts_ms = Some(timestamp);
-            self.first_ts_ms = Some(
-                self.first_ts_ms
-                    .map_or(timestamp, |first| first.min(timestamp)),
-            );
-            self.timestamped_turns = self.timestamped_turns.saturating_add(1);
-            if depth > 0 {
-                let model = event.model.as_deref().map(|model| {
-                    cap_string(
-                        "context.top_depth_examples.model",
-                        model,
-                        &mut self.diagnostics,
-                    )
-                });
-                self.push_depth_example(DepthExample {
-                    ts_ms: timestamp,
-                    depth_tokens: depth,
-                    model,
-                });
-            }
         }
-
-        // A counted turn without a per-record identity breaks verified
-        // previous-turn linkage for the whole session. Only sources whose
-        // capability set claims thread identity read this flag back out.
-        if event.uuid.is_none() {
-            self.thread_identity_missing = true;
-        }
-
-        self.observe_model(event);
-        self.observe_cache_and_compaction(event);
 
         for tool in &event.tools {
             let source_name = if tool.name.eq_ignore_ascii_case("skill") {
@@ -249,146 +155,6 @@ impl SessionEvidenceAccumulator {
         }
     }
 
-    fn observe_model(&mut self, event: &NormalizedEvent) {
-        let delegated = event.source == EventSource::Subagent;
-        if event.role == Role::Assistant {
-            if let Some(model) = event.model.as_deref() {
-                let capped = cap_string("models.by_model", model, &mut self.diagnostics);
-                if capped.len() != model.len() {
-                    self.models_cap_exceeded = true;
-                }
-                if let Some(tokens) = self.models.get_mut(&capped) {
-                    add_model_tokens(tokens, event);
-                } else if self.models.len() == MAX_MODELS {
-                    self.models_cap_exceeded = true;
-                    self.note_collection_cap("models.by_model");
-                } else {
-                    let mut tokens = ModelTokens::default();
-                    add_model_tokens(&mut tokens, event);
-                    self.models.insert(capped, tokens);
-                }
-            } else {
-                self.unattributed_turns = self.unattributed_turns.saturating_add(1);
-            }
-            // Every model-attributed assistant turn (parent or delegated)
-            // is eligible to carry an effort or speed value. Synthetic
-            // records have no model and never carry a setting.
-            if event.model.is_some() {
-                self.effort_eligible_turns = self.effort_eligible_turns.saturating_add(1);
-                self.speed_eligible_turns = self.speed_eligible_turns.saturating_add(1);
-                if event.thinking_mode.is_some() {
-                    self.effort_present_turns = self.effort_present_turns.saturating_add(1);
-                }
-                if event.speed.is_some() {
-                    self.speed_present_turns = self.speed_present_turns.saturating_add(1);
-                }
-            }
-        }
-        if let Some(tier) = event.thinking_mode.as_deref() {
-            let (truncated, capped, diagnostic_capped) = insert_turn_count(
-                &mut self.effort_tiers,
-                tier,
-                "models.effort_tiers",
-                delegated,
-                &mut self.diagnostics,
-            );
-            self.models_cap_exceeded |= truncated || capped;
-            self.session_cap_exceeded |= diagnostic_capped;
-        }
-        if let Some(tier) = event.speed.as_deref() {
-            let (truncated, capped, diagnostic_capped) = insert_turn_count(
-                &mut self.fast_modes,
-                tier,
-                "models.fast_modes",
-                delegated,
-                &mut self.diagnostics,
-            );
-            self.models_cap_exceeded |= truncated || capped;
-            self.session_cap_exceeded |= diagnostic_capped;
-        }
-    }
-
-    fn observe_cache_and_compaction(&mut self, event: &NormalizedEvent) {
-        self.cache_read_tokens = self
-            .cache_read_tokens
-            .saturating_add(event.usage.cache_read_tokens);
-        self.cache_creation_tokens = self
-            .cache_creation_tokens
-            .saturating_add(event.usage.cache_creation_tokens);
-        self.fresh_input_tokens = self
-            .fresh_input_tokens
-            .saturating_add(event.usage.input_tokens);
-        if let Some(ts_ms) = event.ts_ms {
-            if let Some(previous) = self.previous_turn_ts {
-                let gap = ts_ms.saturating_sub(previous).max(0);
-                self.longest_idle_gap_ms = self.longest_idle_gap_ms.max(gap);
-                self.idle_gap_ms_total = self.idle_gap_ms_total.saturating_add(gap);
-            }
-            self.previous_turn_ts = Some(ts_ms);
-        }
-        if let Some(model) = event.model.as_deref() {
-            if let Some(previous) = self.active_model.as_deref()
-                && previous != model
-                && let Some(ts_ms) = event.ts_ms
-            {
-                let from_model = cap_string(
-                    "cache.model_transitions.from_model",
-                    previous,
-                    &mut self.diagnostics,
-                );
-                let to_model = cap_string(
-                    "cache.model_transitions.to_model",
-                    model,
-                    &mut self.diagnostics,
-                );
-                if from_model.len() != previous.len() || to_model.len() != model.len() {
-                    self.cache_cap_exceeded = true;
-                }
-                if self.model_transitions.len() == MAX_MODEL_TRANSITIONS {
-                    self.cache_cap_exceeded = true;
-                    self.note_collection_cap("cache.model_transitions");
-                } else {
-                    self.model_transitions.push(ModelTransition {
-                        ts_ms,
-                        from_model,
-                        to_model,
-                    });
-                }
-            }
-            self.active_model = Some(model.to_owned());
-        }
-        if event.is_compaction_boundary {
-            self.manual_compactions = self.manual_compactions.saturating_add(u64::from(
-                event.compaction_trigger == Some(CompactionTrigger::Manual),
-            ));
-            if self.compaction_boundaries.len() == MAX_COMPACTION_BOUNDARIES {
-                self.compactions_cap_exceeded = true;
-                self.note_collection_cap("compactions.boundaries");
-            } else {
-                self.compaction_boundaries.push(CompactionBoundary {
-                    ts_ms: event.ts_ms.unwrap_or(0),
-                    trigger: event.compaction_trigger,
-                    pre_tokens: event.compaction_pre_tokens,
-                    post_tokens: event.compaction_post_tokens,
-                });
-            }
-        }
-    }
-
-    fn push_depth_example(&mut self, example: DepthExample) {
-        self.depth_examples.push(example);
-        self.depth_examples.sort_by(|left, right| {
-            right
-                .depth_tokens
-                .cmp(&left.depth_tokens)
-                .then_with(|| left.ts_ms.cmp(&right.ts_ms))
-        });
-        if self.depth_examples.len() > MAX_EVIDENCE_EXAMPLES {
-            self.depth_examples.truncate(MAX_EVIDENCE_EXAMPLES);
-            self.note_collection_cap("context.top_depth_examples");
-        }
-    }
-
     fn observe_observation(&mut self, observation: &EvidenceObservation) {
         match observation {
             EvidenceObservation::ContextSource {
@@ -401,15 +167,10 @@ impl SessionEvidenceAccumulator {
                 parent_model,
                 provenance,
             } => self.observe_subagent_spawn(*ts_ms, parent_model.as_deref(), *provenance),
-            EvidenceObservation::DelegatedTurn {
-                is_sidechain,
-                is_assistant,
-                model,
-            } => {
-                if *is_sidechain {
-                    self.observe_delegated_turn(*is_assistant, model.as_deref());
-                }
-            }
+            // Delegated-turn counting and modeling now come entirely from
+            // the row-derived `TurnFacts`; the accumulator does not fold
+            // this observation.
+            EvidenceObservation::DelegatedTurn { .. } => {}
             EvidenceObservation::ThreadLink { uuid, parent_uuid } => {
                 // A parent link is verified only against identities this
                 // source already declared. An unresolved link (a resumed
@@ -429,7 +190,6 @@ impl SessionEvidenceAccumulator {
                     self.ordering = OrderingObservation::OutOfOrder;
                 }
                 self.last_ts_ms = Some(*ts_ms);
-                self.first_ts_ms = Some(self.first_ts_ms.map_or(*ts_ms, |first| first.min(*ts_ms)));
             }
             EvidenceObservation::InheritedRecord => {
                 self.diagnostics.records_observed =
@@ -472,30 +232,6 @@ impl SessionEvidenceAccumulator {
                     }
                 }
             }
-        }
-    }
-
-    fn observe_delegated_turn(&mut self, is_assistant: bool, model: Option<&str>) {
-        self.delegated_turns = self.delegated_turns.saturating_add(1);
-        if !is_assistant {
-            return;
-        }
-        let Some(model) = model else {
-            self.delegated_model_missing = true;
-            return;
-        };
-        let capped = cap_string("subagents.delegated_models", model, &mut self.diagnostics);
-        if capped.len() != model.len() {
-            self.subagents_cap_exceeded = true;
-        }
-        if self.delegated_models.contains(&capped) {
-            return;
-        }
-        if self.delegated_models.len() == MAX_SUBAGENT_MODELS {
-            self.subagents_cap_exceeded = true;
-            self.note_collection_cap("subagents.delegated_models");
-        } else {
-            self.delegated_models.insert(capped);
         }
     }
 
@@ -612,6 +348,85 @@ impl SessionEvidenceAccumulator {
         }
     }
 
+    /// Folds one discovered child transcript that could not be read.
+    pub fn observe_child_unreadable(&mut self) {
+        self.diagnostics.children_discovered =
+            self.diagnostics.children_discovered.saturating_add(1);
+        self.diagnostics.children_unreadable =
+            self.diagnostics.children_unreadable.saturating_add(1);
+    }
+
+    /// Folds one streamed child's residual into this (the parent's)
+    /// residual. Folds the child's record loss, diagnostics counts, and
+    /// out-of-order ordering. Does not fold the child's tools or context
+    /// sources — those stay parent-only by design (deferred: a later
+    /// change may decide a child's skill or MCP use belongs in the
+    /// session's own coverage).
+    pub fn observe_child_coverage(&mut self, child: &SessionEvidenceAccumulator) {
+        self.diagnostics.children_discovered =
+            self.diagnostics.children_discovered.saturating_add(1);
+        if let Some(reason) = child.record_loss_reason {
+            self.set_child_loss_reason(reason);
+        }
+        self.fold_child_diagnostics(&child.diagnostics);
+        if child.ordering == OrderingObservation::OutOfOrder {
+            self.ordering = OrderingObservation::OutOfOrder;
+        }
+    }
+
+    /// A specific child loss reason replaces a cap reason. The cap is the
+    /// weakest claim — the same rule [`Self::set_record_loss_reason`] uses.
+    fn set_child_loss_reason(&mut self, reason: CoverageReason) {
+        if self.child_loss_reason.is_none()
+            || (self.child_loss_reason == Some(CoverageReason::CapExceeded)
+                && reason != CoverageReason::CapExceeded)
+        {
+            self.child_loss_reason = Some(reason);
+        }
+    }
+
+    /// Folds one child's record diagnostics into the parent's own,
+    /// capping the merged collections the same way the parent caps its
+    /// own records.
+    fn fold_child_diagnostics(&mut self, child: &ParseDiagnostics) {
+        self.diagnostics.records_observed = self
+            .diagnostics
+            .records_observed
+            .saturating_add(child.records_observed);
+        self.diagnostics.records_unusable = self
+            .diagnostics
+            .records_unusable
+            .saturating_add(child.records_unusable);
+        self.diagnostics.records_unrecognized_inert = self
+            .diagnostics
+            .records_unrecognized_inert
+            .saturating_add(child.records_unrecognized_inert);
+        for (reason, count) in &child.unusable_reasons {
+            let entry = self
+                .diagnostics
+                .unusable_reasons
+                .entry(*reason)
+                .or_default();
+            *entry = entry.saturating_add(*count);
+        }
+        for discriminator in &child.unrecognized_types {
+            if self.diagnostics.unrecognized_types.contains(discriminator) {
+                continue;
+            }
+            if self.diagnostics.unrecognized_types.len() == MAX_UNRECOGNIZED_TYPES {
+                self.session_cap_exceeded = true;
+                // A capped set means antiburn no longer understands the record format.
+                // Treat the cap as loss so no supported group reports complete.
+                self.set_record_loss_reason(CoverageReason::CapExceeded);
+                self.note_collection_cap("diagnostics.unrecognized_types");
+            } else {
+                self.diagnostics
+                    .unrecognized_types
+                    .insert(discriminator.clone());
+            }
+        }
+    }
+
     /// Folds the end-of-stream facts without taking them.
     pub fn observe_summary(&mut self, summary: &SessionSummary) {
         self.capabilities.cache_write_tokens = summary.cache_write_tokens_available;
@@ -629,51 +444,70 @@ impl SessionEvidenceAccumulator {
         self.source_acceptance = SourceAcceptance::from(outcome);
     }
 
-    pub fn evidence(&self) -> SessionEvidence {
+    /// Builds this session's [`SessionEvidence`] from the row-derived
+    /// `facts` plus whatever this residual observed directly. Most groups
+    /// come from `facts` outright; `tools`, `context_sources`, and the
+    /// subagent relationship shape (`spawn_count`, `children`, `examples`)
+    /// still come from this residual — a row query has no tool catalog and
+    /// no context-source contract, and a child's spawn is only ever seen
+    /// live, as an `EvidenceObservation`.
+    pub fn evidence(&self, facts: &TurnFacts) -> SessionEvidence {
+        // A discovered child that never streamed (or streamed but lost
+        // records of its own) makes every group computed over the union of
+        // rows — models, subagents, cache, context, eligibility, time
+        // range, compactions — no better than that child's worst claim.
+        // `record_loss_reason` (this source's own loss) still outranks it.
+        // Neither degrades `tools` or `context_sources`: those are
+        // parent-only, so a child's coverage cannot touch them. Neither
+        // changes the session-level `coverage` — the child's own evidence
+        // (when it streamed) already reports its own loss.
+        let child_dependent_partial: Option<CoverageReason> = self.child_loss_reason.or({
+            (self.diagnostics.children_unreadable > 0).then_some(CoverageReason::ReadFailed)
+        });
+
+        let mut diagnostics = self.diagnostics.clone();
+        diagnostics.duplicate_turn_identities = facts.duplicate_turn_identities;
+        for field in &facts.diagnostics.truncated_strings {
+            if insert_diagnostic_field(&mut diagnostics.truncated_strings, field) {
+                record_diagnostic_set_cap(&mut diagnostics, "diagnostics.truncated_strings");
+            }
+        }
+        for field in &facts.diagnostics.capped_collections {
+            if insert_diagnostic_field(&mut diagnostics.capped_collections, field) {
+                record_diagnostic_set_cap(&mut diagnostics, "diagnostics.capped_collections");
+            }
+        }
+
         let context = ContextEvidence {
-            max_request_context_tokens: self.max_request_context_tokens,
-            top_depth_examples: self.depth_examples.clone(),
+            max_request_context_tokens: facts.max_request_context_tokens,
+            top_depth_examples: facts.top_depth_examples.clone(),
         };
-        let time_range = SessionTimeRange {
-            first_ts_ms: self.first_ts_ms.unwrap_or(0),
-            last_ts_ms: self.last_ts_ms.unwrap_or(0),
-            timestamped_turns: self.timestamped_turns,
-        };
-        let eligibility = EligibilityEvidence {
-            turns: self.turns,
-            assistant_turns: self.assistant_turns,
-            tool_turns: self.tool_turns,
-            depth_eligible_turns: self.depth_eligible_turns,
-        };
+        let eligibility = facts.eligibility.clone();
         let tools = self.classified_tools();
         let context_sources = self.context_sources();
         let models = ModelEvidence {
-            by_model: self.models.clone(),
-            unattributed_turns: self.unattributed_turns,
-            effort_tiers: self.effort_tiers.clone(),
-            fast_modes: self.fast_modes.clone(),
+            by_model: facts.by_model.clone(),
+            unattributed_turns: facts.unattributed_turns,
+            effort_tiers: facts.effort_tiers.clone(),
+            fast_modes: facts.fast_modes.clone(),
             service_tiers: EvidenceValue::Unsupported,
-            effort_signal: SignalCoverage {
-                eligible_turns: self.effort_eligible_turns,
-                present_turns: self.effort_present_turns,
-            },
-            speed_signal: SignalCoverage {
-                eligible_turns: self.speed_eligible_turns,
-                present_turns: self.speed_present_turns,
-            },
+            effort_signal: facts.effort_signal,
+            speed_signal: facts.speed_signal,
         };
+        let models_cap_exceeded = facts.models_capped || facts.tiers_capped;
         let subagents = SubagentEvidence {
             spawn_count: self.subagent_spawn_count,
-            delegated_turns: self.delegated_turns,
-            delegated_models: self.delegated_models.clone(),
+            delegated_turns: facts.delegated_turns,
+            delegated_models: facts.delegated_models.clone(),
             children: self.subagent_children.clone(),
             examples: self.subagent_examples.clone(),
         };
+        let subagents_cap_exceeded = self.subagents_cap_exceeded || facts.delegated_models_capped;
         // Verified previous-turn linkage: complete only when every counted
         // turn carried its own identity and every parent link resolved to an
         // identity this source declared earlier. `provider_eviction` stays
         // unsupported — no transcript record states an eviction.
-        let thread_identity_gap = self.thread_identity_missing || self.thread_parent_unresolved;
+        let thread_identity_gap = facts.thread_identity_missing || self.thread_parent_unresolved;
         let previous_turn = if !self.capabilities.thread_identity {
             EvidenceValue::Unsupported
         } else if let Some(reason) = self.record_loss_reason {
@@ -690,27 +524,25 @@ impl SessionEvidenceAccumulator {
             EvidenceValue::Complete(())
         };
         let cache = CacheEvidence {
-            cache_read_tokens: self.cache_read_tokens,
-            cache_creation_tokens: self.cache_creation_tokens,
-            fresh_input_tokens: self.fresh_input_tokens,
-            model_transitions: self.model_transitions.clone(),
-            longest_idle_gap_ms: self.longest_idle_gap_ms,
-            idle_gap_ms_total: self.idle_gap_ms_total,
+            cache_read_tokens: facts.cache_read_tokens,
+            cache_creation_tokens: facts.cache_creation_tokens,
+            fresh_input_tokens: facts.fresh_input_tokens,
+            model_transitions: facts.model_transitions.clone(),
+            longest_idle_gap_ms: facts.longest_idle_gap_ms,
+            idle_gap_ms_total: facts.idle_gap_ms_total,
             user_controlled_churn: ChurnCounts {
-                manual_compactions: self.manual_compactions,
+                manual_compactions: facts.manual_compactions,
             },
             previous_turn,
             provider_eviction: EvidenceValue::Unsupported,
         };
         let compactions = CompactionEvidence {
-            boundaries: self.compaction_boundaries.clone(),
+            boundaries: facts.compaction_boundaries.clone(),
         };
-        let diagnostic_cap_exceeded = self
-            .diagnostics
+        let diagnostic_cap_exceeded = diagnostics
             .capped_collections
             .contains("diagnostics.truncated_strings")
-            || self
-                .diagnostics
+            || diagnostics
                 .capped_collections
                 .contains("diagnostics.capped_collections");
         let coverage_reason = self
@@ -723,12 +555,17 @@ impl SessionEvidenceAccumulator {
         SessionEvidence {
             schema_revision: EVIDENCE_SCHEMA_REVISION,
             identity: self.identity.clone(),
-            // No cap can make this group partial. The group holds an exact
-            // maximum and a list of examples. The sink folds the maximum on
-            // every turn, and it keeps the deepest examples. A dropped
-            // example is always less deep than the maximum, so it hides
-            // nothing. Record loss still makes the group partial.
-            context: self.supported_value(context, self.capabilities.request_context_tokens, false),
+            // No cap can make this group partial. The row query folds the
+            // maximum over every row, and it keeps the deepest examples. A
+            // dropped example is always less deep than the maximum, so it
+            // hides nothing. Record loss and a lossy child still make the
+            // group partial.
+            context: self.supported_value(
+                context,
+                self.capabilities.request_context_tokens,
+                child_dependent_partial,
+                false,
+            ),
             capabilities: self.capabilities,
             coverage,
             provenance: SessionProvenance {
@@ -740,21 +577,24 @@ impl SessionEvidenceAccumulator {
                 ordering: self.ordering,
                 harness_version: EvidenceValue::Unsupported,
             },
-            diagnostics: self.diagnostics.clone(),
+            diagnostics,
             time_range: self.supported_value(
-                time_range,
+                facts.time_range.clone(),
                 self.capabilities.timestamps_and_order,
+                child_dependent_partial,
                 false,
             ),
-            eligibility: self.supported_value(eligibility, true, false),
+            eligibility: self.supported_value(eligibility, true, child_dependent_partial, false),
             tools: self.supported_value(
                 ToolEvidence { by_name: tools },
                 self.capabilities.tool_invocations,
+                None,
                 self.tools_cap_exceeded,
             ),
             context_sources: self.supported_value(
                 context_sources,
                 self.capabilities.skill_mcp_attribution,
+                None,
                 self.context_sources_cap_exceeded,
             ),
             models: if !self.capabilities.model_identity || !self.capabilities.token_classes {
@@ -764,12 +604,17 @@ impl SessionEvidenceAccumulator {
                     observed: models,
                     reason,
                 }
-            } else if self.models_cap_exceeded {
+            } else if let Some(reason) = child_dependent_partial {
+                EvidenceValue::Partial {
+                    observed: models,
+                    reason,
+                }
+            } else if models_cap_exceeded {
                 EvidenceValue::Partial {
                     observed: models,
                     reason: CoverageReason::CapExceeded,
                 }
-            } else if self.unattributed_turns > 0 {
+            } else if facts.unattributed_turns > 0 || facts.duplicate_turn_identities > 0 {
                 EvidenceValue::Partial {
                     observed: models,
                     reason: CoverageReason::AttributionIncomplete,
@@ -784,12 +629,19 @@ impl SessionEvidenceAccumulator {
                     observed: subagents,
                     reason,
                 }
-            } else if self.subagents_cap_exceeded {
+            } else if let Some(reason) = child_dependent_partial {
+                EvidenceValue::Partial {
+                    observed: subagents,
+                    reason,
+                }
+            } else if subagents_cap_exceeded {
                 EvidenceValue::Partial {
                     observed: subagents,
                     reason: CoverageReason::CapExceeded,
                 }
-            } else if self.capabilities.subagent_models && self.delegated_model_missing {
+            } else if (self.capabilities.subagent_models && facts.delegated_model_missing)
+                || facts.duplicate_turn_identities > 0
+            {
                 EvidenceValue::Partial {
                     observed: subagents,
                     reason: CoverageReason::AttributionIncomplete,
@@ -802,7 +654,12 @@ impl SessionEvidenceAccumulator {
                     observed: cache,
                     reason,
                 }
-            } else if self.cache_cap_exceeded {
+            } else if let Some(reason) = child_dependent_partial {
+                EvidenceValue::Partial {
+                    observed: cache,
+                    reason,
+                }
+            } else if facts.transitions_capped {
                 EvidenceValue::Partial {
                     observed: cache,
                     reason: CoverageReason::CapExceeded,
@@ -822,7 +679,8 @@ impl SessionEvidenceAccumulator {
             compactions: self.supported_value(
                 compactions,
                 self.capabilities.compaction_boundaries,
-                self.compactions_cap_exceeded,
+                child_dependent_partial,
+                facts.compactions_capped,
             ),
             quota_incidents: EvidenceValue::Unsupported,
         }
@@ -874,15 +732,21 @@ impl SessionEvidenceAccumulator {
         }
     }
 
+    /// `child_dependent_reason` degrades a group that is computed over the
+    /// union of rows (parent and child); pass `None` for a parent-only
+    /// group such as `tools` or `context_sources`.
     fn supported_value<T>(
         &self,
         observed: T,
         supported: bool,
+        child_dependent_reason: Option<CoverageReason>,
         cap_exceeded: bool,
     ) -> EvidenceValue<T> {
         if !supported {
             EvidenceValue::Unsupported
         } else if let Some(reason) = self.record_loss_reason {
+            EvidenceValue::Partial { observed, reason }
+        } else if let Some(reason) = child_dependent_reason {
             EvidenceValue::Partial { observed, reason }
         } else if cap_exceeded {
             EvidenceValue::Partial {
@@ -913,57 +777,6 @@ impl SessionEvidenceAccumulator {
     }
 }
 
-fn add_model_tokens(tokens: &mut ModelTokens, event: &NormalizedEvent) {
-    tokens.input = tokens.input.saturating_add(event.usage.input_tokens);
-    tokens.output = tokens.output.saturating_add(event.usage.output_tokens);
-    tokens.cache_read = tokens
-        .cache_read
-        .saturating_add(event.usage.cache_read_tokens);
-    tokens.cache_creation = tokens
-        .cache_creation
-        .saturating_add(event.usage.cache_creation_tokens);
-    tokens.turns = tokens.turns.saturating_add(1);
-    if let Some(ts_ms) = event.ts_ms {
-        if tokens.turns == 1 || tokens.first_ts_ms == 0 {
-            tokens.first_ts_ms = ts_ms;
-        } else {
-            tokens.first_ts_ms = tokens.first_ts_ms.min(ts_ms);
-        }
-        tokens.last_ts_ms = tokens.last_ts_ms.max(ts_ms);
-    }
-}
-
-fn insert_turn_count(
-    map: &mut BTreeMap<String, TurnCounts>,
-    value: &str,
-    field: &'static str,
-    delegated: bool,
-    diagnostics: &mut ParseDiagnostics,
-) -> (bool, bool, bool) {
-    let capped_value = cap_string(field, value, diagnostics);
-    let truncated = capped_value.len() != value.len();
-    if let Some(counts) = map.get_mut(&capped_value) {
-        increment_turn_count(counts, delegated);
-        return (truncated, false, false);
-    }
-    if map.len() == MAX_TIER_LABELS {
-        let diagnostic_capped = insert_diagnostic_field(&mut diagnostics.capped_collections, field);
-        return (truncated, true, diagnostic_capped);
-    }
-    let mut counts = TurnCounts::default();
-    increment_turn_count(&mut counts, delegated);
-    map.insert(capped_value, counts);
-    (truncated, false, false)
-}
-
-fn increment_turn_count(counts: &mut TurnCounts, delegated: bool) {
-    if delegated {
-        counts.delegated = counts.delegated.saturating_add(1);
-    } else {
-        counts.main_loop = counts.main_loop.saturating_add(1);
-    }
-}
-
 impl RecordSink for SessionEvidenceAccumulator {
     fn record(&mut self, record: NormalizedRecord) {
         self.observe(&record);
@@ -978,6 +791,10 @@ pub struct CompositeSink {
     metrics: SessionMetricsAccumulator,
     evidence: SessionEvidenceAccumulator,
     turn_rows: Option<TurnRowSink>,
+    /// Set once [`Self::evidence`] queries the row store and the query
+    /// fails. `Cell` because the query happens from `evidence(&self)` —
+    /// see that method's doc comment for why `&self` is enough.
+    turn_row_query_failed: Cell<bool>,
 }
 
 impl CompositeSink {
@@ -986,6 +803,7 @@ impl CompositeSink {
             metrics,
             evidence,
             turn_rows: None,
+            turn_row_query_failed: Cell::new(false),
         }
     }
 
@@ -1001,6 +819,7 @@ impl CompositeSink {
             metrics,
             evidence,
             turn_rows: Some(turn_rows),
+            turn_row_query_failed: Cell::new(false),
         }
     }
 
@@ -1008,10 +827,27 @@ impl CompositeSink {
         self.evidence.can_publish().then(|| self.metrics.metrics())
     }
 
+    /// `None` when there is no fanned-out [`TurnRowSink`] — a pass without a
+    /// row store publishes no evidence — or when the finished residual
+    /// cannot publish yet. Otherwise reads the row-derived facts back out
+    /// of the store and builds evidence from them. A query error is kept
+    /// (see [`Self::turn_row_query_failed`]) and this returns `None`.
+    ///
+    /// `&self`, not `&mut self`: [`RecordSink::finish`] already flushes the
+    /// row sink's buffer, so by the time a caller asks for evidence the
+    /// buffer is empty and the store's own query sees every row.
     pub fn evidence(&self) -> Option<SessionEvidence> {
-        self.evidence
-            .can_publish()
-            .then(|| self.evidence.evidence())
+        if !self.evidence.can_publish() {
+            return None;
+        }
+        let turn_rows = self.turn_rows.as_ref()?;
+        match turn_rows.query_turn_facts() {
+            Ok(facts) => Some(self.evidence.evidence(&facts)),
+            Err(_) => {
+                self.turn_row_query_failed.set(true);
+                None
+            }
+        }
     }
 
     pub fn observe_source_outcome(&mut self, outcome: VisitOutcome) {
@@ -1023,6 +859,13 @@ impl CompositeSink {
     /// when this is true — rows and projections would disagree.
     pub fn turn_row_write_failed(&self) -> bool {
         self.turn_rows.as_ref().is_some_and(TurnRowSink::has_error)
+    }
+
+    /// True once a call to [`Self::evidence`] queried the row store and the
+    /// query failed. The caller treats this like a write failure: the pass
+    /// must not publish metrics whose rows it could not read back.
+    pub fn turn_row_query_failed(&self) -> bool {
+        self.turn_row_query_failed.get()
     }
 
     pub fn into_parts(self) -> Option<(SessionMetricsAccumulator, SessionEvidenceAccumulator)> {
@@ -1052,8 +895,11 @@ impl RecordSink for CompositeSink {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::analysis::model::{EventSource, Usage};
+    use crate::analysis::model::Role;
+    use crate::analysis::rows::{MemoryTurnRowStore, TurnRowStore};
     use crate::analysis::{EVIDENCE_STRING_CAP, PartialReason, RawSource, VendorAdapter};
 
     fn accumulator(request_context_tokens: bool) -> SessionEvidenceAccumulator {
@@ -1067,28 +913,25 @@ mod tests {
         })
     }
 
-    fn metric_record(context_tokens: u64, ts_ms: Option<i64>) -> NormalizedRecord {
-        let mut event = NormalizedEvent::new(Role::Assistant);
-        event.source = EventSource::Parent;
-        event.ts_ms = ts_ms;
-        event.usage = Usage {
-            input_tokens: context_tokens,
-            ..Usage::default()
-        };
-        NormalizedRecord::MetricsEvent(Box::new(event))
-    }
-
-    #[test]
-    fn context_depth_is_the_maximum_across_events() {
-        let mut accumulator = accumulator(true);
-        accumulator.record(metric_record(5, Some(1)));
-        accumulator.record(metric_record(12, Some(2)));
-        accumulator.finish(SessionSummary::default());
-
-        let EvidenceValue::Complete(context) = accumulator.evidence().context else {
-            panic!("context must be complete");
-        };
-        assert_eq!(context.max_request_context_tokens, 12);
+    /// A `CompositeSink` with a fresh in-memory row store attached, so
+    /// `composite.evidence()` has facts to build from.
+    fn composite_with_rows(agent: &str, session_id: &str) -> CompositeSink {
+        let store = MemoryTurnRowStore::new(agent, session_id);
+        let turn_rows = crate::analysis::rows::TurnRowSink::new(
+            Arc::clone(&store) as Arc<dyn TurnRowStore>,
+            session_id.to_owned(),
+            None,
+        );
+        CompositeSink::with_turn_rows(
+            SessionMetricsAccumulator::new(agent, session_id),
+            SessionEvidenceAccumulator::new(EvidenceSource {
+                agent: agent.to_owned(),
+                session_id: session_id.to_owned(),
+                kind: SourceKind::Jsonl,
+                capabilities: SourceCapabilities::claude(),
+            }),
+            turn_rows,
+        )
     }
 
     #[test]
@@ -1100,15 +943,7 @@ mod tests {
                 r#"{"type":"attachment","attachment":{"type":"skill_listing","content":"- orbit: Synthetic source."}}"#.to_owned(),
             ),
         };
-        let mut composite = CompositeSink::new(
-            SessionMetricsAccumulator::new("claude", "attachment"),
-            SessionEvidenceAccumulator::new(EvidenceSource {
-                agent: "claude".to_owned(),
-                session_id: "attachment".to_owned(),
-                kind: SourceKind::Jsonl,
-                capabilities: SourceCapabilities::claude(),
-            }),
-        );
+        let mut composite = composite_with_rows("claude", "attachment");
         let outcome = crate::analysis::ClaudeAdapter
             .visit(&input, &mut composite)
             .expect("attachment must parse");
@@ -1126,15 +961,7 @@ mod tests {
             session_id: "unknown".to_owned(),
             source: RawSource::Jsonl(r#"{"type":"telemetry_ping","payload":"private"}"#.to_owned()),
         };
-        let mut composite = CompositeSink::new(
-            SessionMetricsAccumulator::new("claude", "unknown"),
-            SessionEvidenceAccumulator::new(EvidenceSource {
-                agent: "claude".to_owned(),
-                session_id: "unknown".to_owned(),
-                kind: SourceKind::Jsonl,
-                capabilities: SourceCapabilities::claude(),
-            }),
-        );
+        let mut composite = composite_with_rows("claude", "unknown");
         let outcome = crate::analysis::ClaudeAdapter
             .visit(&input, &mut composite)
             .expect("unknown record must be skipped");
@@ -1163,7 +990,7 @@ mod tests {
             kind: SourceKind::Jsonl,
             capabilities: SourceCapabilities::claude(),
         };
-        SessionEvidenceAccumulator::new(source).evidence()
+        SessionEvidenceAccumulator::new(source).evidence(&TurnFacts::default())
     }
 
     #[test]
@@ -1199,7 +1026,7 @@ mod tests {
         let mut accumulator = SessionEvidenceAccumulator::new(source);
         accumulator.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
         assert_eq!(
-            accumulator.evidence().coverage,
+            accumulator.evidence(&TurnFacts::default()).coverage,
             EvidenceCoverage::Partial(CoverageReason::MalformedRecord)
         );
     }
@@ -1237,108 +1064,117 @@ mod tests {
         );
     }
 
+    /// The row query bounds `top_depth_examples`, not the sink — the sink's
+    /// own rule is that no cap can make `context` partial. `models.byModel`,
+    /// `models.effortTiers`, `models.fastModes`, `cache.modelTransitions`,
+    /// `compactions.boundaries`, and `subagents.delegatedModels` caps have
+    /// moved with their fields to `query_turn_facts`'s own tests in
+    /// `evidence_query.rs`.
     #[test]
     fn context_top_depth_examples_cap_keeps_the_group_complete() {
-        let count = MAX_EVIDENCE_EXAMPLES * 2;
-        let mut accumulator = accumulator(true);
-        for index in 0..count {
-            accumulator.record(NormalizedRecord::MetricsEvent(Box::new(assistant_event(
-                index,
-            ))));
-        }
-        let evidence = accumulator.evidence();
-        assert_capped_collection(&evidence, "context.top_depth_examples");
-        let EvidenceValue::Complete(context) = evidence.context else {
-            panic!("an example cap must not make the context group partial");
+        let accumulator = accumulator(true);
+        let facts = TurnFacts {
+            depth_examples_capped: true,
+            ..TurnFacts::default()
         };
-        assert_eq!(context.top_depth_examples.len(), MAX_EVIDENCE_EXAMPLES);
-        // The dropped examples are the shallow ones. The maximum survives.
-        assert_eq!(
-            context.max_request_context_tokens,
-            u64::try_from(count).unwrap()
+        let evidence = accumulator.evidence(&facts);
+        assert!(
+            matches!(evidence.context, EvidenceValue::Complete(_)),
+            "an example cap must not make the context group partial"
         );
     }
 
     #[test]
-    fn models_by_model_overflows_to_partial() {
-        let mut accumulator = accumulator(true);
-        for index in 0..(MAX_MODELS * 2) {
-            accumulator.record(NormalizedRecord::MetricsEvent(Box::new(assistant_event(
-                index,
-            ))));
-        }
-        let evidence = accumulator.evidence();
-        assert_capped_collection(&evidence, "models.by_model");
-        assert_eq!(
-            assert_cap_partial(evidence.models).by_model.len(),
-            MAX_MODELS
-        );
+    fn models_cap_from_facts_overflows_models_to_partial() {
+        let accumulator = accumulator(true);
+        let facts = TurnFacts {
+            models_capped: true,
+            ..TurnFacts::default()
+        };
+        let evidence = accumulator.evidence(&facts);
+        assert_cap_partial(evidence.models);
     }
 
-    fn tier_labels_overflow(effort: bool) -> SessionEvidence {
-        let mut accumulator = accumulator(true);
-        for index in 0..(MAX_TIER_LABELS * 2) {
-            let mut event = assistant_event(index);
-            event.model = Some("model".to_owned());
-            if effort {
-                event.thinking_mode = Some(format!("tier-{index}"));
-            } else {
-                event.speed = Some(format!("speed-{index}"));
+    #[test]
+    fn duplicate_turn_identities_degrade_models_and_subagents_to_attribution_incomplete() {
+        let accumulator = accumulator(true);
+        let facts = TurnFacts {
+            duplicate_turn_identities: 1,
+            ..TurnFacts::default()
+        };
+        let evidence = accumulator.evidence(&facts);
+        assert!(matches!(
+            evidence.models,
+            EvidenceValue::Partial {
+                reason: CoverageReason::AttributionIncomplete,
+                ..
             }
-            accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
+        ));
+        assert!(matches!(
+            evidence.subagents,
+            EvidenceValue::Partial {
+                reason: CoverageReason::AttributionIncomplete,
+                ..
+            }
+        ));
+        assert_eq!(evidence.diagnostics.duplicate_turn_identities, 1);
+    }
+
+    #[test]
+    fn observe_child_coverage_with_a_lossy_child_degrades_child_dependent_groups_but_not_tools() {
+        let mut parent = accumulator(true);
+        let mut child = accumulator(true);
+        child.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
+
+        parent.observe_child_coverage(&child);
+        let evidence = parent.evidence(&TurnFacts::default());
+
+        for reason in [
+            evidence_reason(&evidence.models),
+            evidence_reason(&evidence.subagents),
+            evidence_reason(&evidence.cache),
+            evidence_reason(&evidence.context),
+            evidence_reason(&evidence.eligibility),
+            evidence_reason(&evidence.time_range),
+            evidence_reason(&evidence.compactions),
+        ] {
+            assert_eq!(reason, Some(CoverageReason::MalformedRecord));
         }
-        accumulator.evidence()
+        // Tools stay parent-only: a child's loss does not reach them.
+        assert!(matches!(evidence.tools, EvidenceValue::Complete(_)));
+        // A child's loss does not change the session-level coverage either.
+        assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
     }
 
     #[test]
-    fn synthetic_assistant_turns_are_not_signal_eligible() {
-        // Claude writes zero-usage `<synthetic>` assistant records. The
-        // adapter blanks their model. They never carry effort or speed,
-        // so they must not count against signal coverage.
-        let mut accumulator = accumulator(true);
-        let mut real = assistant_event(0);
-        real.model = Some("model".to_owned());
-        real.thinking_mode = Some("high".to_owned());
-        real.speed = Some("standard".to_owned());
-        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(real)));
-        let mut synthetic = assistant_event(1);
-        synthetic.model = None;
-        synthetic.usage.input_tokens = 0;
-        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(synthetic)));
+    fn observe_child_unreadable_degrades_child_dependent_groups_with_read_failed() {
+        let mut parent = accumulator(true);
+        parent.observe_child_unreadable();
+        let evidence = parent.evidence(&TurnFacts::default());
 
-        // The unattributed synthetic turn leaves the group partial. The
-        // coverage counts must still exclude it.
-        let EvidenceValue::Partial {
-            observed: models,
-            reason: CoverageReason::AttributionIncomplete,
-        } = accumulator.evidence().models
-        else {
-            panic!("expected attribution-incomplete model evidence");
-        };
-        assert_eq!(models.effort_signal.eligible_turns, 1);
-        assert_eq!(models.effort_signal.present_turns, 1);
-        assert_eq!(models.speed_signal.eligible_turns, 1);
-        assert_eq!(models.speed_signal.present_turns, 1);
-    }
-
-    #[test]
-    fn models_effort_tiers_overflows_to_partial() {
-        let evidence = tier_labels_overflow(true);
-        assert_capped_collection(&evidence, "models.effort_tiers");
         assert_eq!(
-            assert_cap_partial(evidence.models).effort_tiers.len(),
-            MAX_TIER_LABELS
+            evidence_reason(&evidence.models),
+            Some(CoverageReason::ReadFailed)
         );
+        assert_eq!(
+            evidence_reason(&evidence.subagents),
+            Some(CoverageReason::ReadFailed)
+        );
+        assert!(matches!(evidence.tools, EvidenceValue::Complete(_)));
+        assert_eq!(evidence.diagnostics.children_discovered, 1);
+        assert_eq!(evidence.diagnostics.children_unreadable, 1);
+        assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
     }
 
-    #[test]
-    fn models_fast_modes_overflows_to_partial() {
-        let evidence = tier_labels_overflow(false);
-        assert_capped_collection(&evidence, "models.fast_modes");
-        assert_eq!(
-            assert_cap_partial(evidence.models).fast_modes.len(),
-            MAX_TIER_LABELS
-        );
+    /// The `CoverageReason` an `EvidenceValue` carries, or `None` for
+    /// `Complete`. Panics on `Unsupported` — every group this helper checks
+    /// is supported by the Claude capability set `accumulator` uses.
+    fn evidence_reason<T>(value: &EvidenceValue<T>) -> Option<CoverageReason> {
+        match value {
+            EvidenceValue::Complete(_) => None,
+            EvidenceValue::Partial { reason, .. } => Some(*reason),
+            EvidenceValue::Unsupported => panic!("group must be supported"),
+        }
     }
 
     #[test]
@@ -1352,7 +1188,7 @@ mod tests {
                 .push(crate::analysis::ToolCall::new(format!("tool-{index}")));
             accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
         }
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_capped_collection(&evidence, "tools.by_name");
         assert_eq!(
             assert_cap_partial(evidence.tools).by_name.len(),
@@ -1371,7 +1207,7 @@ mod tests {
                 },
             )));
         }
-        accumulator.evidence()
+        accumulator.evidence(&TurnFacts::default())
     }
 
     #[test]
@@ -1407,7 +1243,7 @@ mod tests {
                 },
             )));
         }
-        accumulator.evidence()
+        accumulator.evidence(&TurnFacts::default())
     }
 
     #[test]
@@ -1431,61 +1267,6 @@ mod tests {
     }
 
     #[test]
-    fn subagents_delegated_models_overflow_to_partial() {
-        let mut accumulator = accumulator(true);
-        for index in 0..(MAX_SUBAGENT_MODELS * 2) {
-            accumulator.record(NormalizedRecord::Observation(Box::new(
-                EvidenceObservation::DelegatedTurn {
-                    is_sidechain: true,
-                    is_assistant: true,
-                    model: Some(format!("model-{index}")),
-                },
-            )));
-        }
-        let evidence = accumulator.evidence();
-        assert_capped_collection(&evidence, "subagents.delegated_models");
-        assert_eq!(
-            assert_cap_partial(evidence.subagents)
-                .delegated_models
-                .len(),
-            MAX_SUBAGENT_MODELS
-        );
-    }
-
-    #[test]
-    fn cache_model_transitions_overflows_to_partial() {
-        let mut accumulator = accumulator(true);
-        for index in 0..((MAX_MODEL_TRANSITIONS + 1) * 2) {
-            let mut event = assistant_event(index);
-            event.model = Some(format!("transition-{index}"));
-            accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
-        }
-        let evidence = accumulator.evidence();
-        assert_capped_collection(&evidence, "cache.model_transitions");
-        assert_eq!(
-            assert_cap_partial(evidence.cache).model_transitions.len(),
-            MAX_MODEL_TRANSITIONS
-        );
-    }
-
-    #[test]
-    fn compactions_boundaries_overflows_to_partial() {
-        let mut accumulator = accumulator(true);
-        for index in 0..(MAX_COMPACTION_BOUNDARIES * 2) {
-            let mut event = assistant_event(index);
-            event.model = Some("model".to_owned());
-            event.is_compaction_boundary = true;
-            accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
-        }
-        let evidence = accumulator.evidence();
-        assert_capped_collection(&evidence, "compactions.boundaries");
-        assert_eq!(
-            assert_cap_partial(evidence.compactions).boundaries.len(),
-            MAX_COMPACTION_BOUNDARIES
-        );
-    }
-
-    #[test]
     fn an_inert_unrecognized_record_keeps_complete_coverage() {
         let mut accumulator = accumulator(true);
         accumulator.record(NormalizedRecord::Observation(Box::new(
@@ -1495,7 +1276,7 @@ mod tests {
             },
         )));
 
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
         assert_eq!(evidence.diagnostics.records_observed, 1);
         assert_eq!(evidence.diagnostics.records_unrecognized_inert, 1);
@@ -1522,7 +1303,7 @@ mod tests {
             crate::analysis::framing::PartialReason::UnrecognizedRecordType,
         ));
 
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_eq!(
             evidence.coverage,
             EvidenceCoverage::Partial(CoverageReason::UnrecognizedRecordType)
@@ -1564,7 +1345,7 @@ mod tests {
                 },
             )));
         }
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_eq!(
             evidence.diagnostics.unrecognized_types.len(),
             MAX_UNRECOGNIZED_TYPES
@@ -1602,7 +1383,7 @@ mod tests {
         ));
 
         assert_eq!(
-            accumulator.evidence().coverage,
+            accumulator.evidence(&TurnFacts::default()).coverage,
             EvidenceCoverage::Partial(CoverageReason::UnrecognizedRecordType)
         );
     }
@@ -1616,7 +1397,7 @@ mod tests {
         ] {
             accumulator.note_collection_cap(field);
         }
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_eq!(
             evidence.diagnostics.capped_collections.len(),
             crate::analysis::evidence::MAX_DIAGNOSTIC_FIELDS
@@ -1638,7 +1419,7 @@ mod tests {
         ] {
             cap_string(field, &long, &mut accumulator.diagnostics);
         }
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_eq!(
             evidence.diagnostics.truncated_strings.len(),
             crate::analysis::evidence::MAX_DIAGNOSTIC_FIELDS
@@ -1655,73 +1436,6 @@ mod tests {
     }
 
     #[test]
-    fn context_top_depth_example_model_cap_keeps_the_group_complete() {
-        let mut accumulator = accumulator(true);
-        let mut event = assistant_event(1);
-        event.model = Some(long_string());
-        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
-        let evidence = accumulator.evidence();
-        assert_truncated_string(&evidence, "context.top_depth_examples.model");
-        let EvidenceValue::Complete(context) = evidence.context else {
-            panic!("a shortened example name must not make the group partial");
-        };
-        assert_eq!(
-            context.top_depth_examples[0].model.as_ref().unwrap().len(),
-            EVIDENCE_STRING_CAP
-        );
-    }
-
-    #[test]
-    fn models_by_model_key_overflows_to_partial() {
-        let mut accumulator = accumulator(true);
-        let mut event = assistant_event(1);
-        event.model = Some(long_string());
-        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
-        let evidence = accumulator.evidence();
-        assert_truncated_string(&evidence, "models.by_model");
-        let models = assert_cap_partial(evidence.models);
-        assert_eq!(
-            models.by_model.keys().next().unwrap().len(),
-            EVIDENCE_STRING_CAP
-        );
-    }
-
-    fn tier_string_overflow(effort: bool) -> SessionEvidence {
-        let mut accumulator = accumulator(true);
-        let mut event = assistant_event(1);
-        event.model = Some("model".to_owned());
-        if effort {
-            event.thinking_mode = Some(long_string());
-        } else {
-            event.speed = Some(long_string());
-        }
-        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
-        accumulator.evidence()
-    }
-
-    #[test]
-    fn models_effort_tier_key_overflows_to_partial() {
-        let evidence = tier_string_overflow(true);
-        assert_truncated_string(&evidence, "models.effort_tiers");
-        let models = assert_cap_partial(evidence.models);
-        assert_eq!(
-            models.effort_tiers.keys().next().unwrap().len(),
-            EVIDENCE_STRING_CAP
-        );
-    }
-
-    #[test]
-    fn models_fast_mode_key_overflows_to_partial() {
-        let evidence = tier_string_overflow(false);
-        assert_truncated_string(&evidence, "models.fast_modes");
-        let models = assert_cap_partial(evidence.models);
-        assert_eq!(
-            models.fast_modes.keys().next().unwrap().len(),
-            EVIDENCE_STRING_CAP
-        );
-    }
-
-    #[test]
     fn tools_by_name_key_overflows_to_partial() {
         let mut accumulator = accumulator(true);
         let mut event = assistant_event(1);
@@ -1730,7 +1444,7 @@ mod tests {
             .tools
             .push(crate::analysis::ToolCall::new(long_string()));
         accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_truncated_string(&evidence, "tools.by_name");
         let tools = assert_cap_partial(evidence.tools);
         assert_eq!(
@@ -1756,7 +1470,7 @@ mod tests {
                 }),
             },
         )));
-        accumulator.evidence()
+        accumulator.evidence(&TurnFacts::default())
     }
 
     #[test]
@@ -1829,7 +1543,7 @@ mod tests {
                 provenance: crate::analysis::RelationProvenance::TaskToolUse,
             },
         )));
-        accumulator.evidence()
+        accumulator.evidence(&TurnFacts::default())
     }
 
     #[test]
@@ -1855,66 +1569,6 @@ mod tests {
     }
 
     #[test]
-    fn subagents_delegated_model_overflows_to_partial() {
-        let mut accumulator = accumulator(true);
-        accumulator.record(NormalizedRecord::Observation(Box::new(
-            EvidenceObservation::DelegatedTurn {
-                is_sidechain: true,
-                is_assistant: true,
-                model: Some(long_string()),
-            },
-        )));
-        let evidence = accumulator.evidence();
-        assert_truncated_string(&evidence, "subagents.delegated_models");
-        let subagents = assert_cap_partial(evidence.subagents);
-        assert_eq!(
-            subagents.delegated_models.first().unwrap().len(),
-            EVIDENCE_STRING_CAP
-        );
-    }
-
-    fn transition_string_overflow(long_from: bool) -> SessionEvidence {
-        let mut accumulator = accumulator(true);
-        let mut first = assistant_event(1);
-        first.model = Some(if long_from {
-            long_string()
-        } else {
-            "from-model".to_owned()
-        });
-        let mut second = assistant_event(2);
-        second.model = Some(if long_from {
-            "to-model".to_owned()
-        } else {
-            long_string()
-        });
-        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(first)));
-        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(second)));
-        accumulator.evidence()
-    }
-
-    #[test]
-    fn cache_transition_from_model_overflows_to_partial() {
-        let evidence = transition_string_overflow(true);
-        assert_truncated_string(&evidence, "cache.model_transitions.from_model");
-        let cache = assert_cap_partial(evidence.cache);
-        assert_eq!(
-            cache.model_transitions[0].from_model.len(),
-            EVIDENCE_STRING_CAP
-        );
-    }
-
-    #[test]
-    fn cache_transition_to_model_overflows_to_partial() {
-        let evidence = transition_string_overflow(false);
-        assert_truncated_string(&evidence, "cache.model_transitions.to_model");
-        let cache = assert_cap_partial(evidence.cache);
-        assert_eq!(
-            cache.model_transitions[0].to_model.len(),
-            EVIDENCE_STRING_CAP
-        );
-    }
-
-    #[test]
     fn diagnostics_unrecognized_type_string_overflows_to_partial() {
         let mut accumulator = accumulator(true);
         accumulator.record(NormalizedRecord::Observation(Box::new(
@@ -1923,7 +1577,7 @@ mod tests {
                 inert: true,
             },
         )));
-        let evidence = accumulator.evidence();
+        let evidence = accumulator.evidence(&TurnFacts::default());
         assert_eq!(
             evidence
                 .diagnostics
@@ -1963,14 +1617,26 @@ mod tests {
         records
     }
 
+    /// `thread_identity_missing` is row-derived now (`TurnFacts`), not
+    /// something the accumulator sees turn by turn. This mirrors what the
+    /// row query would report for the same chain: missing whenever any
+    /// counted turn in it carries no `uuid`.
     fn previous_turn_for(chain: &[(Option<&str>, Option<&str>)]) -> EvidenceValue<()> {
         let mut accumulator = accumulator(true);
+        let mut thread_identity_missing = false;
         for (index, (uuid, parent_uuid)) in chain.iter().enumerate() {
+            if uuid.is_none() {
+                thread_identity_missing = true;
+            }
             for record in thread_record(*uuid, *parent_uuid, index) {
                 accumulator.record(record);
             }
         }
-        match accumulator.evidence().cache {
+        let facts = TurnFacts {
+            thread_identity_missing,
+            ..TurnFacts::default()
+        };
+        match accumulator.evidence(&facts).cache {
             EvidenceValue::Complete(cache)
             | EvidenceValue::Partial {
                 observed: cache, ..
@@ -2028,7 +1694,8 @@ mod tests {
         for record in thread_record(Some("u-1"), None, 1) {
             accumulator.record(record);
         }
-        let EvidenceValue::Complete(cache) = accumulator.evidence().cache else {
+        let EvidenceValue::Complete(cache) = accumulator.evidence(&TurnFacts::default()).cache
+        else {
             panic!("cache must be complete");
         };
         assert_eq!(cache.previous_turn, EvidenceValue::Unsupported);
@@ -2040,7 +1707,8 @@ mod tests {
         let mut event = assistant_event(1);
         event.tools.push(crate::analysis::ToolCall::new("Mystery"));
         accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
-        let EvidenceValue::Complete(tools) = accumulator.evidence().tools else {
+        let EvidenceValue::Complete(tools) = accumulator.evidence(&TurnFacts::default()).tools
+        else {
             panic!("tools must be complete");
         };
         assert_eq!(tools.by_name["Mystery"].class, ToolClass::Unclassified);

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -91,9 +91,9 @@ pub use vendors::pi::PiAdapter;
 pub use vendors::{adapter_for, has_dedicated_adapter};
 
 pub const PARSER_REVISION: i64 = 5;
-pub const ANALYZER_REVISION: i64 = 7;
+pub const ANALYZER_REVISION: i64 = 8;
 pub const METRICS_SCHEMA_REVISION: i64 = 1;
-pub const EVIDENCE_SCHEMA_REVISION: i64 = 4;
+pub const EVIDENCE_SCHEMA_REVISION: i64 = 5;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -336,6 +336,14 @@ impl TurnRowSink {
         }
     }
 
+    /// Reads the row-derived facts for every row this sink's store holds
+    /// under its own session key and fence. Correct only after
+    /// [`Self::flush`] (or [`RecordSink::finish`], which flushes) — a row
+    /// still buffered here is invisible to the store's own query.
+    pub fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
+        self.store.query_turn_facts()
+    }
+
     /// Writes any buffered rows and clears the buffer.
     pub fn flush(&mut self) {
         if self.error.is_some() || self.buffer.is_empty() {

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use crate::analysis::engine::analyze_session;
 use crate::analysis::merge::merge_subagent_events;
 use crate::analysis::model::{
     CompactionTrigger, EventSource, ModelRun, NormalizedEvent, Role, ToolCategory,
 };
+use crate::analysis::rows::{MemoryTurnRowStore, TurnRowSink, TurnRowStore};
 use crate::analysis::{
     CompositeSink, EvidenceSource, EvidenceValue, NormalizedRecord, PartialReason, RawSource,
     RecordCoverage, RecordSink, SessionCollector, SessionEvidence, SessionEvidenceAccumulator,
@@ -14,7 +16,9 @@ use crate::analysis::{
 
 fn claude_evidence(jsonl: &str) -> SessionEvidence {
     let input = jsonl_input("claude", jsonl);
-    let mut composite = CompositeSink::new(
+    let store = MemoryTurnRowStore::new("claude", "s");
+    let turn_rows = TurnRowSink::new(Arc::clone(&store) as Arc<dyn TurnRowStore>, "s", None);
+    let mut composite = CompositeSink::with_turn_rows(
         SessionMetricsAccumulator::new("claude", "s"),
         SessionEvidenceAccumulator::new(EvidenceSource {
             agent: "claude".to_owned(),
@@ -22,6 +26,7 @@ fn claude_evidence(jsonl: &str) -> SessionEvidence {
             kind: SourceKind::Jsonl,
             capabilities: SourceCapabilities::claude(),
         }),
+        turn_rows,
     );
     let outcome = adapter_for("claude")
         .visit(&input, &mut composite)

--- a/crates/antiburn-local/src/insights/detectors/mod.rs
+++ b/crates/antiburn-local/src/insights/detectors/mod.rs
@@ -254,7 +254,8 @@ pub(crate) fn complete<T>(value: &EvidenceValue<T>) -> Option<&T> {
 #[cfg(test)]
 pub(crate) mod test_support {
     use crate::analysis::{
-        EvidenceSource, SessionEvidence, SessionEvidenceAccumulator, SourceCapabilities, SourceKind,
+        EvidenceSource, SessionEvidence, SessionEvidenceAccumulator, SourceCapabilities,
+        SourceKind, TurnFacts,
     };
 
     /// Builds empty complete evidence with the Claude capability set.
@@ -265,7 +266,7 @@ pub(crate) mod test_support {
             kind: SourceKind::File,
             capabilities: SourceCapabilities::claude(),
         })
-        .evidence()
+        .evidence(&TurnFacts::default())
     }
 }
 

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -449,6 +449,7 @@ mod tests {
         ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, EvidenceSource, ModelTokens, PARSER_REVISION,
         QuotaConfidence, QuotaHitSeverity, QuotaIncident, QuotaLimitKind,
         SessionEvidenceAccumulator, SessionQuotaEvidence, SignalCoverage, SourceKind, TurnCounts,
+        TurnFacts,
     };
     use crate::insights::detectors::{ModelReplacement, NotAssessedReason};
     use crate::insights::quota::QuotaPressureSection;
@@ -460,7 +461,7 @@ mod tests {
             kind: SourceKind::File,
             capabilities: SourceCapabilities::claude(),
         })
-        .evidence()
+        .evidence(&TurnFacts::default())
     }
 
     /// The same claude evidence with one observed assistant turn, so

--- a/crates/antiburn-local/tests/claude_characterization.rs
+++ b/crates/antiburn-local/tests/claude_characterization.rs
@@ -1,14 +1,15 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use antiburn_local::analysis::{
     ANALYZER_REVISION, CompositeSink, CoverageReason, EVIDENCE_SCHEMA_REVISION, EvidenceCoverage,
-    EvidenceSource, EvidenceValue, MAX_RECORD_BYTES, NormalizedSession, OrderingObservation,
-    PARSER_REVISION, PartialReason, RawSource, RecordCoverage, SessionCollector,
-    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SourceCapabilities,
-    SourceKind, adapter_for, analyze_session, analyze_sources_with, merge_metrics,
-    merge_subagent_events, normalize_source,
+    EvidenceSource, EvidenceValue, MAX_RECORD_BYTES, MemoryTurnRowStore, NormalizedSession,
+    OrderingObservation, PARSER_REVISION, PartialReason, RawSource, RecordCoverage,
+    SessionCollector, SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator,
+    SourceCapabilities, SourceKind, TurnRowSink, TurnRowStore, adapter_for, analyze_session,
+    analyze_sources_with, merge_metrics, merge_subagent_events, normalize_source,
 };
 use antiburn_local::insights::{
     CoverageCounts, DetectorId, DetectorStatus, EfficiencyReport, EfficiencyReportAccumulator,
@@ -234,7 +235,13 @@ fn stream_composite(input: &SessionInput) -> CompositeSink {
         kind: SourceKind::from(&input.source),
         capabilities: SourceCapabilities::claude(),
     });
-    let mut composite = CompositeSink::new(metrics, evidence);
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut composite = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
     let outcome = adapter_for("claude")
         .visit(input, &mut composite)
         .expect("Claude source must be visited");
@@ -751,13 +758,15 @@ fn thread_identity_unblocks_sessions_over_depth_and_cache_churn() {
         report.detector_statuses[DetectorId::SessionsOverDepth.index()],
         DetectorStatus::Clean
     );
-    // The chain switches models next to paid cache writes: a real finding.
-    assert!(matches!(
+    // The model switch sits on the delegated sidechain, not the main
+    // loop: a real clean verdict, not CapabilityMissing. Row-derived
+    // transitions never cross a thread boundary into a different scope.
+    assert_eq!(
         report.detector_statuses[DetectorId::CacheChurn.index()],
-        DetectorStatus::Findings(_)
-    ));
+        DetectorStatus::Clean
+    );
     let cache = fixture_cache("thread_identity_chain");
-    assert!(!cache.model_transitions.is_empty());
+    assert!(cache.model_transitions.is_empty());
     assert!(cache.cache_creation_tokens > 0);
 }
 

--- a/crates/antiburn-local/tests/codex_characterization.rs
+++ b/crates/antiburn-local/tests/codex_characterization.rs
@@ -2,13 +2,15 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use antiburn_local::analysis::{
     AppendOnlyGuarantee, CompositeSink, CoverageReason, EvidenceCoverage, EvidenceSource,
-    EvidenceValue, NormalizedSession, PartialReason, RawSource, RecordCoverage, SessionCollector,
-    SessionEvidence, SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator,
-    SourceCapabilities, SourceClaim, SourceKind, VisitOutcome, adapter_for, analyze_sources_with,
-    append_only_guarantee, normalize_source,
+    EvidenceValue, MemoryTurnRowStore, NormalizedSession, PartialReason, RawSource, RecordCoverage,
+    SessionCollector, SessionEvidence, SessionEvidenceAccumulator, SessionInput,
+    SessionMetricsAccumulator, SourceCapabilities, SourceClaim, SourceKind, TurnRowSink,
+    TurnRowStore, VisitOutcome, adapter_for, analyze_sources_with, append_only_guarantee,
+    normalize_source,
 };
 use antiburn_local::discovery::source_version::{
     FINGERPRINT_HEAD_BYTES, FingerprintInputs, SourceStat, head_hash_of,
@@ -88,13 +90,20 @@ fn composite(input: &SessionInput) -> (SessionEvidence, SessionMetricsAccumulato
         kind: SourceKind::from(&input.source),
         capabilities: SourceCapabilities::codex(),
     });
-    let mut sink = CompositeSink::new(metrics, evidence);
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut sink = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
     let outcome = adapter_for("codex")
         .visit(input, &mut sink)
         .expect("Codex fixture must stream");
     sink.observe_source_outcome(outcome);
-    let (metrics, evidence) = sink.into_parts().expect("Codex evidence must publish");
-    (evidence.evidence(), metrics)
+    let evidence = sink.evidence().expect("Codex evidence must publish");
+    let (metrics, _evidence_accumulator) = sink.into_parts().expect("Codex metrics must publish");
+    (evidence, metrics)
 }
 
 fn golden_path(name: &str) -> PathBuf {
@@ -279,11 +288,16 @@ fn claude_capabilities_still_match_published_evidence() {
         kind: SourceKind::from(&input.source),
         capabilities: SourceCapabilities::claude(),
     });
-    let mut sink = CompositeSink::new(metrics, accumulator);
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut sink = CompositeSink::with_turn_rows(metrics, accumulator, turn_rows);
     let outcome = adapter_for("claude").visit(&input, &mut sink).unwrap();
     sink.observe_source_outcome(outcome);
-    let (_, accumulator) = sink.into_parts().unwrap();
-    let evidence = accumulator.evidence();
+    let evidence = sink.evidence().unwrap();
 
     assert_eq!(evidence.capabilities, SourceCapabilities::claude());
     assert!(is_supported(&evidence.context));

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -75,6 +75,9 @@
     },
     "diagnostics": {
       "cappedCollections": [],
+      "childrenDiscovered": 0,
+      "childrenUnreadable": 0,
+      "duplicateTurnIdentities": 0,
       "recordsObserved": 2,
       "recordsUnrecognizedInert": 0,
       "recordsUnusable": 1,
@@ -139,8 +142,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 7,
-      "evidenceSchemaRevision": 4,
+      "analyzerRevision": 8,
+      "evidenceSchemaRevision": 5,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -152,7 +155,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 4,
+    "schemaRevision": 5,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -71,6 +71,9 @@
     "coverage": "complete",
     "diagnostics": {
       "cappedCollections": [],
+      "childrenDiscovered": 0,
+      "childrenUnreadable": 0,
+      "duplicateTurnIdentities": 0,
       "recordsObserved": 8,
       "recordsUnrecognizedInert": 0,
       "recordsUnusable": 0,
@@ -127,8 +130,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 7,
-      "evidenceSchemaRevision": 4,
+      "analyzerRevision": 8,
+      "evidenceSchemaRevision": 5,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -140,7 +143,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 4,
+    "schemaRevision": 5,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -69,6 +69,9 @@
     },
     "diagnostics": {
       "cappedCollections": [],
+      "childrenDiscovered": 0,
+      "childrenUnreadable": 0,
+      "duplicateTurnIdentities": 0,
       "recordsObserved": 1,
       "recordsUnrecognizedInert": 0,
       "recordsUnusable": 1,
@@ -120,8 +123,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 7,
-      "evidenceSchemaRevision": 4,
+      "analyzerRevision": 8,
+      "evidenceSchemaRevision": 5,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -133,7 +136,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 4,
+    "schemaRevision": 5,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -58,6 +58,9 @@
     "coverage": "complete",
     "diagnostics": {
       "cappedCollections": [],
+      "childrenDiscovered": 0,
+      "childrenUnreadable": 0,
+      "duplicateTurnIdentities": 0,
       "recordsObserved": 2,
       "recordsUnrecognizedInert": 0,
       "recordsUnusable": 0,
@@ -109,8 +112,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 7,
-      "evidenceSchemaRevision": 4,
+      "analyzerRevision": 8,
+      "evidenceSchemaRevision": 5,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -122,7 +125,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 4,
+    "schemaRevision": 5,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -75,6 +75,9 @@
     },
     "diagnostics": {
       "cappedCollections": [],
+      "childrenDiscovered": 0,
+      "childrenUnreadable": 0,
+      "duplicateTurnIdentities": 0,
       "recordsObserved": 2,
       "recordsUnrecognizedInert": 0,
       "recordsUnusable": 1,
@@ -138,8 +141,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 7,
-      "evidenceSchemaRevision": 4,
+      "analyzerRevision": 8,
+      "evidenceSchemaRevision": 5,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -151,7 +154,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 4,
+    "schemaRevision": 5,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -69,6 +69,9 @@
     },
     "diagnostics": {
       "cappedCollections": [],
+      "childrenDiscovered": 0,
+      "childrenUnreadable": 0,
+      "duplicateTurnIdentities": 0,
       "recordsObserved": 1,
       "recordsUnrecognizedInert": 0,
       "recordsUnusable": 1,
@@ -120,8 +123,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 7,
-      "evidenceSchemaRevision": 4,
+      "analyzerRevision": 8,
+      "evidenceSchemaRevision": 5,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -133,7 +136,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 4,
+    "schemaRevision": 5,
     "subagents": {
       "state": "unsupported"
     },
@@ -141,8 +144,8 @@
       "state": "partial",
       "value": {
         "observed": {
-          "firstTsMs": 1767225600000,
-          "lastTsMs": 1767225600000,
+          "firstTsMs": 0,
+          "lastTsMs": 0,
           "timestampedTurns": 0
         },
         "reason": "unrecognized_record_type"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -69,6 +69,9 @@
     "coverage": "complete",
     "diagnostics": {
       "cappedCollections": [],
+      "childrenDiscovered": 0,
+      "childrenUnreadable": 0,
+      "duplicateTurnIdentities": 0,
       "recordsObserved": 2,
       "recordsUnrecognizedInert": 0,
       "recordsUnusable": 0,
@@ -120,8 +123,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 7,
-      "evidenceSchemaRevision": 4,
+      "analyzerRevision": 8,
+      "evidenceSchemaRevision": 5,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -133,7 +136,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 4,
+    "schemaRevision": 5,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/opencode_characterization.rs
+++ b/crates/antiburn-local/tests/opencode_characterization.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use antiburn_local::analysis::{
-    CompositeSink, EvidenceSource, NormalizedRecord, PartialReason, RawSource, RecordSink,
-    SessionCollector, SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator,
-    SessionSummary, SourceCapabilities, SourceKind, VisitOutcome, adapter_for,
+    CompositeSink, EvidenceSource, MemoryTurnRowStore, NormalizedRecord, PartialReason, RawSource,
+    RecordSink, SessionCollector, SessionEvidenceAccumulator, SessionInput,
+    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceKind, TurnRowSink,
+    TurnRowStore, VisitOutcome, adapter_for,
 };
 use rusqlite::{Connection, params};
 use serde_json::json;
@@ -362,16 +365,22 @@ fn metrics_and_evidence_publish_from_the_stream() {
         kind: SourceKind::Jsonl,
         capabilities: SourceCapabilities::opencode(),
     });
-    let mut sink = CompositeSink::new(metrics, evidence);
+    let store = MemoryTurnRowStore::new("opencode", "evidence");
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        "evidence",
+        None,
+    );
+    let mut sink = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
     let outcome = adapter_for("opencode")
         .visit(&input, &mut sink)
         .expect("stream export");
     sink.observe_source_outcome(outcome);
-    let (metrics, evidence) = sink.into_parts().expect("published evidence");
-    let evidence = evidence.evidence();
+    let evidence = sink.evidence().expect("published evidence");
+    let metrics = sink.metrics().expect("published metrics");
 
-    assert_eq!(metrics.metrics().tokens_out, 5);
-    assert_eq!(metrics.metrics().tokens_in, 15);
+    assert_eq!(metrics.tokens_out, 5);
+    assert_eq!(metrics.tokens_in, 15);
     assert_eq!(evidence.capabilities, SourceCapabilities::opencode());
     assert!(!json!(evidence).to_string().contains("PRIVATE_PATH"));
 }

--- a/crates/antiburn-local/tests/pi_characterization.rs
+++ b/crates/antiburn-local/tests/pi_characterization.rs
@@ -2,13 +2,15 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use antiburn_local::analysis::{
     AppendOnlyGuarantee, CompositeSink, EvidenceCoverage, EvidenceSource, EvidenceValue,
-    MAX_RECORD_BYTES, NormalizedRecord, NormalizedSession, PartialReason, PiAdapter, RawSource,
-    RecordCoverage, RecordSink, SessionCollector, SessionEvidence, SessionEvidenceAccumulator,
-    SessionInput, SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceClaim,
-    SourceKind, VendorAdapter, VisitOutcome, adapter_for, analyze_session, append_only_guarantee,
+    MAX_RECORD_BYTES, MemoryTurnRowStore, NormalizedRecord, NormalizedSession, PartialReason,
+    PiAdapter, RawSource, RecordCoverage, RecordSink, SessionCollector, SessionEvidence,
+    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SessionSummary,
+    SourceCapabilities, SourceClaim, SourceKind, TurnRowSink, TurnRowStore, VendorAdapter,
+    VisitOutcome, adapter_for, analyze_session, append_only_guarantee,
 };
 use antiburn_local::discovery::source_version::{
     FINGERPRINT_HEAD_BYTES, FingerprintInputs, SourceStat, head_hash_of,
@@ -162,13 +164,20 @@ fn composite_with(
         kind: SourceKind::from(&input.source),
         capabilities,
     });
-    let mut sink = CompositeSink::new(metrics, evidence);
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut sink = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
     let outcome = adapter
         .visit(input, &mut sink)
         .expect("Pi fixture must stream into both sinks");
     sink.observe_source_outcome(outcome);
-    let (metrics, evidence) = sink.into_parts().expect("Pi evidence must publish");
-    (evidence.evidence(), metrics)
+    let evidence = sink.evidence().expect("Pi evidence must publish");
+    let (metrics, _evidence_accumulator) = sink.into_parts().expect("Pi metrics must publish");
+    (evidence, metrics)
 }
 
 fn golden_path(name: &str) -> PathBuf {
@@ -683,10 +692,10 @@ fn fork_ownership_drops_inherited_usage_without_persisting_parent_paths() {
     let EvidenceValue::Complete(child_time) = &child_evidence.time_range else {
         panic!("child time range must be complete");
     };
-    assert_eq!(
-        Some(child_time.first_ts_ms),
-        summary("fork_hazard_child").started_at_ms
-    );
+    // The row-derived time range spans only real turns. "shared-row"
+    // is dropped as inherited, so the child's first turn is its own
+    // "child-row" at 00:00:11, not the session header's 00:00:10.
+    assert_eq!(child_time.first_ts_ms, 1_767_312_011_000);
     assert!(!child_evidence.capabilities.subagent_relationships);
     assert!(matches!(
         child_evidence.subagents,
@@ -759,7 +768,11 @@ fn top_level_timestamps_and_session_start_are_authoritative() {
     let EvidenceValue::Complete(time_range) = evidence.time_range else {
         panic!("Pi time-range evidence must be complete");
     };
-    assert_eq!(time_range.first_ts_ms, 1_767_225_600_000);
+    // The row-derived time range spans only real turns: the earlier
+    // `model_change` and `session_info` markers carry top-level
+    // timestamps but are not turns, so the first turn's own 00:00:02
+    // is authoritative, not their earlier 00:00:00.
+    assert_eq!(time_range.first_ts_ms, 1_767_225_602_000);
     assert_eq!(time_range.last_ts_ms, 1_767_225_603_000);
 
     let (_, metrics) = composite(&input("session_start"));

--- a/crates/antiburn-local/tests/pipeline_corpus.rs
+++ b/crates/antiburn-local/tests/pipeline_corpus.rs
@@ -12,14 +12,16 @@ mod corpus;
 use std::fs::OpenOptions;
 use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use antiburn_local::analysis::{
     ANALYZER_REVISION, AppendOnlyGuarantee, BoundedJsonlReader, ClaudeAdapter, CompositeSink,
     CoverageReason, EVIDENCE_SCHEMA_REVISION, EvidenceCoverage, EvidenceSource, EvidenceValue,
-    MAX_RECORD_BYTES, NormalizedRecord, PARSER_REVISION, RETAINED_METRICS_BYTES_BOUND, RawSource,
-    RecordSink, SCAN_QUANTUM_BYTES, SessionEvidence, SessionEvidenceAccumulator, SessionInput,
-    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceChangedReason,
-    SourceClaim, SourceKind, VisitOutcome, adapter_for,
+    MAX_RECORD_BYTES, MemoryTurnRowStore, NormalizedRecord, PARSER_REVISION,
+    RETAINED_METRICS_BYTES_BOUND, RawSource, RecordSink, SCAN_QUANTUM_BYTES, SessionEvidence,
+    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SessionSummary,
+    SourceCapabilities, SourceChangedReason, SourceClaim, SourceKind, TurnRowSink, TurnRowStore,
+    VisitOutcome, adapter_for,
 };
 use antiburn_local::discovery::source_version::{FingerprintInputs, SourceStat, head_hash_of};
 use antiburn_local::insights::{
@@ -72,7 +74,13 @@ fn composite_for(input: &SessionInput) -> CompositeSink {
         kind: SourceKind::from(&input.source),
         capabilities: SourceCapabilities::claude(),
     });
-    CompositeSink::new(metrics, evidence)
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    CompositeSink::with_turn_rows(metrics, evidence, turn_rows)
 }
 
 /// Runs framing → normalization → metrics + evidence for one input.
@@ -206,7 +214,10 @@ fn large_session_respects_bounded_memory_contracts() {
     assert!(reader.retained_record_bytes_high_water() <= SCAN_QUANTUM_BYTES * 4);
 
     let composite = run_pipeline(&input);
-    let (metrics, evidence) = composite
+    let evidence = composite
+        .evidence()
+        .expect("large clean session must publish");
+    let (metrics, _evidence_accumulator) = composite
         .into_parts()
         .expect("large clean session must publish");
     assert!(metrics.observed_turns() > 0);
@@ -216,7 +227,7 @@ fn large_session_respects_bounded_memory_contracts() {
         metrics.retained_bytes(),
         metrics.observed_turns()
     );
-    assert_eq!(evidence.evidence().coverage, EvidenceCoverage::Complete);
+    assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
 }
 
 #[test]

--- a/crates/antiburn-local/tests/support/claude_fixture.rs
+++ b/crates/antiburn-local/tests/support/claude_fixture.rs
@@ -1,6 +1,9 @@
+use std::sync::Arc;
+
 use antiburn_local::analysis::{
-    CompositeSink, EvidenceSource, RawSource, SessionEvidenceAccumulator, SessionInput,
-    SessionMetricsAccumulator, SourceCapabilities, SourceKind, adapter_for,
+    CompositeSink, EvidenceSource, MemoryTurnRowStore, RawSource, SessionEvidenceAccumulator,
+    SessionInput, SessionMetricsAccumulator, SourceCapabilities, SourceKind, TurnRowSink,
+    TurnRowStore, adapter_for,
 };
 
 pub fn read_fixture(name: &str) -> String {
@@ -39,7 +42,13 @@ fn stream_input(input: SessionInput) -> CompositeSink {
         kind: SourceKind::from(&input.source),
         capabilities: SourceCapabilities::claude(),
     });
-    let mut composite = CompositeSink::new(metrics, evidence);
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut composite = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
     let outcome = adapter_for("claude")
         .visit(&input, &mut composite)
         .expect("synthetic Claude fixture must stream");

--- a/crates/antiburn-local/tests/turn_content_privacy.rs
+++ b/crates/antiburn-local/tests/turn_content_privacy.rs
@@ -11,7 +11,7 @@ use antiburn_local::analysis::{
     CompositeSink, EvidenceSource, RawSource, SessionEvidenceAccumulator, SessionInput,
     SessionMetricsAccumulator, SourceCapabilities, SourceKind, TURN_MIGRATIONS, TurnFacts, TurnRow,
     TurnRowError, TurnRowSink, TurnRowStore, TurnSessionKey, adapter_for, count_turn_content_rows,
-    delete_turn_rows, insert_turn_rows, normalize_source,
+    delete_turn_rows, insert_turn_rows, normalize_source, query_turn_facts,
 };
 use rusqlite::{Connection, params};
 
@@ -116,10 +116,13 @@ impl TurnRowStore for TestWriter {
         insert_turn_rows(&conn, &key(), 1, rows).map_err(TurnRowError::from)
     }
 
-    // Never read: this test inspects `turn_content` through its own
-    // connection handle instead of through the store trait.
+    // Published evidence now reads its facts back through this same
+    // query, so the store must answer it for real, not just accept
+    // writes. The test still inspects `turn_content` through its own
+    // connection handle below, alongside this query.
     fn query_turn_facts(&self) -> Result<TurnFacts, TurnRowError> {
-        Err(TurnRowError("not readable".to_owned()))
+        let conn = self.0.lock().expect("lock");
+        query_turn_facts(&conn, &key(), 1).map_err(TurnRowError::from)
     }
 }
 

--- a/crates/antiburn-local/tests/turn_facts_parity.rs
+++ b/crates/antiburn-local/tests/turn_facts_parity.rs
@@ -1,24 +1,25 @@
-//! Parity check between `query_turn_facts` (the row-derived read side) and
-//! `SessionEvidenceAccumulator` (today's evidence source). See Phase 3 in
-//! `docs/plans/session-evidence-harness-parity.md`.
+//! Assembly check between `query_turn_facts` (the row-derived read side)
+//! and `SessionEvidenceAccumulator::evidence` (the published projection).
+//! See Phase 3 in `docs/plans/session-evidence-harness-parity.md`.
 //!
-//! Each vendor test streams every characterization fixture once, through a
-//! `CompositeSink` fanned out to a `MemoryTurnRowStore`, then compares the
-//! two projections field by field. The set of differences must equal the
-//! documented set in each test, exactly. A new difference is a bug in the
-//! query or a semantic change that needs a documented reason. A documented
-//! difference that no longer appears is a stale entry. Do not weaken a
-//! comparison to make a difference pass.
+//! `SessionEvidence` is now built directly from `TurnFacts`, so this is a
+//! cheap check that the assembly carries every row-derived field through
+//! unchanged, not a comparison between two independent computations. Each
+//! vendor test streams every characterization fixture once, through a
+//! `CompositeSink` fanned out to a `MemoryTurnRowStore`, then asserts the
+//! published `SessionEvidence` groups equal the queried `TurnFacts` values
+//! field by field, for every fixture, with no exceptions.
 //!
-//! The documented differences all come from three rules of the row query:
+//! Row-derived fields still follow three rules, now built into
+//! `query_turn_facts` and no longer worth a per-fixture allowlist:
 //!
-//! - `time_range`: rows hold turns only. The accumulator also folds the
-//!   timestamps of eventless records (`RecordTimestamp` observations).
-//! - `delegated_turns`: rows count delegated turns only. The accumulator
-//!   counts every sidechain record, including inert ones.
-//! - `model_transitions` and idle gaps: rows use `scope='main'` only, per
-//!   thread. The accumulator runs one scan over every event, so an inline
-//!   sidechain event can form a transition or a gap with a main-loop event.
+//! - `time_range` spans turn rows only. An eventless record (a
+//!   `RecordTimestamp` observation with no turn behind it) never moves it.
+//! - `delegated_turns` counts delegated turn rows only. An inert
+//!   sidechain record never becomes a row, so it never counts.
+//! - `model_transitions` and idle gaps use `scope='main'` rows only, per
+//!   thread. A sidechain turn never forms a transition or a gap with a
+//!   main-loop turn.
 
 use std::sync::Arc;
 
@@ -39,50 +40,26 @@ fn published<T: Clone>(value: &EvidenceValue<T>) -> Option<T> {
     }
 }
 
-/// Records a mismatch when `accumulator` and `facts` differ for one field of
-/// one fixture.
+/// Records a mismatch when the published `SessionEvidence` group and the
+/// queried `TurnFacts` differ for one field of one fixture.
 fn diff<T: std::fmt::Debug + PartialEq>(
     mismatches: &mut Vec<Mismatch>,
     fixture: &str,
     field: &str,
-    accumulator: T,
+    evidence_value: T,
     facts: T,
 ) {
-    if accumulator != facts {
+    if evidence_value != facts {
         mismatches.push(Mismatch {
-            fixture: fixture.to_owned(),
-            field: field.to_owned(),
             detail: format!(
-                "fixture={fixture} field={field}\n  accumulator = {accumulator:?}\n  facts       = {facts:?}"
+                "fixture={fixture} field={field}\n  evidence = {evidence_value:?}\n  facts    = {facts:?}"
             ),
         });
     }
 }
 
 struct Mismatch {
-    fixture: String,
-    field: String,
     detail: String,
-}
-
-/// One documented difference: the fixture, the field, and the query rule
-/// that explains it.
-struct Documented {
-    fixture: &'static str,
-    field: &'static str,
-    rule: &'static str,
-}
-
-const TIME_RANGE_RULE: &str = "time_range comes from turn rows only";
-const DELEGATED_TURNS_RULE: &str = "delegated_turns counts turn rows only";
-const MAIN_SCOPE_RULE: &str = "transitions and idle gaps use scope='main' rows only";
-
-const fn documented(fixture: &'static str, field: &'static str, rule: &'static str) -> Documented {
-    Documented {
-        fixture,
-        field,
-        rule,
-    }
 }
 
 /// Streams `jsonl` through the named vendor's adapter into both an evidence
@@ -292,126 +269,20 @@ fn compare_fixture(
     }
 }
 
-/// Asserts that the observed differences are exactly the documented ones.
-const CLAUDE_DIFFERENCES: &[Documented] = &[
-    documented(
-        "unrecognized_inert_sidechain",
-        "subagents.delegatedTurns",
-        DELEGATED_TURNS_RULE,
-    ),
-    documented(
-        "reasoning_and_fast_mode",
-        "cache.modelTransitions",
-        MAIN_SCOPE_RULE,
-    ),
-    documented(
-        "reasoning_and_fast_mode",
-        "cache.longestIdleGapMs",
-        MAIN_SCOPE_RULE,
-    ),
-    documented("delegated_turns", "cache.modelTransitions", MAIN_SCOPE_RULE),
-    documented("delegated_turns", "cache.longestIdleGapMs", MAIN_SCOPE_RULE),
-    documented("delegated_turns", "cache.idleGapMsTotal", MAIN_SCOPE_RULE),
-    documented(
-        "delegated_models",
-        "cache.modelTransitions",
-        MAIN_SCOPE_RULE,
-    ),
-    documented(
-        "delegated_models",
-        "cache.longestIdleGapMs",
-        MAIN_SCOPE_RULE,
-    ),
-    documented("delegated_models", "cache.idleGapMsTotal", MAIN_SCOPE_RULE),
-    documented(
-        "delegated_model_missing",
-        "cache.longestIdleGapMs",
-        MAIN_SCOPE_RULE,
-    ),
-    documented(
-        "delegated_model_missing",
-        "cache.idleGapMsTotal",
-        MAIN_SCOPE_RULE,
-    ),
-    documented(
-        "thread_identity_chain",
-        "cache.modelTransitions",
-        MAIN_SCOPE_RULE,
-    ),
-    documented(
-        "thread_identity_chain",
-        "cache.longestIdleGapMs",
-        MAIN_SCOPE_RULE,
-    ),
-    documented(
-        "sidechain_in_parent",
-        "cache.modelTransitions",
-        MAIN_SCOPE_RULE,
-    ),
-    documented(
-        "sidechain_in_parent",
-        "cache.longestIdleGapMs",
-        MAIN_SCOPE_RULE,
-    ),
-];
-
-const CODEX_DIFFERENCES: &[Documented] = &[];
-
-const PI_DIFFERENCES: &[Documented] = &[
-    documented("minimal_session", "timeRange", TIME_RANGE_RULE),
-    documented("model_change", "timeRange", TIME_RANGE_RULE),
-    documented("thinking_level_change", "timeRange", TIME_RANGE_RULE),
-    documented("compaction_and_inert", "timeRange", TIME_RANGE_RULE),
-    documented("unknown_row_type", "timeRange", TIME_RANGE_RULE),
-    documented("custom_rows", "timeRange", TIME_RANGE_RULE),
-    documented("header_only", "timeRange", TIME_RANGE_RULE),
-    documented("unsupported_version", "timeRange", TIME_RANGE_RULE),
-    documented("fork_hazard_parent", "timeRange", TIME_RANGE_RULE),
-    documented("fork_hazard_child", "timeRange", TIME_RANGE_RULE),
-    documented("fork_no_inherited", "timeRange", TIME_RANGE_RULE),
-    documented("bash_execution_role", "timeRange", TIME_RANGE_RULE),
-    documented("bash_execution_with_usage", "timeRange", TIME_RANGE_RULE),
-    documented("inert_signal_guard", "timeRange", TIME_RANGE_RULE),
-    documented("non_turn_timestamp_ordering", "timeRange", TIME_RANGE_RULE),
-    documented("session_start", "timeRange", TIME_RANGE_RULE),
-];
-
-/// Asserts that the observed differences are exactly the documented ones.
-fn assert_documented_differences(vendor: &str, mismatches: Vec<Mismatch>, expected: &[Documented]) {
-    let undocumented: Vec<&str> = mismatches
+/// Asserts every fixture's published `SessionEvidence` groups carry the
+/// queried `TurnFacts` values through with no change. `evidence()` builds
+/// each group straight from `facts`, so any mismatch here is a bug in that
+/// assembly, not a semantic difference to document.
+fn assert_no_mismatches(vendor: &str, mismatches: Vec<Mismatch>) {
+    let details: Vec<&str> = mismatches
         .iter()
-        .filter(|mismatch| {
-            !expected
-                .iter()
-                .any(|entry| entry.fixture == mismatch.fixture && entry.field == mismatch.field)
-        })
         .map(|mismatch| mismatch.detail.as_str())
         .collect();
     assert!(
-        undocumented.is_empty(),
-        "{vendor}: {} undocumented difference(s) between query_turn_facts and SessionEvidenceAccumulator:\n\n{}",
-        undocumented.len(),
-        undocumented.join("\n\n")
-    );
-    let stale: Vec<String> = expected
-        .iter()
-        .filter(|entry| {
-            !mismatches
-                .iter()
-                .any(|mismatch| mismatch.fixture == entry.fixture && mismatch.field == entry.field)
-        })
-        .map(|entry| {
-            format!(
-                "fixture={} field={} ({})",
-                entry.fixture, entry.field, entry.rule
-            )
-        })
-        .collect();
-    assert!(
-        stale.is_empty(),
-        "{vendor}: {} documented difference(s) no longer appear; remove them:\n{}",
-        stale.len(),
-        stale.join("\n")
+        details.is_empty(),
+        "{vendor}: {} mismatch(es) between the published SessionEvidence and query_turn_facts:\n\n{}",
+        details.len(),
+        details.join("\n\n")
     );
 }
 
@@ -554,7 +425,7 @@ fn claude_facts_match_evidence_for_every_fixture() {
         );
         compare_fixture(&mut mismatches, name, &evidence, &facts);
     }
-    assert_documented_differences("claude", mismatches, CLAUDE_DIFFERENCES);
+    assert_no_mismatches("claude", mismatches);
 }
 
 /* --------------------------------------------------------------------
@@ -619,7 +490,7 @@ fn codex_facts_match_evidence_for_every_fixture() {
         );
         compare_fixture(&mut mismatches, name, &evidence, &facts);
     }
-    assert_documented_differences("codex", mismatches, CODEX_DIFFERENCES);
+    assert_no_mismatches("codex", mismatches);
 }
 
 /* --------------------------------------------------------------------
@@ -742,5 +613,5 @@ fn pi_facts_match_evidence_for_every_fixture() {
         let (evidence, facts) = run_fixture("pi", name, pi_fixture(name), SourceCapabilities::pi());
         compare_fixture(&mut mismatches, name, &evidence, &facts);
     }
-    assert_documented_differences("pi", mismatches, PI_DIFFERENCES);
+    assert_no_mismatches("pi", mismatches);
 }

--- a/crates/antiburn-local/tests/unrecognized_records.rs
+++ b/crates/antiburn-local/tests/unrecognized_records.rs
@@ -330,8 +330,10 @@ fn a_session_of_only_inert_unknowns_is_a_zero_work_session() {
     for detector in [DetectorId::UnusedMcpServers, DetectorId::UnusedSkills] {
         assert_eq!(report.detectors[detector.index()].eligible, 0);
     }
+    // The inert sidechain marker never becomes a turn row, so it carries no
+    // delegated turn or spawn: a real clean verdict, not a contract gap.
     assert_eq!(
         report.detector_statuses[DetectorId::OverpoweredSubagents.index()],
-        DetectorStatus::NotAssessed(NotAssessedReason::EvidenceContractIncomplete)
+        DetectorStatus::Clean
     );
 }


### PR DESCRIPTION
Stacked on #264 (seam 3a). Phase 3 of `docs/plans/session-evidence-harness-parity.md` (rev 4). This is the behaviour change: `SessionEvidence` is computed from turn rows.

## What changes

- **`SessionEvidenceAccumulator::evidence(&TurnFacts)`** — every row-derived group (eligibility, context depth, time range, models/tiers/signals, delegated turns and models, cache sums/transitions/idle gaps, compactions) comes from the row query. The accumulator is now the residual: tools, context sources, diagnostics/coverage, ordering, subagent spawn observations, thread-link verification (a parent link can point at an eventless record that has no row).
- **One logical session.** `stream_vendor_with_hooks` keeps the parent's residual and folds every child into it. `evidence.first()` is deleted. A child-only signal now reaches the parent's hygiene checks — this is the defect the plan set out to fix.
- **Children that cannot be read** (discovered but unreadable, or streamed with record loss) degrade every child-dependent group to `Partial` (`ReadFailed` / the child's own reason). Tools and context sources stay parent-only by design. New `ParseDiagnostics` fields: `childrenDiscovered`, `childrenUnreadable`, `duplicateTurnIdentities`.
- **Overlap guard.** The same `uuid` under two `source_key`s degrades `models` and `subagents` to `Partial(AttributionIncomplete)` rather than double counting.
- **No store, no evidence.** A pass without a row store publishes `None`; a row query failure fails the pass exactly like a write failure (metrics must never disagree with rows the pass could not read back).
- **Revisions:** `EVIDENCE_SCHEMA_REVISION` 4→5, `ANALYZER_REVISION` 7→8. `reconcile_evidence_revisions` requeues existing rows.

## Verdict changes in the characterization suites (intended)

Two Claude fixture expectations change, both following the scope rules documented in `turn_facts_parity.rs` and the plan:

- `thread_identity_chain`: cache churn **Finding → Clean**. The only model switch sits on the inline sidechain (delegated scope); main-scope transitions per thread never see it. A child model switch is not parent reprocessing.
- `unrecognized_inert_sidechain`: overpowered subagents **ContractIncomplete → Clean**. The inert sidechain marker is not a turn, so `delegated_turns` is 0 and there is no subagent activity to assess.

Golden diffs: 7 files — revision bumps plus the three new diagnostics keys; `pi/unknown_row_type` also loses its `timeRange` (a fixture with one unrecognized record and no turns now reads 0/0 — time range comes from turns only).

## Acceptance (Phase 3, all as desktop tests in `analysis.rs`)

- a child-only `speed: "fast"` appears in the parent's `fast_modes["fast"].delegated` and `delegated_models`
- a model switch confined to a child produces no `model_transitions`
- an unreadable discovered child publishes with `subagents`/`models` `Partial(ReadFailed)` and `childrenUnreadable == 1`
- two children with different models share no transition and no idle gap

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — clean in both `crates/antiburn-local` and `apps/desktop/src-tauri` (583).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U7uVd1iQZBdWV2KdmSjSA
