### PR TITLE
feat(analysis): carry chart signals on turn rows

### DIFF
--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -116,6 +116,9 @@ fn turn_row(turn_index: u64) -> TurnRow {
         compaction_trigger: None,
         compaction_pre_tokens: None,
         compaction_post_tokens: None,
+        has_thinking: false,
+        last_tool: None,
+        subagent_launches: 0,
         content: Vec::new(),
     }
 }

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -11,7 +11,7 @@
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
-    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17,
+    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -396,3 +396,11 @@ const V16: &str = antiburn_local::analysis::TURN_SCHEMA_V2_SQL;
 const V17: &str = r#"
 ALTER TABLE session_analysis ADD COLUMN initial_context_json TEXT;
 "#;
+
+/// v18 adds the three chart-signal columns `query_turn_rows` reads:
+/// `has_thinking`, `last_tool`, `subagent_launches`.
+///
+/// `antiburn_local::analysis::TURN_SCHEMA_V3_SQL` owns the column list, for
+/// the same reason [`V16`] re-exports `TURN_SCHEMA_V2_SQL` instead of
+/// stating its own DDL.
+const V18: &str = antiburn_local::analysis::TURN_SCHEMA_V3_SQL;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -3139,66 +3139,6 @@ fn the_migration_ladder_reaches_the_turn_row_schema() {
 }
 
 #[test]
-fn migrating_forward_adds_the_chart_signal_columns_with_their_defaults() {
-    // V18 adds `has_thinking`, `last_tool`, `subagent_launches` to `turn`.
-    // Built by hand up to V17 so only that column-add migration runs; a
-    // fresh `Store::open_in_memory` would already be past it.
-    let connection = rusqlite::Connection::open_in_memory().unwrap();
-    for &sql in &super::schema::MIGRATIONS[..17] {
-        connection.execute_batch(sql).unwrap();
-    }
-    connection
-        .execute(
-            "INSERT INTO session (
-                 environment_key, agent, session_id, source_kind,
-                 source_label, first_seen_at, last_seen_at)
-             VALUES ('native', 'claude-code', 'pre-v18', 'file', 's1',
-                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
-            [],
-        )
-        .unwrap();
-    connection
-        .execute(
-            "INSERT INTO turn (
-                 environment_key, agent, session_id, claim_fence, source_key,
-                 thread_id, turn_index, scope, role, input_tokens,
-                 cache_read_tokens, cache_write_tokens, output_tokens,
-                 is_compaction_boundary)
-             VALUES ('native', 'claude-code', 'pre-v18', 1, 's1', 's1', 0,
-                     'main', 'assistant', 0, 0, 0, 0, 0)",
-            [],
-        )
-        .unwrap();
-    connection
-        .pragma_update(None, "user_version", 17i64)
-        .unwrap();
-
-    let store = Store::from_connection(
-        connection,
-        Path::new("/tmp/antiburn-migration-test").to_path_buf(),
-    )
-    .expect("migrates cleanly to the latest version");
-
-    assert_eq!(
-        store.schema_version().unwrap(),
-        super::schema::MIGRATIONS.len() as i64
-    );
-    let connection = store.lock();
-    let (has_thinking, last_tool, subagent_launches): (i64, Option<String>, i64) = connection
-        .query_row(
-            "SELECT has_thinking, last_tool, subagent_launches FROM turn
-              WHERE environment_key = 'native' AND agent = 'claude-code'
-                AND session_id = 'pre-v18'",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .unwrap();
-    assert_eq!(has_thinking, 0);
-    assert_eq!(last_tool, None);
-    assert_eq!(subagent_launches, 0);
-}
-
-#[test]
 fn a_fenced_turn_row_writer_inserts_rows_the_store_can_count() {
     let store = store();
     let mut record = session("turn-rows-writer", 1_000);

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -2116,7 +2116,7 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 15,
+            parser_revision: 16,
             analyzer_revision: 15,
             metrics_schema_revision: 2,
             evidence_schema_revision: 11,
@@ -3120,6 +3120,9 @@ fn turn_row(turn_index: u64) -> TurnRow {
         compaction_trigger: None,
         compaction_pre_tokens: None,
         compaction_post_tokens: None,
+        has_thinking: false,
+        last_tool: None,
+        subagent_launches: 0,
         content: Vec::new(),
     }
 }
