### PR TITLE
fix(desktop): reduce popover memory usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test the CI control plane
-        run: node --test scripts/build-tool-catalog.test.mjs scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/third-party-notices.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
+        run: node --test scripts/build-tool-catalog.test.mjs scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/mem-report.test.mjs scripts/third-party-notices.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
 
       # The drift guard runs here, not in a classified job. It reads the
       # contract, the stylesheets, and the popover window's own corner

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,12 @@ also runs `pnpm run slop` against the changed files. See
 [docs/debugging.md](docs/debugging.md) for isolated desktop profiles, logs, and
 developer tools.
 
+Popover memory changes also need a local macOS report. Follow
+[docs/runbooks/memory-reporting.md](docs/runbooks/memory-reporting.md). The live
+report requires macOS 13+, a logged-in GUI session, Steve 0.5.1 with
+Accessibility permission, and no other antiburn instance. CI runs only the pure
+Node report tests.
+
 ## Pull requests
 
 Describe the user impact, tests, privacy or performance effects, and any known

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -165,6 +165,8 @@ Frontend packages
 @reduxjs/toolkit@2.12.0 | MIT | https://redux-toolkit.js.org
 @standard-schema/spec@1.1.0 | MIT | https://standardschema.dev
 @standard-schema/utils@0.3.0 | MIT | https://github.com/standard-schema/standard-schema#readme
+@tanstack/react-virtual@3.14.10 | MIT | https://tanstack.com/virtual
+@tanstack/virtual-core@3.17.8 | MIT | https://tanstack.com/virtual
 @tauri-apps/api@2.11.1 | Apache-2.0 OR MIT | https://github.com/tauri-apps/tauri#readme
 @tauri-apps/plugin-dialog@2.7.2 | MIT OR Apache-2.0 | https://github.com/tauri-apps/plugins-workspace#readme
 @types/d3-array@3.2.2 | MIT | https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-array
@@ -1012,6 +1014,34 @@ Used by:
 MIT License
 
 Copyright (c) 2024 Fabian Hiller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+========================================
+
+Used by:
+  @tanstack/react-virtual@3.14.10
+  @tanstack/virtual-core@3.17.8
+
+MIT License
+
+Copyright (c) 2021-present Tanner Linsley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -87,6 +87,10 @@ pnpm --filter @antiburn/desktop exec tauri dev \
 Debug builds load the frontend from the Vite dev server, so `cargo` checks do
 not need a built bundle. Release packaging embeds `apps/desktop/dist`.
 
+The macOS-only [memory reporting runbook](../../docs/runbooks/memory-reporting.md)
+documents the probe-enabled release measurement, Steve setup, and result
+interpretation.
+
 `rusqlite` is compiled from bundled sources, so neither CI nor a checkout needs
 a system SQLite.
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-scroll-area": "1.2.18",
     "@radix-ui/react-switch": "1.3.7",
     "@radix-ui/react-tooltip": "1.2.16",
+    "@tanstack/react-virtual": "3.14.10",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-dialog": "2.7.2",
     "lucide-react": "1.34.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -34,6 +34,8 @@ distribution = []
 # Include the first-party analytics client. Source builds omit it unless the
 # builder selects this feature explicitly.
 analytics = ["dep:getrandom"]
