### PR TITLE
feat(discovery): scan ~/Developer on macOS

### DIFF
--- a/crates/antiburn-local/src/repositories/platform/macos.rs
+++ b/crates/antiburn-local/src/repositories/platform/macos.rs
@@ -8,6 +8,7 @@ use super::PlatformDiscovery;
 
 const MACOS_CODE_DIRS: &[&str] = &[
     "dev",
+    "Developer",
     "Documents/GitHub",
     "src",
     "code",


### PR DESCRIPTION
## What

Adds `Developer` to `MACOS_CODE_DIRS`, so the forward repository scan covers Xcode's default code directory.

## Why

Repos under `~/Developer` that have had an agent session are already found backward from the transcripts in `~/.claude` / `~/.codex`. What was missing is the forward path: repos there with **no** agent sessions yet, which is exactly what the onboarding coverage view wants to surface. Without this, an Xcode user's repo folder looks empty until their first agent run there.

Cost is one `read_dir` at depth 2. `~/Developer` is not TCC-protected (unlike `Documents/GitHub`), so there is no consent prompt.

## Testing

- `cargo fmt --check`, `cargo clippy --lib -D warnings`, and `cargo test --lib repositories` (70 passed) in `crates/antiburn-local`.

_No screenshot — one-line backend list change, nothing visual to show._

🤖 Generated with [Claude Code](https://claude.com/claude-code)