### PR TITLE
feat(desktop): serve the last published analysis while a new pass runs

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -633,7 +633,8 @@ fn requeue_and_wake_worker(app: &tauri::AppHandle, store: &Store, key: &SessionK
 }
 
 /// Nudges the worker when the analysis this pass just served from rows was
-/// published against a transcript that has since changed.
+/// published against a transcript that has since changed. Returns whether it
+/// found one — the caller folds that into the payload's `analysisStale` flag.
 ///
 /// Reuses [`analysis::fingerprint_with_subagents`] — the same cheap
 /// `mtime:size` check `get_session_analysis_fingerprint` computes for the
@@ -648,9 +649,9 @@ async fn nudge_if_evidence_stale(
     key: &SessionKey,
     session_id: &str,
     wsl_distro: Option<&str>,
-) {
+) -> bool {
     let Some(source) = analysis::locate(kind, session_id, wsl_distro).await else {
-        return;
+        return false;
     };
     let live_fingerprint =
         analysis::fingerprint_with_subagents(kind, session_id, wsl_distro, &source).await;
@@ -659,9 +660,11 @@ async fn nudge_if_evidence_stale(
         .ok()
         .flatten()
         .map(|record| record.source_fingerprint);
-    if evidence_is_stale(stored_fingerprint.as_deref(), &live_fingerprint) {
+    let stale = evidence_is_stale(stored_fingerprint.as_deref(), &live_fingerprint);
+    if stale {
         requeue_and_wake_worker(app, store, key);
     }
+    stale
 }
 
 /// Whether the stored analysis's own fingerprint no longer matches the
@@ -669,6 +672,26 @@ async fn nudge_if_evidence_stale(
 /// comparison itself is testable without a located source or an app handle.
 fn evidence_is_stale(stored_fingerprint: Option<&str>, live_fingerprint: &str) -> bool {
     stored_fingerprint != Some(live_fingerprint)
+}
+
+/// Whether a served, replayed analysis is stale: a fresher pass is queued
+/// (`pending`) or running (`processing`) behind the served fence, or that
+/// fence's transcript has already moved past it (`fingerprint_mismatch`).
+///
+/// `failed` is deliberately excluded: a failed pass has given up, so nothing
+/// fresher is queued or running behind the served fence until something
+/// requeues it, at which point it reads `pending` again. Split out from
+/// [`get_session_analysis`] and [`get_subagent_analysis`] so the rule itself
+/// is testable without a store or an app handle.
+fn analysis_is_stale(
+    evidence_status: Option<crate::store::EvidenceStatus>,
+    fingerprint_mismatch: bool,
+) -> bool {
+    let status_stale = matches!(
+        evidence_status,
+        Some(crate::store::EvidenceStatus::Pending | crate::store::EvidenceStatus::Processing)
+    );
+    status_stale || fingerprint_mismatch
 }
 
 fn path_is_under(path: &str, root: &str) -> bool {
@@ -843,16 +866,18 @@ pub async fn get_session_analysis(
 
     // Rows are the only way this command computes an analysis: every agent
     // is in the evidence cohort, so this always serves the worker's last
-    // published pass. A missing or not-yet-published row set reports a
-    // pending payload instead of re-parsing the transcript in-process, and
-    // nudges the worker so the gap closes on its own. Publishing a fresh
-    // pass is the worker's job — see its announce callback in
-    // `insights_worker::spawn` — so this command never caches one itself or
-    // emits `SESSION_ENTRY_CHANGED_EVENT` for it.
-    let (analysis, analysis_pending) =
+    // published pass — the last one that ever finished, even while a fresh
+    // pass is requeued or in flight over an actively-written session. A
+    // session that has never published at all reports a pending payload
+    // instead of re-parsing the transcript in-process, and nudges the
+    // worker so the gap closes on its own. Publishing a fresh pass is the
+    // worker's job — see its announce callback in `insights_worker::spawn`
+    // — so this command never caches one itself or emits
+    // `SESSION_ENTRY_CHANGED_EVENT` for it.
+    let (analysis, analysis_pending, analysis_stale) =
         match analysis::analysis_from_rows(&store, &key, &session_id, &agent) {
             Some(replayed) => {
-                nudge_if_evidence_stale(
+                let fingerprint_mismatch = nudge_if_evidence_stale(
                     &app,
                     &store,
                     kind,
@@ -861,11 +886,13 @@ pub async fn get_session_analysis(
                     wsl_distro.as_deref(),
                 )
                 .await;
-                (replayed, false)
+                let evidence_status = store.evidence(&key).ok().flatten().map(|row| row.status);
+                let stale = analysis_is_stale(evidence_status, fingerprint_mismatch);
+                (replayed, false, stale)
             }
             None => {
                 requeue_and_wake_worker(&app, &store, &key);
-                (analysis::SessionAnalysis::unavailable(), true)
+                (analysis::SessionAnalysis::unavailable(), true, false)
             }
         };
     let relations = resolve_lineage(&app, kind, &key, wsl_distro.as_deref()).await;
@@ -902,6 +929,7 @@ pub async fn get_session_analysis(
         started_at_epoch: analysis.started_at_epoch,
         source_path: analysis.source_path.clone(),
         analysis_pending,
+        analysis_stale,
     })
 }
 
@@ -941,22 +969,30 @@ pub async fn get_subagent_analysis(
         return Err(format!("unknown agent {agent}"));
     };
     // Rows are the only way this command computes an analysis — see the
-    // matching comment in `get_session_analysis`. A missing or not-yet-
-    // published row set reports a pending payload and nudges the worker,
-    // instead of re-parsing the sub-agent's own transcript in-process.
+    // matching comment in `get_session_analysis`. A parent session that has
+    // never published at all reports a pending payload and nudges the
+    // worker, instead of re-parsing the sub-agent's own transcript
+    // in-process.
     let store = app.state::<Store>();
     let parent_key = SessionKey::for_session(&agent, &parent_session_id, wsl_distro.as_deref());
-    let (analysis, analysis_pending) = match analysis::subagent_analysis_from_rows(
+    let (analysis, analysis_pending, analysis_stale) = match analysis::subagent_analysis_from_rows(
         &store,
         &parent_key,
         &parent_session_id,
         &subagent_id,
         &agent,
     ) {
-        Some(replayed) => (replayed, false),
+        Some(replayed) => {
+            let evidence_status = store
+                .evidence(&parent_key)
+                .ok()
+                .flatten()
+                .map(|row| row.status);
+            (replayed, false, analysis_is_stale(evidence_status, false))
+        }
         None => {
             requeue_and_wake_worker(&app, &store, &parent_key);
-            (analysis::SessionAnalysis::unavailable(), true)
+            (analysis::SessionAnalysis::unavailable(), true, false)
         }
     };
     Ok(SessionAnalysis {
@@ -978,6 +1014,7 @@ pub async fn get_subagent_analysis(
         started_at_epoch: analysis.started_at_epoch,
         source_path: analysis.source_path.clone(),
         analysis_pending,
+        analysis_stale,
     })
 }
 
@@ -1954,6 +1991,52 @@ mod tests {
     }
 
     #[test]
+    fn a_ready_or_unsupported_fence_with_no_fingerprint_mismatch_is_not_stale() {
+        assert!(!analysis_is_stale(
+            Some(crate::store::EvidenceStatus::Ready),
+            false
+        ));
+        assert!(!analysis_is_stale(
+            Some(crate::store::EvidenceStatus::Unsupported),
+            false
+        ));
+    }
+
+    #[test]
+    fn a_fence_left_by_a_requeue_or_a_running_pass_is_stale() {
+        // The served rows are the last winning publish's, but the evidence
+        // row itself is not terminal: a fresher pass is queued or running
+        // behind them.
+        assert!(analysis_is_stale(
+            Some(crate::store::EvidenceStatus::Pending),
+            false
+        ));
+        assert!(analysis_is_stale(
+            Some(crate::store::EvidenceStatus::Processing),
+            false
+        ));
+    }
+
+    #[test]
+    fn a_fingerprint_mismatch_is_stale_even_on_a_terminal_status() {
+        assert!(analysis_is_stale(
+            Some(crate::store::EvidenceStatus::Ready),
+            true
+        ));
+    }
+
+    #[test]
+    fn a_failed_pass_behind_an_earlier_publish_is_not_stale_on_its_own() {
+        // Nothing fresher is queued or running: the worker gave up. The
+        // served rows stay marked fresh until something requeues this row,
+        // at which point it reads `pending` again.
+        assert!(!analysis_is_stale(
+            Some(crate::store::EvidenceStatus::Failed),
+            false
+        ));
+    }
+
+    #[test]
     fn a_relative_path_never_reaches_the_platform_opener() {
         for path in [
             "",
@@ -2037,6 +2120,7 @@ mod tests {
             next_attempt_at_epoch: None,
             analyzed_at_epoch: Some(1),
             last_error: None,
+            published_fence: Some(0),
         }
     }
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -196,6 +196,13 @@ pub struct SessionAnalysis {
     ///
     /// [`SessionAnalysis::unavailable`]: crate::analysis::SessionAnalysis::unavailable
     pub analysis_pending: bool,
+    /// True when the fields above come from a published fence that a fresher
+    /// pass is already queued or running behind, or whose transcript has
+    /// since moved on. The data on screen is real, just not the latest —
+    /// unlike [`Self::analysis_pending`], which means there is nothing to
+    /// show yet. The view keeps polling and swaps in the fresh pass once the
+    /// worker publishes it.
+    pub analysis_stale: bool,
 }
 
 /// A protected directory the last pass declined to read, and how many working

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -71,7 +71,7 @@ const EVIDENCE_BY_KEY_SQL: &str = "SELECT environment_key, agent, session_id, st
             parser_revision, analyzer_revision, evidence_schema_revision,
             evidence_json, diagnostics_json, retry_count, claim_fence,
             claimed_at_epoch, lease_expires_at_epoch,
-            next_attempt_at_epoch, analyzed_at_epoch, last_error
+            next_attempt_at_epoch, analyzed_at_epoch, last_error, published_fence
        FROM session_evidence
       WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3";
 
@@ -1162,7 +1162,7 @@ impl Store {
                     evidence_json = ?10, diagnostics_json = ?11,
                     analyzed_at_epoch = ?12, retry_count = 0, last_error = NULL,
                     claimed_at_epoch = NULL, lease_expires_at_epoch = NULL,
-                    next_attempt_at_epoch = NULL
+                    next_attempt_at_epoch = NULL, published_fence = ?13
               WHERE evidence.environment_key = ?1
                 AND evidence.agent = ?2 AND evidence.session_id = ?3
                 AND evidence.status = 'processing' AND evidence.claim_fence = ?13
@@ -1251,24 +1251,21 @@ impl Store {
         )?)
     }
 
-    /// One session's published turn rows, or `None` when no complete,
-    /// published set of rows exists to read.
+    /// One session's last published turn rows, or `None` when this session
+    /// has never published.
     ///
     /// A claim bumps `session_evidence.claim_fence` and writes new rows
     /// under that fence while the last published pass's rows still sit
-    /// under the old fence. A publish that wins deletes every other
-    /// fence's rows and sets status `ready` or `unsupported`; a publish
-    /// that loses its race deletes only its own fence's rows and leaves the
-    /// earlier published fence in place. So `claim_fence` names a complete
-    /// set of rows when status is `ready` or `unsupported` — both are
-    /// terminal states a winning publish reached, so both name a complete
-    /// fence. `unsupported` means no detector was eligible for this source,
-    /// an insights verdict, not a parse-quality one; the rows and the
-    /// session_analysis record are still complete for it. With status
-    /// `pending`, `processing`, or `failed`, `claim_fence` may point at
-    /// partial or missing rows, and this method returns `None` for those.
-    /// The evidence lookup and the row query run under one lock, so a claim
-    /// racing this read cannot swap the fence in between them.
+    /// under `published_fence`. Only a winning publish moves
+    /// `published_fence`, and it always moves it to a complete row set —
+    /// see `EvidenceRow::published_fence`'s doc comment and the `v21`
+    /// migration in `store::schema` for the full contract. So a claim in
+    /// flight, a requeue back to `pending`, or a run that later fails
+    /// changes `status` and `claim_fence` but never touches
+    /// `published_fence`, and this method keeps serving the same rows it
+    /// served before that started. The evidence lookup and the row query
+    /// run under one lock, so a concurrent claim cannot swap
+    /// `published_fence` in between them.
     pub fn published_turn_rows(&self, key: &SessionKey) -> Result<Option<Vec<TurnRow>>> {
         let connection = self.lock();
         let Some(evidence) = connection
@@ -1281,16 +1278,13 @@ impl Store {
         else {
             return Ok(None);
         };
-        if !matches!(
-            evidence.status,
-            EvidenceStatus::Ready | EvidenceStatus::Unsupported
-        ) {
+        let Some(published_fence) = evidence.published_fence else {
             return Ok(None);
-        }
+        };
         Ok(Some(query_turn_rows(
             &connection,
             &turn_session_key(key),
-            evidence.claim_fence,
+            published_fence,
         )?))
     }
 
@@ -2130,6 +2124,7 @@ fn evidence_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EvidenceRow> {
         next_attempt_at_epoch: row.get(15)?,
         analyzed_at_epoch: row.get(16)?,
         last_error: row.get(17)?,
+        published_fence: row.get(18)?,
     })
 }
 

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -211,6 +211,12 @@ pub struct EvidenceRow {
     pub next_attempt_at_epoch: Option<i64>,
     pub analyzed_at_epoch: Option<i64>,
     pub last_error: Option<String>,
+    /// The claim fence a winning publish last stamped, or `None` when this
+    /// session has never published. Unlike `claim_fence`, a later reclaim or
+    /// requeue does not move this value — only the next winning publish
+    /// does. See the `v21` migration in `store::schema` for the full
+    /// contract.
+    pub published_fence: Option<i64>,
 }
 
 /// The current revisions for both transcript-derived projections.

--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -273,9 +273,10 @@ fn a_won_race_removes_turn_rows_from_every_superseded_fence_and_keeps_only_its_o
     );
 }
 
-/* R1: `Store::published_turn_rows` only exposes a complete, published
- * fence — never a claim in flight, never a superseded fence, and never a
- * status other than `ready` or `unsupported`. */
+/* R1: `Store::published_turn_rows` only ever exposes `published_fence`'s own
+ * rows — never a superseded fence, and never a claim in flight's partial
+ * rows, even while that claim moves `status` and `claim_fence` out from
+ * under it. */
 
 fn revisions() -> ProjectionRevisions {
     ProjectionRevisions {
@@ -309,8 +310,16 @@ fn published_turn_rows_returns_the_winning_pass_rows_in_order() {
     );
 }
 
+/// The whole point of `published_fence`: an actively-written session is
+/// reclaimed and requeued constantly, so its evidence `status` is almost
+/// never terminal at drilldown-open. Before `published_fence`,
+/// `published_turn_rows` gated on `status`, so this in-flight claim made it
+/// return `None` — the "Analyzing this session…" screen for minutes, even
+/// though the last publish's rows were still sitting right there. Now it
+/// keeps serving them: only the *next* winning publish moves
+/// `published_fence` (and only then does it delete this fence's rows).
 #[test]
-fn published_turn_rows_is_none_while_a_newer_claim_is_in_flight() {
+fn published_turn_rows_serves_the_last_published_fence_while_a_newer_claim_is_in_flight() {
     let store = store();
     let (record, claim) = claimed_projection(&store, "claim-in-flight", 100, 60);
     let key = record.key.clone();
@@ -322,12 +331,13 @@ fn published_turn_rows_is_none_while_a_newer_claim_is_in_flight() {
             .publish_projections(&record, None, &completion, &[])
             .unwrap()
     );
-    assert!(store.published_turn_rows(&key).unwrap().is_some());
+    let published = store.published_turn_rows(&key).unwrap();
+    assert!(published.is_some());
 
     // A newer pass claims the session: status flips to `processing` and the
-    // fence bumps, while the earlier published fence's rows are still on
-    // disk — only a publish deletes a superseded fence. This pass then
-    // writes some, but not all, of its own rows before this check runs.
+    // fence bumps, while `published_fence` still names the earlier, winning
+    // fence — only a publish moves it. This pass then writes some, but not
+    // all, of its own rows before this check runs.
     mark_evidence_pending_in(&store.lock(), &key).unwrap();
     let next_claim = store
         .claim_next_evidence(&["claude-code"], 200, 60)
@@ -339,8 +349,8 @@ fn published_turn_rows_is_none_while_a_newer_claim_is_in_flight() {
 
     assert_eq!(
         store.published_turn_rows(&key).unwrap(),
-        None,
-        "a claim in flight must never expose the old fence or a partial new one"
+        published,
+        "an in-flight claim's partial rows must never leak into a published_fence read"
     );
 }
 
@@ -384,31 +394,45 @@ fn published_turn_rows_is_none_when_failed() {
     assert_eq!(store.published_turn_rows(&key).unwrap(), None);
 }
 
-/// `Unsupported` is an insights verdict, not a parse-quality one: no
-/// detector was eligible for this source, but the rows and the
-/// `session_analysis` record a winning pass wrote are still complete.
-/// `published_turn_rows` must serve them exactly as it would for `Ready`,
-/// so the drilldown's rows-first read never falls back to a live parse for
-/// a session this terminal.
+/// For a terminal row (`ready` or `unsupported`), `published_fence` always
+/// equals `claim_fence`: a winning publish stamps both from the same
+/// completion in the same statement. So reading rows by `published_fence`
+/// alone serves exactly the rows the old status-gated read served for these
+/// two statuses — including `unsupported`, which is an insights verdict (no
+/// detector was eligible for this source), not a parse-quality one: the
+/// rows and the `session_analysis` record a winning pass wrote are still
+/// complete for it, same as `ready`.
 #[test]
-fn published_turn_rows_serves_rows_when_unsupported() {
+fn published_fence_equals_claim_fence_for_every_terminal_status() {
     let store = store();
-    let (record, claim) = claimed_projection(&store, "unsupported-status", 100, 60);
-    let key = record.key.clone();
-    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
-    writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Unsupported, "{}".into());
-    assert!(
-        store
-            .publish_projections(&record, None, &completion, &[])
-            .unwrap(),
-        "an unsupported completion still publishes"
-    );
-    assert_eq!(
-        store.published_turn_rows(&key).unwrap(),
-        Some(vec![turn_row(0), turn_row(1)]),
-        "status `unsupported` names a complete row projection, same as `ready`"
-    );
+    for status in [PublishedEvidence::Ready, PublishedEvidence::Unsupported] {
+        let session_id = format!("terminal-equivalence-{}", status.as_str());
+        let (record, claim) = claimed_projection(&store, &session_id, 100, 60);
+        let key = record.key.clone();
+        let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+        writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
+        let completion = evidence_completion(&claim, status, "{}".into());
+        assert!(
+            store
+                .publish_projections(&record, None, &completion, &[])
+                .unwrap(),
+            "a {} completion still publishes",
+            status.as_str()
+        );
+
+        let evidence = store.evidence(&key).unwrap().unwrap();
+        assert_eq!(
+            evidence.published_fence,
+            Some(evidence.claim_fence),
+            "a winning publish stamps published_fence and claim_fence together"
+        );
+        assert_eq!(
+            store.published_turn_rows(&key).unwrap(),
+            Some(vec![turn_row(0), turn_row(1)]),
+            "status `{}` names a complete row projection, same as `ready`",
+            status.as_str()
+        );
+    }
 }
 
 #[test]
@@ -454,5 +478,154 @@ fn a_second_publish_supersedes_the_first_in_published_turn_rows() {
         store.published_turn_rows(&key).unwrap().expect("ready"),
         vec![turn_row(0), turn_row(1)],
         "only the new pass's rows must come back, none of the superseded fence's"
+    );
+}
+
+/* R6: `published_fence` itself — a winning publish stamps it, a lost race
+ * and every other evidence transition leave it exactly where it was. */
+
+#[test]
+fn publish_projections_stamps_published_fence_with_the_completion_claim_fence() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "publish-stamps-fence", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    assert_eq!(
+        store.evidence(&key).unwrap().unwrap().published_fence,
+        Some(claim.claim_fence)
+    );
+}
+
+#[test]
+fn a_lost_race_does_not_stamp_published_fence() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "lost-race-no-fence-stamp", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0)]).unwrap();
+    advance_source_generation_past(&store, &key);
+    let completion =
+        evidence_completion(&claim, PublishedEvidence::Ready, "{\"lost\":true}".into());
+
+    assert!(
+        !store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    assert_eq!(store.evidence(&key).unwrap().unwrap().published_fence, None);
+}
+
+#[test]
+fn a_requeue_and_a_reclaim_leave_published_fence_intact() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "requeue-claim-preserve-fence", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+    let published_fence = store.evidence(&key).unwrap().unwrap().published_fence;
+    assert_eq!(published_fence, Some(claim.claim_fence));
+
+    // A fingerprint change requeues the session: status flips back to
+    // `pending`. Only the next winning publish may move `published_fence`.
+    mark_evidence_pending_in(&store.lock(), &key).unwrap();
+    assert_eq!(
+        store.evidence(&key).unwrap().unwrap().published_fence,
+        published_fence
+    );
+
+    // The worker reclaims it: status flips to `processing` and `claim_fence`
+    // bumps, while `published_fence` still names the earlier, winning fence.
+    let next_claim = store
+        .claim_next_evidence(&["claude-code"], 200, 60)
+        .unwrap()
+        .expect("reclaimable");
+    assert_eq!(next_claim.claim_fence, claim.claim_fence + 1);
+    assert_eq!(
+        store.evidence(&key).unwrap().unwrap().published_fence,
+        published_fence
+    );
+}
+
+#[test]
+fn fail_evidence_leaves_published_fence_intact() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "fail-preserve-fence", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+    let published_fence = store.evidence(&key).unwrap().unwrap().published_fence;
+
+    mark_evidence_pending_in(&store.lock(), &key).unwrap();
+    let next_claim = store
+        .claim_next_evidence(&["claude-code"], 200, 60)
+        .unwrap()
+        .expect("reclaimable");
+    assert!(
+        store
+            .fail_evidence(
+                &next_claim,
+                EvidenceFailure::Retry {
+                    next_attempt_at_epoch: 300,
+                },
+                "transient",
+            )
+            .unwrap()
+    );
+
+    assert_eq!(
+        store.evidence(&key).unwrap().unwrap().published_fence,
+        published_fence
+    );
+}
+
+/// The published-analysis carve-out this change exists for: a session
+/// requeued after a publish (an actively-written transcript, fingerprinted
+/// again) still serves its last published rows, not `None`, while the fresh
+/// pass is only queued and has not run yet.
+#[test]
+fn published_turn_rows_serves_the_last_published_fence_after_a_requeue() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "requeue-after-publish", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    mark_evidence_pending_in(&store.lock(), &key).unwrap();
+    assert_eq!(
+        store.evidence(&key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+
+    assert_eq!(
+        store.published_turn_rows(&key).unwrap(),
+        Some(vec![turn_row(0), turn_row(1)]),
+        "a requeue must not hide the last published pass's rows"
     );
 }

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -11,7 +11,7 @@
 /// Every migration, in order. The index of an entry plus one is the
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
-    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20,
+    V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -431,4 +431,20 @@ SELECT environment_key, agent, session_id
   FROM session
  WHERE agent IN ('cursor', 'copilot', 'cline', 'kiro', 'amp-code', 'antigravity', 'windsurf')
 ON CONFLICT(environment_key, agent, session_id) DO NOTHING;
+"#;
+
+/// v21 — the fence a row set was actually published under, tracked apart
+/// from `claim_fence`.
+///
+/// `claim_fence` moves the moment a session is reclaimed, even before the
+/// new pass writes or publishes anything. `published_fence` moves only when
+/// [`super::Store::publish_projections`] wins its race, so it always names a
+/// complete, still-on-disk row set: a claim in flight, or a requeue back to
+/// `pending`, leaves it exactly where the last winning publish put it. The
+/// backfill gives every session `publish_projections` has already reached
+/// its own last winning fence, the only fence whose rows are still on disk
+/// for a `ready` or `unsupported` row.
+const V21: &str = r#"
+ALTER TABLE session_evidence ADD COLUMN published_fence INTEGER;
+UPDATE session_evidence SET published_fence = claim_fence WHERE status IN ('ready','unsupported');
 "#;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -637,6 +637,7 @@ fn session_evidence_table_shape_is_stable() {
             "next_attempt_at_epoch",
             "analyzed_at_epoch",
             "last_error",
+            "published_fence",
         ]
     );
 }
