### PR TITLE
chore(desktop): improve idle memory and main-window responsiveness

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -105,6 +105,10 @@ engine. Release and dependency checks run through the required CI gate.
 
 ## Shell behavior
 
+See [Desktop window renderer lifecycle](../../docs/window-renderer-lifecycle.md)
+for the shared readiness handshake, onboarding prewarm, popover eviction,
+Settings teardown, and the memory rules behind those policies.
+
 - **Tray item.** Primary click toggles the popover. Secondary click opens a
   menu with Pin Window, Settings, and Quit. The Settings sidebar ends in the
   same Quit action — an agent application has no Dock icon and no application
@@ -134,9 +138,13 @@ engine. Release and dependency checks run through the required CI gate.
   window can be reached again once something else takes focus. Finishing it
   puts the window away, drops the Dock icon, and posts the one notification
   that says where the app now lives, anchored under that glyph.
-- **Settings.** An ordinary decorated window, created on demand.
-  A source list on the left, one pane on the right; every control writes
-  through immediately, so there is no Save button and no dirty state.
+- **Settings.** An ordinary decorated window, created on demand and destroyed
+  on close. A source list on the left, one pane on the right; every control
+  writes through immediately, so there is no Save button and no dirty state.
+- **Popover lifetime.** Finishing onboarding starts one hidden renderer before
+  the onboarding window retires. After it becomes ready, the handoff renderer
+  stays warm for up to 60 seconds. The first reveal consumes that lease; later
+  dismissals use the normal 15-second grace period before renderer destruction.
 - **Local store.** One SQLite database under the app data directory
   (`ai.antiburn.desktop`, or `ai.antiburn.desktop.debug` for a development
   build — see above) holds preferences, scan roots, and the local session data

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -79,6 +79,14 @@ pub fn window_ready(window: tauri::WebviewWindow, generation: u64) {
     }
 }
 
+/// Record when the popover's first activity and cached usage state settle.
+#[tauri::command]
+pub fn popover_content_ready(window: tauri::WebviewWindow, generation: u64) {
+    if window.label() == crate::popover::LABEL {
+        crate::popover::content_ready(&window, generation);
+    }
+}
+
 /// Opens, or refocuses, the standalone settings window.
 ///
 /// `pane` is optional and is a *request*: the frontend owns the pane list, so
@@ -341,12 +349,18 @@ pub fn restart_onboarding(app: tauri::AppHandle) -> CommandResult<()> {
     let store = app.state::<Store>();
     let (previous, saved) = store.restart_onboarding().map_err(fail)?;
     apply_settings_transition(&app, &previous, &saved);
-    crate::onboarding::restart(&app).map_err(fail)?;
-    crate::popover::hide_for_onboarding(&app);
-    if let Err(error) = settings::hide(&app) {
-        ::tracing::warn!(event = "settings_hide_after_onboarding_restart_failed", error = %error);
-    }
-    Ok(())
+    restart_onboarding_surfaces(
+        || crate::popover::hide_for_onboarding(&app),
+        || crate::onboarding::restart(&app).map_err(fail),
+    )
+}
+
+fn restart_onboarding_surfaces(
+    hide_popover: impl FnOnce(),
+    open_onboarding: impl FnOnce() -> CommandResult<()>,
+) -> CommandResult<()> {
+    hide_popover();
+    open_onboarding()
 }
 
 /// Commit the first-run choices and finish onboarding as one transition.
@@ -1720,6 +1734,8 @@ fn presentable(path: PathBuf) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use super::*;
 
     #[test]
@@ -1743,6 +1759,22 @@ mod tests {
             wsl_distro: None,
             enabled: true,
         }
+    }
+
+    #[test]
+    fn restarting_onboarding_retires_the_popover_before_opening_setup() {
+        let actions = RefCell::new(Vec::new());
+
+        restart_onboarding_surfaces(
+            || actions.borrow_mut().push("hide_popover"),
+            || {
+                actions.borrow_mut().push("open_onboarding");
+                Ok(())
+            },
+        )
+        .expect("the test transition succeeds");
+
+        assert_eq!(*actions.borrow(), ["hide_popover", "open_onboarding"]);
     }
 
     /// The report request covers thirty days, ends one past now (the end

