### PR TITLE
feat(analysis): rebuild session metrics from turn rows

### DIFF
--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -40,6 +40,7 @@ mod metrics_sink;
 mod model;
 mod pricing;
 pub(crate) mod records;
+mod replay;
 mod rows;
 mod source_validity;
 pub(crate) mod threads;
@@ -82,6 +83,7 @@ pub use model::{
     EventSource, ModelRun, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
 };
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
+pub use replay::{event_from_row, metrics_from_rows};
 pub use rows::{
     MemoryTurnRowStore, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL,
     TURN_SCHEMA_V3_SQL, TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope,

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -83,7 +83,7 @@ pub use model::{
     EventSource, ModelRun, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
 };
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
-pub use replay::{event_from_row, metrics_from_rows};
+pub use replay::{MissingParentRows, event_from_row, metrics_from_rows};
 pub use rows::{
     MemoryTurnRowStore, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL,
     TURN_SCHEMA_V3_SQL, TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope,

--- a/crates/antiburn-local/src/analysis/replay.rs
+++ b/crates/antiburn-local/src/analysis/replay.rs
@@ -1,0 +1,499 @@
+//! Rebuilds `SessionMetrics` from a session's turn rows alone.
+//!
+//! [`turn_row_from_event`] (`rows.rs`) turns a stream of [`NormalizedEvent`]s
+//! into rows. This module inverts that mapping: [`event_from_row`] turns one
+//! row back into an event, and [`metrics_from_rows`] replays a whole row set
+//! through [`SessionMetricsAccumulator`] the same way the live pipeline
+//! drives it, so the same code computes the same numbers. See
+//! `crates/antiburn-local/tests/turn_row_replay_parity.rs` for the proof.
+
+use crate::analysis::engine::SessionMetrics;
+use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary};
+use crate::analysis::metrics_sink::{SessionMetricsAccumulator, merge_metrics};
+use crate::analysis::model::{EventSource, NormalizedEvent, Role, ToolCall, Usage};
+use crate::analysis::rows::{TurnRow, TurnScope};
+
+/// Builds the smallest `Vec<ToolCall>` that reproduces the two reads
+/// `SessionMetricsAccumulator::observe_parent_fields` makes over a row's
+/// tools: `tools.last().name` (the row's own [`TurnRow::last_tool`]) and the
+/// count of tool names equal to `"task"`, case-insensitive (the row's own
+/// [`TurnRow::subagent_launches`]).
+///
+/// A turn's [`TurnRow::last_tool`] that itself reads as `"task"` already
+/// counts toward [`TurnRow::subagent_launches`] — `turn_row_from_event`
+/// derives both from the same `event.tools`, and the last tool is one of
+/// the tools. So this function reserves that last slot for the row's own
+/// `last_tool` string (case preserved, so the reproduced last-tool name
+/// matches exactly) and fills every slot before it with a generic `"Task"`
+/// call, one per remaining launch.
+fn synthesize_tools(row: &TurnRow) -> Vec<ToolCall> {
+    let mut tools = Vec::new();
+    let last_is_task = row
+        .last_tool
+        .as_deref()
+        .is_some_and(|name| name.eq_ignore_ascii_case("task"));
+    let generic_launches = if last_is_task {
+        row.subagent_launches.saturating_sub(1)
+    } else {
+        row.subagent_launches
+    };
+    for _ in 0..generic_launches {
+        tools.push(ToolCall::new("Task"));
+    }
+    if let Some(name) = &row.last_tool {
+        tools.push(ToolCall::new(name.clone()));
+    }
+    tools
+}
+
+/// Rebuilds the [`NormalizedEvent`] one [`TurnRow`] came from, field by
+/// field, inverting `turn_row_from_event` (`rows.rs`).
+///
+/// A row does not carry every field an event can: `wrapper_tool`,
+/// `may_resolve_late_tool`, `late_tool_candidate_is_builtin`, and
+/// `logical_parent_uuid` have no column, so the rebuilt event leaves them at
+/// their default. `SessionMetricsAccumulator` reads none of these to compute
+/// `SessionMetrics`, so the rebuilt event still drives it to the same
+/// result — see the parity test for the fields this does and does not cover.
+///
+/// `event.source` mirrors the row's own [`TurnRow::scope`] directly
+/// (`Main` → `Parent`, `Delegated` → `Subagent`). This is correct for a row
+/// whose accumulator processes it inline, mixed with the rest of its
+/// source's rows — every row in the parity test's fixtures. A source whose
+/// rows are *all* `Delegated` with `child_id` equal to their own
+/// `source_key` is instead an external child transcript: the live pipeline
+/// drives such a source through its own dedicated accumulator, which still
+/// sees its own events as `Parent`, and only `merge_metrics` folds it in as
+/// a sub-agent stream. [`metrics_from_rows`] applies that override itself,
+/// after calling this function, for exactly that case.
+pub fn event_from_row(row: &TurnRow) -> NormalizedEvent {
+    let role = match row.role {
+        "user" => Role::User,
+        "assistant" => Role::Assistant,
+        "system" => Role::System,
+        "tool" => Role::Tool,
+        other => unreachable!("turn row carries an unrecognized role {other:?}"),
+    };
+    let mut event = NormalizedEvent::new(role);
+    event.ts_ms = row.ts_ms;
+    event.source = match row.scope {
+        TurnScope::Main => EventSource::Parent,
+        TurnScope::Delegated => EventSource::Subagent,
+    };
+    event.usage = Usage {
+        input_tokens: row.input_tokens,
+        output_tokens: row.output_tokens,
+        cache_read_tokens: row.cache_read_tokens,
+        cache_creation_tokens: row.cache_write_tokens,
+    };
+    event.tools = synthesize_tools(row);
+    event.model = row.model.clone();
+    event.thinking_mode = row.effort.clone();
+    event.speed = row.speed.clone();
+    event.has_thinking = row.has_thinking;
+    event.message_id = row.message_id.clone();
+    event.is_compaction_boundary = row.is_compaction_boundary;
+    event.compaction_trigger = row.compaction_trigger;
+    event.compaction_pre_tokens = row.compaction_pre_tokens;
+    event.compaction_post_tokens = row.compaction_post_tokens;
+    event.uuid = row.uuid.clone();
+    event.parent_uuid = row.parent_uuid.clone();
+    event.thread_id = Some(row.thread_id.clone());
+    event
+}
+
+/// One `source_key` group of rows, in the row order `query_turn_rows`
+/// already returns them in (by `turn_index`, ascending).
+struct SourceGroup<'a> {
+    source_key: &'a str,
+    rows: Vec<&'a TurnRow>,
+}
+
+/// Splits `rows` into consecutive runs sharing one `source_key`, preserving
+/// `rows`' own order. Correct only when `rows` is already sorted by
+/// `(source_key, turn_index)` — [`crate::analysis::query_turn_rows`]'s own
+/// order.
+fn group_by_source<'a>(rows: &'a [TurnRow]) -> Vec<SourceGroup<'a>> {
+    let mut groups: Vec<SourceGroup<'a>> = Vec::new();
+    for row in rows {
+        match groups.last_mut() {
+            Some(group) if group.source_key == row.source_key => group.rows.push(row),
+            _ => groups.push(SourceGroup {
+                source_key: &row.source_key,
+                rows: vec![row],
+            }),
+        }
+    }
+    groups
+}
+
+/// True when every row in `group` carries the shape [`TurnRowSink`]'s
+/// `forced_scope` always writes for an external child transcript: `Delegated`
+/// scope with `child_id` equal to the group's own `source_key`. A parent
+/// source's rows never carry this shape uniformly — a genuine inline
+/// sub-agent turn's `child_id` is its own thread, not the parent file's
+/// `source_key` (see `turn_row_from_event`'s doc comment), and a parent
+/// source that launches no inline sub-agent has some `Main`-scope row.
+///
+/// [`TurnRowSink`]: crate::analysis::rows::TurnRowSink
+fn is_external_child_group(group: &SourceGroup<'_>) -> bool {
+    !group.rows.is_empty()
+        && group.rows.iter().all(|row| {
+            row.scope == TurnScope::Delegated && row.child_id.as_deref() == Some(group.source_key)
+        })
+}
+
+/// Builds one [`SessionMetricsAccumulator`] from one source's rows.
+/// `force_parent_source` overrides every row's own `event.source` to
+/// `EventSource::Parent` — see [`event_from_row`]'s doc comment for when the
+/// caller sets it.
+fn accumulator_from_group(
+    agent: &str,
+    session_id: &str,
+    group: &SourceGroup<'_>,
+    force_parent_source: bool,
+    summary: SessionSummary,
+) -> SessionMetricsAccumulator {
+    let mut accumulator = SessionMetricsAccumulator::new(agent, session_id);
+    for &row in &group.rows {
+        let mut event = event_from_row(row);
+        if force_parent_source {
+            event.source = EventSource::Parent;
+        }
+        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(event)));
+    }
+    accumulator.finish(summary);
+    accumulator
+}
+
+/// Rebuilds `SessionMetrics` by replaying `rows` through
+/// [`SessionMetricsAccumulator`], the same way the live pipeline drives it
+/// from a normalized event stream.
+///
+/// `rows` must already carry `query_turn_rows`'s own order — sorted by
+/// `(source_key, turn_index)` — since a row's position within its own
+/// source is the only order this function has to go on.
+///
+/// The live pipeline builds one accumulator per source file (the parent
+/// transcript, plus one per discovered child transcript) and combines them
+/// with [`merge_metrics`]; each accumulator finishes with its own source's
+/// `SessionSummary`, built from that source's own raw bytes. Rows carry no
+/// column for a `SessionSummary`'s fields (`model`, `context_window`,
+/// `cache_write_tokens_available`, `started_at_ms`, and the rest), so the
+/// caller supplies one per `source_key` through `summary_for` — the pure
+/// row-based part of this function is everything else: grouping rows by
+/// source, rebuilding each source's events, and driving and merging the
+/// accumulators exactly as the live pipeline does.
+///
+/// Every parity-tested fixture streams through one source, so `summary_for`
+/// runs once; a session with discovered child transcripts calls it once per
+/// `source_key`, parent first, each call's row group passed for context.
+pub fn metrics_from_rows(
+    agent: impl Into<String>,
+    session_id: impl Into<String>,
+    rows: &[TurnRow],
+    mut summary_for: impl FnMut(&str) -> SessionSummary,
+) -> SessionMetrics {
+    let agent = agent.into();
+    let session_id = session_id.into();
+    let groups = group_by_source(rows);
+    if groups.is_empty() {
+        let mut accumulator = SessionMetricsAccumulator::new(agent, session_id);
+        accumulator.finish(summary_for(""));
+        return accumulator.metrics();
+    }
+    // A single source is always the parent, with no other group to weigh it
+    // against — `is_external_child_group`'s shape test only makes sense to
+    // disambiguate among several groups. Deciding this way also sidesteps a
+    // real ambiguity in that test: an inline sub-agent turn whose adapter
+    // derives no thread ID falls back to the parent's own `source_key`
+    // (`turn_row_from_event`'s doc comment), so a source made up entirely of
+    // such turns can carry the external-child shape by coincidence even
+    // though it is the (only) parent.
+    if groups.len() == 1 {
+        let group = &groups[0];
+        let summary = summary_for(group.source_key);
+        let parent = accumulator_from_group(&agent, &session_id, group, false, summary);
+        return parent.metrics();
+    }
+    let mut parent_index: Option<usize> = None;
+    for (index, group) in groups.iter().enumerate() {
+        if !is_external_child_group(group) {
+            assert!(
+                parent_index.is_none(),
+                "metrics_from_rows: more than one source group looks like the parent \
+                 (source_key {:?} and {:?} both carry a non-uniformly-delegated shape)",
+                groups[parent_index.unwrap()].source_key,
+                group.source_key,
+            );
+            parent_index = Some(index);
+        }
+    }
+    let parent_index = parent_index.expect(
+        "metrics_from_rows: every source group looks like an external child transcript; \
+         exactly one must be the parent",
+    );
+    let parent_group = &groups[parent_index];
+    let parent_summary = summary_for(parent_group.source_key);
+    let parent = accumulator_from_group(&agent, &session_id, parent_group, false, parent_summary);
+    let children: Vec<SessionMetricsAccumulator> = groups
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index != parent_index)
+        .map(|(_, group)| {
+            let summary = summary_for(group.source_key);
+            accumulator_from_group(&agent, &session_id, group, true, summary)
+        })
+        .collect();
+    merge_metrics(&parent, &children)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::rows::turn_row_from_event;
+
+    fn base_row() -> TurnRow {
+        let event = NormalizedEvent::new(Role::Assistant);
+        turn_row_from_event(&event, "s1", 0)
+    }
+
+    #[test]
+    fn synthesize_tools_reproduces_last_tool_and_subagent_count_with_no_task_tool() {
+        let mut row = base_row();
+        row.last_tool = Some("Read".to_owned());
+        row.subagent_launches = 0;
+
+        let tools = synthesize_tools(&row);
+        assert_eq!(tools.last().map(|tool| tool.name.as_str()), Some("Read"));
+        assert_eq!(
+            tools
+                .iter()
+                .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn synthesize_tools_reproduces_several_launches_with_an_unrelated_last_tool() {
+        let mut row = base_row();
+        row.last_tool = Some("Read".to_owned());
+        row.subagent_launches = 3;
+
+        let tools = synthesize_tools(&row);
+        assert_eq!(tools.len(), 4);
+        assert_eq!(tools.last().map(|tool| tool.name.as_str()), Some("Read"));
+        assert_eq!(
+            tools
+                .iter()
+                .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+                .count(),
+            3
+        );
+    }
+
+    /// The edge case `synthesize_tools`'s doc comment reasons through: the
+    /// last tool call itself is a `"task"` launch, so it already counts
+    /// toward `subagent_launches`. A naive implementation that always
+    /// appends one generic `"Task"` call per launch, then the row's own
+    /// `last_tool`, would over-count by one.
+    #[test]
+    fn synthesize_tools_does_not_double_count_when_the_last_tool_is_itself_a_task_launch() {
+        let mut row = base_row();
+        row.last_tool = Some("Task".to_owned());
+        row.subagent_launches = 1;
+
+        let tools = synthesize_tools(&row);
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools.last().map(|tool| tool.name.as_str()), Some("Task"));
+        assert_eq!(
+            tools
+                .iter()
+                .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+                .count(),
+            1
+        );
+    }
+
+    /// The row's `last_tool` can carry a different case than the generic
+    /// synthesized calls (e.g. a vendor that logs `"task"` lowercase); the
+    /// exact string still must survive so the accumulator's interned
+    /// `bucket.last_tool` matches byte for byte.
+    #[test]
+    fn synthesize_tools_keeps_the_last_tools_own_case_when_it_is_a_task_launch() {
+        let mut row = base_row();
+        row.last_tool = Some("task".to_owned());
+        row.subagent_launches = 2;
+
+        let tools = synthesize_tools(&row);
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].name, "Task");
+        assert_eq!(tools[1].name, "task");
+    }
+
+    #[test]
+    fn synthesize_tools_is_empty_without_any_tool_call() {
+        let row = base_row();
+        assert!(synthesize_tools(&row).is_empty());
+    }
+
+    #[test]
+    fn event_from_row_inverts_scope_into_source() {
+        let mut event = NormalizedEvent::new(Role::Assistant);
+        event.source = EventSource::Subagent;
+        event.thread_id = Some("sidechain-1".to_owned());
+        let row = turn_row_from_event(&event, "parent-1", 0);
+
+        let rebuilt = event_from_row(&row);
+        assert_eq!(rebuilt.source, EventSource::Subagent);
+    }
+
+    #[test]
+    fn event_from_row_round_trips_every_scalar_field() {
+        let mut event = NormalizedEvent::new(Role::Tool);
+        event.ts_ms = Some(42);
+        event.model = Some("claude-opus-4-6".to_owned());
+        event.thinking_mode = Some("high".to_owned());
+        event.speed = Some("fast".to_owned());
+        event.has_thinking = true;
+        event.message_id = Some("msg-1".to_owned());
+        event.is_compaction_boundary = true;
+        event.compaction_trigger = Some(crate::analysis::model::CompactionTrigger::Manual);
+        event.compaction_pre_tokens = Some(100);
+        event.compaction_post_tokens = Some(20);
+        event.uuid = Some("uuid-1".to_owned());
+        event.parent_uuid = Some("uuid-0".to_owned());
+        event.usage = Usage {
+            input_tokens: 5,
+            output_tokens: 6,
+            cache_read_tokens: 7,
+            cache_creation_tokens: 8,
+        };
+        let row = turn_row_from_event(&event, "parent-1", 0);
+
+        let rebuilt = event_from_row(&row);
+        assert_eq!(rebuilt.role, Role::Tool);
+        assert_eq!(rebuilt.ts_ms, Some(42));
+        assert_eq!(rebuilt.model.as_deref(), Some("claude-opus-4-6"));
+        assert_eq!(rebuilt.thinking_mode.as_deref(), Some("high"));
+        assert_eq!(rebuilt.speed.as_deref(), Some("fast"));
+        assert!(rebuilt.has_thinking);
+        assert_eq!(rebuilt.message_id.as_deref(), Some("msg-1"));
+        assert!(rebuilt.is_compaction_boundary);
+        assert_eq!(
+            rebuilt.compaction_trigger,
+            Some(crate::analysis::model::CompactionTrigger::Manual)
+        );
+        assert_eq!(rebuilt.compaction_pre_tokens, Some(100));
+        assert_eq!(rebuilt.compaction_post_tokens, Some(20));
+        assert_eq!(rebuilt.uuid.as_deref(), Some("uuid-1"));
+        assert_eq!(rebuilt.parent_uuid.as_deref(), Some("uuid-0"));
+        assert_eq!(rebuilt.usage.input_tokens, 5);
+        assert_eq!(rebuilt.usage.output_tokens, 6);
+        assert_eq!(rebuilt.usage.cache_read_tokens, 7);
+        assert_eq!(rebuilt.usage.cache_creation_tokens, 8);
+    }
+
+    #[test]
+    fn metrics_from_rows_matches_a_direct_accumulator_for_one_source() {
+        let mut live = SessionMetricsAccumulator::new("claude", "s1");
+        let mut rows = Vec::new();
+        for index in 0..3u64 {
+            let mut event = NormalizedEvent::new(Role::Assistant);
+            event.ts_ms = Some(1_000 + index as i64 * 1_000);
+            event.model = Some("claude-opus-4-6".to_owned());
+            event.usage = Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+            };
+            rows.push(turn_row_from_event(&event, "s1", index));
+            live.record(NormalizedRecord::MetricsEvent(Box::new(event)));
+        }
+        let summary = SessionSummary {
+            cache_write_tokens_available: true,
+            model: Some("claude-opus-4-6".to_owned()),
+            ..SessionSummary::default()
+        };
+        live.finish(SessionSummary {
+            cache_write_tokens_available: true,
+            model: Some("claude-opus-4-6".to_owned()),
+            ..SessionSummary::default()
+        });
+
+        let replayed = metrics_from_rows("claude", "s1", &rows, |_| SessionSummary {
+            cache_write_tokens_available: summary.cache_write_tokens_available,
+            model: summary.model.clone(),
+            ..SessionSummary::default()
+        });
+
+        assert_eq!(replayed.tokens_in, live.metrics().tokens_in);
+        assert_eq!(replayed.tokens_out, live.metrics().tokens_out);
+        assert_eq!(replayed.model_breakdown, live.metrics().model_breakdown);
+        assert_eq!(replayed.buckets, live.metrics().buckets);
+    }
+
+    #[test]
+    fn metrics_from_rows_drives_an_external_child_source_as_parent_then_merges() {
+        // The parent file has one plain turn. The child file (its own
+        // `source_key`, forced `Delegated` scope with `child_id` equal to
+        // its own key — the shape `TurnRowSink` writes for a discovered
+        // sub-agent transcript) has one turn of its own.
+        let mut parent_event = NormalizedEvent::new(Role::Assistant);
+        parent_event.ts_ms = Some(1_000);
+        parent_event.model = Some("claude-opus-4-6".to_owned());
+        parent_event.usage = Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            ..Usage::default()
+        };
+        let parent_row = turn_row_from_event(&parent_event, "parent-1", 0);
+
+        let mut child_event = NormalizedEvent::new(Role::Assistant);
+        child_event.ts_ms = Some(2_000);
+        child_event.model = Some("claude-haiku-4-6".to_owned());
+        child_event.usage = Usage {
+            input_tokens: 3,
+            output_tokens: 1,
+            ..Usage::default()
+        };
+        let mut child_row = turn_row_from_event(&child_event, "child-1", 0);
+        child_row.scope = TurnScope::Delegated;
+        child_row.child_id = Some("child-1".to_owned());
+
+        let rows = vec![parent_row, child_row];
+
+        // Build the same two accumulators by hand, from the original
+        // events (not rows), and merge them the way the live pipeline
+        // does: this is the reference this test compares against.
+        let mut expected_parent = SessionMetricsAccumulator::new("claude", "s1");
+        expected_parent.record(NormalizedRecord::MetricsEvent(Box::new(parent_event)));
+        expected_parent.finish(SessionSummary {
+            model: Some("claude-opus-4-6".to_owned()),
+            ..SessionSummary::default()
+        });
+        let mut expected_child = SessionMetricsAccumulator::new("claude", "s1");
+        expected_child.record(NormalizedRecord::MetricsEvent(Box::new(child_event)));
+        expected_child.finish(SessionSummary {
+            model: Some("claude-haiku-4-6".to_owned()),
+            ..SessionSummary::default()
+        });
+        let expected = merge_metrics(&expected_parent, &[expected_child]);
+
+        let replayed = metrics_from_rows("claude", "s1", &rows, |source_key| SessionSummary {
+            model: Some(if source_key == "parent-1" {
+                "claude-opus-4-6".to_owned()
+            } else {
+                "claude-haiku-4-6".to_owned()
+            }),
+            ..SessionSummary::default()
+        });
+
+        assert_eq!(replayed.tokens_in, expected.tokens_in);
+        assert_eq!(replayed.tokens_out, expected.tokens_out);
+        assert_eq!(replayed.model_breakdown, expected.model_breakdown);
+        assert_eq!(replayed.buckets, expected.buckets);
+    }
+}