@@ -3129,10 +3132,70 @@ fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pinned so this test fails loudly if a future migration is appended
     // without also being counted here — the number is the whole point of
     // the assertion, not an incidental detail.
-    assert_eq!(super::schema::MIGRATIONS.len(), 17);
+    assert_eq!(super::schema::MIGRATIONS.len(), 18);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 17);
+    assert_eq!(store.schema_version().unwrap(), 18);
+}
+
+#[test]
+fn migrating_forward_adds_the_chart_signal_columns_with_their_defaults() {
+    // V18 adds `has_thinking`, `last_tool`, `subagent_launches` to `turn`.
+    // Built by hand up to V17 so only that column-add migration runs; a
+    // fresh `Store::open_in_memory` would already be past it.
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    for &sql in &super::schema::MIGRATIONS[..17] {
+        connection.execute_batch(sql).unwrap();
+    }
+    connection
+        .execute(
+            "INSERT INTO session (
+                 environment_key, agent, session_id, source_kind,
+                 source_label, first_seen_at, last_seen_at)
+             VALUES ('native', 'claude-code', 'pre-v18', 'file', 's1',
+                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO turn (
+                 environment_key, agent, session_id, claim_fence, source_key,
+                 thread_id, turn_index, scope, role, input_tokens,
+                 cache_read_tokens, cache_write_tokens, output_tokens,
+                 is_compaction_boundary)
+             VALUES ('native', 'claude-code', 'pre-v18', 1, 's1', 's1', 0,
+                     'main', 'assistant', 0, 0, 0, 0, 0)",
+            [],
+        )
+        .unwrap();
+    connection
+        .pragma_update(None, "user_version", 17i64)
+        .unwrap();
+
+    let store = Store::from_connection(
+        connection,
+        Path::new("/tmp/antiburn-migration-test").to_path_buf(),
+    )
+    .expect("migrates cleanly to the latest version");
+
+    assert_eq!(
+        store.schema_version().unwrap(),
+        super::schema::MIGRATIONS.len() as i64
+    );
+    let connection = store.lock();
+    let (has_thinking, last_tool, subagent_launches): (i64, Option<String>, i64) = connection
+        .query_row(
+            "SELECT has_thinking, last_tool, subagent_launches FROM turn
+              WHERE environment_key = 'native' AND agent = 'claude-code'
+                AND session_id = 'pre-v18'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(has_thinking, 0);
+    assert_eq!(last_tool, None);
+    assert_eq!(subagent_launches, 0);
 }
 
 #[test]

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -788,7 +788,7 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 15,
+                "parserRevision": 16,
                 "analyzerRevision": 15,
                 "evidenceSchemaRevision": 11,
                 "sourceKind": "file",

--- a/crates/antiburn-local/src/analysis/evidence_query.rs
+++ b/crates/antiburn-local/src/analysis/evidence_query.rs
@@ -269,7 +269,7 @@ const TURN_ROWS_SQL: &str = "SELECT source_key, thread_id, turn_index, scope, ch
         role, ts_ms, model, effort, speed, input_tokens, cache_read_tokens,
         cache_write_tokens, output_tokens, is_compaction_boundary, message_id,
         uuid, parent_uuid, compaction_trigger, compaction_pre_tokens,
-        compaction_post_tokens
+        compaction_post_tokens, has_thinking, last_tool, subagent_launches
    FROM turn
   WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND claim_fence = ?4
   ORDER BY source_key, turn_index";
@@ -309,6 +309,7 @@ pub fn query_turn_rows(
             let compaction_pre_tokens: Option<i64> = row.get(19)?;
             let compaction_post_tokens: Option<i64> = row.get(20)?;
             let compaction_trigger: Option<String> = row.get(18)?;
+            let has_thinking: i64 = row.get(21)?;
             Ok(TurnRow {
                 source_key: row.get(0)?,
                 thread_id: row.get(1)?,
@@ -333,6 +334,9 @@ pub fn query_turn_rows(
                     .and_then(CompactionTrigger::parse),
                 compaction_pre_tokens: compaction_pre_tokens.map(as_u64),
                 compaction_post_tokens: compaction_post_tokens.map(as_u64),
+                has_thinking: has_thinking != 0,
+                last_tool: row.get(22)?,
+                subagent_launches: as_u64(row.get(23)?) as u32,
                 content: Vec::new(),
             })
         },
@@ -1148,6 +1152,9 @@ mod tests {
             compaction_trigger: None,
             compaction_pre_tokens: None,
             compaction_post_tokens: None,
+            has_thinking: false,
+            last_tool: None,
+            subagent_launches: 0,
             content: Vec::new(),
         }
     }
@@ -1239,6 +1246,9 @@ mod tests {
         row.compaction_trigger = Some(CompactionTrigger::Manual);
         row.compaction_pre_tokens = Some(100);
         row.compaction_post_tokens = Some(20);
+        row.has_thinking = true;
+        row.last_tool = Some("Task".to_owned());
+        row.subagent_launches = 2;
         row.content = vec![crate::analysis::interface::ContentPart::new(
             crate::analysis::interface::ContentKind::ToolResult,
             "captured text",
@@ -1262,6 +1272,9 @@ mod tests {
         assert_eq!(row.compaction_trigger, Some(CompactionTrigger::Manual));
         assert_eq!(row.compaction_pre_tokens, Some(100));
         assert_eq!(row.compaction_post_tokens, Some(20));
+        assert!(row.has_thinking);
+        assert_eq!(row.last_tool.as_deref(), Some("Task"));
+        assert_eq!(row.subagent_launches, 2);
         assert!(
             row.content.is_empty(),
             "this query never joins turn_content"

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -84,9 +84,10 @@ pub use model::{
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
 pub use rows::{
     MemoryTurnRowStore, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL,
-    TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope, TurnSessionKey,
-    count_turn_content_rows, count_turn_rows, delete_turn_rows, delete_turn_rows_except_fence,
-    delete_turn_rows_for_fence, insert_turn_rows, turn_row_from_event,
+    TURN_SCHEMA_V3_SQL, TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope,
+    TurnSessionKey, count_turn_content_rows, count_turn_rows, delete_turn_rows,
+    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
+    turn_row_from_event,
 };
 pub use source_validity::{
     AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,
@@ -95,7 +96,11 @@ pub use vendors::claude::ClaudeAdapter;
 pub use vendors::pi::PiAdapter;
 pub use vendors::{adapter_for, has_dedicated_adapter};
 
-pub const PARSER_REVISION: i64 = 15;
+// +1 for turn row chart signals: `has_thinking`, `last_tool`, and
+// `subagent_launches` are now ingest-derived row columns
+// (`rows::turn_row_from_event`), so every session must reparse to
+// populate them.
+pub const PARSER_REVISION: i64 = 16;
 // +1 for Codex cache-write tokens: `codex_usage` now splits
 // `cache_write_input_tokens` into `cache_creation_tokens` instead of
 // folding it into `input_tokens`, so a stored Codex session must re-ingest

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -87,13 +87,26 @@ ALTER TABLE turn ADD COLUMN compaction_pre_tokens INTEGER;
 ALTER TABLE turn ADD COLUMN compaction_post_tokens INTEGER;
 "#;
 
+/// DDL that adds the chart-signal columns [`TurnRow::has_thinking`],
+/// [`TurnRow::last_tool`], and [`TurnRow::subagent_launches`] to an existing
+/// `turn` table.
+///
+/// These mirror `SessionMetricsAccumulator::observe_parent_fields`'s
+/// per-event derivations, so a later change can rebuild the drilldown's
+/// bucket chart from rows alone instead of from a streamed accumulator.
+pub const TURN_SCHEMA_V3_SQL: &str = r#"
+ALTER TABLE turn ADD COLUMN has_thinking INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE turn ADD COLUMN last_tool TEXT;
+ALTER TABLE turn ADD COLUMN subagent_launches INTEGER NOT NULL DEFAULT 0;
+"#;
+
 /// Every migration that builds the `turn` and `turn_content` schema, in
 /// order. A caller that creates this schema from scratch (a test, an
 /// in-memory store) applies every entry in order; the app applies
-/// [`TURN_SCHEMA_SQL`] and [`TURN_SCHEMA_V2_SQL`] as its own separately
-/// numbered migrations instead, since [`TURN_SCHEMA_SQL`] is already applied
-/// on user machines.
-pub const TURN_MIGRATIONS: &[&str] = &[TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL];
+/// [`TURN_SCHEMA_SQL`], [`TURN_SCHEMA_V2_SQL`], and [`TURN_SCHEMA_V3_SQL`] as
+/// its own separately numbered migrations instead, since [`TURN_SCHEMA_SQL`]
+/// is already applied on user machines.
+pub const TURN_MIGRATIONS: &[&str] = &[TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL, TURN_SCHEMA_V3_SQL];
 
 /// Number of rows a [`TurnRowSink`] buffers before it writes them, unless the
 /// caller picks a different size with [`TurnRowSink::with_batch_size`].
@@ -155,6 +168,16 @@ pub struct TurnRow {
     pub compaction_trigger: Option<CompactionTrigger>,
     pub compaction_pre_tokens: Option<u64>,
     pub compaction_post_tokens: Option<u64>,
+    /// The event's own `has_thinking` flag. Mirrors
+    /// `SessionMetricsAccumulator::observe_parent_fields`.
+    pub has_thinking: bool,
+    /// The name of `event.tools`'s last entry, when the event carries any
+    /// tool call. Mirrors `observe_parent_fields`'s `slot.last_tool`.
+    pub last_tool: Option<String>,
+    /// The count of `event.tools` entries whose name is `"task"`,
+    /// case-insensitive. Mirrors `observe_parent_fields`'s
+    /// `slot.subagent_launches`.
+    pub subagent_launches: u32,
     /// This turn's captured message content, when the source adapter emitted
     /// a `TurnContent` record for it. Attached by [`TurnRowSink`] after
     /// [`turn_row_from_event`] builds the row — an event alone carries none.
@@ -225,6 +248,15 @@ pub fn turn_row_from_event(event: &NormalizedEvent, source_key: &str, turn_index
         compaction_trigger: event.compaction_trigger,
         compaction_pre_tokens: event.compaction_pre_tokens,
         compaction_post_tokens: event.compaction_post_tokens,
+        has_thinking: event.has_thinking,
+        last_tool: event.tools.last().map(|tool| tool.name.clone()),
+        subagent_launches: event
+            .tools
+            .iter()
+            .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+            .count()
+            .try_into()
+            .unwrap_or(u32::MAX),
         content: Vec::new(),
     }
 }
@@ -432,10 +464,11 @@ const INSERT_TURN_SQL: &str = "INSERT INTO turn (
     turn_index, scope, child_id, role, ts_ms, model, effort, speed,
     input_tokens, cache_read_tokens, cache_write_tokens, output_tokens,
     is_compaction_boundary, message_id, uuid, parent_uuid,
-    compaction_trigger, compaction_pre_tokens, compaction_post_tokens
+    compaction_trigger, compaction_pre_tokens, compaction_post_tokens,
+    has_thinking, last_tool, subagent_launches
 ) VALUES (
     ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-    ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25
+    ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28
 )";
 
 const INSERT_TURN_CONTENT_SQL: &str = "INSERT INTO turn_content (
@@ -483,6 +516,9 @@ pub fn insert_turn_rows(
             row.compaction_trigger.map(CompactionTrigger::as_str),
             row.compaction_pre_tokens.map(|tokens| tokens as i64),
             row.compaction_post_tokens.map(|tokens| tokens as i64),
+            i64::from(row.has_thinking),
+            row.last_tool,
+            row.subagent_launches as i64,
         ])?;
         if !row.content.is_empty() {
             let turn_rowid = conn.last_insert_rowid();
@@ -720,7 +756,7 @@ impl TurnRowStore for MemoryTurnRowStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analysis::model::Usage;
+    use crate::analysis::model::{ToolCall, Usage};
 
     fn test_connection() -> Connection {
         let conn = Connection::open_in_memory().expect("open in-memory connection");
@@ -766,6 +802,9 @@ mod tests {
             compaction_trigger: None,
             compaction_pre_tokens: None,
             compaction_post_tokens: None,
+            has_thinking: false,
+            last_tool: None,
+            subagent_launches: 0,
             content: Vec::new(),
         }
     }
@@ -902,6 +941,27 @@ mod tests {
         let event = NormalizedEvent::new(Role::Assistant);
         let row = turn_row_from_event(&event, "parent-1", 0);
         assert_eq!(row.thread_id, "parent-1");
+    }
+
+    #[test]
+    fn turn_row_from_event_derives_the_chart_signal_columns() {
+        let mut event = NormalizedEvent::new(Role::Assistant);
+        event.has_thinking = true;
+        event.tools = vec![ToolCall::new("Read"), ToolCall::new("Task")];
+
+        let row = turn_row_from_event(&event, "parent-1", 0);
+        assert!(row.has_thinking);
+        assert_eq!(row.last_tool.as_deref(), Some("Task"));
+        assert_eq!(row.subagent_launches, 1);
+    }
+
+    #[test]
+    fn turn_row_from_event_defaults_the_chart_signal_columns_without_tools() {
+        let event = NormalizedEvent::new(Role::Assistant);
+        let row = turn_row_from_event(&event, "parent-1", 0);
+        assert!(!row.has_thinking);
+        assert_eq!(row.last_tool, None);
+        assert_eq!(row.subagent_launches, 0);
     }
 
     /// A store that always fails to write, so the sink's error path can be

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -151,7 +151,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -151,7 +151,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -163,7 +163,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -141,7 +141,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -141,7 +141,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -146,7 +146,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -120,7 +120,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -131,7 +131,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -157,7 +157,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -142,7 +142,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -137,7 +137,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -166,7 +166,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -142,7 +142,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 15,
+      "parserRevision": 16,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },


### PR DESCRIPTION
## Summary

- Adds `has_thinking`, `last_tool`, and `subagent_launches` columns to the `turn` row schema (engine `TURN_SCHEMA_V3_SQL`, desktop migration V18), mirroring `SessionMetricsAccumulator::observe_parent_fields`'s per-event derivations.
- Populates these columns in `turn_row_from_event` and reads them back in `query_turn_rows`, so a later seam can rebuild the drilldown's 180-bucket chart from rows alone instead of a streamed accumulator.
- Bumps `PARSER_REVISION` to 16 since rows now carry new ingest-derived data, requiring every session to reparse.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` in `crates/antiburn-local` (13 `test result:` lines, all `ok`)
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` in `apps/desktop/src-tauri` (3 `test result:` lines, all `ok`)
- [x] Golden churn limited to `provenance.parserRevision` (15 -> 16) across codex and pi characterization goldens

🤖 Generated with [Claude Code](https://claude.com/claude-code)