### PR TITLE
feat(desktop): keep the last hygiene verdict visible while checks recompute

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1241,6 +1241,22 @@ fn session_hygiene_payloads(
         .collect()
 }
 
+/// Parses `evidence_json` and, when it parses, serves its badges under
+/// `evidence_state`. Returns `None` when there is no prior evidence to
+/// serve, so the caller falls back to a `not_assessed` payload.
+fn hygiene_payload_from_prior_evidence(
+    evidence_json: Option<String>,
+    evidence_state: &'static str,
+) -> Option<SessionHygienePayload> {
+    let evidence_json = evidence_json?;
+    let evidence = serde_json::from_str::<SessionEvidence>(&evidence_json).ok()?;
+    Some(SessionHygienePayload::for_evidence(
+        session_badges(&evidence, &ReportCatalogs::default()),
+        &evidence,
+        evidence_state,
+    ))
+}
+
 fn session_hygiene_payload(
     row: Option<crate::store::EvidenceRow>,
     source_generation: Option<i64>,
@@ -1264,10 +1280,19 @@ fn session_hygiene_payload(
             let generation_is_current =
                 row.analyzed_generation.is_some() && row.analyzed_generation == source_generation;
             if !revisions_are_current || !generation_is_current {
-                return SessionHygienePayload::not_assessed(
-                    "stale",
-                    NotAssessedReason::IncompleteEvidence,
-                );
+                // The session UI deliberately shows the previous
+                // generation's verdict while the requeue runs, marked
+                // "stale" so the caller knows it is not current.
+                // `CURRENT_EVIDENCE_PREDICATE` in `insights_report.rs` is
+                // unchanged: the report cohort still excludes stale
+                // evidence.
+                return hygiene_payload_from_prior_evidence(row.evidence_json, "stale")
+                    .unwrap_or_else(|| {
+                        SessionHygienePayload::not_assessed(
+                            "stale",
+                            NotAssessedReason::IncompleteEvidence,
+                        )
+                    });
             }
             let Some(evidence_json) = row.evidence_json else {
                 return SessionHygienePayload::not_assessed(
@@ -1298,10 +1323,24 @@ fn session_hygiene_payload(
         crate::store::EvidenceStatus::Unsupported => {
             SessionHygienePayload::not_assessed("unsupported", NotAssessedReason::CapabilityMissing)
         }
-        status => SessionHygienePayload::not_assessed(
-            status.as_str(),
-            NotAssessedReason::IncompleteEvidence,
-        ),
+        crate::store::EvidenceStatus::Pending | crate::store::EvidenceStatus::Processing => {
+            // A row that is pending or processing again (fingerprint
+            // churn on an actively growing session) keeps its last
+            // published evidence_json until the requeue lands. Serve that
+            // last verdict as "stale" instead of a blank not-assessed
+            // state; only a row with no prior evidence falls back to the
+            // status label.
+            let status_label = row.status.as_str();
+            hygiene_payload_from_prior_evidence(row.evidence_json, "stale").unwrap_or_else(|| {
+                SessionHygienePayload::not_assessed(
+                    status_label,
+                    NotAssessedReason::IncompleteEvidence,
+                )
+            })
+        }
+        crate::store::EvidenceStatus::Failed => {
+            SessionHygienePayload::not_assessed("failed", NotAssessedReason::IncompleteEvidence)
+        }
     }
 }
 
@@ -2028,69 +2067,108 @@ mod tests {
             SYNTHETIC_GENERATION,
         );
         assert_eq!(processing.evidence_state, "processing");
-    }
-
-    #[test]
-    fn session_hygiene_marks_old_ready_evidence_as_stale() {
-        let mut row = evidence_row(
-            crate::store::EvidenceStatus::Ready,
-            Some(synthetic_evidence()),
-        );
-        row.parser_revision = Some(PARSER_REVISION - 1);
-
-        let payload = session_hygiene_payload(Some(row), SYNTHETIC_GENERATION);
-        assert_eq!(payload.evidence_state, "stale");
         assert!(
-            payload
+            processing
                 .badges
                 .iter()
-                .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed))
+                .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed)),
+            "a processing row with no prior evidence has nothing to serve"
+        );
+
+        let pending_without_evidence = session_hygiene_payload(
+            Some(evidence_row(crate::store::EvidenceStatus::Pending, None)),
+            SYNTHETIC_GENERATION,
+        );
+        assert_eq!(pending_without_evidence.evidence_state, "pending");
+        assert!(
+            pending_without_evidence
+                .badges
+                .iter()
+                .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed)),
+            "a pending row with no prior evidence has nothing to serve"
+        );
+    }
+
+    /// Debug strings of a payload's badge statuses, in badge order — a
+    /// cheap stand-in for `PartialEq` (the DTO derives `Debug` only).
+    fn badge_signature(payload: &SessionHygienePayload) -> Vec<String> {
+        payload
+            .badges
+            .iter()
+            .map(|badge| format!("{:?}", badge.status))
+            .collect()
+    }
+
+    #[test]
+    fn session_hygiene_serves_the_last_verdict_while_old_revisions_recompute() {
+        // The row's revisions fell behind (a parser/analyzer/schema bump),
+        // so a requeue is pending, but the row still carries the evidence
+        // from its last publish. The session UI shows that last verdict,
+        // marked "stale", instead of a blank not-assessed result.
+        let evidence = synthetic_evidence();
+        let mut stale_row =
+            evidence_row(crate::store::EvidenceStatus::Ready, Some(evidence.clone()));
+        stale_row.parser_revision = Some(PARSER_REVISION - 1);
+        let fresh_row = evidence_row(crate::store::EvidenceStatus::Ready, Some(evidence));
+
+        let stale_payload = session_hygiene_payload(Some(stale_row), SYNTHETIC_GENERATION);
+        let fresh_payload = session_hygiene_payload(Some(fresh_row), SYNTHETIC_GENERATION);
+
+        assert_eq!(stale_payload.evidence_state, "stale");
+        assert_eq!(
+            badge_signature(&stale_payload),
+            badge_signature(&fresh_payload),
+            "a stale row serves the same verdict as the last publish, only marked stale"
         );
     }
 
     #[test]