--- a/apps/desktop/src-tauri/src/insights_ipc.rs
+++ b/apps/desktop/src-tauri/src/insights_ipc.rs
@@ -40,6 +40,8 @@ impl Run {
 #[derive(Default)]
 pub struct InsightsController {
     slot: Mutex<Option<Arc<Run>>>,
+    #[cfg(test)]
+    cancel_requests: std::sync::atomic::AtomicUsize,
 }
 
 impl InsightsController {
@@ -53,9 +55,16 @@ impl InsightsController {
     /// This is the only cancellation signal. A new report request joins
     /// the running reduction instead of cancelling it.
     pub fn cancel(&self) {
+        #[cfg(test)]
+        self.cancel_requests.fetch_add(1, Ordering::SeqCst);
         if let Some(run) = self.lock_slot().as_ref() {
             run.cancel.store(true, Ordering::SeqCst);
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cancel_requests(&self) -> usize {
+        self.cancel_requests.load(Ordering::SeqCst)
     }
 
     /// Resolves one report, sharing the running reduction when one runs.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -108,8 +108,7 @@ impl Schedulers {
 ///
 /// Panics if the webview runtime, tray item, or local database cannot be
 /// created. None has a meaningful degraded mode. The shell opens onboarding
-/// when required and prewarms Settings after setup. Other windows load when
-/// the first interaction requests them.
+/// when required. Other windows load when the first interaction requests them.
 pub fn run() {
     let log_directory_name = if cfg!(debug_assertions) {
         "antiburn-debug"
@@ -182,6 +181,7 @@ pub fn run() {
             commands::list_repositories,
             commands::list_scan_roots,
             commands::open_settings_window,
+            commands::popover_content_ready,
             commands::post_test_notification,
             commands::post_sample_notification,
             commands::quit_app,
@@ -282,8 +282,6 @@ pub fn run() {
                         error = %error
                     );
                 }
-            } else {
-                settings::schedule_prewarm(app.handle());
             }
 
             // Registered before the update scheduler starts, so the first
@@ -428,7 +426,6 @@ fn finish_retention_cleanup(handle: &mut Option<tauri::async_runtime::JoinHandle
 enum ClosePolicy {
     Allow,
     HidePopover,
-    HideSettings,
     HidePendingOnboarding,
     HideNudge,
 }
@@ -436,8 +433,6 @@ enum ClosePolicy {
 fn close_policy(label: &str, onboarding_pending: bool) -> ClosePolicy {
     if label == popover::LABEL {
         ClosePolicy::HidePopover
-    } else if label == settings::LABEL {
-        ClosePolicy::HideSettings
     } else if label == antiburn_nudge::NUDGE_LABEL {
         ClosePolicy::HideNudge
     } else if label == onboarding::LABEL && onboarding_pending {
@@ -463,16 +458,6 @@ fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
                     // Through `popover::hide` rather than `window.hide()`, so
                     // this path answers to the pin like every dismissal does.
                     popover::hide(window.app_handle());
-                }
-                ClosePolicy::HideSettings => {
-                    if let Err(error) = window.hide() {
-                        ::tracing::error!(
-                            event = "settings_window_hide_on_close_failed",
-                            error = %error
-                        );
-                    } else {
-                        api.prevent_close();
-                    }
                 }
                 ClosePolicy::HidePendingOnboarding => {
                     api.prevent_close();
@@ -697,7 +682,7 @@ mod tests {
         );
         assert_eq!(
             close_policy(super::settings::LABEL, false),
-            ClosePolicy::HideSettings
+            ClosePolicy::Allow
         );
         assert_eq!(
             close_policy(antiburn_nudge::NUDGE_LABEL, false),

--- a/apps/desktop/src-tauri/src/onboarding.rs
+++ b/apps/desktop/src-tauri/src/onboarding.rs
@@ -25,7 +25,7 @@
 //! `data-tauri-drag-region` strip (`src/views/onboarding/OnboardingFlow.tsx`).
 
 use std::sync::Mutex;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
@@ -48,7 +48,23 @@ const HEIGHT: f64 = 480.0;
 
 /// Give the final settings command time to return before its caller's webview
 /// is destroyed. The window is hidden immediately, so this delay is invisible.
-const FINISH_TEARDOWN_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+const FINISH_TEARDOWN_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FinishHandoffAction {
+    PrewarmPopover,
+    DestroyOnboarding,
+}
+
+fn finish_handoff_schedule() -> [(Duration, FinishHandoffAction); 2] {
+    [
+        (Duration::ZERO, FinishHandoffAction::PrewarmPopover),
+        (
+            FINISH_TEARDOWN_DELAY,
+            FinishHandoffAction::DestroyOnboarding,
+        ),
+    ]
+}
 
 // The reasons for those two numbers, as build errors rather than tests —
 // following `popover.rs`, and for the same reason: a geometry constant edited
@@ -253,23 +269,35 @@ pub fn finish(app: &AppHandle) {
     // ordered out by it — hence this line before that one, not after.
     apply_activation_policy(app, false);
     crate::notifications::note_menu_bar_home(app);
-    crate::settings::schedule_prewarm(app);
 
     // `finish` runs inside the onboarding webview's final `set_settings` IPC.
-    // Destroying that webview synchronously can cut off the command response;
-    // hide now, then retire it once the response and location nudge are away.
+    // Queue the prewarm after this command yields. Destroy onboarding later so
+    // the command response can leave its renderer.
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        tokio::time::sleep(FINISH_TEARDOWN_DELAY).await;
-        let check_app = app.clone();
-        let _ = app.run_on_main_thread(move || {
-            if is_pending(&check_app) {
-                return;
+        for (delay, action) in finish_handoff_schedule() {
+            if delay.is_zero() {
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(delay).await;
             }
-            if let Some(window) = check_app.get_webview_window(LABEL) {
-                let _ = window.destroy();
-            }
-        });
+            let check_app = app.clone();
+            let _ = app.run_on_main_thread(move || {
+                if is_pending(&check_app) {
+                    return;
+                }
+                match action {
+                    FinishHandoffAction::PrewarmPopover => {
+                        crate::popover::prewarm(&check_app);
+                    }
+                    FinishHandoffAction::DestroyOnboarding => {
+                        if let Some(window) = check_app.get_webview_window(LABEL) {
+                            let _ = window.destroy();
+                        }
+                    }
+                }
+            });
+        }
     });
 }
 
@@ -339,6 +367,20 @@ mod tests {
         assert_eq!(
             LABEL, "onboarding",
             "also listed in capabilities/default.json"
+        );
+    }
+
+    #[test]
+    fn the_finish_handoff_schedules_prewarm_before_renderer_teardown() {
+        assert_eq!(
+            finish_handoff_schedule(),
+            [
+                (Duration::ZERO, FinishHandoffAction::PrewarmPopover),
+                (
+                    FINISH_TEARDOWN_DELAY,
+                    FinishHandoffAction::DestroyOnboarding
+                ),
+            ]
         );
     }
 

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -1,8 +1,9 @@
 //! The tray-anchored popover window.
 //!
 //! The popover is created lazily on the first tray click. After dismissal it
-//! stays warm for the process lifetime, so each later open is immediate and
-//! keeps the state that its views already loaded.
+//! stays warm for a short grace period, so a quick reopen is immediate. Once
+//! the grace period ends, the shell destroys the hidden renderer. The next
+//! open creates a new renderer from native state.
 //!
 //! # Geometry
 //!
@@ -37,6 +38,9 @@
 //! Whichever way it goes, it leaves through [`note_hidden`], which is also
 //! where the menu-bar item is unlit; [`note_shown`] is the other half.
 
+mod retention;
+mod timing;
+
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -50,8 +54,10 @@ use tauri::{
 
 use crate::window_lifecycle::{self, ManagedWindowReadiness};
 use crate::window_readiness::{
-    OpenAction, ToggleAction, WindowReadiness, renderer_generation_script,
+    OpenAction, PrewarmAction, ToggleAction, WindowReadiness, renderer_generation_script,
 };
+
+use self::retention::{DueEviction, EvictionMode, EvictionSchedule, EvictionToken, Retention};
 
 /// Window label. Also listed in `capabilities/default.json`.
 pub const LABEL: &str = "popover";
@@ -248,6 +254,7 @@ fn linux_anchor(window: &WebviewWindow) -> Option<AnchorRect> {
 /// pin stay the ways to put it away.
 #[cfg(target_os = "linux")]
 pub fn open_from_tray_menu(app: &AppHandle) {
+    let requested_at = Instant::now();
     // The same gate [`toggle`] applies: before the first run is finished the
     // popover has nothing to show, so send the reader to the flow they are owed.
     if crate::onboarding::is_pending(app) {
@@ -272,7 +279,7 @@ pub fn open_from_tray_menu(app: &AppHandle) {
     // latch, the item would do nothing right after the menu opens.
     state.clear_auto_hide();
 
-    let request = match request_open_window(app) {
+    let request = match request_open_window(app, Some(requested_at)) {
         Ok(request) => request,
         Err(error) => {
             ::tracing::error!(event = "popover_create_failed", error = %error);
@@ -333,6 +340,12 @@ pub struct PopoverState {
     /// Deliberately not persisted: a pin means "keep this on screen while I
     /// work", and a relaunch is the end of that work.
     pinned: AtomicBool,
+    /// The generation of the current renderer.
+    renderer_generation: AtomicU64,
+    /// The bounded ownership of hidden renderers and eviction callbacks.
+    retention: Mutex<Retention>,
+    /// Content-free timing for the active menu-bar open request.
+    timing: timing::PopoverTiming,
     /// The renderer load and any reveal waiting behind it.
     readiness: Mutex<WindowReadiness>,
 }
@@ -346,6 +359,9 @@ impl Default for PopoverState {
             resize_generation: AtomicU64::new(0),
             focus_hold: AtomicU64::new(0),
             pinned: AtomicBool::new(false),
+            renderer_generation: AtomicU64::new(0),
+            retention: Mutex::new(Retention::default()),
+            timing: timing::PopoverTiming::default(),
             readiness: Mutex::new(WindowReadiness::default()),
         }
     }
@@ -417,6 +433,83 @@ impl PopoverState {
         self.pinned.store(pinned, Ordering::SeqCst);
     }
 
+    fn retention(&self) -> std::sync::MutexGuard<'_, Retention> {
+        self.retention
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn arm_hidden_retention(
+        &self,
+        renderer_generation: u64,
+        now: Instant,
+    ) -> Option<EvictionSchedule> {
+        self.retention()
+            .arm_hidden(renderer_generation, now, self.is_pinned())
+    }
+
+    fn arm_eviction_retry(&self, renderer_generation: u64, mode: EvictionMode) -> EvictionSchedule {
+        self.retention().arm_retry(renderer_generation, mode)
+    }
+
+    fn attach_eviction_task(
+        &self,
+        token: EvictionToken,
+        task: tauri::async_runtime::JoinHandle<()>,
+    ) {
+        self.retention().attach_task(token, task);
+    }
+
+    fn cancel_eviction(&self) {
+        self.retention().cancel_eviction();
+    }
+
+    fn take_eviction_if_due(&self, token: EvictionToken, visible: bool) -> Option<DueEviction> {
+        let renderer_generation = self.renderer_generation.load(Ordering::SeqCst);
+        self.retention()
+            .take_due(token, renderer_generation, visible, self.is_pinned())
+    }
+
+    fn mark_prewarm(&self, generation: u64, now: Instant) {
+        self.retention().begin_prewarm(generation, now);
+    }
+
+    fn is_prewarm(&self, generation: u64) -> bool {
+        self.retention().is_prewarm(generation)
+    }
+
+    fn clear_prewarm(&self) {
+        self.retention().take_prewarm();
+    }
+
+    fn prewarm_generation(&self) -> Option<u64> {
+        self.retention().prewarm_generation()
+    }
+
+    fn transfer_prewarm(&self, from: u64, to: u64) -> bool {
+        self.retention().transfer_prewarm(from, to)
+    }
+
+    fn mark_prewarm_ready(&self, generation: u64, now: Instant) -> bool {
+        self.retention().mark_prewarm_ready(generation, now)
+    }
+
+    fn expired_prewarm(&self, now: Instant) -> Option<DueEviction> {
+        self.retention().expired_prewarm(now)
+    }
+
+    fn clear_prewarm_generation(&self, generation: u64) -> bool {
+        self.retention().clear_prewarm_generation(generation)
+    }
+
+    fn consume_prewarm_on_reveal(&self, generation: u64) -> bool {
+        self.retention().consume_prewarm_on_reveal(generation)
+    }
+
+    fn take_prewarm(&self) -> Option<u64> {
+        self.retention().take_prewarm()
+    }
+
     fn record_anchor(&self, anchor: AnchorRect) {
         if let Ok(mut slot) = self.anchor.lock() {
             *slot = Some(anchor);
@@ -468,6 +561,10 @@ fn ease_out(progress: f64) -> f64 {
 
 /// Build the popover hidden and off the taskbar.
 fn build_window(app: &AppHandle, generation: u64) -> tauri::Result<WebviewWindow> {
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.timing.reset_renderer(generation);
+        state.timing.build_started(generation, Instant::now());
+    }
     ::tracing::info!(
         event = "window_renderer_load_started",
         window = LABEL,
@@ -513,9 +610,24 @@ fn build_window(app: &AppHandle, generation: u64) -> tauri::Result<WebviewWindow
     );
 
     match builder.build() {
-        Ok(window) => Ok(window),
+        Ok(window) => {
+            let state = app.state::<PopoverState>();
+            state
+                .renderer_generation
+                .store(generation, Ordering::SeqCst);
+            if state.is_prewarm(generation) {
+                schedule_idle_eviction(app);
+            }
+            Ok(window)
+        }
         Err(error) => {
             window_lifecycle::cancel_load::<PopoverState>(app, generation);
+            if let Some(state) = app.try_state::<PopoverState>()
+                && state.is_prewarm(generation)
+            {
+                state.clear_prewarm();
+                state.cancel_eviction();
+            }
             Err(error)
         }
     }
@@ -528,8 +640,92 @@ enum WindowRequest {
     Cancelled,
 }
 
-fn request_open_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
+fn begin_open_timing(
+    state: &PopoverState,
+    requested_at: Option<Instant>,
+    generation: u64,
+    renderer_state: &'static str,
+) {
+    let Some(requested_at) = requested_at else {
+        return;
+    };
+    state.timing.begin_open(
+        generation,
+        requested_at,
+        state.is_prewarm(generation),
+        renderer_state,
+    );
+}
+
+fn transfer_prewarm_for_replacement(
+    state: &PopoverState,
+    previous_generation: Option<u64>,
+    replacement_generation: u64,
+) -> bool {
+    let Some(previous_generation) = previous_generation else {
+        return false;
+    };
+    if previous_generation != replacement_generation {
+        state.transfer_prewarm(previous_generation, replacement_generation);
+        state.cancel_eviction();
+    }
+    state.is_prewarm(replacement_generation)
+}
+
+fn replace_expired_prewarm(
+    app: &AppHandle,
+    requested_at: Option<Instant>,
+) -> tauri::Result<Option<WindowRequest>> {
     let state = app.state::<PopoverState>();
+    let Some(expired) = state.expired_prewarm(Instant::now()) else {
+        return Ok(None);
+    };
+    let expired_generation = expired.renderer_generation();
+
+    state.cancel_eviction();
+    state.readiness().reset();
+    state.timing.cancel_open();
+    let generation = {
+        let mut readiness = state.readiness();
+        match readiness.request_open(Instant::now()) {
+            OpenAction::StartLoading { generation } => generation,
+            _ => unreachable!("a reset lifecycle starts loading"),
+        }
+    };
+    begin_open_timing(&state, requested_at, generation, "expired");
+
+    let Some(existing) = app.get_webview_window(LABEL) else {
+        state.clear_prewarm_generation(expired_generation);
+        return build_window(app, generation)
+            .map(WindowRequest::Loading)
+            .map(Some);
+    };
+
+    state.readiness().defer_build_until_destroyed(generation);
+    if let Err(error) = existing.destroy() {
+        window_lifecycle::cancel_load::<PopoverState>(app, generation);
+        let retry = state.arm_eviction_retry(expired_generation, expired.mode());
+        arm_idle_eviction(app, retry);
+        return Err(error);
+    }
+    state.clear_prewarm_generation(expired_generation);
+    Ok(Some(WindowRequest::AwaitingBuild))
+}
+
+fn request_open_window(
+    app: &AppHandle,
+    requested_at: Option<Instant>,
+) -> tauri::Result<WindowRequest> {
+    if let Some(request) = replace_expired_prewarm(app, requested_at)? {
+        return Ok(request);
+    }
+    let state = app.state::<PopoverState>();
+    let prewarm_generation = state.prewarm_generation();
+    let prewarm_loading = prewarm_generation
+        .is_some_and(|generation| state.readiness().loading_generation() == Some(generation));
+    if !prewarm_loading {
+        state.cancel_eviction();
+    }
     let Some(existing) = app.get_webview_window(LABEL) else {
         let mut readiness = state.readiness();
         let action = readiness.request_open(Instant::now());
@@ -537,7 +733,14 @@ fn request_open_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
             OpenAction::StartLoading { generation } | OpenAction::Rebuild { generation } => {
                 generation
             }
-            OpenAction::AwaitReady => return Ok(WindowRequest::AwaitingBuild),
+            OpenAction::AwaitReady => {
+                let generation = readiness
+                    .loading_generation()
+                    .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
+                drop(readiness);
+                begin_open_timing(&state, requested_at, generation, "loading");
+                return Ok(WindowRequest::AwaitingBuild);
+            }
             OpenAction::Reveal => {
                 readiness.reset();
                 match readiness.request_open(Instant::now()) {
@@ -547,6 +750,8 @@ fn request_open_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
             }
         };
         drop(readiness);
+        transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
+        begin_open_timing(&state, requested_at, generation, "build");
         return build_window(app, generation).map(WindowRequest::Loading);
     };
 
@@ -555,14 +760,32 @@ fn request_open_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
         readiness.request_open(Instant::now())
     };
     match action {
-        OpenAction::Reveal => Ok(WindowRequest::Ready(existing)),
-        OpenAction::AwaitReady => Ok(WindowRequest::Loading(existing)),
+        OpenAction::Reveal => {
+            let generation = state.renderer_generation.load(Ordering::SeqCst);
+            begin_open_timing(&state, requested_at, generation, "ready");
+            Ok(WindowRequest::Ready(existing))
+        }
+        OpenAction::AwaitReady => {
+            let generation = state
+                .readiness()
+                .loading_generation()
+                .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
+            begin_open_timing(&state, requested_at, generation, "loading");
+            Ok(WindowRequest::Loading(existing))
+        }
         OpenAction::StartLoading { generation } | OpenAction::Rebuild { generation } => {
+            let prewarmed =
+                transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
+            begin_open_timing(&state, requested_at, generation, "replacement");
             if !state.readiness().defer_build_until_destroyed(generation) {
                 return Ok(WindowRequest::AwaitingBuild);
             }
             if let Err(error) = existing.destroy() {
                 window_lifecycle::cancel_load::<PopoverState>(app, generation);
+                if prewarmed && let Some(prewarm_generation) = prewarm_generation {
+                    state.transfer_prewarm(generation, prewarm_generation);
+                    schedule_idle_eviction(app);
+                }
                 return Err(error);
             }
             Ok(WindowRequest::AwaitingBuild)
@@ -570,8 +793,17 @@ fn request_open_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
     }
 }
 
-fn request_toggle_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
+fn request_toggle_window(app: &AppHandle, requested_at: Instant) -> tauri::Result<WindowRequest> {
+    if let Some(request) = replace_expired_prewarm(app, Some(requested_at))? {
+        return Ok(request);
+    }
     let state = app.state::<PopoverState>();
+    let prewarm_generation = state.prewarm_generation();
+    let prewarm_loading = prewarm_generation
+        .is_some_and(|generation| state.readiness().loading_generation() == Some(generation));
+    if !prewarm_loading {
+        state.cancel_eviction();
+    }
     let Some(existing) = app.get_webview_window(LABEL) else {
         let mut readiness = state.readiness();
         let action = readiness.toggle_open(Instant::now());
@@ -579,8 +811,24 @@ fn request_toggle_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
             ToggleAction::StartLoading { generation } | ToggleAction::Rebuild { generation } => {
                 generation
             }
-            ToggleAction::AwaitReady => return Ok(WindowRequest::AwaitingBuild),
-            ToggleAction::CancelPendingReveal => return Ok(WindowRequest::Cancelled),
+            ToggleAction::AwaitReady => {
+                let generation = readiness
+                    .loading_generation()
+                    .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
+                drop(readiness);
+                state.timing.begin_open(
+                    generation,
+                    requested_at,
+                    prewarm_generation == Some(generation),
+                    "loading",
+                );
+                return Ok(WindowRequest::AwaitingBuild);
+            }
+            ToggleAction::CancelPendingReveal => {
+                drop(readiness);
+                state.timing.cancel_open();
+                return Ok(WindowRequest::Cancelled);
+            }
             ToggleAction::UseWindowVisibility => {
                 readiness.reset();
                 match readiness.toggle_open(Instant::now()) {
@@ -590,6 +838,13 @@ fn request_toggle_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
             }
         };
         drop(readiness);
+        transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
+        state.timing.begin_open(
+            generation,
+            requested_at,
+            state.is_prewarm(generation),
+            "build",
+        );
         return build_window(app, generation).map(WindowRequest::Loading);
     };
 
@@ -598,15 +853,51 @@ fn request_toggle_window(app: &AppHandle) -> tauri::Result<WindowRequest> {
         readiness.toggle_open(Instant::now())
     };
     match action {
-        ToggleAction::UseWindowVisibility => Ok(WindowRequest::Ready(existing)),
-        ToggleAction::AwaitReady => Ok(WindowRequest::Loading(existing)),
-        ToggleAction::CancelPendingReveal => Ok(WindowRequest::Cancelled),
+        ToggleAction::UseWindowVisibility => {
+            let generation = state.renderer_generation.load(Ordering::SeqCst);
+            state.timing.begin_open(
+                generation,
+                requested_at,
+                prewarm_generation == Some(generation),
+                "ready",
+            );
+            Ok(WindowRequest::Ready(existing))
+        }
+        ToggleAction::AwaitReady => {
+            let generation = state
+                .readiness()
+                .loading_generation()
+                .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
+            state.timing.begin_open(
+                generation,
+                requested_at,
+                prewarm_generation == Some(generation),
+                "loading",
+            );
+            Ok(WindowRequest::Loading(existing))
+        }
+        ToggleAction::CancelPendingReveal => {
+            state.timing.cancel_open();
+            Ok(WindowRequest::Cancelled)
+        }
         ToggleAction::StartLoading { generation } | ToggleAction::Rebuild { generation } => {
+            let prewarmed =
+                transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
+            state.timing.begin_open(
+                generation,
+                requested_at,
+                state.is_prewarm(generation),
+                "replacement",
+            );
             if !state.readiness().defer_build_until_destroyed(generation) {
                 return Ok(WindowRequest::AwaitingBuild);
             }
             if let Err(error) = existing.destroy() {
                 window_lifecycle::cancel_load::<PopoverState>(app, generation);
+                if prewarmed && let Some(prewarm_generation) = prewarm_generation {
+                    state.transfer_prewarm(generation, prewarm_generation);
+                    schedule_idle_eviction(app);
+                }
                 return Err(error);
             }
             Ok(WindowRequest::AwaitingBuild)
@@ -619,6 +910,7 @@ pub fn rebuild_after_destroy(app: &AppHandle) {
     let state = app.state::<PopoverState>();
     let generation = window_lifecycle::begin_deferred_build::<PopoverState>(app, Instant::now());
     let Some(generation) = generation else {
+        state.clear_prewarm();
         return;
     };
     match build_window(app, generation) {
@@ -635,10 +927,33 @@ pub fn rebuild_after_destroy(app: &AppHandle) {
     }
 }
 
+/// Build one hidden renderer for the handoff from onboarding to the menu bar.
+pub fn prewarm(app: &AppHandle) {
+    if crate::onboarding::is_pending(app) || app.get_webview_window(LABEL).is_some() {
+        return;
+    }
+    let Some(state) = app.try_state::<PopoverState>() else {
+        return;
+    };
+    let generation = {
+        let mut readiness = state.readiness();
+        match readiness.request_prewarm(Instant::now()) {
+            PrewarmAction::StartLoading { generation } => generation,
+            PrewarmAction::KeepExisting => return,
+        }
+    };
+    state.mark_prewarm(generation, Instant::now());
+    if let Err(error) = build_window(app, generation) {
+        state.clear_prewarm();
+        ::tracing::warn!(event = "popover_prewarm_failed", error = %error);
+    }
+}
+
 /// Handles a click on the menu-bar item.
 ///
 /// `anchor` is the item's screen rectangle as reported by the tray backend.
 pub fn toggle(app: &AppHandle, anchor: Rect) {
+    let requested_at = Instant::now();
     // Before the first run is finished the popover has nothing to show — the
     // activity list is empty by construction, because the scan scheduler is
     // gated on the same flag (see [`crate::scan`]). Send the click to the flow
@@ -668,8 +983,7 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
             let _ = window.set_focus();
             return;
         }
-        let _ = window.hide();
-        note_hidden(app);
+        hide_window(app);
         return;
     }
 
@@ -679,7 +993,7 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
         return;
     }
 
-    let request = match request_toggle_window(app) {
+    let request = match request_toggle_window(app, requested_at) {
         Ok(request) => request,
         Err(error) => {
             ::tracing::error!(event = "popover_create_failed", error = %error);
@@ -689,7 +1003,12 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
     let (window, ready) = match request {
         WindowRequest::Ready(window) => (window, true),
         WindowRequest::Loading(window) => (window, false),
-        WindowRequest::AwaitingBuild | WindowRequest::Cancelled => return,
+        WindowRequest::AwaitingBuild => return,
+        WindowRequest::Cancelled => {
+            note_hidden(app);
+            schedule_idle_eviction(app);
+            return;
+        }
     };
 
     if let Err(error) = anchor_to(&window, anchor) {
@@ -725,14 +1044,117 @@ pub fn hide(app: &AppHandle) {
 ///
 /// This operation keeps the pin choice. The pin applies again after setup.
 pub fn hide_for_onboarding(app: &AppHandle) {
+    if destroy_prewarm(app) {
+        return;
+    }
+    if let Some(state) = app.try_state::<PopoverState>() {
+        cancel_pending_reveal_for_onboarding(&state);
+    }
     hide_window(app);
 }
 
-fn hide_window(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window(LABEL) {
-        let _ = window.hide();
+fn cancel_pending_reveal_for_onboarding(state: &PopoverState) -> bool {
+    state.timing.cancel_open();
+    state.readiness().cancel_pending_reveal()
+}
+
+fn destroy_prewarm(app: &AppHandle) -> bool {
+    let Some(state) = app.try_state::<PopoverState>() else {
+        return false;
+    };
+    let Some(_generation) = state.take_prewarm() else {
+        return false;
+    };
+    state.cancel_eviction();
+    state.readiness().reset();
+    state.timing.cancel_open();
+    let Some(window) = app.get_webview_window(LABEL) else {
+        return true;
+    };
+    match window.destroy() {
+        Ok(()) => true,
+        Err(error) => {
+            ::tracing::warn!(event = "popover_prewarm_cancel_failed", error = %error);
+            false
+        }
     }
+}
+
+fn hide_window(app: &AppHandle) {
+    let Some(window) = app.get_webview_window(LABEL) else {
+        note_hidden(app);
+        return;
+    };
+    let _ = window.hide();
     note_hidden(app);
+    schedule_idle_eviction(app);
+}
+
+fn schedule_idle_eviction(app: &AppHandle) {
+    let Some(state) = app.try_state::<PopoverState>() else {
+        return;
+    };
+    let loading_generation = state.readiness().loading_generation();
+    let renderer_generation =
+        loading_generation.unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
+    let Some(schedule) = state.arm_hidden_retention(renderer_generation, Instant::now()) else {
+        return;
+    };
+    arm_idle_eviction(app, schedule);
+}
+
+fn arm_idle_eviction(app: &AppHandle, schedule: EvictionSchedule) {
+    let Some(state) = app.try_state::<PopoverState>() else {
+        return;
+    };
+    let token = schedule.token();
+    ::tracing::info!(
+        event = "window_renderer_eviction_scheduled",
+        window = LABEL,
+        renderer_generation = schedule.renderer_generation(),
+        mode = ?schedule.mode(),
+        delay_ms = schedule.delay().as_millis() as u64
+    );
+    let task_app = app.clone();
+    let task = tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(schedule.delay()).await;
+        let check_app = task_app.clone();
+        if let Err(error) = task_app.run_on_main_thread(move || {
+            evict_if_due(&check_app, token);
+        }) {
+            ::tracing::warn!(event = "window_renderer_eviction_schedule_failed", error = %error);
+        }
+    });
+    state.attach_eviction_task(token, task);
+}
+
+fn evict_if_due(app: &AppHandle, token: EvictionToken) {
+    let Some(state) = app.try_state::<PopoverState>() else {
+        return;
+    };
+    let Some(window) = app.get_webview_window(LABEL) else {
+        state.cancel_eviction();
+        return;
+    };
+    let visible = window.is_visible().unwrap_or(true);
+    let Some(due) = state.take_eviction_if_due(token, visible) else {
+        return;
+    };
+    match window.destroy() {
+        Ok(()) => {
+            state.clear_prewarm_generation(due.renderer_generation());
+            ::tracing::info!(event = "window_renderer_evicted", window = LABEL);
+        }
+        Err(error) => {
+            ::tracing::warn!(
+                event = "window_renderer_eviction_failed",
+                window = LABEL,
+                error = %error
+            );
+            let retry = state.arm_eviction_retry(due.renderer_generation(), due.mode());
+            arm_idle_eviction(app, retry);
+        }
+    }
 }
 
 /// Resize the popover to the height the current view asked for.
@@ -858,10 +1280,7 @@ fn dismiss(app: &AppHandle) {
         }
         state.record_auto_hide();
     }
-    if let Some(window) = app.get_webview_window(LABEL) {
-        let _ = window.hide();
-    }
-    note_hidden(app);
+    hide_window(app);
 }
 
 /// Begin a focus hold. Paired with [`end_focus_hold`] around a native dialog.
@@ -923,11 +1342,13 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
             && window.is_visible().unwrap_or(false)
         {
             let _ = window.set_focus();
+        } else {
+            schedule_idle_eviction(app);
         }
         return;
     }
 
-    let request = match request_open_window(app) {
+    let request = match request_open_window(app, None) {
         Ok(request) => request,
         Err(error) => {
             ::tracing::error!(event = "popover_create_failed", error = %error);
@@ -986,21 +1407,97 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
 /// Reveal the popover after React commits its shell.
 pub fn renderer_ready(window: &WebviewWindow, generation: u64) {
     let app = window.app_handle();
-    if window_lifecycle::renderer_ready::<PopoverState>(app, LABEL, generation, Instant::now()) {
+    let state = app.state::<PopoverState>();
+    let now = Instant::now();
+    if let Some(expired) = state.expired_prewarm(now)
+        && expired.renderer_generation() == generation
+    {
+        state.cancel_eviction();
+        prepare_expired_renderer_retirement(&state, generation, now);
+        match window.destroy() {
+            Ok(()) => {
+                state.clear_prewarm_generation(generation);
+                ::tracing::info!(event = "window_renderer_evicted", window = LABEL);
+            }
+            Err(error) => {
+                ::tracing::warn!(
+                    event = "window_renderer_eviction_failed",
+                    window = LABEL,
+                    error = %error
+                );
+                let retry = state.arm_eviction_retry(generation, expired.mode());
+                arm_idle_eviction(app, retry);
+            }
+        }
+        return;
+    }
+    let prewarm_became_ready =
+        state.is_prewarm(generation) && state.readiness().loading_generation() == Some(generation);
+    let renderer_became_ready = state.readiness().loading_generation() == Some(generation);
+    if renderer_became_ready {
+        state.mark_prewarm_ready(generation, now);
+        state.timing.renderer_ready(generation, now);
+    }
+    if window_lifecycle::renderer_ready::<PopoverState>(app, LABEL, generation, now) {
         reveal(window);
+    } else if prewarm_became_ready {
+        schedule_idle_eviction(app);
     }
 }
 
-fn reveal(window: &WebviewWindow) {
-    if let Err(error) = window.show() {
-        ::tracing::error!(event = "window_reveal_failed", window = LABEL, error = %error);
+fn prepare_expired_renderer_retirement(state: &PopoverState, generation: u64, now: Instant) {
+    let replacement_generation = state.readiness().replace_expired_loading(generation, now);
+    if let Some(replacement_generation) = replacement_generation {
+        state
+            .readiness()
+            .defer_build_until_destroyed(replacement_generation);
+        state
+            .timing
+            .replace_open_generation(generation, replacement_generation);
         return;
     }
+    if state
+        .readiness()
+        .loading_generation()
+        .is_some_and(|active| active != generation)
+    {
+        return;
+    }
+    state.readiness().reset();
+    state.timing.cancel_open();
+}
+
+/// Record when the activity and cached usage state first settle.
+pub fn content_ready(window: &WebviewWindow, generation: u64) {
+    let app = window.app_handle();
+    let state = app.state::<PopoverState>();
+    state.timing.content_ready(generation, Instant::now());
+}
+
+fn reveal(window: &WebviewWindow) {
+    let app = window.app_handle();
+    let generation = app
+        .try_state::<PopoverState>()
+        .map(|state| state.renderer_generation.load(Ordering::SeqCst))
+        .unwrap_or(0);
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.cancel_eviction();
+    }
+    if let Err(error) = window.show() {
+        ::tracing::error!(event = "window_reveal_failed", window = LABEL, error = %error);
+        schedule_idle_eviction(app);
+        return;
+    }
+    let revealed_at = Instant::now();
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.consume_prewarm_on_reveal(generation);
+        state.timing.revealed(generation, revealed_at);
+    }
+    ::tracing::info!(event = "window_revealed", window = LABEL, generation);
     if let Err(error) = window.set_focus() {
         ::tracing::warn!(event = "window_focus_failed", window = LABEL, error = %error);
     }
-    note_shown(window.app_handle());
-    ::tracing::info!(event = "window_revealed", window = LABEL);
+    note_shown(app);
 }
 
 /// Everything that has to happen when the popover reaches the screen, whichever
@@ -1375,9 +1872,76 @@ mod tests {
     }
 
     #[test]
+    fn onboarding_restart_cancels_a_pending_cold_reveal() {
+        let state = PopoverState::default();
+        let started_at = Instant::now();
+        let generation = match state.readiness().request_open(started_at) {
+            OpenAction::StartLoading { generation } => generation,
+            _ => unreachable!("a fresh lifecycle starts loading"),
+        };
+
+        assert!(cancel_pending_reveal_for_onboarding(&state));
+        assert!(matches!(
+            state
+                .readiness()
+                .renderer_ready(generation, started_at + Duration::from_millis(1)),
+            crate::window_readiness::ReadyAction::StayHidden { .. }
+        ));
+    }
+
+    #[test]
+    fn repeated_expired_readiness_keeps_the_deferred_replacement() {
+        let state = PopoverState::default();
+        let started_at = Instant::now();
+        assert!(matches!(
+            state.readiness().request_prewarm(started_at),
+            PrewarmAction::StartLoading { .. }
+        ));
+        let expired_generation = match state
+            .readiness()
+            .request_open(started_at + Duration::from_secs(64))
+        {
+            OpenAction::Rebuild { generation } => generation,
+            _ => unreachable!("the stale prewarm starts a replacement"),
+        };
+        state.timing.begin_open(
+            expired_generation,
+            started_at + Duration::from_secs(64),
+            true,
+            "loading",
+        );
+
+        let expired_at = started_at + Duration::from_secs(65);
+        prepare_expired_renderer_retirement(&state, expired_generation, expired_at);
+        let replacement = state
+            .readiness()
+            .loading_generation()
+            .expect("the pending click owns a replacement");
+        prepare_expired_renderer_retirement(&state, expired_generation, expired_at);
+
+        assert_eq!(state.readiness().loading_generation(), Some(replacement));
+        assert_eq!(
+            state.readiness().begin_deferred_build(expired_at),
+            Some(replacement)
+        );
+    }
+
+    #[test]
     fn a_fresh_popover_is_not_pinned() {
         let state = PopoverState::default();
         assert!(!state.is_pinned());
+    }
+
+    #[test]
+    fn a_prewarm_marker_belongs_to_one_renderer_generation() {
+        let state = PopoverState::default();
+
+        state.mark_prewarm(4, Instant::now());
+        assert!(state.is_prewarm(4));
+        assert!(!state.is_prewarm(5));
+
+        state.clear_prewarm();
+        assert!(!state.is_prewarm(4));
     }
 
     #[test]
@@ -1387,6 +1951,22 @@ mod tests {
         assert!(state.is_pinned());
         state.set_pinned(false);
         assert!(!state.is_pinned());
+    }
+
+    #[test]
+    fn every_replacement_path_transfers_the_active_prewarm_deadline() {
+        let state = PopoverState::default();
+        let started_at = Instant::now();
+        state.mark_prewarm(4, started_at);
+
+        assert!(transfer_prewarm_for_replacement(&state, Some(4), 5));
+        assert!(!state.is_prewarm(4));
+        assert!(state.is_prewarm(5));
+        let schedule = state
+            .arm_hidden_retention(5, started_at + Duration::from_secs(10))
+            .expect("the transferred prewarm remains retained");
+        assert_eq!(schedule.delay(), Duration::from_secs(55));
+        assert_eq!(schedule.mode(), EvictionMode::PrewarmLoading);
     }
 
     /// The tray right-click that opens the menu hides the popover, arming the

--- a/apps/desktop/src-tauri/src/popover/retention.rs
+++ b/apps/desktop/src-tauri/src/popover/retention.rs
@@ -1,0 +1,513 @@
+//! The popover renderer retention policy.
+//!
+//! This module owns lease deadlines and eviction callback identity. The
+//! popover facade owns all window operations and timer scheduling.
+
+use std::time::{Duration, Instant};
+
+/// How long a hidden popover keeps its renderer after a normal dismissal.
+pub(super) const IDLE_EVICTION_DELAY: Duration = Duration::from_secs(15);
+
+/// How long onboarding keeps a hidden renderer after it becomes ready.
+pub(super) const PREWARM_READY_EVICTION_DELAY: Duration = Duration::from_secs(60);
+
+/// How long onboarding keeps a renderer that does not become ready.
+pub(super) const PREWARM_LOADING_EVICTION_DELAY: Duration = Duration::from_secs(65);
+
+/// How long the shell waits before it retries a failed destruction.
+pub(super) const EVICTION_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum EvictionMode {
+    Normal,
+    PrewarmReady,
+    PrewarmLoading,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct EvictionToken(u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct EvictionSchedule {
+    token: EvictionToken,
+    renderer_generation: u64,
+    delay: Duration,
+    mode: EvictionMode,
+}
+
+impl EvictionSchedule {
+    pub(super) fn token(self) -> EvictionToken {
+        self.token
+    }
+
+    pub(super) fn renderer_generation(self) -> u64 {
+        self.renderer_generation
+    }
+
+    pub(super) fn delay(self) -> Duration {
+        self.delay
+    }
+
+    pub(super) fn mode(self) -> EvictionMode {
+        self.mode
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct DueEviction {
+    renderer_generation: u64,
+    mode: EvictionMode,
+}
+
+impl DueEviction {
+    pub(super) fn renderer_generation(self) -> u64 {
+        self.renderer_generation
+    }
+
+    pub(super) fn mode(self) -> EvictionMode {
+        self.mode
+    }
+}
+
+#[derive(Debug, Default)]
+struct PrewarmLease {
+    generation: Option<u64>,
+    loading_deadline: Option<Instant>,
+    ready_deadline: Option<Instant>,
+}
+
+impl PrewarmLease {
+    fn begin(&mut self, generation: u64, now: Instant) {
+        self.generation = Some(generation);
+        self.loading_deadline = Some(now + PREWARM_LOADING_EVICTION_DELAY);
+        self.ready_deadline = None;
+    }
+
+    fn contains(&self, generation: u64) -> bool {
+        self.generation == Some(generation)
+    }
+
+    fn transfer(&mut self, from: u64, to: u64) -> bool {
+        if !self.contains(from) {
+            return false;
+        }
+        self.generation = Some(to);
+        true
+    }
+
+    fn mark_ready(&mut self, generation: u64, now: Instant) -> bool {
+        if !self.contains(generation)
+            || self
+                .loading_deadline
+                .is_some_and(|deadline| deadline <= now)
+        {
+            return false;
+        }
+        self.ready_deadline = Some(now + PREWARM_READY_EVICTION_DELAY);
+        true
+    }
+
+    fn schedule(&self, generation: u64, now: Instant) -> Option<(Duration, EvictionMode)> {
+        if !self.contains(generation) {
+            return None;
+        }
+        if let Some(deadline) = self.ready_deadline {
+            return Some((
+                deadline.saturating_duration_since(now),
+                EvictionMode::PrewarmReady,
+            ));
+        }
+        self.loading_deadline.map(|deadline| {
+            (
+                deadline.saturating_duration_since(now),
+                EvictionMode::PrewarmLoading,
+            )
+        })
+    }
+
+    fn expired(&self, now: Instant) -> Option<DueEviction> {
+        let renderer_generation = self.generation?;
+        if let Some(deadline) = self.ready_deadline {
+            return (deadline <= now).then_some(DueEviction {
+                renderer_generation,
+                mode: EvictionMode::PrewarmReady,
+            });
+        }
+        self.loading_deadline
+            .filter(|deadline| *deadline <= now)
+            .map(|_| DueEviction {
+                renderer_generation,
+                mode: EvictionMode::PrewarmLoading,
+            })
+    }
+
+    fn take(&mut self) -> Option<u64> {
+        let generation = self.generation;
+        self.clear();
+        generation
+    }
+
+    fn clear(&mut self) {
+        self.generation = None;
+        self.loading_deadline = None;
+        self.ready_deadline = None;
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ArmedEviction {
+    token: EvictionToken,
+    renderer_generation: u64,
+    mode: EvictionMode,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct Retention {
+    prewarm: PrewarmLease,
+    next_token: u64,
+    armed: Option<ArmedEviction>,
+    task: Option<tauri::async_runtime::JoinHandle<()>>,
+}
+
+impl Retention {
+    pub(super) fn begin_prewarm(&mut self, generation: u64, now: Instant) {
+        self.prewarm.begin(generation, now);
+    }
+
+    pub(super) fn is_prewarm(&self, generation: u64) -> bool {
+        self.prewarm.contains(generation)
+    }
+
+    pub(super) fn prewarm_generation(&self) -> Option<u64> {
+        self.prewarm.generation
+    }
+
+    pub(super) fn transfer_prewarm(&mut self, from: u64, to: u64) -> bool {
+        self.prewarm.transfer(from, to)
+    }
+
+    pub(super) fn mark_prewarm_ready(&mut self, generation: u64, now: Instant) -> bool {
+        self.prewarm.mark_ready(generation, now)
+    }
+
+    pub(super) fn expired_prewarm(&self, now: Instant) -> Option<DueEviction> {
+        self.prewarm.expired(now)
+    }
+
+    pub(super) fn consume_prewarm_on_reveal(&mut self, generation: u64) -> bool {
+        if !self.prewarm.contains(generation) {
+            return false;
+        }
+        self.prewarm.clear();
+        true
+    }
+
+    pub(super) fn take_prewarm(&mut self) -> Option<u64> {
+        self.prewarm.take()
+    }
+
+    pub(super) fn clear_prewarm_generation(&mut self, generation: u64) -> bool {
+        if !self.prewarm.contains(generation) {
+            return false;
+        }
+        self.prewarm.clear();
+        true
+    }
+
+    pub(super) fn arm_hidden(
+        &mut self,
+        renderer_generation: u64,
+        now: Instant,
+        pinned: bool,
+    ) -> Option<EvictionSchedule> {
+        let (delay, mode) = match self.prewarm.schedule(renderer_generation, now) {
+            Some(schedule) => schedule,
+            None if pinned => {
+                self.cancel_eviction();
+                return None;
+            }
+            None => (IDLE_EVICTION_DELAY, EvictionMode::Normal),
+        };
+        Some(self.arm(renderer_generation, delay, mode))
+    }
+
+    pub(super) fn arm_retry(
+        &mut self,
+        renderer_generation: u64,
+        mode: EvictionMode,
+    ) -> EvictionSchedule {
+        self.arm(renderer_generation, EVICTION_RETRY_DELAY, mode)
+    }
+
+    pub(super) fn attach_task(
+        &mut self,
+        token: EvictionToken,
+        task: tauri::async_runtime::JoinHandle<()>,
+    ) {
+        if self.armed.is_some_and(|armed| armed.token == token) {
+            self.task = Some(task);
+        } else {
+            task.abort();
+        }
+    }
+
+    pub(super) fn cancel_eviction(&mut self) {
+        self.next_token = self.next_token.wrapping_add(1).max(1);
+        self.armed = None;
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+
+    pub(super) fn take_due(
+        &mut self,
+        token: EvictionToken,
+        current_renderer_generation: u64,
+        visible: bool,
+        pinned: bool,
+    ) -> Option<DueEviction> {
+        let armed = self.armed?;
+        let due = armed.token == token
+            && armed.renderer_generation == current_renderer_generation
+            && !visible
+            && (!pinned || armed.mode != EvictionMode::Normal);
+        if !due {
+            return None;
+        }
+        self.armed = None;
+        self.task = None;
+        Some(DueEviction {
+            renderer_generation: armed.renderer_generation,
+            mode: armed.mode,
+        })
+    }
+
+    fn arm(
+        &mut self,
+        renderer_generation: u64,
+        delay: Duration,
+        mode: EvictionMode,
+    ) -> EvictionSchedule {
+        self.cancel_eviction();
+        let token = EvictionToken(self.next_token);
+        self.armed = Some(ArmedEviction {
+            token,
+            renderer_generation,
+            mode,
+        });
+        EvictionSchedule {
+            token,
+            renderer_generation,
+            delay,
+            mode,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_dismissal_keeps_the_renderer_for_fifteen_seconds() {
+        let now = Instant::now();
+        let mut retention = Retention::default();
+
+        let schedule = retention
+            .arm_hidden(4, now, false)
+            .expect("an unpinned renderer must get an eviction schedule");
+
+        assert_eq!(schedule.delay(), Duration::from_secs(15));
+        assert_eq!(schedule.mode(), EvictionMode::Normal);
+    }
+
+    #[test]
+    fn onboarding_prewarm_changes_from_a_loading_to_a_ready_lease() {
+        let started_at = Instant::now();
+        let mut retention = Retention::default();
+        retention.begin_prewarm(4, started_at);
+
+        let loading = retention
+            .arm_hidden(4, started_at, false)
+            .expect("a loading prewarm must get a fail-safe schedule");
+        assert_eq!(loading.delay(), Duration::from_secs(65));
+        assert_eq!(loading.mode(), EvictionMode::PrewarmLoading);
+
+        let ready_at = started_at + Duration::from_secs(2);
+        assert!(retention.mark_prewarm_ready(4, ready_at));
+        let ready = retention
+            .arm_hidden(4, ready_at, false)
+            .expect("a ready prewarm must keep its renderer");
+        assert_eq!(ready.delay(), Duration::from_secs(60));
+        assert_eq!(ready.mode(), EvictionMode::PrewarmReady);
+    }
+
+    #[test]
+    fn a_generation_transfer_preserves_the_original_loading_deadline() {
+        let started_at = Instant::now();
+        let mut retention = Retention::default();
+        retention.begin_prewarm(4, started_at);
+
+        assert!(retention.transfer_prewarm(4, 5));
+        assert!(!retention.is_prewarm(4));
+        assert!(retention.is_prewarm(5));
+
+        let schedule = retention
+            .arm_hidden(5, started_at + Duration::from_secs(10), false)
+            .expect("the replacement must inherit the lease");
+        assert_eq!(schedule.delay(), Duration::from_secs(55));
+        assert_eq!(schedule.mode(), EvictionMode::PrewarmLoading);
+    }
+
+    #[test]
+    fn a_ready_generation_transfer_preserves_the_absolute_deadline() {
+        let started_at = Instant::now();
+        let ready_at = started_at + Duration::from_secs(2);
+        let mut retention = Retention::default();
+        retention.begin_prewarm(4, started_at);
+        assert!(retention.mark_prewarm_ready(4, ready_at));
+
+        assert!(retention.transfer_prewarm(4, 5));
+        let first = retention
+            .arm_hidden(5, ready_at + Duration::from_secs(10), false)
+            .expect("the transferred ready lease remains active");
+        assert_eq!(first.delay(), Duration::from_secs(50));
+
+        let rearmed = retention
+            .arm_hidden(5, ready_at + Duration::from_secs(20), false)
+            .expect("rearming keeps the original ready deadline");
+        assert_eq!(rearmed.delay(), Duration::from_secs(40));
+        assert_eq!(rearmed.mode(), EvictionMode::PrewarmReady);
+    }
+
+    #[test]
+    fn the_first_reveal_consumes_the_prewarm_lease_once() {
+        let mut retention = Retention::default();
+        retention.begin_prewarm(4, Instant::now());
+
+        assert!(retention.consume_prewarm_on_reveal(4));
+        assert!(!retention.consume_prewarm_on_reveal(4));
+        assert_eq!(retention.prewarm_generation(), None);
+    }
+
+    #[test]
+    fn an_expired_loading_lease_cannot_become_a_ready_lease() {
+        let started_at = Instant::now();
+        let mut retention = Retention::default();
+        retention.begin_prewarm(4, started_at);
+        let expired_at = started_at + PREWARM_LOADING_EVICTION_DELAY;
+
+        assert_eq!(
+            retention.expired_prewarm(expired_at),
+            Some(DueEviction {
+                renderer_generation: 4,
+                mode: EvictionMode::PrewarmLoading,
+            })
+        );
+        assert!(!retention.mark_prewarm_ready(4, expired_at));
+        assert!(retention.is_prewarm(4));
+    }
+
+    #[test]
+    fn a_replacement_schedule_invalidates_the_old_eviction_token() {
+        let now = Instant::now();
+        let mut retention = Retention::default();
+        let first = retention
+            .arm_hidden(4, now, false)
+            .expect("the first dismissal must arm eviction");
+        let replacement = retention
+            .arm_hidden(4, now, false)
+            .expect("the repeated dismissal must replace eviction");
+
+        assert_eq!(retention.take_due(first.token(), 4, false, false), None);
+        assert_eq!(
+            retention.take_due(replacement.token(), 4, false, false),
+            Some(DueEviction {
+                renderer_generation: 4,
+                mode: EvictionMode::Normal,
+            })
+        );
+    }
+
+    #[test]
+    fn pinning_protects_normal_eviction_but_not_prewarm_expiry() {
+        let now = Instant::now();
+        let mut normal = Retention::default();
+        assert_eq!(normal.arm_hidden(4, now, true), None);
+
+        let mut prewarm = Retention::default();
+        prewarm.begin_prewarm(4, now);
+        let schedule = prewarm
+            .arm_hidden(4, now, true)
+            .expect("a pin must not make the prewarm lease unbounded");
+        assert_eq!(
+            prewarm.take_due(schedule.token(), 4, false, true),
+            Some(DueEviction {
+                renderer_generation: 4,
+                mode: EvictionMode::PrewarmLoading,
+            })
+        );
+    }
+
+    #[test]
+    fn visibility_and_renderer_replacement_protect_a_normal_renderer() {
+        let now = Instant::now();
+        let mut visible = Retention::default();
+        let visible_schedule = visible
+            .arm_hidden(4, now, false)
+            .expect("the dismissal must arm eviction");
+        assert_eq!(
+            visible.take_due(visible_schedule.token(), 4, true, false),
+            None
+        );
+
+        let mut replaced = Retention::default();
+        let replaced_schedule = replaced
+            .arm_hidden(4, now, false)
+            .expect("the dismissal must arm eviction");
+        assert_eq!(
+            replaced.take_due(replaced_schedule.token(), 5, false, false),
+            None
+        );
+    }
+
+    #[test]
+    fn a_failed_destruction_retries_without_releasing_the_prewarm_lease() {
+        let now = Instant::now();
+        let mut retention = Retention::default();
+        retention.begin_prewarm(4, now);
+        let first = retention
+            .arm_hidden(4, now, false)
+            .expect("the loading prewarm must arm eviction");
+
+        let due = retention
+            .take_due(first.token(), 4, false, false)
+            .expect("the deadline callback must own the matching renderer");
+        let retry = retention.arm_retry(due.renderer_generation(), due.mode());
+
+        assert_eq!(retry.delay(), Duration::from_secs(1));
+        assert_eq!(retry.mode(), EvictionMode::PrewarmLoading);
+        assert!(retention.is_prewarm(4));
+        assert_eq!(
+            retention.take_due(retry.token(), 4, false, true),
+            Some(DueEviction {
+                renderer_generation: 4,
+                mode: EvictionMode::PrewarmLoading,
+            })
+        );
+    }
+
+    #[test]
+    fn onboarding_restart_takes_the_active_lease_and_invalidates_eviction() {
+        let now = Instant::now();
+        let mut retention = Retention::default();
+        retention.begin_prewarm(4, now);
+        let schedule = retention
+            .arm_hidden(4, now, false)
+            .expect("the loading prewarm must arm eviction");
+
+        assert_eq!(retention.take_prewarm(), Some(4));
+        retention.cancel_eviction();
+        assert_eq!(retention.take_due(schedule.token(), 4, false, false), None);
+    }
+}

--- a/apps/desktop/src-tauri/src/popover/timing.rs
+++ b/apps/desktop/src-tauri/src/popover/timing.rs
@@ -1,0 +1,406 @@
+//! Content-free latency milestones for menu-bar popover opens.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, Default)]
+struct RendererMilestones {
+    generation: u64,
+    renderer_ready_at: Option<Instant>,
+    content_ready_at: Option<Instant>,
+}
+
+#[derive(Debug)]
+struct OpenTiming {
+    generation: u64,
+    requested_at: Instant,
+    prewarmed: bool,
+    renderer_state: &'static str,
+    renderer_ready_at: Option<Instant>,
+    revealed_at: Option<Instant>,
+    content_ready_at: Option<Instant>,
+    content_reported: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RevealTiming {
+    request_to_reveal: Duration,
+    ready_to_reveal: Duration,
+    renderer_ready_before_request: bool,
+    content_before_reveal: bool,
+}
+
+impl OpenTiming {
+    fn new(
+        generation: u64,
+        requested_at: Instant,
+        prewarmed: bool,
+        renderer_state: &'static str,
+        milestones: RendererMilestones,
+    ) -> Self {
+        let milestones = (milestones.generation == generation).then_some(milestones);
+        Self {
+            generation,
+            requested_at,
+            prewarmed,
+            renderer_state,
+            renderer_ready_at: milestones.and_then(|value| value.renderer_ready_at),
+            revealed_at: None,
+            content_ready_at: milestones.and_then(|value| value.content_ready_at),
+            content_reported: false,
+        }
+    }
+
+    fn mark_renderer_ready(&mut self, generation: u64, now: Instant) -> Option<Duration> {
+        if self.generation != generation || self.renderer_ready_at.is_some() {
+            return None;
+        }
+        self.renderer_ready_at = Some(now);
+        Some(now.saturating_duration_since(self.requested_at))
+    }
+
+    fn mark_revealed(&mut self, generation: u64, now: Instant) -> Option<RevealTiming> {
+        if self.generation != generation || self.revealed_at.is_some() {
+            return None;
+        }
+        let renderer_ready_before_request = self
+            .renderer_ready_at
+            .is_some_and(|ready_at| ready_at <= self.requested_at);
+        let ready_boundary = self.renderer_ready_at.unwrap_or(self.requested_at);
+        self.revealed_at = Some(now);
+        let content_before_reveal = self
+            .content_ready_at
+            .is_some_and(|ready_at| ready_at <= now);
+        Some(RevealTiming {
+            request_to_reveal: now.saturating_duration_since(self.requested_at),
+            ready_to_reveal: now.saturating_duration_since(ready_boundary),
+            renderer_ready_before_request,
+            content_before_reveal,
+        })
+    }
+
+    fn mark_content_ready(
+        &mut self,
+        generation: u64,
+        now: Instant,
+    ) -> Option<(Duration, Duration)> {
+        if self.generation != generation || self.content_reported {
+            return None;
+        }
+        self.content_ready_at = Some(now);
+        let revealed_at = self.revealed_at?;
+        self.content_reported = true;
+        Some((
+            now.saturating_duration_since(self.requested_at),
+            now.saturating_duration_since(revealed_at),
+        ))
+    }
+
+    fn take_content_ready_at_reveal(&mut self) -> bool {
+        if self.content_reported || self.content_ready_at.is_none() {
+            return false;
+        }
+        self.content_reported = true;
+        true
+    }
+}
+
+/// Owns renderer milestones and the active menu-bar open measurement.
+#[derive(Debug, Default)]
+pub(super) struct PopoverTiming {
+    milestones: Mutex<RendererMilestones>,
+    open: Mutex<Option<OpenTiming>>,
+}
+
+impl PopoverTiming {
+    pub(super) fn reset_renderer(&self, generation: u64) {
+        if let Ok(mut milestones) = self.milestones.lock() {
+            *milestones = RendererMilestones {
+                generation,
+                ..RendererMilestones::default()
+            };
+        }
+    }
+
+    pub(super) fn begin_open(
+        &self,
+        generation: u64,
+        requested_at: Instant,
+        prewarmed: bool,
+        renderer_state: &'static str,
+    ) {
+        let milestones = self
+            .milestones
+            .lock()
+            .map(|milestones| *milestones)
+            .unwrap_or_default();
+        if let Ok(mut open) = self.open.lock() {
+            *open = Some(OpenTiming::new(
+                generation,
+                requested_at,
+                prewarmed,
+                renderer_state,
+                milestones,
+            ));
+        }
+        ::tracing::info!(
+            event = "popover_open_timing",
+            phase = "requested",
+            generation,
+            prewarmed,
+            renderer_state,
+            elapsed_ms = 0_u64
+        );
+    }
+
+    pub(super) fn cancel_open(&self) {
+        if let Ok(mut open) = self.open.lock() {
+            *open = None;
+        }
+    }
+
+    pub(super) fn replace_open_generation(&self, from: u64, to: u64) -> bool {
+        let Ok(mut open) = self.open.lock() else {
+            return false;
+        };
+        let Some(current) = open.as_ref().filter(|current| current.generation == from) else {
+            return false;
+        };
+        let requested_at = current.requested_at;
+        *open = Some(OpenTiming::new(
+            to,
+            requested_at,
+            false,
+            "expired_replacement",
+            RendererMilestones::default(),
+        ));
+        ::tracing::info!(
+            event = "popover_open_timing",
+            phase = "generation_replaced",
+            generation = to,
+            previous_generation = from,
+            prewarmed = false,
+            renderer_state = "expired_replacement",
+            elapsed_ms = Instant::now()
+                .saturating_duration_since(requested_at)
+                .as_millis() as u64
+        );
+        true
+    }
+
+    pub(super) fn build_started(&self, generation: u64, now: Instant) {
+        let Ok(open) = self.open.lock() else {
+            return;
+        };
+        let Some(open) = open.as_ref().filter(|open| open.generation == generation) else {
+            return;
+        };
+        ::tracing::info!(
+            event = "popover_open_timing",
+            phase = "build_started",
+            generation,
+            prewarmed = open.prewarmed,
+            renderer_state = open.renderer_state,
+            elapsed_ms = now.saturating_duration_since(open.requested_at).as_millis() as u64
+        );
+    }
+
+    pub(super) fn renderer_ready(&self, generation: u64, now: Instant) {
+        if let Ok(mut milestones) = self.milestones.lock()
+            && milestones.generation == generation
+        {
+            milestones.renderer_ready_at = Some(now);
+        }
+        let Ok(mut open) = self.open.lock() else {
+            return;
+        };
+        let Some(open) = open.as_mut() else {
+            return;
+        };
+        let prewarmed = open.prewarmed;
+        let renderer_state = open.renderer_state;
+        let Some(elapsed) = open.mark_renderer_ready(generation, now) else {
+            return;
+        };
+        ::tracing::info!(
+            event = "popover_open_timing",
+            phase = "renderer_ready",
+            generation,
+            prewarmed,
+            renderer_state,
+            elapsed_ms = elapsed.as_millis() as u64
+        );
+    }
+
+    pub(super) fn revealed(&self, generation: u64, now: Instant) {
+        let Ok(mut open) = self.open.lock() else {
+            return;
+        };
+        let Some(open) = open.as_mut() else {
+            return;
+        };
+        let prewarmed = open.prewarmed;
+        let renderer_state = open.renderer_state;
+        let Some(timing) = open.mark_revealed(generation, now) else {
+            return;
+        };
+        ::tracing::info!(
+            event = "popover_open_timing",
+            phase = "revealed",
+            generation,
+            prewarmed,
+            renderer_state,
+            elapsed_ms = timing.request_to_reveal.as_millis() as u64,
+            phase_ms = timing.ready_to_reveal.as_millis() as u64,
+            renderer_ready_before_request = timing.renderer_ready_before_request
+        );
+        if timing.content_before_reveal && open.take_content_ready_at_reveal() {
+            ::tracing::info!(
+                event = "popover_open_timing",
+                phase = "content_ready",
+                generation,
+                prewarmed,
+                renderer_state,
+                elapsed_ms = timing.request_to_reveal.as_millis() as u64,
+                phase_ms = 0_u64,
+                content_before_reveal = true
+            );
+        }
+    }
+
+    pub(super) fn content_ready(&self, generation: u64, now: Instant) {
+        if let Ok(mut milestones) = self.milestones.lock()
+            && milestones.generation == generation
+        {
+            milestones.content_ready_at = Some(now);
+        }
+        let Ok(mut open) = self.open.lock() else {
+            return;
+        };
+        let Some(open) = open.as_mut() else {
+            return;
+        };
+        let prewarmed = open.prewarmed;
+        let renderer_state = open.renderer_state;
+        let Some((elapsed, reveal_to_content)) = open.mark_content_ready(generation, now) else {
+            return;
+        };
+        ::tracing::info!(
+            event = "popover_open_timing",
+            phase = "content_ready",
+            generation,
+            prewarmed,
+            renderer_state,
+            elapsed_ms = elapsed.as_millis() as u64,
+            phase_ms = reveal_to_content.as_millis() as u64,
+            content_before_reveal = false
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_cold_open_reports_each_boundary_once_for_its_generation() {
+        let requested_at = Instant::now();
+        let mut timing = OpenTiming::new(
+            7,
+            requested_at,
+            false,
+            "build",
+            RendererMilestones::default(),
+        );
+
+        assert_eq!(
+            timing.mark_renderer_ready(7, requested_at + Duration::from_millis(900)),
+            Some(Duration::from_millis(900))
+        );
+        assert_eq!(
+            timing.mark_renderer_ready(7, requested_at + Duration::from_secs(1)),
+            None
+        );
+        assert_eq!(
+            timing.mark_revealed(7, requested_at + Duration::from_millis(920)),
+            Some(RevealTiming {
+                request_to_reveal: Duration::from_millis(920),
+                ready_to_reveal: Duration::from_millis(20),
+                renderer_ready_before_request: false,
+                content_before_reveal: false,
+            })
+        );
+        assert_eq!(
+            timing.mark_content_ready(7, requested_at + Duration::from_millis(980)),
+            Some((Duration::from_millis(980), Duration::from_millis(60)))
+        );
+        assert_eq!(
+            timing.mark_content_ready(7, requested_at + Duration::from_secs(2)),
+            None
+        );
+    }
+
+    #[test]
+    fn a_prewarmed_generation_keeps_its_actual_hidden_milestones() {
+        let build_started_at = Instant::now();
+        let requested_at = build_started_at + Duration::from_millis(900);
+        let milestones = RendererMilestones {
+            generation: 7,
+            renderer_ready_at: Some(build_started_at + Duration::from_millis(700)),
+            content_ready_at: Some(build_started_at + Duration::from_millis(800)),
+        };
+        let mut timing = OpenTiming::new(7, requested_at, true, "ready", milestones);
+
+        assert_eq!(
+            timing.mark_revealed(7, requested_at + Duration::from_millis(20)),
+            Some(RevealTiming {
+                request_to_reveal: Duration::from_millis(20),
+                ready_to_reveal: Duration::from_millis(220),
+                renderer_ready_before_request: true,
+                content_before_reveal: true,
+            })
+        );
+        assert!(timing.take_content_ready_at_reveal());
+        assert!(!timing.take_content_ready_at_reveal());
+    }
+
+    #[test]
+    fn a_stale_generation_cannot_complete_the_active_open_timing() {
+        let requested_at = Instant::now();
+        let mut timing = OpenTiming::new(
+            8,
+            requested_at,
+            false,
+            "build",
+            RendererMilestones::default(),
+        );
+
+        assert_eq!(
+            timing.mark_renderer_ready(7, requested_at + Duration::from_millis(50)),
+            None
+        );
+        assert_eq!(
+            timing.mark_content_ready(7, requested_at + Duration::from_millis(60)),
+            None
+        );
+        assert_eq!(
+            timing.mark_revealed(7, requested_at + Duration::from_millis(70)),
+            None
+        );
+    }
+
+    #[test]
+    fn an_expired_replacement_keeps_the_original_click_boundary() {
+        let requested_at = Instant::now();
+        let timing = PopoverTiming::default();
+        timing.begin_open(7, requested_at, true, "loading");
+
+        assert!(timing.replace_open_generation(7, 8));
+        let open = timing.open.lock().expect("the timing lock stays available");
+        let open = open.as_ref().expect("the click remains active");
+        assert_eq!(open.generation, 8);
+        assert_eq!(open.requested_at, requested_at);
+        assert!(!open.prewarmed);
+        assert_eq!(open.renderer_state, "expired_replacement");
+    }
+}

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -2,8 +2,8 @@
 //!
 //! Unlike the popover this is an ordinary window with real decorations: a
 //! place to read and change configuration, not a transient surface. It is
-//! fixed at 960×680 and prewarmed after launch. Closing it hides the resident
-//! webview, so the next request can show the same ready renderer.
+//! fixed at 960×680 and created on demand. Closing it destroys its webview, so
+//! the next request starts a new renderer from persisted settings.
 //!
 //! On macOS the title bar is an overlay: decorations (traffic lights, system
 //! shadow, real close semantics) are kept, the bar itself is transparent, and
@@ -18,9 +18,7 @@ use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 use crate::window_lifecycle::{self, ManagedWindowReadiness};
 use crate::window_placement::center_on_active_monitor;
-use crate::window_readiness::{
-    OpenAction, PrewarmAction, WindowReadiness, renderer_generation_script,
-};
+use crate::window_readiness::{OpenAction, WindowReadiness, renderer_generation_script};
 
 /// Window label. Also listed in `capabilities/default.json`.
 pub const LABEL: &str = "settings";
@@ -76,32 +74,6 @@ const URL: &str = "settings.html";
 // designed for exactly this rectangle.
 const WIDTH: f64 = 960.0;
 const HEIGHT: f64 = 680.0;
-
-/// Schedule one hidden Settings load after launch or onboarding.
-pub fn schedule_prewarm(app: &AppHandle) {
-    let app = app.clone();
-    let prewarm_app = app.clone();
-    if let Err(error) = app.run_on_main_thread(move || prewarm(&prewarm_app)) {
-        ::tracing::warn!(event = "settings_prewarm_schedule_failed", error = %error);
-    }
-}
-
-fn prewarm(app: &AppHandle) {
-    if crate::onboarding::is_pending(app) {
-        return;
-    }
-    let state = app.state::<SettingsWindowState>();
-    let action = {
-        let mut readiness = state.readiness();
-        readiness.request_prewarm(Instant::now())
-    };
-    let PrewarmAction::StartLoading { generation } = action else {
-        return;
-    };
-    if let Err(error) = build(app, generation) {
-        ::tracing::warn!(event = "settings_prewarm_failed", error = %error);
-    }
-}
 
 /// Shows the settings window, creating it if this is the first request.
 ///
@@ -165,6 +137,8 @@ fn pane_event_reaches_renderer(action: OpenAction) -> bool {
 
 /// Build a deferred replacement after Tauri removes the old window label.
 pub fn rebuild_after_destroy(app: &AppHandle) {
+    let insights = app.try_state::<crate::insights_ipc::InsightsController>();
+    cancel_insights(insights.as_deref());
     let generation =
         window_lifecycle::begin_deferred_build::<SettingsWindowState>(app, Instant::now());
     let Some(generation) = generation else {
@@ -172,6 +146,12 @@ pub fn rebuild_after_destroy(app: &AppHandle) {
     };
     if let Err(error) = build(app, generation) {
         ::tracing::error!(event = "window_rebuild_failed", window = LABEL, error = %error);
+    }
+}
+
+fn cancel_insights(insights: Option<&crate::insights_ipc::InsightsController>) {
+    if let Some(insights) = insights {
+        insights.cancel();
     }
 }
 
@@ -247,14 +227,6 @@ fn show(window: &tauri::WebviewWindow) -> tauri::Result<()> {
     Ok(())
 }
 
-/// Hide Settings after it starts work in another window.
-pub fn hide(app: &AppHandle) -> tauri::Result<()> {
-    if let Some(window) = app.get_webview_window(LABEL) {
-        window.hide()?;
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn pane_requests_reach_ready_and_prewarming_renderers() {
+    fn pane_requests_reach_ready_and_loading_renderers() {
         assert!(pane_event_reaches_renderer(OpenAction::Reveal));
         assert!(pane_event_reaches_renderer(OpenAction::AwaitReady));
         assert!(!pane_event_reaches_renderer(OpenAction::StartLoading {
@@ -296,5 +268,14 @@ mod tests {
         // inherit the last banner's destination.
         pending.set(None);
         assert_eq!(pending.take(), None);
+    }
+
+    #[test]
+    fn destroying_settings_requests_native_insights_cancellation() {
+        let insights = crate::insights_ipc::InsightsController::default();
+
+        cancel_insights(Some(&insights));
+
+        assert_eq!(insights.cancel_requests(), 1);
     }
 }

--- a/apps/desktop/src-tauri/src/window_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/window_lifecycle.rs
@@ -13,7 +13,7 @@ pub(crate) trait ManagedWindowReadiness {
     fn readiness(&self) -> MutexGuard<'_, WindowReadiness>;
 }
 
-/// Take the deferred generation after Tauri removes the old window label.
+/// Reset the lifecycle or take its deferred generation after the window ends.
 pub(crate) fn begin_deferred_build<S>(app: &AppHandle, now: Instant) -> Option<u64>
 where
     S: ManagedWindowReadiness + Send + Sync + 'static,

--- a/apps/desktop/src-tauri/src/window_readiness.rs
+++ b/apps/desktop/src-tauri/src/window_readiness.rs
@@ -25,17 +25,6 @@ pub enum OpenAction {
     Rebuild { generation: u64 },
 }
 
-/// The action for a request that warms a hidden renderer.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PrewarmAction {
-    /// Build the first renderer without a pending reveal.
-    StartLoading { generation: u64 },
-    /// Keep the active renderer load and its reveal intent unchanged.
-    AwaitReady,
-    /// Keep the ready resident renderer unchanged.
-    AlreadyReady,
-}
-
 /// The action for a request that toggles a window.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ToggleAction {
@@ -49,6 +38,15 @@ pub enum ToggleAction {
     UseWindowVisibility,
     /// Replace the stale renderer once for this load cycle.
     Rebuild { generation: u64 },
+}
+
+/// The action for a request that warms a hidden window.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrewarmAction {
+    /// Build the first renderer without a pending reveal.
+    StartLoading { generation: u64 },
+    /// Keep the renderer or load that already exists.
+    KeepExisting,
 }
 
 /// The action to take after the renderer reports readiness.
@@ -87,15 +85,14 @@ pub struct WindowReadiness {
 }
 
 impl WindowReadiness {
-    /// Request a hidden renderer without changing an active reveal request.
+    /// Request a hidden renderer without changing an existing reveal request.
     pub fn request_prewarm(&mut self, now: Instant) -> PrewarmAction {
         match &self.phase {
             Phase::Idle => {
                 let generation = self.replace_loading(now, false, false);
                 PrewarmAction::StartLoading { generation }
             }
-            Phase::Loading(_) => PrewarmAction::AwaitReady,
-            Phase::Ready => PrewarmAction::AlreadyReady,
+            Phase::Loading(_) | Phase::Ready => PrewarmAction::KeepExisting,
         }
     }
 
@@ -151,6 +148,17 @@ impl WindowReadiness {
         std::mem::take(&mut load.reveal_pending)
     }
 
+    /// Replace an expired load and keep its pending reveal request.
+    pub fn replace_expired_loading(&mut self, generation: u64, now: Instant) -> Option<u64> {
+        let Phase::Loading(load) = &self.phase else {
+            return None;
+        };
+        if load.generation != generation || !load.reveal_pending {
+            return None;
+        }
+        Some(self.replace_loading(now, true, true))
+    }
+
     /// Defer the matching renderer build until Tauri removes the old window.
     pub fn defer_build_until_destroyed(&mut self, generation: u64) -> bool {
         let Phase::Loading(load) = &mut self.phase else {
@@ -163,16 +171,16 @@ impl WindowReadiness {
         true
     }
 
-    /// Start one deferred build after Tauri reports that the old window ended.
+    /// Reset after normal destruction or start one deferred replacement.
     pub fn begin_deferred_build(&mut self, now: Instant) -> Option<u64> {
-        let Phase::Loading(load) = &mut self.phase else {
-            return None;
-        };
-        if !std::mem::take(&mut load.build_after_destroy) {
-            return None;
+        if let Phase::Loading(load) = &mut self.phase
+            && std::mem::take(&mut load.build_after_destroy)
+        {
+            load.started_at = now;
+            return Some(load.generation);
         }
-        load.started_at = now;
-        Some(load.generation)
+        self.reset();
+        None
     }
 
     /// Mark the matching renderer ready and return its one reveal action.
@@ -263,6 +271,99 @@ mod tests {
             OpenAction::StartLoading { generation } => generation,
             _ => panic!("an idle lifecycle must start loading"),
         }
+    }
+
+    #[test]
+    fn a_prewarmed_renderer_stays_hidden_when_it_becomes_ready() {
+        let started_at = Instant::now();
+        let mut readiness = WindowReadiness::default();
+
+        let PrewarmAction::StartLoading { generation } = readiness.request_prewarm(started_at)
+        else {
+            panic!("an idle lifecycle must start the prewarm load")
+        };
+
+        assert_eq!(
+            readiness.renderer_ready(generation, started_at + Duration::from_secs(1)),
+            ReadyAction::StayHidden {
+                loading_for: Duration::from_secs(1)
+            }
+        );
+        assert_eq!(
+            readiness.request_prewarm(started_at + Duration::from_secs(2)),
+            PrewarmAction::KeepExisting
+        );
+    }
+
+    #[test]
+    fn a_click_during_prewarm_reveals_the_same_renderer() {
+        let started_at = Instant::now();
+        let mut readiness = WindowReadiness::default();
+
+        let PrewarmAction::StartLoading { generation } = readiness.request_prewarm(started_at)
+        else {
+            panic!("an idle lifecycle must start the prewarm load")
+        };
+
+        assert_eq!(
+            readiness.toggle_open(started_at + Duration::from_millis(250)),
+            ToggleAction::AwaitReady
+        );
+        assert_eq!(
+            readiness.renderer_ready(generation, started_at + Duration::from_secs(1)),
+            ReadyAction::Reveal {
+                loading_for: Duration::from_secs(1)
+            }
+        );
+    }
+
+    #[test]
+    fn an_expired_prewarm_replacement_keeps_the_pending_click() {
+        let started_at = Instant::now();
+        let mut readiness = WindowReadiness::default();
+        let PrewarmAction::StartLoading {
+            generation: _generation,
+        } = readiness.request_prewarm(started_at)
+        else {
+            panic!("an idle lifecycle must start the prewarm load")
+        };
+
+        let pending_generation = match readiness.request_open(started_at + Duration::from_secs(64))
+        {
+            OpenAction::Rebuild { generation } => generation,
+            _ => panic!("the stale prewarm starts its one replacement"),
+        };
+        let replaced_at = started_at + Duration::from_secs(65);
+        let replacement = readiness
+            .replace_expired_loading(pending_generation, replaced_at)
+            .expect("the pending click starts a replacement");
+        assert!(readiness.defer_build_until_destroyed(replacement));
+        assert_eq!(
+            readiness.begin_deferred_build(replaced_at),
+            Some(replacement)
+        );
+        assert!(matches!(
+            readiness.renderer_ready(replacement, replaced_at + Duration::from_secs(1)),
+            ReadyAction::Reveal { .. }
+        ));
+    }
+
+    #[test]
+    fn prewarm_does_not_cancel_an_existing_reveal_request() {
+        let started_at = Instant::now();
+        let mut readiness = WindowReadiness::default();
+        let generation = start_loading(&mut readiness, started_at);
+
+        assert_eq!(
+            readiness.request_prewarm(started_at + Duration::from_millis(250)),
+            PrewarmAction::KeepExisting
+        );
+        assert_eq!(
+            readiness.renderer_ready(generation, started_at + Duration::from_secs(1)),
+            ReadyAction::Reveal {
+                loading_for: Duration::from_secs(1)
+            }
+        );
     }
 
     #[test]
@@ -472,8 +573,29 @@ mod tests {
         );
         assert!(readiness.defer_build_until_destroyed(2));
         assert_eq!(readiness.begin_deferred_build(rebuilt_at), Some(2));
-        assert_eq!(readiness.begin_deferred_build(rebuilt_at), None);
         assert_eq!(readiness.loading_generation(), Some(2));
+    }
+
+    #[test]
+    fn destroying_a_ready_renderer_starts_the_next_open_from_idle() {
+        let started_at = Instant::now();
+        let mut readiness = WindowReadiness::default();
+        let generation = start_loading(&mut readiness, started_at);
+        assert_eq!(
+            readiness.renderer_ready(generation, started_at + Duration::from_secs(1)),
+            ReadyAction::Reveal {
+                loading_for: Duration::from_secs(1)
+            }
+        );
+
+        assert_eq!(
+            readiness.begin_deferred_build(started_at + Duration::from_secs(2)),
+            None
+        );
+        assert_eq!(
+            readiness.request_open(started_at + Duration::from_secs(3)),
+            OpenAction::StartLoading { generation: 2 }
+        );
     }
 
     #[test]
@@ -488,70 +610,6 @@ mod tests {
             readiness.renderer_ready(generation, started_at + Duration::from_secs(1)),
             ReadyAction::StayHidden {
                 loading_for: Duration::from_secs(1)
-            }
-        );
-    }
-
-    #[test]
-    fn prewarming_starts_one_hidden_renderer_load() {
-        let started_at = Instant::now();
-        let mut readiness = WindowReadiness::default();
-
-        assert_eq!(
-            readiness.request_prewarm(started_at),
-            PrewarmAction::StartLoading { generation: 1 }
-        );
-        assert_eq!(
-            readiness.request_prewarm(started_at + Duration::from_millis(10)),
-            PrewarmAction::AwaitReady
-        );
-        assert_eq!(
-            readiness.renderer_ready(1, started_at + Duration::from_millis(50)),
-            ReadyAction::StayHidden {
-                loading_for: Duration::from_millis(50)
-            }
-        );
-        assert_eq!(
-            readiness.request_prewarm(started_at + Duration::from_secs(1)),
-            PrewarmAction::AlreadyReady
-        );
-    }
-
-    #[test]
-    fn an_open_during_prewarm_reuses_and_reveals_the_hidden_load() {
-        let started_at = Instant::now();
-        let mut readiness = WindowReadiness::default();
-
-        assert_eq!(
-            readiness.request_prewarm(started_at),
-            PrewarmAction::StartLoading { generation: 1 }
-        );
-        assert_eq!(
-            readiness.request_open(started_at + Duration::from_millis(10)),
-            OpenAction::AwaitReady
-        );
-        assert_eq!(
-            readiness.renderer_ready(1, started_at + Duration::from_millis(50)),
-            ReadyAction::Reveal {
-                loading_for: Duration::from_millis(50)
-            }
-        );
-    }
-
-    #[test]
-    fn prewarming_does_not_cancel_an_open_that_is_already_loading() {
-        let started_at = Instant::now();
-        let mut readiness = WindowReadiness::default();
-        let generation = start_loading(&mut readiness, started_at);
-
-        assert_eq!(
-            readiness.request_prewarm(started_at + Duration::from_millis(10)),
-            PrewarmAction::AwaitReady
-        );
-        assert_eq!(
-            readiness.renderer_ready(generation, started_at + Duration::from_millis(50)),
-            ReadyAction::Reveal {
-                loading_for: Duration::from_millis(50)
             }
         );
     }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -674,6 +674,12 @@ export async function windowReady(generation: number): Promise<void> {
   await invoke("window_ready", { generation })
 }
 
+/** Tell the shell that the popover's initial activity and usage state settled. */
+export async function popoverContentReady(generation: number): Promise<void> {
+  if (!hasShell()) return
+  await invoke("popover_content_ready", { generation })
+}
+
 /**
  * Version stamp of the engine's bundled pricing catalog.
  *
@@ -689,8 +695,8 @@ export async function engineCatalogVersion(): Promise<string | null> {
  * Opens (or refocuses) the standalone settings window.
  *
  * `pane` is a request for a section — an attention banner uses it to land a
- * reader on the pane that can fix what they were told about. Omitting it leaves
- * the window wherever it was.
+ * reader on the pane that can fix what they were told about. Omitting it keeps
+ * an open window on its current pane or opens a new window on General.
  */
 export async function openSettingsWindow(pane?: SettingsPane): Promise<void> {
   if (!hasShell()) return
@@ -711,9 +717,8 @@ export async function takeSettingsPane(): Promise<string | null> {
 /**
  * Asks the shell to close whichever window is calling (⌘W).
  *
- * A close *request*, not a destroy: the shell intercepts `CloseRequested` for
- * every window and hides instead (see `src-tauri/src/lib.rs`), so this takes
- * exactly the same path as the title-bar close button. Needs
+ * This takes the same path as the title-bar close button. The shell applies
+ * each window's close policy; Settings closes and releases its renderer. Needs
  * `core:window:allow-close` in `capabilities/default.json` — the ACL's
  * `core:window:default` set is read-only.
  *

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -257,7 +257,107 @@ describe("PopoverView", () => {
     saveDialog.mockReset()
     openDialog.mockReset()
     listeners.clear()
+    Reflect.deleteProperty(window, "__ANTIBURN_WINDOW_GENERATION__")
     mockCommands()
+  })
+
+  it("reports content readiness after activity and cached usage settle", async () => {
+    let resolveEntries: ((entries: unknown[]) => void) | null = null
+    let resolveUsage: ((usage: unknown) => void) | null = null
+    const entries = new Promise<unknown[]>((resolve) => {
+      resolveEntries = resolve
+    })
+    const usage = new Promise<unknown>((resolve) => {
+      resolveUsage = resolve
+    })
+    Object.defineProperty(window, "__ANTIBURN_WINDOW_GENERATION__", {
+      configurable: true,
+      value: 7,
+    })
+    mockCommands({ list_recent_sessions: entries, get_provider_usage: usage })
+
+    render(<PopoverView />)
+
+    await act(async () => {
+      resolveEntries?.([])
+      await Promise.resolve()
+    })
+    expect(invoke).not.toHaveBeenCalledWith("popover_content_ready", { generation: 7 })
+
+    await act(async () => {
+      resolveUsage?.(PROVIDER_USAGE)
+      await Promise.resolve()
+    })
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("popover_content_ready", { generation: 7 }),
+    )
+    expect(
+      invoke.mock.calls.filter(([command]) => command === "popover_content_ready"),
+    ).toHaveLength(1)
+
+    emit("popover:shown", undefined)
+    await act(async () => Promise.resolve())
+    expect(
+      invoke.mock.calls.filter(([command]) => command === "popover_content_ready"),
+    ).toHaveLength(1)
+  })
+
+  it("retries a failed hidden content report when the popover appears", async () => {
+    Object.defineProperty(window, "__ANTIBURN_WINDOW_GENERATION__", {
+      configurable: true,
+      value: 7,
+    })
+    const baseInvoke = invoke.getMockImplementation()
+    let contentReadyCalls = 0
+    invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "popover_content_ready") {
+        contentReadyCalls += 1
+        return contentReadyCalls === 1
+          ? Promise.reject(new Error("renderer not available"))
+          : Promise.resolve(null)
+      }
+      return baseInvoke?.(command, args)
+    })
+
+    render(<PopoverView />)
+    await waitFor(() => expect(contentReadyCalls).toBe(1))
+    await act(async () => Promise.resolve())
+
+    emit("popover:shown", undefined)
+    await waitFor(() => expect(contentReadyCalls).toBe(2))
+  })
+
+  it("retries once when reveal arrives during a report that later fails", async () => {
+    Object.defineProperty(window, "__ANTIBURN_WINDOW_GENERATION__", {
+      configurable: true,
+      value: 7,
+    })
+    const baseInvoke = invoke.getMockImplementation()
+    let rejectFirstReport: ((error: Error) => void) | null = null
+    let contentReadyCalls = 0
+    invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "popover_content_ready") {
+        contentReadyCalls += 1
+        if (contentReadyCalls === 1) {
+          return new Promise((_resolve, reject) => {
+            rejectFirstReport = reject
+          })
+        }
+        return Promise.resolve(null)
+      }
+      return baseInvoke?.(command, args)
+    })
+
+    render(<PopoverView />)
+    await waitFor(() => expect(contentReadyCalls).toBe(1))
+    emit("popover:shown", undefined)
+    expect(contentReadyCalls).toBe(1)
+
+    await act(async () => {
+      rejectFirstReport?.(new Error("renderer not available"))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(contentReadyCalls).toBe(2))
   })
 
   it("lists the sessions the shell reports for the stored window", async () => {

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -160,6 +160,7 @@ describe("SettingsView", () => {
     invoke.mockReset()
     openDialog.mockReset()
     confirmDialog.mockReset()
+    closeWindow.mockReset()
     listeners.clear()
     delete document.documentElement.dataset["theme"]
     mockCommands()
@@ -978,8 +979,13 @@ describe("SettingsView", () => {
     )
   })
 
-  it("restarts onboarding after explaining what the reset keeps", async () => {
+  it("closes Settings only after onboarding restarts successfully", async () => {
+    let finishRestart!: () => void
+    const restart = new Promise<void>((resolve) => {
+      finishRestart = resolve
+    })
     confirmDialog.mockResolvedValue(true)
+    mockCommands({ restart_onboarding: () => restart })
     render(<SettingsView />)
 
     fireEvent.click(await screen.findByRole("button", { name: "Run setup again…" }))
@@ -989,7 +995,11 @@ describe("SettingsView", () => {
     expect(message).toMatch(/indexed sessions and current settings stay/i)
     expect(message).toMatch(/returns the next time/i)
     await waitFor(() => expect(invoke).toHaveBeenCalledWith("restart_onboarding"))
-    expect(screen.getByRole("button", { name: "Run setup again…" })).toBeEnabled()
+    expect(closeWindow).not.toHaveBeenCalled()
+
+    finishRestart()
+
+    await waitFor(() => expect(closeWindow).toHaveBeenCalledTimes(1))
   })
 
   it("keeps onboarding unchanged when the restart is declined", async () => {
@@ -1011,6 +1021,7 @@ describe("SettingsView", () => {
 
     expect(await screen.findByRole("status")).toHaveTextContent(/setup could not open/i)
     expect(screen.getByRole("status")).toHaveTextContent(/try again or restart antiburn/i)
+    expect(closeWindow).not.toHaveBeenCalled()
   })
 })
 
@@ -1053,7 +1064,7 @@ describe("SettingsView — window chrome", () => {
     expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
   })
 
-  it("closes the window on ⌘W, as a request the shell may turn into a hide", async () => {
+  it("closes the window on ⌘W so the shell can destroy it", async () => {
     render(<SettingsView />)
     await screen.findByRole("switch", { name: "Launch antiburn on startup" })
 

--- a/apps/desktop/src/views/SettingsView.tsx
+++ b/apps/desktop/src/views/SettingsView.tsx
@@ -75,8 +75,8 @@ export function SettingsView() {
 
   // ⌘W closes the window. The shell runs as an accessory app with no
   // application menu, so the standard shortcut has no owner unless it is
-  // handled here. Routed through a close *request* (which the shell turns into
-  // a hide), so this takes the same path as the title-bar button.
+  // handled here. The close request takes the same path as the title-bar
+  // button, and the shell releases this renderer.
   // Esc must NOT close: dismiss-on-Escape is modal behavior and a settings
   // window is not a modal. Do not "fix" this by adding Escape.
   useGlobalKeydown(true, (event) => {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -26,6 +26,7 @@ import {
   onSettingsChanged,
   onStorageHealth,
   openSettingsWindow,
+  popoverContentReady,
   refreshLiveUsage,
   scanNow,
   setPopoverHeight,
@@ -213,6 +214,10 @@ export class PopoverSession {
   /** How many `refreshAnalysis` calls are in flight; see `usageRefreshCount`. */
   private analysisRefreshCount = 0
   private liveUsageRevision = 0
+  private initialContentReady = false
+  private contentReadyReportedGeneration: number | null = null
+  private contentReadyReportInFlightGeneration: number | null = null
+  private contentReadyRetryGeneration: number | null = null
 
   /**
    * The key of the subject the poll's fingerprint belongs to, and the last
@@ -341,6 +346,7 @@ export class PopoverSession {
   private start(): void {
     this.started = true
     const generation = ++this.generation
+    this.initialContentReady = false
 
     void this.loadInitial(generation)
     void this.listenSettings(generation)
@@ -426,6 +432,8 @@ export class PopoverSession {
       usage,
     ])
     if (generation !== this.generation) return
+    this.initialContentReady = true
+    this.reportContentReady()
     void this.refreshUsage()
   }
 
@@ -551,6 +559,7 @@ export class PopoverSession {
   private listenPopoverShown = async (generation: number): Promise<void> => {
     const unlisten = await onPopoverShown(() => {
       if (generation !== this.generation) return
+      if (this.initialContentReady) this.reportContentReady(true)
       void this.restoreFloatingHud(generation)
       void this.refreshUsage()
       void this.refreshAnalysis()
@@ -561,6 +570,35 @@ export class PopoverSession {
     }
     this.stopPopoverShownListening = unlisten
     void this.restoreFloatingHud(generation)
+  }
+
+  private reportContentReady(retryAfterPendingFailure = false): void {
+    const rendererGeneration = window.__ANTIBURN_WINDOW_GENERATION__
+    if (typeof rendererGeneration !== "number" || !Number.isSafeInteger(rendererGeneration))
+      return
+    if (this.contentReadyReportedGeneration === rendererGeneration) return
+    if (this.contentReadyReportInFlightGeneration === rendererGeneration) {
+      if (retryAfterPendingFailure) this.contentReadyRetryGeneration = rendererGeneration
+      return
+    }
+    this.contentReadyReportInFlightGeneration = rendererGeneration
+    void popoverContentReady(rendererGeneration)
+      .then(() => {
+        this.contentReadyReportedGeneration = rendererGeneration
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.contentReadyReportInFlightGeneration === rendererGeneration) {
+          this.contentReadyReportInFlightGeneration = null
+        }
+        const retry =
+          this.contentReadyRetryGeneration === rendererGeneration &&
+          this.contentReadyReportedGeneration !== rendererGeneration
+        if (this.contentReadyRetryGeneration === rendererGeneration) {
+          this.contentReadyRetryGeneration = null
+        }
+        if (retry) this.reportContentReady()
+      })
   }
 
   private restoreFloatingHud = async (generation: number): Promise<void> => {

--- a/apps/desktop/src/views/settings/GeneralPane.tsx
+++ b/apps/desktop/src/views/settings/GeneralPane.tsx
@@ -11,6 +11,7 @@ import { StatusText } from "../../components/ui/StatusText"
 import { ToggleRow } from "../../components/ui/ToggleRow"
 import {
   cancelScan,
+  closeCurrentWindow,
   restartOnboarding,
   scanNow,
   type AppInfo,
@@ -96,6 +97,7 @@ export function GeneralPane({ settings, update, info }: GeneralPaneProps) {
 
       setRestartingSetup(true)
       await restartOnboarding()
+      await closeCurrentWindow()
     } catch {
       setRestartFailed(true)
     } finally {

--- a/apps/desktop/src/views/settings/InsightsSession.test.ts
+++ b/apps/desktop/src/views/settings/InsightsSession.test.ts
@@ -256,8 +256,7 @@ describe("InsightsSession", () => {
     await flush()
     expect(invoke).not.toHaveBeenCalledWith("cancel_insights_report")
 
-    // The shell hides the settings window on close; the pane stays
-    // mounted, so the session must pause on visibility alone.
+    // A system visibility change can pause work before the renderer unmounts.
     setWindowVisibility("hidden")
     expect(invoke).toHaveBeenCalledWith("cancel_insights_report")
 

--- a/apps/desktop/src/views/settings/InsightsSession.ts
+++ b/apps/desktop/src/views/settings/InsightsSession.ts
@@ -33,10 +33,8 @@ const STATUS_POLL_MS = 5_000
  * reduction still in flight, so closing the pane never leaves the shell
  * computing for nobody.
  *
- * The shell hides the settings window on close instead of destroying it,
- * so a close does not unmount the pane. The session therefore also pauses
- * on `visibilitychange`: a hidden window stops the status poll and cancels
- * report work, and a shown window starts both again (FR-16).
+ * Unmounting stops the status poll and cancels report work. The session also
+ * pauses on `visibilitychange` when the operating system hides the window.
  */
 export class InsightsSession {
   private listeners = new Set<() => void>()

--- a/docs/window-renderer-lifecycle.md
+++ b/docs/window-renderer-lifecycle.md
@@ -1,0 +1,264 @@
+# Desktop window renderer lifecycle
+
+_Contributor reference for when desktop webview renderers are created, reused,
+hidden, and destroyed._
+
+The desktop shell stays resident because antiburn is a menu-bar application.
+Its webview renderers do not need the same lifetime. The shell keeps a renderer
+only while it is visible, is likely to be used again soon, or is completing a
+bounded handoff.
+
+This document covers the popover, onboarding, and Settings renderers. The HUD
+and nudge windows have separate ownership rules. See [HUD states](hud-states.md)
+for the HUD and its detail window.
+
+## The shared lifecycle
+
+`WindowReadiness` in
+[`window_readiness.rs`](../apps/desktop/src-tauri/src/window_readiness.rs)
+owns the common state machine:
+
+```text
+Idle --request--> Loading --matching readiness--> Ready
+ ^                    |                              |
+ |                    +--failed or destroyed--------+
+ +------------------------destroyed-----------------+
+```
+
+A native build receives a monotonically increasing renderer generation. The
+shell injects that generation before the page loads. After React commits the
+window shell, `WindowReadyBoundary` reports the generation through
+`window_ready`. The native window appears only when the report matches the
+active generation and a reveal is pending.
+
+This handshake gives the lifecycle these properties:
+
+- A hidden window never appears before React has committed its shell.
+- Repeated open requests share one active load instead of creating renderers.
+- A click during a hidden prewarm changes the same load to reveal on readiness.
+- A readiness report from a destroyed or replaced renderer has no effect.
+- An open request can replace one stale load per load cycle. It does not create
+  an unbounded retry loop.
+
+The shared Tauri adapters in
+[`window_lifecycle.rs`](../apps/desktop/src-tauri/src/window_lifecycle.rs) record
+load timing, warn about the current stale generation, and reset failed loads.
+The popover, Settings, and onboarding modules own their window-specific reveal
+and destruction policies.
+
+## Onboarding handoff and popover prewarm
+
+Completing onboarding performs a deliberate handoff from the first-run window
+to the menu-bar surface:
+
+1. The shell hides onboarding immediately, changes macOS to accessory mode,
+   and shows the menu-bar-location notification.
+2. On the next main-loop turn, the shell requests one hidden popover renderer.
+   This moves renderer startup out of the first menu-bar click.
+3. It waits one second before destroying onboarding. This lets the final
+   settings IPC response leave the renderer that sent it.
+4. The popover remains hidden after it reports readiness. Readiness starts a
+   one-minute handoff lease instead of revealing it.
+
+`prewarm` is a handoff optimization, not a permanent resident window. It does
+nothing while onboarding is pending, when a popover window already exists, or
+when a popover load is already active. Its lease ends on the first reveal,
+onboarding restart, application shutdown, or the one-minute timeout.
+If readiness never arrives, a 65-second loading fail-safe destroys the hidden
+renderer instead of leaving an unbounded WebContent process.
+Clicks, cancellations, Pin, and stale replacement do not restart either
+deadline. A replacement generation inherits the original absolute deadline.
+
+### First click after onboarding
+
+The first tray click reuses the prewarmed generation when it is ready or still
+loading within the stale threshold:
+
+- If the renderer is ready, the shell cancels eviction, places the existing
+  window, and reveals it.
+- If the renderer is still loading, the shell records a pending reveal. The
+  matching readiness report reveals that same renderer when React commits.
+
+If the loading prewarm has crossed the five-second stale threshold, the click
+requests the lifecycle's one permitted replacement for that load cycle. The
+shell destroys the old window and defers the replacement build until Tauri
+releases the old window label. The replacement carries the pending reveal, so
+no two renderers load in parallel.
+
+A second toggle while the active renderer still loads cancels the pending
+reveal. An onboarding prewarm keeps its remaining absolute lease; other loads
+use the normal grace period.
+
+Restarting onboarding cancels and destroys a renderer that still belongs only
+to the onboarding prewarm. This prevents a hidden post-onboarding surface from
+surviving when onboarding becomes the active application surface again.
+
+## Popover idle eviction
+
+Hiding is useful for a quick reopen, but it is not a long-term ownership model.
+The popover keeps a hidden renderer for 15 seconds after:
+
+- an ordinary dismissal, including focus loss, Escape, or a tray toggle; or
+- cancellation of a non-prewarm reveal while the renderer is still loading.
+
+The onboarding prewarm instead keeps its renderer for 60 seconds after
+readiness. Cancelling a pending reveal does not extend or replace that absolute
+deadline. The first reveal consumes the one-shot lease. A later dismissal uses
+the normal 15-second grace period.
+
+At the end of the grace period, the shell destroys the renderer only when all
+of these conditions still hold:
+
+- the eviction request is the current request;
+- it still names the current renderer generation;
+- the window is hidden; and
+- for the normal 15-second grace period, the popover is not pinned.
+
+An unrevealed onboarding prewarm expires at its absolute deadline even when
+Pin is enabled. Pin protects a renderer only after the first successful reveal.
+
+An open request cancels the eviction before it places or reveals the window.
+Starting a newer grace period also invalidates the older timer. A stale timer
+therefore cannot destroy a reopened or replaced renderer.
+
+Pinned popovers are exempt because pinning is an explicit request to keep the
+surface available. Unpinning a hidden popover starts the normal grace period.
+After eviction, the next open starts from `Idle` and creates a fresh renderer
+from native and persisted state.
+
+## Settings teardown
+
+Settings is created on demand and destroyed on close. It does not use a grace
+period because closing an ordinary settings window is an explicit end to that
+interaction, while every control has already written through to persisted
+settings.
+
+The title-bar close button and Command-W use the same native close path. The
+global close policy allows Settings to close, and the `Destroyed` event resets
+its readiness state. A later request creates a new renderer and restores its
+state from persisted settings and the native services each pane reads.
+
+If an open request finds a Settings renderer that has remained loading beyond
+the stale threshold, the lifecycle destroys it and defers one replacement
+until Tauri releases the old window label. Pane requests made during an active
+load are delivered to that renderer; a newly built renderer takes its pending
+pane once when it mounts.
+
+## Insights cancellation at the Settings boundary
+
+The Insights pane can run a native report reduction. Renderer teardown must
+not leave that work running for a reader who has closed the pane or Settings.
+Cancellation is enforced at two boundaries:
+
+- `InsightsSession` cancels when its last subscriber leaves and when the
+  document becomes hidden. It also stops its five-second status poll.
+- The Settings `Destroyed` handler calls the native `InsightsController`
+  directly. This covers native window destruction even when frontend cleanup
+  cannot complete.
+
+The native controller sets a cooperative cancellation flag. The read-only
+reduction stops at its next cancellation probe, so cancellation cannot corrupt
+stored evidence. Concurrent requests normally share one in-flight reduction.
+A new request does not join a run whose cancellation flag is already set; it
+starts a new reduction instead.
+
+Application shutdown uses the same native cancellation signal.
+
+## Lifecycle timing
+
+| Timing     | Purpose                                                                                              | Start point                      |
+| ---------- | ---------------------------------------------------------------------------------------------------- | -------------------------------- |
+| 1 second   | Let onboarding's final IPC response complete before destroying its renderer                          | Onboarding completion            |
+| 5 seconds  | Mark an active renderer load stale; log a warning and permit one replacement on a later open request | Renderer build start             |
+| 15 seconds | Keep a dismissed popover available for a likely near-term reopen, then make it eligible for eviction | Hidden dismissal                 |
+| 60 seconds | Keep the one post-onboarding handoff renderer available for the first menu-bar click                 | Onboarding prewarm readiness     |
+| 65 seconds | Destroy an onboarding prewarm that never reports renderer readiness                                  | Onboarding prewarm build         |
+| 5 seconds  | Refresh Insights processing status only while the pane has subscribers and remains visible           | Insights session start or resume |
+
+These values serve different purposes. The stale threshold is a recovery
+boundary, not an eviction deadline. Each eviction delay is a reuse window, not
+a guarantee that a renderer will remain alive. A lifecycle reset, onboarding
+restart, application shutdown, or build failure can end it earlier.
+
+## Popover latency evidence
+
+The shell records content-free timing boundaries for each menu-bar open:
+
+- the open request and renderer generation;
+- whether the request uses the onboarding prewarm;
+- a renderer build that starts behind the request;
+- renderer readiness and reveal; and
+- the first settled activity and cached usage state.
+
+The frontend reports content readiness only after both activity and cached
+usage settle. An empty activity list counts as settled. A hidden prewarm can
+reach this point before the first click, so the shell retains the milestone by
+renderer generation and reports zero reveal-to-content time after reveal.
+
+These boundaries decide whether a bootstrap snapshot is justified. Add one
+only when release measurements show a median reveal-to-content interval of at
+least 250 milliseconds. A snapshot must remain memory-only, derived from the
+authoritative stores, bounded in serialized size, and invalidated with one
+revision. It must refresh through the existing command path after reveal. If
+the evidence does not meet the gate, renderer prewarm remains the complete
+optimization.
+
+## Memory guiding principles
+
+Use these principles when adding or changing desktop windows:
+
+1. **Keep the native shell resident, not every renderer.** A hidden webview has
+   a process cost even when it paints nothing.
+2. **Create on demand by default.** Prewarm only at a clear handoff where a
+   near-term interaction is likely and the work has a bounded lifetime.
+3. **Reuse one generation.** Coalesce repeated requests and turn an existing
+   hidden load into a reveal rather than creating parallel renderers.
+4. **Destroy after the interaction ends.** Use a short grace period only when
+   it materially improves the next expected interaction.
+5. **Keep durable state outside renderer lifetime.** A fresh renderer must be
+   able to reconstruct the surface from native state, the local database, and
+   persisted preferences.
+6. **Cancel invisible work at the native boundary.** Frontend cleanup improves
+   responsiveness, but native teardown must remain the final ownership gate.
+7. **Bind delayed work to generations.** A timer or readiness report must prove
+   it still belongs to the active renderer before it can reveal or destroy it.
+8. **Treat visibility as a work gate.** Polling and scans should run only while
+   the visible feature needs them.
+9. **Validate the process tree, not only the main process.** Renderer presence
+   and count are part of the lifecycle contract even when no benchmark is
+   recorded in this document.
+10. **Gate caches on measured latency.** A second representation of native
+    state is justified only when a bounded snapshot improves a visible delay.
+
+## Code map
+
+| Concern                                                          | Source                                                                          |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Shared phases, generations, stale-load policy                    | [`window_readiness.rs`](../apps/desktop/src-tauri/src/window_readiness.rs)      |
+| Tauri readiness, timing, and trace adapters                      | [`window_lifecycle.rs`](../apps/desktop/src-tauri/src/window_lifecycle.rs)      |
+| Popover facade, first-click reuse, and Tauri window effects      | [`popover.rs`](../apps/desktop/src-tauri/src/popover.rs)                        |
+| Popover leases, eviction tokens, and deadline ownership          | [`retention.rs`](../apps/desktop/src-tauri/src/popover/retention.rs)            |
+| Popover latency milestones and structured timing                 | [`timing.rs`](../apps/desktop/src-tauri/src/popover/timing.rs)                  |
+| Onboarding completion and delayed teardown                       | [`onboarding.rs`](../apps/desktop/src-tauri/src/onboarding.rs)                  |
+| Settings creation, destruction, and native Insights cancellation | [`settings.rs`](../apps/desktop/src-tauri/src/settings.rs)                      |
+| Global close and destroyed-window routing                        | [`lib.rs`](../apps/desktop/src-tauri/src/lib.rs)                                |
+| React readiness marker                                           | [`WindowReadyMarker.tsx`](../apps/desktop/src/components/WindowReadyMarker.tsx) |
+| Popover content-ready boundary                                   | [`PopoverSession.ts`](../apps/desktop/src/views/popover/PopoverSession.ts)      |
+| Insights visibility and subscriber ownership                     | [`InsightsSession.ts`](../apps/desktop/src/views/settings/InsightsSession.ts)   |
+| Native Insights cancellation and request sharing                 | [`insights_ipc.rs`](../apps/desktop/src-tauri/src/insights_ipc.rs)              |
+
+## Change checklist
+
+When a window lifecycle changes, verify all of these together:
+
+- opening from `Idle`, `Loading`, and `Ready`;
+- repeated opens and toggles during a load;
+- a stale generation reporting readiness after replacement;
+- close or hide behavior before and after readiness;
+- delayed eviction after reopen, pin, unpin, or renderer replacement;
+- destruction resetting readiness before the next build;
+- cancellation of native work when its final visible owner leaves; and
+- fresh reconstruction without relying on the previous renderer's memory.
+
+Keep timings next to the native or frontend owner that enforces them. Tests
+should assert both the duration and the condition that makes delayed work safe.


### PR DESCRIPTION
## Summary

This PR improves idle memory use by giving the main app window and Settings explicit, bounded renderer lifecycles.

Renderers are created when needed, reused briefly when reopening is likely, and destroyed after defined time limits. A one-time preparation period after onboarding improves the first main-window open without keeping its renderer alive indefinitely.

The change also adds content-free timing events that distinguish renderer creation, window readiness, reveal, and populated-content latency.

## User impact

- The main app window releases its renderer after being dismissed and left unused for 15 seconds.
- Settings releases its renderer when closed and cancels associated native Insights work.
- After onboarding, the app prepares the main window in the background and retains it for up to 60 seconds.
- A menu-bar click during preparation reuses the renderer already being created.
- A prepared main window opened in a median of 2 ms in release testing, compared with 159 ms for a fully cold open.
- Idle memory returned below the established 110 MiB envelope after each tested lifecycle cycle.

## Main app window lifecycle

```mermaid
stateDiagram-v2
  direction LR

  state "No renderer" as Idle
  state "Renderer starting" as Starting
  state "Prepared and hidden" as Prepared
  state "Main app window visible" as Visible

  [*] --> Idle

  Idle --> Starting: Open window or finish onboarding
  Starting --> Visible: Open requested
  Starting --> Prepared: Prepared in background
  Starting --> Idle: 65-second fail-safe

  Prepared --> Visible: First menu-bar click
  Prepared --> Idle: Unused for 60 seconds

  Visible --> Idle: Dismissed, then 15-second grace

  note right of Starting
    A click while starting reuses
    the same renderer.
  end note

  note right of Visible
    Reopening during the grace
    period reuses the renderer.
  end note
```

Restarting onboarding or shutting down the application cancels an unused prepared renderer.

Settings follows a separate, simpler lifecycle: it is created on demand, and closing it cancels native Insights work before destroying its renderer.

## Validation

### Automated checks

- 592 desktop Rust tests
- 1,131 engine tests and doctests
- 921 frontend tests
- Rust formatting
- Clippy with warnings denied
- Frontend type checking, linting, production build, dependency analysis, and formatting
- Slop analysis: 100 score with zero findings
- Secret scanning
- Diff integrity checks
- Packaged `.app` and DMG builds

### Release results

All measurements used a packaged release build rather than the development server.

| Flow | Runs | Median result | Renderer/process result |
| --- | ---: | ---: | --- |
| Prepared main-window click → reveal | 10 | 2 ms | No new app WebContent process in 10/10 runs |
| Fully cold click → reveal | 10 | 159 ms | Renderer created on demand |
| Fully cold reveal → populated content | 10 | 97 ms | Existing refresh path completed normally |
| Click during background preparation | 1 focused flow | One renderer load | The click reused the in-progress generation |

The 97 ms reveal-to-populated result remained below the 250 ms gate, so this PR does not add a bootstrap snapshot or duplicate frontend state.

### Detailed release measurements

Prepared click-to-reveal samples, sorted:

`2, 2, 2, 2, 2, 2, 2, 2, 3, 8 ms`

Cold click-to-reveal samples, sorted:

`144, 147, 150, 153, 155, 163, 198, 213, 229, 229 ms`

Cold reveal-to-populated samples, sorted:

`83, 84, 86, 87, 96, 98, 101, 115, 119, 193 ms`

### Memory and renderer release

Memory figures represent aggregate memory for the application process family after each flow reached the stated lifecycle point.

| Flow | Observed state | Aggregate memory | App WebContent processes |
| --- | --- | ---: | ---: |
| Onboarding handoff with active preparation and scan work | Temporary active state | 432.7 MiB | 2 |
| Unused prepared renderer after its 60-second lease expired | Settled idle state | 84.5 MiB | 0 |
| Reveal, dismiss, and eviction cycle 1 | Settled idle state | 81.5 MiB | 0 |
| Reveal, dismiss, and eviction cycle 2 | Settled idle state | 84.6 MiB | 0 |
| Reveal, dismiss, and eviction cycle 3 | Settled idle state | 90.3 MiB | 0 |
| Settings open | Temporary active state | 491.9 MiB | Increased from 1 to 2 |
| Settings closed | Renderer released | — | Returned from 2 to 1 |

The three complete main-window cycles remained below the 110 MiB settled-memory envelope and did not accumulate WebContent processes.

### Visible walkthrough

A packaged release build was also exercised manually through:

- onboarding forward and backward navigation;
- native folder-picker open and cancellation;
- repository selection off and on;
- retention-period changes from 14 to 7 and back to 14 days;
- startup setting enabled and disabled;
- onboarding completion and background main-window preparation;
- a real menu-bar pointer click;
- Settings open and close;
- main-window dismissal and renderer eviction after the 15-second grace period.

## Privacy and performance

The new timing events contain durations, lifecycle disposition, renderer generation, and readiness state only. They do not contain activity content, repository names, paths, prompts, transcripts, provider responses, or other user data.

The lifecycle policy intentionally allows temporary memory growth while a window is active or being prepared. That growth is bounded by:

- a 60-second lease for a ready, unused onboarding preparation;
- a 65-second fail-safe while preparation is still loading;
- a 15-second reuse period after normal dismissal;
- immediate Settings teardown when that window closes.

The implementation keeps renderer-retention policy private to the main-window module. Shared window-readiness code remains generic, and onboarding and command handlers cannot inspect or modify retention internals.

## Final assessment

This PR gives the main app window and Settings deterministic renderer ownership and release points, improving settled idle memory without making normal reopen behavior unnecessarily cold.

Release testing showed:

- a 2 ms median reveal for a prepared first click;
- a 159 ms median reveal for a fully cold click;
- reuse of the existing renderer in every prepared-click run;
- removal of an unused prepared renderer after its lease;
- zero app WebContent processes after settled main-window eviction;
- no process or memory accumulation across three complete lifecycle cycles.

The tradeoff is a temporary increase in memory while the main window or Settings is active, or while the post-onboarding preparation lease is running. The explicit 60-second, 65-second, and 15-second limits—and immediate Settings teardown—bound that cost.

## Checklist

- [x] Tests use synthetic data.
- [x] This change does not include credentials, private session content, real transcripts, repository names, or private paths.
- [x] Every commit includes a DCO sign-off.
- [x] Tests and documentation are updated.