@@ -2379,13 +2380,95 @@ async fn analysis_from_rows_serves_a_published_pass_without_reading_a_transcript
     assert!(replayed.source_path.is_none());
 }
 
-/// Before a worker pass has published anything, `analysis_from_rows` finds
-/// no complete row set and returns `None` — the command switch's own signal
-/// that this session's drilldown is still pending. The worker fills the gap
-/// on its own next pass; the command no longer re-parses the transcript
-/// in-process to answer this call.
+/// The published_fence carve-out this whole change exists for: an
+/// actively-written session is requeued on nearly every fingerprint check,
+/// which used to make `published_turn_rows` — and so `analysis_from_rows`
+/// — return `None` on every drilldown open, however many passes had
+/// already published. Requeuing flips `status` back to `pending` without
+/// touching `published_fence`, so the last winning pass's rows and analysis
+/// stay fully replayable while the fresh pass is only queued.
+#[tokio::test]
+async fn analysis_from_rows_still_serves_a_published_pass_after_a_requeue() {
+    let store = store();
+    let mut record = session("rows-replay-requeued", 1_000);
+    record.source_fingerprint = Some("sv1:rows-replay-requeued".into());
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    let store_for_runner = store.clone();
+    let runner = move |record: &SessionRecord,
+                       _signal: crate::analysis::PassSignal,
+                       claim_fence: i64| {
+        let row_store: Arc<dyn TurnRowStore> = Arc::new(FencedTurnRowStore::new(
+            store_for_runner.clone(),
+            record.key.clone(),
+            claim_fence,
+        ));
+        let mut pass = crate::analysis::evidence_pass_with_turn_rows(
+            &[antiburn_local::analysis::SessionInput {
+                agent: "claude".into(),
+                session_id: record.key.session_id.clone(),
+                source: antiburn_local::analysis::RawSource::Jsonl(
+                    r#"{"type":"assistant","timestamp":100,"message":{"id":"m","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":2,"output_tokens":3},"content":[]}}
+"#
+                    .into(),
+                ),
+            }],
+            &|| false,
+            Some(row_store),
+        );
+        pass.analysis.fingerprint = record
+            .source_fingerprint
+            .clone()
+            .unwrap_or_else(|| crate::analysis::MISSING_FINGERPRINT.into());
+        Box::pin(async move { pass }) as crate::insights_worker::PassFuture
+    };
+    assert!(
+        crate::insights_worker::process_next(
+            &store,
+            &crate::insights_worker::WorkerHandle::default(),
+            &|| 1_100,
+            &runner,
+            &|_| {},
+        )
+        .await
+        .unwrap()
+    );
+
+    // The transcript grew: the drilldown's own nudge requeues the session
+    // for a fresh pass, exactly as `commands::nudge_if_evidence_stale` does.
+    store.requeue_session_evidence(&record.key).unwrap();
+    assert_eq!(
+        store.evidence(&record.key).unwrap().unwrap().status,
+        EvidenceStatus::Pending
+    );
+
+    let replayed = crate::analysis::analysis_from_rows(
+        &store,
+        &record.key,
+        &record.key.session_id,
+        "claude-code",
+    )
+    .expect("a requeued session still replays its last published rows");
+
+    assert!(replayed.metrics.is_some());
+    assert_eq!(replayed.fingerprint, "sv1:rows-replay-requeued");
+}
+
+/// Before a worker pass has ever published anything, `published_fence` is
+/// `NULL`, so `analysis_from_rows` finds no row set and returns `None` — the
+/// command switch's own signal that this session's drilldown is still
+/// pending. The worker fills the gap on its own next pass; the command no
+/// longer re-parses the transcript in-process to answer this call. A claim
+/// in flight over an *already-published* session is a different case —
+/// see `published_turn_rows_serves_the_last_published_fence_while_a_newer_claim_is_in_flight`
+/// in `publish_tests`.
 #[test]