-    fn session_hygiene_never_serves_a_requeued_rows_leftover_evidence() {
+    fn session_hygiene_serves_the_last_verdict_while_a_requeued_row_recomputes() {
         // `reconcile_evidence_revisions` flips a stale Ready row's status to
         // Pending but keeps its old `evidence_json` by design (see
         // `store/mod.rs`). This row copies that shape: a non-Ready status
-        // next to fully current evidence from a previous pass.
-        let mut row = evidence_row(
+        // next to fully current evidence from a previous pass. The
+        // maintainer's ruling: show that last verdict, marked "stale",
+        // instead of "Computing checks…" while the requeue runs.
+        let evidence = synthetic_evidence();
+        let mut pending_row = evidence_row(
             crate::store::EvidenceStatus::Pending,
-            Some(synthetic_evidence()),
+            Some(evidence.clone()),
         );
-        row.retry_count = 0;
+        pending_row.retry_count = 0;
+        let ready_row = evidence_row(crate::store::EvidenceStatus::Ready, Some(evidence));
 
-        let payload = session_hygiene_payload(Some(row), SYNTHETIC_GENERATION);
-        assert_eq!(payload.evidence_state, "pending");
-        assert!(
-            payload
-                .badges
-                .iter()
-                .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed)),
-            "leftover evidence_json on a requeued row must never surface a Clean or Finding badge"
+        let pending_payload = session_hygiene_payload(Some(pending_row), SYNTHETIC_GENERATION);
+        let ready_payload = session_hygiene_payload(Some(ready_row), SYNTHETIC_GENERATION);
+
+        assert_eq!(pending_payload.evidence_state, "stale");
+        assert_eq!(
+            badge_signature(&pending_payload),
+            badge_signature(&ready_payload),
+            "leftover evidence_json on a requeued row serves the last real verdict, not a blank one"
         );
     }
 
     #[test]
-    fn session_hygiene_marks_evidence_from_an_earlier_source_generation_as_stale() {
+    fn session_hygiene_serves_the_last_verdict_from_an_earlier_source_generation() {
         // The source grew a new generation (a requeue not yet run, or still
         // pending) while this row's evidence is still Ready and carries
-        // current revisions from the previous generation.
-        let row = evidence_row(
-            crate::store::EvidenceStatus::Ready,
-            Some(synthetic_evidence()),
-        );
+        // current revisions from the previous generation. The row's own
+        // evidence is served as "stale" rather than blanked out.
+        let evidence = synthetic_evidence();
+        let row = evidence_row(crate::store::EvidenceStatus::Ready, Some(evidence.clone()));
         assert_eq!(row.analyzed_generation, SYNTHETIC_GENERATION);
         let newer_source_generation = Some(2);
+        let current_row = evidence_row(crate::store::EvidenceStatus::Ready, Some(evidence));
 
-        let payload = session_hygiene_payload(Some(row), newer_source_generation);
-        assert_eq!(payload.evidence_state, "stale");
-        assert!(
-            payload
-                .badges
-                .iter()
-                .all(|badge| matches!(badge.status, crate::dto::SessionHygieneStatus::NotAssessed)),
-            "evidence analyzed against a superseded source generation must never surface a Clean or Finding badge"
+        let stale_payload = session_hygiene_payload(Some(row), newer_source_generation);
+        let current_payload = session_hygiene_payload(Some(current_row), SYNTHETIC_GENERATION);
+
+        assert_eq!(stale_payload.evidence_state, "stale");
+        assert_eq!(
+            badge_signature(&stale_payload),
+            badge_signature(&current_payload),
+            "evidence analyzed against a superseded source generation still serves its own verdict, marked stale"
         );
     }
 

--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -219,6 +219,30 @@ describe("SessionList — rows", () => {
     ])
   })
 
+  it("keeps the last verdict on screen, marked stale, while a live session recomputes", async () => {
+    getSessionHygiene.mockResolvedValueOnce([
+      {
+        evidenceState: "stale",
+        badges: [
+          { id: "sessionOverdepth", status: "finding", notAssessedReason: null },
+          { id: "modelOverthinking", status: "clean", notAssessedReason: null },
+          { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
+          { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+          { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+          { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+        ],
+      },
+    ])
+    list({ entries: [entry({ sessionId: "synthetic-hygiene-stale" })] })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Refreshing — 5 of 6 burn checks pass").textContent).toBe(
+        "5/6 burn checks",
+      )
+    })
+    expect(screen.queryByLabelText("Refreshing session hygiene checks")).toBeNull()
+  })
+
   it("states the last-activity time", () => {
     list({ entries: [entry({ timestamp: at(0, 9) })] })
     expect(screen.getByLabelText(/^Last activity /)).toBeTruthy()

--- a/apps/desktop/src/components/session/SessionStatusBar.test.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.test.tsx
@@ -143,6 +143,19 @@ describe("SessionStatusBar", () => {
     expect(verdict.textContent).toBe("Unsupported checks")
   })
 
+  it("shows the verdict, not the state text, once at least one check is assessed", () => {
+    render(<SessionStatusBar checks={CHECKS} evidenceState="processing" />)
+    const verdict = screen.getByLabelText("Computing — 5 of 6 burn checks pass")
+    expect(verdict.textContent).toBe("5/6 burn checks")
+  })
+
+  it("prefixes the transient state onto an assessed but stale verdict", () => {
+    render(<SessionStatusBar checks={CHECKS} evidenceState="stale" />)
+    const verdict = screen.getByLabelText("Refreshing — 5 of 6 burn checks pass")
+    expect(verdict.textContent).toBe("5/6 burn checks")
+    expect(verdict.style.color).toContain("--color-system-orange")
+  })
+
   it("never shows a denominator smaller than the not-assessed tail", () => {
     const oneAssessed: SessionHygieneCheck[] = [
       CHECKS[0]!,

--- a/apps/desktop/src/components/session/SessionStatusBar.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.tsx
@@ -128,22 +128,31 @@ export function SessionStatusBar({
   const stateText = stateLabel
     ? `${stateLabel} checks${sessionHygieneStateIsTransient(evidenceState) ? "…" : ""}`
     : null
+  // Once at least one check is assessed, the verdict is worth more than the
+  // state label — a stale or refreshing session still has a last result. Only
+  // the never-assessed case keeps the plain state text in the count's place.
+  const showStateText = stateLabel !== null && assessedCount === 0
   const checkNoun = checks.length === 1 ? "burn check" : "burn checks"
   const notAssessedText = notAssessed.length > 0 ? ` · ${notAssessed.length} not assessed` : ""
   const countText =
     assessedCount === 0
       ? "Not assessed"
       : `${passed.length}/${checks.length} ${checkNoun}${notAssessedText}`
-  const verdictLabel = stateLabel
+  // A transient state next to an assessed verdict still names itself, as a
+  // prefix on the aria label and the tooltip text.
+  const verdictPrefix = stateLabel && !showStateText ? `${stateLabel} — ` : ""
+  const verdictLabel = showStateText
     ? `${stateLabel} session hygiene checks`
-    : allPassed
-      ? "All checks pass"
-      : assessedCount === 0
-        ? "No checks assessed"
-        : `${passed.length} of ${checks.length} ${checkNoun} pass${
-            notAssessed.length > 0 ? `; ${notAssessed.length} not assessed` : ""
-          }`
-  const tooltip = stateLabel ? verdictLabel : renderTooltip(failed, passed, notAssessed)
+    : `${verdictPrefix}${
+        allPassed
+          ? "All checks pass"
+          : assessedCount === 0
+            ? "No checks assessed"
+            : `${passed.length} of ${checks.length} ${checkNoun} pass${
+                notAssessed.length > 0 ? `; ${notAssessed.length} not assessed` : ""
+              }`
+      }`
+  const tooltip = showStateText ? verdictLabel : renderTooltip(failed, passed, notAssessed)
 
   return (
     <div className="flex w-full items-center justify-between gap-x-1.5 text-label-secondary">
@@ -156,7 +165,7 @@ export function SessionStatusBar({
           className="font-mono type-footnote font-medium! tracking-tight! [word-spacing:-2px] leading-[13px] tabular-nums"
           style={{ color: verdictInk(failedShare, assessedCount) }}
         >
-          {stateText ?? countText}
+          {showStateText ? stateText : countText}
         </span>
       </Tooltip>
 


### PR DESCRIPTION
## Problem

While a session is actively running, its evidence row is almost always requeued (fingerprint churn), so the session list and detail view show "Computing checks…" nearly permanently. The maintainer's ruling: show whatever the last result was until a new result comes in — "Computing checks" is useless.

## What changed

`Store::mark_evidence_pending_in` never clears a row's prior `evidence_json`, so the last published verdict was already sitting on the row `session_hygiene_payload` reads — it just wasn't being served. `session_hygiene_payload` now serves that prior evidence, marked `"stale"`, for:

- a `Pending`/`Processing` row that carries parseable prior evidence (falls back to today's blank `not_assessed` only when there is nothing to serve)
- a `Ready` row whose revisions or source generation are stale

`Failed`, `Unsupported`, and missing-row cases are unchanged.

`SessionStatusBar` and `SessionList` now show the verdict count once at least one check is assessed, even while a transient state label (`Computing`/`Refreshing`) applies — the label becomes a prefix on the tooltip/aria text ("Refreshing — 5 of 6 burn checks pass") instead of replacing the verdict outright. "Computing checks…" still shows for the genuinely never-assessed case (zero checks assessed).

## Honesty note

The insights-report cohort predicate (`CURRENT_EVIDENCE_PREDICATE` in `insights_report.rs`) is unchanged and still excludes stale evidence from the 30-day report — only the live session UI shows the prior verdict, explicitly marked stale/refreshing.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` (644 passed, 0 failed, across 3 binaries) in `apps/desktop/src-tauri`
- [x] `pnpm --filter @antiburn/desktop lint`
- [x] `pnpm --filter @antiburn/desktop type-check`
- [x] `pnpm --filter @antiburn/desktop format` (prettier --check)
- [x] `pnpm --filter @antiburn/desktop test` (944 passed)
- [x] `pnpm --filter @antiburn/desktop build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)