### PR TITLE
fix(desktop): never serve stale evidence as a clean badge

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1205,8 +1205,10 @@ pub async fn get_session_hygiene(
                 )
             })
             .collect::<Vec<_>>();
-        let rows = app.state::<Store>().evidence_batch(&keys).map_err(fail)?;
-        Ok(session_hygiene_payloads(rows))
+        let store = app.state::<Store>();
+        let rows = store.evidence_batch(&keys).map_err(fail)?;
+        let source_generations = store.source_generation_batch(&keys).map_err(fail)?;
+        Ok(session_hygiene_payloads(rows, source_generations))
     })
     .await
     .map_err(fail)?
@@ -1214,11 +1216,18 @@ pub async fn get_session_hygiene(
 
 fn session_hygiene_payloads(
     rows: Vec<Option<crate::store::EvidenceRow>>,
+    source_generations: Vec<Option<i64>>,
 ) -> Vec<SessionHygienePayload> {
-    rows.into_iter().map(session_hygiene_payload).collect()
+    rows.into_iter()
+        .zip(source_generations)
+        .map(|(row, source_generation)| session_hygiene_payload(row, source_generation))
+        .collect()
 }
 
-fn session_hygiene_payload(row: Option<crate::store::EvidenceRow>) -> SessionHygienePayload {
+fn session_hygiene_payload(
+    row: Option<crate::store::EvidenceRow>,
+    source_generation: Option<i64>,
+) -> SessionHygienePayload {
     let Some(row) = row else {
         return SessionHygienePayload::not_assessed(
             "pending",
@@ -1231,7 +1240,13 @@ fn session_hygiene_payload(row: Option<crate::store::EvidenceRow>) -> SessionHyg
             let revisions_are_current = row.parser_revision == Some(PARSER_REVISION)
                 && row.analyzer_revision == Some(ANALYZER_REVISION)
                 && row.evidence_schema_revision == Some(EVIDENCE_SCHEMA_REVISION);
-            if !revisions_are_current {
+            // A session whose source grew a new generation, with the
+            // requeue not yet run or still pending, must not serve badges
+            // from the previous generation's evidence. This mirrors
+            // `CURRENT_EVIDENCE_PREDICATE` in `insights_report.rs`.
+            let generation_is_current =
+                row.analyzed_generation.is_some() && row.analyzed_generation == source_generation;
+            if !revisions_are_current || !generation_is_current {
                 return SessionHygienePayload::not_assessed(
                     "stale",
                     NotAssessedReason::IncompleteEvidence,
@@ -2099,9 +2114,14 @@ mod tests {
         synthetic_evidence_accumulator().evidence(&antiburn_local::analysis::TurnFacts::default())
     }
 
+    // The generation `evidence_row` stamps as `analyzed_generation`. Tests
+    // that are not exercising a generation mismatch pass this back as the
+    // session's current source generation, so the row reads as current.
+    const SYNTHETIC_GENERATION: Option<i64> = Some(1);
+
     #[test]
     fn session_hygiene_preserves_queue_states_without_a_false_clean_result() {
-        let missing = session_hygiene_payload(None);
+        let missing = session_hygiene_payload(None, SYNTHETIC_GENERATION);
         assert_eq!(missing.evidence_state, "pending");
         assert!(
             missing
@@ -2110,10 +2130,10 @@ mod tests {
                 .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed))
         );
 
-        let processing = session_hygiene_payload(Some(evidence_row(
-            crate::store::EvidenceStatus::Processing,
-            None,
-        )));
+        let processing = session_hygiene_payload(
+            Some(evidence_row(crate::store::EvidenceStatus::Processing, None)),
+            SYNTHETIC_GENERATION,
+        );
         assert_eq!(processing.evidence_state, "processing");
     }
 
@@ -2125,7 +2145,7 @@ mod tests {
         );
         row.parser_revision = Some(PARSER_REVISION - 1);
 
-        let payload = session_hygiene_payload(Some(row));
+        let payload = session_hygiene_payload(Some(row), SYNTHETIC_GENERATION);
         assert_eq!(payload.evidence_state, "stale");
         assert!(
             payload
@@ -2136,17 +2156,70 @@ mod tests {
     }
 
     #[test]
+    fn session_hygiene_never_serves_a_requeued_rows_leftover_evidence() {
+        // `reconcile_evidence_revisions` flips a stale Ready row's status to
+        // Pending but keeps its old `evidence_json` by design (see
+        // `store/mod.rs`). This row copies that shape: a non-Ready status
+        // next to fully current evidence from a previous pass.
+        let mut row = evidence_row(
+            crate::store::EvidenceStatus::Pending,
+            Some(synthetic_evidence()),
+        );
+        row.retry_count = 0;
+
+        let payload = session_hygiene_payload(Some(row), SYNTHETIC_GENERATION);
+        assert_eq!(payload.evidence_state, "pending");
+        assert!(
+            payload
+                .badges
+                .iter()
+                .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed)),
+            "leftover evidence_json on a requeued row must never surface a Clean or Finding badge"
+        );
+    }
+
+    #[test]
+    fn session_hygiene_marks_evidence_from_an_earlier_source_generation_as_stale() {
+        // The source grew a new generation (a requeue not yet run, or still
+        // pending) while this row's evidence is still Ready and carries
+        // current revisions from the previous generation.
+        let row = evidence_row(
+            crate::store::EvidenceStatus::Ready,
+            Some(synthetic_evidence()),
+        );
+        assert_eq!(row.analyzed_generation, SYNTHETIC_GENERATION);
+        let newer_source_generation = Some(2);
+
+        let payload = session_hygiene_payload(Some(row), newer_source_generation);
+        assert_eq!(payload.evidence_state, "stale");
+        assert!(
+            payload
+                .badges
+                .iter()
+                .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed)),
+            "evidence analyzed against a superseded source generation must never surface a Clean or Finding badge"
+        );
+    }
+
+    #[test]
     fn session_hygiene_batches_preserve_order_and_isolate_invalid_rows() {
         let mut invalid = evidence_row(crate::store::EvidenceStatus::Ready, None);
         invalid.evidence_json = Some("{".to_owned());
-        let payloads = session_hygiene_payloads(vec![
-            None,
-            Some(invalid),
-            Some(evidence_row(
-                crate::store::EvidenceStatus::Ready,
-                Some(synthetic_evidence()),
-            )),
-        ]);
+        let payloads = session_hygiene_payloads(
+            vec![
+                None,
+                Some(invalid),
+                Some(evidence_row(
+                    crate::store::EvidenceStatus::Ready,
+                    Some(synthetic_evidence()),
+                )),
+            ],
+            vec![
+                SYNTHETIC_GENERATION,
+                SYNTHETIC_GENERATION,
+                SYNTHETIC_GENERATION,
+            ],
+        );
 
         assert_eq!(payloads.len(), 3);
         assert_eq!(payloads[0].evidence_state, "pending");
@@ -2169,7 +2242,7 @@ mod tests {
         ));
         let row = evidence_row(crate::store::EvidenceStatus::Ready, Some(evidence));
 
-        let payload = session_hygiene_payload(Some(row));
+        let payload = session_hygiene_payload(Some(row), SYNTHETIC_GENERATION);
         assert_eq!(payload.evidence_state, "activelyGrowing");
         assert!(payload.badges.iter().all(|badge| {
             // Model Overthinking / Fast Mode Overuse report a missing

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -544,6 +544,40 @@ mod tests {
         }
 
         #[test]
+        fn stale_generation_evidence_never_joins_the_cohort() {
+            // `denominator_partitions_non_cohort_rows_by_reason` above pins
+            // the coverage bucket this row lands in. This test pins the
+            // narrower claim I5 asks for: `COHORT_SQL` itself excludes it,
+            // so the report's badge computation never runs on it.
+            let data_dir = TempDir::new().unwrap();
+            let store = Store::open(data_dir.path()).unwrap();
+
+            publish_ready(&store, "current", 120);
+            publish_ready(&store, "stale", 121);
+            // The source grows a new generation and no requeue has run yet:
+            // this row is still 'ready', with current revisions, but was
+            // analyzed against the generation the source has since moved
+            // past.
+            change_source(&store, "stale", &[]);
+
+            let report = reduce_on_snapshot(
+                data_dir.path(),
+                request(),
+                &mut || {},
+                &AtomicBool::new(false),
+            )
+            .unwrap();
+
+            assert_eq!(report.context.coverage.discovered, 2);
+            assert_eq!(report.context.coverage.ready, 1);
+            assert_eq!(report.context.coverage.stale, 1);
+            assert_eq!(
+                report.assessed_sessions, 1,
+                "evidence analyzed against a superseded source generation must not join the cohort"
+            );
+        }
+
+        #[test]
         fn pi_backfill_moves_awaiting_support_into_the_pending_queue() {
             let data_dir = TempDir::new().unwrap();
             let store = Store::open(data_dir.path()).unwrap();

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -27,6 +27,8 @@ mod schema;
 #[cfg(test)]
 mod privacy_tests;
 #[cfg(test)]
+mod publish_tests;
+#[cfg(test)]
 mod tests;
 
 use std::collections::{HashMap, HashSet};
@@ -679,6 +681,31 @@ impl Store {
                     .query_row(
                         params![key.environment_key, key.agent, key.session_id],
                         evidence_from_row,
+                    )
+                    .optional()
+                    .map_err(Into::into)
+            })
+            .collect()
+    }
+
+    /// Each session's current source generation, in request order.
+    ///
+    /// A caller compares this against an evidence row's own
+    /// `analyzed_generation` to find evidence analyzed against a generation
+    /// the source has since moved past — see `session_hygiene_payload` in
+    /// `commands.rs`. `None` marks a key with no `session` row.
+    pub fn source_generation_batch(&self, keys: &[SessionKey]) -> Result<Vec<Option<i64>>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(
+            "SELECT source_generation FROM session
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+        )?;
+        keys.iter()
+            .map(|key| {
+                statement
+                    .query_row(
+                        params![key.environment_key, key.agent, key.session_id],
+                        |row| row.get(0),
                     )
                     .optional()
                     .map_err(Into::into)

--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -1,0 +1,269 @@
+//! Store-level pinning tests for atomic evidence publication.
+//!
+//! `Store::publish_projections` guards its write with the evidence row's own
+//! claim fence and the session's current source generation (see `store/mod.rs`).
+//! A losing pass must publish nothing it computed, and a winning pass must
+//! remove every turn row an earlier, superseded pass left behind. This module
+//! pins both halves directly against turn rows and a zero-baseline session,
+//! a case the existing suite in `store/tests.rs` does not cover on its own.
+//! See `docs/plans/local-insights-followups.md` for the wider publish
+//! contract this backs.
+
+use std::path::Path;
+
+use antiburn_local::analysis::{TurnRow, TurnScope, count_turn_rows, insert_turn_rows};
+
+use super::model::PublishedEvidence;
+use super::*;
+
+fn store() -> Store {
+    Store::open_in_memory(Path::new("/tmp/antiburn-publish-test-state")).expect("in-memory store")
+}
+
+fn session(session_id: &str, updated_at: i64) -> SessionRecord {
+    SessionRecord {
+        key: SessionKey::new("native", "claude-code", session_id),
+        source_kind: "file".into(),
+        source_label: format!("/home/avery/.claude/projects/demo/{session_id}.jsonl"),
+        wsl_distro: None,
+        title: Some("Wire the popover".into()),
+        title_source: Some("explicit".into()),
+        cwd: Some("/home/avery/code/widgets".into()),
+        surface: "cli".into(),
+        updated_at_epoch: Some(updated_at),
+        activity_cursor: String::new(),
+        activity_source: "mtime".into(),
+        subagent_count: 0,
+        fork_parent_session_id: None,
+        source_fingerprint: None,
+    }
+}
+
+fn projection_record(key: SessionKey, fingerprint: &str, generation: i64) -> AnalysisRecord {
+    AnalysisRecord {
+        key,
+        model_breakdown_json: "{}".into(),
+        inclusive_models_json: "[]".into(),
+        source_fingerprint: fingerprint.into(),
+        pricing_generation: 1,
+        analyzed_generation: generation,
+        parser_revision: 1,
+        analyzer_revision: 1,
+        metrics_schema_revision: 1,
+    }
+}
+
+fn claimed_projection(
+    store: &Store,
+    session_id: &str,
+    now_epoch: i64,
+    lease_secs: i64,
+) -> (AnalysisRecord, EvidenceClaim) {
+    let mut record = session(session_id, 1_000);
+    let fingerprint = format!("sv1:{session_id}");
+    record.source_fingerprint = Some(fingerprint.clone());
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    let claim = store
+        .claim_next_evidence(&["claude-code"], now_epoch, lease_secs)
+        .unwrap()
+        .unwrap();
+    (
+        projection_record(record.key, &fingerprint, claim.source_generation),
+        claim,
+    )
+}
+
+fn evidence_completion(
+    claim: &EvidenceClaim,
+    status: PublishedEvidence,
+    evidence_json: String,
+) -> EvidenceCompletion {
+    EvidenceCompletion {
+        claim_fence: claim.claim_fence,
+        status,
+        evidence_schema_revision: 1,
+        evidence_json,
+        diagnostics_json: Some("[]".into()),
+    }
+}
+
+fn turn_row(turn_index: u64) -> TurnRow {
+    TurnRow {
+        source_key: "s1".into(),
+        thread_id: "s1".into(),
+        turn_index,
+        scope: TurnScope::Main,
+        child_id: None,
+        role: "assistant",
+        ts_ms: Some(1_000 + turn_index as i64),
+        model: Some("claude-opus-4-6".into()),
+        effort: None,
+        speed: None,
+        input_tokens: 10,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        output_tokens: 5,
+        is_compaction_boundary: false,
+        message_id: None,
+        uuid: None,
+        parent_uuid: None,
+        compaction_trigger: None,
+        compaction_pre_tokens: None,
+        compaction_post_tokens: None,
+        content: Vec::new(),
+    }
+}
+
+/// Advances the session's source generation past the given claim, the same
+/// way a concurrent, faster pass would before this pass tries to publish.
+fn advance_source_generation_past(store: &Store, key: &SessionKey) {
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET source_generation = source_generation + 1
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .unwrap();
+}
+
+/* I1(a): a lost race publishes nothing, from a zero baseline. */
+
+#[test]
+fn a_lost_race_from_a_zero_baseline_publishes_no_evidence_no_analysis_and_no_turn_rows() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "lost-race-zero-baseline", 100, 60);
+    let key = record.key.clone();
+    // Nothing has ever published for this session: no session_analysis row
+    // exists yet, and session_evidence still sits at its claimed, unpublished
+    // state.
+    assert!(store.analysis(&key).unwrap().is_none());
+
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0)]).unwrap();
+
+    // A faster, concurrent pass wins the race first, which advances the
+    // session's source generation past this pass's own claim. The baseline
+    // is captured after this, so the comparison below isolates exactly what
+    // `publish_projections` itself is and is not allowed to change.
+    advance_source_generation_past(&store, &key);
+    let evidence_before = store.evidence(&key).unwrap().unwrap();
+    assert_eq!(evidence_before.evidence_json, None);
+    let completion =
+        evidence_completion(&claim, PublishedEvidence::Ready, "{\"lost\":true}".into());
+
+    let published = store
+        .publish_projections(&record, None, &completion, &[])
+        .unwrap();
+    assert!(
+        !published,
+        "a lost race must report that it did not publish"
+    );
+
+    // No session_analysis row appeared, the evidence row is exactly what it
+    // was before this pass ran, and this pass's own turn rows are gone.
+    assert!(store.analysis(&key).unwrap().is_none());
+    assert_eq!(store.evidence(&key).unwrap().unwrap(), evidence_before);
+    let connection = store.lock();
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence).unwrap(),
+        0
+    );
+}
+
+#[test]
+fn a_lost_race_leaves_relations_untouched() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "lost-race-relations", 100, 60);
+    let key = record.key.clone();
+    store
+        .replace_relations(
+            &key,
+            RelationKind::Subagent,
+            &[RelationRecord {
+                kind: RelationKind::Subagent,
+                related_id: "kept-child".into(),
+                label: None,
+            }],
+        )
+        .unwrap();
+    let relations_before = store.relations(&key).unwrap();
+
+    advance_source_generation_past(&store, &key);
+    let completion =
+        evidence_completion(&claim, PublishedEvidence::Ready, "{\"lost\":true}".into());
+    let losing_relations = [RelationRecord {
+        kind: RelationKind::Subagent,
+        related_id: "should-not-land".into(),
+        label: None,
+    }];
+
+    assert!(
+        !store
+            .publish_projections(&record, None, &completion, &losing_relations)
+            .unwrap()
+    );
+    assert_eq!(store.relations(&key).unwrap(), relations_before);
+}
+
+/* I1(b): a won race removes every turn row from every superseded fence. */
+
+#[test]
+fn a_won_race_removes_turn_rows_from_every_superseded_fence_and_keeps_only_its_own() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "won-race-many-fences", 100, 60);
+    let key = record.key.clone();
+
+    // Two fences older than the winning one, left over from two earlier,
+    // superseded passes.
+    {
+        let connection = store.lock();
+        insert_turn_rows(
+            &connection,
+            &turn_session_key(&key),
+            claim.claim_fence - 2,
+            &[turn_row(0)],
+        )
+        .unwrap();
+        insert_turn_rows(
+            &connection,
+            &turn_session_key(&key),
+            claim.claim_fence - 1,
+            &[turn_row(0)],
+        )
+        .unwrap();
+    }
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer
+        .write_turn_rows(&[turn_row(0), turn_row(1), turn_row(2)])
+        .unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    let connection = store.lock();
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence - 2).unwrap(),
+        0,
+        "the oldest superseded fence must be gone"
+    );
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence - 1).unwrap(),
+        0,
+        "the nearer superseded fence must be gone"
+    );
+    assert_eq!(
+        count_turn_rows(&connection, &turn_session_key(&key), claim.claim_fence).unwrap(),
+        3,
+        "the winning fence's own rows must survive untouched"
+    );
+}