--- a/crates/antiburn-local/src/analysis/replay.rs
+++ b/crates/antiburn-local/src/analysis/replay.rs
@@ -59,13 +59,14 @@ fn synthesize_tools(row: &TurnRow) -> Vec<ToolCall> {
 /// `event.source` mirrors the row's own [`TurnRow::scope`] directly
 /// (`Main` → `Parent`, `Delegated` → `Subagent`). This is correct for a row
 /// whose accumulator processes it inline, mixed with the rest of its
-/// source's rows — every row in the parity test's fixtures. A source whose
-/// rows are *all* `Delegated` with `child_id` equal to their own
-/// `source_key` is instead an external child transcript: the live pipeline
-/// drives such a source through its own dedicated accumulator, which still
-/// sees its own events as `Parent`, and only `merge_metrics` folds it in as
-/// a sub-agent stream. [`metrics_from_rows`] applies that override itself,
-/// after calling this function, for exactly that case.
+/// source's rows — every row in the parity test's fixtures. A row from a
+/// discovered child transcript (see [`is_parent_group`]'s doc comment for
+/// how [`metrics_from_rows`] tells one from the parent's own rows) is
+/// different: the live pipeline drives such a source through its own
+/// dedicated accumulator, which still sees its own events as `Parent`, and
+/// only `merge_metrics` folds it in as a sub-agent stream.
+/// [`metrics_from_rows`] applies that override itself, after calling this
+/// function, for exactly that case.
 pub fn event_from_row(row: &TurnRow) -> NormalizedEvent {
     let role = match row.role {
         "user" => Role::User,
@@ -127,20 +128,27 @@ fn group_by_source<'a>(rows: &'a [TurnRow]) -> Vec<SourceGroup<'a>> {
     groups
 }
 
-/// True when every row in `group` carries the shape [`TurnRowSink`]'s
-/// `forced_scope` always writes for an external child transcript: `Delegated`
-/// scope with `child_id` equal to the group's own `source_key`. A parent
-/// source's rows never carry this shape uniformly — a genuine inline
-/// sub-agent turn's `child_id` is its own thread, not the parent file's
-/// `source_key` (see `turn_row_from_event`'s doc comment), and a parent
-/// source that launches no inline sub-agent has some `Main`-scope row.
+/// True when `group` is the parent transcript's own rows, among possibly
+/// several sources.
+///
+/// The live pipeline gives every source's [`TurnRowSink`] the same
+/// [`crate::analysis::TurnRowStore`], fenced to one fixed session key for
+/// the whole pass (`FencedTurnRowStore`, `apps/desktop/src-tauri/src/store/
+/// mod.rs`), but a distinct `source_key` per input
+/// (`TurnRowSink::new(store, input.session_id.clone(), scope)`,
+/// `stream_vendor_with_hooks`). For the parent input (index 0),
+/// `input.session_id` is that same session's own id — the parent
+/// transcript *is* the session — so its rows' `source_key` equals
+/// `session_id`. A discovered child transcript's `input.session_id` is that
+/// child's own, distinct id, so its rows' `source_key` never does. This is
+/// the same rule `query_model_runs` (`evidence_query.rs`) already uses to
+/// split parent runs from child runs. It needs no row shape (`scope`,
+/// `child_id`): those still round-trip through [`event_from_row`], but
+/// `metrics_from_rows` never inspects them to tell sources apart.
 ///
 /// [`TurnRowSink`]: crate::analysis::rows::TurnRowSink
-fn is_external_child_group(group: &SourceGroup<'_>) -> bool {
-    !group.rows.is_empty()
-        && group.rows.iter().all(|row| {
-            row.scope == TurnScope::Delegated && row.child_id.as_deref() == Some(group.source_key)
-        })
+fn is_parent_group(group: &SourceGroup<'_>, session_id: &str) -> bool {
+    group.source_key == session_id
 }
 
 /// Builds one [`SessionMetricsAccumulator`] from one source's rows.
@@ -166,6 +174,26 @@ fn accumulator_from_group(
     accumulator
 }
 
+/// [`metrics_from_rows`] found no source group whose `source_key` equals
+/// the session's own id, so it could not tell which source is the parent
+/// transcript — see [`is_parent_group`]'s doc comment for that rule. A row
+/// set should never actually have this shape; the caller should fall back
+/// to the live parse path rather than trust a rebuild that cannot find its
+/// own parent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingParentRows;
+
+impl std::fmt::Display for MissingParentRows {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "metrics_from_rows: no source group's source_key equals the session id"
+        )
+    }
+}
+
+impl std::error::Error for MissingParentRows {}
+
 /// Rebuilds `SessionMetrics` by replaying `rows` through
 /// [`SessionMetricsAccumulator`], the same way the live pipeline drives it
 /// from a normalized event stream.
