### PR TITLE
feat(desktop): retire the drilldown live-parse fallback

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -516,36 +516,25 @@ fn inline_fingerprint(content: &str) -> String {
     .fingerprint()
 }
 
-fn stream_vendor(inputs: &[SessionInput], cancel: &CancelFlag) -> StreamOutcome {
-    stream_vendor_with_claim_hook(inputs, cancel, &test_subagent_after_claim)
-}
+/// No-op `after_claim` hook for [`stream_vendor_with_hooks`]. Production
+/// callers (`analyze_for_evidence`) have no reason to observe a source's
+/// claim as it streams; a test that does inject its own hook directly
+/// instead, through [`stream_vendor_with_claim_hook`].
+fn no_after_claim(_: usize, _: &std::path::Path) {}
 
-#[cfg(not(test))]
-fn test_subagent_after_claim(_: usize, _: &std::path::Path) {}
+// `stream_vendor` and `stream_vendor_with_claim_hook` have no production
+// caller left: the drilldown's live-parse fallback (`analyze_subagent`) is
+// gone, and every remaining caller is test scaffolding for
+// `stream_vendor_with_hooks`'s streaming contract — see the `save_analysis`
+// precedent for the same treatment. `stream_vendor_with_hooks` itself stays
+// outside `#[cfg(test)]`: `analyze_for_evidence` still calls it directly in
+// production.
+#[cfg(test)]
+fn stream_vendor(inputs: &[SessionInput], cancel: &CancelFlag) -> StreamOutcome {
+    stream_vendor_with_claim_hook(inputs, cancel, &no_after_claim)
+}
 
 #[cfg(test)]