### PR DESCRIPTION
## Summary

Proves, and where broken minimally fixes, the atomic-publish invariants: a
publish is all-or-nothing, a requeued row never serves badges, a Ready row
with outdated revisions never serves badges, and — the one real hole — a
Ready row analyzed against a source generation the session has since moved
past never serves badges either, including Clean.

- **I1** (publish is all-or-nothing): already held in `Store::publish_projections`.
  Pinned in new `store/publish_tests.rs`: a lost race from a zero
  `session_analysis` baseline publishes nothing (no analysis row, evidence
  unchanged, no leaked turn rows), and a won race removes turn rows from
  *every* superseded fence, not just the nearest one.
- **I2** (a requeued row never serves badges): already held —
  `session_hygiene_payload` routes any non-Ready status to NotAssessed
  regardless of leftover `evidence_json`. Pinned with a new payload-level
  test that shapes a row the way `reconcile_evidence_revisions` leaves one.
- **I3** (a Ready row with outdated revisions never serves badges): already
  held and already pinned by an existing test.
- **I4** (INVESTIGATE): confirmed hole. `session_hygiene_payload` compared
  parser/analyzer/evidence-schema revisions but never the session's source
  generation against the evidence row's own `analyzed_generation`, unlike
  the report path's `CURRENT_EVIDENCE_PREDICATE`. Fixed: `get_session_hygiene`
  now also reads each session's current generation (new
  `Store::source_generation_batch`, additive in `store/mod.rs`) and
  `session_hygiene_payload` treats a mismatch as stale. Pinned with a new
  test.
- **I5** (the report cohort never counts stale evidence): already held.
  Added one focused test in `insights_report.rs` pinning that `COHORT_SQL`
  itself excludes a stale-generation row, not just the coverage bucket it
  is counted under.

No frontend changes: I4's fix reuses the existing `"stale"` payload state
string, which `sessionHygiene.ts` already renders as not-assessed.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test
      --no-fail-fast` in `crates/antiburn-local` — 13 `test result:` lines,
      all green (0 failed)
- [x] Same in `apps/desktop/src-tauri` — 3 `test result:` lines, all green
      (622 lib tests passing, up from 616)
- [x] No TypeScript touched, no goldens changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)