### PR TITLE
feat(opencode): stream descendant sessions as delegated threads

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -1651,7 +1651,8 @@ mod tests {
         connection
             .execute_batch(
                 r#"CREATE TABLE session (
-                     id TEXT PRIMARY KEY, parent_id TEXT, time_created INTEGER, time_updated INTEGER
+                     id TEXT PRIMARY KEY, parent_id TEXT, title TEXT,
+                     time_created INTEGER, time_updated INTEGER
                  );
                  CREATE TABLE message (
                      id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
@@ -1661,7 +1662,8 @@ mod tests {
                      id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
                      time_created INTEGER, time_updated INTEGER, data TEXT
                  );
-                 INSERT INTO session VALUES ('root', NULL, 100, 120);
+                 INSERT INTO session (id, parent_id, time_created, time_updated)
+                 VALUES ('root', NULL, 100, 120);
                  INSERT INTO message VALUES (
                      'message', 'root', 110, 110,
                      '{"role":"assistant","modelID":"model-a","tokens":{"input":12,"output":3}}'
@@ -1712,6 +1714,75 @@ mod tests {
         assert_eq!(session.parent.billable_input_tokens, 12);
         assert_eq!(session.parent.billable_output_tokens, 3);
         assert!(session.evidence.is_some());
+    }
+
+    /// Like [`opencode_database`], with one `parent_id` child session
+    /// carrying one assistant message on `model`. A separate helper (rather
+    /// than a parameter on `opencode_database`) keeps that helper's own
+    /// fingerprint assertions stable.
+    fn opencode_database_with_delegated_child(
+        model: &str,
+    ) -> (tempfile::TempDir, std::path::PathBuf) {
+        let directory = tempfile::TempDir::new().expect("tempdir");
+        let path = directory.path().join("opencode.db");
+        let connection = rusqlite::Connection::open(&path).expect("database");
+        connection
+            .execute_batch(
+                r#"CREATE TABLE session (
+                     id TEXT PRIMARY KEY, parent_id TEXT, title TEXT,
+                     time_created INTEGER, time_updated INTEGER
+                 );
+                 CREATE TABLE message (
+                     id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+                     time_updated INTEGER, data TEXT
+                 );
+                 CREATE TABLE part (
+                     id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+                     time_created INTEGER, time_updated INTEGER, data TEXT
+                 );
+                 INSERT INTO session (id, parent_id, time_created, time_updated)
+                 VALUES ('root', NULL, 100, 120);
+                 INSERT INTO session (id, parent_id, time_created, time_updated)
+                 VALUES ('child', 'root', 110, 115);
+                 INSERT INTO message VALUES (
+                     'message', 'root', 100, 100,
+                     '{"role":"assistant","modelID":"model-a","tokens":{"input":12,"output":3}}'
+                 );"#,
+            )
+            .expect("OpenCode fixture");
+        connection
+            .execute(
+                "INSERT INTO message VALUES ('child-message', 'child', 110, 110, ?1)",
+                [format!(
+                    r#"{{"role":"assistant","modelID":"{model}","tokens":{{"input":4,"output":1}}}}"#
+                )],
+            )
+            .expect("child message");
+        drop(connection);
+        (directory, path)
+    }
+
+    #[test]
+    fn an_opencode_parent_id_child_links_as_a_delegated_thread() {
+        let (_directory, path) = opencode_database_with_delegated_child("model-b");
+        let input = SessionInput {
+            agent: "opencode".to_owned(),
+            session_id: "root".to_owned(),
+            source: RawSource::Sqlite(path),
+        };
+
+        let pass = evidence_pass_with_turn_rows(
+            &[input],
+            &|| false,
+            Some(turn_row_store("opencode", "root")),
+        );
+        let evidence = pass.evidence.expect("published evidence");
+
+        assert!(matches!(evidence.subagents, EvidenceValue::Complete(_)));
+        let subagents = observed(&evidence.subagents);
+        assert_eq!(subagents.spawn_count, 1);
+        assert!(subagents.delegated_models.contains("model-b"));
+        assert_eq!(subagents.delegated_turns, 1);
     }
 
     fn codex_record() -> String {

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -1442,10 +1442,10 @@ mod tests {
         let stored = store.evidence(&pi.key).unwrap().unwrap();
         assert_eq!(stored.status, EvidenceStatus::Ready);
         let evidence_json = stored.evidence_json.as_deref().unwrap();
-        assert!(evidence_json.contains("\"schemaRevision\":6"));
+        assert!(evidence_json.contains("\"schemaRevision\":7"));
         let evidence: SessionEvidence = serde_json::from_str(evidence_json).unwrap();
         assert_eq!(evidence.capabilities, SourceCapabilities::pi());
-        assert_eq!(evidence.schema_revision, 6);
+        assert_eq!(evidence.schema_revision, 7);
 
         let report = crate::insights_report::reduce_report(
             data_dir.path().to_path_buf(),

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -2011,10 +2011,10 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 8,
+            parser_revision: 9,
             analyzer_revision: 9,
             metrics_schema_revision: 1,
-            evidence_schema_revision: 6,
+            evidence_schema_revision: 7,
         }
     );
 }
@@ -2084,7 +2084,7 @@ async fn reprocessing_a_revision_one_row_leaves_no_placeholder_in_stored_evidenc
 
     let ready = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(ready.status, EvidenceStatus::Ready);
-    assert_eq!(ready.evidence_schema_revision, Some(6));
+    assert_eq!(ready.evidence_schema_revision, Some(7));
     assert!(!ready.evidence_json.unwrap().contains("unimplemented"));
 }
 
@@ -2125,7 +2125,7 @@ async fn a_terminal_failure_clears_an_outdated_placeholder_payload() {
 
     let failed = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(failed.status, EvidenceStatus::Failed);
-    assert_eq!(failed.evidence_schema_revision, Some(6));
+    assert_eq!(failed.evidence_schema_revision, Some(7));
     assert!(failed.evidence_json.is_none());
     assert!(failed.diagnostics_json.is_none());
 }

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -389,8 +389,17 @@ impl SourceCapabilities {
     /// Message and part timestamps provide deterministic order within one database snapshot.
     /// Tool and patch parts identify invocations but do not provide a tool catalog.
     /// `modelID` and `variant` identify each assistant model run and reasoning tier.
-    /// Compaction parts identify boundaries, but OpenCode provides no thread or quota contract.
-    /// Descendant sessions are included, but their orchestration relationship is not inferred.
+    /// Compaction parts identify boundaries, but OpenCode provides no quota contract.
+    ///
+    /// `subagent_relationships`, `subagent_models`, and `thread_identity` are
+    /// set. A descendant session's `parent_id` row is the relationship; the
+    /// adapter emits `SubagentSpawn` the first time a descendant session's
+    /// messages stream. The descendant's own `modelID` reaches
+    /// `subagents.delegated_models` through its `Delegated`-scope rows. The
+    /// session id is the thread: every row's `thread_id` is its own session,
+    /// so a child model switch or idle gap never reads as parent
+    /// reprocessing. A fork (null `parent_id`) is a separate root and never
+    /// enters this relationship.
     pub fn opencode() -> Self {
         Self {
             request_context_tokens: true,
@@ -404,10 +413,10 @@ impl SourceCapabilities {
             reasoning_effort_tier: true,
             fast_tier: false,
             service_tier: false,
-            subagent_relationships: false,
-            subagent_models: false,
+            subagent_relationships: true,
+            subagent_models: true,
             compaction_boundaries: true,
-            thread_identity: false,
+            thread_identity: true,
             quota_incidents: false,
             harness_version: false,
         }
@@ -664,7 +673,7 @@ mod tests {
         truncated_strings: serde_json::Value,
     ) -> serde_json::Value {
         json!({
-            "schemaRevision": 6,
+            "schemaRevision": 7,
             "identity": {"agent": "claude", "sessionId": session_id},
             "context": {"state": "complete", "value": {"maxRequestContextTokens": 0, "topDepthExamples": []}},
             "capabilities": {
@@ -688,9 +697,9 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 8,
+                "parserRevision": 9,
                 "analyzerRevision": 9,
-                "evidenceSchemaRevision": 6,
+                "evidenceSchemaRevision": 7,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",
                 "ordering": "monotonic",

--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -162,6 +162,8 @@ pub enum RelationProvenance {
     TaskToolUse,
     /// A Codex `spawn_agent` function call.
     SpawnAgentCall,
+    /// An OpenCode descendant session's `parent_id` row.
+    SessionParentLink,
 }
 
 /// Session facts that an adapter can state only after the last record.

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -92,10 +92,10 @@ pub use vendors::claude::ClaudeAdapter;
 pub use vendors::pi::PiAdapter;
 pub use vendors::{adapter_for, has_dedicated_adapter};
 
-pub const PARSER_REVISION: i64 = 8;
+pub const PARSER_REVISION: i64 = 9;
 pub const ANALYZER_REVISION: i64 = 9;
 pub const METRICS_SCHEMA_REVISION: i64 = 1;
-pub const EVIDENCE_SCHEMA_REVISION: i64 = 6;
+pub const EVIDENCE_SCHEMA_REVISION: i64 = 7;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -451,10 +451,10 @@ fn opencode_sqlite_vendor_is_extracted() {
     {
         let conn = rusqlite::Connection::open(&path).unwrap();
         conn.execute_batch(
-            "CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+            "CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, title TEXT, time_created INTEGER, time_updated INTEGER);
              CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
              CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
-             INSERT INTO session VALUES ('x', NULL, 1, 1);",
+             INSERT INTO session (id, parent_id, time_created, time_updated) VALUES ('x', NULL, 1, 1);",
         )
         .unwrap();
         let message = r#"{"role":"assistant","tokens":{"input":300,"output":40}}"#;

--- a/crates/antiburn-local/src/analysis/vendors/opencode.rs
+++ b/crates/antiburn-local/src/analysis/vendors/opencode.rs
@@ -5,7 +5,7 @@
 //! immediately followed by its parts. This adapter retains only one normalized
 //! message while it consumes either representation.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Cursor, Read};
 use std::path::Path;
@@ -21,18 +21,25 @@ use crate::analysis::framing::{
 };
 use crate::analysis::interface::{
     ContentKind, ContentPart, EvidenceObservation, NormalizedRecord, RawSource, RecordSink,
-    SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
+    RelationProvenance, SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter,
+    VisitOutcome,
 };
 use crate::analysis::model::{
-    CompactionTrigger, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
+    CompactionTrigger, EventSource, NormalizedEvent, NormalizedSession, Role, ToolCall,
+    ToolCategory, Usage,
 };
 use crate::analysis::records::{compact_json_text, parse_ts, tool_call_from_input};
 use crate::discovery::agents::opencode::{
-    db_session_fingerprint_connection, db_session_has_parent_id,
+    db_session_fingerprint_connection, db_session_has_parent_id, opencode_fork_parent_title,
 };
 use crate::discovery::source_version::provider_db_fingerprint;
 
 const MAX_MESSAGE_PART_BYTES: usize = MAX_RECORD_BYTES;
+
+/// Caps the descendant sessions [`OpenCodeStreamState`] tracks by identity,
+/// mirroring [`crate::analysis::threads::ThreadResolver`]'s bound for a
+/// pathologically wide fan-out of subagents.
+const MAX_TRACKED_CHILD_SESSIONS: usize = 50_000;
 
 pub struct OpenCodeAdapter;
 
@@ -171,11 +178,13 @@ fn visit_database_connection(
     } else {
         "WITH cluster(id) AS (SELECT id FROM session WHERE id = ?1)"
     };
+    state.descendant_sessions = query_db_descendant_sessions(conn, cluster, root_session_id)?;
     let mut messages = conn.prepare(&format!(
         "{cluster}
          SELECT message.id, message.time_created, message.time_updated,
                 CASE WHEN length(CAST(message.data AS BLOB)) <= ?2 THEN message.data END,
-                length(CAST(message.data AS BLOB))
+                length(CAST(message.data AS BLOB)),
+                message.session_id
          FROM message JOIN cluster ON message.session_id = cluster.id
          ORDER BY COALESCE(message.time_created, message.time_updated, 0),
                    message.session_id, message.id"
@@ -191,6 +200,7 @@ fn visit_database_connection(
         let updated: Option<i64> = row.get(2).ok();
         let data: Option<String> = row.get(3).ok().flatten();
         let data_len = row.get::<_, Option<i64>>(4)?.unwrap_or(0).max(0) as usize;
+        let session_id: String = row.get(5)?;
         let fallback_ts = created.or(updated).and_then(parse_db_ts);
 
         if data_len > MAX_RECORD_BYTES {
@@ -208,11 +218,12 @@ fn visit_database_connection(
             drain_message_parts(&mut parts, &message_id, cancel, sink)?;
             continue;
         };
-        let Some(event) = message_event(&value, fallback_ts) else {
+        let Some(mut event) = message_event(&value, fallback_ts) else {
             report_invalid_message(&value, sink);
             drain_message_parts(&mut parts, &message_id, cancel, sink)?;
             continue;
         };
+        state.apply_session(&mut event, &session_id, session_id != root_session_id, sink);
         state.observe_model(&event);
         let mut pending = PendingMessage {
             id: message_id,
@@ -230,6 +241,40 @@ fn visit_database_connection(
         }
     }
     Ok(state.finish())
+}
+
+/// Loads each descendant session's own creation timestamp and fork-title
+/// signal in one query, so a message row never needs its own join back to
+/// `session`. One row per session, not per message; forks (null
+/// `parent_id`) never join `cluster` and never appear here.
+fn query_db_descendant_sessions(
+    conn: &Connection,
+    cluster: &str,
+    root_session_id: &str,
+) -> rusqlite::Result<HashMap<String, DescendantSessionMeta>> {
+    let mut statement = conn.prepare(&format!(
+        "{cluster}
+         SELECT session.id, session.time_created, session.title
+         FROM session JOIN cluster ON session.id = cluster.id
+         WHERE session.id != ?1"
+    ))?;
+    let mut rows = statement.query(params![root_session_id])?;
+    let mut out = HashMap::new();
+    while let Some(row) = rows.next()? {
+        let id: String = row.get(0)?;
+        let created: Option<i64> = row.get(1).ok();
+        let title: Option<String> = row.get(2).ok();
+        out.insert(
+            id,
+            DescendantSessionMeta {
+                ts_ms: created.and_then(parse_db_ts),
+                looks_like_fork: title
+                    .as_deref()
+                    .is_some_and(|title| opencode_fork_parent_title(title).is_some()),
+            },
+        );
+    }
+    Ok(out)
 }
 
 fn prepare_db_parts(conn: &Connection) -> rusqlite::Result<Statement<'_>> {
@@ -311,10 +356,41 @@ fn drain_message_parts(
     visit_db_parts(statement, &mut pending, cancel, sink)
 }
 
+/// One descendant session's own creation timestamp and fork-title signal,
+/// known from `session` (database) or `session_member` (export) before its
+/// first message streams.
+#[derive(Default)]
+struct DescendantSessionMeta {
+    ts_ms: Option<i64>,
+    looks_like_fork: bool,
+}
+
 #[derive(Default)]
 struct OpenCodeStreamState {
     pending: Option<PendingMessage>,
     model: Option<String>,
+    /// The root session id, known from the export's `session_meta` row.
+    /// `None` for a synthetic stream with no session wrapper; every message
+    /// then stays main-scope, matching the pre-relationship behavior.
+    root_session_id: Option<String>,
+    /// The root's own most recently observed model, reported as
+    /// `SubagentSpawn::parent_model`.
+    root_model: Option<String>,
+    /// Spawn timestamp and fork-title signal per descendant session,
+    /// prefetched (database) or accumulated from `session_member` rows
+    /// (export) ahead of that session's first message.
+    descendant_sessions: HashMap<String, DescendantSessionMeta>,
+    /// Descendant sessions already reported through `SubagentSpawn`, capped
+    /// like [`crate::analysis::threads::ThreadResolver`].
+    seen_child_sessions: HashSet<String>,
+    /// True once [`MAX_TRACKED_CHILD_SESSIONS`] is reached and a further
+    /// descendant session goes unreported.
+    children_capped: bool,
+    /// True once a `parent_id` descendant's title also looks like an
+    /// OpenCode fork title (`opencode_fork_parent_title`). Discovery's
+    /// `infer_db_fork_observation` owns real fork detection; this only
+    /// degrades attribution for the ambiguous shape.
+    saw_fork_titled_child: bool,
 }
 
 struct PendingMessage {
@@ -340,10 +416,19 @@ impl OpenCodeStreamState {
                 };
                 let payload = value.get("payload").unwrap_or(&value);
                 let fallback_ts = value.pointer("/time/created").and_then(parse_ts);
-                let Some(event) = message_event(payload, fallback_ts) else {
+                let Some(mut event) = message_event(payload, fallback_ts) else {
                     report_invalid_message(payload, sink);
                     return;
                 };
+                if let Some(session_id) = value.get("sessionID").and_then(Value::as_str) {
+                    let session_role = value.get("sessionRole").and_then(Value::as_str);
+                    let is_child = session_role == Some("child")
+                        || self
+                            .root_session_id
+                            .as_deref()
+                            .is_some_and(|root| root != session_id);
+                    self.apply_session(&mut event, session_id, is_child, sink);
+                }
                 self.observe_model(&event);
                 self.pending = Some(PendingMessage {
                     id: id.to_owned(),
@@ -375,17 +460,31 @@ impl OpenCodeStreamState {
                 let fallback_ts = value.pointer("/time/created").and_then(parse_ts);
                 apply_part(payload, fallback_ts, pending, sink);
             }
-            Some("session_meta" | "session_member") => {
+            Some("session_meta") => {
                 self.flush(sink);
-                if let Some(ts_ms) = value
-                    .pointer("/time/created")
-                    .and_then(parse_ts)
-                    .or_else(|| value.pointer("/time/updated").and_then(parse_ts))
-                {
-                    sink.record(NormalizedRecord::Observation(Box::new(
-                        EvidenceObservation::RecordTimestamp { ts_ms },
-                    )));
+                if self.root_session_id.is_none() {
+                    self.root_session_id = value
+                        .pointer("/payload/id")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
                 }
+                self.observe_record_timestamp(&value, sink);
+            }
+            Some("session_member") => {
+                self.flush(sink);
+                if let Some(child_id) = value.get("originSessionID").and_then(Value::as_str) {
+                    let ts_ms = value.pointer("/time/created").and_then(parse_ts);
+                    let title = value.pointer("/payload/title").and_then(Value::as_str);
+                    self.descendant_sessions.insert(
+                        child_id.to_owned(),
+                        DescendantSessionMeta {
+                            ts_ms,
+                            looks_like_fork: title
+                                .is_some_and(|title| opencode_fork_parent_title(title).is_some()),
+                        },
+                    );
+                }
+                self.observe_record_timestamp(&value, sink);
             }
             Some(discriminator) => {
                 self.flush(sink);
@@ -396,6 +495,72 @@ impl OpenCodeStreamState {
                 unrecognized("<missing>", sink);
             }
         }
+    }
+
+    fn observe_record_timestamp(&self, value: &Value, sink: &mut dyn RecordSink) {
+        if let Some(ts_ms) = value
+            .pointer("/time/created")
+            .and_then(parse_ts)
+            .or_else(|| value.pointer("/time/updated").and_then(parse_ts))
+        {
+            sink.record(NormalizedRecord::Observation(Box::new(
+                EvidenceObservation::RecordTimestamp { ts_ms },
+            )));
+        }
+    }
+
+    /// Applies one message's session identity to its event: sets
+    /// `thread_id` to the message's own session and, for a descendant
+    /// session, `EventSource::Subagent`. Otherwise updates the root's
+    /// current model, reported by a later spawn as `parent_model`.
+    fn apply_session(
+        &mut self,
+        event: &mut NormalizedEvent,
+        session_id: &str,
+        is_child: bool,
+        sink: &mut dyn RecordSink,
+    ) {
+        event.thread_id = Some(session_id.to_owned());
+        if !is_child {
+            if event.model.is_some() {
+                self.root_model = event.model.clone();
+            }
+            return;
+        }
+        event.source = EventSource::Subagent;
+        if self
+            .descendant_sessions
+            .get(session_id)
+            .is_some_and(|meta| meta.looks_like_fork)
+        {
+            self.saw_fork_titled_child = true;
+        }
+        self.spawn_child(session_id, sink);
+    }
+
+    /// Emits one `SubagentSpawn` the first time `session_id` streams, up to
+    /// [`MAX_TRACKED_CHILD_SESSIONS`]. Past the cap, the session goes
+    /// untracked and [`Self::finish`] reports `AttributionIncomplete`.
+    fn spawn_child(&mut self, session_id: &str, sink: &mut dyn RecordSink) {
+        if self.seen_child_sessions.contains(session_id) {
+            return;
+        }
+        if self.seen_child_sessions.len() >= MAX_TRACKED_CHILD_SESSIONS {
+            self.children_capped = true;
+            return;
+        }
+        self.seen_child_sessions.insert(session_id.to_owned());
+        let ts_ms = self
+            .descendant_sessions
+            .get(session_id)
+            .and_then(|meta| meta.ts_ms);
+        sink.record(NormalizedRecord::Observation(Box::new(
+            EvidenceObservation::SubagentSpawn {
+                ts_ms,
+                parent_model: self.root_model.clone(),
+                provenance: RelationProvenance::SessionParentLink,
+            },
+        )));
     }
 
     fn observe_model(&mut self, event: &NormalizedEvent) {
@@ -416,12 +581,20 @@ impl OpenCodeStreamState {
     }
 
     fn finish(&self) -> SessionSummary {
+        // A capped or fork-titled descendant means some records could not
+        // be attributed to their real relationship: the same kind of
+        // attribution loss the Claude adapter's capped thread resolver
+        // reports.
+        let mut coverage_gaps = Vec::new();
+        if self.children_capped || self.saw_fork_titled_child {
+            coverage_gaps.push(PartialReason::AttributionIncomplete);
+        }
         SessionSummary {
             cache_write_tokens_available: true,
             context_window: None,
             model: self.model.clone(),
             started_at_ms: None,
-            coverage_gaps: Vec::new(),
+            coverage_gaps,
             late_tools: Vec::new(),
             initial_context: None,
             skill_descriptions: HashMap::new(),

--- a/crates/antiburn-local/src/analysis/vendors/opencode.rs
+++ b/crates/antiburn-local/src/analysis/vendors/opencode.rs
@@ -223,6 +223,9 @@ fn visit_database_connection(
             drain_message_parts(&mut parts, &message_id, cancel, sink)?;
             continue;
         };
+        // The message id is the record identity. The sink reads a missing
+        // `uuid` as a thread-identity gap and degrades the cache group.
+        event.uuid = Some(message_id.clone());
         state.apply_session(&mut event, &session_id, session_id != root_session_id, sink);
         state.observe_model(&event);
         let mut pending = PendingMessage {
@@ -420,6 +423,7 @@ impl OpenCodeStreamState {
                     report_invalid_message(payload, sink);
                     return;
                 };
+                event.uuid = Some(id.to_owned());
                 if let Some(session_id) = value.get("sessionID").and_then(Value::as_str) {
                     let session_role = value.get("sessionRole").and_then(Value::as_str);
                     let is_child = session_role == Some("child")

--- a/crates/antiburn-local/src/discovery/agents/opencode.rs
+++ b/crates/antiburn-local/src/discovery/agents/opencode.rs
@@ -2826,7 +2826,12 @@ fn opencode_content_visible_items(content: &str) -> Vec<(String, String)> {
         .collect()
 }
 
-fn opencode_fork_parent_title(title: &str) -> Option<&str> {
+/// Checks `title` for the OpenCode fork title shape (`"<parent> (fork
+/// #N)"`) and returns the parent's own title. The analysis adapter reuses
+/// this function to flag a `parent_id` child whose title also looks like a
+/// fork. The adapter does not decide fork identity; that stays a discovery
+/// task.
+pub(crate) fn opencode_fork_parent_title(title: &str) -> Option<&str> {
     let (parent, suffix) = title.trim().rsplit_once(" (fork #")?;
     let number = suffix.strip_suffix(')')?;
     (!parent.is_empty() && !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()))

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -143,19 +143,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "partial",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -131,19 +131,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -129,19 +129,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -124,19 +124,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "partial",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -113,19 +113,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -142,19 +142,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -124,19 +124,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -124,19 +124,19 @@
     },
     "provenance": {
       "analyzerRevision": 9,
-      "evidenceSchemaRevision": 6,
+      "evidenceSchemaRevision": 7,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 8,
+      "parserRevision": 9,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 6,
+    "schemaRevision": 7,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/opencode_characterization.rs
+++ b/crates/antiburn-local/tests/opencode_characterization.rs
@@ -343,6 +343,11 @@ fn subagent_children_stream_as_delegated_threads() {
     );
 
     assert!(matches!(evidence.subagents, EvidenceValue::Complete(_)));
+    assert!(
+        matches!(evidence.cache, EvidenceValue::Complete(_)),
+        "every row carries its message id, so the thread-identity claim holds: {:?}",
+        evidence.cache
+    );
     let subagents = observed(&evidence.subagents);
     assert_eq!(subagents.spawn_count, 2);
     assert!(subagents.delegated_models.contains("model-b"));

--- a/crates/antiburn-local/tests/opencode_characterization.rs
+++ b/crates/antiburn-local/tests/opencode_characterization.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use antiburn_local::analysis::{
-    CompositeSink, EvidenceSource, MemoryTurnRowStore, NormalizedRecord, PartialReason, RawSource,
-    RecordSink, SessionCollector, SessionEvidenceAccumulator, SessionInput,
-    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceKind, TurnRowSink,
-    TurnRowStore, VisitOutcome, adapter_for,
+    CompositeSink, CoverageReason, EventSource, EvidenceSource, EvidenceValue, MemoryTurnRowStore,
+    NormalizedRecord, PartialReason, RawSource, RecordSink, SessionCollector, SessionEvidence,
+    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SessionSummary,
+    SourceCapabilities, SourceKind, TurnRowSink, TurnRowStore, VisitOutcome, adapter_for,
 };
 use rusqlite::{Connection, params};
 use serde_json::json;
@@ -17,7 +17,8 @@ fn create_database() -> (TempDir, std::path::PathBuf) {
     connection
         .execute_batch(
             "CREATE TABLE session (
-                 id TEXT PRIMARY KEY, parent_id TEXT, time_created INTEGER, time_updated INTEGER
+                 id TEXT PRIMARY KEY, parent_id TEXT, title TEXT,
+                 time_created INTEGER, time_updated INTEGER
              );
              CREATE TABLE message (
                  id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
@@ -41,13 +42,80 @@ fn sqlite_input(path: &std::path::Path, session_id: &str) -> SessionInput {
     }
 }
 
-fn insert_session(connection: &Connection, id: &str, parent: Option<&str>, timestamp: i64) {
+fn insert_session(
+    connection: &Connection,
+    id: &str,
+    parent: Option<&str>,
+    title: Option<&str>,
+    timestamp: i64,
+) {
     connection
         .execute(
-            "INSERT INTO session VALUES (?1, ?2, ?3, ?3)",
-            params![id, parent, timestamp],
+            "INSERT INTO session (id, parent_id, title, time_created, time_updated)
+             VALUES (?1, ?2, ?3, ?4, ?4)",
+            params![id, parent, title, timestamp],
         )
         .expect("session");
+}
+
+/// Streams `session_id` through the OpenCode adapter and the real evidence
+/// and turn-row pipeline, the same path production uses. Returns the
+/// published evidence plus the row store, so a test can also read rows back
+/// directly with [`MemoryTurnRowStore::with_connection`].
+fn evidence_and_rows(input: &SessionInput) -> (SessionEvidence, Arc<MemoryTurnRowStore>) {
+    let metrics = SessionMetricsAccumulator::new(&input.agent, &input.session_id);
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::from(&input.source),
+        capabilities: SourceCapabilities::opencode(),
+    });
+    let store = MemoryTurnRowStore::new(&input.agent, &input.session_id);
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        &input.session_id,
+        None,
+    );
+    let mut sink = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
+    let outcome = adapter_for("opencode")
+        .visit(input, &mut sink)
+        .expect("stream opencode source");
+    sink.observe_source_outcome(outcome);
+    let evidence = sink.evidence().expect("published evidence");
+    (evidence, store)
+}
+
+/// Reads back `(scope, thread_id, child_id)` for every row of one session,
+/// in turn order, straight off [`MemoryTurnRowStore`]'s in-memory database.
+fn turn_identities(
+    store: &MemoryTurnRowStore,
+    session_id: &str,
+) -> Vec<(String, String, Option<String>)> {
+    store.with_connection(|connection| {
+        let mut statement = connection
+            .prepare(
+                "SELECT scope, thread_id, child_id FROM turn
+                  WHERE environment_key = 'native' AND agent = 'opencode'
+                    AND session_id = ?1 AND claim_fence = 1
+                  ORDER BY turn_index",
+            )
+            .expect("prepare");
+        statement
+            .query_map(params![session_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .expect("query")
+            .map(|row| row.expect("row"))
+            .collect()
+    })
+}
+
+fn observed<T: Clone>(value: &EvidenceValue<T>) -> T {
+    match value {
+        EvidenceValue::Complete(observed) => observed.clone(),
+        EvidenceValue::Partial { observed, .. } => observed.clone(),
+        EvidenceValue::Unsupported => panic!("evidence unexpectedly unsupported"),
+    }
 }
 
 fn insert_message(connection: &Connection, id: &str, session_id: &str, timestamp: i64, data: &str) {
@@ -91,10 +159,10 @@ fn opencode_capabilities_match_the_observed_contract() {
             reasoning_effort_tier: true,
             fast_tier: false,
             service_tier: false,
-            subagent_relationships: false,
-            subagent_models: false,
+            subagent_relationships: true,
+            subagent_models: true,
             compaction_boundaries: true,
-            thread_identity: false,
+            thread_identity: true,
             quota_incidents: false,
             harness_version: false,
         }
@@ -105,8 +173,8 @@ fn opencode_capabilities_match_the_observed_contract() {
 fn native_sqlite_streams_root_and_descendant_messages_in_order() {
     let (_directory, path) = create_database();
     let connection = Connection::open(&path).expect("database");
-    insert_session(&connection, "root", None, 10);
-    insert_session(&connection, "child", Some("root"), 20);
+    insert_session(&connection, "root", None, None, 10);
+    insert_session(&connection, "child", Some("root"), None, 20);
     insert_message(
         &connection,
         "later",
@@ -173,9 +241,15 @@ fn native_sqlite_streams_root_and_descendant_messages_in_order() {
 
     assert_eq!(session.events.len(), 3);
     assert_eq!(session.events[0].role, antiburn_local::analysis::Role::User);
+    // The child's messages carry the child's own session as their thread and
+    // stream as a descendant, even interleaved before the root's message.
+    assert_eq!(session.events[0].thread_id.as_deref(), Some("child"));
+    assert_eq!(session.events[0].source, EventSource::Subagent);
     let child_assistant = &session.events[1];
     assert_eq!(child_assistant.model.as_deref(), Some("model-child"));
     assert_eq!(child_assistant.tools.len(), 1);
+    assert_eq!(child_assistant.thread_id.as_deref(), Some("child"));
+    assert_eq!(child_assistant.source, EventSource::Subagent);
     let assistant = &session.events[2];
     assert_eq!(assistant.usage.input_tokens, 100);
     assert_eq!(assistant.usage.output_tokens, 25);
@@ -186,6 +260,10 @@ fn native_sqlite_streams_root_and_descendant_messages_in_order() {
     assert!(assistant.has_thinking);
     assert!(assistant.is_compaction_boundary);
     assert_eq!(assistant.tools.len(), 2);
+    // The root's own message carries the root session as its thread and
+    // stays main-scope.
+    assert_eq!(assistant.thread_id.as_deref(), Some("root"));
+    assert_eq!(assistant.source, EventSource::Parent);
 
     let retained = serde_json::to_string(&session).expect("serialize normalized session");
     for private in [
@@ -197,6 +275,263 @@ fn native_sqlite_streams_root_and_descendant_messages_in_order() {
     ] {
         assert!(!retained.contains(private));
     }
+}
+
+#[test]
+fn subagent_children_stream_as_delegated_threads() {
+    let (_directory, path) = create_database();
+    let connection = Connection::open(&path).expect("database");
+    insert_session(&connection, "root", None, None, 10);
+    insert_session(&connection, "child", Some("root"), None, 20);
+    insert_session(&connection, "grandchild", Some("child"), None, 22);
+    insert_message(
+        &connection,
+        "r1",
+        "root",
+        10,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    insert_message(&connection, "c1", "child", 20, r#"{"role":"user"}"#);
+    insert_message(
+        &connection,
+        "c2",
+        "child",
+        30,
+        r#"{"role":"assistant","modelID":"model-b","tokens":{"input":2,"output":2}}"#,
+    );
+    insert_message(
+        &connection,
+        "g1",
+        "grandchild",
+        32,
+        r#"{"role":"assistant","modelID":"model-c","tokens":{"input":1,"output":1}}"#,
+    );
+    insert_message(
+        &connection,
+        "r2",
+        "root",
+        60,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    drop(connection);
+
+    let input = sqlite_input(&path, "root");
+    let (evidence, store) = evidence_and_rows(&input);
+
+    let rows = turn_identities(&store, "root");
+    assert_eq!(
+        rows,
+        vec![
+            ("main".to_owned(), "root".to_owned(), None),
+            (
+                "delegated".to_owned(),
+                "child".to_owned(),
+                Some("child".to_owned())
+            ),
+            (
+                "delegated".to_owned(),
+                "child".to_owned(),
+                Some("child".to_owned())
+            ),
+            (
+                "delegated".to_owned(),
+                "grandchild".to_owned(),
+                Some("grandchild".to_owned())
+            ),
+            ("main".to_owned(), "root".to_owned(), None),
+        ]
+    );
+
+    assert!(matches!(evidence.subagents, EvidenceValue::Complete(_)));
+    let subagents = observed(&evidence.subagents);
+    assert_eq!(subagents.spawn_count, 2);
+    assert!(subagents.delegated_models.contains("model-b"));
+
+    let facts = store.query_turn_facts().expect("turn facts");
+    assert!(
+        facts.model_transitions.is_empty(),
+        "the child's model switch must not read as a root transition"
+    );
+    assert_eq!(
+        facts.longest_idle_gap_ms, 50_000,
+        "the child's activity between the root's two messages must not split the root's own gap"
+    );
+}
+
+#[test]
+fn a_fork_is_its_own_root() {
+    let (_directory, path) = create_database();
+    let connection = Connection::open(&path).expect("database");
+    insert_session(
+        &connection,
+        "parent",
+        None,
+        Some("Investigate the outage"),
+        10,
+    );
+    insert_session(
+        &connection,
+        "fork",
+        None,
+        Some("Investigate the outage (fork #1)"),
+        50,
+    );
+    insert_message(&connection, "p1", "parent", 10, r#"{"role":"user"}"#);
+    insert_message(
+        &connection,
+        "p2",
+        "parent",
+        20,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    insert_message(&connection, "p3", "parent", 30, r#"{"role":"user"}"#);
+    // Copied prefix: the fork's first three messages carry new ids but keep
+    // the parent's own `time_created`, older than the fork session itself.
+    insert_message(&connection, "f1", "fork", 10, r#"{"role":"user"}"#);
+    insert_message(
+        &connection,
+        "f2",
+        "fork",
+        20,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    insert_message(&connection, "f3", "fork", 30, r#"{"role":"user"}"#);
+    insert_message(&connection, "f4", "fork", 60, r#"{"role":"user"}"#);
+    drop(connection);
+
+    let parent_input = sqlite_input(&path, "parent");
+    let mut parent_collector = SessionCollector::new("opencode", "parent");
+    adapter_for("opencode")
+        .visit(&parent_input, &mut parent_collector)
+        .expect("stream parent");
+    let parent_session = parent_collector.into_session().expect("finished parent");
+    assert_eq!(parent_session.events.len(), 3);
+    assert!(
+        parent_session
+            .events
+            .iter()
+            .all(|event| event.thread_id.as_deref() == Some("parent"))
+    );
+    let (parent_evidence, _) = evidence_and_rows(&parent_input);
+    assert_eq!(observed(&parent_evidence.subagents).spawn_count, 0);
+
+    let fork_input = sqlite_input(&path, "fork");
+    let mut fork_collector = SessionCollector::new("opencode", "fork");
+    adapter_for("opencode")
+        .visit(&fork_input, &mut fork_collector)
+        .expect("stream fork");
+    let fork_session = fork_collector.into_session().expect("finished fork");
+    assert_eq!(fork_session.events.len(), 4);
+    assert!(
+        fork_session
+            .events
+            .iter()
+            .all(|event| event.thread_id.as_deref() == Some("fork"))
+    );
+    let (fork_evidence, _) = evidence_and_rows(&fork_input);
+    assert_eq!(observed(&fork_evidence.subagents).spawn_count, 0);
+}
+
+#[test]
+fn a_fork_title_without_a_copied_prefix_is_an_ordinary_root() {
+    let (_directory, path) = create_database();
+    let connection = Connection::open(&path).expect("database");
+    insert_session(
+        &connection,
+        "lonely",
+        None,
+        Some("Refactor payments (fork #2)"),
+        10,
+    );
+    insert_message(&connection, "m1", "lonely", 10, r#"{"role":"user"}"#);
+    insert_message(
+        &connection,
+        "m2",
+        "lonely",
+        20,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    drop(connection);
+
+    let input = sqlite_input(&path, "lonely");
+    let (evidence, _) = evidence_and_rows(&input);
+
+    assert_eq!(observed(&evidence.subagents).spawn_count, 0);
+    assert!(matches!(evidence.subagents, EvidenceValue::Complete(_)));
+}
+
+#[test]
+fn a_parent_id_child_with_a_fork_title_degrades_attribution() {
+    let (_directory, path) = create_database();
+    let connection = Connection::open(&path).expect("database");
+    insert_session(&connection, "root", None, Some("Ship the release"), 10);
+    insert_session(
+        &connection,
+        "child",
+        Some("root"),
+        Some("Ship the release (fork #1)"),
+        20,
+    );
+    insert_message(
+        &connection,
+        "r1",
+        "root",
+        10,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    insert_message(&connection, "c1", "child", 20, r#"{"role":"user"}"#);
+    insert_message(
+        &connection,
+        "c2",
+        "child",
+        30,
+        r#"{"role":"assistant","modelID":"model-b","tokens":{"input":1,"output":1}}"#,
+    );
+    drop(connection);
+
+    let input = sqlite_input(&path, "root");
+    let (evidence, _) = evidence_and_rows(&input);
+
+    match &evidence.subagents {
+        EvidenceValue::Partial { reason, .. } => {
+            assert_eq!(*reason, CoverageReason::AttributionIncomplete);
+        }
+        other => panic!("expected partial subagents evidence, got {other:?}"),
+    }
+}
+
+#[test]
+fn export_stream_marks_a_child_message_as_delegated_with_one_spawn() {
+    let jsonl = concat!(
+        r#"{"type":"session_meta","sessionID":"root","sessionRole":"root","time":{"created":1000},"payload":{"id":"root","title":"Root session"}}"#,
+        "\n",
+        r#"{"type":"session_member","rootSessionID":"root","originSessionID":"child","sessionRole":"child","parentSessionID":"root","time":{"created":1500},"payload":{"id":"child","title":"Child session"}}"#,
+        "\n",
+        r#"{"type":"message","rootSessionID":"root","sessionID":"root","sessionRole":"root","messageID":"m1","time":{"created":1000},"payload":{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}}"#,
+        "\n",
+        r#"{"type":"message","rootSessionID":"root","sessionID":"child","sessionRole":"child","parentSessionID":"root","messageID":"m2","time":{"created":1600},"payload":{"role":"user"}}"#,
+        "\n",
+    );
+    let input = SessionInput {
+        agent: "opencode".to_owned(),
+        session_id: "root".to_owned(),
+        source: RawSource::Jsonl(jsonl.to_owned()),
+    };
+
+    let mut collector = SessionCollector::new("opencode", "root");
+    adapter_for("opencode")
+        .visit(&input, &mut collector)
+        .expect("stream export");
+    let session = collector.into_session().expect("finished session");
+
+    assert_eq!(session.events.len(), 2);
+    assert_eq!(session.events[0].thread_id.as_deref(), Some("root"));
+    assert_eq!(session.events[0].source, EventSource::Parent);
+    assert_eq!(session.events[1].thread_id.as_deref(), Some("child"));
+    assert_eq!(session.events[1].source, EventSource::Subagent);
+
+    let (evidence, _) = evidence_and_rows(&input);
+    assert_eq!(observed(&evidence.subagents).spawn_count, 1);
 }
 
 #[cfg(feature = "test-instrumentation")]
@@ -227,7 +562,7 @@ fn malformed_unknown_and_oversized_rows_report_partial_without_payload() {
     const PRIVATE: &str = "PRIVATE_OVERSIZED_CONTENT";
     let (_directory, path) = create_database();
     let connection = Connection::open(&path).expect("database");
-    insert_session(&connection, "root", None, 10);
+    insert_session(&connection, "root", None, None, 10);
     insert_message(&connection, "malformed", "root", 20, "{not-json");
     insert_message(
         &connection,
@@ -281,7 +616,7 @@ fn malformed_unknown_and_oversized_rows_report_partial_without_payload() {
 fn database_claim_is_checked_inside_the_snapshot() {
     let (_directory, path) = create_database();
     let connection = Connection::open(&path).expect("database");
-    insert_session(&connection, "root", None, 100);
+    insert_session(&connection, "root", None, None, 100);
     insert_message(&connection, "message", "root", 120, r#"{"role":"user"}"#);
     drop(connection);
     let input = sqlite_input(&path, "root");

--- a/crates/antiburn-local/tests/support/corpus.rs
+++ b/crates/antiburn-local/tests/support/corpus.rs
@@ -557,7 +557,8 @@ pub fn write_provider_db(path: &Path, session: &GeneratedSession) -> anyhow::Res
     let mut connection = rusqlite::Connection::open(path)?;
     connection.execute_batch(
         "CREATE TABLE session (
-             id TEXT PRIMARY KEY, parent_id TEXT, time_created INTEGER, time_updated INTEGER
+             id TEXT PRIMARY KEY, parent_id TEXT, title TEXT,
+             time_created INTEGER, time_updated INTEGER
          );
          CREATE TABLE message (
              id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
@@ -576,7 +577,7 @@ pub fn write_provider_db(path: &Path, session: &GeneratedSession) -> anyhow::Res
     let transaction = connection.transaction()?;
     {
         transaction.execute(
-            "INSERT INTO session VALUES (?1, NULL, 0, 0)",
+            "INSERT INTO session (id, parent_id, time_created, time_updated) VALUES (?1, NULL, 0, 0)",
             [&session.session_id],
         )?;
         let mut insert_message =


### PR DESCRIPTION
Seam 4e of `docs/plans/session-evidence-harness-parity.md`. Follows #270.

## What changes

- Every OpenCode message row gets `thread_id` = its own session id.
- A `parent_id` descendant's messages stream as `EventSource::Subagent` → `Delegated` scope, `child_id` = session id. Subagent turns no longer fold into the parent's transitions, idle gaps, or model set.
- One `SubagentSpawn` per descendant session (new `RelationProvenance::SessionParentLink`), `ts_ms` from the child session's `time_created`, `parent_model` = the root's current model. Both the SQLite path (one-shot `session` join over the cluster) and the export path (`session_member` rows keyed by `originSessionID`, `message.sessionRole == "child"` / `sessionID != root`) apply the same rule.
- Tracked children capped at 50 000 like `ThreadResolver`; past the cap → `AttributionIncomplete`.
- A `parent_id` child whose title matches `opencode_fork_parent_title` is still delegated but degrades `subagents` to `Partial(AttributionIncomplete)`. Forks (null `parent_id`) never enter the cluster; fixtures freeze that. Fork detection stays in discovery.
- `SourceCapabilities::opencode()`: `subagent_relationships`, `subagent_models`, `thread_identity` → true. `SessionsOverDepth`, `OverpoweredSubagents`, and `CacheChurn` become assessable for OpenCode; `OveruseOfFastMode` stays out (no speed signal).
- `PARSER_REVISION` 8→9, `EVIDENCE_SCHEMA_REVISION` 6→7. The 8 golden diffs (4 Codex, 4 Pi) are revision-only.

## Tests

New in `opencode_characterization.rs`: delegated child + grandchild threads, fork is its own root, fork-title-without-prefix is an ordinary root, fork-titled `parent_id` child degrades attribution, export-path spawn. Desktop acceptance test `an_opencode_parent_id_child_links_as_a_delegated_thread`. Test DB schemas gained the `title` column the new query joins.

fmt / clippy `-D warnings` / tests clean in both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