@@ -188,51 +216,40 @@ fn accumulator_from_group(
 /// Every parity-tested fixture streams through one source, so `summary_for`
 /// runs once; a session with discovered child transcripts calls it once per
 /// `source_key`, parent first, each call's row group passed for context.
+///
+/// Returns [`MissingParentRows`] when no source group's `source_key` equals
+/// `session_id` — this rebuild is meant to back a live production command,
+/// so an unexpected row shape returns an error the caller can fall back on
+/// instead of panicking. Because [`group_by_source`] partitions rows into
+/// groups with distinct `source_key`s, at most one group can ever match, so
+/// there is no corresponding "more than one parent" case to handle.
 pub fn metrics_from_rows(
     agent: impl Into<String>,
     session_id: impl Into<String>,
     rows: &[TurnRow],
     mut summary_for: impl FnMut(&str) -> SessionSummary,
-) -> SessionMetrics {
+) -> Result<SessionMetrics, MissingParentRows> {
     let agent = agent.into();
     let session_id = session_id.into();
     let groups = group_by_source(rows);
     if groups.is_empty() {
         let mut accumulator = SessionMetricsAccumulator::new(agent, session_id);
         accumulator.finish(summary_for(""));
-        return accumulator.metrics();
+        return Ok(accumulator.metrics());
     }
-    // A single source is always the parent, with no other group to weigh it
-    // against — `is_external_child_group`'s shape test only makes sense to
-    // disambiguate among several groups. Deciding this way also sidesteps a
-    // real ambiguity in that test: an inline sub-agent turn whose adapter
-    // derives no thread ID falls back to the parent's own `source_key`
-    // (`turn_row_from_event`'s doc comment), so a source made up entirely of
-    // such turns can carry the external-child shape by coincidence even
-    // though it is the (only) parent.
+    // A single source needs no parent/child call: there is no other group
+    // to fold it in as a sub-agent stream of, so it is the parent
+    // regardless of its own `source_key`.
     if groups.len() == 1 {
         let group = &groups[0];
         let summary = summary_for(group.source_key);
         let parent = accumulator_from_group(&agent, &session_id, group, false, summary);
-        return parent.metrics();
+        return Ok(parent.metrics());
     }
-    let mut parent_index: Option<usize> = None;
-    for (index, group) in groups.iter().enumerate() {
-        if !is_external_child_group(group) {
-            assert!(
-                parent_index.is_none(),
-                "metrics_from_rows: more than one source group looks like the parent \
-                 (source_key {:?} and {:?} both carry a non-uniformly-delegated shape)",
-                groups[parent_index.unwrap()].source_key,
-                group.source_key,
-            );
-            parent_index = Some(index);
-        }
-    }
-    let parent_index = parent_index.expect(
-        "metrics_from_rows: every source group looks like an external child transcript; \
-         exactly one must be the parent",
-    );
+    let parent_index = groups
+        .iter()
+        .position(|group| is_parent_group(group, &session_id))
+        .ok_or(MissingParentRows)?;
     let parent_group = &groups[parent_index];
     let parent_summary = summary_for(parent_group.source_key);
     let parent = accumulator_from_group(&agent, &session_id, parent_group, false, parent_summary);
@@ -245,7 +262,7 @@ pub fn metrics_from_rows(
             accumulator_from_group(&agent, &session_id, group, true, summary)
         })
         .collect();
-    merge_metrics(&parent, &children)
+    Ok(merge_metrics(&parent, &children))
 }
 
 #[cfg(test)]
