### PR TITLE
feat(evidence): codex attests record linkage from linear rollout order

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -2118,10 +2118,12 @@ mod tests {
 
     /// Seam 5a: a Codex rollout is one thread, but its records carry no
     /// per-record id. `thread_identity` stays set and unblocks
-    /// SessionsOverDepth; `record_identity` stays unset and blocks
-    /// CacheChurn.
+    /// SessionsOverDepth; `record_identity` stays unset, but Codex's own
+    /// `linear_record_order` (one rollout, one append-only stream) attests
+    /// `RecordLinkage` from line order instead, so CacheChurn can read
+    /// clean once more.
     #[test]
-    fn codex_thread_identity_without_record_identity_supports_overdepth_and_a_never_clean_cache_churn()
+    fn codex_thread_identity_without_record_identity_still_attests_linkage_from_order_for_cache_churn()
      {
         let input = SessionInput {
             agent: "codex".to_owned(),
@@ -2139,6 +2141,7 @@ mod tests {
 
         assert!(evidence.capabilities.thread_identity);
         assert!(!evidence.capabilities.record_identity);
+        assert!(evidence.capabilities.linear_record_order);
 
         assert!(
             eligible(DetectorId::SessionsOverDepth, &evidence),
@@ -2146,16 +2149,16 @@ mod tests {
         );
         // Codex reports `token_classes` and `request_context_tokens` but no
         // `cache_write_tokens`, so `repeated_context` resolves to
-        // uncached-input accounting: Cache Churn is eligible. It can never
-        // read clean, though, because Codex has no `record_identity` and
-        // `RecordLinkage` stays unsupported.
+        // uncached-input accounting: Cache Churn is eligible. This fixture
+        // carries no record loss, so the order route reads `RecordLinkage`
+        // complete, and Cache Churn now reads clean for Codex.
         assert!(
             eligible(DetectorId::CacheChurn, &evidence),
             "CacheChurn must be eligible for Codex under uncached-input accounting"
         );
         assert!(
-            !clean_facts_complete(DetectorId::CacheChurn, &evidence),
-            "CacheChurn must never read clean for Codex"
+            clean_facts_complete(DetectorId::CacheChurn, &evidence),
+            "CacheChurn must read clean for Codex once linear record order attests linkage"
         );
     }
 

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -544,6 +544,7 @@ mod tests {
             compaction_boundaries: false,
             thread_identity: false,
             record_identity: false,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }
@@ -1508,10 +1509,10 @@ mod tests {
         let stored = store.evidence(&pi.key).unwrap().unwrap();
         assert_eq!(stored.status, EvidenceStatus::Ready);
         let evidence_json = stored.evidence_json.as_deref().unwrap();
-        assert!(evidence_json.contains("\"schemaRevision\":11"));
+        assert!(evidence_json.contains("\"schemaRevision\":12"));
         let evidence: SessionEvidence = serde_json::from_str(evidence_json).unwrap();
         assert_eq!(evidence.capabilities, SourceCapabilities::pi());
-        assert_eq!(evidence.schema_revision, 11);
+        assert_eq!(evidence.schema_revision, 12);
 
         let report = crate::insights_report::reduce_report(
             data_dir.path().to_path_buf(),

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -2499,7 +2499,7 @@ async fn reprocessing_a_revision_one_row_leaves_no_placeholder_in_stored_evidenc
 
     let ready = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(ready.status, EvidenceStatus::Ready);
-    assert_eq!(ready.evidence_schema_revision, Some(11));
+    assert_eq!(ready.evidence_schema_revision, Some(12));
     assert!(!ready.evidence_json.unwrap().contains("unimplemented"));
 }
 
@@ -2540,7 +2540,7 @@ async fn a_terminal_failure_clears_an_outdated_placeholder_payload() {
 
     let failed = store.evidence(&record.key).unwrap().unwrap();
     assert_eq!(failed.status, EvidenceStatus::Failed);
-    assert_eq!(failed.evidence_schema_revision, Some(11));
+    assert_eq!(failed.evidence_schema_revision, Some(12));
     assert!(failed.evidence_json.is_none());
     assert!(failed.diagnostics_json.is_none());
 }

--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -29,9 +29,9 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
             parser_revision: 16,
-            analyzer_revision: 15,
+            analyzer_revision: 16,
             metrics_schema_revision: 2,
-            evidence_schema_revision: 11,
+            evidence_schema_revision: 12,
         }
     );
 }

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -381,6 +381,11 @@ pub struct SourceCapabilities {
     /// Every counted row carries its own record id (`uuid`) and its parent
     /// link (`parent_uuid`) resolves to an id this source declared earlier.
     pub record_identity: bool,
+    /// The source writes records of one thread to one append-only stream.
+    /// Line order is the turn chain. A turn's predecessor is always the
+    /// counted record immediately before it, with no id needed to prove it.
+    #[serde(default)]
+    pub linear_record_order: bool,
     pub quota_incidents: bool,
     pub harness_version: bool,
 }
@@ -408,6 +413,7 @@ impl SourceCapabilities {
             compaction_boundaries: true,
             thread_identity: true,
             record_identity: true,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }
@@ -433,7 +439,13 @@ impl SourceCapabilities {
     /// discovered child rollout streams with `Delegated` scope, so a
     /// child thread never merges into the parent's main-scope facts.
     /// `record_identity` stays unset: Codex records carry no per-record
-    /// id, so `previous_turn` stays unsupported.
+    /// id, so the id-based `previous_turn` route never applies.
+    ///
+    /// `linear_record_order` is set: a Codex rollout is one append-only
+    /// file that holds exactly one thread, so a counted turn's predecessor
+    /// is always the counted record immediately before it in the file.
+    /// This lets `previous_turn` attest linkage structurally, from order
+    /// alone, in place of the id-based route.
     pub fn codex() -> Self {
         Self {
             request_context_tokens: true,
@@ -452,6 +464,7 @@ impl SourceCapabilities {
             compaction_boundaries: true,
             thread_identity: true,
             record_identity: false,
+            linear_record_order: true,
             quota_incidents: false,
             harness_version: false,
         }
@@ -494,6 +507,7 @@ impl SourceCapabilities {
             compaction_boundaries: true,
             thread_identity: true,
             record_identity: true,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }
@@ -539,6 +553,7 @@ impl SourceCapabilities {
             compaction_boundaries: true,
             thread_identity: true,
             record_identity: true,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }
@@ -581,6 +596,7 @@ impl SourceCapabilities {
             compaction_boundaries: false,
             thread_identity: false,
             record_identity: false,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }
@@ -626,6 +642,7 @@ impl SourceCapabilities {
             compaction_boundaries: false,
             thread_identity: false,
             record_identity: false,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }
@@ -656,6 +673,7 @@ impl SourceCapabilities {
             compaction_boundaries: false,
             thread_identity: false,
             record_identity: false,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }
@@ -880,7 +898,7 @@ mod tests {
         truncated_strings: serde_json::Value,
     ) -> serde_json::Value {
         json!({
-            "schemaRevision": 11,
+            "schemaRevision": 12,
             "identity": {"agent": "claude", "sessionId": session_id},
             "context": {"state": "complete", "value": {"maxRequestContextTokens": 0, "topDepthExamples": []}},
             "capabilities": {
@@ -900,14 +918,15 @@ mod tests {
                 "compactionBoundaries": true,
                 "threadIdentity": true,
                 "recordIdentity": true,
+                "linearRecordOrder": false,
                 "quotaIncidents": false,
                 "harnessVersion": false
             },
             "coverage": coverage,
             "provenance": {
                 "parserRevision": 16,
-                "analyzerRevision": 15,
-                "evidenceSchemaRevision": 11,
+                "analyzerRevision": 16,
+                "evidenceSchemaRevision": 12,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",
                 "ordering": "monotonic",
@@ -1122,6 +1141,7 @@ mod tests {
                 compaction_boundaries: false,
                 thread_identity: false,
                 record_identity: false,
+                linear_record_order: false,
                 quota_incidents: false,
                 harness_version: false,
             }

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -523,28 +523,46 @@ impl SessionEvidenceAccumulator {
             examples: self.subagent_examples.clone(),
         };
         let subagents_cap_exceeded = self.subagents_cap_exceeded || facts.delegated_models_capped;
-        // Verified previous-turn linkage: complete only when every counted
-        // turn carried its own identity and every parent link resolved to an
-        // identity this source declared earlier. `provider_eviction` stays
-        // unsupported — no transcript record states an eviction.
+        // Verified previous-turn linkage, attested through either of two
+        // routes. The id route (`record_identity`): complete only when
+        // every counted turn carried its own identity and every parent link
+        // resolved to an identity this source declared earlier.
         // `thread_identity_missing` feeds the record-identity claim here: a
         // row with no `uuid` is a record-identity gap, not a thread-identity
-        // gap.
+        // gap. The order route (`linear_record_order`): a source with no
+        // per-record id but one thread per append-only stream needs none —
+        // a counted turn's predecessor is always the counted record
+        // immediately before it, so linkage is complete whenever this
+        // source lost no record. The id-gap concept does not apply here: an
+        // id-less source never emits `ThreadLink`, so `record_identity_gap`
+        // is gated to the id route and never degrades this one.
+        // `provider_eviction` stays unsupported — no transcript record
+        // states an eviction.
         let record_identity_gap = facts.thread_identity_missing || self.thread_parent_unresolved;
-        let previous_turn = if !self.capabilities.record_identity {
-            EvidenceValue::Unsupported
-        } else if let Some(reason) = self.record_loss_reason {
-            EvidenceValue::Partial {
-                observed: (),
-                reason,
+        let previous_turn = if self.capabilities.record_identity {
+            if let Some(reason) = self.record_loss_reason {
+                EvidenceValue::Partial {
+                    observed: (),
+                    reason,
+                }
+            } else if record_identity_gap {
+                EvidenceValue::Partial {
+                    observed: (),
+                    reason: CoverageReason::AttributionIncomplete,
+                }
+            } else {
+                EvidenceValue::Complete(())
             }
-        } else if record_identity_gap {
-            EvidenceValue::Partial {
-                observed: (),
-                reason: CoverageReason::AttributionIncomplete,
+        } else if self.capabilities.linear_record_order {
+            match self.record_loss_reason {
+                Some(reason) => EvidenceValue::Partial {
+                    observed: (),
+                    reason,
+                },
+                None => EvidenceValue::Complete(()),
             }
         } else {
-            EvidenceValue::Complete(())
+            EvidenceValue::Unsupported
         };
         // The same precedence the `cache` group's own `EvidenceValue` below
         // resolves to: this source's own record loss outranks a lossy
@@ -1989,6 +2007,55 @@ mod tests {
             panic!("cache must stay complete: this source never claimed record identity");
         };
         assert_eq!(cache.previous_turn, EvidenceValue::Unsupported);
+    }
+
+    /// A source with `linear_record_order` but no `record_identity`
+    /// (Codex's shape) attests linkage from line order alone: no counted
+    /// record was lost, so every turn's predecessor is the counted record
+    /// immediately before it.
+    #[test]
+    fn a_linear_order_source_with_no_loss_completes_previous_turn() {
+        let mut accumulator = SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "codex".to_owned(),
+            session_id: "s1".to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::codex(),
+        });
+        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(assistant_event(1))));
+        let EvidenceValue::Complete(cache) = accumulator.evidence(&TurnFacts::default()).cache
+        else {
+            panic!("cache must be complete: no record loss and no child");
+        };
+        assert_eq!(cache.previous_turn, EvidenceValue::Complete(()));
+    }
+
+    /// The same linear-order source, but a record was lost: the order
+    /// claim can no longer prove line N-1 is the predecessor of line N, so
+    /// linkage degrades to the same reason the loss itself carries.
+    #[test]
+    fn a_linear_order_source_with_a_record_loss_degrades_previous_turn() {
+        let mut accumulator = SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "codex".to_owned(),
+            session_id: "s1".to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::codex(),
+        });
+        accumulator.record(NormalizedRecord::MetricsEvent(Box::new(assistant_event(1))));
+        accumulator.record(NormalizedRecord::Unusable(PartialReason::MalformedRecord));
+        let cache = match accumulator.evidence(&TurnFacts::default()).cache {
+            EvidenceValue::Complete(cache)
+            | EvidenceValue::Partial {
+                observed: cache, ..
+            } => cache,
+            EvidenceValue::Unsupported => panic!("cache group must stay supported"),
+        };
+        assert_eq!(
+            cache.previous_turn,
+            EvidenceValue::Partial {
+                observed: (),
+                reason: CoverageReason::MalformedRecord,
+            }
+        );
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -126,7 +126,11 @@ pub const PARSER_REVISION: i64 = 16;
 // Overthinking now assess only the turns that report a speed or effort
 // value, instead of demanding every eligible turn carry one. A session
 // with subagent work is no longer always `SignalMissing`.
-pub const ANALYZER_REVISION: i64 = 15;
+// +1 for `linear_record_order`: `previous_turn` now also attests complete
+// from line order alone, for a source with no per-record id
+// (`evidence_sink::SessionEvidenceAccumulator::evidence`), so a Codex
+// session already assessed as `CapabilityMissing` may now assess clean.
+pub const ANALYZER_REVISION: i64 = 16;
 // +1 for seam R2: the worker path now derives `inclusive_model_breakdown`
 // and `model_runs` from published turn rows instead of the accumulator
 // (`query_model_breakdown`, `query_model_runs`), so every session in the
@@ -135,7 +139,8 @@ pub const ANALYZER_REVISION: i64 = 15;
 pub const METRICS_SCHEMA_REVISION: i64 = 2;
 // +1 for `RepeatedContext` (`evidence::CacheEvidence::repeated_context`).
 // +1 more for `RepeatedContext::paid_tokens` (part F).
-pub const EVIDENCE_SCHEMA_REVISION: i64 = 11;
+// +1 more for `SourceCapabilities::linear_record_order`.
+pub const EVIDENCE_SCHEMA_REVISION: i64 = 12;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -1034,6 +1034,7 @@ mod tests {
             compaction_boundaries: true,
             thread_identity: true,
             record_identity: true,
+            linear_record_order: true,
             quota_incidents: true,
             harness_version: true,
         };

--- a/crates/antiburn-local/tests/badge_matrix.rs
+++ b/crates/antiburn-local/tests/badge_matrix.rs
@@ -642,15 +642,17 @@ fn matrix() -> Vec<Row> {
         Row {
             // Codex has no `cache_write_tokens`, but `repeated_context`
             // resolves to uncached-input accounting from `token_classes`
-            // and `request_context_tokens`, so the badge is eligible; it
-            // never reads clean, because Codex has no `record_identity`
-            // (the matrix's "Conditional using uncached-input accounting").
-            // The unsupported `RecordLinkage` clean fact reports the
-            // capability gap, not the coverage.
+            // and `request_context_tokens`, so the badge is eligible. Codex
+            // has no `record_identity`, but it does have
+            // `linear_record_order`: one rollout is one append-only thread,
+            // so `previous_turn` attests linkage from line order alone.
+            // This fixture carries no record loss, so `RecordLinkage`
+            // reads complete and the badge now reads clean (the matrix's
+            // "Conditional using uncached-input accounting").
             harness: "codex",
             fixture: "records_all_kinds",
             badge: ExcessCacheRehydration,
-            expected: NotAssessed(CapabilityMissing),
+            expected: Clean,
         },
         Row {
             harness: "codex",

--- a/crates/antiburn-local/tests/codex_characterization.rs
+++ b/crates/antiburn-local/tests/codex_characterization.rs
@@ -290,6 +290,7 @@ fn codex_capabilities_match_published_evidence() {
     assert!(capabilities.subagent_models);
     assert!(capabilities.thread_identity);
     assert!(!capabilities.record_identity);
+    assert!(capabilities.linear_record_order);
     assert!(!capabilities.quota_incidents);
     assert!(!capabilities.harness_version);
     assert!(matches!(
@@ -308,7 +309,8 @@ fn codex_capabilities_match_published_evidence() {
         panic!("the supported cache fields must remain available");
     };
     assert_eq!(cache.cache_creation_tokens, 0);
-    assert!(matches!(cache.previous_turn, EvidenceValue::Unsupported));
+    // No record loss in this fixture: the order route attests linkage complete.
+    assert!(matches!(cache.previous_turn, EvidenceValue::Complete(())));
     let EvidenceValue::Complete(models) = evidence.models else {
         panic!("model evidence must be complete");
     };

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -10,7 +10,8 @@
         "longestIdleGapMs": 600000,
         "modelTransitions": [],
         "previousTurn": {
-          "state": "unsupported"
+          "state": "complete",
+          "value": null
         },
         "providerEviction": {
           "state": "unsupported"
@@ -35,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -145,8 +147,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -158,7 +160,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -10,7 +10,8 @@
         "longestIdleGapMs": 600000,
         "modelTransitions": [],
         "previousTurn": {
-          "state": "unsupported"
+          "state": "complete",
+          "value": null
         },
         "providerEviction": {
           "state": "unsupported"
@@ -35,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -145,8 +147,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -158,7 +160,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -11,7 +11,11 @@
           "longestIdleGapMs": 0,
           "modelTransitions": [],
           "previousTurn": {
-            "state": "unsupported"
+            "state": "partial",
+            "value": {
+              "observed": null,
+              "reason": "malformed_record"
+            }
           },
           "providerEviction": {
             "state": "unsupported"
@@ -41,6 +45,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -157,8 +162,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -170,7 +175,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "partial",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -10,7 +10,8 @@
         "longestIdleGapMs": 0,
         "modelTransitions": [],
         "previousTurn": {
-          "state": "unsupported"
+          "state": "complete",
+          "value": null
         },
         "providerEviction": {
           "state": "unsupported"
@@ -35,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -135,8 +137,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -148,7 +150,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -10,7 +10,8 @@
         "longestIdleGapMs": 1000,
         "modelTransitions": [],
         "previousTurn": {
-          "state": "unsupported"
+          "state": "complete",
+          "value": null
         },
         "providerEviction": {
           "state": "unsupported"
@@ -35,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -142,8 +144,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -155,7 +157,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -10,7 +10,8 @@
         "longestIdleGapMs": 0,
         "modelTransitions": [],
         "previousTurn": {
-          "state": "unsupported"
+          "state": "complete",
+          "value": null
         },
         "providerEviction": {
           "state": "unsupported"
@@ -35,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -135,8 +137,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -148,7 +150,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -10,7 +10,8 @@
         "longestIdleGapMs": 1000,
         "modelTransitions": [],
         "previousTurn": {
-          "state": "unsupported"
+          "state": "complete",
+          "value": null
         },
         "providerEviction": {
           "state": "unsupported"
@@ -35,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -140,8 +142,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -153,7 +155,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -10,7 +10,8 @@
         "longestIdleGapMs": 0,
         "modelTransitions": [],
         "previousTurn": {
-          "state": "unsupported"
+          "state": "complete",
+          "value": null
         },
         "providerEviction": {
           "state": "unsupported"
@@ -35,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": true,
       "harnessVersion": false,
+      "linearRecordOrder": true,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -114,8 +116,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -127,7 +129,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "complete",
       "value": {

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -36,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": false,
       "harnessVersion": false,
+      "linearRecordOrder": false,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -125,8 +126,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -138,7 +139,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -42,6 +42,7 @@
       "compactionBoundaries": true,
       "fastTier": false,
       "harnessVersion": false,
+      "linearRecordOrder": false,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -151,8 +152,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -164,7 +165,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -36,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": false,
       "harnessVersion": false,
+      "linearRecordOrder": false,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -136,8 +137,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -149,7 +150,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -36,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": false,
       "harnessVersion": false,
+      "linearRecordOrder": false,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -131,8 +132,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -144,7 +145,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -45,6 +45,7 @@
       "compactionBoundaries": true,
       "fastTier": false,
       "harnessVersion": false,
+      "linearRecordOrder": false,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -160,8 +161,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -173,7 +174,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -45,6 +45,7 @@
       "compactionBoundaries": true,
       "fastTier": false,
       "harnessVersion": false,
+      "linearRecordOrder": false,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -142,8 +143,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -155,7 +156,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -36,6 +36,7 @@
       "compactionBoundaries": true,
       "fastTier": false,
       "harnessVersion": false,
+      "linearRecordOrder": false,
       "modelIdentity": true,
       "quotaIncidents": false,
       "reasoningEffortTier": true,
@@ -136,8 +137,8 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 15,
-      "evidenceSchemaRevision": 11,
+      "analyzerRevision": 16,
+      "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"
       },
@@ -149,7 +150,7 @@
     "quotaIncidents": {
       "state": "unsupported"
     },
-    "schemaRevision": 11,
+    "schemaRevision": 12,
     "subagents": {
       "state": "unsupported"
     },

--- a/crates/antiburn-local/tests/opencode_characterization.rs
+++ b/crates/antiburn-local/tests/opencode_characterization.rs
@@ -164,6 +164,7 @@ fn opencode_capabilities_match_the_observed_contract() {
             compaction_boundaries: true,
             thread_identity: true,
             record_identity: true,
+            linear_record_order: false,
             quota_incidents: false,
             harness_version: false,
         }

--- a/crates/antiburn-local/tests/pi_characterization.rs
+++ b/crates/antiburn-local/tests/pi_characterization.rs
@@ -889,6 +889,7 @@ fn pi_capabilities_match_published_evidence_and_session_cache_support() {
         compaction_boundaries: true,
         thread_identity: true,
         record_identity: true,
+        linear_record_order: false,
         quota_incidents: false,
         harness_version: false,
     };


### PR DESCRIPTION
## Summary

- Codex's `CacheChurn`/`ExcessCacheRehydration` clean verdict has been structurally unreachable: it requires `Fact::RecordLinkage`, which reads `cache.previous_turn`, which the sink marks `Unsupported` whenever `SourceCapabilities.record_identity` is `false` — and Codex, whose records carry no per-record `uuid`, has never set that flag. But a Codex rollout is one append-only file and one thread: a turn's predecessor is always the previous line, no id needed. A broken/oversized line is already parser-visible and degrades via `record_loss_reason` → `Partial`, which correctly blocks clean. So Codex can attest linkage structurally, from line order, instead of never attesting it at all.
- Adds `SourceCapabilities::linear_record_order: bool` (`#[serde(default)]`, following the `RepeatedContext::paid_tokens` precedent for old-evidence deserialization), set `true` only in `SourceCapabilities::codex()`; every other constructor sets it `false` explicitly. No other vendor was flipped — Claude/OpenCode/Pi already have `record_identity: true` (a strictly stronger claim) and don't need the order route; Cursor/Antigravity/generic have no established per-line/per-thread contract to lean on.
- `evidence_sink.rs`'s `previous_turn` derivation now has two attestation routes:
  - **id route** (`record_identity`, unchanged): loss → `Partial(record_loss_reason)`; id-gap → `Partial(AttributionIncomplete)`; else `Complete`.
  - **order route** (`record_identity` false, `linear_record_order` true, new): `Complete` when this source lost no record; `Partial(record_loss_reason)` when it did. The id-gap concept does not apply — an id-less source never emits `ThreadLink`, so `record_identity_gap` is gated to the id route only (see honesty verification below for why this gating matters).
  - both false (unchanged): `Unsupported`.

## Honesty verification (item 3: does the structural claim actually hold for the Codex adapter?)

Traced every skip/error path in `vendors/codex.rs`'s streaming visit (`visit_reader` → `CodexStreamState::observe`/`process_value`, the path that feeds the evidence sink — `normalize()`/`parse_codex` is a separate, non-evidence live-metrics path and is out of scope here) against how `evidence_sink.rs` learns of loss (`RecordSink::record(NormalizedRecord::Unusable(reason))` → `SessionEvidenceAccumulator::observe` → `set_record_loss_reason`, `evidence_sink.rs:120-129`):

- **Oversized / incomplete-tail line** (`RecordSkip::Oversized | IncompleteTail`, from `BoundedJsonlReader`) → `Unusable(skip.partial_reason())` → feeds `record_loss_reason`. Honest.
- **Unparseable JSON** (`serde_json::from_str` fails) → `Unusable(MalformedRecord)` → feeds `record_loss_reason`. Honest.
- **A recognized turn-shaped record with no timestamp** (`record_to_event(&value).is_some_and(|e| e.ts_ms.is_none())`) → `Unusable(MalformedRecord)` → feeds `record_loss_reason`. This is an extra loss path I found beyond the spec's named cases — also honest.
- **Unrecognized `(type, payload.type)` that is *not* proven inert** (`is_inert_codex_record` fails its structural scan for `CODEX_SCALAR_EVIDENCE_KEYS`/dispatched types/named-tool shapes) → `Unusable(UnrecognizedRecordType)` → feeds `record_loss_reason`. Honest.
- **Unrecognized record proven inert** (the `is_recognized_eventless` allowlist — `session_meta`, `turn_context`, `world_state`, `task_started`/`complete`, `turn_started`/`complete`, `user_message`/`agent_message` echoes, `turn_aborted`, `thread_settings_applied`, `item_completed`, `response_item`/`agent_message` — plus anything the light key/type/tool-shape scan proves carries no evidence) is **not** counted as loss, by design (matches the module's own #229-parity doc comment: "does not fail the session closed by default"). This is the "benign non-record lines the format defines as ignorable" case the spec asks me to distinguish from failed parses — confirmed distinct and correctly excluded.
- **`ReadFailed`/`Cancelled`** → `anyhow::bail!`, aborting the whole `visit` with an `Err`. Loud failure, not a silent drop that could fake a `Complete`.

No silent-vanishing path found for the general line-skip cases the spec asks about. I also traced one **adjacent, pre-existing, unrelated-to-this-change** behavior worth flagging for awareness: during subagent-fork replay-prefix handling (`ForkOwnership::Pending`, a child rollout file that opens with a verbatim replay of its parent's context), a non-owned `token_count` record is discarded before either `Unusable` or `MetricsEvent` (`process_value`'s `if is_token_count { if !usage_is_owned { return; } }`), to keep the parent's usage out of the child's own accounting. This is a deliberate ownership-scoping exclusion (dropping a turn that belongs to a *different* thread), not a parse failure, and it does not corrupt the order claim for *this* thread's own file — it only matters in the minority subagent-rollout case, which is untouched by this PR either way.

**Golden regeneration confirms the honesty end-to-end**: of the 8 Codex characterization fixtures, 7 (no record loss) flip `previousTurn` from `Unsupported` to `Complete(null)`; the 8th (`malformed_between_valid`, which deliberately contains a malformed line) flips to `Partial({reason: "malformed_record"})`, not `Complete` — the loss is correctly reflected, not laundered away.

## Revision

Followed the precedent set by `feat(evidence): split thread identity from record identity` (d550e4b, which added `record_identity` and bumped `EVIDENCE_SCHEMA_REVISION` 7→8 and `ANALYZER_REVISION` 9→10) and by the `RepeatedContext` commits (which bumped both together again, 9→10 / 12→13). This PR adds a new persisted `SourceCapabilities` field *and* changes `previous_turn` derivation logic (an assessed-outcome change for already-ingested Codex sessions), matching both prior triggers, so both bump: `EVIDENCE_SCHEMA_REVISION` 11→12, `ANALYZER_REVISION` 15→16. `PARSER_REVISION` is untouched — nothing about parsing changed.

## Deltas

- `crates/antiburn-local/src/analysis/evidence.rs`: `linear_record_order` field + all 7 constructors; doc comments; schema-revision test literal.
- `crates/antiburn-local/src/analysis/evidence_sink.rs`: `previous_turn` two-route derivation; two new sink unit tests (`a_linear_order_source_with_no_loss_completes_previous_turn`, `a_linear_order_source_with_a_record_loss_degrades_previous_turn`).
- `crates/antiburn-local/src/analysis/mod.rs`: `EVIDENCE_SCHEMA_REVISION` 11→12, `ANALYZER_REVISION` 15→16, with `+1 for` precedent-style comments.
- `crates/antiburn-local/tests/codex_characterization.rs`: `codex_capabilities_match_published_evidence` now asserts `linear_record_order` true and `previous_turn` `Complete` for the loss-free `records_all_kinds` fixture (was `Unsupported`).
- `crates/antiburn-local/tests/badge_matrix.rs`: the `codex`/`records_all_kinds`/`ExcessCacheRehydration` row flips `NotAssessed(CapabilityMissing)` → `Clean`, with an updated comment.
- 8 `codex_characterization` goldens + 8 `pi_characterization` goldens regenerated (`UPDATE_GOLDENS=1`), diffed by hand: Codex goldens show `previousTurn` moving from `Unsupported` to `Complete`/`Partial(malformed_record)` per-fixture as described above, plus `linearRecordOrder: true` and the revision bumps; Pi goldens show only `linearRecordOrder: false` and the revision bumps (no behavior change, since Pi keeps `record_identity: true`).
- `crates/antiburn-local/src/insights/report.rs`, `tests/opencode_characterization.rs`, `tests/pi_characterization.rs`: added the new field to hand-built `SourceCapabilities` literals (compile-required, no behavior change).
- `apps/desktop/src-tauri/src/analysis.rs`: renamed and inverted `codex_thread_identity_without_record_identity_supports_overdepth_and_a_never_clean_cache_churn` → `..._still_attests_linkage_from_order_for_cache_churn`, since the "CacheChurn must never read clean for Codex" invariant it pinned is exactly what this PR overturns.
- `apps/desktop/src-tauri/src/insights_worker.rs`, `src/store/tests.rs`: added the new capability field to a hand-built literal, and updated 3 hardcoded `evidence_schema_revision`/`ProjectionRevisions` literals that pinned the old revision numbers (11/15 → 12/16). Other `evidence_schema_revision: 1` literals elsewhere in the desktop crate are unrelated arbitrary test-fixture placeholders, left untouched.
- Frontend: zero changes (verified via `git status`) — `notAssessedReasonLabel` copy and clean-badge rendering are generic over the reason/status already.

## Overlap with the maintainer's local unstaged work

The main worktree carries unstaged, not-yet-landed changes (not present on `origin/main`, so not part of this branch) that flip `SourceCapabilities::codex().cache_write_tokens` to `true` (reading `cache_write_input_tokens`), orthogonal to this PR's `linear_record_order` addition. When that work lands, expect textual conflicts (both touch the same `codex()` doc comment and struct literal) in:
- `crates/antiburn-local/src/analysis/evidence.rs` (the `codex()` doc comment + struct literal)
- `crates/antiburn-local/tests/codex_characterization.rs`
- `crates/antiburn-local/tests/badge_matrix.rs`
- `apps/desktop/src-tauri/src/analysis.rs`

(That work also touches `efficiency.rs`, `evidence_query.rs`, and `metrics_sink/slots.rs`, which this PR does not touch at all.)

## Test plan

- [x] `crates/antiburn-local`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — 14 binaries, all `test result: ok`, 0 failed (1255 tests total).
- [x] `apps/desktop/src-tauri`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — 3 binaries, all `test result: ok`, 0 failed (644 tests total).
- [x] `git status` on `apps/desktop/src` confirms zero frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)