### PR TITLE
feat(store): add a read-only path from commands to turn rows

### DIFF
--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 use antiburn_local::analysis::{
     TurnFacts, TurnRow, TurnRowError, TurnRowStore, TurnSessionKey, count_turn_rows,
     delete_turn_rows, delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
-    query_turn_facts,
+    query_turn_facts, query_turn_rows,
 };
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
@@ -1204,6 +1204,42 @@ impl Store {
             &turn_session_key(key),
             claim_fence,
         )?)
+    }
+
+    /// One session's published turn rows, or `None` when no complete,
+    /// published set of rows exists to read.
+    ///
+    /// A claim bumps `session_evidence.claim_fence` and writes new rows
+    /// under that fence while the last published pass's rows still sit
+    /// under the old fence. A publish that wins deletes every other
+    /// fence's rows and sets status `ready`; a publish that loses its race
+    /// deletes only its own fence's rows and leaves the earlier published
+    /// fence in place. So `claim_fence` names a complete set of rows only
+    /// when status is `ready` — with status `pending`, `processing`,
+    /// `failed`, or `unsupported`, `claim_fence` may point at partial or
+    /// missing rows, and this method returns `None` for all of them. The
+    /// evidence lookup and the row query run under one lock, so a claim
+    /// racing this read cannot swap the fence in between them.
+    pub fn published_turn_rows(&self, key: &SessionKey) -> Result<Option<Vec<TurnRow>>> {
+        let connection = self.lock();
+        let Some(evidence) = connection
+            .query_row(
+                EVIDENCE_BY_KEY_SQL,
+                params![key.environment_key, key.agent, key.session_id],
+                evidence_from_row,
+            )
+            .optional()?
+        else {
+            return Ok(None);
+        };
+        if evidence.status != EvidenceStatus::Ready {
+            return Ok(None);
+        }
+        Ok(Some(query_turn_rows(
+            &connection,
+            &turn_session_key(key),
+            evidence.claim_fence,
+        )?))
     }
 
     /// Cache one session's derived analysis.

--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -267,3 +267,179 @@ fn a_won_race_removes_turn_rows_from_every_superseded_fence_and_keeps_only_its_o
         "the winning fence's own rows must survive untouched"
     );
 }
