### PR TITLE
test(store): pin every requeue decision in reconcile_evidence_revisions

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -93,29 +93,17 @@ fn evidence_completion(
     }
 }
 
-fn seed_current_session_evidence(store: &Store, session_id: &str) -> SessionRecord {
+/// Seed a session and mark its evidence row Ready with every column current,
+/// but write no `session_analysis` row. Use this to isolate the
+/// missing-analysis requeue arm from the `metrics_schema_revision` join it
+/// depends on.
+fn seed_ready_evidence_row(store: &Store, session_id: &str) -> SessionRecord {
     let mut record = session(session_id, 1_000);
     record.source_fingerprint = Some("sv1:current".into());
     store
         .upsert_sessions(
             std::slice::from_ref(&record),
             &crate::agents::evidence_cohort(),
-        )
-        .unwrap();
-    store
-        .save_analysis(
-            &AnalysisRecord {
-                key: record.key.clone(),
-                model_breakdown_json: "{}".into(),
-                inclusive_models_json: "[]".into(),
-                source_fingerprint: "sv1:current".into(),
-                pricing_generation: 1,
-                analyzed_generation: 1,
-                parser_revision: 1,
-                analyzer_revision: 1,
-                metrics_schema_revision: 1,
-            },
-            None,
         )
         .unwrap();
     store
@@ -133,6 +121,17 @@ fn seed_current_session_evidence(store: &Store, session_id: &str) -> SessionReco
                 record.key.agent,
                 record.key.session_id
             ],
+        )
+        .unwrap();
+    record
+}
+
+fn seed_current_session_evidence(store: &Store, session_id: &str) -> SessionRecord {
+    let record = seed_ready_evidence_row(store, session_id);
+    store
+        .save_analysis(
+            &projection_record(record.key.clone(), "sv1:current", 1),
+            None,
         )
         .unwrap();
     record
@@ -2023,6 +2022,22 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
 fn a_revision_change_requeues_session_evidence_without_touching_the_generation() {
     let store = store();
     let record = seed_current_session_evidence(&store, "revision-requeue");
+    // Set nonzero retry state first. Then the test can show that
+    // reconcile resets the state, not that it was already zero.
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence
+                SET retry_count = 3, last_error = 'stale attempt',
+                    next_attempt_at_epoch = 500
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
     let before = store.session_source_state(&record.key).unwrap().unwrap();
     let revisions = ProjectionRevisions {
         evidence_schema_revision: 2,
@@ -2039,6 +2054,9 @@ fn a_revision_change_requeues_session_evidence_without_touching_the_generation()
     let evidence = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(evidence.status, EvidenceStatus::Pending);
     assert_eq!(evidence.evidence_json.as_deref(), Some("{\"groups\":[]}"));
+    assert_eq!(evidence.retry_count, 0);
+    assert_eq!(evidence.last_error, None);
+    assert_eq!(evidence.next_attempt_at_epoch, None);
     assert_eq!(
         store.session_source_state(&record.key).unwrap().unwrap(),
         before
@@ -3291,4 +3309,379 @@ fn clearing_local_session_data_removes_turn_content_written_through_the_fenced_w
         .query_row("SELECT COUNT(*) FROM turn_content", [], |row| row.get(0))
         .unwrap();
     assert_eq!(remaining, 0);
+}
+
+// The tests below pin `reconcile_evidence_revisions`'s individual requeue
+// decisions. Each test isolates one arm of its SQL. A future edit that
+// changes requeue behavior then fails one named test.
+
+#[test]
+fn a_parser_revision_mismatch_alone_requeues_and_resets_retry_state() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "parser-revision-requeue");
+    // Set nonzero retry state first. Then the test can show that
+    // reconcile resets the state, not that it was already zero.
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence
+                SET retry_count = 3, last_error = 'stale attempt',
+                    next_attempt_at_epoch = 500
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let before = store.session_source_state(&record.key).unwrap().unwrap();
+    let revisions = ProjectionRevisions {
+        parser_revision: 2,
+        ..projection_revisions()
+    };
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], revisions)
+            .unwrap(),
+        1
+    );
+
+    let evidence = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(evidence.status, EvidenceStatus::Pending);
+    assert_eq!(evidence.retry_count, 0);
+    assert_eq!(evidence.last_error, None);
+    assert_eq!(evidence.next_attempt_at_epoch, None);
+    assert_eq!(
+        store.session_source_state(&record.key).unwrap().unwrap(),
+        before
+    );
+}
+
+#[test]
+fn an_analyzer_revision_mismatch_alone_requeues_session_evidence() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "analyzer-revision-requeue");
+    let before = store.session_source_state(&record.key).unwrap().unwrap();
+    let revisions = ProjectionRevisions {
+        analyzer_revision: 2,
+        ..projection_revisions()
+    };
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], revisions)
+            .unwrap(),
+        1
+    );
+
+    let evidence = store.evidence(&record.key).unwrap().unwrap();
+    assert_eq!(evidence.status, EvidenceStatus::Pending);
+    assert_eq!(evidence.evidence_json.as_deref(), Some("{\"groups\":[]}"));
+    assert_eq!(
+        store.session_source_state(&record.key).unwrap().unwrap(),
+        before
+    );
+}
+
+#[test]
+fn a_stale_metrics_schema_revision_in_session_analysis_requeues_a_current_row() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "metrics-stale-requeue");
+    // The evidence row's own columns, and `analyzed_generation`, are current.
+    // Only the joined `session_analysis` row's `metrics_schema_revision` is
+    // stale, so this isolates the missing-analysis requeue arm.
+    store
+        .lock()
+        .execute(
+            "UPDATE session_analysis SET metrics_schema_revision = 0
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
+fn a_missing_session_analysis_row_requeues_an_otherwise_current_evidence_row() {
+    let store = store();
+    let record = seed_ready_evidence_row(&store, "metrics-missing-requeue");
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
+fn an_analyzed_generation_behind_the_session_requeues_even_when_revisions_match() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "generation-behind-requeue");
+    // Increase the session's generation directly. This bypasses
+    // `upsert_sessions` and tests only the generation check in
+    // `reconcile_evidence_revisions`.
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET source_generation = 2
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
+fn a_failed_row_with_a_revision_mismatch_requeues_despite_its_status() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "failed-revision-requeue");
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence SET status = 'failed', last_error = 'earlier failure'
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let revisions = ProjectionRevisions {
+        evidence_schema_revision: 2,
+        ..projection_revisions()
+    };
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], revisions)
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
+fn a_failed_row_current_except_for_a_missing_analysis_row_does_not_requeue() {
+    let store = store();
+    let record = seed_ready_evidence_row(&store, "failed-missing-analysis-guard");
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence SET status = 'failed', last_error = 'earlier failure'
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let before = store.evidence(&record.key).unwrap().unwrap();
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        0
+    );
+
+    assert_eq!(store.evidence(&record.key).unwrap().unwrap(), before);
+}
+
+#[test]
+fn an_unsupported_row_with_a_revision_mismatch_requeues_despite_its_status() {
+    let store = store();
+    let record = seed_current_session_evidence(&store, "unsupported-revision-requeue");
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence SET status = 'unsupported'
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let revisions = ProjectionRevisions {
+        evidence_schema_revision: 2,
+        ..projection_revisions()
+    };
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], revisions)
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+}
+
+#[test]
+fn an_unsupported_row_current_except_for_a_missing_analysis_row_does_not_requeue() {
+    let store = store();
+    let record = seed_ready_evidence_row(&store, "unsupported-missing-analysis-guard");
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence SET status = 'unsupported'
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                record.key.environment_key,
+                record.key.agent,
+                record.key.session_id
+            ],
+        )
+        .unwrap();
+    let before = store.evidence(&record.key).unwrap().unwrap();
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], projection_revisions())
+            .unwrap(),
+        0
+    );
+
+    assert_eq!(store.evidence(&record.key).unwrap().unwrap(), before);
+}
+
+#[test]
+fn a_stale_row_for_an_agent_outside_the_list_is_neither_enrolled_nor_requeued() {
+    let store = store();
+    let claude = seed_current_session_evidence(&store, "agent-filter-claude");
+    let mut codex = session("agent-filter-codex", 1_000);
+    codex.key.agent = "codex".into();
+    codex.source_fingerprint = Some("sv1:current".into());
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&codex),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    store
+        .save_analysis(
+            &projection_record(codex.key.clone(), "sv1:current", 1),
+            None,
+        )
+        .unwrap();
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence
+                SET status = 'ready', analyzed_generation = 1,
+                    processed_fingerprint = 'sv1:current', parser_revision = 1,
+                    analyzer_revision = 1, evidence_schema_revision = 1,
+                    evidence_json = '{\"groups\":[]}', diagnostics_json = '[]',
+                    retry_count = 0, claim_fence = 4, analyzed_at_epoch = 900
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![
+                codex.key.environment_key,
+                codex.key.agent,
+                codex.key.session_id
+            ],
+        )
+        .unwrap();
+    let codex_before = store.evidence(&codex.key).unwrap().unwrap();
+    let mut codex_unseen = session("agent-filter-codex-unseen", 1_000);
+    codex_unseen.key.agent = "codex".into();
+    store
+        .upsert_sessions(std::slice::from_ref(&codex_unseen), &[])
+        .unwrap();
+    // The mismatch spans two revisions, not one. An agent-filter
+    // bug would still requeue this row.
+    let revisions = ProjectionRevisions {
+        evidence_schema_revision: 2,
+        ..projection_revisions()
+    };
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], revisions)
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(
+        store.evidence(&claude.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+    assert_eq!(store.evidence(&codex.key).unwrap().unwrap(), codex_before);
+    assert!(store.evidence(&codex_unseen.key).unwrap().is_none());
+}
+
+#[test]
+fn reconcile_counts_enrollment_and_requeue_together_in_one_call() {
+    let store = store();
+    let requeue_target = seed_current_session_evidence(&store, "combined-requeue");
+    let mut new_session = session("combined-enroll", 1_000);
+    new_session.source_fingerprint = Some("sv1:new".into());
+    store
+        .upsert_sessions(std::slice::from_ref(&new_session), &[])
+        .unwrap();
+    assert!(store.evidence(&new_session.key).unwrap().is_none());
+    let revisions = ProjectionRevisions {
+        parser_revision: 2,
+        ..projection_revisions()
+    };
+
+    assert_eq!(
+        store
+            .reconcile_evidence_revisions(&["claude-code"], revisions)
+            .unwrap(),
+        2
+    );
+
+    assert!(store.evidence(&new_session.key).unwrap().is_some());
+    assert_eq!(
+        store.evidence(&requeue_target.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
 }


### PR DESCRIPTION
## Summary
- Pin each requeue decision `Store::reconcile_evidence_revisions` makes (`apps/desktop/src-tauri/src/store/mod.rs:717`) with a focused, synthetic test in `apps/desktop/src-tauri/src/store/tests.rs`, so a future edit that changes requeue behavior fails a specific, named test.
- Test-only change: no production code, migrations, or revisions are touched.

## Decisions pinned
1. Parser-revision mismatch alone requeues and resets retry state (`retry_count`/`last_error`/`next_attempt_at_epoch`), leaving `source_generation` untouched — new test.
2. Analyzer-revision mismatch alone requeues — new test.
3. Evidence-schema-revision mismatch alone requeues (existing test extended to also assert the retry-state reset).
4. Metrics-schema-revision mismatch requeues only via the missing-`session_analysis` arm — two new tests: a stale `metrics_schema_revision` on an existing analysis row, and a missing analysis row entirely. The "matches → no requeue" half is already covered by decision 6's existing test.
5. `analyzed_generation` behind `session.source_generation` requeues even when every revision matches — new test.
6. A fully current row is not requeued (already pinned by an existing test — verified, no change needed).
7. A `failed` row: a revision mismatch still requeues it (no status guard on that arm); a `failed` row current except for the missing-analysis arm does not requeue (status guard) — two new tests.
8. Same as 7, for `unsupported` — two new tests.
9. The agent filter excludes a stale row for an agent outside the passed list from both enrollment and requeue — new test.
10. `reconcile_evidence_revisions` counts enrollment and requeue together in one call — new test.

## Behavior notes (no behavior changed)
- The requeue SQL has no `session_evidence.metrics_schema_revision` column to compare directly — `metrics_schema_revision` only participates through the join to `session_analysis` inside the missing-analysis arm, and that arm is the only place a `metrics_schema_revision` bump can trigger a requeue.
- The missing-analysis arm is guarded by `status NOT IN ('failed', 'unsupported')`, but the revision-mismatch arm (parser/analyzer/evidence-schema/generation) has no such guard — a `failed` or `unsupported` row still requeues on a plain revision change.
- `upsert_sessions` has its own, separate generation-bump-triggers-pending path (`mark_evidence_pending_in`), distinct from `reconcile_evidence_revisions`'s own `analyzed_generation <> source_generation` check. The new generation test bypasses `upsert_sessions` (direct SQL) to isolate `reconcile`'s own check.

## Test plan
Ran in both crate directories:
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --no-fail-fast`

Results: `crates/antiburn-local` — 13 `test result:` lines, all `ok` (1122 unit tests plus integration suites). `apps/desktop/src-tauri` — 3 `test result:` lines, all `ok` (627 tests). No goldens changed; `git status` shows only `apps/desktop/src-tauri/src/store/tests.rs` modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)