### PR TITLE
fix(insights): report capability gaps on blocked clean claims

### DIFF
--- a/crates/antiburn-local/src/insights/badges.rs
+++ b/crates/antiburn-local/src/insights/badges.rs
@@ -2,7 +2,7 @@ use crate::analysis::{EvidenceCoverage, SessionEvidence};
 
 use super::DetectorId;
 use super::detectors::{self, NotAssessedReason, Observation, ReportCatalogs};
-use super::report::{clean_facts_complete, eligible};
+use super::report::{clean_fact_unsupported, clean_facts_complete, eligible};
 
 /// Identifies one session-level hygiene badge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -80,6 +80,11 @@ fn badge_status(
                 && evidence.coverage == EvidenceCoverage::Complete
             {
                 BadgeStatus::Clean
+            } else if clean_fact_unsupported(detector, evidence) {
+                // An `Unsupported` clean fact blocks a clean claim for
+                // every session from this source. Report the capability
+                // gap, not the coverage.
+                BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing)
             } else {
                 BadgeStatus::NotAssessed(NotAssessedReason::IncompleteEvidence)
             }
@@ -284,6 +289,24 @@ mod tests {
             BadgeStatus::Clean => Some(DetectorStatus::Clean),
             BadgeStatus::Finding => None,
         }
+    }
+
+    #[test]
+    fn an_unsupported_clean_fact_reads_capability_missing() {
+        // Codex sessions have no record identity, so the `RecordLinkage`
+        // clean fact stays `Unsupported` and cache churn can never read
+        // clean. The badge must report the capability gap, not the
+        // coverage.
+        let mut evidence = claude_evidence("synthetic-unsupported-linkage");
+        let EvidenceValue::Complete(cache) = &mut evidence.cache else {
+            panic!("the synthetic evidence must carry a cache group");
+        };
+        cache.previous_turn = EvidenceValue::Unsupported;
+
+        assert_eq!(
+            badge(&evidence, BadgeId::ExcessCacheRehydration).status,
+            BadgeStatus::NotAssessed(NotAssessedReason::CapabilityMissing)
+        );
     }
 
     #[test]

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -283,6 +283,15 @@ pub fn clean_facts_complete(detector: DetectorId, evidence: &SessionEvidence) ->
         .all(|fact| fact.state(evidence) == FactState::Complete)
 }
 
+/// A clean claim is out of reach for `detector` when a clean fact is
+/// `Unsupported`. The source does not record what the claim needs.
+pub fn clean_fact_unsupported(detector: DetectorId, evidence: &SessionEvidence) -> bool {
+    requirements(detector)
+        .clean
+        .iter()
+        .any(|fact| fact.state(evidence) == FactState::Unsupported)
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CoverageCounts {
     pub discovered: u64,

--- a/crates/antiburn-local/tests/badge_matrix.rs
+++ b/crates/antiburn-local/tests/badge_matrix.rs
@@ -644,10 +644,12 @@ fn matrix() -> Vec<Row> {
             // and `request_context_tokens`, so the badge is eligible; it
             // never reads clean, because Codex has no `record_identity`
             // (the matrix's "Conditional using uncached-input accounting").
+            // The unsupported `RecordLinkage` clean fact reports the
+            // capability gap, not the coverage.
             harness: "codex",
             fixture: "records_all_kinds",
             badge: ExcessCacheRehydration,
-            expected: NotAssessed(IncompleteEvidence),
+            expected: NotAssessed(CapabilityMissing),
         },
         Row {
             harness: "codex",


### PR DESCRIPTION
## What

When a detector observes **no finding** but a clean claim is blocked by an `Unsupported` clean fact, the badge now reports `NotAssessed(CapabilityMissing)` instead of `NotAssessed(IncompleteEvidence)`.

## Why

Codex has no `record_identity`, so `Fact::RecordLinkage` is permanently `Unsupported` and Excess Context Re-reads can never read Clean for Codex (the plan's "Conditional using uncached-input accounting"). The tooltip said *"couldn't read the whole session log"* — wrong and alarming. It now says *"this agent's logs don't record what this check needs"* — accurate: the gap is a source capability, not coverage.

Coverage-driven blocks (malformed records → `Partial` facts) still read `IncompleteEvidence`; the badge matrix proves only the codex cache-churn row flips.

## How

- `report.rs`: new `clean_fact_unsupported` helper beside `clean_facts_complete`.
- `badges.rs`: the `NoFinding` branch checks it before falling back to `IncompleteEvidence`; new unit test; matrix row updated with its rationale.
- No revision bump: badges compute at read time from stored evidence.

## Tests

- `crates/antiburn-local`: fmt, clippy `-D warnings`, `cargo test --no-fail-fast` — 13/13 suites ok.
- `apps/desktop/src-tauri`: same — 3/3 suites ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)