@@ -427,7 +444,8 @@ mod tests {
             cache_write_tokens_available: summary.cache_write_tokens_available,
             model: summary.model.clone(),
             ..SessionSummary::default()
-        });
+        })
+        .expect("a single source group needs no parent lookup");
 
         assert_eq!(replayed.tokens_in, live.metrics().tokens_in);
         assert_eq!(replayed.tokens_out, live.metrics().tokens_out);
@@ -437,10 +455,15 @@ mod tests {
 
     #[test]
     fn metrics_from_rows_drives_an_external_child_source_as_parent_then_merges() {
-        // The parent file has one plain turn. The child file (its own
-        // `source_key`, forced `Delegated` scope with `child_id` equal to
-        // its own key — the shape `TurnRowSink` writes for a discovered
-        // sub-agent transcript) has one turn of its own.
+        // The parent file's own rows carry `source_key == session_id`
+        // ("parent-1" — the live pipeline's own `SessionInput.session_id`
+        // for the parent input is the session's own id). The child file's
+        // rows carry a distinct `source_key` ("child-1"), with `Delegated`
+        // scope and `child_id` equal to that same key — the shape
+        // `TurnRowSink` writes for a discovered sub-agent transcript. Only
+        // the `source_key` difference decides which group is the parent;
+        // the `scope`/`child_id` shape here just matches what production
+        // actually writes.
         let mut parent_event = NormalizedEvent::new(Role::Assistant);
         parent_event.ts_ms = Some(1_000);
         parent_event.model = Some("claude-opus-4-6".to_owned());
@@ -468,13 +491,13 @@ mod tests {
         // Build the same two accumulators by hand, from the original
         // events (not rows), and merge them the way the live pipeline
         // does: this is the reference this test compares against.
-        let mut expected_parent = SessionMetricsAccumulator::new("claude", "s1");
+        let mut expected_parent = SessionMetricsAccumulator::new("claude", "parent-1");
         expected_parent.record(NormalizedRecord::MetricsEvent(Box::new(parent_event)));
         expected_parent.finish(SessionSummary {
             model: Some("claude-opus-4-6".to_owned()),
             ..SessionSummary::default()
         });
-        let mut expected_child = SessionMetricsAccumulator::new("claude", "s1");
+        let mut expected_child = SessionMetricsAccumulator::new("claude", "parent-1");
         expected_child.record(NormalizedRecord::MetricsEvent(Box::new(child_event)));
         expected_child.finish(SessionSummary {
             model: Some("claude-haiku-4-6".to_owned()),
@@ -482,18 +505,46 @@ mod tests {
         });
         let expected = merge_metrics(&expected_parent, &[expected_child]);
 
-        let replayed = metrics_from_rows("claude", "s1", &rows, |source_key| SessionSummary {
-            model: Some(if source_key == "parent-1" {
-                "claude-opus-4-6".to_owned()
-            } else {
-                "claude-haiku-4-6".to_owned()
-            }),
-            ..SessionSummary::default()
-        });
+        let replayed =
+            metrics_from_rows("claude", "parent-1", &rows, |source_key| SessionSummary {
+                model: Some(if source_key == "parent-1" {
+                    "claude-opus-4-6".to_owned()
+                } else {
+                    "claude-haiku-4-6".to_owned()
+                }),
+                ..SessionSummary::default()
+            })
+            .expect("the parent group's source_key equals the session id");
 
         assert_eq!(replayed.tokens_in, expected.tokens_in);
         assert_eq!(replayed.tokens_out, expected.tokens_out);
         assert_eq!(replayed.model_breakdown, expected.model_breakdown);
         assert_eq!(replayed.buckets, expected.buckets);
+    }
+
+    #[test]
+    fn metrics_from_rows_reports_a_missing_parent_instead_of_panicking() {
+        // Neither source's `source_key` equals the session id passed in, so
+        // there is no row group `metrics_from_rows` can call the parent.
+        let mut event_a = NormalizedEvent::new(Role::Assistant);
+        event_a.usage = Usage {
+            input_tokens: 1,
+            output_tokens: 1,
+            ..Usage::default()
+        };
+        let row_a = turn_row_from_event(&event_a, "source-a", 0);
+        let mut event_b = NormalizedEvent::new(Role::Assistant);
+        event_b.usage = Usage {
+            input_tokens: 1,
+            output_tokens: 1,
+            ..Usage::default()
+        };
+        let row_b = turn_row_from_event(&event_b, "source-b", 0);
+
+        let result = metrics_from_rows("claude", "neither-source-key", &[row_a, row_b], |_| {
+            SessionSummary::default()
+        });
+
+        assert_eq!(result, Err(MissingParentRows));
     }
 }

--- a/crates/antiburn-local/tests/turn_row_replay_parity.rs
+++ b/crates/antiburn-local/tests/turn_row_replay_parity.rs
@@ -1,0 +1,929 @@
+//! Parity check between the live pipeline's `SessionMetrics` and the same
+//! metrics rebuilt from turn rows alone. See seam R3b in
+//! `docs/plans/session-evidence-harness-parity.md`.
+//!
+//! For every vendor characterization fixture `turn_facts_parity.rs` sweeps,
+//! this streams the fixture once through a `CompositeSink` (accumulator +
+//! evidence + `TurnRowSink` into a `MemoryTurnRowStore`), reads the rows
+//! back with `query_turn_rows`, replays them with `metrics_from_rows`, and
+//! asserts the result equals the live accumulator's own `SessionMetrics`
+//! field by field.
+//!
+//! `metrics_from_rows` takes rows plus a `SessionSummary` per source — rows
+//! carry no column for a summary's fields (`model`, `context_window`,
+//! `cache_write_tokens_available`, `started_at_ms`, and the rest). Every
+//! fixture here streams through one source, so this file gets a real,
+//! fixture-accurate summary the same deterministic way the live pipeline
+//! does: by running the same adapter over the same fixture bytes a second
+//! time, into a sink that only captures the `SessionSummary` `finish` hands
+//! it. This is a test-only convenience — `metrics_from_rows` itself never
+//! touches raw bytes, a store, or Tauri.
+//!
+//! Three `SessionMetrics` fields are out of the comparison for every
+//! fixture, not as a per-fixture exception but as this seam's own scope
+//! boundary (see the PR description and `replay.rs`'s module doc comment):
+//! `tool_calls_by_name`, `mcp_tool_calls`, and `skill_uses` need every tool
+//! call a turn made, and a row keeps only its last tool's name and its
+//! `"task"`-launch count. `initial_context` is downstream of those same
+//! per-tool counts (`bound_initial_context`'s `use_count` reads the
+//! accumulator's own observed tool/skill/MCP names), so it is out of scope
+//! for the same reason.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use antiburn_local::analysis::{
+    Bucket, CompositeSink, EvidenceSource, MemoryTurnRowStore, NormalizedRecord, RawSource,
+    RecordSink, SessionEvidenceAccumulator, SessionInput, SessionMetrics,
+    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceKind, TurnRowSink,
+    TurnRowStore, TurnSessionKey, adapter_for, metrics_from_rows, query_turn_rows,
+};
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+/// Records a mismatch when the replayed `SessionMetrics` and the live
+/// accumulator's own `SessionMetrics` differ for one field of one fixture.
+fn diff<T: std::fmt::Debug + PartialEq>(
+    mismatches: &mut Vec<Mismatch>,
+    fixture: &str,
+    field: &str,
+    replayed: T,
+    live: T,
+) {
+    if replayed != live {
+        mismatches.push(Mismatch {
+            detail: format!(
+                "fixture={fixture} field={field}\n  replayed = {replayed:?}\n  live     = {live:?}"
+            ),
+        });
+    }
+}
+
+struct Mismatch {
+    detail: String,
+}
+
+fn assert_no_mismatches(vendor: &str, mismatches: Vec<Mismatch>) {
+    let details: Vec<&str> = mismatches
+        .iter()
+        .map(|mismatch| mismatch.detail.as_str())
+        .collect();
+    assert!(
+        details.is_empty(),
+        "{vendor}: {} mismatch(es) between metrics_from_rows and the live accumulator:\n\n{}",
+        details.len(),
+        details.join("\n\n")
+    );
+}
+
+/// A [`RecordSink`] that keeps only the [`SessionSummary`] `finish` hands
+/// it, so a second, deterministic run of the same adapter over the same
+/// bytes recovers the exact summary the live run also used — see this
+/// file's module doc comment for why that is a legitimate test-only step.
+#[derive(Default)]
+struct SummaryCapture(Option<SessionSummary>);
+
+impl RecordSink for SummaryCapture {
+    fn record(&mut self, _record: NormalizedRecord) {}
+
+    fn finish(&mut self, summary: SessionSummary) {
+        self.0 = Some(summary);
+    }
+}
+
+/// Streams `input` through the real adapter and the real evidence and
+/// turn-row pipeline, then rebuilds `SessionMetrics` from the rows that
+/// pipeline wrote. Returns `(live, replayed)`.
+fn run_fixture_and_replay(
+    agent: &str,
+    fixture: &str,
+    input: &SessionInput,
+    capabilities: SourceCapabilities,
+) -> (SessionMetrics, SessionMetrics) {
+    let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::from(&input.source),
+        capabilities,
+    });
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut composite = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
+    let outcome = adapter_for(agent)
+        .visit(input, &mut composite)
+        .expect("fixture must stream");
+    composite.observe_source_outcome(outcome);
+    assert!(
+        !composite.turn_row_write_failed(),
+        "fixture {fixture}: turn row write must not fail"
+    );
+    let live = composite
+        .metrics()
+        .expect("finished source must publish metrics");
+
+    let key = TurnSessionKey {
+        environment_key: "native",
+        agent,
+        session_id: &input.session_id,
+    };
+    let rows = store
+        .with_connection(|conn| query_turn_rows(conn, &key, 1).expect("query rows must succeed"));
+
+    let mut capture = SummaryCapture::default();
+    adapter_for(agent)
+        .visit(input, &mut capture)
+        .expect("fixture must stream for summary capture");
+    let mut summary = capture.0;
+    let replayed = metrics_from_rows(agent, input.session_id.clone(), &rows, |source_key| {
+        summary.take().unwrap_or_else(|| {
+            panic!(
+                "fixture {fixture}: metrics_from_rows asked for a second source's summary \
+                 ({source_key:?}), but every fixture here streams through one source"
+            )
+        })
+    });
+
+    (live, replayed)
+}
+
+/// Strips the one documented, principled gap this seam accepts before
+/// comparing `live`'s buckets to the replay's: Claude's
+/// `late_skill_metrics` fixture names its skill through a trailing
+/// `attachment` record, which `ClaudeAdapter` resolves only in
+/// `SessionSummary::late_tools`, after the pipeline already wrote this
+/// turn's row (turn ordinal 1, bucket 0) with no tool call at all —
+/// `TurnRowSink` observes each row at `record` time, before `finish`
+/// resolves late tools. `SessionMetricsAccumulator::finish_summary` then
+/// folds the resolved `"skill"` call into `bucket.last_tool` for the live
+/// run; the replayed run never reserves a late-tool candidate for a
+/// synthesized event (`event_from_row`'s doc comment), so
+/// `finish_summary`'s `late_tools` loop finds no candidate to fold it into,
+/// and the replayed bucket's `last_tool` stays `None`. No other field, of
+/// any other bucket, of any other fixture, carries this gap — see the PR
+/// description for why this is the seam's one accepted exclusion, mirroring
+/// seam R2's own `delegated_model_missing` precedent.
+fn live_buckets_for_comparison(fixture: &str, buckets: &[Bucket]) -> Vec<Bucket> {
+    let mut buckets = buckets.to_vec();
+    if fixture == "late_skill_metrics" {
+        buckets[0].last_tool = None;
+    }
+    buckets
+}
+
+/// Compares every in-scope `SessionMetrics` field between `live` and
+/// `replayed` for one fixture, pushing each mismatch into `mismatches`. See
+/// this file's module doc comment for the three fields left out of scope,
+/// and [`live_buckets_for_comparison`] for the one per-fixture exclusion.
+fn compare_metrics(
+    mismatches: &mut Vec<Mismatch>,
+    fixture: &str,
+    live: &SessionMetrics,
+    replayed: &SessionMetrics,
+) {
+    diff(
+        mismatches,
+        fixture,
+        "duration_secs",
+        replayed.duration_secs,
+        live.duration_secs,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "active_secs",
+        replayed.active_secs,
+        live.active_secs,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "event_count",
+        replayed.event_count,
+        live.event_count,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "tokens_in",
+        replayed.tokens_in,
+        live.tokens_in,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "tokens_out",
+        replayed.tokens_out,
+        live.tokens_out,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "peak_context_tokens",
+        replayed.peak_context_tokens,
+        live.peak_context_tokens,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "compaction_count",
+        replayed.compaction_count,
+        live.compaction_count,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "cache_routing_miss_count",
+        replayed.cache_routing_miss_count,
+        live.cache_routing_miss_count,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "cache_rehydration_count",
+        replayed.cache_rehydration_count,
+        live.cache_rehydration_count,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "context_available",
+        replayed.context_available,
+        live.context_available,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "context_window",
+        replayed.context_window,
+        live.context_window,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "buckets",
+        replayed.buckets.clone(),
+        live_buckets_for_comparison(fixture, &live.buckets),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "model",
+        replayed.model.clone(),
+        live.model.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "model_runs",
+        replayed.model_runs.clone(),
+        live.model_runs.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "billable_input_tokens",
+        replayed.billable_input_tokens,
+        live.billable_input_tokens,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "billable_output_tokens",
+        replayed.billable_output_tokens,
+        live.billable_output_tokens,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "billable_cache_read_tokens",
+        replayed.billable_cache_read_tokens,
+        live.billable_cache_read_tokens,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "billable_cache_creation_tokens",
+        replayed.billable_cache_creation_tokens,
+        live.billable_cache_creation_tokens,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "model_breakdown",
+        replayed.model_breakdown.clone(),
+        live.model_breakdown.clone(),
+    );
+    diff(mismatches, fixture, "cost", replayed.cost, live.cost);
+    diff(
+        mismatches,
+        fixture,
+        "efficiency",
+        replayed.efficiency,
+        live.efficiency,
+    );
+}
+
+/* --------------------------------------------------------------------
+ * Claude fixtures. Same 28 fixtures `turn_facts_parity.rs` sweeps.
+ * ----------------------------------------------------------------- */
+
+fn claude_fixture(name: &str) -> &'static str {
+    match name {
+        "records_all_kinds" => {
+            include_str!("fixtures/claude_characterization/records_all_kinds.jsonl")
+        }
+        "timestamps_repeated_and_out_of_order" => include_str!(
+            "fixtures/claude_characterization/timestamps_repeated_and_out_of_order.jsonl"
+        ),
+        "malformed_between_valid" => {
+            include_str!("fixtures/claude_characterization/malformed_between_valid.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/claude_characterization/incomplete_final_record.jsonl")
+        }
+        "unrecognized_type" => {
+            include_str!("fixtures/claude_characterization/unrecognized_type.jsonl")
+        }
+        "unrecognized_role_with_usage" => {
+            include_str!("fixtures/claude_characterization/unrecognized_role_with_usage.jsonl")
+        }
+        "unrecognized_evidence_shapes" => {
+            include_str!("fixtures/claude_characterization/unrecognized_evidence_shapes.jsonl")
+        }
+        "unrecognized_inert_records" => {
+            include_str!("fixtures/claude_characterization/unrecognized_inert_records.jsonl")
+        }
+        "unrecognized_inert_sidechain" => {
+            include_str!("fixtures/claude_characterization/unrecognized_inert_sidechain.jsonl")
+        }
+        "parent_with_task_spawn" => {
+            include_str!("fixtures/claude_characterization/parent_with_task_spawn.jsonl")
+        }
+        "subagent_child" => include_str!("fixtures/claude_characterization/subagent_child.jsonl"),
+        "multi_model_session" => {
+            include_str!("fixtures/claude_characterization/multi_model_session.jsonl")
+        }
+        "compaction_with_cache_rehydration" => {
+            include_str!("fixtures/claude_characterization/compaction_with_cache_rehydration.jsonl")
+        }
+        "inferred_cache_rehydration" => {
+            include_str!("fixtures/claude_characterization/inferred_cache_rehydration.jsonl")
+        }
+        "mcp_and_skill_sources" => {
+            include_str!("fixtures/claude_characterization/mcp_and_skill_sources.jsonl")
+        }
+        "reasoning_and_fast_mode" => {
+            include_str!("fixtures/claude_characterization/reasoning_and_fast_mode.jsonl")
+        }
+        "delegated_turns" => {
+            include_str!("fixtures/claude_characterization/delegated_turns.jsonl")
+        }
+        "delegated_models" => {
+            include_str!("fixtures/claude_characterization/delegated_models.jsonl")
+        }
+        "delegated_model_missing" => {
+            include_str!("fixtures/claude_characterization/delegated_model_missing.jsonl")
+        }
+        "housekeeping_records" => {
+            include_str!("fixtures/claude_characterization/housekeeping_records.jsonl")
+        }
+        "thread_identity_chain" => {
+            include_str!("fixtures/claude_characterization/thread_identity_chain.jsonl")
+        }
+        "thread_identity_missing_uuid" => {
+            include_str!("fixtures/claude_characterization/thread_identity_missing_uuid.jsonl")
+        }
+        "sidechain_in_parent" => {
+            include_str!("fixtures/claude_characterization/sidechain_in_parent.jsonl")
+        }
+        "late_skill_metrics" => {
+            include_str!("fixtures/claude_characterization/late_skill_metrics.jsonl")
+        }
+        "two_compactions_second_without_metadata" => include_str!(
+            "fixtures/claude_characterization/two_compactions_second_without_metadata.jsonl"
+        ),
+        "rehydration_gap_none" => {
+            include_str!("fixtures/claude_characterization/rehydration_gap_none.jsonl")
+        }
+        "disorder_ladder" => {
+            include_str!("fixtures/claude_characterization/disorder_ladder.jsonl")
+        }
+        "subagent_single_timestamp" => {
+            include_str!("fixtures/claude_characterization/subagent_single_timestamp.jsonl")
+        }
+        _ => panic!("unknown Claude characterization fixture: {name}"),
+    }
+}
+
+fn claude_fixture_names() -> [&'static str; 28] {
+    [
+        "records_all_kinds",
+        "timestamps_repeated_and_out_of_order",
+        "malformed_between_valid",
+        "incomplete_final_record",
+        "unrecognized_type",
+        "unrecognized_role_with_usage",
+        "unrecognized_evidence_shapes",
+        "unrecognized_inert_records",
+        "unrecognized_inert_sidechain",
+        "parent_with_task_spawn",
+        "subagent_child",
+        "multi_model_session",
+        "compaction_with_cache_rehydration",
+        "inferred_cache_rehydration",
+        "mcp_and_skill_sources",
+        "reasoning_and_fast_mode",
+        "delegated_turns",
+        "delegated_models",
+        "delegated_model_missing",
+        "housekeeping_records",
+        "thread_identity_chain",
+        "thread_identity_missing_uuid",
+        "sidechain_in_parent",
+        "late_skill_metrics",
+        "two_compactions_second_without_metadata",
+        "rehydration_gap_none",
+        "disorder_ladder",
+        "subagent_single_timestamp",
+    ]
+}
+
+#[test]
+fn claude_metrics_from_rows_matches_the_accumulator_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in claude_fixture_names() {
+        let input = SessionInput {
+            agent: "claude".to_owned(),
+            session_id: name.to_owned(),
+            source: RawSource::Jsonl(claude_fixture(name).to_owned()),
+        };
+        let (live, replayed) =
+            run_fixture_and_replay("claude", name, &input, SourceCapabilities::claude());
+        compare_metrics(&mut mismatches, name, &live, &replayed);
+    }
+    assert_no_mismatches("claude", mismatches);
+}
+
+/* --------------------------------------------------------------------
+ * Codex fixtures. Same 9 fixtures `turn_facts_parity.rs` sweeps.
+ * ----------------------------------------------------------------- */
+
+fn codex_fixture(name: &str) -> &'static str {
+    match name {
+        "records_all_kinds" => {
+            include_str!("fixtures/codex_characterization/records_all_kinds.jsonl")
+        }
+        "malformed_between_valid" => {
+            include_str!("fixtures/codex_characterization/malformed_between_valid.jsonl")
+        }
+        "unrecognized_type" => {
+            include_str!("fixtures/codex_characterization/unrecognized_type.jsonl")
+        }
+        "absent_model_and_effort" => {
+            include_str!("fixtures/codex_characterization/absent_model_and_effort.jsonl")
+        }
+        "resolved_fork" => include_str!("fixtures/codex_characterization/resolved_fork.jsonl"),
+        "fork_developer_lookbehind" => {
+            include_str!("fixtures/codex_characterization/fork_developer_lookbehind.jsonl")
+        }
+        "fork_disputed_window" => {
+            include_str!("fixtures/codex_characterization/fork_disputed_window.jsonl")
+        }
+        "unresolved_fork" => {
+            include_str!("fixtures/codex_characterization/unresolved_fork.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/codex_characterization/incomplete_final_record.jsonl")
+        }
+        _ => panic!("unknown Codex characterization fixture: {name}"),
+    }
+}
+
+fn codex_fixture_names() -> [&'static str; 9] {
+    [
+        "records_all_kinds",
+        "malformed_between_valid",
+        "unrecognized_type",
+        "absent_model_and_effort",
+        "resolved_fork",
+        "fork_developer_lookbehind",
+        "fork_disputed_window",
+        "unresolved_fork",
+        "incomplete_final_record",
+    ]
+}
+
+#[test]
+fn codex_metrics_from_rows_matches_the_accumulator_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in codex_fixture_names() {
+        let input = SessionInput {
+            agent: "codex".to_owned(),
+            session_id: name.to_owned(),
+            source: RawSource::Jsonl(codex_fixture(name).to_owned()),
+        };
+        let (live, replayed) =
+            run_fixture_and_replay("codex", name, &input, SourceCapabilities::codex());
+        compare_metrics(&mut mismatches, name, &live, &replayed);
+    }
+    assert_no_mismatches("codex", mismatches);
+}
+
+/* --------------------------------------------------------------------
+ * Pi fixtures. Same 28 fixtures `turn_facts_parity.rs` sweeps.
+ * ----------------------------------------------------------------- */
+
+fn pi_fixture(name: &str) -> &'static str {
+    match name {
+        "minimal_session" => include_str!("fixtures/pi_characterization/minimal_session.jsonl"),
+        "role_ordering" => include_str!("fixtures/pi_characterization/role_ordering.jsonl"),
+        "content_blocks" => include_str!("fixtures/pi_characterization/content_blocks.jsonl"),
+        "usage_all_buckets" => {
+            include_str!("fixtures/pi_characterization/usage_all_buckets.jsonl")
+        }
+        "usage_subset_keys" => {
+            include_str!("fixtures/pi_characterization/usage_subset_keys.jsonl")
+        }
+        "model_change" => include_str!("fixtures/pi_characterization/model_change.jsonl"),
+        "thinking_level_change" => {
+            include_str!("fixtures/pi_characterization/thinking_level_change.jsonl")
+        }
+        "compaction_and_inert" => {
+            include_str!("fixtures/pi_characterization/compaction_and_inert.jsonl")
+        }
+        "unknown_row_type" => {
+            include_str!("fixtures/pi_characterization/unknown_row_type.jsonl")
+        }
+        "unknown_content_block" => {
+            include_str!("fixtures/pi_characterization/unknown_content_block.jsonl")
+        }
+        "custom_rows" => include_str!("fixtures/pi_characterization/custom_rows.jsonl"),
+        "malformed_middle" => {
+            include_str!("fixtures/pi_characterization/malformed_middle.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/pi_characterization/incomplete_final_record.jsonl")
+        }
+        "header_only" => include_str!("fixtures/pi_characterization/header_only.jsonl"),
+        "unsupported_version" => {
+            include_str!("fixtures/pi_characterization/unsupported_version.jsonl")
+        }
+        "fork_hazard_parent" => {
+            include_str!("fixtures/pi_characterization/fork_hazard_parent.jsonl")
+        }
+        "fork_hazard_child" => {
+            include_str!("fixtures/pi_characterization/fork_hazard_child.jsonl")
+        }
+        "fork_no_inherited" => {
+            include_str!("fixtures/pi_characterization/fork_no_inherited.jsonl")
+        }
+        "timestamp_disagreement" => {
+            include_str!("fixtures/pi_characterization/timestamp_disagreement.jsonl")
+        }
+        "image_block" => include_str!("fixtures/pi_characterization/image_block.jsonl"),
+        "bash_execution_role" => {
+            include_str!("fixtures/pi_characterization/bash_execution_role.jsonl")
+        }
+        "bash_execution_with_usage" => {
+            include_str!("fixtures/pi_characterization/bash_execution_with_usage.jsonl")
+        }
+        "mixed_api" => include_str!("fixtures/pi_characterization/mixed_api.jsonl"),
+        "skill_tool_privacy" => {
+            include_str!("fixtures/pi_characterization/skill_tool_privacy.jsonl")
+        }
+        "inert_signal_guard" => {
+            include_str!("fixtures/pi_characterization/inert_signal_guard.jsonl")
+        }
+        "non_turn_timestamp_ordering" => {
+            include_str!("fixtures/pi_characterization/non_turn_timestamp_ordering.jsonl")
+        }
+        "session_start" => include_str!("fixtures/pi_characterization/session_start.jsonl"),
+        "headerless_tools" => {
+            include_str!("fixtures/pi_characterization/headerless_tools.jsonl")
+        }
+        "headerless_usage" => {
+            include_str!("fixtures/pi_characterization/headerless_usage.jsonl")
+        }
+        _ => panic!("unknown Pi characterization fixture: {name}"),
+    }
+}
+
+fn pi_fixture_names() -> [&'static str; 28] {
+    [
+        "minimal_session",
+        "role_ordering",
+        "content_blocks",
+        "usage_all_buckets",
+        "usage_subset_keys",
+        "model_change",
+        "thinking_level_change",
+        "compaction_and_inert",
+        "unknown_row_type",
+        "unknown_content_block",
+        "custom_rows",
+        "malformed_middle",
+        "header_only",
+        "unsupported_version",
+        "fork_hazard_parent",
+        "fork_hazard_child",
+        "fork_no_inherited",
+        "timestamp_disagreement",
+        "image_block",
+        "bash_execution_role",
+        "bash_execution_with_usage",
+        "mixed_api",
+        "skill_tool_privacy",
+        "inert_signal_guard",
+        "non_turn_timestamp_ordering",
+        "session_start",
+        "headerless_tools",
+        "headerless_usage",
+    ]
+}
+
+#[test]
+fn pi_metrics_from_rows_matches_the_accumulator_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in pi_fixture_names() {
+        let input = SessionInput {
+            agent: "pi".to_owned(),
+            session_id: name.to_owned(),
+            source: RawSource::Jsonl(pi_fixture(name).to_owned()),
+        };
+        let (live, replayed) = run_fixture_and_replay("pi", name, &input, SourceCapabilities::pi());
+        compare_metrics(&mut mismatches, name, &live, &replayed);
+    }
+    assert_no_mismatches("pi", mismatches);
+}
+
+/* --------------------------------------------------------------------
+ * OpenCode fixtures. Same five scenarios `turn_facts_parity.rs` builds
+ * inline — copied here for the same reason that file documents: OpenCode
+ * has no `fixtures/opencode_characterization` directory of its own, and
+ * duplicating this synthetic content keeps `opencode_characterization.rs`
+ * itself untouched.
+ * ----------------------------------------------------------------- */
+
+fn opencode_create_database() -> (TempDir, std::path::PathBuf) {
+    let directory = TempDir::new().expect("tempdir");
+    let path = directory.path().join("opencode.db");
+    let connection = Connection::open(&path).expect("database");
+    connection
+        .execute_batch(
+            "CREATE TABLE session (
+                 id TEXT PRIMARY KEY, parent_id TEXT, title TEXT,
+                 time_created INTEGER, time_updated INTEGER
+             );
+             CREATE TABLE message (
+                 id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+                 time_updated INTEGER, data TEXT
+             );
+             CREATE TABLE part (
+                 id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+                 time_created INTEGER, time_updated INTEGER, data TEXT
+             );",
+        )
+        .expect("schema");
+    drop(connection);
+    (directory, path)
+}
+
+fn opencode_insert_session(
+    connection: &Connection,
+    id: &str,
+    parent: Option<&str>,
+    timestamp: i64,
+) {
+    connection
+        .execute(
+            "INSERT INTO session (id, parent_id, title, time_created, time_updated)
+             VALUES (?1, ?2, NULL, ?3, ?3)",
+            params![id, parent, timestamp],
+        )
+        .expect("session");
+}
+
+fn opencode_insert_message(
+    connection: &Connection,
+    id: &str,
+    session_id: &str,
+    timestamp: i64,
+    data: &str,
+) {
+    connection
+        .execute(
+            "INSERT INTO message VALUES (?1, ?2, ?3, ?3, ?4)",
+            params![id, session_id, timestamp, data],
+        )
+        .expect("message");
+}
+
+fn opencode_insert_part(
+    connection: &Connection,
+    id: &str,
+    message_id: &str,
+    session_id: &str,
+    timestamp: i64,
+    data: &str,
+) {
+    connection
+        .execute(
+            "INSERT INTO part VALUES (?1, ?2, ?3, ?4, ?4, ?5)",
+            params![id, message_id, session_id, timestamp, data],
+        )
+        .expect("part");
+}
+
+fn opencode_sqlite_input(path: &Path, session_id: &str) -> SessionInput {
+    SessionInput {
+        agent: "opencode".to_owned(),
+        session_id: session_id.to_owned(),
+        source: RawSource::Sqlite(path.to_owned()),
+    }
+}
+
+fn opencode_fixture_messages_with_cache_and_reasoning() -> (TempDir, SessionInput) {
+    let (directory, path) = opencode_create_database();
+    let connection = Connection::open(&path).expect("database");
+    opencode_insert_session(&connection, "root", None, 10);
+    opencode_insert_message(
+        &connection,
+        "m1",
+        "root",
+        20,
+        r#"{"role":"assistant","modelID":"model-a","variant":"high","tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":30,"write":40}}}"#,
+    );
+    drop(connection);
+    let input = opencode_sqlite_input(&path, "root");
+    (directory, input)
+}
+
+fn opencode_fixture_subagent_delegation_with_model_transition() -> (TempDir, SessionInput) {
+    let (directory, path) = opencode_create_database();
+    let connection = Connection::open(&path).expect("database");
+    opencode_insert_session(&connection, "root", None, 10);
+    opencode_insert_message(
+        &connection,
+        "r1",
+        "root",
+        10,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    opencode_insert_session(&connection, "child", Some("root"), 20);
+    opencode_insert_message(
+        &connection,
+        "c1",
+        "child",
+        20,
+        r#"{"role":"assistant","modelID":"model-b","tokens":{"input":2,"output":2}}"#,
+    );
+    opencode_insert_message(
+        &connection,
+        "r2",
+        "root",
+        60,
+        r#"{"role":"assistant","modelID":"model-c","tokens":{"input":1,"output":1}}"#,
+    );
+    drop(connection);
+    let input = opencode_sqlite_input(&path, "root");
+    (directory, input)
+}
+
+fn opencode_fixture_malformed_between_valid() -> (TempDir, SessionInput) {
+    let (directory, path) = opencode_create_database();
+    let connection = Connection::open(&path).expect("database");
+    opencode_insert_session(&connection, "root", None, 10);
+    opencode_insert_message(
+        &connection,
+        "m1",
+        "root",
+        20,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":40,"output":8}}"#,
+    );
+    opencode_insert_message(&connection, "m2", "root", 30, "{not-json");
+    opencode_insert_message(
+        &connection,
+        "m3",
+        "root",
+        40,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":10,"output":2}}"#,
+    );
+    drop(connection);
+    let input = opencode_sqlite_input(&path, "root");
+    (directory, input)
+}
+
+fn opencode_fixture_compaction_boundary() -> (TempDir, SessionInput) {
+    let (directory, path) = opencode_create_database();
+    let connection = Connection::open(&path).expect("database");
+    opencode_insert_session(&connection, "root", None, 10);
+    opencode_insert_message(
+        &connection,
+        "m1",
+        "root",
+        20,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":40,"output":8}}"#,
+    );
+    opencode_insert_part(
+        &connection,
+        "compaction",
+        "m1",
+        "root",
+        21,
+        r#"{"type":"compaction","auto":true,"snapshot":"snapshot"}"#,
+    );
+    drop(connection);
+    let input = opencode_sqlite_input(&path, "root");
+    (directory, input)
+}
+
+fn opencode_fixture_export_jsonl_child_delegation() -> SessionInput {
+    let jsonl = concat!(
+        r#"{"type":"session_meta","sessionID":"root","sessionRole":"root","time":{"created":1000},"payload":{"id":"root","title":"Root session"}}"#,
+        "\n",
+        r#"{"type":"session_member","rootSessionID":"root","originSessionID":"child","sessionRole":"child","parentSessionID":"root","time":{"created":1500},"payload":{"id":"child","title":"Child session"}}"#,
+        "\n",
+        r#"{"type":"message","rootSessionID":"root","sessionID":"root","sessionRole":"root","messageID":"m1","time":{"created":1000},"payload":{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}}"#,
+        "\n",
+        r#"{"type":"message","rootSessionID":"root","sessionID":"child","sessionRole":"child","parentSessionID":"root","messageID":"m2","time":{"created":1600},"payload":{"role":"user"}}"#,
+        "\n",
+    );
+    SessionInput {
+        agent: "opencode".to_owned(),
+        session_id: "root".to_owned(),
+        source: RawSource::Jsonl(jsonl.to_owned()),
+    }
+}
+
+#[test]
+fn opencode_metrics_from_rows_matches_the_accumulator_for_every_fixture() {
+    let mut mismatches = Vec::new();
+
+    let (_messages_dir, messages_input) = opencode_fixture_messages_with_cache_and_reasoning();
+    let (live, replayed) = run_fixture_and_replay(
+        "opencode",
+        "messages_with_cache_and_reasoning",
+        &messages_input,
+        SourceCapabilities::opencode(),
+    );
+    compare_metrics(
+        &mut mismatches,
+        "messages_with_cache_and_reasoning",
+        &live,
+        &replayed,
+    );
+
+    let (_subagent_dir, subagent_input) =
+        opencode_fixture_subagent_delegation_with_model_transition();
+    let (live, replayed) = run_fixture_and_replay(
+        "opencode",
+        "subagent_delegation_with_model_transition",
+        &subagent_input,
+        SourceCapabilities::opencode(),
+    );
+    compare_metrics(
+        &mut mismatches,
+        "subagent_delegation_with_model_transition",
+        &live,
+        &replayed,
+    );
+
+    let (_malformed_dir, malformed_input) = opencode_fixture_malformed_between_valid();
+    let (live, replayed) = run_fixture_and_replay(
+        "opencode",
+        "malformed_between_valid",
+        &malformed_input,
+        SourceCapabilities::opencode(),
+    );
+    compare_metrics(&mut mismatches, "malformed_between_valid", &live, &replayed);
+
+    let (_compaction_dir, compaction_input) = opencode_fixture_compaction_boundary();
+    let (live, replayed) = run_fixture_and_replay(
+        "opencode",
+        "compaction_boundary",
+        &compaction_input,
+        SourceCapabilities::opencode(),
+    );
+    compare_metrics(&mut mismatches, "compaction_boundary", &live, &replayed);
+
+    let export_input = opencode_fixture_export_jsonl_child_delegation();
+    let (live, replayed) = run_fixture_and_replay(
+        "opencode",
+        "export_jsonl_child_delegation",
+        &export_input,
+        SourceCapabilities::opencode(),
+    );
+    compare_metrics(
+        &mut mismatches,
+        "export_jsonl_child_delegation",
+        &live,
+        &replayed,
+    );
+
+    assert_no_mismatches("opencode", mismatches);
+}

--- a/crates/antiburn-local/tests/turn_row_replay_parity.rs
+++ b/crates/antiburn-local/tests/turn_row_replay_parity.rs
@@ -146,7 +146,8 @@ fn run_fixture_and_replay(
                  ({source_key:?}), but every fixture here streams through one source"
             )
         })
