### PR TITLE
feat(desktop): widen the evidence cohort to every agent and retire the on-demand analysis paths

### DIFF
--- a/apps/desktop/src-tauri/src/agents.rs
+++ b/apps/desktop/src-tauri/src/agents.rs
@@ -44,13 +44,11 @@ pub fn kind_from_slug(slug: &str) -> Option<AgentKind> {
 }
 
 /// Return the agents that use the durable evidence queue.
-pub fn evidence_cohort() -> [&'static str; 4] {
-    [
-        AgentKind::Claude.slug(),
-        AgentKind::Codex.slug(),
-        AgentKind::OpenCode.slug(),
-        AgentKind::Pi.slug(),
-    ]
+///
+/// Every supported [`AgentKind`] is in the cohort, so this can never drift
+/// from the engine's discovery matrix.
+pub fn evidence_cohort() -> Vec<&'static str> {
+    AgentKind::ALL.iter().map(|kind| kind.slug()).collect()
 }
 
 #[cfg(test)]
@@ -106,13 +104,21 @@ mod tests {
     fn the_evidence_cohort_uses_the_discovery_slug() {
         assert_eq!(
             evidence_cohort(),
-            [
-                AgentKind::Claude.slug(),
-                AgentKind::Codex.slug(),
-                AgentKind::OpenCode.slug(),
-                AgentKind::Pi.slug(),
+            vec![
+                "claude-code",
+                "codex",
+                "cursor",
+                "copilot",
+                "cline",
+                "opencode",
+                "kiro",
+                "amp-code",
+                "antigravity",
+                "windsurf",
+                "pi",
             ]
         );
+        assert_eq!(evidence_cohort().len(), AgentKind::ALL.len());
         assert_eq!(AgentKind::Codex.slug(), vendor_label(AgentKind::Codex));
         assert_eq!(
             AgentKind::OpenCode.slug(),

--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -19,12 +19,11 @@ use std::sync::{
 use antiburn_local::analysis::{
     ANALYZER_REVISION, ActiveSessionsSummary, CompositeSink, EVIDENCE_SCHEMA_REVISION,
     EfficiencyTotals, EvidenceSource, InitialContextBreakdown, METRICS_SCHEMA_REVISION, ModelRun,
-    NormalizedSession, PARSER_REVISION, RawSource, SessionCost, SessionEvidence,
-    SessionEvidenceAccumulator, SessionInput, SessionMetrics, SessionMetricsAccumulator,
-    SessionSummary, SkillUse, SourceCapabilities, SourceClaim, SourceKind, TurnRow, TurnRowSink,
-    TurnRowStore, TurnScope, VisitOutcome, adapter_for, aggregate_metrics, analyze_session,
-    analyze_sources_with, append_only_guarantee, merge_metrics, merge_subagent_events,
-    metrics_by_source, metrics_from_rows, normalize_source, price_breakdown, pricing_generation,
+    PARSER_REVISION, RawSource, SessionCost, SessionEvidence, SessionEvidenceAccumulator,
+    SessionInput, SessionMetrics, SessionMetricsAccumulator, SessionSummary, SkillUse,
+    SourceCapabilities, SourceClaim, SourceKind, TurnRow, TurnRowSink, TurnRowStore, TurnScope,
+    VisitOutcome, adapter_for, aggregate_metrics, append_only_guarantee, merge_metrics,
+    metrics_by_source, metrics_from_rows, price_breakdown, pricing_generation,
 };
 use antiburn_local::discovery::{
     ACTIVE_SESSION_WINDOW_SECS, Explorers, FORK_OBSERVATION_KEY, FingerprintInputs,
@@ -35,7 +34,8 @@ use antiburn_local::pricing::ModelTokens;
 
 #[cfg(test)]
 use antiburn_local::analysis::{
-    ClaudeAdapter, CoverageReason, EvidenceValue, FAST_SPEED_KEY, MemoryTurnRowStore, VendorAdapter,
+    ClaudeAdapter, CoverageReason, EvidenceValue, FAST_SPEED_KEY, MemoryTurnRowStore,
+    VendorAdapter, analyze_sources_with,
 };
 #[cfg(test)]
 use antiburn_local::insights::{DetectorId, clean_facts_complete, eligible};
@@ -568,13 +568,23 @@ fn stream_vendor_with_claim_hook(
     stream_vendor_with_hooks(inputs, &|| cancel.cancelled(), after_claim, None, None)
 }
 
-fn capabilities_for_vendor(agent: &str) -> Option<SourceCapabilities> {
+/// Every vendor label's evidence-streaming contract. Total: an
+/// uncharacterized vendor (Cursor, Antigravity, or any generic-JSONL agent)
+/// still gets a real `SourceCapabilities` profile — an honest, mostly- or
+/// fully-unset one — so it takes the same streaming path as every other
+/// vendor instead of a separate, uncharacterized fallback. `published_status`
+/// (insights_worker.rs) is what turns an unset profile into the terminal
+/// `Unsupported` state; this function's job is only to describe the source,
+/// never to decide whether it is good enough.
+fn capabilities_for_vendor(agent: &str) -> SourceCapabilities {
     match agent {
-        "claude" => Some(SourceCapabilities::claude()),
-        "codex" => Some(SourceCapabilities::codex()),
-        "opencode" => Some(SourceCapabilities::opencode()),
-        "pi" => Some(SourceCapabilities::pi()),
-        _ => None,
+        "claude" => SourceCapabilities::claude(),
+        "codex" => SourceCapabilities::codex(),
+        "opencode" => SourceCapabilities::opencode(),
+        "pi" => SourceCapabilities::pi(),
+        "cursor" => SourceCapabilities::cursor(),
+        "antigravity" => SourceCapabilities::antigravity(),
+        _ => SourceCapabilities::generic(),
     }
 }
 
@@ -611,12 +621,12 @@ fn stream_vendor_with_hooks(
         if cancelled() {
             return StreamOutcome::ParentUnreadable;
         }
-        let Some(capabilities) = capabilities_for_vendor(&input.agent) else {
-            if index == 0 {
-                return StreamOutcome::ParentUnsupported;
-            }
-            continue;
-        };
+        // Every vendor label now resolves to a real (possibly all-unset)
+        // capability profile, so this can never fall through to
+        // `StreamOutcome::ParentUnsupported` the way an unrecognized vendor
+        // used to; a Sqlite source from a non-OpenCode vendor is the one
+        // remaining path that outcome still covers, further down.
+        let capabilities = capabilities_for_vendor(&input.agent);
         let adapter = adapter_for(&input.agent);
         let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
         let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
@@ -812,37 +822,11 @@ fn stream_vendor_with_hooks(
     }
 }
 
-/// Normalize the parent and every sub-agent input, then merge their events
-/// into one time-aligned session via [`merge_subagent_events`].
-///
-/// Matches inputs to the parent by `session_id` rather than by position, so
-/// this stays correct even if a vendor adapter fails to read one input (the
-/// same tolerance [`analyze_sources_with`] gives the per-source batch).
-/// `None` when the parent itself could not be normalized.
 fn attributed_generation(claimed: &ClaimedSource, actual_fingerprint: Option<&str>) -> i64 {
     match (claimed.fingerprint.as_deref(), actual_fingerprint) {
         (Some(expected), Some(actual)) if expected == actual => claimed.generation,
         _ => 0,
     }
-}
-
-fn merge_parent_and_subagents(
-    inputs: &[SessionInput],
-    parent_session_id: &str,
-) -> Option<NormalizedSession> {
-    let mut parent = None;
-    let mut subagents = Vec::new();
-    for input in inputs {
-        let Ok(normalized) = normalize_source(input) else {
-            continue;
-        };
-        if normalized.session_id == parent_session_id {
-            parent = Some(normalized);
-        } else {
-            subagents.push(normalized);
-        }
-    }
-    Some(merge_subagent_events(parent?, subagents))
 }
 
 /// Order the sub-agent roster earliest-first.
@@ -882,11 +866,7 @@ pub async fn analyze(
         None,
     )
     .await;
-    debug_assert!(
-        pass.evidence.is_none()
-            || (capabilities_for_vendor(vendor_label(agent)).is_some()
-                && pass.outcome == PassOutcome::Published)
-    );
+    debug_assert!(pass.evidence.is_none() || pass.outcome == PassOutcome::Published);
     pass.analysis
 }
 
@@ -975,76 +955,43 @@ pub async fn analyze_for_evidence(
         .map(|(id, label, _)| (id, label))
         .collect();
 
-    let inputs_for_merge = inputs.clone();
-    let parent_session_id_for_merge = parent_session_id.clone();
-    let streams_evidence = capabilities_for_vendor(label).is_some();
-
     // The engine's analysis is synchronous and CPU-bound; keep it off the
-    // runtime's worker threads.
+    // runtime's worker threads. Every vendor now has a real (possibly
+    // all-unset) `SourceCapabilities` profile, so every session streams
+    // through `stream_vendor_with_hooks` — there is no separate,
+    // uncharacterized-vendor fallback pass any more.
     let signal_for_pass = signal.clone();
     let computed = tauri::async_runtime::spawn_blocking(move || {
-        if streams_evidence {
-            let cancelled = || signal_for_pass.observe();
-            return match stream_vendor_with_hooks(
-                &inputs,
-                &cancelled,
-                &test_subagent_after_claim,
-                database_claim.as_deref(),
-                turn_row_store,
-            ) {
-                StreamOutcome::Published {
-                    session,
-                    parent_fingerprint,
-                } => ComputedAnalysis::Published {
-                    parent: Box::new(session.parent),
-                    merged: Box::new(session.merged),
-                    subagents: session.subagents,
-                    started_at_epoch: session.started_at_epoch,
-                    parent_fingerprint,
-                    evidence: Box::new(session.evidence),
-                    row_projections: session.row_projections,
-                    source_summaries: session.source_summaries,
-                },
-                StreamOutcome::SourceChanged => ComputedAnalysis::SourceChanged,
-                StreamOutcome::ParentMissing => ComputedAnalysis::Missing,
-                StreamOutcome::ParentUnsupported => ComputedAnalysis::Unsupported,
-                StreamOutcome::ParentUnreadable => ComputedAnalysis::Unavailable,
-            };
-        }
-        let batch = analyze_sources_with(inputs, true);
-        let Some(merged) =
-            merge_parent_and_subagents(&inputs_for_merge, &parent_session_id_for_merge)
-                .map(|session| analyze_session(&session))
-        else {
-            return ComputedAnalysis::Unavailable;
-        };
-        let mut sessions = batch.sessions;
-        let Some(parent_index) = sessions
-            .iter()
-            .position(|metrics| metrics.session_id == parent_session_id_for_merge)
-        else {
-            return ComputedAnalysis::Unavailable;
-        };
-        let parent = sessions.remove(parent_index);
-        ComputedAnalysis::Published {
-            parent: Box::new(parent),
-            merged: Box::new(merged),
-            // This path has no per-event accumulator to read a child's
-            // earliest timestamp from, so every child's start stays unknown.
-            subagents: sessions
-                .into_iter()
-                .map(|metrics| (metrics, None))
-                .collect(),
-            started_at_epoch: None,
-            parent_fingerprint: None,
-            evidence: Box::new(None),
-            row_projections: None,
-            source_summaries: None,
+        let cancelled = || signal_for_pass.observe();
+        match stream_vendor_with_hooks(
+            &inputs,
+            &cancelled,
+            &test_subagent_after_claim,
+            database_claim.as_deref(),
+            turn_row_store,
+        ) {
+            StreamOutcome::Published {
+                session,
+                parent_fingerprint,
+            } => ComputedAnalysis::Published {
+                parent: Box::new(session.parent),
+                merged: Box::new(session.merged),
+                subagents: session.subagents,
+                started_at_epoch: session.started_at_epoch,
+                parent_fingerprint,
+                evidence: Box::new(session.evidence),
+                row_projections: session.row_projections,
+                source_summaries: session.source_summaries,
+            },
+            StreamOutcome::SourceChanged => ComputedAnalysis::SourceChanged,
+            StreamOutcome::ParentMissing => ComputedAnalysis::Missing,
+            StreamOutcome::ParentUnsupported => ComputedAnalysis::Unsupported,
+            StreamOutcome::ParentUnreadable => ComputedAnalysis::Unavailable,
         }
     })
     .await;
 
-    debug_assert!(capabilities_for_vendor(vendor_label(agent)).is_none() || signal.progress() > 0);
+    debug_assert!(signal.progress() > 0);
     let Ok(computed) = computed else {
         return unavailable_evidence_pass(PassOutcome::Unreadable, source_path, Some(fingerprint));
     };
@@ -1554,26 +1501,20 @@ pub async fn analyze_subagent(
     let source_path = source_path(&source);
     let agent_slug = agent.slug().to_string();
 
-    let streams_evidence = capabilities_for_vendor(vendor_label(agent)).is_some();
-    let computed = tauri::async_runtime::spawn_blocking(move || {
-        if streams_evidence {
-            return match stream_vendor(&[input], &cancel) {
-                StreamOutcome::Published { session, .. } => {
-                    Some((session.parent, session.started_at_epoch))
-                }
-                StreamOutcome::SourceChanged
-                | StreamOutcome::ParentMissing
-                | StreamOutcome::ParentUnsupported
-                | StreamOutcome::ParentUnreadable => None,
-            };
-        }
-        analyze_sources_with(vec![input], true)
-            .sessions
-            .into_iter()
-            .next()
-            .map(|metrics| (metrics, None))
-    })
-    .await;
+    // Every vendor now has a real `SourceCapabilities` profile (see
+    // `capabilities_for_vendor`), so this always streams — there is no
+    // separate, uncharacterized-vendor fallback pass any more.
+    let computed =
+        tauri::async_runtime::spawn_blocking(move || match stream_vendor(&[input], &cancel) {
+            StreamOutcome::Published { session, .. } => {
+                Some((session.parent, session.started_at_epoch))
+            }
+            StreamOutcome::SourceChanged
+            | StreamOutcome::ParentMissing
+            | StreamOutcome::ParentUnsupported
+            | StreamOutcome::ParentUnreadable => None,
+        })
+        .await;
     let Ok(Some((metrics, started_at_epoch))) = computed else {
         return SessionAnalysis {
             source_path,

--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -58,10 +58,6 @@ pub struct ClaimedSource {
 pub struct CancelFlag(Arc<AtomicBool>);
 
 impl CancelFlag {
-    pub fn from_flag(flag: Arc<AtomicBool>) -> Self {
-        Self(flag)
-    }
-
     pub fn never() -> Self {
         Self(Arc::new(AtomicBool::new(false)))
     }
@@ -452,16 +448,6 @@ fn combined_fingerprint(source: &SessionSource, subagent_paths: &[std::path::Pat
     serde_json::to_string(&parts.collect::<Vec<_>>())
         .map(|fingerprint| format!("v{ANALYSIS_FINGERPRINT_VERSION}:{fingerprint}"))
         .unwrap_or_else(|_| MISSING_FINGERPRINT.to_string())
-}
-
-/// Whether a cached analysis is still good for `source`.
-///
-/// A cache entry is stale when the transcript changed or when a newer pricing
-/// snapshot was installed, since cost is baked into the cached record.
-pub fn cache_is_fresh(cached: &AnalysisRecord, fingerprint: &str) -> bool {
-    fingerprint != MISSING_FINGERPRINT
-        && cached.source_fingerprint == fingerprint
-        && cached.pricing_generation == pricing_generation() as i64
 }
 
 /// The path of a file-backed source.
@@ -1349,9 +1335,8 @@ pub fn analysis_from_rows(
         fingerprint: record.source_fingerprint,
         analyzed_generation: record.analyzed_generation,
         started_at_epoch,
-        // Nothing new to persist: this call reads the cache, it does not
-        // extend it, and `cache_detail_analysis` skips evidence-cohort
-        // agents anyway.
+        // Nothing new to persist: this call replays the worker's own
+        // published rows, it does not write anything.
         source_summaries: None,
     }))
 }
@@ -3031,10 +3016,10 @@ mod tests {
         let directory = tempfile::TempDir::new().expect("tempdir");
         let path = directory.path().join("parent.jsonl");
         std::fs::write(&path, claude_record("parent", 1_760_000_000)).expect("write parent");
-        let flag = Arc::new(AtomicBool::new(true));
+        let flag = CancelFlag(Arc::new(AtomicBool::new(true)));
 
         assert!(matches!(
-            stream_vendor(&[file_input(&path, "parent")], &CancelFlag::from_flag(flag),),
+            stream_vendor(&[file_input(&path, "parent")], &flag),
             StreamOutcome::ParentUnreadable
         ));
     }
@@ -3046,49 +3031,6 @@ mod tests {
         assert!(is_active(Some(now), now));
         assert!(!is_active(Some(now - ACTIVE_SESSION_WINDOW_SECS - 1), now));
         assert!(!is_active(None, now));
-    }
-
-    #[test]
-    fn a_source_with_no_file_behind_it_never_satisfies_the_cache() {
-        let cached = AnalysisRecord {
-            key: SessionKey::new("native", "claude-code", "abc"),
-            model_breakdown_json: "{}".into(),
-            inclusive_models_json: "[]".into(),
-            initial_context_json: None,
-            source_summaries_json: None,
-            source_fingerprint: MISSING_FINGERPRINT.into(),
-            pricing_generation: pricing_generation() as i64,
-            analyzed_generation: 0,
-            parser_revision: 0,
-            analyzer_revision: 0,
-            metrics_schema_revision: 0,
-        };
-        assert!(!cache_is_fresh(&cached, MISSING_FINGERPRINT));
-
-        let cached = AnalysisRecord {
-            source_fingerprint: "123:456".into(),
-            ..cached
-        };
-        assert!(cache_is_fresh(&cached, "123:456"));
-        assert!(!cache_is_fresh(&cached, "123:999"));
-    }
-
-    #[test]
-    fn a_stale_pricing_generation_invalidates_a_matching_fingerprint() {
-        let cached = AnalysisRecord {
-            key: SessionKey::new("native", "claude-code", "abc"),
-            model_breakdown_json: "{}".into(),
-            inclusive_models_json: "[]".into(),
-            initial_context_json: None,
-            source_summaries_json: None,
-            source_fingerprint: "123:456".into(),
-            pricing_generation: pricing_generation() as i64 - 1,
-            analyzed_generation: 0,
-            parser_revision: 0,
-            analyzer_revision: 0,
-            metrics_schema_revision: 0,
-        };
-        assert!(!cache_is_fresh(&cached, "123:456"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -46,8 +46,8 @@ use crate::scan::{self, ScanController};
 use crate::settings;
 use crate::store::model::environment_key;
 use crate::store::{
-    AnalysisRecord, AppSettings, RelationKind, RelationRecord, RepositoryRecord, SessionKey,
-    SessionRecord, Store, iso_from_epoch,
+    AppSettings, RelationKind, RelationRecord, RepositoryRecord, SessionKey, SessionRecord, Store,
+    iso_from_epoch,
 };
 
 /// Anything that goes wrong becomes a string the webview can show.
@@ -613,36 +613,6 @@ fn repository_label(repositories: &[RepositoryRecord], cwd: Option<&str>) -> Str
     }
 }
 
-/// Whether `next` carries model data the popover list would render
-/// differently from `previous`.
-///
-/// Compares only the two fields the list reads (`model_breakdown_json` for
-/// cost, `inclusive_models_json` for the model pills). The fingerprint and
-/// pricing generation can change on every re-analysis without moving either
-/// figure, and an event for that would be noise the popover cannot show.
-fn analysis_changed(previous: Option<&AnalysisRecord>, next: &AnalysisRecord) -> bool {
-    match previous {
-        None => true,
-        Some(previous) => {
-            previous.model_breakdown_json != next.model_breakdown_json
-                || previous.inclusive_models_json != next.inclusive_models_json
-        }
-    }
-}
-
-fn cache_detail_analysis(
-    store: &Store,
-    record: &AnalysisRecord,
-    started_at_epoch: Option<i64>,
-) -> bool {
-    if crate::agents::evidence_cohort().contains(&record.key.agent.as_str()) {
-        return false;
-    }
-    let previous = store.analysis(&record.key).ok().flatten();
-    store.save_analysis(record, started_at_epoch).is_ok()
-        && analysis_changed(previous.as_ref(), record)
-}
-
 /// Requeues one session's evidence row and wakes the durable worker, so a
 /// gap the drilldown just found (rows not ready, or ready but stale) closes
 /// on its own without the caller waiting on it. Errors are swallowed: this
@@ -690,15 +660,6 @@ async fn nudge_if_evidence_stale(
 /// comparison itself is testable without a located source or an app handle.
 fn evidence_is_stale(stored_fingerprint: Option<&str>, live_fingerprint: &str) -> bool {
     stored_fingerprint != Some(live_fingerprint)
-}
-
-fn cache_detail_relations(store: &Store, key: &SessionKey, members: &[RelationRecord]) -> bool {
-    if crate::agents::evidence_cohort().contains(&key.agent.as_str()) {
-        return false;
-    }
-    store
-        .replace_relations(key, RelationKind::Subagent, members)
-        .is_ok()
 }
 
 fn path_is_under(path: &str, root: &str) -> bool {
@@ -883,75 +844,38 @@ pub async fn get_session_analysis(
             generation: 0,
         });
 
-    // Rows first, for an evidence-cohort agent: the drilldown serves the
-    // worker's last published pass instead of re-parsing the transcript
-    // inline. A fresh transcript replays cheaply; a missing or not-ready
-    // row set falls back to the live parse exactly as before, and nudges
-    // the worker so the gap closes for next time.
-    let analysis = if crate::agents::evidence_cohort().contains(&agent.as_str()) {
-        match analysis::analysis_from_rows(&store, &key, &session_id, &agent) {
-            Some(replayed) => {
-                nudge_if_evidence_stale(
-                    &app,
-                    &store,
-                    kind,
-                    &key,
-                    &session_id,
-                    wsl_distro.as_deref(),
-                )
+    // Rows first: every agent is in the evidence cohort, so the drilldown
+    // always serves the worker's last published pass instead of re-parsing
+    // the transcript inline. A fresh transcript replays cheaply; a missing
+    // or not-ready row set falls back to the live parse, and nudges the
+    // worker so the gap closes for next time. Publishing a fresh live parse
+    // is the worker's job now — see its announce callback in
+    // `insights_worker::spawn` — so this command no longer caches one itself
+    // or emits `SESSION_ENTRY_CHANGED_EVENT` for it.
+    let analysis = match analysis::analysis_from_rows(&store, &key, &session_id, &agent) {
+        Some(replayed) => {
+            nudge_if_evidence_stale(&app, &store, kind, &key, &session_id, wsl_distro.as_deref())
                 .await;
-                replayed
-            }
-            None => {
-                requeue_and_wake_worker(&app, &store, &key);
-                analysis::analyze(
-                    kind,
-                    &session_id,
-                    wsl_distro.as_deref(),
-                    claimed,
-                    analysis::CancelFlag::never(),
-                )
-                .await
-            }
+            replayed
         }
-    } else {
-        analysis::analyze(
-            kind,
-            &session_id,
-            wsl_distro.as_deref(),
-            claimed,
-            analysis::CancelFlag::never(),
-        )
-        .await
+        None => {
+            requeue_and_wake_worker(&app, &store, &key);
+            analysis::analyze(
+                kind,
+                &session_id,
+                wsl_distro.as_deref(),
+                claimed,
+                analysis::CancelFlag::never(),
+            )
+            .await
+        }
     };
     let relations = resolve_lineage(&app, kind, &key, wsl_distro.as_deref()).await;
 
     let stored = store.session(&key).ok().flatten();
 
-    if let Some(record) = analysis.record(&key)
-        && cache_detail_analysis(&store, &record, analysis.started_at_epoch)
-        && let Some(session_record) = stored.clone()
-    {
-        let repositories = store.repositories().unwrap_or_default();
-        let now = scan::unix_now();
-        if let Ok(entry) = activity_entry(&store, &repositories, session_record, now) {
-            let _ = app.emit(SESSION_ENTRY_CHANGED_EVENT, &entry);
-        }
-    }
     let orchestration = match &analysis.orchestration {
-        Some(orchestration) => {
-            let members: Vec<RelationRecord> = orchestration
-                .members
-                .iter()
-                .map(|member| RelationRecord {
-                    kind: RelationKind::Subagent,
-                    related_id: member.subagent_id.clone(),
-                    label: Some(member.label.clone()),
-                })
-                .collect();
-            cache_detail_relations(&store, &key, &members);
-            Some(orchestration.clone())
-        }
+        Some(orchestration) => Some(orchestration.clone()),
         // The listing came back empty. That is usually the truth, but it is
         // also what a momentarily unreadable transcript looks like, so a roster
         // the store already recorded is shown rather than silently dropped.
@@ -1017,38 +941,30 @@ pub async fn get_subagent_analysis(
     let Some(kind) = kind_from_slug(&agent) else {
         return Err(format!("unknown agent {agent}"));
     };
-    let analysis = if crate::agents::evidence_cohort().contains(&agent.as_str()) {
-        let store = app.state::<Store>();
-        let parent_key = SessionKey::for_session(&agent, &parent_session_id, wsl_distro.as_deref());
-        match analysis::subagent_analysis_from_rows(
-            &store,
-            &parent_key,
-            &parent_session_id,
-            &subagent_id,
-            &agent,
-        ) {
-            Some(replayed) => replayed,
-            None => {
-                requeue_and_wake_worker(&app, &store, &parent_key);
-                analysis::analyze_subagent(
-                    kind,
-                    &parent_session_id,
-                    &subagent_id,
-                    wsl_distro.as_deref(),
-                    analysis::CancelFlag::never(),
-                )
-                .await
-            }
+    // Every agent is in the evidence cohort, so this always tries the
+    // worker's last published pass before falling back to a live parse —
+    // see the matching comment in `get_session_analysis`.
+    let store = app.state::<Store>();
+    let parent_key = SessionKey::for_session(&agent, &parent_session_id, wsl_distro.as_deref());
+    let analysis = match analysis::subagent_analysis_from_rows(
+        &store,
+        &parent_key,
+        &parent_session_id,
+        &subagent_id,
+        &agent,
+    ) {
+        Some(replayed) => replayed,
+        None => {
+            requeue_and_wake_worker(&app, &store, &parent_key);
+            analysis::analyze_subagent(
+                kind,
+                &parent_session_id,
+                &subagent_id,
+                wsl_distro.as_deref(),
+                analysis::CancelFlag::never(),
+            )
+            .await
         }
-    } else {
-        analysis::analyze_subagent(
-            kind,
-            &parent_session_id,
-            &subagent_id,
-            wsl_distro.as_deref(),
-            analysis::CancelFlag::never(),
-        )
-        .await
     };
     Ok(SessionAnalysis {
         summary: analysis.summary.clone(),
@@ -1987,151 +1903,6 @@ mod tests {
         // A session with no activity still yields a parseable stamp rather
         // than an empty string the list would drop.
         assert_eq!(iso_from_epoch(None), "1970-01-01T00:00:00Z");
-    }
-
-    fn analysis_record(model_breakdown_json: &str, inclusive_models_json: &str) -> AnalysisRecord {
-        AnalysisRecord {
-            key: SessionKey::new("env", "claude-code", "session-1"),
-            model_breakdown_json: model_breakdown_json.into(),
-            inclusive_models_json: inclusive_models_json.into(),
-            initial_context_json: None,
-            source_summaries_json: None,
-            source_fingerprint: "fingerprint".into(),
-            pricing_generation: 1,
-            analyzed_generation: 1,
-            parser_revision: 1,
-            analyzer_revision: 1,
-            metrics_schema_revision: 1,
-        }
-    }
-
-    #[test]
-    fn a_first_analysis_always_counts_as_changed() {
-        let next = analysis_record("{}", "[]");
-        assert!(analysis_changed(None, &next));
-    }
-
-    #[test]
-    fn identical_model_data_is_not_a_change() {
-        let previous = analysis_record(
-            r#"{"claude-fable-5":{}}"#,
-            r#"[{"model":"claude-fable-5"}]"#,
-        );
-        let next = analysis_record(
-            r#"{"claude-fable-5":{}}"#,
-            r#"[{"model":"claude-fable-5"}]"#,
-        );
-        assert!(!analysis_changed(Some(&previous), &next));
-    }
-
-    #[test]
-    fn a_new_model_in_either_field_counts_as_changed() {
-        let previous = analysis_record("{}", "[]");
-        let breakdown_changed = analysis_record(r#"{"claude-fable-5":{}}"#, "[]");
-        let models_changed = analysis_record("{}", r#"[{"model":"claude-fable-5"}]"#);
-        assert!(analysis_changed(Some(&previous), &breakdown_changed));
-        assert!(analysis_changed(Some(&previous), &models_changed));
-    }
-
-    #[test]
-    fn the_detail_path_does_not_persist_evidence_cohort_projections() {
-        let directory = tempfile::TempDir::new().unwrap();
-        let store = Store::open_in_memory(directory.path()).unwrap();
-        let session = |agent: &str, id: &str| SessionRecord {
-            key: SessionKey::new("native", agent, id),
-            source_kind: "file".into(),
-            source_label: format!("/tmp/{id}.jsonl"),
-            wsl_distro: None,
-            title: None,
-            title_source: None,
-            cwd: None,
-            surface: "cli".into(),
-            updated_at_epoch: Some(100),
-            activity_cursor: String::new(),
-            activity_source: "event".into(),
-            subagent_count: 0,
-            fork_parent_session_id: None,
-            source_fingerprint: Some(format!("sv1:{id}")),
-        };
-        let claude = session("claude-code", "claude-detail");
-        let codex = session("codex", "codex-detail");
-        store
-            .upsert_sessions(
-                &[claude.clone(), codex.clone()],
-                &crate::agents::evidence_cohort(),
-            )
-            .unwrap();
-        let _claim = store
-            .claim_next_evidence(&crate::agents::evidence_cohort(), 100, 300)
-            .unwrap()
-            .unwrap();
-        let sentinel = AnalysisRecord {
-            key: claude.key.clone(),
-            model_breakdown_json: r#"{"sentinel":{}}"#.into(),
-            inclusive_models_json: "[]".into(),
-            initial_context_json: None,
-            source_summaries_json: None,
-            source_fingerprint: "sv1:sentinel".into(),
-            pricing_generation: 1,
-            analyzed_generation: 0,
-            parser_revision: 1,
-            analyzer_revision: 1,
-            metrics_schema_revision: 1,
-        };
-        store.save_analysis(&sentinel, None).unwrap();
-        let sentinel_relation = RelationRecord {
-            kind: RelationKind::Subagent,
-            related_id: "sentinel-child".into(),
-            label: None,
-        };
-        store
-            .replace_relations(
-                &claude.key,
-                RelationKind::Subagent,
-                std::slice::from_ref(&sentinel_relation),
-            )
-            .unwrap();
-        let mut claude_next = sentinel.clone();
-        claude_next.model_breakdown_json = r#"{"replacement":{}}"#.into();
-        let replacement = RelationRecord {
-            kind: RelationKind::Subagent,
-            related_id: "replacement-child".into(),
-            label: None,
-        };
-
-        assert!(!cache_detail_analysis(&store, &claude_next, None));
-        assert!(!cache_detail_relations(
-            &store,
-            &claude.key,
-            std::slice::from_ref(&replacement),
-        ));
-        assert_eq!(store.analysis(&claude.key).unwrap(), Some(sentinel));
-        assert_eq!(
-            store.relations(&claude.key).unwrap(),
-            vec![sentinel_relation]
-        );
-
-        let codex_analysis = AnalysisRecord {
-            key: codex.key.clone(),
-            model_breakdown_json: r#"{"codex":{}}"#.into(),
-            inclusive_models_json: "[]".into(),
-            initial_context_json: None,
-            source_summaries_json: None,
-            source_fingerprint: "sv1:codex-detail".into(),
-            pricing_generation: 1,
-            analyzed_generation: 1,
-            parser_revision: 1,
-            analyzer_revision: 1,
-            metrics_schema_revision: 1,
-        };
-        assert!(!cache_detail_analysis(&store, &codex_analysis, None));
-        assert!(!cache_detail_relations(
-            &store,
-            &codex.key,
-            std::slice::from_ref(&replacement),
-        ));
-        assert_eq!(store.analysis(&codex.key).unwrap(), None);
-        assert!(store.relations(&codex.key).unwrap().is_empty());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -436,6 +436,17 @@ mod tests {
     mod population {
         use super::*;
 
+        // The evidence cohort now covers every AgentKind
+        // (crate::agents::evidence_cohort), so a real scan never leaves a
+        // session with no session_evidence row: `awaiting_provider_support`
+        // trends to zero once the widened-cohort migration backfills every
+        // existing session. The tests below still exercise DENOMINATOR_SQL's
+        // partitioning directly, by passing a literal `evidence_agents` list
+        // (`&[]` or `&["claude-code"]`) to `upsert_sessions`/`change_source`
+        // rather than the real `evidence_cohort()`, so they stay a synthetic,
+        // SQL-level pin of the bucket rather than a claim that production
+        // still produces that row shape.
+
         #[test]
         fn denominator_partitions_non_cohort_rows_by_reason() {
             let data_dir = TempDir::new().unwrap();
@@ -579,6 +590,13 @@ mod tests {
             );
         }
 
+        // Pi names the fixture agent, not a Pi-specific behavior:
+        // `reconcile_evidence_revisions(&crate::agents::evidence_cohort(), ..)`
+        // now enrolls every agent's late-joining session the same way, since
+        // the cohort covers all of them. This still exercises the real
+        // `evidence_cohort()` (unlike the other `population` tests above),
+        // so it pins that the widened cohort keeps moving a session with no
+        // evidence row out of `awaiting_provider_support`.
         #[test]
         fn pi_backfill_moves_awaiting_support_into_the_pending_queue() {
             let data_dir = TempDir::new().unwrap();

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -465,6 +465,34 @@ mod tests {
         pass
     }
 
+    /// Like [`published_pass`], but for a generic-JSONL agent (Copilot):
+    /// `capabilities_for_vendor` maps it to `SourceCapabilities::generic()`
+    /// (every field unset), so this exercises the real GENERIC-adapter path
+    /// a widened-cohort worker pass now takes for an uncharacterized vendor.
+    fn generic_published_pass(record: &SessionRecord) -> EvidencePass {
+        let store: Arc<dyn TurnRowStore> =
+            MemoryTurnRowStore::new("copilot", record.key.session_id.clone());
+        let mut pass = analysis::evidence_pass_with_turn_rows(
+            &[SessionInput {
+                agent: "copilot".into(),
+                session_id: record.key.session_id.clone(),
+                source: RawSource::Jsonl(
+                    r#"{"role":"user","content":"hi"}
+{"role":"assistant","content":"hello","usage":{"prompt_tokens":2,"completion_tokens":3}}
+"#
+                    .into(),
+                ),
+            }],
+            &|| false,
+            Some(store),
+        );
+        pass.analysis.fingerprint = record
+            .source_fingerprint
+            .clone()
+            .unwrap_or_else(|| analysis::MISSING_FINGERPRINT.into());
+        pass
+    }
+
     async fn captured_signal(slot: &Mutex<Option<PassSignal>>) -> PassSignal {
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
@@ -569,6 +597,45 @@ mod tests {
             store.evidence(&claim.key).unwrap().unwrap().status,
             EvidenceStatus::Unsupported
         );
+    }
+
+    /// The widened cohort now enqueues generic-JSONL agents (Copilot, Cline,
+    /// Kiro, Amp, Windsurf) alongside the vendors with a dedicated adapter.
+    /// Before capabilities_for_vendor was made total, a Published pass with
+    /// no evidence (the legacy analyze_sources_with path's shape) made
+    /// apply_outcome error, leaving the claim stuck reprocessing forever.
+    /// With every vendor streaming through a real `SourceCapabilities`
+    /// profile, a generic-agent session must instead complete terminally —
+    /// here, `SourceCapabilities::generic()` is all-unset, so no detector is
+    /// eligible and the terminal status is `Unsupported`, never a stuck
+    /// `Processing` claim or an `apply_outcome` error.
+    #[tokio::test]
+    async fn a_generic_agent_session_completes_terminally_through_process_next() {
+        let store = store();
+        let mut copilot_record = record("generic-terminal");
+        copilot_record.key.agent = "copilot".to_owned();
+        store
+            .upsert_sessions(&[copilot_record], &crate::agents::evidence_cohort())
+            .unwrap();
+        let handle = WorkerHandle::default();
+        let runner = |record: &SessionRecord, _: PassSignal, _: i64| {
+            let pass = generic_published_pass(record);
+            Box::pin(async move { pass }) as PassFuture
+        };
+
+        let processed = process_next(&store, &handle, &|| 100, &runner, &|_| {})
+            .await
+            .unwrap();
+        assert!(processed);
+
+        let key = SessionKey::new("native", "copilot", "generic-terminal");
+        let evidence = store.evidence(&key).unwrap().unwrap();
+        assert_eq!(
+            evidence.status,
+            EvidenceStatus::Unsupported,
+            "a capability-free source publishes as unsupported, not stuck processing"
+        );
+        assert_ne!(evidence.status, EvidenceStatus::Processing);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -53,13 +53,12 @@
 //! a retry), and [`crate::notifications`] once per run of the app, for someone
 //! who is not looking at antiburn at all.
 //!
-//! Every pass is bounded: discovery is windowed to the widest activity view, the
-//! per-session metadata reads run at a fixed concurrency, and analysis is
-//! capped at [`MAX_ANALYSES_PER_PASS`] sessions so one pass cannot grow with
-//! the size of the machine. Sessions already indexed are retained until the
-//! reader explicitly clears them; the bounded discovery window is not a data
-//! expiry policy. The scheduler is a single task whose handle the app aborts on
-//! exit, so nothing outlives the process.
+//! Every pass is bounded: discovery is windowed to the widest activity view,
+//! and the per-session metadata reads run at a fixed concurrency, so one pass
+//! cannot grow with the size of the machine. Sessions already indexed are
+//! retained until the reader explicitly clears them; the bounded discovery
+//! window is not a data expiry policy. The scheduler is a single task whose
+//! handle the app aborts on exit, so nothing outlives the process.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -89,12 +88,6 @@ pub const TICK: Duration = Duration::from_secs(60);
 /// How many session logs have their metadata read at once. Bounds open files
 /// and blocking-pool pressure during a whole-machine pass.
 const METADATA_CONCURRENCY: usize = 16;
-
-/// Sessions analyzed per pass. Analysis reads whole transcripts, so a machine
-/// with hundreds of recent sessions catches up over several passes rather than
-/// spending one very long pass on all of them. Newest first, so the rows a
-/// reader actually sees are the ones that fill in first.
-const MAX_ANALYSES_PER_PASS: usize = 60;
 
 /// Scope key for the engine's ignored-path store. The engine namespaces opt-outs
 /// so one machine can hold several independent sets; this app keeps one.
@@ -142,10 +135,6 @@ impl ScanController {
 
     fn cancelled(&self) -> bool {
         self.cancel.load(Ordering::SeqCst)
-    }
-
-    pub fn cancel_flag(&self) -> analysis::CancelFlag {
-        analysis::CancelFlag::from_flag(Arc::clone(&self.cancel))
     }
 
     /// The current or last pass.
@@ -284,9 +273,8 @@ pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> Sca
 
 /// The body of one pass. Split out so [`run_pass`] owns only the in-flight
 /// bookkeeping and the events.
-async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Result<usize> {
+async fn pass(app: &AppHandle, _activity_window_days: Option<u32>) -> anyhow::Result<usize> {
     let store = app.state::<Store>();
-    let settings = store.settings()?;
     let now = unix_now();
     // Discovery always covers the widest list the UI can request, so changing
     // the display window is instant. Previously indexed sessions outside this
@@ -350,35 +338,6 @@ async fn pass(app: &AppHandle, activity_window_days: Option<u32>) -> anyhow::Res
     // Everything discovered so far is already persisted, so a cancel here keeps
     // the reader's results and only skips the work still ahead.
     let controller = app.state::<ScanController>();
-    if controller.cancelled() {
-        return Ok(records.len());
-    }
-
-    // Derived analysis for the newest sessions in the visible window, so the
-    // list's cost and time pills are populated without opening every row.
-    let activity_window_days = activity_window_days
-        .unwrap_or(settings.activity_window_days)
-        .clamp(
-            crate::store::MIN_ACTIVITY_DAYS,
-            crate::store::MAX_ACTIVITY_DAYS,
-        );
-    top_up_analysis(
-        &store,
-        &controller,
-        TopUpScope {
-            now,
-            activity_days: i64::from(activity_window_days),
-            evidence_agents: &agents::evidence_cohort(),
-        },
-        |agent, session_id, wsl_distro| async move {
-            analysis::locate(agent, &session_id, wsl_distro.as_deref()).await
-        },
-        |agent, session_id, wsl_distro, claimed, cancel| async move {
-            analysis::analyze(agent, &session_id, wsl_distro.as_deref(), claimed, cancel).await
-        },
-    )
-    .await?;
-
     if controller.cancelled() {
         return Ok(records.len());
     }
@@ -897,115 +856,6 @@ fn per_agent_totals(records: &[SessionRecord]) -> Vec<(String, i64, Option<i64>)
         .into_iter()
         .map(|(agent, (seen, cursor))| (agent, seen, cursor))
         .collect()
-}
-
-struct TopUpScope<'a> {
-    now: i64,
-    activity_days: i64,
-    evidence_agents: &'a [&'a str],
-}
-
-/// Analyze the newest sessions whose cached analysis is missing or stale.
-async fn top_up_analysis<F, Fut, A, AFut>(
-    store: &Store,
-    controller: &ScanController,
-    scope: TopUpScope<'_>,
-    mut locate: F,
-    mut analyze: A,
-) -> anyhow::Result<()>
-where
-    F: FnMut(AgentKind, String, Option<String>) -> Fut,
-    Fut: std::future::Future<Output = Option<SessionSource>>,
-    A: FnMut(
-        AgentKind,
-        String,
-        Option<String>,
-        analysis::ClaimedSource,
-        analysis::CancelFlag,
-    ) -> AFut,
-    AFut: std::future::Future<Output = analysis::SessionAnalysis>,
-{
-    let since = scope.now - scope.activity_days.max(1) * 86_400;
-    let candidates = store.recent_sessions(since, MAX_ANALYSES_PER_PASS)?;
-
-    for record in candidates {
-        if scope.evidence_agents.contains(&record.key.agent.as_str()) {
-            continue;
-        }
-        // Analysis is the long tail of a pass — one whole transcript read per
-        // session — so this is where a cancel is felt.
-        if controller.cancelled() {
-            return Ok(());
-        }
-        let Some(agent) = crate::agents::kind_from_slug(&record.key.agent) else {
-            continue;
-        };
-        if !analysis::analysis_supported(agent) {
-            // A generically-parsed transcript would produce a half-confident
-            // metric; the view says so instead of showing one.
-            continue;
-        }
-        let Some(source) = locate(
-            agent,
-            record.key.session_id.clone(),
-            record.wsl_distro.clone(),
-        )
-        .await
-        else {
-            continue;
-        };
-        let fingerprint = analysis::fingerprint_with_subagents(
-            agent,
-            &record.key.session_id,
-            record.wsl_distro.as_deref(),
-            &source,
-        )
-        .await;
-        if let Some(cached) = store.analysis(&record.key)?
-            && analysis::cache_is_fresh(&cached, &fingerprint)
-        {
-            continue;
-        }
-
-        let source_state = store.session_source_state(&record.key)?;
-        let claimed = source_state
-            .map(|state| analysis::ClaimedSource {
-                fingerprint: state.source_fingerprint,
-                generation: state.source_generation,
-            })
-            .unwrap_or(analysis::ClaimedSource {
-                fingerprint: None,
-                generation: 0,
-            });
-        let analysis = analyze(
-            agent,
-            record.key.session_id.clone(),
-            record.wsl_distro.clone(),
-            claimed,
-            controller.cancel_flag(),
-        )
-        .await;
-        if let Some(cache) = analysis.record(&record.key) {
-            store.save_analysis(&cache, analysis.started_at_epoch)?;
-        }
-        if let Some(orchestration) = &analysis.orchestration {
-            let relations: Vec<_> = orchestration
-                .members
-                .iter()
-                .map(|member| crate::store::RelationRecord {
-                    kind: crate::store::RelationKind::Subagent,
-                    related_id: member.subagent_id.clone(),
-                    label: Some(member.label.clone()),
-                })
-                .collect();
-            store.replace_relations(
-                &record.key,
-                crate::store::RelationKind::Subagent,
-                &relations,
-            )?;
-        }
-    }
-    Ok(())
 }
 
 /// The current time in unix seconds.
@@ -1626,178 +1476,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cache_freshness_ignores_the_session_source_fingerprint() {
-        let home = tempfile::TempDir::new().unwrap();
-        let session_id = "cache-contract-session";
-        let source = SessionSource::File(write_claude_session(home.path(), session_id));
-        let mut session = record("claude-code", session_id, Some(100));
-        session.source_fingerprint = Some("sv1:session-source".to_string());
-        let SessionSource::File(source_path) = &source else {
-            unreachable!("the fixture uses a file source");
-        };
-        session.source_label = source_path.to_string_lossy().into_owned();
-        let store = Store::open_in_memory(home.path()).unwrap();
-        store
-            .upsert_sessions(std::slice::from_ref(&session), &agents::evidence_cohort())
-            .unwrap();
-
-        let legacy_fingerprint =
-            analysis::fingerprint_with_subagents(AgentKind::Claude, session_id, None, &source)
-                .await;
-        let cached = crate::store::AnalysisRecord {
-            key: session.key.clone(),
-            model_breakdown_json: r#"{"cached":true}"#.to_string(),
-            inclusive_models_json: "[]".to_string(),
-            initial_context_json: None,
-            source_summaries_json: None,
-            source_fingerprint: legacy_fingerprint.clone(),
-            pricing_generation: antiburn_local::analysis::pricing_generation() as i64,
-            analyzed_generation: 0,
-            parser_revision: 0,
-            analyzer_revision: 0,
-            metrics_schema_revision: 0,
-        };
-        store.save_analysis(&cached, None).unwrap();
-
-        let persisted_session = store
-            .session(&session.key)
-            .unwrap()
-            .expect("persisted session");
-        assert_eq!(
-            persisted_session.source_fingerprint.as_deref(),
-            Some("sv1:session-source")
-        );
-        assert!(analysis::cache_is_fresh(
-            &store
-                .analysis(&session.key)
-                .unwrap()
-                .expect("persisted analysis"),
-            &legacy_fingerprint
-        ));
-
-        let locate_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let observed_locates = locate_calls.clone();
-        let analysis_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let observed_analyses = analysis_calls.clone();
-        let located_source = source.clone();
-        let expected_id = session_id.to_string();
-        top_up_analysis(
-            &store,
-            &ScanController::default(),
-            TopUpScope {
-                now: 200,
-                activity_days: 1,
-                evidence_agents: &[],
-            },
-            move |agent, candidate_id, wsl_distro| {
-                observed_locates.fetch_add(1, Ordering::SeqCst);
-                let source = located_source.clone();
-                let matches = agent == AgentKind::Claude
-                    && candidate_id == expected_id
-                    && wsl_distro.is_none();
-                async move { matches.then_some(source) }
-            },
-            move |_, _, _, _, _| {
-                observed_analyses.fetch_add(1, Ordering::SeqCst);
-                async { analysis::SessionAnalysis::unavailable() }
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(locate_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(analysis_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(
-            store.analysis(&session.key).unwrap().as_ref(),
-            Some(&cached)
-        );
-    }
-
-    #[tokio::test]
-    async fn top_up_analysis_analyzes_a_candidate_whose_source_changed_one_second_ago() {
-        let home = tempfile::TempDir::new().unwrap();
-        let store = Store::open_in_memory(home.path()).unwrap();
-        let mut session = record("claude-code", "recent-change", Some(100));
-        session.source_fingerprint = Some("sv1:recent".to_string());
-        store
-            .upsert_sessions(&[session], &agents::evidence_cohort())
-            .unwrap();
-        let analysis_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let observed = Arc::clone(&analysis_calls);
-
-        top_up_analysis(
-            &store,
-            &ScanController::default(),
-            TopUpScope {
-                now: 101,
-                activity_days: 1,
-                evidence_agents: &[],
-            },
-            |_, _, _| async {
-                Some(SessionSource::Inline {
-                    label: "recent-change".to_string(),
-                    content: String::new(),
-                })
-            },
-            move |_, _, _, _, _| {
-                observed.fetch_add(1, Ordering::SeqCst);
-                async { analysis::SessionAnalysis::unavailable() }
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(analysis_calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn top_up_analysis_skips_the_evidence_cohort() {
-        let home = tempfile::TempDir::new().unwrap();
-        let store = Store::open_in_memory(home.path()).unwrap();
-        store
-            .upsert_sessions(
-                &[
-                    record("claude-code", "queued", Some(100)),
-                    record("codex", "direct", Some(99)),
-                ],
-                &agents::evidence_cohort(),
-            )
-            .unwrap();
-        let located = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let located_by_pass = Arc::clone(&located);
-        let analyzed = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let analyzed_by_pass = Arc::clone(&analyzed);
-
-        top_up_analysis(
-            &store,
-            &ScanController::default(),
-            TopUpScope {
-                now: 101,
-                activity_days: 1,
-                evidence_agents: &agents::evidence_cohort(),
-            },
-            move |agent, session_id, _| {
-                located_by_pass.lock().unwrap().push(session_id);
-                async move {
-                    Some(SessionSource::Inline {
-                        label: agent.slug().to_string(),
-                        content: String::new(),
-                    })
-                }
-            },
-            move |_, session_id, _, _, _| {
-                analyzed_by_pass.lock().unwrap().push(session_id);
-                async { analysis::SessionAnalysis::unavailable() }
-            },
-        )
-        .await
-        .unwrap();
-
-        assert!(located.lock().unwrap().is_empty());
-        assert!(analyzed.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
     async fn an_opted_out_working_directory_never_reaches_the_store() {
         let home = tempfile::TempDir::new().unwrap();
         let claude = write_claude_session(home.path(), "aaaa-bbbb");
@@ -2397,19 +2075,6 @@ mod tests {
         assert!(!on_demand_start(&controller));
         controller.running.store(false, Ordering::SeqCst);
         assert!(on_demand_start(&controller));
-    }
-
-    #[test]
-    fn a_cloned_cancel_flag_observes_request_cancel_and_the_pass_reset() {
-        let controller = ScanController::default();
-        let flag = controller.cancel_flag();
-        controller.running.store(true, Ordering::SeqCst);
-        controller.request_cancel();
-        controller.running.store(false, Ordering::SeqCst);
-        assert!(flag.cancelled());
-
-        assert!(on_demand_start(&controller));
-        assert!(!flag.cancelled());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -1259,7 +1259,14 @@ impl Store {
         )?))
     }
 
-    /// Cache one session's derived analysis.
+    /// Write one session's analysis columns directly, without the evidence
+    /// claim `publish_projections` requires.
+    ///
+    /// Test scaffolding only. Every production write goes through
+    /// `publish_projections`, which also settles the session's evidence
+    /// claim; this method exists so fixture setup can seed
+    /// `session_analysis` without first driving a claim through the worker.
+    #[cfg(test)]
     pub fn save_analysis(
         &self,
         record: &AnalysisRecord,

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -11,7 +11,7 @@
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
-    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19,
+    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -415,4 +415,20 @@ const V18: &str = antiburn_local::analysis::TURN_SCHEMA_V3_SQL;
 /// on-demand and scan-triggered passes leave it `NULL`.
 const V19: &str = r#"
 ALTER TABLE session_analysis ADD COLUMN source_summaries_json TEXT;
+"#;
+
+/// v20 — add existing sessions of the newly widened evidence cohort agents to
+/// the durable evidence queue.
+///
+/// The evidence cohort now covers every [`AgentKind`](antiburn_local::model::AgentKind):
+/// Cursor, Copilot, Cline, Kiro, Amp, Antigravity, and Windsurf join Claude,
+/// Codex, OpenCode, and Pi. A normal upsert queues future source generations
+/// for these agents; this migration also queues rows that scans stored before
+/// they joined the cohort, following the same shape as [`V12`]/[`V13`]/[`V14`].
+const V20: &str = r#"
+INSERT INTO session_evidence (environment_key, agent, session_id)
+SELECT environment_key, agent, session_id
+  FROM session
+ WHERE agent IN ('cursor', 'copilot', 'cline', 'kiro', 'amp-code', 'antigravity', 'windsurf')
+ON CONFLICT(environment_key, agent, session_id) DO NOTHING;
 "#;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1777,65 +1777,6 @@ fn opencode_cohort_migration_queues_existing_sessions_without_resetting_evidence
 }
 
 #[test]
-fn widened_cohort_migration_queues_existing_sessions_without_resetting_evidence() {
-    // Mirrors codex_cohort_migration_queues_existing_sessions_without_resetting_evidence:
-    // the backfill queues an existing session of a newly joined agent (here,
-    // Cursor) and leaves an existing ready Claude evidence row untouched.
-    let connection = rusqlite::Connection::open_in_memory().unwrap();
-    for &sql in &super::schema::MIGRATIONS[..19] {
-        connection.execute_batch(sql).unwrap();
-    }
-    connection.pragma_update(None, "user_version", 19).unwrap();
-    connection
-        .execute_batch(
-            "INSERT INTO session (
-                 environment_key, agent, session_id, source_kind, source_label,
-                 surface, first_seen_at, last_seen_at
-             ) VALUES
-                 ('native', 'cursor', 'new', 'file', '/synthetic/new.jsonl', 'cli', 'x', 'x'),
-                 ('native', 'claude-code', 'ready', 'file', '/synthetic/claude.jsonl', 'cli', 'x', 'x');
-             INSERT INTO session_evidence (
-                 environment_key, agent, session_id, status
-             ) VALUES ('native', 'claude-code', 'ready', 'ready');",
-        )
-        .unwrap();
-
-    let store = Store::from_connection(
-        connection,
-        Path::new("/tmp/antiburn-widened-cohort-migration-test").to_path_buf(),
-    )
-    .unwrap();
-    let connection = store.lock();
-    let statuses = connection
-        .prepare(
-            "SELECT agent, session_id, status FROM session_evidence ORDER BY agent, session_id",
-        )
-        .unwrap()
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-            ))
-        })
-        .unwrap()
-        .collect::<rusqlite::Result<Vec<_>>>()
-        .unwrap();
-
-    assert_eq!(
-        statuses,
-        vec![
-            (
-                "claude-code".to_owned(),
-                "ready".to_owned(),
-                "ready".to_owned()
-            ),
-            ("cursor".to_owned(), "new".to_owned(), "pending".to_owned()),
-        ]
-    );
-}
-
-#[test]
 fn migrating_from_every_prior_schema_version_reaches_the_current_head() {
     for start in 0..super::schema::MIGRATIONS.len() {
         let connection = rusqlite::Connection::open_in_memory().unwrap();

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1128,72 +1128,37 @@ fn analysis_round_trips_and_is_replaced_rather_than_duplicated() {
     assert_eq!(stored.source_fingerprint, "1700000900:8192");
 }
 
+/// `publish_projections` is the worker's own write path (`save_analysis` is
+/// test scaffolding only), so this pins the generation and revision columns
+/// against the path production actually uses.
 #[test]
-fn save_analysis_writes_the_generation_and_revision_columns() {
+fn publish_projections_writes_the_generation_and_revision_columns() {
     let store = store();
-    let key = SessionKey::new("native", "claude-code", "revisions");
-    store
-        .upsert_sessions(
-            &[session("revisions", 1_000)],
-            &crate::agents::evidence_cohort(),
-        )
-        .unwrap();
+    let (record, claim) = claimed_projection(&store, "revisions", 100, 60);
     let record = AnalysisRecord {
-        key: key.clone(),
-        model_breakdown_json: "{}".into(),
-        inclusive_models_json: "[]".into(),
-        initial_context_json: None,
-        source_summaries_json: None,
-        source_fingerprint: "sv1:source".into(),
         pricing_generation: 3,
-        analyzed_generation: 8,
         parser_revision: 1,
         analyzer_revision: 2,
         metrics_schema_revision: 3,
+        ..record
     };
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
 
-    store.save_analysis(&record, Some(900)).unwrap();
+    assert!(
+        store
+            .publish_projections(&record, Some(900), &completion, &[])
+            .unwrap()
+    );
 
-    assert_eq!(store.analysis(&key).unwrap(), Some(record));
+    assert_eq!(store.analysis(&record.key).unwrap(), Some(record.clone()));
     assert_eq!(
         store
-            .session_source_state(&key)
+            .session_source_state(&record.key)
             .unwrap()
             .expect("source state")
             .started_at_epoch,
         Some(900)
     );
-}
-
-/// V17 adds `initial_context_json`. `save_analysis` and `publish_projections`
-/// both round-trip it through `analysis()`, the same as every other column.
-#[test]
-fn save_analysis_round_trips_initial_context_json() {
-    let store = store();
-    let key = SessionKey::new("native", "claude-code", "initial-context");
-    store
-        .upsert_sessions(
-            &[session("initial-context", 1_000)],
-            &crate::agents::evidence_cohort(),
-        )
-        .unwrap();
-    let record = AnalysisRecord {
-        key: key.clone(),
-        model_breakdown_json: "{}".into(),
-        inclusive_models_json: "[]".into(),
-        initial_context_json: Some(r#"{"sources":[]}"#.into()),
-        source_summaries_json: None,
-        source_fingerprint: "sv1:source".into(),
-        pricing_generation: 1,
-        analyzed_generation: 1,
-        parser_revision: 1,
-        analyzer_revision: 1,
-        metrics_schema_revision: 1,
-    };
-
-    store.save_analysis(&record, None).unwrap();
-
-    assert_eq!(store.analysis(&key).unwrap(), Some(record));
 }
 
 #[test]
@@ -1253,36 +1218,40 @@ fn publish_projections_round_trips_source_summaries_json() {
     );
 }
 
+/// A later publish with no `started_at_epoch` (the common case: the worker
+/// already learned the start time on an earlier pass) must not clear it.
 #[test]
-fn save_analysis_never_clears_a_known_start_time() {
+fn publish_projections_never_clears_a_known_start_time() {
     let store = store();
-    let key = SessionKey::new("native", "claude-code", "known-start");
-    store
-        .upsert_sessions(
-            &[session("known-start", 1_000)],
-            &crate::agents::evidence_cohort(),
-        )
-        .unwrap();
-    let record = AnalysisRecord {
-        key: key.clone(),
-        model_breakdown_json: "{}".into(),
-        inclusive_models_json: "[]".into(),
-        initial_context_json: None,
-        source_summaries_json: None,
-        source_fingerprint: "sv1:source".into(),
-        pricing_generation: 0,
-        analyzed_generation: 1,
-        parser_revision: 1,
-        analyzer_revision: 1,
-        metrics_schema_revision: 1,
-    };
+    let (record, claim) = claimed_projection(&store, "known-start", 100, 60);
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, Some(800), &completion, &[])
+            .unwrap()
+    );
 
-    store.save_analysis(&record, Some(800)).unwrap();
-    store.save_analysis(&record, None).unwrap();
+    // Requeue and reclaim, mirroring a second worker pass over the same
+    // session, then publish again with no start time.
+    store.requeue_session_evidence(&record.key).unwrap();
+    let claim = store
+        .claim_next_evidence(&["claude-code"], 200, 60)
+        .unwrap()
+        .expect("requeued session is claimable");
+    let record = AnalysisRecord {
+        analyzed_generation: claim.source_generation,
+        ..record
+    };
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
 
     assert_eq!(
         store
-            .session_source_state(&key)
+            .session_source_state(&record.key)
             .unwrap()
             .expect("source state")
             .started_at_epoch,

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1808,6 +1808,65 @@ fn opencode_cohort_migration_queues_existing_sessions_without_resetting_evidence
 }
 
 #[test]
+fn widened_cohort_migration_queues_existing_sessions_without_resetting_evidence() {
+    // Mirrors codex_cohort_migration_queues_existing_sessions_without_resetting_evidence:
+    // the backfill queues an existing session of a newly joined agent (here,
+    // Cursor) and leaves an existing ready Claude evidence row untouched.
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    for &sql in &super::schema::MIGRATIONS[..19] {
+        connection.execute_batch(sql).unwrap();
+    }
+    connection.pragma_update(None, "user_version", 19).unwrap();
+    connection
+        .execute_batch(
+            "INSERT INTO session (
+                 environment_key, agent, session_id, source_kind, source_label,
+                 surface, first_seen_at, last_seen_at
+             ) VALUES
+                 ('native', 'cursor', 'new', 'file', '/synthetic/new.jsonl', 'cli', 'x', 'x'),
+                 ('native', 'claude-code', 'ready', 'file', '/synthetic/claude.jsonl', 'cli', 'x', 'x');
+             INSERT INTO session_evidence (
+                 environment_key, agent, session_id, status
+             ) VALUES ('native', 'claude-code', 'ready', 'ready');",
+        )
+        .unwrap();
+
+    let store = Store::from_connection(
+        connection,
+        Path::new("/tmp/antiburn-widened-cohort-migration-test").to_path_buf(),
+    )
+    .unwrap();
+    let connection = store.lock();
+    let statuses = connection
+        .prepare(
+            "SELECT agent, session_id, status FROM session_evidence ORDER BY agent, session_id",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+
+    assert_eq!(
+        statuses,
+        vec![
+            (
+                "claude-code".to_owned(),
+                "ready".to_owned(),
+                "ready".to_owned()
+            ),
+            ("cursor".to_owned(), "new".to_owned(), "pending".to_owned()),
+        ]
+    );
+}
+
+#[test]
 fn migrating_from_every_prior_schema_version_reaches_the_current_head() {
     for start in 0..super::schema::MIGRATIONS.len() {
         let connection = rusqlite::Connection::open_in_memory().unwrap();
@@ -2439,21 +2498,30 @@ fn reconciling_session_evidence_skips_a_disabled_agent() {
 }
 
 #[test]
-fn a_session_outside_the_evidence_cohort_gets_no_row() {
+fn every_agent_kind_is_in_the_evidence_cohort_and_gets_a_row() {
+    // The cohort now covers every AgentKind (crate::agents::evidence_cohort
+    // derives from AgentKind::ALL), so upserting a session for any slug
+    // queues an evidence row. No agent is outside the cohort any more.
     let store = store();
-    let claude = session("cohort-claude", 1_000);
-    let mut cursor = session("cohort-cursor", 1_000);
-    cursor.key.agent = "cursor".to_string();
+    let cohort = crate::agents::evidence_cohort();
+    let sessions: Vec<SessionRecord> = cohort
+        .iter()
+        .map(|slug| {
+            let mut record = session(&format!("cohort-{slug}"), 1_000);
+            record.key.agent = (*slug).to_string();
+            record
+        })
+        .collect();
 
-    store
-        .upsert_sessions(
-            &[claude.clone(), cursor.clone()],
-            &crate::agents::evidence_cohort(),
-        )
-        .unwrap();
+    store.upsert_sessions(&sessions, &cohort).unwrap();
 
-    assert!(store.evidence(&claude.key).unwrap().is_some());
-    assert!(store.evidence(&cursor.key).unwrap().is_none());
+    for record in &sessions {
+        assert!(
+            store.evidence(&record.key).unwrap().is_some(),
+            "{} should get an evidence row",
+            record.key.agent
+        );
+    }
 }
 
 #[test]
@@ -3257,10 +3325,10 @@ fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pinned so this test fails loudly if a future migration is appended
     // without also being counted here — the number is the whole point of
     // the assertion, not an incidental detail.
-    assert_eq!(super::schema::MIGRATIONS.len(), 19);
+    assert_eq!(super::schema::MIGRATIONS.len(), 20);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 19);
+    assert_eq!(store.schema_version().unwrap(), 20);
 }
 
 #[test]

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -543,6 +543,123 @@ impl SourceCapabilities {
             harness_version: false,
         }
     }
+
+    /// Cursor's shared JSON record shape (`RecordShape::Cursor`) never reads
+    /// `message.usage`, an effort field, or a top-level thread-identity pair
+    /// (`uuid`/`parentUuid`), so this profile carries no token-class, cache,
+    /// reasoning-tier, or thread/record identity claim.
+    ///
+    /// `timestamps_and_order` is set: every record shape reads a top-level
+    /// `timestamp`. `model_identity` is set: the model comes from
+    /// `message.model` or a top-level `model` key, tried in that order.
+    ///
+    /// `tool_invocations` is set: `message.content`/top-level content blocks
+    /// and a top-level `tool_calls[]` array both feed the shared content and
+    /// tool-call parsing. `tool_definitions` stays unset — neither shape
+    /// carries a tool catalog.
+    ///
+    /// The adapter emits no `SubagentSpawn`, `ThreadLink`, or `ContextSource`
+    /// observation (those come from `evidence_observations`, which only the
+    /// Claude adapter calls), so `subagent_relationships`, `subagent_models`,
+    /// and `skill_mcp_attribution` stay unset. Cursor writes no compaction,
+    /// quota, or harness-version record either.
+    pub fn cursor() -> Self {
+        Self {
+            request_context_tokens: false,
+            cache_write_tokens: false,
+            timestamps_and_order: true,
+            tool_invocations: true,
+            skill_mcp_attribution: false,
+            tool_definitions: false,
+            model_identity: true,
+            token_classes: false,
+            reasoning_effort_tier: false,
+            fast_tier: false,
+            service_tier: false,
+            subagent_relationships: false,
+            subagent_models: false,
+            compaction_boundaries: false,
+            thread_identity: false,
+            record_identity: false,
+            quota_incidents: false,
+            harness_version: false,
+        }
+    }
+
+    /// Antigravity's own module documents its token-usage and tool-name
+    /// field locations as undocumented by the vendor: the adapter reads
+    /// likely containers (`usage`/`tokenUsage`/`tokens`) and leaves missing
+    /// values empty rather than reading a confirmed contract. That
+    /// uncertainty keeps `request_context_tokens`, `cache_write_tokens`, and
+    /// `token_classes` unset.
+    ///
+    /// `timestamps_and_order` is set: the step timestamp locations
+    /// (`created_at`/`timestamp`/`createdAt`, plus the API-cascade
+    /// `metadata.createdAt`/`metadata.startedAt` fallback) are confirmed
+    /// against real captures, not guessed.
+    ///
+    /// `tool_invocations` is set: the adapter reads a step's `tool_calls[]`
+    /// array by name, a documented, load-bearing shape (`PLANNER_RESPONSE`
+    /// steps carry it), plus a same-step fallback for a tool-role step that
+    /// names its tool inline. `tool_definitions` stays unset — neither path
+    /// carries a tool catalog.
+    ///
+    /// Every other field stays unset: the adapter never sets `NormalizedSession.model`
+    /// or an event's model (so `model_identity` is unset), and emits no
+    /// thread-identity, subagent, compaction, quota, or harness-version
+    /// signal at all.
+    pub fn antigravity() -> Self {
+        Self {
+            request_context_tokens: false,
+            cache_write_tokens: false,
+            timestamps_and_order: true,
+            tool_invocations: true,
+            skill_mcp_attribution: false,
+            tool_definitions: false,
+            model_identity: false,
+            token_classes: false,
+            reasoning_effort_tier: false,
+            fast_tier: false,
+            service_tier: false,
+            subagent_relationships: false,
+            subagent_models: false,
+            compaction_boundaries: false,
+            thread_identity: false,
+            record_identity: false,
+            quota_incidents: false,
+            harness_version: false,
+        }
+    }
+
+    /// The generic JSONL fallback's profile: every field unset.
+    ///
+    /// An unknown vendor's transcript proves no vendor-specific contract —
+    /// the same reasoning `GenericJsonlAdapter::normalize` already applies to
+    /// `cache_write_tokens_available` (see `vendors/generic_jsonl.rs`). This
+    /// adapter cannot vouch for any evidence contract, so every detector that
+    /// needs one reads this source as unsupported rather than guessing.
+    pub fn generic() -> Self {
+        Self {
+            request_context_tokens: false,
+            cache_write_tokens: false,
+            timestamps_and_order: false,
+            tool_invocations: false,
+            skill_mcp_attribution: false,
+            tool_definitions: false,
+            model_identity: false,
+            token_classes: false,
+            reasoning_effort_tier: false,
+            fast_tier: false,
+            service_tier: false,
+            subagent_relationships: false,
+            subagent_models: false,
+            compaction_boundaries: false,
+            thread_identity: false,
+            record_identity: false,
+            quota_incidents: false,
+            harness_version: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -898,6 +1015,116 @@ mod tests {
                 "identity.agent".to_owned(),
                 "identity.session_id".to_owned()
             ])
+        );
+    }
+
+    /// Pins `SourceCapabilities::cursor()` against what the Cursor adapter
+    /// actually emits: every claimed-true signal (timestamps, model, tool
+    /// invocations) appears, and every claimed-false one (usage-derived
+    /// token classes, thread identity) never does.
+    #[test]
+    fn cursor_capabilities_match_what_the_adapter_actually_emits() {
+        use crate::analysis::interface::SessionInput;
+        use crate::analysis::model::Usage;
+        use crate::analysis::vendors::adapter_for;
+
+        let input = SessionInput {
+            agent: "cursor".to_owned(),
+            session_id: "cursor-probe".to_owned(),
+            source: RawSource::Jsonl(
+                r#"{"role":"user","content":"hi","timestamp":"2026-01-01T00:00:00.000Z"}
+{"role":"assistant","model":"gpt-5","content":"working on it","tool_calls":[{"name":"read_file","arguments":"{}"}],"timestamp":"2026-01-01T00:00:05.000Z"}
+"#
+                .to_owned(),
+            ),
+        };
+        let session = adapter_for("cursor")
+            .normalize(&input)
+            .expect("a synthetic Cursor session normalizes");
+        let caps = SourceCapabilities::cursor();
+
+        assert!(caps.timestamps_and_order);
+        assert!(session.events.iter().all(|event| event.ts_ms.is_some()));
+
+        assert!(caps.model_identity);
+        assert!(session.events.iter().any(|event| event.model.is_some()));
+
+        assert!(caps.tool_invocations);
+        assert!(session.events.iter().any(|event| !event.tools.is_empty()));
+
+        assert!(!caps.token_classes);
+        assert!(
+            session
+                .events
+                .iter()
+                .all(|event| event.usage == Usage::default())
+        );
+
+        assert!(!caps.thread_identity);
+        assert!(session.events.iter().all(|event| event.uuid.is_none()));
+    }
+
+    /// Pins `SourceCapabilities::antigravity()` against the adapter: the
+    /// step timestamp and `tool_calls[]` locations it claims are confirmed
+    /// really do populate events, while it never claims a model, since the
+    /// adapter sets none.
+    #[test]
+    fn antigravity_capabilities_match_what_the_adapter_actually_emits() {
+        use crate::analysis::interface::SessionInput;
+        use crate::analysis::vendors::adapter_for;
+
+        let input = SessionInput {
+            agent: "antigravity".to_owned(),
+            session_id: "antigravity-probe".to_owned(),
+            source: RawSource::Jsonl(
+                r#"{"type":"USER_INPUT","created_at":"2026-01-01T00:00:00.000Z","content":"hi"}
+{"type":"PLANNER_RESPONSE","created_at":"2026-01-01T00:00:05.000Z","content":"working on it","tool_calls":[{"name":"read_file"}]}
+"#
+                .to_owned(),
+            ),
+        };
+        let session = adapter_for("antigravity")
+            .normalize(&input)
+            .expect("a synthetic Antigravity session normalizes");
+        let caps = SourceCapabilities::antigravity();
+
+        assert!(caps.timestamps_and_order);
+        assert!(session.events.iter().all(|event| event.ts_ms.is_some()));
+
+        assert!(caps.tool_invocations);
+        assert!(session.events.iter().any(|event| !event.tools.is_empty()));
+
+        assert!(!caps.model_identity);
+        assert!(session.events.iter().all(|event| event.model.is_none()));
+        assert!(session.model.is_none());
+    }
+
+    /// The generic fallback vouches for nothing: every capability is unset.
+    #[test]
+    fn generic_capabilities_are_all_unset() {
+        let caps = SourceCapabilities::generic();
+        assert_eq!(
+            caps,
+            SourceCapabilities {
+                request_context_tokens: false,
+                cache_write_tokens: false,
+                timestamps_and_order: false,
+                tool_invocations: false,
+                skill_mcp_attribution: false,
+                tool_definitions: false,
+                model_identity: false,
+                token_classes: false,
+                reasoning_effort_tier: false,
+                fast_tier: false,
+                service_tier: false,
+                subagent_relationships: false,
+                subagent_models: false,
+                compaction_boundaries: false,
+                thread_identity: false,
+                record_identity: false,
+                quota_incidents: false,
+                harness_version: false,
+            }
         );
     }
 }


### PR DESCRIPTION
## Summary

- **(a0) Make `capabilities_for_vendor` total.** `capabilities_for_vendor` (apps/desktop/src-tauri/src/analysis.rs) covered only 4 of 11 agent vendors, returning `Option<SourceCapabilities>`. Added `SourceCapabilities::cursor()`, `::antigravity()`, and `::generic()` to `crates/antiburn-local/src/analysis/evidence.rs`, each derived by reading the actual adapter code (not copied from another vendor), and made the function total (`SourceCapabilities`, no `Option`). This let every vendor take the normal evidence-streaming path; the engine's existing `published_status` classifies evidence that satisfies no detector as `PublishedEvidence::Unsupported`, which is the honest terminal state for an uncharacterized vendor. Deleted the now-unreachable legacy `analyze_sources_with` branch inside `analyze_for_evidence`.
- **(a) Widen the evidence cohort.** `evidence_cohort()` (apps/desktop/src-tauri/src/agents.rs) now derives from `AgentKind::ALL` (11 kinds) instead of a hand-maintained 4-agent array, so it cannot drift from the engine's discovery matrix again. Every agent's sessions now flow through the durable evidence worker and turn-rows pipeline. Added migration V20 (`apps/desktop/src-tauri/src/store/schema.rs`) backfilling pending `session_evidence` rows for existing sessions of the seven newly-joining agents (Cursor, Copilot, Cline, Kiro, Amp, Antigravity, Windsurf), following the V12/V13/V14 template; it does not reset or clobber an existing evidence row.
- **(b) Retire the legacy on-demand analysis paths.** With the cohort universal, `cache_detail_analysis`, `analysis_changed`, `cache_detail_relations`, `top_up_analysis`/`TopUpScope`/`MAX_ANALYSES_PER_PASS`, and their exclusive plumbing are dead. Deleted them. `get_session_analysis`/`get_subagent_analysis` now unconditionally serve the rows-first path with a live-parse fallback. `Store::save_analysis` is demoted to `#[cfg(test)]` test scaffolding (its only remaining callers are fixture setups); the three tests that pinned its column writes are re-pointed at `publish_projections`, the worker's real write path, so column coverage is not lost.

## Consequences / notes for reviewers

- **`awaiting_provider_support`** (insights_report.rs's `DENOMINATOR_SQL`) is exactly the non-cohort population, so it trends to zero once the V20 backfill runs. New agents land in the existing `unsupported`/`ready` coverage buckets instead. The field and SQL are kept (DTO compatibility); the pinning tests were updated to reflect this rather than deleted.
- **`SESSION_ENTRY_CHANGED_EVENT` timing**: the synchronous emission from drilldown open (`cache_detail_analysis`'s call site) is gone. The worker's own announce callback (`insights_worker::spawn`) still emits this event on every publish, so the popover list still updates — just from the worker's pass rather than the drilldown's.
- **`supports_analysis`/`has_dedicated_adapter` are unchanged** (explicit non-goal). Drilldown UI gating stays on the adapter set; widening the cohort only makes evidence rows, hygiene, list cost pills, and provider-usage attribution exist for the new agents. Zero TS changes.
- **Known limitation**: Cursor, Antigravity, and the generic-JSONL kinds have no characterization fixture corpora in this repo. Their worker path is covered only by the new synthetic tests (engine-side `SourceCapabilities` pins reading the real adapter code; desktop-side a synthetic generic-agent `process_next` test asserting a terminal published status, never a stuck `processing` claim).
- Base: this branch was cut from `origin/feat/drilldown-from-rows` (PR #302), which has since merged into `main`; this PR now targets `main` directly and contains only the 3 commits above.

## Test plan

Both crates, per repo convention:
- [x] `crates/antiburn-local`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — 14 binaries, all `0 failed` (1143 + 2 + 75 + 33 + 11 + 30 + 10 + 8 + 10 + 5 + 8 + 5 + 11 + 1 passed)
- [x] `apps/desktop/src-tauri`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — 3 binaries, all `0 failed` (645 passed)
- [x] Zero changes under `apps/desktop/src/**` (confirmed via diff against `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)