+
+/* R1: `Store::published_turn_rows` only exposes a complete, published
+ * fence — never a claim in flight, never a superseded fence, and never a
+ * status other than `ready`. */
+
+fn revisions() -> ProjectionRevisions {
+    ProjectionRevisions {
+        parser_revision: 1,
+        analyzer_revision: 1,
+        metrics_schema_revision: 1,
+        evidence_schema_revision: 1,
+    }
+}
+
+#[test]
+fn published_turn_rows_returns_the_winning_pass_rows_in_order() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "published-rows-order", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    let written = [turn_row(2), turn_row(0), turn_row(1)];
+    writer.write_turn_rows(&written).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    let rows = store.published_turn_rows(&key).unwrap().expect("ready");
+    assert_eq!(
+        rows,
+        vec![turn_row(0), turn_row(1), turn_row(2)],
+        "rows must come back sorted by (source_key, turn_index), not insertion order"
+    );
+}
+
+#[test]
+fn published_turn_rows_is_none_while_a_newer_claim_is_in_flight() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "claim-in-flight", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+    assert!(store.published_turn_rows(&key).unwrap().is_some());
+
+    // A newer pass claims the session: status flips to `processing` and the
+    // fence bumps, while the earlier published fence's rows are still on
+    // disk — only a publish deletes a superseded fence. This pass then
+    // writes some, but not all, of its own rows before this check runs.
+    mark_evidence_pending_in(&store.lock(), &key).unwrap();
+    let next_claim = store
+        .claim_next_evidence(&["claude-code"], 200, 60)
+        .unwrap()
+        .expect("reclaimable");
+    assert_eq!(next_claim.claim_fence, claim.claim_fence + 1);
+    let next_writer = FencedTurnRowStore::new(store.clone(), key.clone(), next_claim.claim_fence);
+    next_writer.write_turn_rows(&[turn_row(0)]).unwrap();
+
+    assert_eq!(
+        store.published_turn_rows(&key).unwrap(),
+        None,
+        "a claim in flight must never expose the old fence or a partial new one"
+    );
+}
+
+#[test]
+fn published_turn_rows_is_none_with_no_evidence_row() {
+    let store = store();
+    let key = SessionKey::new("native", "claude-code", "never-claimed");
+    assert_eq!(store.published_turn_rows(&key).unwrap(), None);
+}
+
+#[test]
+fn published_turn_rows_is_none_while_pending() {
+    let store = store();
+    let mut record = session("pending-status", 1_000);
+    record.source_fingerprint = Some("sv1:pending-status".into());
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    assert_eq!(store.published_turn_rows(&record.key).unwrap(), None);
+}
+
+#[test]
+fn published_turn_rows_is_none_when_failed() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "failed-status", 100, 60);
+    let key = record.key.clone();
+    assert!(
+        store
+            .fail_evidence(
+                &claim,
+                EvidenceFailure::Failed {
+                    revisions: revisions(),
+                },
+                "source-unreadable",
+            )
+            .unwrap()
+    );
+    assert_eq!(store.published_turn_rows(&key).unwrap(), None);
+}
+
+#[test]
+fn published_turn_rows_is_none_when_unsupported() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "unsupported-status", 100, 60);
+    let key = record.key.clone();
+    let completion = evidence_completion(&claim, PublishedEvidence::Unsupported, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap(),
+        "an unsupported completion still publishes"
+    );
+    assert_eq!(
+        store.published_turn_rows(&key).unwrap(),
+        None,
+        "only status `ready` names a complete row projection"
+    );
+}
+
+#[test]
+fn a_second_publish_supersedes_the_first_in_published_turn_rows() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "second-publish-supersedes", 100, 60);
+    let key = record.key.clone();
+    let first_writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    first_writer.write_turn_rows(&[turn_row(0)]).unwrap();
+    let first_completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &first_completion, &[])
+            .unwrap()
+    );
+    assert_eq!(
+        store.published_turn_rows(&key).unwrap().expect("ready"),
+        vec![turn_row(0)]
+    );
+
+    mark_evidence_pending_in(&store.lock(), &key).unwrap();
+    let next_claim = store
+        .claim_next_evidence(&["claude-code"], 200, 60)
+        .unwrap()
+        .expect("reclaimable");
+    let next_record = projection_record(
+        key.clone(),
+        "sv1:second-publish-supersedes",
+        next_claim.source_generation,
+    );
+    let next_writer = FencedTurnRowStore::new(store.clone(), key.clone(), next_claim.claim_fence);
+    next_writer
+        .write_turn_rows(&[turn_row(0), turn_row(1)])
+        .unwrap();
+    let next_completion = evidence_completion(&next_claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&next_record, None, &next_completion, &[])
+            .unwrap()
+    );
+
+    assert_eq!(
+        store.published_turn_rows(&key).unwrap().expect("ready"),
+        vec![turn_row(0), turn_row(1)],
+        "only the new pass's rows must come back, none of the superseded fence's"
+    );
+}

--- a/crates/antiburn-local/src/analysis/evidence_query.rs
+++ b/crates/antiburn-local/src/analysis/evidence_query.rs
@@ -19,7 +19,7 @@ use crate::analysis::evidence::{
     cap_string, insert_diagnostic_field, record_diagnostic_set_cap,
 };
 use crate::analysis::model::CompactionTrigger;
-use crate::analysis::rows::TurnSessionKey;
+use crate::analysis::rows::{TurnRow, TurnScope, TurnSessionKey, parse_role};
 
 /// The row-derived facts for one session, at one claim fence.
 ///