-    });
+    })
+    .unwrap_or_else(|error| panic!("fixture {fixture}: metrics_from_rows failed: {error}"));
 
     (live, replayed)
 }


### PR DESCRIPTION
## Summary

Seam R3b: rebuilds the drilldown's `SessionMetrics` (buckets, durations,
cost breakdown, model runs, efficiency) from a session's turn rows alone,
by replaying rows as `NormalizedEvent`s through the existing
`SessionMetricsAccumulator` — not by reimplementing its fold. Stacks on
#298.

- **`event_from_row`** (`crates/antiburn-local/src/analysis/replay.rs`)
  inverts `turn_row_from_event` field by field. A row keeps only
  `last_tool` and `subagent_launches`, not every tool call, so it
  synthesizes the smallest `Vec<ToolCall>` that reproduces the
  accumulator's two reads over tools (`tools.last().name` and the
  case-insensitive `"task"` count): generic `"Task"` calls for every
  launch before the last, then the row's own `last_tool` string (case
  preserved) as the final call — reserving that slot avoids
  double-counting when the last tool is itself a `"task"` launch. Unit
  tests cover that edge directly.
- **`metrics_from_rows`** groups rows by `source_key`, rebuilds each
  source's events, and drives one `SessionMetricsAccumulator` per source
  the way the live pipeline does (`stream_vendor_with_hooks`), merging
  with the existing `merge_metrics` when a session has more than one
  source. A single-source session (every fixture here) skips the
  parent/child classification entirely, since there is nothing to weigh
  it against — this also sidesteps a real ambiguity in that
  classification: an inline sub-agent turn with no derived thread ID
  falls back to the parent's own `source_key`, so an all-delegated single
  source can otherwise look like an external child transcript by
  coincidence (`late_skill_metrics`'s `subagent_single_timestamp`-style
  fixture hit exactly this during development).