+# Add local memory fixtures and WebContent PID diagnostics.
+memory-probe = []
 
 [[bin]]
 name = "antiburn"

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -170,9 +170,10 @@ pub fn hide_popover(app: tauri::AppHandle) {
 /// Clamped shell-side, so a webview bug cannot produce a window taller than the
 /// display or shorter than its own chrome. `animate` is the *webview's* call:
 /// the reduced-motion preference lives there, and a height change is motion.
+/// Returns `true` only when this request reaches its target.
 #[tauri::command]
-pub fn set_popover_height(app: tauri::AppHandle, height: f64, animate: Option<bool>) {
-    popover::set_height(&app, height, animate.unwrap_or(true));
+pub async fn set_popover_height(app: tauri::AppHandle, height: f64, animate: Option<bool>) -> bool {
+    popover::set_height(&app, height, animate.unwrap_or(true)).await
 }
 
 /// Keep the popover on screen while a native dialog it opened holds focus.
@@ -533,6 +534,10 @@ pub fn list_recent_sessions(
     app: tauri::AppHandle,
     window_days: Option<u32>,
 ) -> CommandResult<Vec<ActivityEntry>> {
+    #[cfg(feature = "memory-probe")]
+    if let Some(entries) = crate::memory_probe::synthetic_sessions()? {
+        return Ok(entries);
+    }
     let store = app.state::<Store>();
     let days = match window_days {
         Some(days) => days.clamp(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -60,6 +60,8 @@ mod hud;
 mod insights_ipc;
 mod insights_report;
 mod insights_worker;
+#[cfg(feature = "memory-probe")]
+mod memory_probe;
 mod notifications;
 mod nudges;
 mod onboarding;
@@ -89,6 +91,9 @@ mod window_readiness;
 use std::sync::Mutex;
 
 use tauri::{Manager, RunEvent, WindowEvent};
+
+#[cfg(all(feature = "memory-probe", feature = "distribution"))]
+compile_error!("memory-probe and distribution features cannot be enabled together");
 
 /// Handles of the app's background tasks, kept so it can abort them on exit
 /// rather than leaving them running against a store that is going away.
@@ -332,9 +337,11 @@ pub fn run() {
             Ok(())
         });
 
-    let app = builder
-        .build(tauri::generate_context!())
-        .expect("failed to build the antiburn application");
+    #[cfg(not(feature = "memory-probe"))]
+    let app = builder.build(tauri::generate_context!());
+    #[cfg(feature = "memory-probe")]
+    let app = builder.build(tauri::generate_context!("tauri.memory-probe.conf.json"));
+    let app = app.expect("failed to build the antiburn application");
     let mut retention_cleanup = retention_log_dir.map(|log_dir| {
         tauri::async_runtime::spawn_blocking(move || {
             match antiburn_trace::clean_old_logs(&log_dir, antiburn_trace::DEFAULT_LOG_MAX_AGE) {

--- a/apps/desktop/src-tauri/src/memory_probe.rs
+++ b/apps/desktop/src-tauri/src/memory_probe.rs
@@ -32,7 +32,7 @@ pub fn synthetic_sessions() -> Result<Option<Vec<ActivityEntry>>, String> {
         .transpose()
         .map_err(|error| format!("invalid {FIXTURE_SEED_ENV}: {error}"))?
         .unwrap_or(0);
-    generate_sessions(count, seed).map(Some)
+    generate_sessions(count, seed, time::OffsetDateTime::now_utc()).map(Some)
 }
 
 #[cfg(target_os = "macos")]
@@ -80,10 +80,18 @@ fn web_content_event(generation: u64, pid: u32) -> String {
     .expect("the WebContent diagnostic is serializable")
 }
 
-fn generate_sessions(count: usize, seed: u64) -> Result<Vec<ActivityEntry>, String> {
+fn generate_sessions(
+    count: usize,
+    seed: u64,
+    now: time::OffsetDateTime,
+) -> Result<Vec<ActivityEntry>, String> {
     if count > MAX_SESSIONS {
         return Err(format!("{SESSIONS_ENV} must not exceed {MAX_SESSIONS}"));
     }
+    let now = now
+        .replace_second(0)
+        .and_then(|value| value.replace_nanosecond(0))
+        .expect("zero is a valid second and nanosecond");
     let agents = ["claude-code", "codex", "gemini-cli"];
     let models = ["claude-opus-4-1", "gpt-5", "gemini-2.5-pro"];
     Ok((0..count)
@@ -91,8 +99,7 @@ fn generate_sessions(count: usize, seed: u64) -> Result<Vec<ActivityEntry>, Stri
             let shape = (index as u64).wrapping_add(seed) as usize;
             let agent = agents[shape % agents.len()];
             let model = models[shape % models.len()];
-            let day = (index / 40).min(13);
-            let hour = 23 - (index % 20);
+            let timestamp = now - time::Duration::minutes(index as i64 * 15);
             ActivityEntry {
                 agent: agent.to_string(),
                 session_id: format!("probe-{seed:08x}-{index:04}"),
@@ -101,7 +108,9 @@ fn generate_sessions(count: usize, seed: u64) -> Result<Vec<ActivityEntry>, Stri
                 } else {
                     format!("synthetic-repo-{}", shape % 7)
                 },
-                timestamp: format!("2026-08-{:02}T{:02}:00:00Z", 31 - day, hour),
+                timestamp: timestamp
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .expect("OffsetDateTime supports RFC 3339"),
                 is_active: index < 3,
                 surface: if shape.is_multiple_of(4) {
                     "ide_desktop"
@@ -142,16 +151,23 @@ mod tests {
 
     #[test]
     fn synthetic_rows_are_deterministic_full_shape_and_bounded() {
+        let now = time::OffsetDateTime::from_unix_timestamp(1_788_192_000).unwrap();
         assert_eq!(
-            serde_json::to_value(generate_sessions(225, 42).unwrap()).unwrap(),
-            serde_json::to_value(generate_sessions(225, 42).unwrap()).unwrap()
+            serde_json::to_value(generate_sessions(225, 42, now).unwrap()).unwrap(),
+            serde_json::to_value(generate_sessions(225, 42, now).unwrap()).unwrap()
         );
-        let rows = generate_sessions(225, 42).unwrap();
-        assert_eq!(rows.len(), 225);
+        let rows = generate_sessions(500, 42, now).unwrap();
+        let oldest = time::OffsetDateTime::parse(
+            &rows.last().unwrap().timestamp,
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 500);
+        assert!(now - oldest < time::Duration::days(7));
         assert!(rows.iter().any(|row| row.wsl_distro.is_some()));
         assert!(rows.iter().any(|row| row.has_fork_parent));
         assert!(rows.iter().all(|row| row.cost.is_some()));
-        assert!(generate_sessions(501, 0).is_err());
+        assert!(generate_sessions(501, 0, now).is_err());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/memory_probe.rs
+++ b/apps/desktop/src-tauri/src/memory_probe.rs
@@ -1,0 +1,171 @@
+//! Deterministic rows and read-only PID diagnostics for local memory reports.
+
+use antiburn_local::analysis::{ModelRun, SessionCost};
+use serde::Serialize;
+
+use crate::dto::ActivityEntry;
+
+const SESSIONS_ENV: &str = "ANTIBURN_MEMORY_SESSIONS";
+const FIXTURE_SEED_ENV: &str = "ANTIBURN_MEMORY_FIXTURE_SEED";
+const MAX_SESSIONS: usize = 500;
+const PREFIX: &str = "@antiburn-mem ";
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WebContentEvent<'a> {
+    event: &'static str,
+    window: &'a str,
+    generation: u64,
+    pid: u32,
+}
+
+pub fn synthetic_sessions() -> Result<Option<Vec<ActivityEntry>>, String> {
+    let Some(count) = std::env::var(SESSIONS_ENV).ok() else {
+        return Ok(None);
+    };
+    let count = count
+        .parse::<usize>()
+        .map_err(|error| format!("invalid {SESSIONS_ENV}: {error}"))?;
+    let seed = std::env::var(FIXTURE_SEED_ENV)
+        .ok()
+        .map(|value| value.parse::<u64>())
+        .transpose()
+        .map_err(|error| format!("invalid {FIXTURE_SEED_ENV}: {error}"))?
+        .unwrap_or(0);
+    generate_sessions(count, seed).map(Some)
+}
+
+#[cfg(target_os = "macos")]
+pub fn report_web_content(window: &tauri::WebviewWindow, generation: u64) {
+    use objc2::runtime::AnyObject;
+
+    let result = window.with_webview(move |webview| {
+        // SAFETY: Tauri supplies a live WKWebView on the main thread. This
+        // feature is excluded from distributed builds.
+        let pid = unsafe {
+            let view = &*webview.inner().cast::<AnyObject>();
+            let selector = objc2::sel!(_webProcessIdentifier);
+            let responds: bool = objc2::msg_send![view, respondsToSelector: selector];
+            if responds {
+                let value: i32 = objc2::msg_send![view, _webProcessIdentifier];
+                u32::try_from(value).ok().filter(|value| *value > 0)
+            } else {
+                None
+            }
+        };
+        if let Some(pid) = pid {
+            eprintln!("{}{}", PREFIX, web_content_event(generation, pid));
+        } else {
+            eprintln!("{PREFIX}{{\"event\":\"webcontent-unavailable\",\"window\":\"popover\",\"generation\":{generation}}}");
+        }
+    });
+    if let Err(error) = result {
+        eprintln!(
+            "{PREFIX}{{\"event\":\"webcontent-error\",\"window\":\"popover\",\"generation\":{generation},\"message\":{}}}",
+            serde_json::Value::String(error.to_string())
+        );
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn report_web_content(_window: &tauri::WebviewWindow, _generation: u64) {}
+
+fn web_content_event(generation: u64, pid: u32) -> String {
+    serde_json::to_string(&WebContentEvent {
+        event: "webcontent",
+        window: crate::popover::LABEL,
+        generation,
+        pid,
+    })
+    .expect("the WebContent diagnostic is serializable")
+}
+
+fn generate_sessions(count: usize, seed: u64) -> Result<Vec<ActivityEntry>, String> {
+    if count > MAX_SESSIONS {
+        return Err(format!("{SESSIONS_ENV} must not exceed {MAX_SESSIONS}"));
+    }
+    let agents = ["claude-code", "codex", "gemini-cli"];
+    let models = ["claude-opus-4-1", "gpt-5", "gemini-2.5-pro"];
+    Ok((0..count)
+        .map(|index| {
+            let shape = (index as u64).wrapping_add(seed) as usize;
+            let agent = agents[shape % agents.len()];
+            let model = models[shape % models.len()];
+            let day = (index / 40).min(13);
+            let hour = 23 - (index % 20);
+            ActivityEntry {
+                agent: agent.to_string(),
+                session_id: format!("probe-{seed:08x}-{index:04}"),
+                repo: if shape.is_multiple_of(9) {
+                    "deterministic-repository-with-a-long-display-name".to_string()
+                } else {
+                    format!("synthetic-repo-{}", shape % 7)
+                },
+                timestamp: format!("2026-08-{:02}T{:02}:00:00Z", 31 - day, hour),
+                is_active: index < 3,
+                surface: if shape.is_multiple_of(4) {
+                    "ide_desktop"
+                } else {
+                    "cli"
+                }
+                .to_string(),
+                wsl_distro: shape
+                    .is_multiple_of(11)
+                    .then(|| "Ubuntu-24.04".to_string()),
+                title: Some(if shape.is_multiple_of(8) {
+                    "Investigate deterministic renderer memory with a deliberately long synthetic title".to_string()
+                } else {
+                    format!("Synthetic coding session {index}")
+                }),
+                has_fork_parent: shape.is_multiple_of(13),
+                fork_child_count: u32::from(shape.is_multiple_of(17)) * 2,
+                cost: Some(SessionCost {
+                    total_usd: 0.25 + (shape % 100) as f64 / 10.0,
+                    input_usd: 0.1,
+                    output_usd: 0.1,
+                    cache_read_usd: 0.025,
+                    cache_write_usd: 0.025,
+                }),
+                models: vec![model.to_string()],
+                model_runs: vec![ModelRun {
+                    model: model.to_string(),
+                    thinking_mode: shape.is_multiple_of(5).then(|| "high".to_string()),
+                }],
+            }
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthetic_rows_are_deterministic_full_shape_and_bounded() {
+        assert_eq!(
+            serde_json::to_value(generate_sessions(225, 42).unwrap()).unwrap(),
+            serde_json::to_value(generate_sessions(225, 42).unwrap()).unwrap()
+        );
+        let rows = generate_sessions(225, 42).unwrap();
+        assert_eq!(rows.len(), 225);
+        assert!(rows.iter().any(|row| row.wsl_distro.is_some()));
+        assert!(rows.iter().any(|row| row.has_fork_parent));
+        assert!(rows.iter().all(|row| row.cost.is_some()));
+        assert!(generate_sessions(501, 0).is_err());
+    }
+
+    #[test]
+    fn web_content_diagnostic_has_one_prefixed_json_payload() {
+        let line = format!("{PREFIX}{}", web_content_event(7, 48122));
+        assert_eq!(line.lines().count(), 1);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&line[PREFIX.len()..]).unwrap(),
+            serde_json::json!({
+                "event": "webcontent",
+                "window": "popover",
+                "generation": 7,
+                "pid": 48122
+            })
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -585,20 +585,28 @@ pub fn note_sample(app: &AppHandle, kind: Kind) {
 /// platforms need no authorization. The gate self-skips for unbundled dev
 /// binaries, which cannot hold the signed entitlement.
 pub fn maybe_initialize_authorization(app: &AppHandle) {
-    let ready = app
-        .try_state::<Store>()
-        .and_then(|store| store.settings().ok())
-        .is_some_and(|settings| settings.onboarding_completed && settings.notifications_enabled);
-    if !ready {
-        return;
-    }
-    let init_app = app.clone();
-    if let Err(error) = app.run_on_main_thread(move || {
-        if let Some(gate) = init_app.try_state::<antiburn_nudge::NotificationGate>() {
-            gate.initialize_authorization();
+    #[cfg(feature = "memory-probe")]
+    let _ = app;
+
+    #[cfg(not(feature = "memory-probe"))]
+    {
+        let ready = app
+            .try_state::<Store>()
+            .and_then(|store| store.settings().ok())
+            .is_some_and(|settings| {
+                settings.onboarding_completed && settings.notifications_enabled
+            });
+        if !ready {
+            return;
         }
-    }) {
-        tracing::debug!(event = "nudge_authorization_dispatch_failed", %error);
+        let init_app = app.clone();
+        if let Err(error) = app.run_on_main_thread(move || {
+            if let Some(gate) = init_app.try_state::<antiburn_nudge::NotificationGate>() {
+                gate.initialize_authorization();
+            }
+        }) {
+            tracing::debug!(event = "nudge_authorization_dispatch_failed", %error);
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -328,6 +328,8 @@ pub struct PopoverState {
     /// Bumped by every height request, so an animation still in flight can see
     /// that a newer one superseded it and stop rather than fight it.
     resize_generation: AtomicU64,
+    /// Serializes resize ownership checks and window writes.
+    resize_apply_guard: Mutex<()>,
     /// While positive, losing focus does not hide the popover. Held around
     /// native dialogs (the folder picker) the popover itself opens: the dialog
     /// takes focus by design, and hiding would tear down the surface the
@@ -357,6 +359,7 @@ impl Default for PopoverState {
             anchor: Mutex::new(None),
             height: Mutex::new(DEFAULT_HEIGHT),
             resize_generation: AtomicU64::new(0),
+            resize_apply_guard: Mutex::new(()),
             focus_hold: AtomicU64::new(0),
             pinned: AtomicBool::new(false),
             renderer_generation: AtomicU64::new(0),
@@ -588,7 +591,13 @@ fn build_window(app: &AppHandle, generation: u64) -> tauri::Result<WebviewWindow
         .skip_taskbar(true)
         .visible(false)
         .focused(false)
-        .on_page_load(|window, payload| {
+        .on_page_load(move |window, payload| {
+            #[cfg(feature = "memory-probe")]
+            let finished = matches!(payload.event(), tauri::webview::PageLoadEvent::Finished);
+            #[cfg(feature = "memory-probe")]
+            if finished {
+                crate::memory_probe::report_web_content(&window, generation);
+            }
             window_lifecycle::trace_page_load::<PopoverState>(window, payload, LABEL);
         });
 
@@ -1161,66 +1170,83 @@ fn evict_if_due(app: &AppHandle, token: EvictionToken) {
 ///
 /// Clamped to [`MIN_HEIGHT`]..=[`MAX_HEIGHT`], animated unless the caller says
 /// otherwise, and re-anchored on the way so a popover hanging off a
-/// bottom-of-screen panel grows upward instead of off the display.
-pub fn set_height(app: &AppHandle, requested: f64, animate: bool) {
+/// bottom-of-screen panel grows upward instead of off the display. Returns
+/// `true` only when this request still owns the resize at its target.
+pub async fn set_height(app: &AppHandle, requested: f64, animate: bool) -> bool {
     let Some(state) = app.try_state::<PopoverState>() else {
-        return;
+        return false;
     };
-    let Some(window) = app.get_webview_window(LABEL) else {
-        return;
-    };
+    if app.get_webview_window(LABEL).is_none() {
+        return false;
+    }
 
     let target = clamp_height(requested);
-    let from = state.height();
-    // Sub-pixel requests are the view re-reporting the height it already has.
-    if (from - target).abs() < 1.0 {
-        return;
-    }
-
-    let generation = state.begin_resize();
-    if !animate {
-        state.set_height(target);
-        apply_height(&window, target);
-        return;
-    }
-
-    let app = app.clone();
-    tauri::async_runtime::spawn(async move {
-        let step = RESIZE_DURATION / RESIZE_STEPS;
-        for frame in 1..=RESIZE_STEPS {
-            tokio::time::sleep(step).await;
-            let Some(state) = app.try_state::<PopoverState>() else {
-                return;
-            };
-            // A newer request owns the window now.
-            if !state.resize_is_current(generation) {
-                return;
-            }
-            let progress = f64::from(frame) / f64::from(RESIZE_STEPS);
-            let height = from + (target - from) * ease_out(progress);
-            state.set_height(height);
-            let Some(window) = app.get_webview_window(LABEL) else {
-                return;
-            };
-            apply_height(&window, height);
+    let (from, generation) = {
+        let Ok(_guard) = state.resize_apply_guard.lock() else {
+            return false;
+        };
+        (state.height(), state.begin_resize())
+    };
+    // Reduced motion and sub-pixel corrections reach the exact target now.
+    if !animate || (from - target).abs() < 1.0 {
+        let Ok(_guard) = state.resize_apply_guard.lock() else {
+            return false;
+        };
+        if !state.resize_is_current(generation) {
+            return false;
         }
-    });
+        let Some(window) = app.get_webview_window(LABEL) else {
+            return false;
+        };
+        if !apply_height(&window, target) {
+            return false;
+        }
+        state.set_height(target);
+        return state.resize_is_current(generation);
+    }
+
+    let step = RESIZE_DURATION / RESIZE_STEPS;
+    for frame in 1..=RESIZE_STEPS {
+        tokio::time::sleep(step).await;
+        let Some(state) = app.try_state::<PopoverState>() else {
+            return false;
+        };
+        let Ok(_guard) = state.resize_apply_guard.lock() else {
+            return false;
+        };
+        // A newer request owns the window now.
+        if !state.resize_is_current(generation) {
+            return false;
+        }
+        let progress = f64::from(frame) / f64::from(RESIZE_STEPS);
+        let height = from + (target - from) * ease_out(progress);
+        let Some(window) = app.get_webview_window(LABEL) else {
+            return false;
+        };
+        if !apply_height(&window, height) {
+            return false;
+        }
+        state.set_height(height);
+    }
+    app.try_state::<PopoverState>()
+        .is_some_and(|state| state.resize_is_current(generation))
 }
 
 /// Size the window and put it back where its anchor says it belongs.
-fn apply_height(window: &WebviewWindow, height: f64) {
+fn apply_height(window: &WebviewWindow, height: f64) -> bool {
     if window.set_size(LogicalSize::new(WIDTH, height)).is_err() {
-        return;
+        return false;
     }
     let Some(state) = window.app_handle().try_state::<PopoverState>() else {
-        return;
+        return true;
     };
     let Some(anchor) = state.anchor() else {
         // Never opened, so there is nothing to anchor to yet; the next open
         // places it.
-        return;
+        return true;
     };
     let _ = place(window, anchor, WIDTH, height);
+    true
 }
 
 /// Hides the popover after it loses focus, remembering when it happened.
@@ -2001,7 +2027,7 @@ mod tests {
     }
 
     #[test]
-    fn a_newer_height_request_invalidates_the_animation_already_running() {
+    fn only_the_newest_height_request_can_report_completion() {
         let state = PopoverState::default();
         let first = state.begin_resize();
         assert!(state.resize_is_current(first));
@@ -2010,7 +2036,7 @@ mod tests {
         assert!(state.resize_is_current(second));
         assert!(
             !state.resize_is_current(first),
-            "the superseded animation must stop rather than fight the new one"
+            "a superseded request must report that it did not reach the target"
         );
     }
 

--- a/apps/desktop/src-tauri/tauri.memory-probe.conf.json
+++ b/apps/desktop/src-tauri/tauri.memory-probe.conf.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "antiburn-memory-probe",
+  "mainBinaryName": "antiburn",
+  "version": "0.2.0",
+  "identifier": "ai.antiburn.desktop.memory-probe",
+  "build": {
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "macOSPrivateApi": true,
+    "windows": [],
+    "security": {
+      "csp": "default-src 'self'; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost"
+    }
+  },
+  "bundle": {
+    "active": true,
+    "createUpdaterArtifacts": false
+  }
+}

--- a/apps/desktop/src/components/presentation/Tooltip.tsx
+++ b/apps/desktop/src/components/presentation/Tooltip.tsx
@@ -1,5 +1,16 @@
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
-import { useState, type ReactNode } from "react"
+import {
+  cloneElement,
+  createContext,
+  isValidElement,
+  useCallback,
+  useContext,
+  useState,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefCallback,
+} from "react"
 
 export interface TooltipProps {
   /** Tooltip body. Rich content is allowed — the surface sizes to it. */
@@ -16,21 +27,64 @@ export interface TooltipProps {
   interactive?: boolean
 }
 
-/**
- * A tooltip on the platform surface style (`.ui-tooltip`).
- *
- * Accessibility, dismissal, and collision handling come from Radix; the only
- * behavior added here is the optional click toggle, which has to suppress
- * Radix's pointer-down auto-dismiss or the click would open and immediately
- * close it.
- */
-export function Tooltip({
+export interface SharedTooltipRegistration {
+  label: ReactNode
+  side: NonNullable<TooltipProps["side"]>
+  delayMs: number
+}
+
+export interface SharedTooltipOwner {
+  register: (node: HTMLElement, registration: SharedTooltipRegistration) => () => void
+}
+
+export const SharedTooltipOwnerContext = createContext<SharedTooltipOwner | null>(null)
+
+function setRef<T>(ref: Ref<T> | undefined, value: T | null): void | (() => void) {
+  if (typeof ref === "function") return ref(value)
+  if (ref) ref.current = value
+}
+
+function SharedTooltip({
+  owner,
   label,
   children,
-  side = "top",
-  delayMs = 600,
-  interactive = false,
-}: TooltipProps) {
+  side,
+  delayMs,
+}: Required<Pick<TooltipProps, "label" | "children" | "side" | "delayMs">> & {
+  owner: SharedTooltipOwner
+}) {
+  const child = isValidElement(children)
+    ? (children as ReactElement<{
+        ref?: Ref<HTMLElement> | undefined
+        "data-shared-tooltip-trigger"?: string | undefined
+      }>)
+    : null
+  const childRef = child?.props.ref
+  const assignTriggerRef = useCallback<RefCallback<HTMLElement>>(
+    (node) => {
+      const childCleanup = setRef(childRef, node)
+      if (!node) return childCleanup
+      const unregister = owner.register(node, { label, side, delayMs })
+      return () => {
+        unregister()
+        if (childCleanup) childCleanup()
+        else setRef(childRef, null)
+      }
+    },
+    [childRef, delayMs, label, owner, side],
+  )
+
+  if (!child) throw new Error("Tooltip requires one element child")
+  return cloneElement(child, { ref: assignTriggerRef, "data-shared-tooltip-trigger": "" })
+}
+
+function StandaloneTooltip({
+  label,
+  children,
+  side,
+  delayMs,
+  interactive,
+}: Required<TooltipProps>) {
   const [open, setOpen] = useState(false)
 
   const rootProps = interactive ? { open, onOpenChange: setOpen } : {}
@@ -60,5 +114,36 @@ export function Tooltip({
         </TooltipPrimitive.Portal>
       </TooltipPrimitive.Root>
     </TooltipPrimitive.Provider>
+  )
+}
+
+/**
+ * A tooltip on the platform surface style (`.ui-tooltip`).
+ *
+ * Accessibility, dismissal, and collision handling come from Radix; the only
+ * behavior added here is the optional click toggle, which has to suppress
+ * Radix's pointer-down auto-dismiss or the click would open and immediately
+ * close it.
+ */
+export function Tooltip({
+  label,
+  children,
+  side = "top",
+  delayMs = 600,
+  interactive = false,
+}: TooltipProps) {
+  const owner = useContext(SharedTooltipOwnerContext)
+  if (owner && !interactive) {
+    return (
+      <SharedTooltip owner={owner} label={label} side={side} delayMs={delayMs}>
+        {children}
+      </SharedTooltip>
+    )
+  }
+
+  return (
+    <StandaloneTooltip label={label} side={side} delayMs={delayMs} interactive={interactive}>
+      {children}
+    </StandaloneTooltip>
   )
 }

--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -1,4 +1,12 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type * as InsightsIpc from "../../lib/insightsIpc"
@@ -14,9 +22,59 @@ vi.mock("../../lib/insightsIpc", async (importOriginal) => ({
 beforeEach(() => {
   getSessionHygiene.mockReset()
   getSessionHygiene.mockResolvedValue(null)
+
+  vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    return this.classList.contains("ui-scroll-viewport") ? 356 : 340
+  })
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    if (this.classList.contains("ui-scroll-viewport")) return 320
+    if (this.dataset.virtualKind === "heading") {
+      return this.querySelector(".sr-only") ? 0 : 28
+    }
+    if (this.dataset.virtualKind === "row") {
+      return this.textContent?.includes("Tall fixture") ? 120 : 72
+    }
+    return 0
+  })
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (
+    this: Element,
+  ) {
+    const element = this as HTMLElement
+    const viewport = element.classList.contains("ui-scroll-viewport")
+      ? element
+      : element.closest<HTMLElement>(".ui-scroll-viewport")
+    const measuredItem = element.closest<HTMLElement>("[data-index]")
+    const start = Number(measuredItem?.style.transform.match(/[-\d.]+/)?.[0] ?? 0)
+    const top =
+      viewport && !element.classList.contains("ui-scroll-viewport")
+        ? start - viewport.scrollTop
+        : 0
+    const height = element.classList.contains("ui-scroll-viewport")
+      ? element.offsetHeight
+      : (measuredItem?.offsetHeight ?? element.offsetHeight)
+    return {
+      x: 0,
+      y: top,
+      top,
+      left: 0,
+      right: element.offsetWidth,
+      bottom: top + height,
+      width: element.offsetWidth,
+      height,
+      toJSON: () => ({}),
+    }
+  })
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
 
 const NOW = new Date("2026-03-04T12:00:00.000Z")
 
@@ -46,6 +104,16 @@ function list(over: Partial<SessionListProps> = {}) {
     ...over,
   }
   return render(<SessionList {...props} />)
+}
+
+function entries(count: number): SessionListEntry[] {
+  return Array.from({ length: count }, (_, index) =>
+    entry({
+      sessionId: `session-${index}`,
+      title: `Fixture session ${index}`,
+      timestamp: new Date(NOW.getTime() - index * 1_000).toISOString(),
+    }),
+  )
 }
 
 describe("SessionList — rows", () => {
@@ -321,6 +389,309 @@ describe("SessionList — grouping", () => {
     })
     expect(screen.getByText("Inside")).toBeTruthy()
     expect(screen.queryByText("Outside")).toBeNull()
+  })
+})
+
+describe("SessionList — virtualization", () => {
+  it.each([225, 500])("bounds mounted rows for %i sessions", async (count) => {
+    list({ entries: entries(count), onOpenSession: vi.fn() })
+
+    await waitFor(() => {
+      const mountedRows = screen.getAllByRole("button")
+      expect(mountedRows.length).toBeGreaterThan(1)
+      expect(mountedRows.length).toBeLessThan(20)
+    })
+    expect(screen.getByText("Fixture session 0")).toBeTruthy()
+    expect(screen.queryByText(`Fixture session ${count - 1}`)).toBeNull()
+  })
+
+  it("measures variable row heights without overlap", async () => {
+    const { container } = list({
+      entries: [
+        entry({ sessionId: "normal", title: "Normal fixture", timestamp: at(0, 11) }),
+        entry({ sessionId: "tall", title: "Tall fixture", timestamp: at(0, 10) }),
+        entry({ sessionId: "after", title: "After fixture", timestamp: at(0, 9) }),
+      ],
+    })
+
+    await waitFor(() => {
+      const rows = [...container.querySelectorAll<HTMLElement>('[data-virtual-kind="row"]')]
+      expect(rows).toHaveLength(3)
+      const tall = rows.find((row) => row.textContent?.includes("Tall fixture"))!
+      const after = rows.find((row) => row.textContent?.includes("After fixture"))!
+      const tallStart = Number(tall.style.transform.match(/[-\d.]+/)?.[0])
+      const afterStart = Number(after.style.transform.match(/[-\d.]+/)?.[0])
+      expect(afterStart).toBeGreaterThanOrEqual(tallStart + tall.offsetHeight)
+    })
+  })
+
+  it("mounts the final row after scrolling to the end", async () => {
+    const { container } = list({ entries: entries(225), onOpenSession: vi.fn() })
+    const viewport = container.querySelector<HTMLElement>(".ui-scroll-viewport")!
+
+    viewport.scrollTop = 20_000
+    fireEvent.scroll(viewport)
+
+    await waitFor(() => {
+      expect(screen.getByText("Fixture session 224")).toBeTruthy()
+    })
+    expect(screen.queryByText("Fixture session 0")).toBeNull()
+    expect(screen.getAllByRole("button").length).toBeLessThan(20)
+  })
+
+  it("keeps the focused row mounted while the list scrolls", async () => {
+    const { container } = list({ entries: entries(225), onOpenSession: vi.fn() })
+    const firstRow = screen.getByRole("button", { name: /Fixture session 0/ })
+    const viewport = container.querySelector<HTMLElement>(".ui-scroll-viewport")!
+
+    firstRow.focus()
+    viewport.scrollTop = 20_000
+    fireEvent.scroll(viewport)
+
+    await waitFor(() => {
+      expect(screen.getByText("Fixture session 224")).toBeTruthy()
+    })
+    expect(firstRow).toBe(document.activeElement)
+    expect(screen.getAllByRole("button").length).toBeLessThan(20)
+  })
+
+  it("moves Tab focus into the next virtual range", async () => {
+    const { container } = list({ entries: entries(225), onOpenSession: vi.fn() })
+    const viewport = container.querySelector<HTMLElement>(".ui-scroll-viewport")!
+    Object.defineProperty(viewport, "scrollTo", {
+      value: ({ top }: ScrollToOptions) => {
+        viewport.scrollTop = top ?? 0
+        fireEvent.scroll(viewport)
+      },
+    })
+    const mountedRows = screen.getAllByRole("button")
+    const lastMounted = mountedRows.at(-1)!
+    const previousIndex = Number(
+      lastMounted.closest<HTMLElement>("[data-index]")?.dataset.index,
+    )
+    expect(
+      viewport.querySelector(`[data-virtual-kind="row"][data-index="${previousIndex + 1}"]`),
+    ).toBeNull()
+    lastMounted.focus()
+
+    expect(fireEvent.keyDown(lastMounted, { key: "Tab" })).toBe(false)
+
+    await waitFor(() => {
+      const focusedRow = document.activeElement?.closest<HTMLElement>("[data-index]")
+      expect(Number(focusedRow?.dataset.index)).toBeGreaterThan(previousIndex)
+    })
+  })
+
+  it("updates the pinned label from measured group headings", async () => {
+    const { container } = list({
+      entries: [
+        entry({ sessionId: "today", title: "Today fixture", timestamp: at(0) }),
+        entry({ sessionId: "yesterday", title: "Yesterday fixture", timestamp: at(1) }),
+      ],
+    })
+    const viewport = container.querySelector<HTMLElement>(".ui-scroll-viewport")!
+    const yesterdayHeading = screen.getByRole("heading", { name: "Yesterday" })
+    const headingItem = yesterdayHeading.closest<HTMLElement>("[data-index]")!
+
+    viewport.scrollTop = Number(headingItem.style.transform.match(/[-\d.]+/)?.[0])
+    fireEvent.scroll(viewport)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-pinned-group-label").textContent).toBe("Yesterday")
+    })
+  })
+
+  it("preserves the viewport callback ref cleanup", () => {
+    const cleanupRef = vi.fn()
+    const viewportRef = vi.fn((node: HTMLDivElement | null) => (node ? cleanupRef : undefined))
+    const { unmount } = list({ viewportRef })
+
+    expect(viewportRef).toHaveBeenCalledWith(expect.any(HTMLDivElement))
+    unmount()
+    expect(cleanupRef).toHaveBeenCalledOnce()
+  })
+})
+
+describe("SessionList — shared tooltips", () => {
+  it("mounts one owner for every populated list size and none for an empty list", async () => {
+    const { container, rerender } = list({ entries: entries(500) })
+
+    await waitFor(() =>
+      expect(container.querySelectorAll("[data-session-tooltip-owner]")).toHaveLength(1),
+    )
+    expect(container.querySelectorAll("[data-shared-tooltip-trigger]").length).toBeGreaterThan(
+      1,
+    )
+
+    rerender(<SessionList entries={[]} days={7} now={NOW} />)
+    expect(container.querySelectorAll("[data-session-tooltip-owner]")).toHaveLength(0)
+  })
+
+  it("shares rich status and cost content with fork, repository, and WSL labels", async () => {
+    getSessionHygiene.mockResolvedValueOnce([
+      {
+        evidenceState: "ready",
+        badges: [
+          { id: "sessionOverdepth", status: "finding", notAssessedReason: null },
+          { id: "modelOverthinking", status: "clean", notAssessedReason: null },
+          { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
+          { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+          { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+          { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+        ],
+      },
+    ])
+    const { container } = list({
+      entries: [
+        entry({
+          additionalRepos: ["avery/docs"],
+          hasForkParent: true,
+          forkChildCount: 2,
+          wslDistro: "Ubuntu-24.04",
+          cost: {
+            totalUsd: 2.4,
+            figureLabel: "Estimated cost",
+            models: ["claude-fable-5"],
+            breakdownRows: [{ label: "Output", usd: 1.25 }],
+          },
+        }),
+      ],
+    })
+    const status = await screen.findByLabelText("5 of 6 burn checks pass")
+    const cost = screen.getByLabelText("Estimated cost $2.40")
+    const fork = screen.getByLabelText("Forked from another session")
+    const repository = screen.getByText("avery/widgets +1")
+    const wsl = screen.getByLabelText("Found in Ubuntu-24.04 on Windows Subsystem for Linux")
+    const row = status.closest(".group")!
+
+    vi.useFakeTimers()
+
+    fireEvent.pointerOver(status)
+    act(() => vi.advanceTimersByTime(149))
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+    act(() => vi.advanceTimersByTime(1))
+    expect(document.querySelector(".ui-tooltip")?.textContent).toContain(
+      "Open the session for details",
+    )
+    expect(status.dataset.state).toBe("delayed-open")
+    expect(status.getAttribute("aria-describedby")).toBe(
+      document.querySelector(".ui-tooltip")?.id,
+    )
+    expect(row.querySelector('[data-state="delayed-open"]')).toBe(status)
+
+    fireEvent.pointerOut(status)
+    fireEvent.pointerOver(cost)
+    act(() => vi.advanceTimersByTime(150))
+    const costTooltip = document.querySelector<HTMLElement>(".ui-tooltip")!
+    expect(costTooltip.dataset.side).toBe("bottom")
+    expect(costTooltip.textContent).toContain("claude-fable-5")
+    expect(costTooltip.textContent).toContain("Output")
+
+    fireEvent.pointerOut(cost)
+    fireEvent.pointerOver(fork)
+    act(() => vi.advanceTimersByTime(500))
+    expect(document.querySelector(".ui-tooltip")?.textContent).toBe(
+      "Forked from another session",
+    )
+
+    fireEvent.pointerOut(fork)
+    fireEvent.pointerOver(repository)
+    act(() => vi.advanceTimersByTime(600))
+    expect(document.querySelector(".ui-tooltip")?.textContent).toBe("Also observed: avery/docs")
+
+    fireEvent.pointerOut(repository)
+    fireEvent.pointerOver(wsl)
+    act(() => vi.advanceTimersByTime(600))
+    expect(document.querySelector(".ui-tooltip")?.textContent).toBe(
+      "Found in Ubuntu-24.04 on Windows Subsystem for Linux",
+    )
+    expect(container.querySelectorAll("[data-session-tooltip-owner]")).toHaveLength(1)
+  })
+
+  it("dismisses and clears superseded timers without leaving stale trigger state", () => {
+    const { container, unmount } = list({
+      entries: [entry({ hasForkParent: true, repo: "avery/widgets", wslDistro: "Ubuntu" })],
+    })
+    const status = screen.getByLabelText("Computing session hygiene checks")
+    const fork = screen.getByLabelText("Forked from another session")
+    const repository = screen.getByText("avery/widgets")
+    const wsl = screen.getByLabelText("Found in Ubuntu on Windows Subsystem for Linux")
+    const viewport = container.querySelector<HTMLElement>(".ui-scroll-viewport")!
+    vi.useFakeTimers()
+
+    fireEvent.pointerOver(fork)
+    act(() => vi.advanceTimersByTime(499))
+    fireEvent.pointerOut(fork, { relatedTarget: repository })
+    fireEvent.pointerOver(repository, { relatedTarget: fork })
+    act(() => vi.advanceTimersByTime(101))
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+    expect(fork.dataset.state).toBe("closed")
+    fireEvent.scroll(viewport)
+    act(() => vi.advanceTimersByTime(499))
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+
+    fireEvent.pointerOver(repository)
+    act(() => vi.advanceTimersByTime(600))
+    expect(document.querySelector(".ui-tooltip")?.textContent).toBe("avery/widgets")
+
+    fireEvent.scroll(viewport)
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+    expect(repository.dataset.state).toBe("closed")
+
+    fireEvent.focus(status)
+    expect(document.querySelector(".ui-tooltip")?.textContent).toBe(
+      "Computing session hygiene checks",
+    )
+    fireEvent.blur(status)
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+
+    fireEvent.pointerOver(wsl)
+    act(() => vi.advanceTimersByTime(600))
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+    expect(wsl.dataset.state).toBe("closed")
+
+    fireEvent.pointerOver(repository)
+    unmount()
+    act(() => vi.runAllTimers())
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+  })
+
+  it("does not open a tooltip from a touch pointer", () => {
+    list({ entries: [entry({ hasForkParent: true })] })
+    const fork = screen.getByLabelText("Forked from another session")
+    vi.useFakeTimers()
+
+    fireEvent.pointerOver(fork, { pointerType: "touch" })
+    act(() => vi.runAllTimers())
+
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+    expect(fork.dataset.state).toBe("closed")
+  })
+
+  it("keeps an open rich tooltip through a list rerender", () => {
+    const props: SessionListProps = {
+      entries: [
+        entry({
+          cost: {
+            totalUsd: 2.4,
+            figureLabel: "Estimated cost",
+            models: ["claude-fable-5"],
+          },
+        }),
+      ],
+      days: 7,
+      now: NOW,
+    }
+    const { rerender } = render(<SessionList {...props} />)
+    const cost = screen.getByLabelText("Estimated cost $2.40")
+
+    fireEvent.focus(cost)
+    expect(document.querySelector(".ui-tooltip")?.textContent).toContain("claude-fable-5")
+    rerender(<SessionList {...props} />)
+
+    expect(document.querySelector(".ui-tooltip")?.textContent).toContain("claude-fable-5")
+    expect(cost.dataset.state).toBe("instant-open")
   })
 })
 

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -1,5 +1,6 @@
 import { GitBranchPlus, GitFork, SquareTerminal } from "lucide-react"
-import type { ReactNode } from "react"
+import { defaultRangeExtractor, useVirtualizer } from "@tanstack/react-virtual"
+import { useCallback, useRef, useState, type ReactNode } from "react"
 
 import { cn } from "../../lib/cn"
 import type { SessionHygienePayload } from "../../lib/insightsIpc"
@@ -20,6 +21,7 @@ import { Tooltip } from "../presentation/Tooltip"
 import { TruncatedText } from "../presentation/TruncatedText"
 import { WslOriginBadge } from "../presentation/WslOriginBadge"
 import { SessionStatusBar } from "./SessionStatusBar"
+import { SessionTooltipOwner } from "./SessionTooltipOwner"
 import { type SessionCostBadgeProps } from "./metrics/SessionCostBadge"
 import { ScrollPane } from "../ui/ScrollPane"
 import { countGroupedItems, groupActivityByDay } from "../activity/activityFeedGrouping"
@@ -101,6 +103,36 @@ function EmptySessionList({ title, description }: { title: string; description: 
       </div>
     </div>
   )
+}
+
+type GroupedSessionItem = ReturnType<
+  typeof groupActivityByDay<{
+    entry: SessionListEntry
+    at: string
+    isActive: boolean
+    key: string
+  }>
+>[number]["items"][number]
+
+type VirtualSessionItem =
+  | {
+      type: "heading"
+      key: string
+      groupIndex: number
+      groupLabel: string
+    }
+  | {
+      type: "row"
+      key: string
+      groupIndex: number
+      groupLabel: string
+      itemIndex: number
+      rowPosition: number
+      item: GroupedSessionItem
+    }
+
+function groupHeadingId(label: string): string {
+  return `activity-${label.replaceAll(" ", "-").toLowerCase()}`
 }
 
 interface SessionRowProps {
@@ -302,6 +334,25 @@ export function SessionList({
 
   const groups = groupActivityByDay(items, { days, ...(now ? { now } : {}) })
   const visibleCount = countGroupedItems(groups)
+  let rowPosition = 0
+  const virtualItems: VirtualSessionItem[] = groups.flatMap((group, groupIndex) => [
+    {
+      type: "heading" as const,
+      key: `heading:${group.label}`,
+      groupIndex,
+      groupLabel: group.label,
+    },
+    ...group.items.map((item, itemIndex) => ({
+      type: "row" as const,
+      key: `row:${item.key}`,
+      groupIndex,
+      groupLabel: group.label,
+      itemIndex,
+      rowPosition: ++rowPosition,
+      item,
+    })),
+  ])
+  const rowIndexes = virtualItems.flatMap((item, index) => (item.type === "row" ? [index] : []))
   const hygieneSessions = groups.flatMap((group) =>
     group.items.flatMap(({ entry }) =>
       entry.sessionId
@@ -321,12 +372,93 @@ export function SessionList({
     groups.map((group) => group.label),
     viewportRef,
   )
+  const scrollElementRef = useRef<HTMLDivElement | null>(null)
+  const [pendingFocusIndex, setPendingFocusIndex] = useState<number | null>(null)
+  // TanStack Virtual owns mutable measurement state, so the React Compiler cannot memoize this component.
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: virtualItems.length,
+    getScrollElement: () => scrollElementRef.current,
+    getItemKey: (index) => virtualItems[index]?.key ?? index,
+    estimateSize: (index) => (virtualItems[index]?.type === "heading" ? 28 : 88),
+    // Mount the initial overscan before the viewport ref attaches.
+    initialRect: { width: 0, height: 1 },
+    // Three items keep short wheel and keyboard moves mounted without retaining
+    // a large part of the session list.
+    overscan: 3,
+    rangeExtractor: (range) => {
+      const indexes = new Set(defaultRangeExtractor(range))
+
+      // Keep the few group headings mounted for semantic grouping and pinning.
+      virtualItems.forEach((item, index) => {
+        if (item.type === "heading") indexes.add(index)
+      })
+      if (pendingFocusIndex !== null) indexes.add(pendingFocusIndex)
+
+      const activeElement = document.activeElement
+      if (activeElement && scrollElementRef.current?.contains(activeElement)) {
+        const focusedItem = activeElement.closest<HTMLElement>("[data-index]")
+        const focusedIndex = Number(focusedItem?.dataset.index)
+        if (Number.isInteger(focusedIndex)) indexes.add(focusedIndex)
+      }
+
+      return [...indexes].sort((left, right) => left - right)
+    },
+  })
+  const measuredItems = virtualizer.getVirtualItems()
+  const measureAndRestoreFocus = useCallback(
+    (node: HTMLDivElement | null) => {
+      virtualizer.measureElement(node)
+      if (!node || Number(node.dataset.index) !== pendingFocusIndex) return
+      node.querySelector<HTMLElement>('[role="button"][tabindex="0"]')?.focus()
+      setPendingFocusIndex(null)
+    },
+    [pendingFocusIndex, virtualizer],
+  )
+  const moveVirtualFocus = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Tab" || event.altKey || event.ctrlKey || event.metaKey) return
+      const target = event.target instanceof Element ? event.target : null
+      const currentItem = target?.closest<HTMLElement>('[data-virtual-kind="row"]')
+      if (!currentItem || !target?.closest('[role="button"][tabindex="0"]')) return
+      const currentPosition = rowIndexes.indexOf(Number(currentItem.dataset.index))
+      const nextIndex = rowIndexes[currentPosition + (event.shiftKey ? -1 : 1)]
+      if (nextIndex === undefined) return
+      const nextRow = scrollElementRef.current?.querySelector<HTMLElement>(
+        `[data-virtual-kind="row"][data-index="${nextIndex}"]`,
+      )
+      event.preventDefault()
+      if (nextRow) {
+        nextRow.querySelector<HTMLElement>('[role="button"][tabindex="0"]')?.focus()
+        return
+      }
+      setPendingFocusIndex(nextIndex)
+      virtualizer.scrollToIndex(nextIndex, { align: "auto" })
+    },
+    [rowIndexes, virtualizer],
+  )
+  const assignVirtualViewportRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      scrollElementRef.current = node
+      const cleanup = assignViewportRef(node)
+      if (!cleanup) return
+      return () => {
+        scrollElementRef.current = null
+        cleanup()
+      }
+    },
+    [assignViewportRef],
+  )
 
   const resolvedEmptyTitle =
     emptyTitle ?? (days === 1 ? "No sessions today" : `No sessions in the last ${days} days`)
 
   return (
-    <section aria-label="Sessions" className="flex h-full min-h-0 flex-col pt-2">
+    <section
+      aria-label="Sessions"
+      className="flex h-full min-h-0 flex-col pt-2"
+      onKeyDownCapture={moveVirtualFocus}
+    >
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {visibleCount === 0 ? resolvedEmptyTitle : ""}
       </span>
@@ -345,53 +477,93 @@ export function SessionList({
 
       <ScrollPane
         topEdgeFade
-        viewportRef={assignViewportRef}
+        viewportRef={assignVirtualViewportRef}
         viewportClassName={cn("px-3", visibleCount === 0 && "[&>div]:h-full")}
       >
         {visibleCount === 0 ? (
           <EmptySessionList title={resolvedEmptyTitle} description={emptyDescription} />
         ) : (
-          <div className="space-y-2 pb-3">
-            {groups.map((group, groupIndex) => {
-              const headingId = `activity-${group.label.replaceAll(" ", "-").toLowerCase()}`
-              return (
-                <section key={group.label} aria-labelledby={headingId}>
-                  <h3
-                    ref={registerHeading(group.label)}
-                    id={headingId}
-                    className={
-                      groupIndex === 0
-                        ? "sr-only"
-                        : "py-1 type-caption font-medium tracking-wide uppercase text-label-tertiary"
-                    }
-                  >
-                    {group.label}
-                  </h3>
+          <SessionTooltipOwner>
+            <div>
+              <div
+                role="list"
+                className="relative"
+                style={{ height: virtualizer.getTotalSize() }}
+              >
+                {groups.map((group) => {
+                  const headingId = groupHeadingId(group.label)
+                  return (
+                    <section
+                      key={group.label}
+                      aria-labelledby={headingId}
+                      className="absolute inset-x-0 top-0"
+                    >
+                      {measuredItems.flatMap((measuredItem) => {
+                        const virtualItem = virtualItems[measuredItem.index]
+                        if (!virtualItem || virtualItem.groupLabel !== group.label) return []
 
-                  <div className="space-y-2">
-                    {group.items.map((item) => (
-                      <SessionRow
-                        key={item.key}
-                        entry={item.entry}
-                        hygiene={
-                          item.entry.sessionId
-                            ? sessionHygieneFor(hygieneBySession, {
-                                agent: item.entry.agent,
-                                sessionId: item.entry.sessionId,
-                                wslDistro: item.entry.wslDistro ?? null,
-                              })
-                            : INITIAL_SESSION_HYGIENE
-                        }
-                        {...(onOpenSession ? { onOpen: () => onOpenSession(item.entry) } : {})}
-                        {...(renderAgentIcon ? { renderAgentIcon } : {})}
-                        {...(wslIcon ? { wslIcon } : {})}
-                      />
-                    ))}
-                  </div>
-                </section>
-              )
-            })}
-          </div>
+                        return (
+                          <div
+                            key={virtualItem.key}
+                            ref={measureAndRestoreFocus}
+                            data-index={measuredItem.index}
+                            data-virtual-kind={virtualItem.type}
+                            {...(virtualItem.type === "row"
+                              ? {
+                                  role: "listitem" as const,
+                                  "aria-posinset": virtualItem.rowPosition,
+                                  "aria-setsize": visibleCount,
+                                }
+                              : {})}
+                            className={cn(
+                              "absolute top-0 left-0 w-full",
+                              ((virtualItem.type === "heading" && virtualItem.groupIndex > 0) ||
+                                (virtualItem.type === "row" && virtualItem.itemIndex > 0)) &&
+                                "pt-2",
+                            )}
+                            style={{ transform: `translateY(${measuredItem.start}px)` }}
+                          >
+                            {virtualItem.type === "heading" ? (
+                              <h3
+                                ref={registerHeading(group.label)}
+                                id={headingId}
+                                className={
+                                  virtualItem.groupIndex === 0
+                                    ? "sr-only"
+                                    : "py-1 type-caption font-medium tracking-wide uppercase text-label-tertiary"
+                                }
+                              >
+                                {group.label}
+                              </h3>
+                            ) : (
+                              <SessionRow
+                                entry={virtualItem.item.entry}
+                                hygiene={
+                                  virtualItem.item.entry.sessionId
+                                    ? sessionHygieneFor(hygieneBySession, {
+                                        agent: virtualItem.item.entry.agent,
+                                        sessionId: virtualItem.item.entry.sessionId,
+                                        wslDistro: virtualItem.item.entry.wslDistro ?? null,
+                                      })
+                                    : INITIAL_SESSION_HYGIENE
+                                }
+                                {...(onOpenSession
+                                  ? { onOpen: () => onOpenSession(virtualItem.item.entry) }
+                                  : {})}
+                                {...(renderAgentIcon ? { renderAgentIcon } : {})}
+                                {...(wslIcon ? { wslIcon } : {})}
+                              />
+                            )}
+                          </div>
+                        )
+                      })}
+                    </section>
+                  )
+                })}
+              </div>
+              <div className="h-3" aria-hidden="true" />
+            </div>
+          </SessionTooltipOwner>
         )}
       </ScrollPane>
     </section>

--- a/apps/desktop/src/components/session/SessionTooltipOwner.tsx
+++ b/apps/desktop/src/components/session/SessionTooltipOwner.tsx
@@ -1,0 +1,230 @@
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type PointerEvent,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefCallback,
+  type UIEvent,
+} from "react"
+
+import {
+  SharedTooltipOwnerContext,
+  type SharedTooltipOwner,
+  type SharedTooltipRegistration,
+} from "../presentation/Tooltip"
+
+interface ActiveTooltip extends SharedTooltipRegistration {
+  rect: DOMRect
+}
+
+type OwnedElementProps = {
+  children?: ReactNode
+  ref?: Ref<HTMLElement> | undefined
+  onPointerOver?: ((event: PointerEvent<HTMLElement>) => void) | undefined
+  onPointerOut?: ((event: PointerEvent<HTMLElement>) => void) | undefined
+  onPointerDown?: ((event: PointerEvent<HTMLElement>) => void) | undefined
+  onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined
+  onFocusCapture?: ((event: FocusEvent<HTMLElement>) => void) | undefined
+  onBlurCapture?: ((event: FocusEvent<HTMLElement>) => void) | undefined
+  onScrollCapture?: ((event: UIEvent<HTMLElement>) => void) | undefined
+}
+
+function setRef<T>(ref: Ref<T> | undefined, value: T | null): void | (() => void) {
+  if (typeof ref === "function") return ref(value)
+  if (ref) ref.current = value
+}
+
+function triggerFrom(target: EventTarget | null): HTMLElement | null {
+  return target instanceof Element
+    ? target.closest<HTMLElement>("[data-shared-tooltip-trigger]")
+    : null
+}
+
+export function SessionTooltipOwner({ children }: { children: ReactNode }) {
+  const registrations = useRef(new WeakMap<HTMLElement, SharedTooltipRegistration>())
+  const timer = useRef<number | null>(null)
+  const currentNode = useRef<HTMLElement | null>(null)
+  const [active, setActive] = useState<ActiveTooltip | null>(null)
+  const [open, setOpen] = useState(false)
+  const contentId = useId()
+
+  const clearTimer = useCallback(() => {
+    if (timer.current === null) return
+    window.clearTimeout(timer.current)
+    timer.current = null
+  }, [])
+
+  const close = useCallback(() => {
+    clearTimer()
+    const node = currentNode.current
+    if (node) {
+      node.dataset.state = "closed"
+      if (node.getAttribute("aria-describedby") === contentId) {
+        node.removeAttribute("aria-describedby")
+      }
+    }
+    currentNode.current = null
+    setOpen(false)
+    setActive(null)
+  }, [clearTimer, contentId])
+
+  const show = useCallback(
+    (node: HTMLElement, delayed: boolean) => {
+      const registration = registrations.current.get(node)
+      if (!registration) return
+
+      close()
+      currentNode.current = node
+      node.dataset.state = "closed"
+      setActive({ ...registration, rect: node.getBoundingClientRect() })
+
+      const openTooltip = () => {
+        if (currentNode.current !== node || !node.isConnected) return
+        timer.current = null
+        node.dataset.state = delayed ? "delayed-open" : "instant-open"
+        node.setAttribute("aria-describedby", contentId)
+        setOpen(true)
+      }
+
+      if (delayed && registration.delayMs > 0) {
+        timer.current = window.setTimeout(openTooltip, registration.delayMs)
+      } else {
+        openTooltip()
+      }
+    },
+    [close, contentId],
+  )
+
+  const register = useCallback<SharedTooltipOwner["register"]>(
+    (node, registration) => {
+      registrations.current.set(node, registration)
+      node.dataset.state = "closed"
+      if (currentNode.current === node) {
+        setActive({ ...registration, rect: node.getBoundingClientRect() })
+      }
+      return () => {
+        registrations.current.delete(node)
+        queueMicrotask(() => {
+          if (registrations.current.has(node)) return
+          if (currentNode.current === node) close()
+          delete node.dataset.state
+          if (node.getAttribute("aria-describedby") === contentId) {
+            node.removeAttribute("aria-describedby")
+          }
+        })
+      }
+    },
+    [close, contentId],
+  )
+
+  const owner = useMemo<SharedTooltipOwner>(() => ({ register }), [register])
+
+  const child = isValidElement(children) ? (children as ReactElement<OwnedElementProps>) : null
+  const childRef = child?.props.ref
+  const assignBoundaryRef = useCallback<RefCallback<HTMLElement>>(
+    (node) => {
+      const childCleanup = setRef(childRef, node)
+      if (!node) return childCleanup
+      const viewport = node.closest(".ui-scroll-viewport")
+      viewport?.addEventListener("scroll", close)
+      return () => {
+        viewport?.removeEventListener("scroll", close)
+        close()
+        if (childCleanup) childCleanup()
+        else setRef(childRef, null)
+      }
+    },
+    [childRef, close],
+  )
+
+  if (!child) throw new Error("SessionTooltipOwner requires one element child")
+
+  // React uses this callback only as the cloned element's ref.
+  // eslint-disable-next-line react-hooks/refs
+  const ownedChild = cloneElement(child, {
+    ref: assignBoundaryRef,
+    onPointerOver: (event) => {
+      child.props.onPointerOver?.(event)
+      if (event.defaultPrevented || event.pointerType === "touch") return
+      const node = triggerFrom(event.target)
+      if (!node || node === triggerFrom(event.relatedTarget)) return
+      show(node, true)
+    },
+    onPointerOut: (event) => {
+      child.props.onPointerOut?.(event)
+      if (event.defaultPrevented) return
+      const node = triggerFrom(event.target)
+      if (node && node !== triggerFrom(event.relatedTarget)) close()
+    },
+    onPointerDown: (event) => {
+      child.props.onPointerDown?.(event)
+      if (!event.defaultPrevented && triggerFrom(event.target)) close()
+    },
+    onClick: (event) => {
+      child.props.onClick?.(event)
+      if (!event.defaultPrevented && triggerFrom(event.target)) close()
+    },
+    onFocusCapture: (event) => {
+      child.props.onFocusCapture?.(event)
+      if (event.defaultPrevented) return
+      const node = triggerFrom(event.target)
+      if (node) show(node, false)
+    },
+    onBlurCapture: (event) => {
+      child.props.onBlurCapture?.(event)
+      if (event.defaultPrevented) return
+      const node = triggerFrom(event.target)
+      if (node && node !== triggerFrom(event.relatedTarget)) close()
+    },
+    onScrollCapture: (event) => {
+      child.props.onScrollCapture?.(event)
+      close()
+    },
+  })
+
+  return (
+    <SharedTooltipOwnerContext value={owner}>
+      {ownedChild}
+      <TooltipPrimitive.Provider>
+        <TooltipPrimitive.Root open={open} onOpenChange={(nextOpen) => !nextOpen && close()}>
+          <TooltipPrimitive.Trigger asChild>
+            <span
+              data-session-tooltip-owner=""
+              aria-hidden="true"
+              tabIndex={-1}
+              style={{
+                position: "fixed",
+                pointerEvents: "none",
+                opacity: 0,
+                top: active?.rect.top ?? 0,
+                left: active?.rect.left ?? 0,
+                width: active?.rect.width ?? 0,
+                height: active?.rect.height ?? 0,
+              }}
+            />
+          </TooltipPrimitive.Trigger>
+          <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+              id={contentId}
+              side={active?.side ?? "top"}
+              sideOffset={4}
+              collisionPadding={8}
+              className="ui-tooltip max-w-[220px] whitespace-normal"
+            >
+              {active?.label}
+            </TooltipPrimitive.Content>
+          </TooltipPrimitive.Portal>
+        </TooltipPrimitive.Root>
+      </TooltipPrimitive.Provider>
+    </SharedTooltipOwnerContext>
+  )
+}

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -817,11 +817,12 @@ export async function withPopoverHold<T>(action: () => Promise<T>): Promise<T> {
  *
  * The shell clamps the value, so this is a request rather than an instruction.
  * `animate` is decided here because the reduced-motion preference is a
- * webview-side media query and a height change is motion.
+ * webview-side media query and a height change is motion. The result is true
+ * only when this request reaches its target before a newer request replaces it.
  */
-export async function setPopoverHeight(height: number, animate: boolean): Promise<void> {
-  if (!hasShell()) return
-  await invoke("set_popover_height", { height, animate })
+export async function setPopoverHeight(height: number, animate: boolean): Promise<boolean> {
+  if (!hasShell()) return true
+  return invoke<boolean>("set_popover_height", { height, animate })
 }
 
 /** Resize the floating HUD around its measured panel. */

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -2,6 +2,38 @@ import "@testing-library/jest-dom/vitest"
 import { cleanup } from "@testing-library/react"
 import { afterEach } from "vitest"
 
+const nativeOffsetHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "offsetHeight",
+)?.get
+const nativeOffsetWidth = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "offsetWidth",
+)?.get
+
+// jsdom has no layout. Give virtual lists stable DOM geometry for component tests.
+Object.defineProperties(HTMLElement.prototype, {
+  offsetHeight: {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.classList.contains("ui-scroll-viewport")) return 600
+      if (this.dataset.virtualKind === "heading") {
+        return this.querySelector(".sr-only") ? 0 : 28
+      }
+      if (this.dataset.virtualKind === "row") return 72
+      return nativeOffsetHeight?.call(this) ?? 0
+    },
+  },
+  offsetWidth: {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.classList.contains("ui-scroll-viewport")) return 356
+      if (this.dataset.virtualKind) return 340
+      return nativeOffsetWidth?.call(this) ?? 0
+    },
+  },
+})
+
 afterEach(() => {
   cleanup()
 })

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -245,6 +245,8 @@ function mockCommands(overrides: Record<string, unknown> = {}) {
         return Promise.resolve([])
       case "get_storage_health":
         return Promise.resolve(HEALTHY_STORAGE)
+      case "set_popover_height":
+        return Promise.resolve(true)
       default:
         return Promise.resolve(null)
     }
@@ -1013,6 +1015,38 @@ describe("PopoverView — window behaviour", () => {
       .map(([, args]) => (args as { height: number }).height)
     expect(heights.length).toBeGreaterThan(0)
     expect(Math.max(...heights)).toBeLessThanOrEqual(780)
+  })
+
+  it("keeps Usage mounted and session rows absent until contraction completes", async () => {
+    let finishContraction: (() => void) | null = null
+    const baseInvoke = invoke.getMockImplementation()!
+    invoke.mockImplementation((command: string, args?: unknown) => {
+      if (
+        command === "set_popover_height" &&
+        (args as { height?: number } | undefined)?.height === 700
+      ) {
+        return new Promise<boolean>((resolve) => {
+          finishContraction = () => resolve(true)
+        })
+      }
+      return baseInvoke(command, args)
+    })
+    render(<PopoverView />)
+    await screen.findByText("Wire the tray popover")
+
+    fireEvent.click(await screen.findByRole("button", { name: "Codex at 40 percent" }))
+    expect(await screen.findByRole("heading", { name: "Usage" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Back to activity" }))
+
+    expect(screen.getByRole("heading", { name: "Usage" })).toBeInTheDocument()
+    expect(screen.queryByRole("region", { name: "Sessions" })).not.toBeInTheDocument()
+    expect(screen.queryByText("Wire the tray popover")).not.toBeInTheDocument()
+
+    await act(async () => {
+      finishContraction?.()
+      await Promise.resolve()
+    })
+    expect(await screen.findByText("Wire the tray popover")).toBeInTheDocument()
   })
 
   it("dismisses the popover on Escape", async () => {

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -162,15 +162,14 @@ export function PopoverView() {
     session.getSnapshot,
   )
 
-  const current = state.stack.at(-1) ?? null
+  const current = state.presentedSession
   const windowDays = state.settings?.activityWindowDays ?? DEFAULT_SETTINGS.activityWindowDays
 
   /* ---------------------------------------------------------------------
    * Window behaviour: which surface is showing, and focus on the way in
    * ------------------------------------------------------------------ */
 
-  const surface: PopoverSurface =
-    state.showUsage && state.usage ? "usage" : current ? "session" : "activity"
+  const surface: PopoverSurface = state.presentedSurface
 
   // Conditional render swaps the whole surface; without this, focus is left
   // on <body> and a keyboard or screen-reader user has to walk back in from
@@ -244,7 +243,7 @@ export function PopoverView() {
   function body() {
     // Usage sits over the list rather than in the session stack: it is a second
     // way of reading the same activity, not a place a session leads to.
-    if (state.showUsage && state.usage) {
+    if (surface === "usage" && state.usage) {
       return (
         <UsageView
           summary={state.usage}
@@ -254,7 +253,7 @@ export function PopoverView() {
       )
     }
 
-    if (current) {
+    if (surface === "session" && current) {
       // Traversal only applies to a session that is actually in the list; a
       // sub-agent or a fork opened from elsewhere has no neighbours.
       const position = current.subagent

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -8,12 +8,107 @@ import type { SessionSubject } from "./SessionPane"
 const getSessionAnalysis = vi.hoisted(() => vi.fn())
 const getSessionAnalysisFingerprint = vi.hoisted(() => vi.fn())
 const getSubagentAnalysis = vi.hoisted(() => vi.fn())
+const setPopoverHeight = vi.hoisted(() => vi.fn())
 
 // The analysis commands are overridden. All other wrappers keep their real
 // no-shell fallback because `hasShell()` is false outside Tauri.
 vi.mock("../../lib/ipc", async (importOriginal) => {
   const actual = await importOriginal<typeof Ipc>()
-  return { ...actual, getSessionAnalysis, getSessionAnalysisFingerprint, getSubagentAnalysis }
+  return {
+    ...actual,
+    getSessionAnalysis,
+    getSessionAnalysisFingerprint,
+    getSubagentAnalysis,
+    setPopoverHeight,
+  }
+})
+
+describe("PopoverSession surface presentation", () => {
+  const subject: SessionSubject = {
+    agent: "claude-code",
+    sessionId: "session-1",
+    wslDistro: null,
+  }
+
+  beforeEach(() => {
+    setPopoverHeight.mockReset()
+    setPopoverHeight.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("keeps Usage presented until the winning resize presents the requested session", async () => {
+    const pending: ((completed: boolean) => void)[] = []
+    setPopoverHeight.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          pending.push(resolve)
+        }),
+    )
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() => expect(session.getSnapshot().usage).not.toBeNull())
+    expect(pending).toHaveLength(1)
+    pending.shift()?.(true)
+    await Promise.resolve()
+
+    session.setShowUsage(true)
+    expect(session.getSnapshot().showUsage).toBe(true)
+    expect(pending).toHaveLength(1)
+    pending.shift()?.(true)
+    await vi.waitFor(() => expect(session.getSnapshot().presentedSurface).toBe("usage"))
+
+    session.setShowUsage(false)
+    session.openSession(subject)
+    expect(session.getSnapshot().presentedSurface).toBe("usage")
+
+    pending.shift()?.(true)
+    await Promise.resolve()
+    expect(session.getSnapshot().presentedSurface).toBe("usage")
+
+    pending.shift()?.(true)
+    await vi.waitFor(() => expect(session.getSnapshot().presentedSurface).toBe("session"))
+    unsubscribe()
+  })
+
+  it("presents equal-height navigation without waiting for native completion", () => {
+    setPopoverHeight.mockImplementation(() => new Promise<boolean>(() => {}))
+    const session = new PopoverSession()
+
+    session.openSession(subject)
+
+    expect(session.getSnapshot().presentedSurface).toBe("session")
+    expect(session.getSnapshot().presentedSession).toEqual(subject)
+  })
+
+  it("does not leave Usage presented after the winning contraction fails", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() => expect(session.getSnapshot().usage).not.toBeNull())
+
+    session.setShowUsage(true)
+    expect(session.getSnapshot().presentedSurface).toBe("usage")
+    setPopoverHeight.mockResolvedValue(false)
+    session.setShowUsage(false)
+    expect(session.getSnapshot().presentedSurface).toBe("usage")
+
+    await vi.waitFor(() => expect(session.getSnapshot().presentedSurface).toBe("activity"))
+    unsubscribe()
+  })
+
+  it("requests an immediate native resize when reduced motion is enabled", async () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true })),
+    )
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+
+    await vi.waitFor(() => expect(setPopoverHeight).toHaveBeenCalledWith(700, false))
+    unsubscribe()
+  })
 })
 
 /**

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -123,6 +123,10 @@ export interface PopoverSnapshot {
   usageRefreshing: boolean
   /** Whether the full Usage view is showing over the activity list. */
   showUsage: boolean
+  /** The surface whose native resize has completed and React can render. */
+  presentedSurface: PopoverSurface
+  /** The session retained while a request to present another surface is in flight. */
+  presentedSession: SessionSubject | null
   storage: StorageHealthPayload
   /** Banners the reader has waved away this run. */
   dismissed: readonly AttentionKind[]
@@ -229,6 +233,7 @@ export class PopoverSession {
   private started = false
   private generation = 0
   private analysisToken = 0
+  private resizeToken = 0
   /**
    * How many `refreshUsage` calls are currently in flight.
    *
@@ -278,6 +283,8 @@ export class PopoverSession {
     liveUsage: EMPTY_LIVE_USAGE,
     usageRefreshing: false,
     showUsage: false,
+    presentedSurface: "activity",
+    presentedSession: null,
     storage: HEALTHY_STORAGE,
     dismissed: [],
     stack: [],
@@ -910,9 +917,28 @@ export class PopoverSession {
   // Reduced motion is a webview preference, so the decision is made here and
   // the shell simply honours it.
   private syncHeight(): void {
-    void setPopoverHeight(popoverHeightFor(this.surface()), !prefersReducedMotion()).catch(
-      () => {},
-    )
+    const surface = this.surface()
+    const presentedSession = surface === "session" ? (this.snapshot.stack.at(-1) ?? null) : null
+    const targetHeight = popoverHeightFor(surface)
+    const token = ++this.resizeToken
+
+    // A taller or equal-height surface fits immediately. A shorter surface
+    // waits so its larger replacement stays mounted during the contraction.
+    if (targetHeight >= popoverHeightFor(this.snapshot.presentedSurface)) {
+      this.update({ presentedSurface: surface, presentedSession })
+    }
+
+    void setPopoverHeight(targetHeight, !prefersReducedMotion())
+      .then(() => {
+        if (token !== this.resizeToken || surface !== this.surface()) return
+        // A failed shell resize must not leave old navigation active forever.
+        // The shell has already stopped a failed or superseded animation.
+        this.update({ presentedSurface: surface, presentedSession })
+      })
+      .catch(() => {
+        if (token !== this.resizeToken || surface !== this.surface()) return
+        this.update({ presentedSurface: surface, presentedSession })
+      })
   }
 
   private update(change: Partial<PopoverSnapshot>): void {

--- a/docs/plans/issue-237-popover-memory-and-reporting.md
+++ b/docs/plans/issue-237-popover-memory-and-reporting.md
@@ -1,0 +1,459 @@
+# Issue #237: reduce the popover WebContent footprint
+
+**Issue:** [antiburn#237](https://github.com/antiburn/antiburn/issues/237)
+
+**Status:** Complete
+
+**Acceptance target:** Every independent release run with 225 deterministic
+session rows has a settled popover WebContent physical-footprint median below
+100 MiB.
+
+This plan replaces the earlier native scenario controller. The controller
+changed application startup and window behavior, then stalled while it tried to
+create and inspect WKWebViews from control threads. Those changes made the
+measurement less representative than normal application use.
+
+The new harness treats the application as a black box. It uses the macOS
+Accessibility API through [Steve](https://github.com/mikker/steve) to click the
+real menu-bar item and wait for visible content. The feature-gated native code
+only supplies deterministic rows and reports the exact WebContent PID.
+
+---
+
+## 1. Scope
+
+### Goals
+
+- [x] Measure shell and exact popover WebContent memory on macOS.
+- [x] Use a new isolated profile for each independent run.
+- [x] Keep raw samples and per-run medians in machine-readable reports.
+- [x] Drive the real menu-bar click, placement, readiness, hide, and quit paths.
+- [x] Capture a release baseline before changing `SessionList`.
+- [x] Bound mounted session rows to the viewport plus overscan.
+- [x] Replace per-row tooltip trees with one shared list tooltip.
+- [x] Keep the session list unmounted during native height contraction.
+- [x] Add no `useEffect`.
+- [x] Document operation, interpretation, privacy, and known limits.
+
+### Result
+
+The valid 225-row release baseline had renderer physical-footprint run medians
+from 125,191,008 to 126,649,184 bytes. The optimized report had run medians
+from 60,080,896 to 60,670,768 bytes, with no failures. The maximum run median
+fell by 52.1% and is below the 100 MiB acceptance target. The aggregate
+physical-footprint maximum run median fell from 156,288,920 to 89,573,200
+bytes.
+
+### Non-goals
+
+- Do not build a general desktop scenario protocol.
+- Do not automate Settings or transcript processing in this issue.
+- Do not add memory thresholds to pull-request CI.
+- Do not read a developer's normal profile or real transcripts.
+- Do not identify WebContent ownership by process name or parent PID.
+- Do not add unrestricted JavaScript or native window-control endpoints.
+- Do not claim Linux or Windows memory-report support.
+- Do not reduce the existing 500-row application input bound.
+- Do not redesign the visible session-row content.
+
+---
+
+## 2. Requirements
+
+The live memory report has these hard requirements:
+
+- macOS 13 or later.
+- A logged-in graphical session with the menu bar visible.
+- The maintained upstream Steve CLI, pinned to version 0.5.1 or a documented
+  compatible version.
+- Accessibility permission for Steve in System Settings > Privacy & Security >
+  Accessibility.
+- `/usr/bin/footprint` and `/bin/ps`, which ship with macOS.
+- No other running antiburn instance.
+
+Install Steve with:
+
+```bash
+brew tap mikker/tap
+brew install steve
+```
+
+The linked `salah2277/steve` repository is not the implementation dependency.
+The maintained MIT-licensed upstream is `mikker/steve`.
+
+CI runs only the pure Node parser and report tests. CI does not run live memory
+measurements because hosted runners do not provide a stable interactive macOS
+desktop, Accessibility permission, or comparable WebKit memory conditions.
+
+---
+
+## 3. Architecture
+
+### 3.1 External action layer
+
+`scripts/mem-report.mjs` launches the final `.app` through macOS Launch Services,
+resolves its exact shell PID, and invokes Steve as a separate command. Launch
+Services supplies the bundle privacy descriptions required by macOS.
+
+Steve performs only user-observable actions:
+
+```text
+elements --pid PID        Find the antiburn menu-bar item and its frame
+click-at X Y              Open or hide through the real tray callback
+wait --pid PID --text     Wait for the Sessions accessibility landmark
+click-at X Y --right      Open the native tray menu
+click --pid PID --title   Select Quit antiburn from that menu
+```
+
+`AXPress` does not activate this status item. The runner uses the item's reported
+frame with `steve click-at`. It does not call a native popover-opening helper.
+
+### 3.2 Minimal native feature
+
+The Cargo feature remains named `memory-probe`. Distribution builds cannot
+enable it.
+
+It has two responsibilities:
+
+1. Return deterministic full-shape `ActivityEntry` rows from
+   `list_recent_sessions` when `ANTIBURN_MEMORY_SESSIONS` is set.
+2. Emit one prefixed JSON line from the real popover page-load callback with the
+   exact `_webProcessIdentifier` and renderer generation.
+
+Example diagnostic line:
+
+```text
+@antiburn-mem {"event":"webcontent","window":"popover","generation":1,"pid":48122}
+```
+
+The feature does not create, show, hide, close, inspect, or retain windows. It
+does not start a protocol thread, read stdin, modify `RunEvent`, skip production
+subsystems, or evaluate renderer JavaScript.
+
+### 3.3 Why the PID hook remains
+
+WKWebView content runs outside the application process. macOS does not expose a
+reliable public API that maps a WebKit helper process back to its responsible
+application. Process names and PPID traversal can select another application's
+WebContent process.
+
+The feature-gated hook uses WebKit's private `_webProcessIdentifier` selector.
+It is acceptable only in local non-distributed measurement builds. If the
+selector is unavailable or returns zero, the run fails instead of guessing.
+
+### 3.4 Isolated profiles
+
+Each run receives a directory with redirected home and application paths:
+
+```text
+<profile-root>/popover/run-001-XXXXXX/
+  home/
+  temp/
+  data/
+  config/
+  state/
+```
+
+The runner sets `HOME`, `CFFIXED_USER_HOME`, `TMPDIR`, and the XDG paths. It also
+sets `ANTIBURN_ANALYTICS_ENABLED=false` and uses synthetic session rows.
+
+A separate unmeasured launch completes onboarding through Steve. The runner
+then stops that setup process after the settings write finishes. The measured
+launch reuses the isolated profile and runs normal application initialization.
+The runner never opens or deletes the normal release or debug profile.
+
+### 3.5 Measurement model
+
+`--runs` means independent profiles and application launches. `--samples` means
+repeated observations of one settled visible popover in one run. Samples from
+different runs are never flattened into one population.
+
+The runner records:
+
+- Shell RSS and physical footprint.
+- Exact popover WebContent RSS and physical footprint.
+- A deduplicated multi-PID application physical footprint.
+- Optional accessibility-tree node diagnostics.
+- Operating system, hardware, Git revision, dirty state, fixture count, and
+  fixture seed.
+
+Before and after every memory command, the runner verifies that the shell and
+WebContent PIDs still have the expected process-start identity. A changed or
+dead PID invalidates the run.
+
+---
+
+## 4. CLI Contract
+
+The issue acceptance command is:
+
+```bash
+node scripts/mem-report.mjs --release
+```
+
+Defaults:
+
+```text
+scenario: popover
+sessions: 225
+runs: 5 for --release, 1 otherwise
+samples: 5
+fixture seed: 237
+metric: both
+settle: 2s
+timeout: 30s
+profile retention: failure
+```
+
+Supported options:
+
+```text
+--release                   Build and measure an optimized .app
+--app <path>                Use an existing probe-enabled executable
+--no-build                  Require the existing executable
+--runs <count>              Independent profiles and launches
+--samples <count>           Samples of the settled popover
+--sample-interval <time>    Delay between samples
+--settle <time>             Delay after accessibility readiness
+--timeout <time>            Per-action timeout
+--metric <name>             rss, footprint, or both
+--sessions <count>          Deterministic rows, from 0 through 500
+--fixture-seed <integer>    Deterministic row-shape seed
+--steve <path>              Steve executable, default from PATH
+--format <name>             table, json, ndjson, or csv
+--output <path>             Report destination
+--summary <path>            Compact JSON summary destination
+--profile-root <path>       Parent for isolated profiles
+--keep-profile <policy>     never, failure, or always
+--quiet                     Hide successful child diagnostics
+--help                      Print usage
+```
+
+Durations require units such as `250ms` or `2s`.
+
+---
+
+## 5. Popover Run Contract
+
+Each run executes these observed phases:
+
+```text
+profile-created
+onboarding-started
+onboarding-complete
+measured-process-started
+shell-idle
+popover-open-requested
+popover-content-ready
+popover-visible-settled
+popover-hidden
+process-exited
+```
+
+The measured samples belong only to `popover-visible-settled`.
+
+The runner must prove:
+
+- Steve can identify one antiburn status item.
+- The status-item action opens a window anchored beside that item.
+- The application accessibility tree exposes `Sessions`.
+- The page-load diagnostic supplies one live WebContent PID.
+- The measured process identity remains stable for every sample.
+- The second status-item action hides the popover.
+- The application exits without a forced kill.
+
+The runner stops the unmeasured onboarding process after its settings write.
+For the measured process, it can use a forced kill only during failure cleanup.
+A forced measured-process cleanup marks the run failed.
+
+---
+
+## 6. Implementation Phases
+
+### Phase 1: Replace the plan and prove Steve control
+
+- [x] Replace the native-controller plan with this black-box plan.
+- [x] Install Steve 0.5.1 from the maintained upstream Homebrew tap.
+- [x] Grant and verify Accessibility permission.
+- [x] Confirm PID-scoped `steve elements` finds the framed status item.
+- [x] Confirm `steve click-at` opens the correctly anchored popover.
+- [x] Confirm Steve can wait for the `Sessions` landmark by shell PID.
+
+Exit gate: a manually launched normal popover opens and becomes accessible
+without any native probe action.
+
+### Phase 2: Reduce native instrumentation
+
+- [x] Delete the stdin protocol and control thread.
+- [x] Remove probe-specific startup, exit, subsystem, Settings, readiness, and
+      popover-control behavior.
+- [x] Keep deterministic rows with a 500-row bound.
+- [x] Add a page-load-only WebContent PID diagnostic.
+- [x] Keep `memory-probe` incompatible with `distribution`.
+- [x] Add focused Rust tests for fixture determinism and diagnostic encoding.
+
+Exit gate: a probe-enabled build follows the same window lifecycle as a normal
+build and emits the exact PID after a real status-item click.
+
+### Phase 3: Simplify the Node runner
+
+- [x] Remove protocol framing, request dispatch, generic scenarios, Settings,
+      transcript, DOM-control, worker, and eviction code.
+- [x] Make popover with 225 rows the default command.
+- [x] Add Steve discovery, permission, status-item, wait, and quit
+      adapters with JSON parsing and actionable failures.
+- [x] Add unmeasured onboarding preparation through accessible controls.
+- [x] Parse the prefixed PID diagnostic from application output.
+- [x] Keep safe profiles, memory parsers, summaries, formats, and cleanup.
+- [x] Verify process identity before and after every sample.
+- [x] Keep pure Node tests in CI.
+
+Exit gate: one debug run completes from profile creation through normal quit and
+produces shell, WebContent, and aggregate samples.
+
+### Phase 4: Document operation
+
+Create `docs/runbooks/memory-reporting.md` and update the desktop and contributor
+documentation.
+
+The documentation must include:
+
+- [x] macOS 13+ and logged-in GUI requirements.
+- [x] Steve upstream, pinned version, Homebrew install, and Accessibility setup.
+- [x] Why Linux, Windows, SSH-only, and headless CI are unsupported.
+- [x] The exact release and existing-build commands.
+- [x] Profile isolation, synthetic data, cleanup, and privacy guarantees.
+- [x] The native feature boundary and private WebKit PID selector.
+- [x] RSS, physical footprint, aggregate totals, runs, samples, and medians.
+- [x] Before-and-after comparison on the same machine and OS version.
+- [x] Troubleshooting for permissions, hidden status items, duplicate app
+      instances, status-item matching, missing PID diagnostics, and `footprint`.
+- [x] Why only pure parser/report tests run in CI.
+
+Exit gate: a maintainer unfamiliar with the code can install Steve, grant the
+required macOS permission, run the report, and interpret it from the docs.
+
+### Phase 5: Capture the pre-change baseline
+
+- [ ] Run zero-row diagnostic measurements.
+- [x] Run the 225-row release acceptance fixture for five independent runs.
+- [ ] Run a 500-row stress measurement.
+- [x] Keep canonical JSON reports outside temporary profiles.
+- [x] Record machine, macOS, WebKit/build, Git, and variance information.
+- [x] Confirm no optimization code changed before the baseline.
+
+Exit gate: the same commands and fixture seed can be repeated after the UI
+changes.
+
+### Phase 6: Virtualize `SessionList`
+
+- [x] Use the smallest suitable virtualization implementation or dependency.
+- [x] Flatten day headings and rows into one stable keyed virtual sequence.
+- [x] Measure variable row and heading heights.
+- [x] Use a small documented overscan.
+- [x] Preserve the 500-row input bound, grouping, pinned day, fade, scroll
+      restoration, click, Enter, Space, focus, and accessibility behavior.
+- [x] Add no `useEffect`.
+
+Tests must prove bounded mounting at 225 and 500 rows, first-to-last scrolling,
+non-overlapping variable rows, pinned-heading changes, restoration, and keyboard
+activation.
+
+### Phase 7: Use one shared list tooltip
+
+- [x] Reuse current status and cost tooltip content.
+- [x] Render row triggers without private tooltip roots.
+- [x] Delegate pointer and focus handling at the list boundary.
+- [x] Render one controlled tooltip surface.
+- [x] Preserve accessible names, descriptions, delay, placement, Escape, blur,
+      unmount, and surface-change behavior.
+- [x] Keep standalone tooltips outside `SessionList` unchanged.
+- [x] Add no `useEffect`.
+
+Tests must prove constant tooltip component count and correct content for every
+row tooltip kind.
+
+### Phase 8: Isolate the list from height animation
+
+- [x] Keep Usage mounted during the 780-to-700 contraction.
+- [x] Mount Activity only after the winning resize reaches its target.
+- [x] Ignore stale resize completions.
+- [x] Keep reduced-motion resizing immediate.
+- [x] Preserve warm renderer reuse and scroll restoration.
+
+Tests must prove that no session rows exist during contraction and that stale
+requests cannot mount the wrong surface.
+
+### Phase 9: Final measurement and validation
+
+- [ ] Repeat the exact zero, 225, and 500-row baseline commands.
+- [x] Use the same machine, OS, build profile, sample count, run count, and seed.
+- [x] Compare raw values, run medians, run peaks, and accessibility diagnostics.
+- [x] Confirm every 225-row run median is below 100 MiB.
+- [x] Run frontend format, lint, type checks, tests, and build.
+- [x] Run shell format, Clippy, and tests with and without `memory-probe`.
+- [x] Run Node tests, design drift, notices, secrets, and `aislop scan --changes`.
+
+Exit gate: issue #237 meets its target, or the retained reports identify the
+remaining measured blocker.
+
+---
+
+## 7. Report Interpretation
+
+The canonical JSON report contains configuration, platform details, phase
+timings, process identities, raw samples, per-run summaries, cross-run
+summaries, warnings, and failures.
+
+Per run and process role, report count, minimum, median, p95, maximum, mean, and
+standard deviation. Across runs, summarize run medians and run peaks.
+
+RSS is useful for quick diagnostics but includes shared resident pages in a
+simple sum. The acceptance value is the WebContent process `phys_footprint`
+reported by macOS `footprint`. The multi-PID aggregate is diagnostic and is not
+the sum of individual physical footprints.
+
+Results are comparable only on the same machine, macOS version, build profile,
+fixture, and measurement configuration. A different WebKit or operating-system
+build can change the baseline.
+
+---
+
+## 8. Risks
+
+| Risk                                                | Mitigation                                                                 |
+| --------------------------------------------------- | -------------------------------------------------------------------------- |
+| Steve lacks Accessibility permission                | Check before launch and print the exact System Settings path.              |
+| Steve cannot identify the status item               | Inspect PID-scoped `elements`; require one framed menu-bar item.           |
+| `AXPress` does not trigger Tauri                    | Fall back to a real coordinate click at the reported status-item frame.    |
+| Another antiburn instance owns the matched item     | Require no other instance and target all app waits by exact shell PID.     |
+| WebKit replaces the content process                 | Verify process identity around every sample and fail if it changes.        |
+| The private selector changes                        | Fail when no positive PID is emitted; never guess by process name.         |
+| `footprint` perturbs memory                         | Settle first, use a small fixed sample count, and compare identical runs.  |
+| Virtualization breaks keyboard or screen-reader use | Preserve semantic grouping and test focus and activation across ranges.    |
+| A tooltip targets a recycled row                    | Key active tooltip state to row and tooltip identity; close it on unmount. |
+| Height completion races                             | Give each resize request ownership and ignore stale completion.            |
+
+---
+
+## 9. Progress
+
+| Phase                   | Status      | Evidence                            |
+| ----------------------- | ----------- | ----------------------------------- |
+| 1. Plan and Steve spike | Complete    | Live status-item control proved     |
+| 2. Minimal native hooks | Complete    | Rust checks and focused tests pass  |
+| 3. Steve-based runner   | Complete    | End-to-end debug smoke passes       |
+| 4. Documentation        | Complete    | Runbook and contributor links added |
+| 5. Baseline             | Not started |                                     |
+| 6. Virtualized list     | Not started |                                     |
+| 7. Shared tooltip       | Not started |                                     |
+| 8. Height isolation     | Not started |                                     |
+| 9. Final validation     | Not started |                                     |
+
+Final values:
+
+| Measurement                                     |       Before |   After |                 Target |
+| ----------------------------------------------- | -----------: | ------: | ---------------------: |
+| 225-row maximum run-median WebContent footprint |      Pending | Pending |              < 100 MiB |
+| 225-row mounted session rows                    | 225 expected | Pending | Viewport plus overscan |
+| Shared list tooltip roots                       |      Pending | Pending |                      1 |

--- a/docs/runbooks/memory-reporting.md
+++ b/docs/runbooks/memory-reporting.md
@@ -1,0 +1,121 @@
+# Desktop memory reporting
+
+The memory report measures the real antiburn menu-bar popover with deterministic
+synthetic sessions. It uses normal application startup and tray behavior. The
+`memory-probe` Cargo feature adds only fixture rows and the exact popover WebKit
+content-process PID diagnostic.
+
+## Requirements
+
+Live reports require:
+
+- macOS 13 or later.
+- A logged-in desktop session. SSH-only and headless sessions are unsupported.
+- The maintained [mikker/steve](https://github.com/mikker/steve) CLI. The tested
+  version is 0.5.1.
+- Accessibility permission for Steve in **System Settings > Privacy & Security
+  > Accessibility**.
+- `/bin/ps` and `/usr/bin/footprint`, which macOS supplies.
+- No running antiburn or antiburn memory-probe instance.
+
+Install Steve from its maintained Homebrew tap:
+
+```bash
+brew tap mikker/tap
+brew install steve
+```
+
+Run `steve apps` once. If macOS denies access, add the installed Steve executable
+to Accessibility and run the command again.
+
+Linux, Windows, and headless CI cannot run this report because it uses macOS
+Accessibility, menu-bar geometry, WebKit process APIs, and `footprint`. CI runs
+only the platform-independent parser and report tests.
+
+## Run a report
+
+Run the standard release measurement from the repository root:
+
+```bash
+node scripts/mem-report.mjs --release \
+  --output /tmp/antiburn-memory.json \
+  --summary /tmp/antiburn-memory-summary.json
+```
+
+This builds a probe-enabled release `.app`, creates five independent profiles,
+and measures five settled samples per profile. The default fixture contains 225
+sessions.
+
+Reuse the existing debug or release bundle without rebuilding:
+
+```bash
+node scripts/mem-report.mjs --no-build --runs 1 --samples 1
+```
+
+Use `node scripts/mem-report.mjs --help` for fixture, timing, metric, format,
+profile-retention, and executable options.
+
+## Measurement flow
+
+For each run, the runner:
+
+1. Creates an isolated home, temporary directory, and XDG directories.
+2. Completes onboarding through Steve in an unmeasured setup launch.
+3. Starts a fresh measured `.app` through macOS Launch Services.
+4. Finds the app's menu-bar item through PID-scoped accessibility elements.
+5. Clicks the reported item coordinates and waits for the `Sessions` landmark.
+6. Reads the exact WebContent PID from the real page-load callback.
+7. Samples the shell and WebContent processes after the settle delay.
+8. Hides the popover and selects **Quit antiburn** from the native tray menu.
+
+The runner rejects another antiburn instance, ambiguous status items, missing
+PIDs, changed process start identities, and incomplete memory output. Failed
+profiles can be retained with `--keep-profile failure`.
+
+## Results
+
+RSS comes from `/bin/ps`. Physical footprint comes from `/usr/bin/footprint`.
+The aggregate physical footprint is the deduplicated total for the shell and
+WebContent process, not the sum of two independently reported shared regions.
+
+Each run reports individual samples and medians. The cross-run summary reports
+the distribution of run medians. Use the maximum run median for the issue 237
+acceptance gate.
+
+Compare before and after results only when these values are identical:
+
+- Machine and macOS build.
+- Release or debug profile.
+- Session count and fixture seed.
+- Settle delay, sample count, interval, and run count.
+- Metric selection.
+
+The isolated profiles contain synthetic session data only. The runner disables
+analytics and does not read a normal antiburn profile. Successful profiles are
+removed by default. Do not commit reports because they contain local paths,
+process IDs, timestamps, and machine-specific measurements.
+
+## Native boundary
+
+The `memory-probe` feature cannot be combined with `distribution`. It provides
+bounded deterministic `ActivityEntry` values and reads WKWebView's private
+`_webProcessIdentifier` selector after the real popover page loads. Distribution
+builds contain neither behavior.
+
+## Troubleshooting
+
+- **Steve reports a permission error:** Enable Steve in **System Settings >
+  Privacy & Security > Accessibility**. Restart Steve after changing permission.
+- **Another antiburn instance is reported:** Quit all normal, debug, and probe
+  instances. The runner intentionally refuses ambiguous ownership.
+- **No status item appears:** Make sure the macOS menu bar is visible and has
+  room for the antiburn item. The runner waits for one framed `AXMenuBarItem`.
+- **The `Sessions` wait times out:** Keep the desktop session unlocked and do
+  not click the app while the report runs.
+- **The WebContent PID is missing:** Rebuild without `--no-build`. Confirm the
+  build uses the `memory-probe` feature and the generated probe `.app`.
+- **`footprint` fails:** Run the command from a local interactive administrator
+  session. Use `--metric rss` only for diagnosis, not the physical-footprint
+  acceptance gate.
+- **A profile remains:** The report retained a failure for diagnosis. Use the
+  reported profile path only after confirming its marker file and ownership.

--- a/docs/runbooks/memory-reporting.md
+++ b/docs/runbooks/memory-reporting.md
@@ -38,6 +38,7 @@ Run the standard release measurement from the repository root:
 
 ```bash
 node scripts/mem-report.mjs --release \
+  --format json \
   --output /tmp/antiburn-memory.json \
   --summary /tmp/antiburn-memory-summary.json
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.16
         version: 1.2.16(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-virtual':
+        specifier: 3.14.10
+        version: 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tauri-apps/api':
         specifier: 2.11.1
         version: 2.11.1
@@ -1421,6 +1424,15 @@ packages:
     resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
@@ -4725,6 +4737,14 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
       vite: 8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@tanstack/react-virtual@3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@tauri-apps/api@2.11.1': {}
 

--- a/scripts/mem-report.mjs
+++ b/scripts/mem-report.mjs
@@ -1,0 +1,1435 @@
+#!/usr/bin/env node
+
+import { spawn as nodeSpawn } from "node:child_process";
+import { constants as fsConstants, existsSync } from "node:fs";
+import {
+  access,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { homedir, platform, release, tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+
+export const REPORT_SCHEMA_VERSION = 2;
+export const PROFILE_MARKER = ".antiburn-memory-profile-v2";
+export const DIAGNOSTIC_PREFIX = "@antiburn-mem ";
+export const STEVE_UPSTREAM = "https://github.com/mikker/steve";
+const MEMORY_BUNDLE_ID = "ai.antiburn.desktop.memory-probe";
+const LAUNCH_ENVIRONMENT_KEYS = [
+  "HOME",
+  "CFFIXED_USER_HOME",
+  "TMPDIR",
+  "XDG_DATA_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_STATE_HOME",
+  "ANTIBURN_ANALYTICS_ENABLED",
+  "ANTIBURN_MEMORY_SESSIONS",
+  "ANTIBURN_MEMORY_FIXTURE_SEED",
+  "RUST_BACKTRACE",
+  "RUST_LOG",
+];
+
+const PHASES = Object.freeze([
+  "profile-created",
+  "onboarding-started",
+  "onboarding-complete",
+  "measured-process-started",
+  "shell-idle",
+  "popover-open-requested",
+  "popover-content-ready",
+  "popover-visible-settled",
+  "popover-hidden",
+  "process-exited",
+]);
+
+function argumentError(message) {
+  const error = new Error(message);
+  error.code = "ERR_ARGUMENT";
+  return error;
+}
+
+export function parseDuration(value, name = "duration") {
+  const match = /^(\d+(?:\.\d+)?)(ms|s|m)$/.exec(String(value));
+  if (!match) throw argumentError(`${name} requires a unit: ms, s, or m`);
+  const factor = { ms: 1, s: 1_000, m: 60_000 }[match[2]];
+  const milliseconds = Number(match[1]) * factor;
+  if (!Number.isSafeInteger(milliseconds) || milliseconds <= 0) {
+    throw argumentError(
+      `${name} must be a positive whole number of milliseconds`,
+    );
+  }
+  return milliseconds;
+}
+
+function integer(
+  value,
+  name,
+  { minimum = 1, maximum = Number.MAX_SAFE_INTEGER } = {},
+) {
+  if (!/^-?\d+$/.test(String(value))) {
+    throw argumentError(`${name} must be an integer`);
+  }
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < minimum || number > maximum) {
+    throw argumentError(`${name} must be between ${minimum} and ${maximum}`);
+  }
+  return number;
+}
+
+const OPTION_DEFINITIONS = {
+  app: { key: "app" },
+  runs: { key: "runs", parse: (value) => integer(value, "--runs") },
+  samples: { key: "samples", parse: (value) => integer(value, "--samples") },
+  "sample-interval": {
+    key: "sampleIntervalMs",
+    parse: (value) => parseDuration(value, "--sample-interval"),
+  },
+  settle: {
+    key: "settleMs",
+    parse: (value) => parseDuration(value, "--settle"),
+  },
+  timeout: {
+    key: "timeoutMs",
+    parse: (value) => parseDuration(value, "--timeout"),
+  },
+  metric: { key: "metric" },
+  format: { key: "format" },
+  output: { key: "output" },
+  summary: { key: "summary" },
+  "profile-root": { key: "profileRoot" },
+  "keep-profile": { key: "keepProfile" },
+  sessions: {
+    key: "sessions",
+    parse: (value) =>
+      integer(value, "--sessions", { minimum: 0, maximum: 500 }),
+  },
+  "fixture-seed": {
+    key: "fixtureSeed",
+    parse: (value) => integer(value, "--fixture-seed", { minimum: 0 }),
+  },
+  steve: { key: "steve" },
+};
+
+export function parseArguments(arguments_) {
+  const options = {
+    release: false,
+    noBuild: false,
+    runs: 1,
+    samples: 5,
+    sampleIntervalMs: 250,
+    settleMs: 2_000,
+    timeoutMs: 30_000,
+    metric: "both",
+    format: "table",
+    keepProfile: "failure",
+    sessions: 225,
+    fixtureSeed: 237,
+    steve: "steve",
+    quiet: false,
+    help: false,
+  };
+  const seen = new Set();
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (!argument.startsWith("--") || argument === "--") {
+      throw argumentError(`unexpected argument: ${argument}`);
+    }
+    const [rawName, inlineValue] = argument.slice(2).split(/=(.*)/s, 2);
+    if (["release", "no-build", "quiet", "help"].includes(rawName)) {
+      if (inlineValue !== undefined) {
+        throw argumentError(`--${rawName} does not take a value`);
+      }
+      if (seen.has(rawName)) {
+        throw argumentError(`--${rawName} was provided more than once`);
+      }
+      seen.add(rawName);
+      options[
+        {
+          release: "release",
+          "no-build": "noBuild",
+          quiet: "quiet",
+          help: "help",
+        }[rawName]
+      ] = true;
+      continue;
+    }
+    const definition = OPTION_DEFINITIONS[rawName];
+    if (!definition) throw argumentError(`unknown option: --${rawName}`);
+    if (seen.has(rawName)) {
+      throw argumentError(`--${rawName} was provided more than once`);
+    }
+    const value = inlineValue ?? arguments_[++index];
+    if (value === undefined || value.startsWith("--")) {
+      throw argumentError(`--${rawName} requires a value`);
+    }
+    seen.add(rawName);
+    options[definition.key] = definition.parse
+      ? definition.parse(value)
+      : value;
+  }
+  if (options.help) return options;
+  if (options.release && !seen.has("runs")) options.runs = 5;
+  if (!new Set(["rss", "footprint", "both"]).has(options.metric)) {
+    throw argumentError("--metric must be rss, footprint, or both");
+  }
+  if (!new Set(["table", "json", "ndjson", "csv"]).has(options.format)) {
+    throw argumentError("--format must be table, json, ndjson, or csv");
+  }
+  if (!new Set(["never", "failure", "always"]).has(options.keepProfile)) {
+    throw argumentError("--keep-profile must be never, failure, or always");
+  }
+  if (options.app !== undefined) options.app = resolve(options.app);
+  if (options.app !== undefined && options.release) {
+    throw argumentError("--app conflicts with --release");
+  }
+  if (options.profileRoot !== undefined) {
+    options.profileRoot = validateProfileRoot(options.profileRoot);
+  }
+  if (options.output !== undefined) options.output = resolve(options.output);
+  if (options.summary !== undefined) options.summary = resolve(options.summary);
+  if (options.output !== undefined && options.output === options.summary) {
+    throw argumentError("--output and --summary must use different paths");
+  }
+  return options;
+}
+
+export function validateProfileRoot(
+  path,
+  { home = homedir(), temporary = tmpdir() } = {},
+) {
+  if (!isAbsolute(path)) {
+    throw argumentError("--profile-root must be an absolute path");
+  }
+  const root = resolve(path);
+  if (["/", resolve(home), resolve(temporary)].includes(root)) {
+    throw argumentError(`unsafe profile root: ${root}`);
+  }
+  const known = [
+    join(
+      resolve(home),
+      "Library",
+      "Application Support",
+      "ai.antiburn.desktop",
+    ),
+    join(resolve(home), ".config", "antiburn"),
+    join(resolve(home), ".local", "share", "antiburn"),
+  ];
+  if (
+    known.some(
+      (item) =>
+        root === item ||
+        item.startsWith(`${root}/`) ||
+        root.startsWith(`${item}/`),
+    )
+  ) {
+    throw argumentError(
+      `profile root overlaps an application profile: ${root}`,
+    );
+  }
+  return root;
+}
+
+export async function createRunProfile({ root, run }) {
+  const safeRoot = validateProfileRoot(
+    root ?? join(tmpdir(), "antiburn-memory-report"),
+  );
+  await mkdir(safeRoot, { recursive: true, mode: 0o700 });
+  const resolvedRoot = validateProfileRoot(await realpath(safeRoot));
+  const scenarioRoot = join(resolvedRoot, "popover");
+  await mkdir(scenarioRoot, { recursive: true, mode: 0o700 });
+  const stat = await lstat(scenarioRoot);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`unsafe profile directory: ${scenarioRoot}`);
+  }
+  const runPath = await mkdtemp(
+    join(scenarioRoot, `run-${String(run).padStart(3, "0")}-`),
+  );
+  await writeFile(join(runPath, PROFILE_MARKER), `${REPORT_SCHEMA_VERSION}\n`, {
+    flag: "wx",
+    mode: 0o600,
+  });
+  const directories = Object.fromEntries(
+    ["home", "temp", "data", "config", "state"].map((name) => [
+      name,
+      join(runPath, name),
+    ]),
+  );
+  await Promise.all(
+    Object.values(directories).map((path) => mkdir(path, { mode: 0o700 })),
+  );
+  return { path: runPath, ...directories };
+}
+
+export function profileEnvironment(profile, base = process.env) {
+  return {
+    ...base,
+    HOME: profile.home,
+    CFFIXED_USER_HOME: profile.home,
+    TMPDIR: profile.temp,
+    XDG_DATA_HOME: profile.data,
+    XDG_CONFIG_HOME: profile.config,
+    XDG_STATE_HOME: profile.state,
+    ANTIBURN_ANALYTICS_ENABLED: "false",
+  };
+}
+
+export async function removeRunProfile(path) {
+  const stat = await lstat(path);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`refusing to remove non-directory profile: ${path}`);
+  }
+  const resolved = await realpath(path);
+  const marker = await readFile(join(resolved, PROFILE_MARKER), "utf8").catch(
+    () => null,
+  );
+  if (marker !== `${REPORT_SCHEMA_VERSION}\n`) {
+    throw new Error(`refusing to remove unmarked profile: ${path}`);
+  }
+  await rm(resolved, { recursive: true });
+}
+
+export function shouldKeepProfile(policy, failed) {
+  return policy === "always" || (policy === "failure" && failed);
+}
+
+export function parseDiagnosticLine(line) {
+  if (!line.startsWith(DIAGNOSTIC_PREFIX)) return null;
+  let value;
+  try {
+    value = JSON.parse(line.slice(DIAGNOSTIC_PREFIX.length));
+  } catch (error) {
+    throw new Error(`invalid memory diagnostic JSON: ${error.message}`);
+  }
+  if (!value || typeof value.event !== "string") {
+    throw new Error("invalid memory diagnostic envelope");
+  }
+  if (
+    value.event === "webcontent" &&
+    (!Number.isSafeInteger(value.pid) ||
+      value.pid <= 0 ||
+      !Number.isSafeInteger(value.generation) ||
+      value.generation <= 0 ||
+      value.window !== "popover")
+  ) {
+    throw new Error("invalid WebContent diagnostic");
+  }
+  return value;
+}
+
+export class LineCapture {
+  #buffer = "";
+  #lines = [];
+  #offsets;
+
+  constructor(paths = []) {
+    this.#offsets = new Map(paths.map((path) => [path, 0]));
+  }
+
+  accept(chunk) {
+    this.#buffer += chunk;
+    for (;;) {
+      const newline = this.#buffer.indexOf("\n");
+      if (newline < 0) break;
+      const line = this.#buffer.slice(0, newline).replace(/\r$/, "");
+      this.#buffer = this.#buffer.slice(newline + 1);
+      this.#lines.push(line);
+    }
+  }
+
+  get lines() {
+    return [...this.#lines];
+  }
+
+  async #readFiles() {
+    for (const [path, offset] of this.#offsets) {
+      const contents = await readFile(path, "utf8").catch((error) => {
+        if (error.code === "ENOENT") return "";
+        throw error;
+      });
+      if (contents.length > offset) {
+        this.accept(contents.slice(offset));
+        this.#offsets.set(path, contents.length);
+      }
+    }
+  }
+
+  async waitFor(predicate, timeoutMs) {
+    const find = () => this.#lines.map(parseDiagnosticLine).find(predicate);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      await this.#readFiles();
+      const found = find();
+      if (found) return found;
+      await delay(50);
+    }
+    throw new Error(`memory diagnostic timed out after ${timeoutMs}ms`);
+  }
+}
+
+export function spawnApplication(
+  executable,
+  {
+    env = process.env,
+    spawn = nodeSpawn,
+    outputId = `${process.pid}-${performance.now()}`,
+  } = {},
+) {
+  const application = resolve(dirname(executable), "../..");
+  const outputRoot = env.TMPDIR ?? tmpdir();
+  const stdoutPath = join(outputRoot, `antiburn-memory-${outputId}-stdout.log`);
+  const stderrPath = join(outputRoot, `antiburn-memory-${outputId}-stderr.log`);
+  const environment = LAUNCH_ENVIRONMENT_KEYS.flatMap((key) =>
+    env[key] === undefined ? [] : ["--env", `${key}=${env[key]}`],
+  );
+  const child = spawn(
+    "/usr/bin/open",
+    [
+      "-W",
+      "-n",
+      "-o",
+      stdoutPath,
+      "--stderr",
+      stderrPath,
+      ...environment,
+      application,
+    ],
+    {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const capture = new LineCapture([stdoutPath, stderrPath]);
+  for (const stream of [child.stdout, child.stderr]) {
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => capture.accept(chunk));
+  }
+  return { child, capture };
+}
+
+export async function runCommand(
+  file,
+  arguments_,
+  { spawn = nodeSpawn, timeoutMs = 30_000, env = process.env } = {},
+) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(file, arguments_, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(
+        Object.assign(new Error(`${file} timed out after ${timeoutMs}ms`), {
+          stdout,
+          stderr,
+        }),
+      );
+    }, timeoutMs);
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) resolvePromise({ stdout, stderr });
+      else {
+        reject(
+          Object.assign(new Error(`${file} exited with ${code ?? signal}`), {
+            stdout,
+            stderr,
+            exitCode: code,
+            signal,
+          }),
+        );
+      }
+    });
+  });
+}
+
+export function parseSteveOutput(output) {
+  let envelope;
+  try {
+    envelope = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`Steve returned invalid JSON: ${error.message}`);
+  }
+  if (envelope?.ok !== true) {
+    throw new Error(envelope?.error ?? "Steve command failed");
+  }
+  return envelope.data;
+}
+
+async function runSteve(options, arguments_, timeoutMs = options.timeoutMs) {
+  let result;
+  try {
+    result = await runCommand(
+      options.steve,
+      [...arguments_, "--format", "json"],
+      { timeoutMs },
+    );
+  } catch (error) {
+    if (error.exitCode === 4) {
+      throw new Error(
+        "Steve needs macOS Accessibility permission. Enable it in System Settings > Privacy & Security > Accessibility.",
+      );
+    }
+    if (error.code === "ENOENT") {
+      throw new Error(
+        `Steve is required. Install it from ${STEVE_UPSTREAM} with: brew tap mikker/tap && brew install steve`,
+      );
+    }
+    throw Object.assign(
+      new Error(error.stderr?.trim() || error.stdout?.trim() || error.message),
+      { cause: error },
+    );
+  }
+  return parseSteveOutput(result.stdout);
+}
+
+export function findStatusItem(tree) {
+  const matches = [];
+  const visit = (node) => {
+    if (!node || typeof node !== "object") return;
+    const frame = node.frame;
+    if (
+      node.role === "AXMenuBarItem" &&
+      Number(frame?.width) > 0 &&
+      Number(frame?.height) > 0 &&
+      Number(frame?.y) < 40
+    ) {
+      matches.push(node);
+    }
+    for (const child of node.children ?? []) visit(child);
+  };
+  for (const root of Array.isArray(tree) ? tree : [tree]) visit(root);
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected one antiburn status item; found ${matches.length}. Close other antiburn instances and make the item visible.`,
+    );
+  }
+  return matches[0];
+}
+
+function frameCenter(item) {
+  return {
+    x: item.frame.x + item.frame.width / 2,
+    y: item.frame.y + item.frame.height / 2,
+  };
+}
+
+async function statusItem(options, pid) {
+  const deadline = Date.now() + options.timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    const tree = await runSteve(options, [
+      "elements",
+      "--pid",
+      String(pid),
+      "--depth",
+      "3",
+    ]);
+    try {
+      return findStatusItem(tree);
+    } catch (error) {
+      if (!error.message.includes("found 0")) throw error;
+      lastError = error;
+      await delay(100);
+    }
+  }
+  throw lastError ?? new Error("antiburn status item did not appear");
+}
+
+async function clickStatusItem(options, item, right = false) {
+  const point = frameCenter(item);
+  await runSteve(options, [
+    "click-at",
+    String(point.x),
+    String(point.y),
+    ...(right ? ["--right"] : []),
+  ]);
+}
+
+async function waitForText(options, pid, text) {
+  await runSteve(options, [
+    "wait",
+    "--pid",
+    String(pid),
+    "--text",
+    text,
+    "--timeout",
+    String(Math.ceil(options.timeoutMs / 1_000)),
+  ]);
+}
+
+async function waitForTextGone(options, pid, text) {
+  await runSteve(options, [
+    "wait",
+    "--pid",
+    String(pid),
+    "--text",
+    text,
+    "--gone",
+    "--timeout",
+    String(Math.ceil(options.timeoutMs / 1_000)),
+  ]);
+}
+
+async function waitForApp(options, pid) {
+  const deadline = Date.now() + options.timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      return await runSteve(
+        options,
+        ["resolve", "--pid", String(pid)],
+        Math.min(5_000, options.timeoutMs),
+      );
+    } catch (error) {
+      lastError = error;
+      await delay(200);
+    }
+  }
+  throw new Error(
+    `Steve could not attach to application ${pid}: ${lastError?.message ?? "not found"}`,
+  );
+}
+
+async function waitForLaunchedPid(options, excludedPids = new Set()) {
+  const deadline = Date.now() + options.timeoutMs;
+  while (Date.now() < deadline) {
+    const matches = (await runSteve(options, ["apps"])).filter(
+      (app) => app.bundleId === MEMORY_BUNDLE_ID && !excludedPids.has(app.pid),
+    );
+    if (matches.length === 1) return matches[0].pid;
+    if (matches.length > 1) {
+      throw new Error(
+        `expected one memory probe application; found ${matches.length}`,
+      );
+    }
+    await delay(100);
+  }
+  throw new Error("memory probe application did not launch");
+}
+
+async function existingProbePids(options) {
+  return new Set(
+    (await runSteve(options, ["apps"]))
+      .filter((app) => app.bundleId === MEMORY_BUNDLE_ID)
+      .map((app) => app.pid),
+  );
+}
+
+async function waitAndClick(options, pid, title) {
+  const deadline = Date.now() + options.timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const matches = await runSteve(
+        options,
+        ["find", "--pid", String(pid), "--title", title],
+        Math.min(5_000, options.timeoutMs),
+      );
+      const target = matches.find(
+        (item) =>
+          Number(item.frame?.width) > 0 && Number(item.frame?.height) > 0,
+      );
+      if (target) {
+        const point = frameCenter(target);
+        await runSteve(options, ["click-at", String(point.x), String(point.y)]);
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(200);
+  }
+  throw new Error(
+    `Steve could not click ${JSON.stringify(title)}: ${lastError?.message ?? "element not found"}`,
+  );
+}
+
+async function quitFromTray(options, pid, item) {
+  await clickStatusItem(options, item, true);
+  await runSteve(options, [
+    "click",
+    "--pid",
+    String(pid),
+    "--title",
+    "Quit antiburn",
+  ]);
+}
+
+export function parsePsRss(output, expectedPids = []) {
+  const rows = [];
+  for (const line of output.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const match = /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/.exec(line);
+    if (!match) {
+      throw Object.assign(new Error(`could not parse ps RSS output: ${line}`), {
+        rawOutput: output,
+      });
+    }
+    rows.push({
+      pid: Number(match[1]),
+      rssBytes: Number(match[2]) * 1024,
+      startedAt: match[3],
+    });
+  }
+  verifyExpectedPids(rows, expectedPids, output);
+  return rows;
+}
+
+function verifyExpectedPids(rows, expectedPids, rawOutput) {
+  const expected = [...new Set(expectedPids)].sort((a, b) => a - b);
+  const actual = rows.map((row) => row.pid).sort((a, b) => a - b);
+  if (
+    expected.length &&
+    (expected.length !== actual.length ||
+      expected.some((pid, index) => pid !== actual[index]))
+  ) {
+    throw Object.assign(
+      new Error(
+        `ps returned PIDs ${actual.join(", ")}; expected ${expected.join(", ")}`,
+      ),
+      { rawOutput },
+    );
+  }
+}
+
+function parseMemoryValue(number, unit = "B") {
+  const normalized = unit.toUpperCase().replace("IB", "B");
+  const factor = {
+    B: 1,
+    K: 2 ** 10,
+    KB: 2 ** 10,
+    M: 2 ** 20,
+    MB: 2 ** 20,
+    G: 2 ** 30,
+    GB: 2 ** 30,
+  }[normalized];
+  if (!factor) throw new Error(`unsupported memory unit: ${unit}`);
+  const bytes = Number(number.replaceAll(",", "")) * factor;
+  if (!Number.isSafeInteger(bytes) || bytes < 0) {
+    throw new Error(`invalid memory value: ${number} ${unit}`);
+  }
+  return bytes;
+}
+
+export function parseFootprint(output, expectedPids = []) {
+  const processes = [];
+  let current = null;
+  let aggregatePhysicalFootprintBytes = null;
+  for (const line of output.split(/\r?\n/)) {
+    const processMatch =
+      /^(?:\s*(?:Process|Footprint for process)\s*:?\s*.*?)?[^[]*\[(\d+)](?::.*Footprint:.*)?\s*$/i.exec(
+        line,
+      );
+    if (processMatch) {
+      current = { pid: Number(processMatch[1]), physicalFootprintBytes: null };
+      processes.push(current);
+      continue;
+    }
+    const physicalMatch =
+      /^\s*phys_footprint\s*[:=]\s*([\d,.]+)\s*([KMGT]?i?B|[KMGT])?\s*$/i.exec(
+        line,
+      );
+    if (physicalMatch && current) {
+      current.physicalFootprintBytes = parseMemoryValue(
+        physicalMatch[1],
+        physicalMatch[2] ?? "B",
+      );
+      continue;
+    }
+    const aggregateMatch =
+      /^\s*(?:(?:Summary\s+)?TOTAL(?:\s+physical footprint)?|Summary Footprint)\s*[:=]?\s*([\d,.]+)\s*([KMGT]?i?B|[KMGT])\s*$/i.exec(
+        line,
+      );
+    if (aggregateMatch) {
+      aggregatePhysicalFootprintBytes = parseMemoryValue(
+        aggregateMatch[1],
+        aggregateMatch[2],
+      );
+    }
+  }
+  const expected = [...new Set(expectedPids)];
+  const found = processes
+    .filter((item) => item.physicalFootprintBytes !== null)
+    .map((item) => item.pid);
+  if (
+    aggregatePhysicalFootprintBytes === null &&
+    expected.length === 1 &&
+    processes.length === 1 &&
+    processes[0].physicalFootprintBytes !== null
+  ) {
+    aggregatePhysicalFootprintBytes = processes[0].physicalFootprintBytes;
+  }
+  if (
+    expected.some((pid) => !found.includes(pid)) ||
+    aggregatePhysicalFootprintBytes === null
+  ) {
+    throw Object.assign(
+      new Error(
+        "could not parse all footprint process ledgers and the deduplicated TOTAL",
+      ),
+      { rawOutput: output },
+    );
+  }
+  return { processes, aggregatePhysicalFootprintBytes, rawOutput: output };
+}
+
+export async function processIdentities(
+  pids,
+  { command = runCommand, timeoutMs = 30_000 } = {},
+) {
+  const { stdout } = await command(
+    "/bin/ps",
+    ["-o", "pid=,rss=,lstart=", "-p", [...new Set(pids)].join(",")],
+    { timeoutMs },
+  );
+  return parsePsRss(stdout, pids).map(
+    ({ rssBytes: _, ...identity }) => identity,
+  );
+}
+
+export async function collectMemory(
+  processes,
+  metric,
+  { command = runCommand, timeoutMs = 30_000 } = {},
+) {
+  const pids = processes.map((item) => item.pid);
+  const result = {
+    processes: processes.map((process) => ({ ...process, memory: {} })),
+  };
+  if (metric === "rss" || metric === "both") {
+    const { stdout } = await command(
+      "/bin/ps",
+      ["-o", "pid=,rss=,lstart=", "-p", pids.join(",")],
+      { timeoutMs },
+    );
+    const rows = parsePsRss(stdout, pids);
+    for (const target of result.processes) {
+      const row = rows.find((item) => item.pid === target.pid);
+      if (row.startedAt !== target.startedAt) {
+        throw new Error(`process ${target.pid} start identity changed`);
+      }
+      target.memory.rssBytes = row.rssBytes;
+    }
+    result.rssSumBytes = result.processes.reduce(
+      (sum, item) => sum + item.memory.rssBytes,
+      0,
+    );
+  }
+  if (metric === "footprint" || metric === "both") {
+    const { stdout } = await command(
+      "/usr/bin/footprint",
+      ["-f", "bytes", ...pids.flatMap((pid) => ["-p", String(pid)])],
+      { timeoutMs },
+    );
+    const parsed = parseFootprint(stdout, pids);
+    for (const target of result.processes) {
+      target.memory.physicalFootprintBytes = parsed.processes.find(
+        (item) => item.pid === target.pid,
+      ).physicalFootprintBytes;
+    }
+    result.aggregatePhysicalFootprintBytes =
+      parsed.aggregatePhysicalFootprintBytes;
+  }
+  const after = await processIdentities(pids, { command, timeoutMs });
+  for (const process of processes) {
+    if (
+      after.find((item) => item.pid === process.pid)?.startedAt !==
+      process.startedAt
+    ) {
+      throw new Error(
+        `process ${process.pid} identity changed during sampling`,
+      );
+    }
+  }
+  return result;
+}
+
+export function statistics(values) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mean = sorted.reduce((sum, value) => sum + value, 0) / sorted.length;
+  const middle = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2
+      ? sorted[middle]
+      : (sorted[middle - 1] + sorted[middle]) / 2;
+  const variance =
+    sorted.reduce((sum, value) => sum + (value - mean) ** 2, 0) / sorted.length;
+  return {
+    count: sorted.length,
+    minimum: sorted[0],
+    median,
+    p95: sorted[Math.max(0, Math.ceil(sorted.length * 0.95) - 1)],
+    maximum: sorted.at(-1),
+    mean,
+    standardDeviation: Math.sqrt(variance),
+  };
+}
+
+export function summarizeSamples(samples) {
+  const groups = new Map();
+  for (const sample of samples) {
+    for (const [metric, value] of Object.entries(sample.memory)) {
+      const key = JSON.stringify([sample.run, sample.process.role, metric]);
+      const group = groups.get(key) ?? {
+        run: sample.run,
+        scenario: "popover",
+        phase: "popover-visible-settled",
+        role: sample.process.role,
+        metric,
+        values: [],
+      };
+      group.values.push(value);
+      groups.set(key, group);
+    }
+  }
+  const runs = [...groups.values()].map(({ values, ...group }) => ({
+    ...group,
+    ...statistics(values),
+  }));
+  const acrossGroups = new Map();
+  for (const summary of runs) {
+    const key = JSON.stringify([summary.role, summary.metric]);
+    const group = acrossGroups.get(key) ?? {
+      scenario: "popover",
+      phase: "popover-visible-settled",
+      role: summary.role,
+      metric: summary.metric,
+      medians: [],
+      peaks: [],
+    };
+    group.medians.push(summary.median);
+    group.peaks.push(summary.maximum);
+    acrossGroups.set(key, group);
+  }
+  const acrossRuns = [...acrossGroups.values()].map(
+    ({ medians, peaks, ...group }) => ({
+      ...group,
+      runMedianSummary: statistics(medians),
+      runPeakSummary: statistics(peaks),
+    }),
+  );
+  return { runs, acrossRuns };
+}
+
+export function recordPhase(report, run, phase, details = {}) {
+  if (!PHASES.includes(phase))
+    throw new Error(`unknown popover phase: ${phase}`);
+  const value = {
+    run,
+    scenario: "popover",
+    phase,
+    wallTime: new Date().toISOString(),
+    monotonicMs: performance.now(),
+    ...details,
+  };
+  report.phaseTimings.push(value);
+  return value;
+}
+
+function countAccessibilityNodes(tree) {
+  let nodes = 0;
+  let syntheticSessionLabels = 0;
+  const visit = (node) => {
+    if (!node || typeof node !== "object") return;
+    nodes += 1;
+    if (
+      [node.title, node.value, node.description].some((value) =>
+        String(value ?? "").includes("Synthetic coding session"),
+      )
+    ) {
+      syntheticSessionLabels += 1;
+    }
+    for (const child of node.children ?? []) visit(child);
+  };
+  for (const root of tree) visit(root);
+  return { accessibilityNodes: nodes, syntheticSessionLabels };
+}
+
+async function sampleVisiblePopover(context, processes) {
+  const tree = await runSteve(context.options, [
+    "elements",
+    "--pid",
+    String(context.pid),
+    "--depth",
+    "8",
+  ]);
+  const dimensions = countAccessibilityNodes(tree);
+  await delay(context.options.settleMs);
+  for (let sequence = 1; sequence <= context.options.samples; sequence += 1) {
+    const collected = await collectMemory(processes, context.options.metric, {
+      timeoutMs: context.options.timeoutMs,
+    });
+    for (const process of collected.processes) {
+      context.report.samples.push({
+        run: context.run,
+        scenario: "popover",
+        phase: "popover-visible-settled",
+        sequence,
+        wallTime: new Date().toISOString(),
+        monotonicMs: performance.now(),
+        process: Object.fromEntries(
+          Object.entries(process).filter(([key]) => key !== "memory"),
+        ),
+        memory: process.memory,
+        dimensions,
+      });
+    }
+    context.report.samples.push({
+      run: context.run,
+      scenario: "popover",
+      phase: "popover-visible-settled",
+      sequence,
+      wallTime: new Date().toISOString(),
+      monotonicMs: performance.now(),
+      process: {
+        role: "application-total",
+        pids: collected.processes.map((process) => process.pid),
+      },
+      memory: Object.fromEntries(
+        Object.entries({
+          rssSumBytes: collected.rssSumBytes,
+          aggregatePhysicalFootprintBytes:
+            collected.aggregatePhysicalFootprintBytes,
+        }).filter(([, value]) => value !== undefined),
+      ),
+      dimensions,
+    });
+    if (sequence < context.options.samples) {
+      await delay(context.options.sampleIntervalMs);
+    }
+  }
+}
+
+function delay(milliseconds) {
+  return new Promise((resolvePromise) =>
+    setTimeout(resolvePromise, milliseconds),
+  );
+}
+
+function killIfRunning(pid) {
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+}
+
+function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolvePromise, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`application did not exit after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolvePromise({ code, signal });
+    });
+  });
+}
+
+async function prepareProfile(options, executable, profile, report, run) {
+  const excludedPids = await existingProbePids(options);
+  const launched = spawnApplication(executable, {
+    env: profileEnvironment(profile),
+  });
+  let pid;
+  let stage = "find preparation process";
+  try {
+    pid = await waitForLaunchedPid(options, excludedPids);
+    recordPhase(report, run, "onboarding-started", { pid });
+    stage = "attach to onboarding";
+    await waitForApp(options, pid);
+    stage = "wait for welcome";
+    await waitForText(options, pid, "Stop hitting your token limits");
+    stage = "continue from welcome";
+    await waitAndClick(options, pid, "Continue");
+    stage = "wait for repository setup";
+    await waitForText(options, pid, "Repo search locations");
+    stage = "continue from repository setup";
+    await waitAndClick(options, pid, "Continue");
+    stage = "wait for ready step";
+    await waitForText(options, pid, "Ready");
+    stage = "finish onboarding";
+    await waitAndClick(options, pid, "Start using antiburn");
+    stage = "wait for onboarding handoff";
+    await waitForTextGone(options, pid, "Start using antiburn");
+    recordPhase(report, run, "onboarding-complete");
+    stage = "stop preparation launch";
+    await delay(500);
+    killIfRunning(pid);
+    const exit = await waitForExit(launched.child, options.timeoutMs);
+    if (exit.code !== 0) {
+      throw new Error(
+        `preparation launch exited with ${exit.code ?? exit.signal}`,
+      );
+    }
+    return pid;
+  } catch (error) {
+    throw Object.assign(new Error(`${stage}: ${error.message}`), {
+      cause: error,
+      preparationDiagnostics: launched.capture.lines,
+    });
+  } finally {
+    if (launched.child.exitCode === null) {
+      if (pid) killIfRunning(pid);
+      launched.child.kill("SIGKILL");
+    }
+  }
+}
+
+async function executableFor(options) {
+  if (options.app) {
+    await access(options.app, fsConstants.X_OK);
+    return options.app;
+  }
+  const profile = options.release ? "release" : "debug";
+  const executable = resolve(
+    "apps/desktop/src-tauri/target",
+    profile,
+    "bundle/macos/antiburn-memory-probe.app/Contents/MacOS/antiburn",
+  );
+  if (options.noBuild) {
+    if (!existsSync(executable)) {
+      throw new Error(`memory executable does not exist: ${executable}`);
+    }
+  } else {
+    await runCommand(
+      "pnpm",
+      [
+        "--filter",
+        "@antiburn/desktop",
+        "exec",
+        "tauri",
+        "build",
+        "--bundles",
+        "app",
+        "--features",
+        "memory-probe",
+        "--config",
+        "src-tauri/tauri.memory-probe.conf.json",
+        ...(!options.release ? ["--debug"] : []),
+      ],
+      { timeoutMs: 30 * 60_000 },
+    );
+  }
+  await access(executable, fsConstants.X_OK);
+  return executable;
+}
+
+async function verifySteve(options) {
+  await runSteve(options, ["apps"]);
+}
+
+async function rejectRunningAntiburn(options) {
+  const apps = await runSteve(options, ["apps"]);
+  const running = apps.filter((app) =>
+    String(app.bundleId).startsWith("ai.antiburn.desktop"),
+  );
+  if (running.length) {
+    throw new Error(
+      `close other antiburn instances before measuring: ${running.map((app) => app.pid).join(", ")}`,
+    );
+  }
+}
+
+export async function runReport(options) {
+  if (platform() !== "darwin") {
+    throw new Error("memory reporting requires macOS 13 or later");
+  }
+  await verifySteve(options);
+  await rejectRunningAntiburn(options);
+  const executable = await executableFor(options);
+  const report = {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    configuration: { ...options, app: executable, scenario: "popover" },
+    platform: {
+      platform: platform(),
+      osRelease: release(),
+      node: process.version,
+      steve: STEVE_UPSTREAM,
+    },
+    phaseTimings: [],
+    samples: [],
+    summaries: { runs: [], acrossRuns: [] },
+    warnings: [],
+    failures: [],
+  };
+  for (let run = 1; run <= options.runs; run += 1) {
+    const profile = await createRunProfile({ root: options.profileRoot, run });
+    let failed = false;
+    let launched;
+    recordPhase(report, run, "profile-created", { profile: profile.path });
+    try {
+      await prepareProfile(options, executable, profile, report, run);
+      const excludedPids = await existingProbePids(options);
+      launched = spawnApplication(executable, {
+        env: profileEnvironment(profile, {
+          ...process.env,
+          ANTIBURN_MEMORY_SESSIONS: String(options.sessions),
+          ANTIBURN_MEMORY_FIXTURE_SEED: String(options.fixtureSeed),
+        }),
+      });
+      const pid = await waitForLaunchedPid(options, excludedPids);
+      recordPhase(report, run, "measured-process-started", { pid });
+      await waitForApp(options, pid);
+      const [shell] = await processIdentities([pid], {
+        timeoutMs: options.timeoutMs,
+      });
+      recordPhase(report, run, "shell-idle");
+      const item = await statusItem(options, pid);
+      recordPhase(report, run, "popover-open-requested", { frame: item.frame });
+      await clickStatusItem(options, item);
+      await waitForText(options, pid, "Sessions");
+      const rendererEvent = await launched.capture.waitFor(
+        (event) => event?.event === "webcontent" && event.window === "popover",
+        options.timeoutMs,
+      );
+      recordPhase(report, run, "popover-content-ready", {
+        generation: rendererEvent.generation,
+        webContentPid: rendererEvent.pid,
+      });
+      const [renderer] = await processIdentities([rendererEvent.pid], {
+        timeoutMs: options.timeoutMs,
+      });
+      const processes = [
+        { role: "shell", ...shell },
+        {
+          role: "renderer",
+          window: "popover",
+          generation: rendererEvent.generation,
+          ...renderer,
+        },
+      ];
+      recordPhase(report, run, "popover-visible-settled");
+      await sampleVisiblePopover({ options, report, run, pid }, processes);
+      await clickStatusItem(options, item);
+      await runSteve(options, [
+        "wait",
+        "--pid",
+        String(pid),
+        "--window-count",
+        "0",
+        "--timeout",
+        String(Math.ceil(options.timeoutMs / 1_000)),
+      ]);
+      recordPhase(report, run, "popover-hidden");
+      await quitFromTray(options, pid, item);
+      const exit = await waitForExit(launched.child, options.timeoutMs);
+      if (exit.code !== 0) {
+        throw new Error(`application exited with ${exit.code ?? exit.signal}`);
+      }
+      recordPhase(report, run, "process-exited");
+    } catch (error) {
+      failed = true;
+      report.failures.push({
+        run,
+        scenario: "popover",
+        message: error.message,
+        code: error.code,
+        rawOutput: error.rawOutput,
+        diagnostics: [
+          ...(error.preparationDiagnostics ?? []),
+          ...(launched?.capture.lines ?? []),
+        ],
+        profile: profile.path,
+      });
+    } finally {
+      if (launched?.child.exitCode === null) {
+        const matches = await runSteve(options, ["apps"]).catch(() => []);
+        for (const app of matches) {
+          if (app.bundleId === MEMORY_BUNDLE_ID) {
+            killIfRunning(app.pid);
+          }
+        }
+        launched.child.kill("SIGKILL");
+      }
+      if (!shouldKeepProfile(options.keepProfile, failed)) {
+        await removeRunProfile(profile.path);
+      }
+    }
+  }
+  report.summaries = summarizeSamples(report.samples);
+  return report;
+}
+
+function csvCell(value) {
+  const text = value === undefined || value === null ? "" : String(value);
+  return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+export function formatReport(report, format) {
+  if (format === "json") return `${JSON.stringify(report, null, 2)}\n`;
+  if (format === "ndjson") {
+    const records = [
+      {
+        type: "report",
+        schemaVersion: report.schemaVersion,
+        configuration: report.configuration,
+        platform: report.platform,
+      },
+      ...report.phaseTimings.map((value) => ({ type: "phase", ...value })),
+      ...report.samples.map((value) => ({ type: "sample", ...value })),
+      ...report.summaries.runs.map((value) => ({
+        type: "run-summary",
+        ...value,
+      })),
+      ...report.summaries.acrossRuns.map((value) => ({
+        type: "cross-run-summary",
+        ...value,
+      })),
+      ...report.failures.map((value) => ({ type: "failure", ...value })),
+    ];
+    return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+  }
+  if (format === "csv") {
+    const header = [
+      "run",
+      "phase",
+      "sequence",
+      "role",
+      "pid",
+      "rssBytes",
+      "physicalFootprintBytes",
+      "accessibilityNodes",
+      "syntheticSessionLabels",
+    ];
+    const rows = report.samples.map((sample) => [
+      sample.run,
+      sample.phase,
+      sample.sequence,
+      sample.process.role,
+      sample.process.pid,
+      sample.memory.rssBytes,
+      sample.memory.physicalFootprintBytes,
+      sample.dimensions.accessibilityNodes,
+      sample.dimensions.syntheticSessionLabels,
+    ]);
+    return `${[header, ...rows]
+      .map((row) => row.map(csvCell).join(","))
+      .join("\n")}\n`;
+  }
+  const heading =
+    "Run Role              Metric                              Median       Peak";
+  const lines = report.summaries.runs.map(
+    (item) =>
+      `${String(item.run).padStart(3)} ${item.role.padEnd(17)} ${item.metric.padEnd(34)} ${formatBytes(item.median).padStart(10)} ${formatBytes(item.maximum).padStart(10)}`,
+  );
+  if (report.failures.length) {
+    lines.push(
+      ...report.failures.map(
+        (failure) => `FAIL run ${failure.run}: ${failure.message}`,
+      ),
+    );
+  }
+  return `${heading}\n${lines.join("\n")}\n`;
+}
+
+export function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return "-";
+  for (const [unit, factor] of [
+    ["GiB", 2 ** 30],
+    ["MiB", 2 ** 20],
+    ["KiB", 2 ** 10],
+  ]) {
+    if (bytes >= factor) return `${(bytes / factor).toFixed(1)} ${unit}`;
+  }
+  return `${bytes.toFixed(0)} B`;
+}
+
+export async function writeReport(report, { format, output, summary }) {
+  const content = formatReport(report, format);
+  if (output) await writeFile(output, content, { flag: "wx" });
+  else process.stdout.write(content);
+  if (summary) {
+    await writeFile(
+      summary,
+      `${JSON.stringify(
+        {
+          schemaVersion: report.schemaVersion,
+          summaries: report.summaries,
+          failures: report.failures,
+        },
+        null,
+        2,
+      )}\n`,
+      { flag: "wx" },
+    );
+  }
+}
+
+export function usage() {
+  return `Usage: node scripts/mem-report.mjs [options]
+
+Measures the settled antiburn popover with 225 deterministic rows by default.
+Live measurements require macOS 13+, a logged-in GUI session, and Steve with
+Accessibility permission. Install Steve with:
+  brew tap mikker/tap && brew install steve
+
+Options:
+  --release                   Build and measure an optimized .app
+  --app <path>                Use an existing probe-enabled executable
+  --no-build                  Require the existing executable
+  --runs <count>              Independent profiles and launches
+  --samples <count>           Settled popover samples (default: 5)
+  --sample-interval <time>    Delay between samples (default: 250ms)
+  --settle <time>             Delay after content readiness (default: 2s)
+  --timeout <time>            Per-action timeout (default: 30s)
+  --metric <name>             rss, footprint, or both (default: both)
+  --sessions <count>          Deterministic rows, 0 through 500 (default: 225)
+  --fixture-seed <integer>    Deterministic fixture seed (default: 237)
+  --steve <path>              Steve executable (default: steve from PATH)
+  --format <name>             table, json, ndjson, or csv
+  --output <path>             Report destination
+  --summary <path>            Compact JSON summary destination
+  --profile-root <path>       Parent for isolated profiles
+  --keep-profile <policy>     never, failure, or always
+  --quiet                     Hide successful diagnostics
+  --help                      Print this help
+`;
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArguments(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(usage());
+      return;
+    }
+    const report = await runReport(options);
+    await writeReport(report, options);
+    if (report.failures.length) process.exitCode = 1;
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/scripts/mem-report.test.mjs
+++ b/scripts/mem-report.test.mjs
@@ -1,0 +1,343 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+
+import {
+  DIAGNOSTIC_PREFIX,
+  LineCapture,
+  PROFILE_MARKER,
+  collectMemory,
+  createRunProfile,
+  findStatusItem,
+  formatReport,
+  parseArguments,
+  parseDiagnosticLine,
+  parseDuration,
+  parseFootprint,
+  parsePsRss,
+  parseSteveOutput,
+  profileEnvironment,
+  recordPhase,
+  removeRunProfile,
+  shouldKeepProfile,
+  spawnApplication,
+  statistics,
+  summarizeSamples,
+  validateProfileRoot,
+} from "./mem-report.mjs";
+
+test("parses defaults, release defaults, and explicit options", () => {
+  const defaults = parseArguments([]);
+  assert.equal(defaults.sessions, 225);
+  assert.equal(defaults.runs, 1);
+  assert.equal(defaults.samples, 5);
+  assert.equal(parseArguments(["--release"]).runs, 5);
+  const explicit = parseArguments([
+    "--release",
+    "--runs",
+    "2",
+    "--sessions=0",
+    "--metric",
+    "rss",
+    "--steve",
+    "/opt/steve",
+  ]);
+  assert.equal(explicit.runs, 2);
+  assert.equal(explicit.sessions, 0);
+  assert.equal(explicit.steve, "/opt/steve");
+  assert.throws(
+    () => parseArguments(["--app", "app", "--release"]),
+    /conflicts/,
+  );
+  assert.throws(() => parseArguments(["--sessions", "501"]), /between/);
+  assert.throws(() => parseArguments(["--unknown"]), /unknown option/);
+});
+
+test("parses explicit duration units", () => {
+  assert.equal(parseDuration("250ms"), 250);
+  assert.equal(parseDuration("1.5s"), 1_500);
+  assert.equal(parseDuration("2m"), 120_000);
+  for (const value of ["250", "0s", "1 sec", "-1s"]) {
+    assert.throws(() => parseDuration(value), /unit|positive/);
+  }
+});
+
+test("rejects unsafe profile roots without filesystem access", () => {
+  assert.throws(() => validateProfileRoot("relative/path"), /absolute/);
+  assert.throws(() => validateProfileRoot("/"), /unsafe/);
+  assert.throws(
+    () =>
+      validateProfileRoot("/Users/test", {
+        home: "/Users/test",
+        temporary: "/tmp",
+      }),
+    /unsafe/,
+  );
+  assert.throws(
+    () =>
+      validateProfileRoot("/Users/test/Library/Application Support", {
+        home: "/Users/test",
+        temporary: "/tmp",
+      }),
+    /overlaps/,
+  );
+});
+
+test("creates isolated profiles and deletes only marked directories", async (t) => {
+  const parent = await mkdtemp(join(tmpdir(), "mem-report-test-"));
+  t.after(() => rm(parent, { recursive: true, force: true }));
+  const profile = await createRunProfile({
+    root: join(parent, "profiles"),
+    run: 1,
+  });
+  assert.equal(
+    await readFile(join(profile.path, PROFILE_MARKER), "utf8"),
+    "2\n",
+  );
+  for (const key of ["home", "temp", "data", "config", "state"]) {
+    assert.ok(profile[key].startsWith(profile.path));
+  }
+  const env = profileEnvironment(profile, { PATH: "/bin" });
+  assert.equal(env.HOME, profile.home);
+  assert.equal(env.ANTIBURN_ANALYTICS_ENABLED, "false");
+  await removeRunProfile(profile.path);
+  const unsafe = join(parent, "unsafe");
+  await mkdir(unsafe);
+  await assert.rejects(removeRunProfile(unsafe), /unmarked/);
+});
+
+test("applies profile retention policies", () => {
+  assert.equal(shouldKeepProfile("never", true), false);
+  assert.equal(shouldKeepProfile("failure", false), false);
+  assert.equal(shouldKeepProfile("failure", true), true);
+  assert.equal(shouldKeepProfile("always", false), true);
+});
+
+test("parses only prefixed WebContent diagnostics", () => {
+  assert.equal(parseDiagnosticLine("normal log"), null);
+  assert.deepEqual(
+    parseDiagnosticLine(
+      `${DIAGNOSTIC_PREFIX}{"event":"webcontent","window":"popover","generation":2,"pid":42}`,
+    ),
+    { event: "webcontent", window: "popover", generation: 2, pid: 42 },
+  );
+  assert.throws(
+    () => parseDiagnosticLine(`${DIAGNOSTIC_PREFIX}not-json`),
+    /invalid/,
+  );
+  assert.throws(
+    () =>
+      parseDiagnosticLine(
+        `${DIAGNOSTIC_PREFIX}{"event":"webcontent","window":"popover","generation":0,"pid":42}`,
+      ),
+    /invalid WebContent/,
+  );
+});
+
+test("line capture waits for a diagnostic across stream chunks", async () => {
+  const capture = new LineCapture();
+  const pending = capture.waitFor(
+    (event) => event?.event === "webcontent",
+    1_000,
+  );
+  capture.accept("ordinary log\n@antiburn-");
+  capture.accept(
+    'mem {"event":"webcontent","window":"popover","generation":1,"pid":9}\n',
+  );
+  assert.equal((await pending).pid, 9);
+  assert.equal(capture.lines[0], "ordinary log");
+});
+
+test("launches the application bundle through macOS Launch Services", () => {
+  let call;
+  const child = {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+  };
+  const launched = spawnApplication(
+    "/tmp/antiburn.app/Contents/MacOS/antiburn",
+    {
+      env: { HOME: "/tmp/home", TMPDIR: "/tmp", TEST: "1" },
+      outputId: "test",
+      spawn: (...arguments_) => {
+        call = arguments_;
+        return child;
+      },
+    },
+  );
+  assert.equal(launched.child, child);
+  assert.deepEqual(call, [
+    "/usr/bin/open",
+    [
+      "-W",
+      "-n",
+      "-o",
+      "/tmp/antiburn-memory-test-stdout.log",
+      "--stderr",
+      "/tmp/antiburn-memory-test-stderr.log",
+      "--env",
+      "HOME=/tmp/home",
+      "--env",
+      "TMPDIR=/tmp",
+      "/tmp/antiburn.app",
+    ],
+    {
+      env: { HOME: "/tmp/home", TMPDIR: "/tmp", TEST: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  ]);
+});
+
+test("parses Steve envelopes and finds one framed status item", () => {
+  assert.deepEqual(parseSteveOutput('{"ok":true,"data":[1]}'), [1]);
+  assert.throws(
+    () => parseSteveOutput('{"ok":false,"error":"denied"}'),
+    /denied/,
+  );
+  assert.throws(() => parseSteveOutput("not json"), /invalid JSON/);
+  const item = findStatusItem([
+    {
+      role: "AXApplication",
+      children: [
+        {
+          role: "AXMenuBar",
+          children: [
+            {
+              role: "AXMenuBarItem",
+              frame: { x: 0, y: 30, width: 0, height: 0 },
+            },
+          ],
+        },
+        {
+          role: "AXMenuBar",
+          children: [
+            {
+              id: "ax://42/0.1.0",
+              role: "AXMenuBarItem",
+              frame: { x: 900, y: 3, width: 36, height: 24 },
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+  assert.equal(item.id, "ax://42/0.1.0");
+  assert.throws(() => findStatusItem([]), /expected one/);
+});
+
+test("parses ps RSS and preserves raw output on failure", () => {
+  const output =
+    "  42  1024 Mon Aug 31 12:10:11 2026\n43 2048 Mon Aug 31 12:10:12 2026\n";
+  assert.deepEqual(parsePsRss(output, [42, 43]), [
+    { pid: 42, rssBytes: 2 ** 20, startedAt: "Mon Aug 31 12:10:11 2026" },
+    { pid: 43, rssBytes: 2 ** 21, startedAt: "Mon Aug 31 12:10:12 2026" },
+  ]);
+  assert.throws(
+    () => parsePsRss("HEADER\n", [42]),
+    (error) => error.rawOutput === "HEADER\n",
+  );
+  assert.throws(
+    () => parsePsRss(output, [42]),
+    (error) => error.rawOutput === output,
+  );
+});
+
+test("parses formatted, byte, and native footprint output", () => {
+  const formatted = `Process: antiburn [42]\nphys_footprint: 12.5 MiB\nProcess: WebContent [43]\nphys_footprint = 20 MB\nSummary TOTAL physical footprint: 30 MiB\n`;
+  const parsed = parseFootprint(formatted, [42, 43]);
+  assert.equal(parsed.processes[0].physicalFootprintBytes, 12.5 * 2 ** 20);
+  assert.equal(parsed.aggregatePhysicalFootprintBytes, 30 * 2 ** 20);
+  const native = `======================================================================\nsleep [42]: 64-bit    Footprint: 884952 B (16384 bytes per page)\n======================================================================\n\nAuxiliary data:\n    phys_footprint: 901336 B\n\n======================================================================\nSummary Footprint: 884952 B\n======================================================================\n`;
+  assert.equal(
+    parseFootprint(native, [42]).aggregatePhysicalFootprintBytes,
+    884952,
+  );
+  const single = `sleep [42]: 64-bit    Footprint: 1 B\nphys_footprint: 901336 B\n`;
+  assert.equal(
+    parseFootprint(single, [42]).aggregatePhysicalFootprintBytes,
+    901336,
+  );
+});
+
+test("collects memory and verifies identities after footprint", async () => {
+  const calls = [];
+  const command = async (file, arguments_) => {
+    calls.push([file, arguments_]);
+    if (file === "/bin/ps") {
+      return {
+        stdout:
+          "42 100 Mon Aug 31 12:10:11 2026\n43 200 Mon Aug 31 12:10:12 2026\n",
+      };
+    }
+    return {
+      stdout:
+        "Process: shell [42]\nphys_footprint: 1000 B\nProcess: renderer [43]\nphys_footprint: 2000 B\nTOTAL 2500 B\n",
+    };
+  };
+  const result = await collectMemory(
+    [
+      { role: "shell", pid: 42, startedAt: "Mon Aug 31 12:10:11 2026" },
+      { role: "renderer", pid: 43, startedAt: "Mon Aug 31 12:10:12 2026" },
+    ],
+    "both",
+    { command },
+  );
+  assert.equal(result.rssSumBytes, 300 * 1024);
+  assert.equal(result.aggregatePhysicalFootprintBytes, 2500);
+  assert.equal(calls.filter(([file]) => file === "/bin/ps").length, 2);
+});
+
+test("calculates statistics and keeps independent run summaries", () => {
+  assert.deepEqual(statistics([4, 1, 3, 2]), {
+    count: 4,
+    minimum: 1,
+    median: 2.5,
+    p95: 4,
+    maximum: 4,
+    mean: 2.5,
+    standardDeviation: Math.sqrt(1.25),
+  });
+  const samples = [
+    { run: 1, process: { role: "renderer" }, memory: { rssBytes: 10 } },
+    { run: 1, process: { role: "renderer" }, memory: { rssBytes: 20 } },
+    { run: 2, process: { role: "renderer" }, memory: { rssBytes: 100 } },
+  ];
+  const summary = summarizeSamples(samples);
+  assert.equal(summary.runs.length, 2);
+  assert.equal(summary.runs[0].median, 15);
+  assert.equal(summary.acrossRuns[0].runMedianSummary.count, 2);
+});
+
+test("records only declared popover phases", () => {
+  const report = { phaseTimings: [] };
+  assert.equal(recordPhase(report, 1, "shell-idle").phase, "shell-idle");
+  assert.throws(() => recordPhase(report, 1, "settings-ready"), /unknown/);
+});
+
+test("formats the same samples as JSON, NDJSON, CSV, and table", () => {
+  const sample = {
+    run: 1,
+    scenario: "popover",
+    phase: "popover-visible-settled",
+    sequence: 1,
+    process: { role: "renderer", pid: 42 },
+    memory: { rssBytes: 1024 },
+    dimensions: { accessibilityNodes: 10, syntheticSessionLabels: 1 },
+  };
+  const report = {
+    schemaVersion: 2,
+    configuration: {},
+    platform: {},
+    phaseTimings: [],
+    samples: [sample],
+    summaries: summarizeSamples([sample]),
+    failures: [],
+  };
+  assert.deepEqual(JSON.parse(formatReport(report, "json")).samples, [sample]);
+  assert.match(formatReport(report, "ndjson"), /"type":"sample"/);
+  assert.match(formatReport(report, "csv"), /accessibilityNodes/);
+  assert.match(formatReport(report, "table"), /1\.0 KiB/);
+});


### PR DESCRIPTION
## Summary
- Add a macOS black-box memory report that uses the real tray lifecycle, isolated synthetic profiles, exact WebContent PID capture, and physical-footprint samples.
- Virtualize variable-height session rows, preserve keyboard and accessibility navigation, and replace per-row tooltip trees with one list owner.
- Keep the activity list unmounted during native height contraction and ignore stale resize completions.

## Measured Result
The standard release report used 225 deterministic sessions, five independent profiles, and five settled samples per profile.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Maximum renderer run median | 126,649,184 bytes | 60,670,768 bytes | -52.1% |
| Maximum aggregate run median | 156,288,920 bytes | 89,573,200 bytes | -42.7% |

All five optimized renderer run medians are below the 100 MiB acceptance target. The final report completed with no failures. Machine-specific reports remain outside the repository.

## Validation
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test` (970 tests)
- `pnpm --filter @antiburn/desktop build`
- `cargo clippy --all-targets --features memory-probe -- -D warnings`
- `cargo test --features memory-probe` (663 tests)
- `node --test scripts/mem-report.test.mjs` (15 tests)
- Design drift, third-party notices, secrets, formatting, and `aislop scan --changes`
- Five-run probe-enabled release memory report

## Privacy
The report uses bounded synthetic session data in isolated profiles. It does not read normal profiles or commit machine-specific process data.

Closes #237