-fn test_subagent_after_claim(_: usize, path: &std::path::Path) {
-    use std::io::Write;
-
-    let append = {
-        let mut override_ = subagent_test_override()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        override_
-            .as_mut()
-            .filter(|override_| override_.source_path == path)
-            .and_then(|override_| override_.append_after_claim.take())
-    };
-    if let Some(append) = append {
-        std::fs::OpenOptions::new()
-            .append(true)
-            .open(path)
-            .expect("open changed sub-agent source")
-            .write_all(append.as_bytes())
-            .expect("append changed sub-agent source");
-    }
-}
-
 fn stream_vendor_with_claim_hook(
     inputs: &[SessionInput],
     cancel: &CancelFlag,
@@ -836,6 +825,11 @@ fn sort_members(members: &mut [SubagentMember]) {
 /// session's own headline metrics — buckets, token totals, tool mix — so the
 /// detail view's chart and header sum a sub-agent's activity into the same
 /// session instead of hiding it.
+///
+/// `export_session` (`commands.rs`) is this function's only caller now. The
+/// drilldown itself reads rows instead — see `analysis_from_rows` — because
+/// export wants a live parse: a fresh fingerprint and a `source_path` an
+/// exported document can point to, neither of which a row replay carries.
 pub async fn analyze(
     agent: AgentKind,
     session_id: &str,
@@ -952,7 +946,7 @@ pub async fn analyze_for_evidence(
         match stream_vendor_with_hooks(
             &inputs,
             &cancelled,
-            &test_subagent_after_claim,
+            &no_after_claim,
             database_claim.as_deref(),
             turn_row_store,
         ) {
@@ -1384,7 +1378,7 @@ fn unavailable_evidence_pass(
 
 #[cfg(test)]
 pub(crate) fn evidence_pass(inputs: &[SessionInput], cancelled: &dyn Fn() -> bool) -> EvidencePass {
-    evidence_pass_with_hook(inputs, cancelled, &test_subagent_after_claim, None)
+    evidence_pass_with_hook(inputs, cancelled, &no_after_claim, None)
 }
 
 /// Like [`evidence_pass`], with a [`TurnRowStore`] fanned out through the
@@ -1397,12 +1391,7 @@ pub(crate) fn evidence_pass_with_turn_rows(
     cancelled: &dyn Fn() -> bool,
     turn_row_store: Option<Arc<dyn TurnRowStore>>,
 ) -> EvidencePass {
-    evidence_pass_with_hook(
-        inputs,
-        cancelled,
-        &test_subagent_after_claim,
-        turn_row_store,
-    )
+    evidence_pass_with_hook(inputs, cancelled, &no_after_claim, turn_row_store)
 }
 
 #[cfg(test)]
@@ -1456,72 +1445,11 @@ pub fn projection_revisions() -> ProjectionRevisions {
     }
 }
 
-/// Analyze one sub-agent transcript on its own.
-///
-/// A sub-agent is a session in its own right. The analysis surface opens its
-/// transcript like any other session. Vendors do not nest orchestration, so
-/// this path analyzes one input.
-pub async fn analyze_subagent(
-    agent: AgentKind,
-    parent_session_id: &str,
-    subagent_id: &str,
-    wsl_distro: Option<&str>,
-    cancel: CancelFlag,
-) -> SessionAnalysis {
-    let Some(source) =
-        locate_subagent_source(agent, parent_session_id, subagent_id, wsl_distro).await
-    else {
-        return SessionAnalysis::unavailable();
-    };
-    let Some(raw) = raw_source(&source).await else {
-        return SessionAnalysis::unavailable();
-    };
-
-    let input = SessionInput {
-        agent: vendor_label(agent).to_string(),
-        session_id: subagent_id.to_string(),
-        source: raw,
-    };
-    let fingerprint = fingerprint_of(&source);
-    let source_path = source_path(&source);
-    let agent_slug = agent.slug().to_string();
-
-    // Every vendor now has a real `SourceCapabilities` profile (see
-    // `capabilities_for_vendor`), so this always streams — there is no
-    // separate, uncharacterized-vendor fallback pass any more.
-    let computed =
-        tauri::async_runtime::spawn_blocking(move || match stream_vendor(&[input], &cancel) {
-            StreamOutcome::Published { session, .. } => {
-                Some((session.parent, session.started_at_epoch))
-            }
-            StreamOutcome::SourceChanged
-            | StreamOutcome::ParentMissing
-            | StreamOutcome::ParentUnsupported
-            | StreamOutcome::ParentUnreadable => None,
-        })
-        .await;
-    let Ok(Some((metrics, started_at_epoch))) = computed else {
-        return SessionAnalysis {
-            source_path,
-            fingerprint,
-            ..SessionAnalysis::unavailable()
-        };
-    };
-    standalone_session_analysis(
-        metrics,
-        agent_slug,
-        source_path,
-        fingerprint,
-        started_at_epoch,
-    )
-}
-
 /// Builds the session-detail [`SessionAnalysis`] for a transcript with no
-/// sub-agent split of its own — a sub-agent viewed on its own, whether from
-/// a live parse ([`analyze_subagent`]) or the drilldown's rows-replay path
-/// ([`subagent_analysis_from_rows`]). `cost` and `top_level_cost` name the
-/// same figure: a sub-agent launches no sub-agent of its own, so its own
-/// transcript is the whole story.
+/// sub-agent split of its own — a sub-agent viewed on its own, from the
+/// drilldown's rows-replay path ([`subagent_analysis_from_rows`]). `cost` and
+/// `top_level_cost` name the same figure: a sub-agent launches no sub-agent
+/// of its own, so its own transcript is the whole story.
 fn standalone_session_analysis(
     mut metrics: SessionMetrics,
     agent_slug: String,
@@ -1602,44 +1530,6 @@ pub fn subagent_analysis_from_rows(
         record.source_fingerprint,
         started_at_epoch,
     ))
-}
-
-async fn locate_subagent_source(
-    agent: AgentKind,
-    parent_session_id: &str,
-    subagent_id: &str,
-    wsl_distro: Option<&str>,
-) -> Option<SessionSource> {
-    #[cfg(test)]
-    {
-        let override_ = subagent_test_override()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(override_) = override_.as_ref()
-            && override_.parent_session_id == parent_session_id
-            && override_.subagent_id == subagent_id
-        {
-            return Some(SessionSource::File(override_.source_path.clone()));
-        }
-    }
-    Explorers::DISK
-        .locate_subagent_source_in_environment(&agent, parent_session_id, subagent_id, wsl_distro)
-        .await
-}
-
-#[cfg(test)]
-struct SubagentTestOverride {
-    parent_session_id: String,
-    subagent_id: String,
-    source_path: std::path::PathBuf,
-    append_after_claim: Option<String>,
-}
-
-#[cfg(test)]
-fn subagent_test_override() -> &'static std::sync::Mutex<Option<SubagentTestOverride>> {
-    static OVERRIDE: std::sync::OnceLock<std::sync::Mutex<Option<SubagentTestOverride>>> =
-        std::sync::OnceLock::new();
-    OVERRIDE.get_or_init(|| std::sync::Mutex::new(None))
 }
 
 /// Whether analysis of this agent's transcripts is more than a generic parse.
@@ -2102,16 +1992,6 @@ mod tests {
         ]
         .join("\n")
             + "\n"
-    }
-
-    struct SubagentOverrideGuard;
-
-    impl Drop for SubagentOverrideGuard {
-        fn drop(&mut self) {
-            *subagent_test_override()
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
-        }
     }
 
     #[test]
@@ -2864,44 +2744,6 @@ mod tests {
         assert!(first.observe());
         assert!(!second.observe());
         assert_eq!(second.progress(), 1);
-    }
-
-    #[tokio::test]
-    async fn a_changed_subagent_source_rejects_the_direct_subagent_view() {
-        let directory = tempfile::TempDir::new().expect("tempdir");
-        let path = directory.path().join("agent-review-gap.jsonl");
-        std::fs::write(&path, claude_record("before-change", 1_760_000_000))
-            .expect("write sub-agent");
-        let parent_session_id = "review-gap-parent";
-        let subagent_id = "review-gap-child";
-        {
-            let mut override_ = subagent_test_override()
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            assert!(override_.is_none());
-            *override_ = Some(SubagentTestOverride {
-                parent_session_id: parent_session_id.to_string(),
-                subagent_id: subagent_id.to_string(),
-                source_path: path,
-                append_after_claim: Some(claude_record("after-change", 1_760_000_001)),
-            });
-        }
-        let _guard = SubagentOverrideGuard;
-
-        let analysis = analyze_subagent(
-            AgentKind::Claude,
-            parent_session_id,
-            subagent_id,
-            None,
-            CancelFlag::never(),
-        )
-        .await;
-
-        assert!(analysis.metrics.is_none());
-        assert!(analysis.summary.is_none());
-        assert!(analysis.cost.is_none());
-        assert!(analysis.inclusive_tokens.is_none());
-        assert!(analysis.inclusive_model_breakdown.is_empty());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -831,45 +831,34 @@ pub async fn get_session_analysis(
     };
     let key = SessionKey::for_session(&agent, &session_id, wsl_distro.as_deref());
     let store = app.state::<Store>();
-    let claimed = store
-        .session_source_state(&key)
-        .ok()
-        .flatten()
-        .map(|state| analysis::ClaimedSource {
-            fingerprint: state.source_fingerprint,
-            generation: state.source_generation,
-        })
-        .unwrap_or(analysis::ClaimedSource {
-            fingerprint: None,
-            generation: 0,
-        });
 
-    // Rows first: every agent is in the evidence cohort, so the drilldown
-    // always serves the worker's last published pass instead of re-parsing
-    // the transcript inline. A fresh transcript replays cheaply; a missing
-    // or not-ready row set falls back to the live parse, and nudges the
-    // worker so the gap closes for next time. Publishing a fresh live parse
-    // is the worker's job now — see its announce callback in
-    // `insights_worker::spawn` — so this command no longer caches one itself
-    // or emits `SESSION_ENTRY_CHANGED_EVENT` for it.
-    let analysis = match analysis::analysis_from_rows(&store, &key, &session_id, &agent) {
-        Some(replayed) => {
-            nudge_if_evidence_stale(&app, &store, kind, &key, &session_id, wsl_distro.as_deref())
+    // Rows are the only way this command computes an analysis: every agent
+    // is in the evidence cohort, so this always serves the worker's last
+    // published pass. A missing or not-yet-published row set reports a
+    // pending payload instead of re-parsing the transcript in-process, and
+    // nudges the worker so the gap closes on its own. Publishing a fresh
+    // pass is the worker's job — see its announce callback in
+    // `insights_worker::spawn` — so this command never caches one itself or
+    // emits `SESSION_ENTRY_CHANGED_EVENT` for it.
+    let (analysis, analysis_pending) =
+        match analysis::analysis_from_rows(&store, &key, &session_id, &agent) {
+            Some(replayed) => {
+                nudge_if_evidence_stale(
+                    &app,
+                    &store,
+                    kind,
+                    &key,
+                    &session_id,
+                    wsl_distro.as_deref(),
+                )
                 .await;
-            replayed
-        }
-        None => {
-            requeue_and_wake_worker(&app, &store, &key);
-            analysis::analyze(
-                kind,
-                &session_id,
-                wsl_distro.as_deref(),
-                claimed,
-                analysis::CancelFlag::never(),
-            )
-            .await
-        }
-    };
+                (replayed, false)
+            }
+            None => {
+                requeue_and_wake_worker(&app, &store, &key);
+                (analysis::SessionAnalysis::unavailable(), true)
+            }
+        };
     let relations = resolve_lineage(&app, kind, &key, wsl_distro.as_deref()).await;
 
     let stored = store.session(&key).ok().flatten();
@@ -903,6 +892,7 @@ pub async fn get_session_analysis(
         relations: (!relations.is_empty()).then_some(relations),
         started_at_epoch: analysis.started_at_epoch,
         source_path: analysis.source_path.clone(),
+        analysis_pending,
     })
 }
 
@@ -941,29 +931,23 @@ pub async fn get_subagent_analysis(
     let Some(kind) = kind_from_slug(&agent) else {
         return Err(format!("unknown agent {agent}"));
     };
-    // Every agent is in the evidence cohort, so this always tries the
-    // worker's last published pass before falling back to a live parse —
-    // see the matching comment in `get_session_analysis`.
+    // Rows are the only way this command computes an analysis — see the
+    // matching comment in `get_session_analysis`. A missing or not-yet-
+    // published row set reports a pending payload and nudges the worker,
+    // instead of re-parsing the sub-agent's own transcript in-process.
     let store = app.state::<Store>();
     let parent_key = SessionKey::for_session(&agent, &parent_session_id, wsl_distro.as_deref());
-    let analysis = match analysis::subagent_analysis_from_rows(
+    let (analysis, analysis_pending) = match analysis::subagent_analysis_from_rows(
         &store,
         &parent_key,
         &parent_session_id,
         &subagent_id,
         &agent,
     ) {
-        Some(replayed) => replayed,
+        Some(replayed) => (replayed, false),
         None => {
             requeue_and_wake_worker(&app, &store, &parent_key);
-            analysis::analyze_subagent(
-                kind,
-                &parent_session_id,
-                &subagent_id,
-                wsl_distro.as_deref(),
-                analysis::CancelFlag::never(),
-            )
-            .await
+            (analysis::SessionAnalysis::unavailable(), true)
         }
     };
     Ok(SessionAnalysis {
@@ -984,6 +968,7 @@ pub async fn get_subagent_analysis(
         relations: None,
         started_at_epoch: analysis.started_at_epoch,
         source_path: analysis.source_path.clone(),
+        analysis_pending,
     })
 }
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -189,6 +189,13 @@ pub struct SessionAnalysis {
     /// The transcript's own path, for the reveal action. Absent for sessions
     /// held in a vendor database rather than a file.
     pub source_path: Option<String>,
+    /// True when no published row set exists yet for this session, so every
+    /// other field above is [`SessionAnalysis::unavailable`]'s placeholder
+    /// rather than a real read. The worker fills the gap on its own; the
+    /// view should show an indexing state, not an empty-transcript state.
+    ///
+    /// [`SessionAnalysis::unavailable`]: crate::analysis::SessionAnalysis::unavailable
+    pub analysis_pending: bool,
 }
 
 /// A protected directory the last pass declined to read, and how many working

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -1229,13 +1229,17 @@ impl Store {
     /// A claim bumps `session_evidence.claim_fence` and writes new rows
     /// under that fence while the last published pass's rows still sit
     /// under the old fence. A publish that wins deletes every other
-    /// fence's rows and sets status `ready`; a publish that loses its race
-    /// deletes only its own fence's rows and leaves the earlier published
-    /// fence in place. So `claim_fence` names a complete set of rows only
-    /// when status is `ready` — with status `pending`, `processing`,
-    /// `failed`, or `unsupported`, `claim_fence` may point at partial or
-    /// missing rows, and this method returns `None` for all of them. The
-    /// evidence lookup and the row query run under one lock, so a claim
+    /// fence's rows and sets status `ready` or `unsupported`; a publish
+    /// that loses its race deletes only its own fence's rows and leaves the
+    /// earlier published fence in place. So `claim_fence` names a complete
+    /// set of rows when status is `ready` or `unsupported` — both are
+    /// terminal states a winning publish reached, so both name a complete
+    /// fence. `unsupported` means no detector was eligible for this source,
+    /// an insights verdict, not a parse-quality one; the rows and the
+    /// session_analysis record are still complete for it. With status
+    /// `pending`, `processing`, or `failed`, `claim_fence` may point at
+    /// partial or missing rows, and this method returns `None` for those.
+    /// The evidence lookup and the row query run under one lock, so a claim
     /// racing this read cannot swap the fence in between them.
     pub fn published_turn_rows(&self, key: &SessionKey) -> Result<Option<Vec<TurnRow>>> {
         let connection = self.lock();
@@ -1249,7 +1253,10 @@ impl Store {
         else {
             return Ok(None);
         };
-        if evidence.status != EvidenceStatus::Ready {
+        if !matches!(
+            evidence.status,
+            EvidenceStatus::Ready | EvidenceStatus::Unsupported
+        ) {
             return Ok(None);
         }
         Ok(Some(query_turn_rows(

--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -275,7 +275,7 @@ fn a_won_race_removes_turn_rows_from_every_superseded_fence_and_keeps_only_its_o
 
 /* R1: `Store::published_turn_rows` only exposes a complete, published
  * fence — never a claim in flight, never a superseded fence, and never a
- * status other than `ready`. */
+ * status other than `ready` or `unsupported`. */
 
 fn revisions() -> ProjectionRevisions {
     ProjectionRevisions {
@@ -384,11 +384,19 @@ fn published_turn_rows_is_none_when_failed() {
     assert_eq!(store.published_turn_rows(&key).unwrap(), None);
 }
 
+/// `Unsupported` is an insights verdict, not a parse-quality one: no
+/// detector was eligible for this source, but the rows and the
+/// `session_analysis` record a winning pass wrote are still complete.
+/// `published_turn_rows` must serve them exactly as it would for `Ready`,
+/// so the drilldown's rows-first read never falls back to a live parse for
+/// a session this terminal.
 #[test]
-fn published_turn_rows_is_none_when_unsupported() {
+fn published_turn_rows_serves_rows_when_unsupported() {
     let store = store();
     let (record, claim) = claimed_projection(&store, "unsupported-status", 100, 60);
     let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
     let completion = evidence_completion(&claim, PublishedEvidence::Unsupported, "{}".into());
     assert!(
         store
@@ -398,8 +406,8 @@ fn published_turn_rows_is_none_when_unsupported() {
     );
     assert_eq!(
         store.published_turn_rows(&key).unwrap(),
-        None,
-        "only status `ready` names a complete row projection"
+        Some(vec![turn_row(0), turn_row(1)]),
+        "status `unsupported` names a complete row projection, same as `ready`"
     );
 }
 

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -2218,8 +2218,10 @@ async fn analysis_from_rows_serves_a_published_pass_without_reading_a_transcript
 }
 
 /// Before a worker pass has published anything, `analysis_from_rows` finds
-/// no ready row set and returns `None` — the command switch's own signal to
-/// fall back to a live parse.
+/// no complete row set and returns `None` — the command switch's own signal
+/// that this session's drilldown is still pending. The worker fills the gap
+/// on its own next pass; the command no longer re-parses the transcript
+/// in-process to answer this call.
 #[test]
 fn analysis_from_rows_returns_none_before_rows_are_ready() {
     let store = store();
@@ -2238,6 +2240,40 @@ fn analysis_from_rows_returns_none_before_rows_are_ready() {
         )
         .is_none()
     );
+}
+
+/// `published_turn_rows`' widening (R5 part 1) reaches `analysis_from_rows`
+/// too: a pass published with status `unsupported` is exactly as replayable
+/// as one published `ready`, because `Unsupported` is an insights verdict
+/// (no detector was eligible), not a parse-quality one — the rows and the
+/// `session_analysis` record a winning pass wrote are complete either way.
+#[test]
+fn analysis_from_rows_serves_a_pass_published_unsupported() {
+    let store = store();
+    let (mut record, claim) = claimed_projection(&store, "s1", 100, 60);
+    // A row whose own `source_key` names the parent session, so
+    // `metrics_by_source` groups it under `record.key.session_id` the way
+    // `analysis_from_rows` expects for the parent entry.
+    record.source_summaries_json = Some("{}".into());
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Unsupported, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+    assert_eq!(
+        store.evidence(&key).unwrap().unwrap().status,
+        EvidenceStatus::Unsupported
+    );
+
+    let replayed =
+        crate::analysis::analysis_from_rows(&store, &key, &key.session_id, "claude-code")
+            .expect("an unsupported, published pass still replays from rows");
+
+    assert!(replayed.metrics.is_some());
 }
 
 /// The drilldown's rows-replay path requeues a session whose stored

--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -125,6 +125,7 @@ function presentationProps(
       wslDistro: null,
     },
     supportsAnalysis: true,
+    analysisPending: false,
     cost: null,
     costSplit: null,
     efficiency: null,
@@ -385,6 +386,15 @@ describe("SessionDetailPresentation — states", () => {
       session: { agent: "kiro", sessionId: "s1", wslDistro: null },
     })
     expect(screen.getByText(/Session analysis for Kiro sessions/)).toBeTruthy()
+  })
+
+  it("shows an indexing message while the drilldown is pending, not the empty-transcript copy", () => {
+    view({ summary: null, analysisPending: true })
+    expect(screen.getByText("Analyzing this session…")).toBeTruthy()
+    expect(screen.queryByText("No session analysis available")).toBeNull()
+    expect(
+      screen.queryByText("This session has no analyzable messages in its local transcript."),
+    ).toBeNull()
   })
 
   it("renders supported Pi analysis instead of the generic unsupported state", () => {

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -101,6 +101,12 @@ export interface SessionDetailPresentationProps {
    * empty state from "nothing happened" to "we cannot read this yet".
    */
   supportsAnalysis: boolean
+  /**
+   * True when no published row set exists yet for this session. Changes the
+   * empty state to an indexing message: the worker has not analyzed the
+   * session yet, so "no analyzable messages" would be wrong.
+   */
+  analysisPending: boolean
 
   /** The cost result the breakdown describes, when one was priced. */
   cost: LocalSessionCost | null
@@ -409,6 +415,7 @@ export function SessionDetailPresentation({
   error,
   session,
   supportsAnalysis,
+  analysisPending,
   cost,
   costSplit,
   efficiency,
@@ -590,7 +597,14 @@ export function SessionDetailPresentation({
         {showEmptyState && (
           <div className="flex flex-col items-center justify-center px-8 py-12 text-center">
             <Moon size={28} aria-hidden="true" className="mb-3 text-label-tertiary" />
-            {!supportsAnalysis ? (
+            {analysisPending ? (
+              <>
+                <p className="type-body text-label">Analyzing this session…</p>
+                <p className="mt-1 type-callout text-label-tertiary">
+                  Indexing is in progress. This view updates on its own once it finishes.
+                </p>
+              </>
+            ) : !supportsAnalysis ? (
               <p className="type-body text-label">
                 Session analysis for {agentDisplayName(session.agent)} sessions isn&apos;t
                 available yet

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -255,6 +255,11 @@ export interface SessionAnalysisPayload {
    * unknown. The sub-agent roster uses it to show each member's start as
    * elapsed time from the session start. */
   startedAtEpoch: number | null
+  /** True when no published row set exists yet for this session, so every
+   * other field above is a placeholder rather than a real read. The worker
+   * fills the gap on its own; the view should show an indexing state, not
+   * an empty-transcript state. */
+  analysisPending: boolean
 }
 
 /**

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -122,6 +122,7 @@ describe("PopoverSession live analysis poll", () => {
     relations: null,
     sourcePath: null,
     startedAtEpoch: null,
+    analysisPending: false,
     ...overrides,
   })
 
@@ -195,6 +196,58 @@ describe("PopoverSession live analysis poll", () => {
     await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
 
     expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("re-loads on every tick while the drilldown is pending, fingerprint unchanged", async () => {
+    getSessionAnalysis.mockResolvedValue(analysisPayload({ analysisPending: true }))
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
+
+    // Unbounded, unlike the unavailable-analysis retry budget below: a
+    // pending drilldown keeps refetching every tick until the worker
+    // actually publishes something, however many ticks that takes.
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(6)
+    unsubscribe()
+  })
+
+  it("stops re-loading once a pending drilldown resolves", async () => {
+    getSessionAnalysis
+      .mockResolvedValueOnce(analysisPayload({ analysisPending: true }))
+      .mockResolvedValueOnce(analysisPayload({ analysisPending: true }))
+      .mockResolvedValue(usableAnalysis())
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
+
+    // 1 initial load + 2 pending re-loads, then the third re-load lands
+    // usable and the poll goes back to comparing fingerprints alone.
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(3)
+    unsubscribe()
+  })
+
+  it("re-loads a pending sub-agent drilldown too, unlike the unavailable-analysis retry", async () => {
+    getSubagentAnalysis.mockResolvedValue(analysisPayload({ analysisPending: true }))
+    const subagent: SessionSubject = {
+      ...subject,
+      subagent: { parentSessionId: subject.sessionId, subagentId: "subagent-1" },
+    }
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subagent)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 2)
+
+    expect(getSubagentAnalysis).toHaveBeenCalledTimes(3)
     unsubscribe()
   })
 

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -83,6 +83,20 @@ function isUnavailableAnalysis(state: PopoverAnalysisState, key: string): boolea
   )
 }
 
+/**
+ * Whether the settled analysis for `key` reports the drilldown as still
+ * pending: the worker has not published a row set for this session yet, so
+ * the shell served a placeholder payload rather than a real read.
+ */
+function isAnalysisPending(state: PopoverAnalysisState, key: string): boolean {
+  return (
+    state !== null &&
+    state.key === key &&
+    state.payload !== null &&
+    state.payload.analysisPending
+  )
+}
+
 export interface PopoverSnapshot {
   appVersion: string | null
   debugBuild: boolean
@@ -744,6 +758,14 @@ export class PopoverSession {
    * since the last tick (or the seed), re-load the analysis. Overlapping
    * ticks are dropped rather than queued — a slow fetch is left to finish on
    * its own, and the next interval simply tries again.
+   *
+   * A pending analysis (the worker has not published rows for this session
+   * yet) re-loads on every tick, unbounded, whether or not the fingerprint
+   * moved: there is nothing to compare against until the worker's first
+   * pass lands, and that pass is what this poll is waiting for. That check
+   * runs before, and short-circuits, the bounded unavailable-analysis retry
+   * below, which answers a different question — a published pass that
+   * turned up nothing to show.
    */
   private tickAnalysisPoll = (): void => {
     if (this.analysisPollInFlight) return
@@ -758,6 +780,10 @@ export class PopoverSession {
         const previous = this.analysisFingerprint
         this.analysisFingerprint = fingerprint
         if (previous !== null && fingerprint !== previous) {
+          void this.refreshAnalysis()
+          return
+        }
+        if (isAnalysisPending(this.snapshot.analysis, key)) {
           void this.refreshAnalysis()
           return
         }

--- a/apps/desktop/src/views/popover/SessionPane.tsx
+++ b/apps/desktop/src/views/popover/SessionPane.tsx
@@ -354,6 +354,7 @@ export function SessionPane({
           : {}),
       }}
       supportsAnalysis={payload?.supportsAnalysis ?? agentSupportsAnalysis(subject.agent)}
+      analysisPending={payload?.analysisPending ?? false}
       cost={cost}
       costSplit={costSplit}
       efficiency={payload?.efficiency ?? null}


### PR DESCRIPTION
## Summary

Deletes the session/sub-agent drilldown's live-parse fallback so rows are the only way a session drilldown is computed. On a miss (no complete published row set yet), the drilldown reports a pending state and lets the worker fill it in, instead of re-parsing the transcript in-process.

- **Part 1 — serve terminally-published rows regardless of insights eligibility.** `published_status` publishes `Unsupported` when no detector is eligible for a source — an insights verdict, not a parse-quality one; `publish_projections` commits the rows and the `session_analysis` record for those sessions just as completely as for a `ready` pass. Widened `Store::published_turn_rows` to serve status `ready` OR `unsupported` (pending/processing/failed still return `None`). `Store::analysis` (the other read `analysis_from_rows`/`subagent_analysis_from_rows` depend on) is not status-gated at all, so `published_turn_rows` was the only widening the rows-first read path needed.
- **Part 2 — replace the fallback with a pending state.** `get_session_analysis` and `get_subagent_analysis` now requeue + wake the worker and return a pending payload (`SessionAnalysis::unavailable()` plus a new `analysisPending: true` field) on a rows miss, instead of calling the live-parse path. `analyze_subagent` is now unreachable and deleted, along with `locate_subagent_source` and the test-only `SubagentTestOverride` machinery it alone used. `stream_vendor`/`stream_vendor_with_claim_hook` lose their last production caller and move under `#[cfg(test)]` (the `save_analysis` precedent), since ~14 tests still exercise `stream_vendor_with_hooks` through them.
- **Part 3 — frontend pending rendering + refresh.** `SessionDetailPresentation` renders a distinct "Analyzing this session…" message for the pending state, reusing the existing empty-state layout/classes (no new tokens or stylesheets). The popover's existing analysis poll now also refetches on every tick while the last-settled payload was pending, unconditionally (not the bounded unavailable-analysis retry, which answers a different question).
- **Part 4 — contract cleanups**, called out explicitly since they're easy to miss in the diff:
  - (a) The R2 model-less delegated-turn exception is now the only behavior — the accumulator's fold into the primary model no longer reaches any display path (the fold itself stays, feeding billable/inclusive sums).
  - (b) `initial_context_json` is deliberately kept: it is not superseded by `source_summaries_json`. The worker's version is bounded against the full observed tool/skill/MCP set; the replay-side bounding is last-tool-only.
  - (c) `export_session` is deliberately kept on the live parse (`analysis::analyze`) — export wants a fresh fingerprint and a `source_path` a document can point to, neither of which a row replay carries. `analyze`'s doc comment now says so.
  - (d) The batch engine (`analyze_sources`/`analyze_sources_with`, `engine::aggregate`, `analyze_session`, `merge_subagent_events`, `thread_efficiency`) stays untouched — production-dead already, but the golden reference for the characterization/parity suites. Its deletion is out of scope for this PR.

`crates/antiburn-local/src/analysis/efficiency.rs` was not touched at all, per the scope guard (an unrelated maintainer change is in flight there).

## Test plan

- [x] `crates/antiburn-local`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — 14 binaries, all `0 failed` (1143/2/75/33/11/30/10/8/10/5/8/5/11/1 passed)
- [x] `apps/desktop/src-tauri`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — 3 binaries, all `0 failed` (644/0/0 passed)
- [x] `pnpm --filter @antiburn/desktop lint / type-check / format / test` — 87 files, 941 tests passed
- [x] `pnpm --filter @antiburn/desktop build`
- [x] `node scripts/check-design-drift.mjs` — in sync (no styling change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)