- **Parity proof** (`tests/turn_row_replay_parity.rs`): streams every
  claude (28), codex (9), pi (28), and opencode (5) characterization
  fixture through the live composite pipeline (accumulator + evidence +
  `TurnRowSink` into a `MemoryTurnRowStore`) and through
  `metrics_from_rows`, asserting the two `SessionMetrics` agree field by
  field. `metrics_from_rows` takes a `SessionSummary` per source, since
  rows carry no column for one — the test gets a real, fixture-accurate
  summary by running the same deterministic adapter over the same bytes
  a second time into a summary-only-capturing sink; `metrics_from_rows`
  itself never touches raw bytes, a store, or Tauri.

### Scope boundary (every fixture, by design)

`tool_calls_by_name`, `mcp_tool_calls`, and `skill_uses` need every tool
call a turn made; a row keeps only its last tool's name and its
`"task"`-launch count. `initial_context` is downstream of those same
per-tool counts (`bound_initial_context`'s `use_count` reads the
accumulator's own observed tool/skill/MCP names), so it is out of scope
for the same reason. These are not per-fixture exceptions — they follow
directly from what a row keeps, for every fixture alike — so the parity
test never compares them; the module doc comment on `replay.rs` and the
test file's own doc comment both explain this.

### One documented, narrow exclusion

Claude's `late_skill_metrics` fixture names its skill through a trailing
`attachment` record, which `ClaudeAdapter` resolves only in
`SessionSummary::late_tools`, after the pipeline already wrote that
turn's row (turn ordinal 1, bucket 0) with no tool call at all —
`TurnRowSink` observes each row at `record` time, before `finish`
resolves late tools. The live accumulator's `finish_summary` then folds
the resolved `"skill"` call into that bucket's `last_tool`; the replayed
run never reserves a late-tool candidate for a synthesized event (rows
carry no `may_resolve_late_tool`/`late_tool_candidate_is_builtin`
column), so `finish_summary`'s `late_tools` loop finds no candidate to
fold it into, and the replayed bucket's `last_tool` stays `None`. This is
the one field, of one bucket, of one fixture, excluded from the parity
test's comparison — documented in `live_buckets_for_comparison` in
`tests/turn_row_replay_parity.rs` — mirroring seam R2's own
`delegated_model_missing` precedent (one documented, narrow information-loss
gap, not a broad exclusion).

No mismatch was widespread or structural, so nothing else needed
excluding, and nothing here required stopping to report a broader
problem.

### Scope guard

No production caller changes — `analyze()`/commands stay on the live
path, and the desktop crate is untouched. `SessionMetricsAccumulator`'s
semantics are unchanged; the only new surface is `event_from_row` and
`metrics_from_rows`. No stored output changes, no revision bump.

## Test plan

- [x] `cargo fmt` (both `crates/antiburn-local` and
      `apps/desktop/src-tauri`)
- [x] `cargo clippy --all-targets -- -D warnings` (both crates, clean)
- [x] `cargo test --no-fail-fast` — engine: 14 binaries, all `ok`
      (1137 + 2 + 75 + 33 + 11 + 30 + 10 + 8 + 10 + 5 + 8 + **4 new** + 11
      + 1 doctest); desktop: 3 binaries, all `ok` (644 + 0 + 0 doctests)
- [x] No goldens changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)