-fn analysis_from_rows_returns_none_before_rows_are_ready() {
+fn analysis_from_rows_returns_none_before_anything_was_ever_published() {
     let store = store();
     let (_, claim) = claimed_projection(&store, "rows-not-ready", 100, 60);
     assert_eq!(
@@ -3433,10 +3516,10 @@ fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pinned so this test fails loudly if a future migration is appended
     // without also being counted here — the number is the whole point of
     // the assertion, not an incidental detail.
-    assert_eq!(super::schema::MIGRATIONS.len(), 20);
+    assert_eq!(super::schema::MIGRATIONS.len(), 21);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 20);
+    assert_eq!(store.schema_version().unwrap(), 21);
 }
 
 #[test]

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -262,6 +262,11 @@ export interface SessionAnalysisPayload {
    * fills the gap on its own; the view should show an indexing state, not
    * an empty-transcript state. */
   analysisPending: boolean
+  /** True when the fields above come from a published fence that a fresher
+   * pass is already queued or running behind, or whose transcript has since
+   * moved on. The data on screen is real, just not the latest — unlike
+   * `analysisPending`, which means there is nothing to show yet. */
+  analysisStale: boolean
 }
 
 /**

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -123,6 +123,7 @@ describe("PopoverSession live analysis poll", () => {
     sourcePath: null,
     startedAtEpoch: null,
     analysisPending: false,
+    analysisStale: false,
     ...overrides,
   })
 
@@ -248,6 +249,41 @@ describe("PopoverSession live analysis poll", () => {
     await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 2)
 
     expect(getSubagentAnalysis).toHaveBeenCalledTimes(3)
+    unsubscribe()
+  })
+
+  it("re-loads on every tick while the analysis is stale, fingerprint unchanged", async () => {
+    getSessionAnalysis.mockResolvedValue({ ...usableAnalysis(), analysisStale: true })
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
+
+    // Unbounded, the same as a pending drilldown: a stale analysis keeps
+    // refetching every tick until the fresher pass the worker already
+    // queued or is already running actually publishes.
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(6)
+    unsubscribe()
+  })
+
+  it("stops re-loading once a stale analysis comes back fresh", async () => {
+    getSessionAnalysis
+      .mockResolvedValueOnce({ ...usableAnalysis(), analysisStale: true })
+      .mockResolvedValueOnce({ ...usableAnalysis(), analysisStale: true })
+      .mockResolvedValue(usableAnalysis())
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    session.openSession(subject)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
+
+    // 1 initial load + 2 stale re-loads, then the third re-load lands fresh
+    // and the poll goes back to comparing fingerprints alone.
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(3)
     unsubscribe()
   })
 

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -97,6 +97,19 @@ function isAnalysisPending(state: PopoverAnalysisState, key: string): boolean {
   )
 }
 
+/**
+ * Whether the settled analysis for `key` reports itself as stale: it comes
+ * from a published fence a fresher pass is already queued or running
+ * behind, or whose transcript has since moved on. The data on screen is
+ * real, so this does not gate what renders — it only keeps the poll running
+ * so the fresh pass swaps in once the worker publishes it.
+ */
+function isAnalysisStale(state: PopoverAnalysisState, key: string): boolean {
+  return (
+    state !== null && state.key === key && state.payload !== null && state.payload.analysisStale
+  )
+}
+
 export interface PopoverSnapshot {
   appVersion: string | null
   debugBuild: boolean
@@ -760,12 +773,13 @@ export class PopoverSession {
    * its own, and the next interval simply tries again.
    *
    * A pending analysis (the worker has not published rows for this session
-   * yet) re-loads on every tick, unbounded, whether or not the fingerprint
-   * moved: there is nothing to compare against until the worker's first
-   * pass lands, and that pass is what this poll is waiting for. That check
-   * runs before, and short-circuits, the bounded unavailable-analysis retry
-   * below, which answers a different question — a published pass that
-   * turned up nothing to show.
+   * yet) or a stale one (rows are published, but a fresher pass is queued or
+   * running behind them) re-loads on every tick, unbounded, whether or not
+   * the fingerprint moved: there is nothing newer to compare against until
+   * the worker's next pass lands, and that pass is what this poll is
+   * waiting for. That check runs before, and short-circuits, the bounded
+   * unavailable-analysis retry below, which answers a different question —
+   * a published pass that turned up nothing to show.
    */
   private tickAnalysisPoll = (): void => {
     if (this.analysisPollInFlight) return
@@ -783,7 +797,10 @@ export class PopoverSession {
           void this.refreshAnalysis()
           return
         }
-        if (isAnalysisPending(this.snapshot.analysis, key)) {
+        if (
+          isAnalysisPending(this.snapshot.analysis, key) ||
+          isAnalysisStale(this.snapshot.analysis, key)
+        ) {
           void this.refreshAnalysis()
           return
         }


### PR DESCRIPTION
## Problem

An actively-written session is requeued on nearly every fingerprint change (see `commands::nudge_if_evidence_stale`), so its evidence `status` is almost never `ready` at drilldown-open. `Store::published_turn_rows` gated on `status IN (ready, unsupported)`, so it returned `None` and the drilldown showed "Analyzing this session…" for minutes — a full worker pass over a huge transcript in a debug build — even though the previous publish's turn rows and `session_analysis` record were still physically present on disk. Requeuing only ever flips `status`; rows are deleted only by the *next successful publish*.

## Design: `published_fence`

Added `session_evidence.published_fence INTEGER` (nullable), backfilled from `claim_fence` for every row already `ready`/`unsupported` (v21 migration, `store/schema.rs`).

- **Publish**: `Store::publish_projections` now stamps `published_fence = completion.claim_fence` in the same UPDATE statement (and same transaction) that flips `status` and runs `delete_turn_rows_except_fence`. A lost race rolls the whole transaction back without a commit, so it never touches `published_fence` (pinned by `a_lost_race_does_not_stamp_published_fence`). `mark_evidence_pending_in` (requeue) and `claim_next_evidence` (claim) never reference the column at all, so a requeue or a reclaim leaves it exactly where the last winning publish put it (pinned by `a_requeue_and_a_reclaim_leave_published_fence_intact`, `fail_evidence_leaves_published_fence_intact`).
- **Read**: `Store::published_turn_rows` now serves rows for `published_fence` whenever it is non-`NULL`, regardless of current `status`. Querying by the stored fence is race-free under the store's connection lock: a claim in flight writes its own rows under a *newer* fence, and this read never reaches them until they are the ones actually published (pinned by `published_turn_rows_serves_the_last_published_fence_while_a_newer_claim_is_in_flight`). For a terminal row, `published_fence == claim_fence` always (both are stamped together), so behavior is byte-identical to the old status-gated read for `ready`/`unsupported` — pinned directly by `published_fence_equals_claim_fence_for_every_terminal_status`, which folds in what was `published_turn_rows_serves_rows_when_unsupported`.
- **Commands**: `analysis_from_rows`/`subagent_analysis_from_rows` (and so `get_session_analysis`/`get_subagent_analysis`) now succeed whenever a published fence + `session_analysis` record exist — not only when status is terminal. Added `analysisStale: bool` to the payload: true when the served fence's evidence status is `pending`/`processing` (a fresher pass is queued or running behind it), or when `nudge_if_evidence_stale`'s own fingerprint check finds the live transcript has already moved past what was served. `failed` is deliberately *not* stale on its own — the worker has given up, nothing fresher is queued or running, until something requeues it back to `pending`. `analysisPending` stays true only for the genuine "never published" case, which still drives `requeue_and_wake_worker` + the placeholder payload.
- **Frontend**: `ipc.ts` mirrors `analysisStale`; `PopoverSession`'s poll (`tickAnalysisPoll`) now refetches unconditionally while `analysisStale`, the same as it already does while `analysisPending` — the drilldown updates in place once the fresh publish lands. No visual change for the stale case (real data is already on screen); the "Analyzing…" copy remains reserved for the never-analyzed case.

## Consistency finding (item 6)

Verified rather than assumed: `publish_projections` upserts `session_analysis` *and* stamps `published_fence` (deleting every other fence's rows) inside the same transaction, under the same connection mutex. A losing race drops that whole transaction uncommitted, so `session_analysis` only ever changes on a transaction that also moves `published_fence` to name the very rows it leaves behind — the two are never updated independently. `analysis_from_rows` does take two separate lock acquisitions (`published_turn_rows` then `analysis`), so there is in principle a read-side window between them; but exploiting it requires an entire worker publish (claim → analyze → commit) to land inside the gap between two back-to-back function calls with no I/O between them. That window existed identically before this change (the old status-gated read had the same two-call shape) — this change does not widen it, since `published_fence` and `session_analysis` still only ever move together, in one commit, exactly as `claim_fence`/`status` and `session_analysis` always did.

## Carve-out

The pending screen (`analysisPending: true`, `requeue_and_wake_worker`) is now reserved strictly for a session that has never published anything — no fence, no record. Every other session, however stale its evidence queue state, serves its last published analysis immediately and polls for the fresher one in the background.

Composes with #305 (hygiene last-verdict): same ruling — serve the last completed verdict while a fresher pass recomputes — applied here to the drilldown's full analysis payload instead of the hygiene badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)