### PR TITLE
refactor(analysis): move the shared record parser out of vendors

### DIFF
--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -39,6 +39,7 @@ mod merge;
 mod metrics_sink;
 mod model;
 mod pricing;
+pub(crate) mod records;
 mod rows;
 mod source_validity;
 pub mod tool_catalog;

--- a/crates/antiburn-local/src/analysis/model.rs
+++ b/crates/antiburn-local/src/analysis/model.rs
@@ -180,7 +180,7 @@ pub struct ToolCall {
     pub category: ToolCategory,
     /// Optional, generic per-call detail. Today this carries the skill name for a
     /// `Skill` tool call (the JSON layer populates it via
-    /// `vendors::jsonl::tool_call_from_input`); `None` for every other tool. Kept
+    /// `analysis::records::tool_call_from_input`); `None` for every other tool. Kept
     /// generic so the "skill" concept never leaks into the core tool model — the
     /// engine reads `detail` only when `name` is a skill.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/antiburn-local/src/analysis/records.rs
+++ b/crates/antiburn-local/src/analysis/records.rs
@@ -7,8 +7,11 @@
 //! `completion_tokens`), and Pi's generic JSONL shape (`toolCall` content blocks
 //! with `arguments`, `toolResult` messages, and `input` / `output` /
 //! `cacheRead` / `cacheWrite` usage keys). Unrecognized records are skipped.
-
-use std::collections::HashSet;
+//!
+//! [`parse_record`] takes an explicit [`RecordShape`] naming the key locations its
+//! caller's records actually use, so a bespoke adapter reads only its own vendor's
+//! layout. [`RecordShape::Generic`] keeps the full historical fallback set for the
+//! vendors without a bespoke adapter (see [`super::vendors::generic_jsonl`]).
 
 use serde_json::Value;
 use time::OffsetDateTime;
@@ -21,28 +24,35 @@ use crate::analysis::model::{
     CompactionTrigger, EventSource, NormalizedEvent, Role, ToolCall, Usage,
 };
 
-/// Parse line-delimited JSON into normalized events, skipping blank/malformed
-/// lines.
-///
-/// Two passes over the transcript: a cheap pre-scan collects the set of skills that
-/// actually ran (their "Base directory for this skill:" markers), then the main pass
-/// builds events and — for any user-typed skill *slash command* (a `<command-name>`
-/// tag, which is **not** a `Skill` tool_use) — synthesizes a `skill` tool call so
-/// the engine emits a marker for it too. Cross-referencing the base-name set keeps
-/// non-skill commands (`/clear`, `/compact`, custom commands) from ever qualifying.
-pub fn parse_jsonl(content: &str) -> Vec<NormalizedEvent> {
-    // Only the few marker-bearing records are parsed in the pre-scan; the substring
-    // gate skips the rest, and parsing (rather than scanning raw JSON) keeps Windows
-    // paths intact through their `\\` escaping.
-    let mut skill_base_names: HashSet<String> = HashSet::new();
-    for line in content.lines() {
-        if line.contains(SKILL_BASE_MARKER)
-            && let Ok(value) = serde_json::from_str::<Value>(line.trim())
-        {
-            collect_skill_base_names_from_text(&record_text(&value), &mut skill_base_names);
-        }
-    }
+/// The record layout a caller expects. Each variant names the key locations that
+/// carry the role, usage, model, effort, speed, timestamp, and thread identity for
+/// that caller's records. [`parse_record`] reads only the locations its shape
+/// names — no fallback to another shape's keys.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RecordShape {
+    /// Claude Code's transcript: role/usage/model/message-id under `message`;
+    /// effort, timestamp, `isSidechain`, and thread identity (`uuid`/
+    /// `parentUuid`) at the top level.
+    Claude,
+    /// Pi v3's transcript: role/usage/model always under `message`, with Pi's
+    /// disjoint usage buckets (`input`/`output`/`cacheRead`/`cacheWrite`). The
+    /// caller stamps its own timestamp and speed onto the event afterward, so
+    /// this shape never reads either.
+    Pi,
+    /// Cursor's transcript: role is always top-level; content and model can be
+    /// top-level or nested under `message`, depending on the source tier.
+    /// Cursor never reports usage, effort, or thread identity.
+    Cursor,
+    /// Any vendor without a bespoke adapter: every key location `parse_record`
+    /// has ever supported, tried together per record — the Anthropic, OpenAI,
+    /// and Pi transcript conventions all at once.
+    Generic,
+}
 
+/// Parse line-delimited JSON into normalized events, skipping blank/malformed
+/// lines. Used only by the generic fallback adapter, so every record is parsed
+/// with [`RecordShape::Generic`].
+pub fn parse_jsonl(content: &str) -> Vec<NormalizedEvent> {
     let mut events = Vec::new();
     for line in content.lines() {
         let line = line.trim();
@@ -50,180 +60,41 @@ pub fn parse_jsonl(content: &str) -> Vec<NormalizedEvent> {
             continue;
         }
         if let Ok(value) = serde_json::from_str::<Value>(line)
-            && let Some(mut ev) = parse_record(&value)
+            && let Some(ev) = parse_record(&value, RecordShape::Generic)
         {
-            if !skill_base_names.is_empty() && line.contains("<command-name>") {
-                synthesize_command_skills(&value, &skill_base_names, &mut ev);
-            }
             events.push(ev);
         }
     }
     events
 }
 
-pub(super) const SKILL_BASE_MARKER: &str = "Base directory for this skill:";
-
-/// Flatten a record's message text — string content, or the `text` of its content
-/// blocks — for scanning `<command-name>` tags and skill base-directory markers.
-/// Only Claude transcripts carry these conventions, so it's inert for other vendors.
-pub(super) fn record_text(value: &Value) -> String {
-    let Some(obj) = value.as_object() else {
-        return String::new();
-    };
-    let content = obj
-        .get("message")
-        .and_then(|m| m.as_object())
-        .and_then(|m| m.get("content"))
-        .or_else(|| obj.get("content"));
-    match content {
-        Some(Value::String(s)) => s.clone(),
-        Some(Value::Array(items)) => {
-            let mut out = String::new();
-            for item in items {
-                if let Some(text) = item.get("text").and_then(Value::as_str) {
-                    out.push_str(text);
-                    out.push('\n');
-                }
-            }
-            out
-        }
-        _ => String::new(),
-    }
-}
-
-/// Record the skill name from every "Base directory for this skill: <path>" marker
-/// in `text` — the set of skills that actually loaded this session.
-pub(super) fn collect_skill_base_names_from_text(text: &str, out: &mut HashSet<String>) {
-    for line in text.lines() {
-        if let Some((_, rest)) = line.split_once(SKILL_BASE_MARKER)
-            && let Some(name) = skill_base_name_from_path(rest)
-        {
-            out.insert(name);
-        }
-    }
-}
-
-/// Skill name from a base-directory marker path: the final path segment, or its
-/// parent when the path points straight at the `SKILL.md` file. Cross-platform
-/// (splits on `/` and `\`).
-pub(super) fn skill_base_name_from_path(path: &str) -> Option<String> {
-    let mut segments: Vec<&str> = path
-        .trim()
-        .trim_matches(['`', '"', '\''])
-        .split(['/', '\\'])
-        .map(str::trim)
-        .filter(|segment| !segment.is_empty())
-        .collect();
-    let last = segments.pop()?;
-    if last.eq_ignore_ascii_case("SKILL.md") {
-        return segments.pop().map(str::to_string);
-    }
-    Some(last.to_string())
-}
-
-/// Synthesize a `skill` tool call on `ev` for each user-typed `<command-name>` that
-/// names a skill in `skill_base_names`, so the engine emits a marker for it just
-/// like a `Skill` tool_use.
-fn synthesize_command_skills(
-    value: &Value,
-    skill_base_names: &HashSet<String>,
-    ev: &mut NormalizedEvent,
-) {
-    for command in command_names_in_text(&record_text(value)) {
-        if let Some(skill) = command_skill_name(&command, skill_base_names) {
-            let mut call = ToolCall::new("skill");
-            call.detail = Some(skill);
-            ev.tools.push(call);
-        }
-    }
-}
-
-/// The `<command-name>` values in `text`, leading `/` stripped:
-/// `<command-name>/code-review</command-name>` → `"code-review"`.
-pub(super) fn command_names_in_text(text: &str) -> Vec<String> {
-    const OPEN: &str = "<command-name>";
-    const CLOSE: &str = "</command-name>";
-    let mut out = Vec::new();
-    let mut rest = text;
-    while let Some(start) = rest.find(OPEN) {
-        let after = &rest[start + OPEN.len()..];
-        let Some(end) = after.find(CLOSE) else {
-            break;
-        };
-        let name = after[..end].trim().trim_start_matches('/').trim();
-        if !name.is_empty() {
-            out.push(name.to_string());
-        }
-        rest = &after[end + CLOSE.len()..];
-    }
-    out
-}
-
-/// The skill base name a command resolves to, if any: a direct hit, or a
-/// `plugin:skill` whose bare segment ran. `None` for non-skill commands.
-pub(super) fn command_skill_name(
-    command: &str,
-    skill_base_names: &HashSet<String>,
-) -> Option<String> {
-    if skill_base_names.contains(command) {
-        return Some(command.to_string());
-    }
-    let bare = command.rsplit(':').next().unwrap_or(command);
-    skill_base_names.contains(bare).then(|| bare.to_string())
-}
-
-pub(super) fn evidence_observations(value: &Value) -> Vec<EvidenceObservation> {
+pub(crate) fn evidence_observations(value: &Value) -> Vec<EvidenceObservation> {
     let mut observations = Vec::new();
-    if let Some(attachment) = value.get("attachment") {
-        match attachment.get("type").and_then(Value::as_str) {
-            Some("skill_listing") => {
-                let sources = attachment
-                    .get("content")
-                    .and_then(Value::as_str)
-                    .into_iter()
-                    .flat_map(|content| content.lines())
-                    .filter_map(|line| {
-                        let (name, description) =
-                            line.trim().strip_prefix("- ")?.split_once(':')?;
-                        let name = name.trim();
-                        if name.is_empty() {
-                            return None;
-                        }
-                        let description = description.trim();
-                        Some(EvidenceObservation::ContextSource {
-                            kind: ContextSourceKind::Skill,
-                            name: name.to_owned(),
-                            description: (!description.is_empty()).then(|| description.to_owned()),
-                        })
-                    });
-                observations.extend(sources);
+    if let Some(attachment) = value.get("attachment")
+        && attachment.get("type").and_then(Value::as_str) == Some("mcp_instructions_delta")
+    {
+        let names = attachment
+            .get("addedNames")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten();
+        observations.extend(names.filter_map(|name| {
+            let name = name.as_str()?.trim();
+            if name.is_empty() {
+                return None;
             }
-            Some("mcp_instructions_delta") => {
-                let names = attachment
-                    .get("addedNames")
-                    .and_then(Value::as_array)
-                    .into_iter()
-                    .flatten();
-                observations.extend(names.filter_map(|name| {
-                    let name = name.as_str()?.trim();
-                    if name.is_empty() {
-                        return None;
-                    }
-                    // Only the server name is kept (#228, Option B). The
-                    // paired `addedBlocks` entry is the server's full injected
-                    // instruction text, not a description: persisting a prefix
-                    // of it stretched the "names and descriptions" evidence
-                    // invariant, and nothing downstream reads MCP descriptions
-                    // (the Unused MCP Servers detector only needs `invoked`).
-                    Some(EvidenceObservation::ContextSource {
-                        kind: ContextSourceKind::McpServer,
-                        name: name.to_owned(),
-                        description: None,
-                    })
-                }));
-            }
-            _ => {}
-        }
+            // Only the server name is kept (#228, Option B). The
+            // paired `addedBlocks` entry is the server's full injected
+            // instruction text, not a description: persisting a prefix
+            // of it stretched the "names and descriptions" evidence
+            // invariant, and nothing downstream reads MCP descriptions
+            // (the Unused MCP Servers detector only needs `invoked`).
+            Some(EvidenceObservation::ContextSource {
+                kind: ContextSourceKind::McpServer,
+                name: name.to_owned(),
+                description: None,
+            })
+        }));
     }
 
     let is_sidechain = value
@@ -650,84 +521,123 @@ pub(super) fn compact_json_text(value: &Value) -> Option<String> {
 /// Parse a single JSON record into a normalized event, or `None` if the record
 /// carries no analyzable signal (titles, summaries, metadata lines, …).
 ///
-/// Every read here is a rejected key in `is_inert_unrecognized` or an exempt row
-/// in `INERTNESS_MIRROR_CASES`. Add one of the two before you update the fingerprint.
-pub fn parse_record(value: &Value) -> Option<NormalizedEvent> {
+/// `shape` names the key locations this call site's records actually use; see
+/// [`RecordShape`]. For [`RecordShape::Generic`], every read here is a rejected
+/// key in `is_inert_unrecognized` or an exempt row in `INERTNESS_MIRROR_CASES`
+/// (that table only has to hold for the generic fallback, since it alone reads
+/// every location). Add one of the two before you update the fingerprint.
+pub(crate) fn parse_record(value: &Value, shape: RecordShape) -> Option<NormalizedEvent> {
     let obj = value.as_object()?;
     let msg = obj.get("message").and_then(|m| m.as_object());
     let top_type = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
-    let role = resolve_role(msg, obj, top_type)?;
+    let role = resolve_role(msg, obj, top_type, shape)?;
     let mut ev = NormalizedEvent::new(role);
-    if obj
-        .get("isSidechain")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    if matches!(shape, RecordShape::Claude | RecordShape::Generic)
+        && obj
+            .get("isSidechain")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
     {
         ev.source = EventSource::Subagent;
     }
 
-    ev.ts_ms = obj
-        .get("timestamp")
-        .or_else(|| obj.get("ts"))
-        .or_else(|| obj.get("created_at"))
-        .or_else(|| obj.get("createdAt"))
-        .and_then(parse_ts);
+    // The record's timestamp. Claude and Cursor always write "timestamp";
+    // Pi's caller stamps its own timestamp onto the event afterward, so this
+    // shape never reads one. Generic tries every spelling any vendor has used.
+    let ts_value = match shape {
+        RecordShape::Claude | RecordShape::Cursor => obj.get("timestamp"),
+        RecordShape::Pi => None,
+        RecordShape::Generic => obj
+            .get("timestamp")
+            .or_else(|| obj.get("ts"))
+            .or_else(|| obj.get("created_at"))
+            .or_else(|| obj.get("createdAt")),
+    };
+    ev.ts_ms = ts_value.and_then(parse_ts);
 
-    // Usage may live under message.usage (Anthropic) or top-level usage (OpenAI).
-    let usage_value = msg
-        .and_then(|m| m.get("usage"))
-        .or_else(|| obj.get("usage"));
+    // Usage lives under message.usage for Claude and Pi; Cursor never reports
+    // it. Generic tries message.usage, then top-level usage (OpenAI's
+    // location).
+    let usage_value = match shape {
+        RecordShape::Claude | RecordShape::Pi => msg.and_then(|m| m.get("usage")),
+        RecordShape::Cursor => None,
+        RecordShape::Generic => msg
+            .and_then(|m| m.get("usage"))
+            .or_else(|| obj.get("usage")),
+    };
     ev.usage = parse_usage(usage_value);
 
-    // The response speed (Claude's "standard"/"fast" fast-mode signal), when
-    // the transcript records it: message.usage.speed, top-level usage.speed,
+    // The response speed (Claude's "standard"/"fast" fast-mode signal): only
+    // Claude and the generic fallback ever carry it, as message.usage.speed
     // or a bare top-level speed field.
-    ev.speed = usage_value
-        .and_then(|u| u.get("speed"))
-        .or_else(|| obj.get("speed"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|speed| !speed.is_empty())
-        .map(str::to_string);
+    ev.speed = match shape {
+        RecordShape::Claude | RecordShape::Generic => usage_value
+            .and_then(|u| u.get("speed"))
+            .or_else(|| obj.get("speed")),
+        RecordShape::Pi | RecordShape::Cursor => None,
+    }
+    .and_then(Value::as_str)
+    .map(str::trim)
+    .filter(|speed| !speed.is_empty())
+    .map(str::to_string);
 
-    // Model that produced this turn, when recorded: message.model (Anthropic) or
-    // top-level model (OpenAI shape). `<synthetic>` is Claude's sentinel for
-    // injected, unbilled turns — skip it so it never becomes a pricing key.
-    ev.model = msg
-        .and_then(|m| m.get("model"))
-        .or_else(|| obj.get("model"))
+    // Model that produced this turn, when recorded. Claude and Pi always nest
+    // it under message.model; Cursor's synthesized records place it top-level
+    // (its own source tiers disagree, so both locations are tried) and
+    // generic mirrors OpenAI's top-level location too. `<synthetic>` is
+    // Claude's sentinel for injected, unbilled turns — skip it so it never
+    // becomes a pricing key.
+    let model_value = match shape {
+        RecordShape::Claude | RecordShape::Pi => msg.and_then(|m| m.get("model")),
+        RecordShape::Cursor | RecordShape::Generic => msg
+            .and_then(|m| m.get("model"))
+            .or_else(|| obj.get("model")),
+    };
+    ev.model = model_value
         .and_then(Value::as_str)
         .filter(|m| !m.is_empty() && *m != "<synthetic>")
         .map(str::to_string);
 
-    ev.thinking_mode = obj
-        .get("effort")
-        .or_else(|| obj.get("reasoning_effort"))
-        .or_else(|| msg.and_then(|m| m.get("effort")))
-        .or_else(|| msg.and_then(|m| m.get("reasoning_effort")))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|mode| !mode.is_empty())
-        .map(str::to_string);
+    // The reasoning-effort tier: only Claude and the generic fallback carry
+    // it. Claude always writes it top-level; generic also tries
+    // message.effort for a vendor that nests it.
+    ev.thinking_mode = match shape {
+        RecordShape::Claude => obj.get("effort").or_else(|| obj.get("reasoning_effort")),
+        RecordShape::Generic => obj
+            .get("effort")
+            .or_else(|| obj.get("reasoning_effort"))
+            .or_else(|| msg.and_then(|m| m.get("effort")))
+            .or_else(|| msg.and_then(|m| m.get("reasoning_effort"))),
+        RecordShape::Pi | RecordShape::Cursor => None,
+    }
+    .and_then(Value::as_str)
+    .map(str::trim)
+    .filter(|mode| !mode.is_empty())
+    .map(str::to_string);
 
     // Per-record thread identity (Claude's top-level `uuid` / `parentUuid`).
     // `parentUuid: null` marks a thread root and stays `None`.
-    ev.uuid = thread_identity_field(value, "uuid");
-    ev.parent_uuid = thread_identity_field(value, "parentUuid");
+    if matches!(shape, RecordShape::Claude | RecordShape::Generic) {
+        ev.uuid = thread_identity_field(value, "uuid");
+        ev.parent_uuid = thread_identity_field(value, "parentUuid");
+    }
 
     // Provider message id (Anthropic `message.id`), used by the Claude adapter to
     // de-duplicate re-logged copies of the same assistant message.
-    ev.message_id = msg
-        .and_then(|m| m.get("id"))
-        .and_then(Value::as_str)
-        .filter(|id| !id.is_empty())
-        .map(str::to_string);
+    if matches!(shape, RecordShape::Claude | RecordShape::Generic) {
+        ev.message_id = msg
+            .and_then(|m| m.get("id"))
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string);
+    }
 
     // Claude marks a compaction boundary with a top-level system record, and
     // (on most records) names the trigger and before/after size in
     // compactMetadata.
-    if top_type == "system"
+    if matches!(shape, RecordShape::Claude | RecordShape::Generic)
+        && top_type == "system"
         && obj.get("subtype").and_then(Value::as_str) == Some("compact_boundary")
     {
         ev.is_compaction_boundary = true;
@@ -745,52 +655,68 @@ pub fn parse_record(value: &Value) -> Option<NormalizedEvent> {
         }
     }
 
-    // Standalone, top-level tool-shaped records.
-    match top_type {
-        "tool_use" => push_named_tool(obj.get("name"), obj.get("input"), &mut ev),
-        "function_call" => push_named_tool(
-            obj.get("name").or_else(|| {
-                obj.get("payload")
-                    .and_then(|p| p.as_object())
-                    .and_then(|p| p.get("name"))
-            }),
-            obj.get("input").or_else(|| obj.get("arguments")),
-            &mut ev,
-        ),
-        "tool_result" | "toolResult" | "function_call_output" => {}
-        _ => {}
+    // Standalone, top-level tool-shaped records — a generic-vendor
+    // convention; Claude, Pi, and Cursor never write a bare tool record.
+    if shape == RecordShape::Generic {
+        match top_type {
+            "tool_use" => push_named_tool(obj.get("name"), obj.get("input"), &mut ev),
+            "function_call" => push_named_tool(
+                obj.get("name").or_else(|| {
+                    obj.get("payload")
+                        .and_then(|p| p.as_object())
+                        .and_then(|p| p.get("name"))
+                }),
+                obj.get("input").or_else(|| obj.get("arguments")),
+                &mut ev,
+            ),
+            "tool_result" | "toolResult" | "function_call_output" => {}
+            _ => {}
+        }
     }
 
-    // Content block: Anthropic array, OpenAI string, or nested under message.
-    let content = msg
-        .and_then(|m| m.get("content"))
-        .or_else(|| obj.get("content"));
+    // Content block: Claude and Cursor accept it nested under message.content
+    // or top-level (Claude's compact-boundary system records, Cursor's
+    // flat-JSONL tier); Pi always nests it. Generic tries both locations.
+    let content = match shape {
+        RecordShape::Pi => msg.and_then(|m| m.get("content")),
+        RecordShape::Claude | RecordShape::Cursor | RecordShape::Generic => msg
+            .and_then(|m| m.get("content"))
+            .or_else(|| obj.get("content")),
+    };
     process_content(content, &mut ev);
     // Claude Code writes a tool result as a `user` record whose content is a
     // `tool_result` block. That is the tool's turn, not a user prompt.
-    if ev.role == Role::User && has_tool_result_block(content) {
+    if matches!(shape, RecordShape::Claude | RecordShape::Generic)
+        && ev.role == Role::User
+        && has_tool_result_block(content)
+    {
         ev.role = Role::Tool;
     }
 
-    // OpenAI-style tool calls.
-    if let Some(calls) = msg
-        .and_then(|m| m.get("tool_calls"))
-        .or_else(|| obj.get("tool_calls"))
-        .and_then(|c| c.as_array())
-    {
-        for call in calls {
-            let name = call
-                .get("function")
-                .and_then(|f| f.get("name"))
-                .or_else(|| call.get("name"))
-                .and_then(|n| n.as_str());
-            // OpenAI carries the args as a JSON string under function.arguments.
-            let args = call
-                .get("function")
-                .and_then(|f| f.get("arguments"))
-                .or_else(|| call.get("arguments"))
-                .or_else(|| call.get("input"));
-            push_named_tool_str(name, args, &mut ev);
+    // OpenAI-style tool calls: Cursor's flat-JSONL tier and the generic
+    // fallback are the only shapes that carry them.
+    if matches!(shape, RecordShape::Cursor | RecordShape::Generic) {
+        let calls = if shape == RecordShape::Cursor {
+            obj.get("tool_calls")
+        } else {
+            msg.and_then(|m| m.get("tool_calls"))
+                .or_else(|| obj.get("tool_calls"))
+        };
+        if let Some(calls) = calls.and_then(|c| c.as_array()) {
+            for call in calls {
+                let name = call
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .or_else(|| call.get("name"))
+                    .and_then(|n| n.as_str());
+                // OpenAI carries the args as a JSON string under function.arguments.
+                let args = call
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .or_else(|| call.get("arguments"))
+                    .or_else(|| call.get("input"));
+                push_named_tool_str(name, args, &mut ev);
+            }
         }
     }
 
@@ -801,26 +727,58 @@ fn resolve_role(
     msg: Option<&serde_json::Map<String, Value>>,
     obj: &serde_json::Map<String, Value>,
     top_type: &str,
+    shape: RecordShape,
 ) -> Option<Role> {
-    let role_str = msg
-        .and_then(|m| m.get("role"))
-        .or_else(|| obj.get("role"))
-        .and_then(|r| r.as_str());
-    let role = match role_str {
-        Some("assistant") => Role::Assistant,
-        Some("user") => Role::User,
-        Some("system") => Role::System,
-        Some("tool" | "toolResult") => Role::Tool,
-        _ => match top_type {
-            "assistant" => Role::Assistant,
-            "user" => Role::User,
-            "system" => Role::System,
-            "tool_use" | "function_call" => Role::Assistant,
-            "tool_result" | "toolResult" | "function_call_output" => Role::Tool,
-            _ => return None,
-        },
-    };
-    Some(role)
+    match shape {
+        RecordShape::Claude => {
+            role_from_str(msg.and_then(|m| m.get("role")).and_then(Value::as_str))
+                .or_else(|| role_from_claude_type(top_type))
+        }
+        RecordShape::Pi => role_from_str(msg.and_then(|m| m.get("role")).and_then(Value::as_str)),
+        RecordShape::Cursor => role_from_str(obj.get("role").and_then(Value::as_str)),
+        RecordShape::Generic => {
+            let role_str = msg
+                .and_then(|m| m.get("role"))
+                .or_else(|| obj.get("role"))
+                .and_then(|r| r.as_str());
+            role_from_str(role_str).or_else(|| role_from_generic_type(top_type))
+        }
+    }
+}
+
+fn role_from_str(role: Option<&str>) -> Option<Role> {
+    match role? {
+        "assistant" => Some(Role::Assistant),
+        "user" => Some(Role::User),
+        "system" => Some(Role::System),
+        "tool" | "toolResult" => Some(Role::Tool),
+        _ => None,
+    }
+}
+
+/// Claude's top-level `type` also names the role for records with no
+/// `message` wrapper (e.g. a `system` compact-boundary record).
+fn role_from_claude_type(top_type: &str) -> Option<Role> {
+    match top_type {
+        "assistant" => Some(Role::Assistant),
+        "user" => Some(Role::User),
+        "system" => Some(Role::System),
+        _ => None,
+    }
+}
+
+/// A generic-vendor convention: some non-bespoke vendors write a bare
+/// top-level tool record (`{"type":"tool_use",...}` or the OpenAI-flavored
+/// `function_call` / `function_call_output`) with no `role` field at all.
+fn role_from_generic_type(top_type: &str) -> Option<Role> {
+    match top_type {
+        "assistant" => Some(Role::Assistant),
+        "user" => Some(Role::User),
+        "system" => Some(Role::System),
+        "tool_use" | "function_call" => Some(Role::Assistant),
+        "tool_result" | "toolResult" | "function_call_output" => Some(Role::Tool),
+        _ => None,
+    }
 }
 
 fn has_tool_result_block(content: Option<&Value>) -> bool {
@@ -1024,7 +982,7 @@ pub(crate) fn parse_ts(v: &Value) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analysis::model::{Role, ToolCategory};
+    use crate::analysis::model::ToolCategory;
     use serde_json::json;
 
     #[test]
@@ -1041,9 +999,9 @@ mod tests {
 
     #[test]
     fn parse_record_changes_require_an_inertness_review() {
-        const EXPECTED_FINGERPRINT: u64 = 9_811_810_106_425_720_840;
-        let source = include_str!("jsonl.rs").replace("\r\n", "\n");
-        let start = source.find("pub fn parse_record").unwrap();
+        const EXPECTED_FINGERPRINT: u64 = 12_458_132_889_981_452_038;
+        let source = include_str!("records.rs").replace("\r\n", "\n");
+        let start = source.find("pub(crate) fn parse_record").unwrap();
         let end = source[start..].find("\n#[cfg(test)]\nmod tests").unwrap() + start;
         let fingerprint = source.as_bytes()[start..end]
             .iter()
@@ -1255,40 +1213,6 @@ mod tests {
     }
 
     #[test]
-    fn message_usage_speed_is_parsed() {
-        let record = json!({
-            "type": "assistant",
-            "message": {
-                "role": "assistant",
-                "usage": {"input_tokens": 10, "output_tokens": 5, "speed": "fast"}
-            }
-        });
-        let ev = parse_record(&record).expect("record should parse");
-        assert_eq!(ev.speed.as_deref(), Some("fast"));
-    }
-
-    #[test]
-    fn top_level_speed_is_parsed_when_usage_carries_none() {
-        let record = json!({
-            "type": "assistant",
-            "message": {"role": "assistant", "usage": {"input_tokens": 10}},
-            "speed": "standard"
-        });
-        let ev = parse_record(&record).expect("record should parse");
-        assert_eq!(ev.speed.as_deref(), Some("standard"));
-    }
-
-    #[test]
-    fn missing_speed_leaves_it_none() {
-        let record = json!({
-            "type": "assistant",
-            "message": {"role": "assistant", "usage": {"input_tokens": 10}}
-        });
-        let ev = parse_record(&record).expect("record should parse");
-        assert_eq!(ev.speed, None);
-    }
-
-    #[test]
     fn thinking_content_block_sets_has_thinking() {
         let record = json!({
             "type": "assistant",
@@ -1297,7 +1221,7 @@ mod tests {
                 "content": [{"type": "thinking", "thinking": "let me see"}]
             }
         });
-        let ev = parse_record(&record).expect("record should parse");
+        let ev = parse_record(&record, RecordShape::Generic).expect("record should parse");
         assert!(ev.has_thinking);
     }
 
@@ -1310,7 +1234,7 @@ mod tests {
                 "content": [{"type": "text", "text": "hi"}]
             }
         });
-        let ev = parse_record(&record).expect("record should parse");
+        let ev = parse_record(&record, RecordShape::Generic).expect("record should parse");
         assert!(!ev.has_thinking);
     }
 
@@ -1420,94 +1344,6 @@ mod tests {
     }
 
     #[test]
-    fn pi_tool_call_content_block_yields_named_tool() {
-        let record = json!({
-            "type": "message",
-            "message": {
-                "role": "assistant",
-                "content": [{
-                    "type": "toolCall",
-                    "id": "call_1",
-                    "name": "read",
-                    "arguments": {"path": "src/lib.rs"}
-                }]
-            }
-        });
-
-        let ev = parse_record(&record).expect("record should parse");
-        assert_eq!(ev.role, Role::Assistant);
-        assert_eq!(ev.tools.len(), 1);
-        assert_eq!(ev.tools[0].name, "read");
-        assert_eq!(ev.tools[0].category, ToolCategory::Read);
-    }
-
-    #[test]
-    fn pi_tool_call_arguments_feed_bash_test_classification() {
-        let record = json!({
-            "type": "message",
-            "message": {
-                "role": "assistant",
-                "content": [{
-                    "type": "toolCall",
-                    "id": "call_1",
-                    "name": "bash",
-                    "arguments": {"command": "cargo test --workspace"}
-                }]
-            }
-        });
-
-        let ev = parse_record(&record).expect("record should parse");
-        assert_eq!(ev.tools.len(), 1);
-        assert_eq!(ev.tools[0].category, ToolCategory::Test);
-    }
-
-    #[test]
-    fn claude_tool_result_user_record_is_a_tool_event() {
-        let result = json!({
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
-            }
-        });
-        let prompt = json!({
-            "type": "user",
-            "message": {"role": "user", "content": [{"type": "text", "text": "go"}]}
-        });
-        assert_eq!(parse_record(&result).unwrap().role, Role::Tool);
-        assert_eq!(parse_record(&prompt).unwrap().role, Role::User);
-    }
-
-    #[test]
-    fn pi_tool_result_message_role_is_parsed() {
-        let errored = json!({
-            "type": "message",
-            "message": {
-                "role": "toolResult",
-                "toolCallId": "call_1",
-                "toolName": "bash",
-                "isError": true,
-                "content": [{"type": "text", "text": "boom"}]
-            }
-        });
-        let ok = json!({
-            "type": "message",
-            "message": {
-                "role": "toolResult",
-                "toolCallId": "call_2",
-                "toolName": "bash",
-                "content": [{"type": "text", "text": "ok"}]
-            }
-        });
-
-        let errored = parse_record(&errored).expect("tool result should parse");
-        assert_eq!(errored.role, Role::Tool);
-
-        let ok = parse_record(&ok).expect("tool result should parse");
-        assert_eq!(ok.role, Role::Tool);
-    }
-
-    #[test]
     fn extract_skill_name_reads_explicit_fields_in_priority_order() {
         assert_eq!(
             extract_skill_name(Some(&json!({"skill": "deep-research"}))),
@@ -1585,191 +1421,6 @@ mod tests {
         // A lowercase `skill` tool (non-Claude agents) is captured too.
         let lower = tool_call_from_input("skill", Some(&json!({"name": "checkpoint"})));
         assert_eq!(lower.detail.as_deref(), Some("checkpoint"));
-    }
-
-    #[test]
-    fn skill_base_name_from_path_takes_dir_or_skill_md_parent() {
-        assert_eq!(
-            skill_base_name_from_path("/home/avery/.claude/skills/grill-me"),
-            Some("grill-me".to_string())
-        );
-        assert_eq!(
-            skill_base_name_from_path("/home/avery/.claude/skills/code-review/SKILL.md"),
-            Some("code-review".to_string())
-        );
-        // Windows separators.
-        assert_eq!(
-            skill_base_name_from_path("C:\\u\\.claude\\skills\\plan"),
-            Some("plan".to_string())
-        );
-    }
-
-    #[test]
-    fn command_names_in_text_extracts_and_strips_slash() {
-        let text = "<command-message>code-review</command-message>\n\
-                    <command-name>/code-review</command-name>\n\
-                    <command-args>changelist</command-args>";
-        assert_eq!(command_names_in_text(text), vec!["code-review".to_string()]);
-        assert_eq!(command_names_in_text("no tags here"), Vec::<String>::new());
-    }
-
-    #[test]
-    fn command_skill_name_matches_directly_and_via_plugin_namespace() {
-        let names: HashSet<String> = ["frontend-design".to_string(), "code-review".to_string()]
-            .into_iter()
-            .collect();
-        // Direct hit.
-        assert_eq!(
-            command_skill_name("code-review", &names),
-            Some("code-review".to_string())
-        );
-        // `plugin:skill` resolves to its bare segment.
-        assert_eq!(
-            command_skill_name("frontend-design:frontend-design", &names),
-            Some("frontend-design".to_string())
-        );
-        // A command that didn't run as a skill is rejected (no base-dir marker).
-        assert_eq!(command_skill_name("clear", &names), None);
-    }
-
-    #[test]
-    fn parse_jsonl_synthesizes_skill_from_command_when_it_actually_ran() {
-        // A user-typed `/code-review` (a command, not a Skill tool_use) plus the
-        // skill's base-directory marker → one synthesized skill tool. A `/clear`
-        // command with no base marker stays a non-skill.
-        let content = concat!(
-            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Base directory for this skill: /home/avery/.claude/skills/code-review\n\nReview the diff."}]}}"#,
-            "\n",
-            r#"{"type":"user","timestamp":"2024-06-01T12:00:00Z","message":{"role":"user","content":"<command-name>/code-review</command-name>"}}"#,
-            "\n",
-            r#"{"type":"user","message":{"role":"user","content":"<command-name>/clear</command-name>"}}"#,
-        );
-        let events = parse_jsonl(content);
-        let skills: Vec<&str> = events
-            .iter()
-            .flat_map(|ev| &ev.tools)
-            .filter(|t| t.name.eq_ignore_ascii_case("skill"))
-            .filter_map(|t| t.detail.as_deref())
-            .collect();
-        assert_eq!(skills, vec!["code-review"]);
-    }
-
-    #[test]
-    fn parse_jsonl_ignores_command_names_when_no_skill_ran() {
-        // Without any base-directory marker, command-name tags never synthesize
-        // skills — guards against custom slash commands becoming markers.
-        let content = r#"{"type":"user","message":{"role":"user","content":"<command-name>/code-review</command-name>"}}"#;
-        let events = parse_jsonl(content);
-        let any_skill = events
-            .iter()
-            .flat_map(|ev| &ev.tools)
-            .any(|t| t.name.eq_ignore_ascii_case("skill"));
-        assert!(!any_skill);
-    }
-
-    #[test]
-    fn claude_compact_boundary_record_sets_compaction_flag() {
-        let record = json!({
-            "type": "system",
-            "subtype": "compact_boundary",
-            "timestamp": "2024-06-01T12:05:00Z",
-            "content": "Compacted conversation"
-        });
-
-        let ev = parse_record(&record).expect("compact_boundary should parse");
-        assert_eq!(ev.role, Role::System);
-        assert!(ev.is_compaction_boundary);
-    }
-
-    #[test]
-    fn claude_compact_boundary_parses_manual_trigger_and_sizes() {
-        let record = json!({
-            "type": "system",
-            "subtype": "compact_boundary",
-            "timestamp": "2024-06-01T12:05:00Z",
-            "compactMetadata": {
-                "trigger": "manual",
-                "preTokens": 196_000,
-                "postTokens": 11_000,
-            }
-        });
-
-        let ev = parse_record(&record).expect("compact_boundary should parse");
-        assert_eq!(ev.compaction_trigger, Some(CompactionTrigger::Manual));
-        assert_eq!(ev.compaction_pre_tokens, Some(196_000));
-        assert_eq!(ev.compaction_post_tokens, Some(11_000));
-    }
-
-    #[test]
-    fn claude_compact_boundary_parses_auto_trigger() {
-        let record = json!({
-            "type": "system",
-            "subtype": "compact_boundary",
-            "timestamp": "2024-06-01T12:05:00Z",
-            "compactMetadata": {
-                "trigger": "auto",
-                "preTokens": 200_000,
-                "postTokens": 12_000,
-            }
-        });
-
-        let ev = parse_record(&record).expect("compact_boundary should parse");
-        assert_eq!(ev.compaction_trigger, Some(CompactionTrigger::Auto));
-    }
-
-    #[test]
-    fn claude_compact_boundary_without_metadata_leaves_trigger_and_sizes_none() {
-        let record = json!({
-            "type": "system",
-            "subtype": "compact_boundary",
-            "timestamp": "2024-06-01T12:05:00Z",
-        });
-
-        let ev = parse_record(&record).expect("compact_boundary should parse");
-        assert!(ev.is_compaction_boundary);
-        assert_eq!(ev.compaction_trigger, None);
-        assert_eq!(ev.compaction_pre_tokens, None);
-        assert_eq!(ev.compaction_post_tokens, None);
-    }
-
-    #[test]
-    fn claude_compact_boundary_without_post_tokens_leaves_it_none() {
-        // Some older records omit postTokens entirely.
-        let record = json!({
-            "type": "system",
-            "subtype": "compact_boundary",
-            "timestamp": "2024-06-01T12:05:00Z",
-            "compactMetadata": {
-                "trigger": "auto",
-                "preTokens": 196_000,
-            }
-        });
-
-        let ev = parse_record(&record).expect("compact_boundary should parse");
-        assert_eq!(ev.compaction_trigger, Some(CompactionTrigger::Auto));
-        assert_eq!(ev.compaction_pre_tokens, Some(196_000));
-        assert_eq!(ev.compaction_post_tokens, None);
-    }
-
-    #[test]
-    fn unrelated_system_records_do_not_set_compaction_flag() {
-        // No subtype at all.
-        let plain = json!({
-            "type": "system",
-            "timestamp": "2024-06-01T12:05:00Z",
-            "content": "hook ran"
-        });
-        let ev = parse_record(&plain).expect("system record should parse");
-        assert!(!ev.is_compaction_boundary);
-
-        // A different subtype.
-        let other = json!({
-            "type": "system",
-            "subtype": "turn_limit_reached",
-            "content": "stop"
-        });
-        let ev = parse_record(&other).expect("system record should parse");
-        assert!(!ev.is_compaction_boundary);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/vendors/antigravity.rs
+++ b/crates/antiburn-local/src/analysis/vendors/antigravity.rs
@@ -23,10 +23,10 @@
 use anyhow::Context;
 use serde_json::Value;
 
-use super::jsonl::{parse_ts, parse_usage, tool_call_from_input};
 use super::read_source;
 use crate::analysis::interface::{SessionInput, VendorAdapter};
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role};
+use crate::analysis::records::{parse_ts, parse_usage, tool_call_from_input};
 
 pub struct AntigravityAdapter;
 

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -13,20 +13,143 @@ use std::io::{BufRead, BufReader, Cursor, Read};
 use anyhow::Context;
 use serde_json::Value;
 
-use super::jsonl::{
-    SKILL_BASE_MARKER, collect_skill_base_names_from_text, command_names_in_text,
-    command_skill_name, evidence_observations, extract_content_parts,
-    is_inert_recognized_eventless, is_inert_unrecognized, is_recognized_eventless, parse_record,
-    record_discriminator, record_text,
-};
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, RecordSkip};
 use crate::analysis::initial_context::ClaudeContextAccumulator;
 use crate::analysis::interface::{
-    NormalizedRecord, RawSource, RecordSink, SessionCollector, SessionInput, SessionSummary,
-    TurnContent, VendorAdapter, VisitOutcome,
+    ContextSourceKind, EvidenceObservation, NormalizedRecord, RawSource, RecordSink,
+    SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, ToolCall, Usage};
+use crate::analysis::records::{
+    RecordShape, evidence_observations, extract_content_parts, is_inert_recognized_eventless,
+    is_inert_unrecognized, is_recognized_eventless, parse_record, record_discriminator,
+};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
+
+/// The marker Claude Code writes into a `Skill` tool's transcript output,
+/// naming the skill's base directory. Its presence records the skill as one
+/// that actually ran, distinct from a `<command-name>` that merely typed the
+/// skill's slash command.
+const SKILL_BASE_MARKER: &str = "Base directory for this skill:";
+
+/// Flatten a record's message text — string content, or the `text` of its content
+/// blocks — for scanning `<command-name>` tags and skill base-directory markers.
+fn record_text(value: &Value) -> String {
+    let Some(obj) = value.as_object() else {
+        return String::new();
+    };
+    let content = obj
+        .get("message")
+        .and_then(|m| m.as_object())
+        .and_then(|m| m.get("content"))
+        .or_else(|| obj.get("content"));
+    match content {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(items)) => {
+            let mut out = String::new();
+            for item in items {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    out.push_str(text);
+                    out.push('\n');
+                }
+            }
+            out
+        }
+        _ => String::new(),
+    }
+}
+
+/// Record the skill name from every "Base directory for this skill: <path>" marker
+/// in `text` — the set of skills that actually loaded this session.
+fn collect_skill_base_names_from_text(text: &str, out: &mut HashSet<String>) {
+    for line in text.lines() {
+        if let Some((_, rest)) = line.split_once(SKILL_BASE_MARKER)
+            && let Some(name) = skill_base_name_from_path(rest)
+        {
+            out.insert(name);
+        }
+    }
+}
+
+/// Skill name from a base-directory marker path: the final path segment, or its
+/// parent when the path points straight at the `SKILL.md` file. Cross-platform
+/// (splits on `/` and `\`).
+fn skill_base_name_from_path(path: &str) -> Option<String> {
+    let mut segments: Vec<&str> = path
+        .trim()
+        .trim_matches(['`', '"', '\''])
+        .split(['/', '\\'])
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    let last = segments.pop()?;
+    if last.eq_ignore_ascii_case("SKILL.md") {
+        return segments.pop().map(str::to_string);
+    }
+    Some(last.to_string())
+}
+
+/// The `<command-name>` values in `text`, leading `/` stripped:
+/// `<command-name>/code-review</command-name>` → `"code-review"`.
+fn command_names_in_text(text: &str) -> Vec<String> {
+    const OPEN: &str = "<command-name>";
+    const CLOSE: &str = "</command-name>";
+    let mut out = Vec::new();
+    let mut rest = text;
+    while let Some(start) = rest.find(OPEN) {
+        let after = &rest[start + OPEN.len()..];
+        let Some(end) = after.find(CLOSE) else {
+            break;
+        };
+        let name = after[..end].trim().trim_start_matches('/').trim();
+        if !name.is_empty() {
+            out.push(name.to_string());
+        }
+        rest = &after[end + CLOSE.len()..];
+    }
+    out
+}
+
+/// The skill base name a command resolves to, if any: a direct hit, or a
+/// `plugin:skill` whose bare segment ran. `None` for non-skill commands.
+fn command_skill_name(command: &str, skill_base_names: &HashSet<String>) -> Option<String> {
+    if skill_base_names.contains(command) {
+        return Some(command.to_string());
+    }
+    let bare = command.rsplit(':').next().unwrap_or(command);
+    skill_base_names.contains(bare).then(|| bare.to_string())
+}
+
+/// The skill descriptions from a `skill_listing` attachment: each `- name:
+/// description` line becomes a `ContextSource` observation for the named
+/// skill. Only Claude's transcript writes this attachment type.
+fn skill_listing_observations(value: &Value) -> Vec<EvidenceObservation> {
+    let Some(attachment) = value.get("attachment") else {
+        return Vec::new();
+    };
+    if attachment.get("type").and_then(Value::as_str) != Some("skill_listing") {
+        return Vec::new();
+    }
+    attachment
+        .get("content")
+        .and_then(Value::as_str)
+        .into_iter()
+        .flat_map(|content| content.lines())
+        .filter_map(|line| {
+            let (name, description) = line.trim().strip_prefix("- ")?.split_once(':')?;
+            let name = name.trim();
+            if name.is_empty() {
+                return None;
+            }
+            let description = description.trim();
+            Some(EvidenceObservation::ContextSource {
+                kind: ContextSourceKind::Skill,
+                name: name.to_owned(),
+                description: (!description.is_empty()).then(|| description.to_owned()),
+            })
+        })
+        .collect()
+}
 
 pub struct ClaudeAdapter;
 
@@ -158,7 +281,10 @@ impl ClaudeAdapter {
                     };
 
                     state.context.observe(&value);
-                    for observation in evidence_observations(&value) {
+                    for observation in skill_listing_observations(&value)
+                        .into_iter()
+                        .chain(evidence_observations(&value))
+                    {
                         sink.record(NormalizedRecord::Observation(Box::new(observation)));
                     }
                     let has_skill_marker = record.contains(SKILL_BASE_MARKER);
@@ -171,7 +297,7 @@ impl ClaudeAdapter {
                         );
                     }
 
-                    let Some(mut event) = parse_record(&value) else {
+                    let Some(mut event) = parse_record(&value, RecordShape::Claude) else {
                         let allowlisted = is_recognized_eventless(&value);
                         let structurally_inert = if allowlisted {
                             is_inert_recognized_eventless(&value)
@@ -746,5 +872,221 @@ mod tests {
 
             Err(Error::other("synthetic read failure"))
         }
+    }
+
+    #[test]
+    fn skill_base_name_from_path_takes_dir_or_skill_md_parent() {
+        assert_eq!(
+            skill_base_name_from_path("/home/avery/.claude/skills/grill-me"),
+            Some("grill-me".to_string())
+        );
+        assert_eq!(
+            skill_base_name_from_path("/home/avery/.claude/skills/code-review/SKILL.md"),
+            Some("code-review".to_string())
+        );
+        // Windows separators.
+        assert_eq!(
+            skill_base_name_from_path("C:\\u\\.claude\\skills\\plan"),
+            Some("plan".to_string())
+        );
+    }
+
+    #[test]
+    fn command_names_in_text_extracts_and_strips_slash() {
+        let text = "<command-message>code-review</command-message>\n\
+                    <command-name>/code-review</command-name>\n\
+                    <command-args>changelist</command-args>";
+        assert_eq!(command_names_in_text(text), vec!["code-review".to_string()]);
+        assert_eq!(command_names_in_text("no tags here"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn command_skill_name_matches_directly_and_via_plugin_namespace() {
+        let names: HashSet<String> = ["frontend-design".to_string(), "code-review".to_string()]
+            .into_iter()
+            .collect();
+        // Direct hit.
+        assert_eq!(
+            command_skill_name("code-review", &names),
+            Some("code-review".to_string())
+        );
+        // `plugin:skill` resolves to its bare segment.
+        assert_eq!(
+            command_skill_name("frontend-design:frontend-design", &names),
+            Some("frontend-design".to_string())
+        );
+        // A command that didn't run as a skill is rejected (no base-dir marker).
+        assert_eq!(command_skill_name("clear", &names), None);
+    }
+
+    #[test]
+    fn claude_tool_result_user_record_is_a_tool_event() {
+        let result = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+            }
+        });
+        let prompt = serde_json::json!({
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": "go"}]}
+        });
+        assert_eq!(
+            parse_record(&result, RecordShape::Claude).unwrap().role,
+            crate::analysis::model::Role::Tool
+        );
+        assert_eq!(
+            parse_record(&prompt, RecordShape::Claude).unwrap().role,
+            crate::analysis::model::Role::User
+        );
+    }
+
+    #[test]
+    fn message_usage_speed_is_parsed() {
+        let record = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "usage": {"input_tokens": 10, "output_tokens": 5, "speed": "fast"}
+            }
+        });
+        let ev = parse_record(&record, RecordShape::Claude).expect("record should parse");
+        assert_eq!(ev.speed.as_deref(), Some("fast"));
+    }
+
+    #[test]
+    fn top_level_speed_is_parsed_when_usage_carries_none() {
+        let record = serde_json::json!({
+            "type": "assistant",
+            "message": {"role": "assistant", "usage": {"input_tokens": 10}},
+            "speed": "standard"
+        });
+        let ev = parse_record(&record, RecordShape::Claude).expect("record should parse");
+        assert_eq!(ev.speed.as_deref(), Some("standard"));
+    }
+
+    #[test]
+    fn missing_speed_leaves_it_none() {
+        let record = serde_json::json!({
+            "type": "assistant",
+            "message": {"role": "assistant", "usage": {"input_tokens": 10}}
+        });
+        let ev = parse_record(&record, RecordShape::Claude).expect("record should parse");
+        assert_eq!(ev.speed, None);
+    }
+
+    #[test]
+    fn claude_compact_boundary_record_sets_compaction_flag() {
+        let record = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "timestamp": "2024-06-01T12:05:00Z",
+            "content": "Compacted conversation"
+        });
+
+        let ev = parse_record(&record, RecordShape::Claude).expect("compact_boundary should parse");
+        assert_eq!(ev.role, crate::analysis::model::Role::System);
+        assert!(ev.is_compaction_boundary);
+    }
+
+    #[test]
+    fn claude_compact_boundary_parses_manual_trigger_and_sizes() {
+        let record = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "timestamp": "2024-06-01T12:05:00Z",
+            "compactMetadata": {
+                "trigger": "manual",
+                "preTokens": 196_000,
+                "postTokens": 11_000,
+            }
+        });
+
+        let ev = parse_record(&record, RecordShape::Claude).expect("compact_boundary should parse");
+        assert_eq!(
+            ev.compaction_trigger,
+            Some(crate::analysis::model::CompactionTrigger::Manual)
+        );
+        assert_eq!(ev.compaction_pre_tokens, Some(196_000));
+        assert_eq!(ev.compaction_post_tokens, Some(11_000));
+    }
+
+    #[test]
+    fn claude_compact_boundary_parses_auto_trigger() {
+        let record = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "timestamp": "2024-06-01T12:05:00Z",
+            "compactMetadata": {
+                "trigger": "auto",
+                "preTokens": 200_000,
+                "postTokens": 12_000,
+            }
+        });
+
+        let ev = parse_record(&record, RecordShape::Claude).expect("compact_boundary should parse");
+        assert_eq!(
+            ev.compaction_trigger,
+            Some(crate::analysis::model::CompactionTrigger::Auto)
+        );
+    }
+
+    #[test]
+    fn claude_compact_boundary_without_metadata_leaves_trigger_and_sizes_none() {
+        let record = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "timestamp": "2024-06-01T12:05:00Z",
+        });
+
+        let ev = parse_record(&record, RecordShape::Claude).expect("compact_boundary should parse");
+        assert!(ev.is_compaction_boundary);
+        assert_eq!(ev.compaction_trigger, None);
+        assert_eq!(ev.compaction_pre_tokens, None);
+        assert_eq!(ev.compaction_post_tokens, None);
+    }
+
+    #[test]
+    fn claude_compact_boundary_without_post_tokens_leaves_it_none() {
+        // Some older records omit postTokens entirely.
+        let record = serde_json::json!({
+            "type": "system",
+            "subtype": "compact_boundary",
+            "timestamp": "2024-06-01T12:05:00Z",
+            "compactMetadata": {
+                "trigger": "auto",
+                "preTokens": 196_000,
+            }
+        });
+
+        let ev = parse_record(&record, RecordShape::Claude).expect("compact_boundary should parse");
+        assert_eq!(
+            ev.compaction_trigger,
+            Some(crate::analysis::model::CompactionTrigger::Auto)
+        );
+        assert_eq!(ev.compaction_pre_tokens, Some(196_000));
+        assert_eq!(ev.compaction_post_tokens, None);
+    }
+
+    #[test]
+    fn unrelated_system_records_do_not_set_compaction_flag() {
+        // No subtype at all.
+        let plain = serde_json::json!({
+            "type": "system",
+            "timestamp": "2024-06-01T12:05:00Z",
+            "content": "hook ran"
+        });
+        let ev = parse_record(&plain, RecordShape::Claude).expect("system record should parse");
+        assert!(!ev.is_compaction_boundary);
+
+        // A different subtype.
+        let other = serde_json::json!({
+            "type": "system",
+            "subtype": "turn_limit_reached",
+            "content": "stop"
+        });
+        let ev = parse_record(&other, RecordShape::Claude).expect("system record should parse");
+        assert!(!ev.is_compaction_boundary);
     }
 }

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -34,10 +34,6 @@ use std::io::{BufRead, BufReader, Cursor, Read};
 use anyhow::Context;
 use serde_json::{Map, Value};
 