@@ -262,6 +262,81 @@ fn query_core(
             })
         },
     )
+}
+
+const TURN_ROWS_SQL: &str = "SELECT source_key, thread_id, turn_index, scope, child_id,
+        role, ts_ms, model, effort, speed, input_tokens, cache_read_tokens,
+        cache_write_tokens, output_tokens, is_compaction_boundary, message_id,
+        uuid, parent_uuid, compaction_trigger, compaction_pre_tokens,
+        compaction_post_tokens
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
+  ORDER BY source_key, turn_index";
+
+/// Reads the full ordered turn rows for `key` at `claim_fence`, without
+/// their `turn_content` text. A later change adds a separate content read.
+///
+/// Rows come back ordered by `(source_key, turn_index)`, the same order a
+/// pass wrote them in. Every returned row carries an empty
+/// [`TurnRow::content`] — this query never joins `turn_content`.
+pub fn query_turn_rows(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<Vec<TurnRow>> {
+    let mut statement = conn.prepare(TURN_ROWS_SQL)?;
+    let rows = statement.query_map(
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+        |row| {
+            let scope_text: String = row.get(3)?;
+            let scope = TurnScope::parse(&scope_text).ok_or_else(|| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    3,
+                    rusqlite::types::Type::Text,
+                    format!("unrecognized turn scope {scope_text:?}").into(),
+                )
+            })?;
+            let role_text: String = row.get(5)?;
+            let role = parse_role(&role_text).ok_or_else(|| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    5,
+                    rusqlite::types::Type::Text,
+                    format!("unrecognized turn role {role_text:?}").into(),
+                )
+            })?;
+            let is_compaction_boundary: i64 = row.get(14)?;
+            let compaction_pre_tokens: Option<i64> = row.get(19)?;
+            let compaction_post_tokens: Option<i64> = row.get(20)?;
+            let compaction_trigger: Option<String> = row.get(18)?;
+            Ok(TurnRow {
+                source_key: row.get(0)?,
+                thread_id: row.get(1)?,
+                turn_index: as_u64(row.get(2)?),
+                scope,
+                child_id: row.get(4)?,
+                role,
+                ts_ms: row.get(6)?,
+                model: row.get(7)?,
+                effort: row.get(8)?,
+                speed: row.get(9)?,
+                input_tokens: as_u64(row.get(10)?),
+                cache_read_tokens: as_u64(row.get(11)?),
+                cache_write_tokens: as_u64(row.get(12)?),
+                output_tokens: as_u64(row.get(13)?),
+                is_compaction_boundary: is_compaction_boundary != 0,
+                message_id: row.get(15)?,
+                uuid: row.get(16)?,
+                parent_uuid: row.get(17)?,
+                compaction_trigger: compaction_trigger
+                    .as_deref()
+                    .and_then(CompactionTrigger::parse),
+                compaction_pre_tokens: compaction_pre_tokens.map(as_u64),
+                compaction_post_tokens: compaction_post_tokens.map(as_u64),
+                content: Vec::new(),
+            })
+        },
+    )?;
+    rows.collect()
 }
 
 /* --------------------------------------------------------------------
@@ -962,6 +1037,85 @@ mod tests {
         insert_turn_rows(&conn, &KEY, 2, &[base_row("s1", 0)]).expect("insert other fence");
         let facts = query_turn_facts(&conn, &KEY, 1).expect("query facts");
         assert_eq!(facts.eligibility.turns, 0);
+    }
+
+    #[test]
+    fn turn_rows_come_back_ordered_by_source_key_then_turn_index() {
+        let conn = test_connection();
+        insert(
+            &conn,
+            &[
+                base_row("s2", 1),
+                base_row("s1", 1),
+                base_row("s2", 0),
+                base_row("s1", 0),
+            ],
+        );
+        let rows = query_turn_rows(&conn, &KEY, 1).expect("query rows");
+        let order: Vec<(&str, u64)> = rows
+            .iter()
+            .map(|row| (row.source_key.as_str(), row.turn_index))
+            .collect();
+        assert_eq!(
+            order,
+            vec![("s1", 0), ("s1", 1), ("s2", 0), ("s2", 1)],
+            "rows must sort by (source_key, turn_index)"
+        );
+    }
+
+    #[test]
+    fn turn_rows_omits_rows_under_another_fence() {
+        let conn = test_connection();
+        insert_turn_rows(&conn, &KEY, 2, &[base_row("s1", 0)]).expect("insert other fence");
+        let rows = query_turn_rows(&conn, &KEY, 1).expect("query rows");
+        assert!(rows.is_empty(), "another fence's rows must not appear");
+    }
+
+    #[test]
+    fn turn_rows_carries_every_scalar_column_and_leaves_content_empty() {
+        let conn = test_connection();
+        let mut row = base_row("s1", 0);
+        row.scope = TurnScope::Delegated;
+        row.child_id = Some("s1".to_owned());
+        row.role = "tool";
+        row.effort = Some("high".to_owned());
+        row.speed = Some("fast".to_owned());
+        row.cache_read_tokens = 3;
+        row.cache_write_tokens = 4;
+        row.is_compaction_boundary = true;
+        row.message_id = Some("msg-1".to_owned());
+        row.uuid = Some("uuid-1".to_owned());
+        row.parent_uuid = Some("uuid-0".to_owned());
+        row.compaction_trigger = Some(CompactionTrigger::Manual);
+        row.compaction_pre_tokens = Some(100);
+        row.compaction_post_tokens = Some(20);
+        row.content = vec![crate::analysis::interface::ContentPart::new(
+            crate::analysis::interface::ContentKind::ToolResult,
+            "captured text",
+        )];
+        insert(&conn, &[row]);
+
+        let rows = query_turn_rows(&conn, &KEY, 1).expect("query rows");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.scope, TurnScope::Delegated);
+        assert_eq!(row.child_id.as_deref(), Some("s1"));
+        assert_eq!(row.role, "tool");
+        assert_eq!(row.effort.as_deref(), Some("high"));
+        assert_eq!(row.speed.as_deref(), Some("fast"));
+        assert_eq!(row.cache_read_tokens, 3);
+        assert_eq!(row.cache_write_tokens, 4);
+        assert!(row.is_compaction_boundary);
+        assert_eq!(row.message_id.as_deref(), Some("msg-1"));
+        assert_eq!(row.uuid.as_deref(), Some("uuid-1"));
+        assert_eq!(row.parent_uuid.as_deref(), Some("uuid-0"));
+        assert_eq!(row.compaction_trigger, Some(CompactionTrigger::Manual));
+        assert_eq!(row.compaction_pre_tokens, Some(100));
+        assert_eq!(row.compaction_post_tokens, Some(20));
+        assert!(
+            row.content.is_empty(),
+            "this query never joins turn_content"
+        );
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -62,7 +62,7 @@ pub use evidence::{
     SourceKind, SubagentChild, SubagentEvidence, SubagentExample, ToolClass, ToolEvidence, ToolUse,
     TurnCounts,
 };
-pub use evidence_query::{TurnFacts, query_turn_facts};
+pub use evidence_query::{TurnFacts, query_turn_facts, query_turn_rows};
 pub use evidence_sink::{CompositeSink, RETAINED_EVIDENCE_BYTES_BOUND, SessionEvidenceAccumulator};
 pub use framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -113,6 +113,18 @@ impl TurnScope {
             TurnScope::Delegated => "delegated",
         }
     }
+
+    /// Reads back a value [`Self::as_str`] wrote. Returns `None` for any
+    /// other text. The `turn` table's `CHECK` constraint keeps this column
+    /// to `'main'` or `'delegated'`, so `None` signals a row this crate did
+    /// not write.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "main" => Some(TurnScope::Main),
+            "delegated" => Some(TurnScope::Delegated),
+            _ => None,
+        }
+    }
 }
 
 /// One parsed turn, ready to become a `turn` row.
@@ -155,6 +167,19 @@ fn role_key(role: Role) -> &'static str {
         Role::Assistant => "assistant",
         Role::System => "system",
         Role::Tool => "tool",
+    }
+}
+
+/// Reads back a value [`role_key`] wrote. Returns `None` for any other
+/// text, so a caller can treat it as a corrupted row instead of guessing a
+/// role.
+pub(crate) fn parse_role(value: &str) -> Option<&'static str> {
+    match value {
+        "user" => Some("user"),
+        "assistant" => Some("assistant"),
+        "system" => Some("system"),
+        "tool" => Some("tool"),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `query_turn_rows`, an engine-side query in `crates/antiburn-local/src/analysis/evidence_query.rs` that reads the full ordered `TurnRow`s for one `(environment_key, agent, session_id, claim_fence)`, sorted deterministically by `(source_key, turn_index)`. It never joins `turn_content`; every returned row's `content` is empty.
- Adds `TurnScope::parse` and a crate-private `parse_role` helper in `rows.rs`, mirroring the existing `CompactionTrigger::parse` convention, so the new query can read the `scope` and `role` columns back into their typed/static forms.
- Adds `Store::published_turn_rows(&self, key: &SessionKey) -> Result<Option<Vec<TurnRow>>>` in `apps/desktop/src-tauri/src/store/mod.rs`. It looks up the session's evidence row and its `claim_fence` under one lock, returns `None` unless status is `ready`, and otherwise runs the new engine query at that fence. This is the first production reader other than `FencedTurnRowStore`, and it changes no existing behavior.
- No stored output changes, no revision bumps, no goldens touched.

This lands the read-only seam later work (list/drilldown reads over rows) will build on. `FencedTurnRowStore` and `TurnRowStore` are untouched.

## Fence lifecycle (verified against `store/mod.rs`)

- `claim_next_evidence` (`~805-880` in `main`, now shifted slightly) bumps `session_evidence.claim_fence` and sets status `processing`. The pass then writes new turn rows progressively under the new fence while rows from the last published pass still sit under the old fence.
- `publish_projections` (`~1074-1189`): a winning publish (`updated == 1`, i.e. this pass's fence and source generation are still current) deletes every fence except the winner's own and sets `status = completion.status` — which can be `ready` **or** `unsupported` (both come from `PassOutcome::Published`, see `insights_worker.rs`'s `published_status`). A losing publish rolls back everything it would have written to `session_analysis`, and separately deletes only its own fence's turn rows.
- So `claim_fence` on the evidence row names a complete, published set of rows only when status is exactly `ready`. `pending`, `processing`, `failed`, and `unsupported` may all point `claim_fence` at partial, missing, or (for `unsupported`) simply non-authoritative rows. `published_turn_rows` gates strictly on `status == Ready`, matching this.

## Test plan

- [x] `cargo fmt` (both crates)
- [x] `cargo clippy --all-targets -- -D warnings` (both crates) — clean, no suppressions added
- [x] `cargo test --no-fail-fast` in `crates/antiburn-local` — 13 `test result:` lines, all `ok`
- [x] `cargo test --no-fail-fast` in `apps/desktop/src-tauri` — 3 `test result:` lines, all `ok` (640 passed in the lib suite, including 6 new `publish_tests` cases)
- New tests in `store/publish_tests.rs` cover: rows come back for a winning publish, in `(source_key, turn_index)` order; `None` while a newer claim is in flight (old fence's rows still on disk, new fence partially written); `None` with no evidence row; `None` for `pending`, `failed`, and `unsupported`; a second publish supersedes the first (only the new fence's rows come back).
- New engine-side tests in `evidence_query.rs` cover: row ordering, fence filtering, and every scalar column round-tripping (with content always empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)