-use super::jsonl::{
-    compact_json_text, concatenated_text, extract_content_parts_from_container, parse_ts,
-    tool_call_from_input,
-};
 use super::read_source;
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::initial_context::CodexContextAccumulator;
@@ -46,6 +42,10 @@ use crate::analysis::interface::{
     SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role, ToolCall, Usage};
+use crate::analysis::records::{
+    compact_json_text, concatenated_text, extract_content_parts_from_container, parse_ts,
+    tool_call_from_input,
+};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
 
 const MAX_PENDING_FORK_ROWS: usize = 256;

--- a/crates/antiburn-local/src/analysis/vendors/cursor.rs
+++ b/crates/antiburn-local/src/analysis/vendors/cursor.rs
@@ -4,10 +4,10 @@ use anyhow::Context;
 use serde_json::Value;
 use time::{Date, Month, PrimitiveDateTime, Time, UtcOffset};
 
-use super::jsonl::{parse_record, parse_ts};
 use super::read_source;
 use crate::analysis::interface::{SessionInput, VendorAdapter};
 use crate::analysis::model::{NormalizedEvent, NormalizedSession};
+use crate::analysis::records::{RecordShape, parse_record, parse_ts};
 
 pub struct CursorAdapter;
 
@@ -45,7 +45,7 @@ fn parse_cursor(content: &str) -> (Vec<NormalizedEvent>, Option<String>) {
         if session_model.is_none() {
             session_model = model_from(&value).map(str::to_string);
         }
-        let Some(mut event) = parse_record(&value) else {
+        let Some(mut event) = parse_record(&value, RecordShape::Cursor) else {
             continue;
         };
         if event.ts_ms.is_none() {

--- a/crates/antiburn-local/src/analysis/vendors/generic_jsonl.rs
+++ b/crates/antiburn-local/src/analysis/vendors/generic_jsonl.rs
@@ -8,10 +8,10 @@
 
 use anyhow::Context;
 
-use super::jsonl::parse_jsonl;
 use super::read_source;
 use crate::analysis::interface::{SessionInput, VendorAdapter};
 use crate::analysis::model::NormalizedSession;
+use crate::analysis::records::parse_jsonl;
 
 pub struct GenericJsonlAdapter;
 

--- a/crates/antiburn-local/src/analysis/vendors/mod.rs
+++ b/crates/antiburn-local/src/analysis/vendors/mod.rs
@@ -9,7 +9,6 @@ pub mod claude;
 mod codex;
 mod cursor;
 mod generic_jsonl;
-mod jsonl;
 mod opencode;
 pub(crate) mod pi;
 

--- a/crates/antiburn-local/src/analysis/vendors/opencode.rs
+++ b/crates/antiburn-local/src/analysis/vendors/opencode.rs
@@ -14,7 +14,6 @@ use anyhow::Context;
 use rusqlite::{Connection, OpenFlags, Statement, params};
 use serde_json::{Map, Value};
 
-use super::jsonl::{compact_json_text, parse_ts, tool_call_from_input};
 use crate::analysis::EVIDENCE_STRING_CAP;
 use crate::analysis::SourceChangedReason;
 use crate::analysis::framing::{
@@ -27,6 +26,7 @@ use crate::analysis::interface::{
 use crate::analysis::model::{
     CompactionTrigger, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
 };
+use crate::analysis::records::{compact_json_text, parse_ts, tool_call_from_input};
 use crate::discovery::agents::opencode::{
     db_session_fingerprint_connection, db_session_has_parent_id,
 };

--- a/crates/antiburn-local/src/analysis/vendors/pi.rs
+++ b/crates/antiburn-local/src/analysis/vendors/pi.rs
@@ -20,13 +20,13 @@ use std::io::{BufRead, BufReader, Cursor, Read};
 use anyhow::Context;
 use serde_json::Value;
 
-use super::jsonl::{extract_content_parts, parse_record, parse_ts};
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::interface::{
     ContentPart, EvidenceObservation, NormalizedRecord, RawSource, RecordSink, SessionCollector,
     SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role};
+use crate::analysis::records::{RecordShape, extract_content_parts, parse_record, parse_ts};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
 
 /// Parses Pi transcript files without retaining transcript content.
@@ -271,7 +271,7 @@ impl PiStreamState {
             sink.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
             return;
         };
-        let Some(mut event) = parse_record(value) else {
+        let Some(mut event) = parse_record(value, RecordShape::Pi) else {
             sink.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
             return;
         };
@@ -529,6 +529,7 @@ mod tests {
 
     use super::*;
     use crate::analysis::interface::ContentKind;
+    use crate::analysis::model::ToolCategory;
 
     /// Collects every `TurnContent` record a visit emits, in order.
     #[derive(Default)]
@@ -661,5 +662,76 @@ mod tests {
             }
         });
         assert!(!is_inert_shape(&evidence_bearing));
+    }
+
+    #[test]
+    fn pi_tool_call_content_block_yields_named_tool() {
+        let record = json!({
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "toolCall",
+                    "id": "call_1",
+                    "name": "read",
+                    "arguments": {"path": "src/lib.rs"}
+                }]
+            }
+        });
+
+        let ev = parse_record(&record, RecordShape::Pi).expect("record should parse");
+        assert_eq!(ev.role, Role::Assistant);
+        assert_eq!(ev.tools.len(), 1);
+        assert_eq!(ev.tools[0].name, "read");
+        assert_eq!(ev.tools[0].category, ToolCategory::Read);
+    }
+
+    #[test]
+    fn pi_tool_call_arguments_feed_bash_test_classification() {
+        let record = json!({
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "toolCall",
+                    "id": "call_1",
+                    "name": "bash",
+                    "arguments": {"command": "cargo test --workspace"}
+                }]
+            }
+        });
+
+        let ev = parse_record(&record, RecordShape::Pi).expect("record should parse");
+        assert_eq!(ev.tools.len(), 1);
+        assert_eq!(ev.tools[0].category, ToolCategory::Test);
+    }
+
+    #[test]
+    fn pi_tool_result_message_role_is_parsed() {
+        let errored = json!({
+            "type": "message",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "call_1",
+                "toolName": "bash",
+                "isError": true,
+                "content": [{"type": "text", "text": "boom"}]
+            }
+        });
+        let ok = json!({
+            "type": "message",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "call_2",
+                "toolName": "bash",
+                "content": [{"type": "text", "text": "ok"}]
+            }
+        });
+
+        let errored = parse_record(&errored, RecordShape::Pi).expect("tool result should parse");
+        assert_eq!(errored.role, Role::Tool);
+
+        let ok = parse_record(&ok, RecordShape::Pi).expect("tool result should parse");
+        assert_eq!(ok.role, Role::Tool);
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 "Shared parser cleanup" from `docs/plans/session-evidence-harness-parity.md` (#259). Pure refactor, no golden changes, no revision bump.

- `vendors/jsonl.rs` → `analysis/records.rs`. It is the shared record parser, not a vendor.
- Claude-only skill/command logic (`SKILL_BASE_MARKER`, `collect_skill_base_names_from_text`, `command_skill_name`, `command_names_in_text`, `record_text`, the `skill_listing` observation) moves into `vendors/claude.rs`. The generic fallback no longer runs Claude skill synthesis; `synthesize_command_skills` had no caller after that and is removed.
- `parse_record(value, RecordShape)`: `Claude`, `Pi`, `Cursor`, `Generic`. Each bespoke adapter passes its shape and only the keys that shape names are read (derived from the characterization fixtures; every removed fallback is one that adapter never exercised). `Generic` keeps the full historical key set so unknown vendors behave exactly as before.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` in `crates/antiburn-local` (1167 pass) and `apps/desktop/src-tauri` (583 pass)
- [x] No file under `tests/**/goldens` changed

Next: seam 4b (Claude `thread_id` from the uuid chain) stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U7uVd1iQZBdWV2KdmSjSA