### PR TITLE
Expand the session efficiency breakdown

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -321,7 +321,7 @@ Notes for what isn't expressible as a token:
   `html[data-keyboard]`, which `src/lib/focusModality.ts` sets on Tab and clears on any pointer
   press. This is deliberate — webviews paint `:focus-visible` for programmatic and
   window-activation focus too, which would put a ring on a window that simply reopened. Buttons use
-  the arrow cursor everywhere.
+  the arrow cursor by default. A full-row disclosure can use `cursor-pointer!` as a click affordance.
 - **Motion** — `prefers-reduced-motion: reduce` clamps every animation and transition globally
   (`src/styles/motion.css`). A surface that still needs a hint of movement re-states a short
   duration there, with the reason; today the only such exception is the segmented control's

--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -215,7 +215,7 @@ describe("SessionDetailPresentation — chrome", () => {
     expect(screen.queryByText("Cost")).toBeNull()
   })
 
-  it("shows the Efficiency card under the Cost card with a definition", () => {
+  it("shows the Efficiency card above the Cost card with a definition", () => {
     view({
       cost: cost(),
       efficiency: {
@@ -232,7 +232,11 @@ describe("SessionDetailPresentation — chrome", () => {
     expect(screen.getByText("Efficiency")).toBeTruthy()
     expect(screen.getByText("$/MTok")).toBeTruthy()
     expect(
-      screen.getByText("Relative to real work: context growth and output tokens."),
+      screen.getByText("Cost for real work: context growth and output tokens."),
+    ).toBeTruthy()
+    expect(
+      screen.getByText("Efficiency").compareDocumentPosition(screen.getByText("Cost")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
   })
 

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -776,6 +776,15 @@ export function SessionDetailPresentation({
               />
             )}
 
+            {efficiencyCard && (
+              <Card
+                title="Efficiency"
+                subtitle="Cost for real work: context growth and output tokens."
+              >
+                <EfficiencyBreakdown metrics={efficiencyCard} />
+              </Card>
+            )}
+
             {tokensCard && (
               <Card title="Context" subtitle={tokensCard.hint}>
                 <ContextTokensChart
@@ -796,15 +805,6 @@ export function SessionDetailPresentation({
                   split={tokensCard.split}
                   onOpenSubagent={onOpenSubagent}
                 />
-              </Card>
-            )}
-
-            {cost && tokensCard && efficiencyCard && (
-              <Card
-                title="Efficiency"
-                subtitle="Relative to real work: context growth and output tokens."
-              >
-                <EfficiencyBreakdown metrics={efficiencyCard} />
               </Card>
             )}
 

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, describe, expect, it } from "vitest"
 
 import { efficiencyMetrics } from "../../../lib/presentation/sessionEfficiency"
@@ -22,36 +22,53 @@ function totals(over: Partial<SessionEfficiency> = {}): SessionEfficiency {
 }
 
 describe("EfficiencyBreakdown", () => {
-  it("renders the three rows with their values and band words", () => {
+  it("renders the headline and three spend rows with their values", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
     expect(screen.getByText("$/MTok")).toBeTruthy()
     expect(screen.getByText("Real Work %")).toBeTruthy()
     expect(screen.getByText("Rewrite Waste %")).toBeTruthy()
+    expect(screen.getByText("Carry %")).toBeTruthy()
     expect(screen.getByText("$40.00")).toBeTruthy()
     expect(screen.getByText("34%")).toBeTruthy()
     expect(screen.getByText("12%")).toBeTruthy()
-    expect(screen.getAllByText("ok")).toHaveLength(3)
+    expect(screen.getByText("54%")).toBeTruthy()
+    expect(screen.getAllByText("ok")).toHaveLength(4)
   })
 
-  it("draws a thermometer per row with the mark where the session sits", () => {
+  it("shows the cost bands and aligns the three spend components below them", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
-    // $40 per MTok sits inside the ok band, which runs from $33 to $80.
     const cost = screen.getByTestId("thermometer-costPerMTok")
-    expect(cost.getAttribute("data-position")).toBe("0.383")
+    expect(cost.dataset.position).toBe("0.383")
     expect(cost.children).toHaveLength(4)
     expect(cost.children[0]?.getAttribute("class")).toContain("bg-system-green")
+    expect(cost.children[1]?.getAttribute("class")).toContain("bg-separator")
     expect(cost.children[2]?.getAttribute("class")).toContain("bg-system-orange")
-    // Real work reads higher-is-better, so its good segment sits on the right.
-    const realWork = screen.getByTestId("thermometer-realWorkShare")
-    expect(realWork.children[0]?.getAttribute("class")).toContain("bg-system-orange")
-    expect(realWork.children[2]?.getAttribute("class")).toContain("bg-system-green")
+
+    const realWork = screen.getByTestId("share-segment-realWorkShare")
+    expect(realWork.dataset).toMatchObject({
+      start: "0.000",
+      width: "0.340",
+    })
+    expect(realWork.children[0]?.getAttribute("class")).toContain("bg-system-blue")
+    const rewrite = screen.getByTestId("share-segment-rewriteShare")
+    expect(rewrite.dataset).toMatchObject({
+      start: "0.340",
+      width: "0.120",
+    })
+    expect(rewrite.children[1]?.getAttribute("class")).toContain("bg-system-indigo")
+    const carry = screen.getByTestId("share-segment-carryShare")
+    expect(carry.dataset).toMatchObject({
+      start: "0.460",
+      width: "0.540",
+    })
+    expect(carry.children[1]?.getAttribute("class")).toContain("bg-system-gold")
   })
 
   it("colours a good reading green and names a bad one by direction", () => {
     render(
       <EfficiencyBreakdown
         metrics={efficiencyMetrics(
-          totals({ totalUsd: 25, newWorkUsd: 4, rewriteUsd: 7 }),
+          totals({ totalUsd: 25, newWorkUsd: 4, carryUsd: 14, rewriteUsd: 7 }),
           "claude-code",
         )}
       />,
@@ -66,7 +83,7 @@ describe("EfficiencyBreakdown", () => {
     render(
       <EfficiencyBreakdown
         metrics={efficiencyMetrics(
-          totals({ totalUsd: 5, newWorkUsd: 4, rewriteUsd: 0.2 }),
+          totals({ totalUsd: 5, newWorkUsd: 4, carryUsd: 0.8, rewriteUsd: 0.2 }),
           "codex",
         )}
       />,
@@ -76,8 +93,8 @@ describe("EfficiencyBreakdown", () => {
     }
   })
 
-  it("shows a dash and no band when there is no spend", () => {
-    render(
+  it("renders nothing when there is no spend", () => {
+    const { container } = render(
       <EfficiencyBreakdown
         metrics={efficiencyMetrics(
           totals({ totalUsd: 0, newWorkUsd: 0, rewriteUsd: 0 }),
@@ -85,15 +102,33 @@ describe("EfficiencyBreakdown", () => {
         )}
       />,
     )
-    expect(screen.getAllByText("—")).toHaveLength(3)
-    expect(screen.queryByText("ok")).toBeNull()
-    expect(screen.queryByTestId("thermometer-costPerMTok")).toBeNull()
+    expect(container).toBeEmptyDOMElement()
   })
 
-  it("gives each row its own info mark", () => {
+  it("opens one metric explanation at a time", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "codex")} />)
-    expect(screen.getByLabelText("About $/MTok")).toBeTruthy()
-    expect(screen.getByLabelText("About Real Work %")).toBeTruthy()
-    expect(screen.getByLabelText("About Rewrite Waste %")).toBeTruthy()
+    const cost = screen.getByRole("button", { name: "$/MTok details" })
+    const realWork = screen.getByRole("button", { name: "Real Work % details" })
+    const rewrite = screen.getByRole("button", { name: "Rewrite Waste % details" })
+    const carry = screen.getByRole("button", { name: "Carry % details" })
+
+    for (const row of [cost, realWork, rewrite, carry]) {
+      expect(row.classList).toContain("cursor-pointer!")
+      expect(row.getAttribute("aria-expanded")).toBe("false")
+    }
+
+    fireEvent.click(cost)
+    expect(cost.getAttribute("aria-expanded")).toBe("true")
+    expect(screen.getByText(/avg cost for each million tokens/)).toBeTruthy()
+
+    fireEvent.click(realWork)
+    expect(cost.getAttribute("aria-expanded")).toBe("false")
+    expect(realWork.getAttribute("aria-expanded")).toBe("true")
+    expect(screen.queryByText(/avg cost for each million tokens/)).toBeNull()
+    expect(screen.getByText(/fresh input and output/)).toBeTruthy()
+    expect(screen.getByText("For Codex, aim for above 33%. Below 17% is too low.")).toBeTruthy()
+
+    fireEvent.click(realWork)
+    expect(realWork.getAttribute("aria-expanded")).toBe("false")
   })
 })

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
@@ -1,11 +1,10 @@
-import { Info } from "lucide-react"
+import { useId, useState, type ReactNode } from "react"
 
 import { cn } from "../../../lib/cn"
 import {
   efficiencyBandWord,
-  efficiencyMetricDescription,
+  efficiencyThresholdGuidance,
   efficiencyThermometer,
-  efficiencyThresholdsText,
   formatCostPerMTok,
   formatSharePercent,
   type EfficiencyBand,
@@ -13,7 +12,6 @@ import {
   type EfficiencyMetrics,
   type EfficiencyProfile,
 } from "../../../lib/presentation/sessionEfficiency"
-import { Tooltip } from "../../presentation/Tooltip"
 
 export interface EfficiencyBreakdownProps {
   metrics: EfficiencyMetrics
@@ -31,31 +29,117 @@ const BAND_SEGMENT_CLASS: Record<EfficiencyBand, string> = {
   bad: "bg-system-orange/50",
 }
 
-type MetricKey = "costPerMTok" | "realWorkShare" | "rewriteShare"
+type MetricKey = "costPerMTok" | ShareMetricKey
+type ShareMetricKey = "realWorkShare" | "rewriteShare" | "carryShare"
 
-const ROWS: { key: MetricKey; label: string; format: (value: number) => string }[] = [
-  { key: "costPerMTok", label: "$/MTok", format: formatCostPerMTok },
-  { key: "realWorkShare", label: "Real Work %", format: formatSharePercent },
-  { key: "rewriteShare", label: "Rewrite Waste %", format: formatSharePercent },
+const METRIC_SUMMARY: Record<MetricKey, string[]> = {
+  costPerMTok: [
+    "The avg cost for each million tokens of context growth and output in this session.",
+  ],
+  realWorkShare: ["The share of the session's cost spent on fresh input and output."],
+  rewriteShare: [
+    "The share of the session's cost spent rehydrating the cache with old context.",
+  ],
+  carryShare: ["The share of the session's cost spent resending cached context."],
+}
+
+const METRIC_GUIDANCE: Record<MetricKey, string[]> = {
+  costPerMTok: [
+    "Craft tight workflows, and use cheaper models when they're good enough.",
+    "Pay attention to which of these next three categories are out of band.",
+  ],
+  realWorkShare: [
+    "Maximise this by minimising the other two dimesions.",
+    "Usually a focused and short session will be best here.",
+  ],
+  rewriteShare: [
+    "If you have long breaks in your session, the cache expires, so manually compact immediately after you return.",
+    "Model or reasoning changes also cause rewrites.",
+  ],
+  carryShare: [
+    "Keep context down by actively compacting when the session gets too big.",
+    "It also can be handy to rewind if the session's gone in the wrong direction.",
+    "Or even ask the agent for a summary then start a clean session with that.",
+  ],
+}
+
+interface ShareRow {
+  key: ShareMetricKey
+  label: string
+  fillColor: string
+}
+
+const SHARE_ROWS: ShareRow[] = [
+  {
+    key: "realWorkShare",
+    label: "Real Work %",
+    fillColor: "bg-system-blue/50",
+  },
+  {
+    key: "rewriteShare",
+    label: "Rewrite Waste %",
+    fillColor: "bg-system-indigo/50",
+  },
+  {
+    key: "carryShare",
+    label: "Carry %",
+    fillColor: "bg-system-gold/50",
+  },
 ]
 
-function Thermometer({
-  value,
-  metricKey,
-  profile,
-  title,
-}: {
-  value: number
-  metricKey: MetricKey
-  profile: EfficiencyProfile
-  title: string
-}) {
-  const scale = efficiencyThermometer(value, metricKey, profile)
+interface ShareSegment extends ShareRow {
+  metric: EfficiencyMetric
+  start: number
+  width: number
+  displayPercent: string
+}
+
+function shareSegments(metrics: EfficiencyMetrics): ShareSegment[] {
+  const rows = SHARE_ROWS.flatMap((row) => {
+    const metric = metrics[row.key]
+    return metric ? [{ ...row, metric }] : []
+  })
+  const total = rows.reduce((sum, row) => sum + row.metric.value, 0)
+  if (rows.length !== SHARE_ROWS.length || total <= 0) return []
+
+  let start = 0
+  const segments = rows.map((row) => {
+    const width = row.metric.value / total
+    const segment = { ...row, start, width, displayPercent: "" }
+    start += width
+    return segment
+  })
+
+  // Round the shares as one composition so the displayed values total 100%.
+  const smallestPercent = Math.min(
+    ...segments.filter((segment) => segment.width > 0).map((segment) => segment.width * 100),
+  )
+  const decimalPlaces = Math.min(6, Math.max(0, 1 - Math.floor(Math.log10(smallestPercent))))
+  const unitsPerPercent = 10 ** decimalPlaces
+  const totalUnits = 100 * unitsPerPercent
+  const exactUnits = segments.map((segment) => segment.width * totalUnits)
+  const roundedUnits = exactUnits.map(Math.floor)
+  const remainingUnits = totalUnits - roundedUnits.reduce((sum, value) => sum + value, 0)
+  const remainderOrder = exactUnits
+    .map((value, index) => ({ index, remainder: value - roundedUnits[index]! }))
+    .sort((a, b) => b.remainder - a.remainder)
+
+  for (let index = 0; index < remainingUnits; index += 1) {
+    roundedUnits[remainderOrder[index]!.index]! += 1
+  }
+
+  return segments.map((segment, index) => ({
+    ...segment,
+    displayPercent: `${Number((roundedUnits[index]! / unitsPerPercent).toFixed(decimalPlaces))}%`,
+  }))
+}
+
+function CostThermometer({ value, profile }: { value: number; profile: EfficiencyProfile }) {
+  const scale = efficiencyThermometer(value, "costPerMTok", profile)
   return (
     <div
       className="relative flex h-full items-center"
-      title={title}
-      data-testid={`thermometer-${metricKey}`}
+      data-testid="thermometer-costPerMTok"
       data-position={scale.position.toFixed(3)}
       aria-hidden
     >
@@ -63,7 +147,7 @@ function Thermometer({
         <span
           key={index}
           className={cn(
-            "h-1.5 flex-1",
+            "h-[7px] flex-1",
             index === 0 && "rounded-s-full",
             index === scale.segments.length - 1 && "rounded-e-full",
             BAND_SEGMENT_CLASS[segment],
@@ -71,29 +155,79 @@ function Thermometer({
         />
       ))}
       <span
-        className="absolute inset-y-1 w-1.5 -translate-x-1/2 rounded-full border border-label bg-surface opacity-80 dark:bg-separator"
+        className="absolute h-[10px] w-1.5 -translate-x-1/2 rounded-full border border-label bg-surface opacity-80 dark:bg-separator"
         style={{ left: `${scale.position * 100}%` }}
       />
     </div>
   )
 }
 
-function RowInfo({ label, metricKey }: { label: string; metricKey: MetricKey }) {
+function ShareSegmentBar({ segment }: { segment: ShareSegment }) {
+  const segmentEnd = segment.start + segment.width
+
+  const isLeftHandSegment = segment.start === 0
+  const isRightHandSegment = segmentEnd === 1
+
   return (
-    <Tooltip
-      label={efficiencyMetricDescription(metricKey)}
-      side="top"
-      interactive
-      delayMs={150}
+    <div
+      className="relative h-1.5"
+      data-testid={`share-segment-${segment.key}`}
+      data-start={segment.start.toFixed(3)}
+      data-width={segment.width.toFixed(3)}
+      aria-hidden
     >
-      <button
-        type="button"
-        aria-label={`About ${label}`}
-        className="leading-none text-label-tertiary transition-colors duration-[var(--duration-fast)] ease-out hover:text-label-secondary"
-      >
-        <Info size={12} aria-hidden="true" />
-      </button>
-    </Tooltip>
+      {!isLeftHandSegment && (
+        <span
+          className={cn(
+            "absolute inset-y-0 border border-separator border-dotted rounded-s-full",
+          )}
+          style={{ left: 0, width: `${segment.start * 100}%` }}
+        />
+      )}
+      <span
+        className={cn(
+          "absolute -inset-y-[1px]",
+          segment.fillColor,
+          isLeftHandSegment && "rounded-s-full",
+          isRightHandSegment && "rounded-e-full",
+        )}
+        style={{ left: `${segment.start * 100}%`, width: `${segment.width * 100}%` }}
+      />
+      {!isRightHandSegment && (
+        <span
+          className={cn(
+            "absolute inset-y-0 border border-separator border-dotted rounded-e-full",
+          )}
+          style={{ left: `${segmentEnd * 100}%`, width: `${(1 - segmentEnd) * 100}%` }}
+        />
+      )}
+    </div>
+  )
+}
+
+function MetricGuidance({
+  metricKey,
+  profile,
+}: {
+  metricKey: MetricKey
+  profile: EfficiencyProfile
+}) {
+  return (
+    <div className="space-y-1 text-pretty type-footnote text-label-secondary border-b border-x border-separator pb-3 px-3 rounded-lg">
+      {METRIC_SUMMARY[metricKey].map((sentence) => (
+        <p key={sentence} className="font-bold">
+          {sentence}
+        </p>
+      ))}
+      {efficiencyThresholdGuidance(metricKey, profile).map((sentence) => (
+        <p key={sentence} className="italic">
+          {sentence}
+        </p>
+      ))}
+      {METRIC_GUIDANCE[metricKey].map((sentence) => (
+        <p key={sentence}>{sentence}</p>
+      ))}
+    </div>
   )
 }
 
@@ -101,56 +235,126 @@ function EfficiencyRowLine({
   label,
   metric,
   metricKey,
-  format,
   profile,
+  children,
+  formattedValue,
+  open,
+  onToggle,
+  separated = false,
 }: {
   label: string
   metric: EfficiencyMetric | null
   metricKey: MetricKey
-  format: (value: number) => string
   profile: EfficiencyProfile
+  children?: ReactNode
+  formattedValue?: string
+  open: boolean
+  onToggle: () => void
+  separated?: boolean
 }) {
+  const bodyId = useId()
+
   return (
-    <div className="col-span-4 grid grid-cols-subgrid items-center gap-x-3 -mx-1 px-1 py-1 rounded-control type-caption transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover">
-      <span className="flex items-center gap-1 text-label-tertiary">
-        {label}
-        <RowInfo label={label} metricKey={metricKey} />
-      </span>
-      {metric ? (
-        <Thermometer
-          value={metric.value}
-          metricKey={metricKey}
-          profile={profile}
-          title={efficiencyThresholdsText(metricKey, profile)}
-        />
-      ) : (
-        <span />
-      )}
-      <span className="text-right text-label tabular-nums">
-        {metric ? format(metric.value) : "—"}
-      </span>
-      {metric && (
-        <span className={cn("type-caption whitespace-nowrap", BAND_TEXT_CLASS[metric.band])}>
-          {efficiencyBandWord(metric.band, metricKey)}
+    <>
+      <button
+        type="button"
+        aria-label={`${label} details`}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={onToggle}
+        className="col-span-4 grid cursor-pointer! grid-cols-subgrid items-center gap-x-3 -mx-1 px-1 py-1 rounded-control text-left type-caption transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover active:transform-none active:opacity-100"
+      >
+        <span className="text-label-tertiary">{label}</span>
+        {metric ? children : <span />}
+        <span className="text-center text-label tabular-nums">
+          {metric
+            ? (formattedValue ??
+              (metricKey === "costPerMTok" ? formatCostPerMTok : formatSharePercent)(
+                metric.value,
+              ))
+            : "—"}
         </span>
+        {metric && (
+          <span
+            className={cn(
+              "type-caption text-center whitespace-nowrap",
+              BAND_TEXT_CLASS[metric.band],
+            )}
+          >
+            {efficiencyBandWord(metric.band, metricKey)}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          id={bodyId}
+          role="region"
+          aria-label={`${label} guidance`}
+          className="col-span-full px-1 pb-2"
+        >
+          <MetricGuidance metricKey={metricKey} profile={profile} />
+        </div>
       )}
-    </div>
+
+      {separated && (
+        <div className="col-span-full border-b border-separator border-dashed my-1" />
+      )}
+    </>
   )
 }
 
 export function EfficiencyBreakdown({ metrics }: EfficiencyBreakdownProps) {
+  const segments = shareSegments(metrics)
+  const [openMetric, setOpenMetric] = useState<MetricKey | null>(null)
+
+  const toggleMetric = (metricKey: MetricKey) => {
+    setOpenMetric((current) => (current === metricKey ? null : metricKey))
+  }
+
+  if (!metrics.costPerMTok) {
+    return null
+  }
+
   return (
-    <div className="grid grid-cols-[max-content_1fr_max-content_max-content] gap-y-1 mt-2 pt-2 border-t border-separator">
-      {ROWS.map((row) => (
+    <div className="grid grid-cols-[max-content_1fr_max-content_max-content] gap-y-1">
+      <EfficiencyRowLine
+        label="$/MTok"
+        metric={metrics.costPerMTok}
+        metricKey="costPerMTok"
+        profile={metrics.profile}
+        open={openMetric === "costPerMTok"}
+        onToggle={() => toggleMetric("costPerMTok")}
+        separated
+      >
+        <CostThermometer value={metrics.costPerMTok.value} profile={metrics.profile} />
+      </EfficiencyRowLine>
+      {segments.map((segment) => (
         <EfficiencyRowLine
-          key={row.key}
-          label={row.label}
-          metric={metrics[row.key]}
-          metricKey={row.key}
-          format={row.format}
+          key={segment.key}
+          label={segment.label}
+          metric={segment.metric}
+          metricKey={segment.key}
           profile={metrics.profile}
-        />
+          formattedValue={segment.displayPercent}
+          open={openMetric === segment.key}
+          onToggle={() => toggleMetric(segment.key)}
+        >
+          <ShareSegmentBar segment={segment} />
+        </EfficiencyRowLine>
       ))}
+      {segments.length === 0 &&
+        SHARE_ROWS.map((row) => (
+          <EfficiencyRowLine
+            key={row.key}
+            label={row.label}
+            metric={metrics[row.key]}
+            metricKey={row.key}
+            profile={metrics.profile}
+            open={openMetric === row.key}
+            onToggle={() => toggleMetric(row.key)}
+          />
+        ))}
     </div>
   )
 }

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
@@ -5,9 +5,7 @@ import {
   efficiencyBandWord,
   efficiencyMetrics,
   efficiencyProfile,
-  efficiencyThresholdsText,
-  efficiencyMetricDescription,
-  efficiencyThermometer,
+  efficiencyThresholdGuidance,
   formatCostPerMTok,
   formatSharePercent,
 } from "./sessionEfficiency"
@@ -27,38 +25,47 @@ function totals(over: Partial<SessionEfficiency> = {}): SessionEfficiency {
 }
 
 describe("efficiencyMetrics", () => {
-  it("derives the three ratios from the totals", () => {
+  it("derives the headline cost and three spend shares", () => {
     const m = efficiencyMetrics(totals(), "claude-code")
     expect(m.costPerMTok?.value).toBeCloseTo(40)
     expect(m.realWorkShare?.value).toBeCloseTo(0.34)
     expect(m.rewriteShare?.value).toBeCloseTo(0.12)
+    expect(m.carryShare?.value).toBeCloseTo(0.54)
     expect(m.unpricedTurns).toBe(0)
     expect(m.profile).toBe("claude")
   })
 
-  it("bands a ok Claude session as ok on every metric", () => {
+  it("bands an ok Claude session as ok on every metric", () => {
     const m = efficiencyMetrics(totals(), "claude-code")
     expect(m.costPerMTok?.band).toBe("ok")
     expect(m.realWorkShare?.band).toBe("ok")
     expect(m.rewriteShare?.band).toBe("ok")
+    expect(m.carryShare?.band).toBe("ok")
   })
 
-  it("bands the Claude edges: cost, rewrite, and real work", () => {
+  it("bands the Claude edges for each metric", () => {
     const cheap = efficiencyMetrics(
-      totals({ totalUsd: 5, newWorkUsd: 4, rewriteUsd: 0.2 }),
+      totals({ totalUsd: 5, newWorkUsd: 4, carryUsd: 0.8, rewriteUsd: 0.2 }),
       "claude-code",
     )
     expect(cheap.costPerMTok?.band).toBe("good")
     expect(cheap.realWorkShare?.band).toBe("good")
     expect(cheap.rewriteShare?.band).toBe("good")
+    expect(cheap.carryShare?.band).toBe("good")
 
     const dear = efficiencyMetrics(
-      totals({ totalUsd: 25, newWorkUsd: 4, rewriteUsd: 7 }),
+      totals({ totalUsd: 25, newWorkUsd: 4, carryUsd: 14, rewriteUsd: 7 }),
       "claude-code",
     )
     expect(dear.costPerMTok?.band).toBe("bad")
     expect(dear.realWorkShare?.band).toBe("bad")
     expect(dear.rewriteShare?.band).toBe("bad")
+
+    const highCarry = efficiencyMetrics(
+      totals({ totalUsd: 10, newWorkUsd: 2, carryUsd: 6, rewriteUsd: 2 }),
+      "claude-code",
+    )
+    expect(highCarry.carryShare?.band).toBe("bad")
   })
 
   it("treats the Claude gaps between ok and bad as ok", () => {
@@ -79,7 +86,7 @@ describe("efficiencyMetrics", () => {
     expect(dear.costPerMTok?.band).toBe("bad")
     expect(dear.rewriteShare?.band).toBe("good")
     const good = efficiencyMetrics(
-      totals({ totalUsd: 4, newWorkUsd: 1.4, rewriteUsd: 0.2 }),
+      totals({ totalUsd: 4, newWorkUsd: 1.4, carryUsd: 2.4, rewriteUsd: 0.2 }),
       "codex",
     )
     expect(good.costPerMTok?.band).toBe("good")
@@ -91,6 +98,7 @@ describe("efficiencyMetrics", () => {
     expect(m.costPerMTok).toBeNull()
     expect(m.realWorkShare).toBeNull()
     expect(m.rewriteShare).toBeNull()
+    expect(m.carryShare).toBeNull()
   })
 
   it("returns a null cost per MTok when the token denominator is zero", () => {
@@ -123,45 +131,27 @@ describe("formatting", () => {
     expect(formatSharePercent(0)).toBe("0%")
   })
 
-  it("places a value on its thermometer by band thirds", () => {
-    // Lower is better: good | ok | bad, edges at $33 and $80, top at $160.
-    expect(efficiencyThermometer(0, "costPerMTok", "claude")).toEqual({
-      segments: ["good", "ok", "bad"],
-      position: 0,
-    })
-    expect(efficiencyThermometer(33, "costPerMTok", "claude").position).toBeCloseTo(1 / 3)
-    expect(efficiencyThermometer(80, "costPerMTok", "claude").position).toBeCloseTo(2 / 3)
-    expect(efficiencyThermometer(120, "costPerMTok", "claude").position).toBeCloseTo(5 / 6)
-    expect(efficiencyThermometer(999, "costPerMTok", "claude").position).toBe(1)
-    // Higher is better: bad | ok | good, edges at 18% and 36%.
-    const realWork = efficiencyThermometer(0.27, "realWorkShare", "claude")
-    expect(realWork.segments).toEqual(["bad", "ok", "good"])
-    expect(realWork.position).toBeCloseTo(0.5)
-  })
-
-  it("describes each metric in a sentence", () => {
-    expect(efficiencyMetricDescription("costPerMTok")).toMatch(/Cost for real work/)
-    expect(efficiencyMetricDescription("realWorkShare")).toMatch(/spent on real work/)
-    expect(efficiencyMetricDescription("rewriteShare")).toMatch(/rewriting the cache/)
-  })
-
   it("names the direction of a bad reading", () => {
     expect(efficiencyBandWord("good", "costPerMTok")).toBe("good")
     expect(efficiencyBandWord("ok", "rewriteShare")).toBe("ok")
     expect(efficiencyBandWord("bad", "costPerMTok")).toBe("high")
     expect(efficiencyBandWord("bad", "rewriteShare")).toBe("high")
     expect(efficiencyBandWord("bad", "realWorkShare")).toBe("low")
+    expect(efficiencyBandWord("bad", "carryShare")).toBe("high")
   })
 
   it("spells the thresholds for the agent's profile", () => {
-    expect(efficiencyThresholdsText("costPerMTok", "claude")).toBe(
-      "[Good = below $33; High = over $80; otherwise OK]",
-    )
-    expect(efficiencyThresholdsText("realWorkShare", "codex")).toBe(
-      "[Good = over 33%; Low = below 17%; otherwise OK]",
-    )
-    expect(efficiencyThresholdsText("rewriteShare", "codex")).toBe(
-      "[Good = below 8%; High = over 14%; otherwise OK]",
-    )
+    expect(efficiencyThresholdGuidance("costPerMTok", "claude")).toEqual([
+      "For Claude, aim for below $33. Above $80 is too high.",
+    ])
+    expect(efficiencyThresholdGuidance("realWorkShare", "codex")).toEqual([
+      "For Codex, aim for above 33%. Below 17% is too low.",
+    ])
+    expect(efficiencyThresholdGuidance("rewriteShare", "codex")).toEqual([
+      "For Codex, aim for below 8%. Above 14% is too high.",
+    ])
+    expect(efficiencyThresholdGuidance("carryShare", "codex")).toEqual([
+      "For Codex, aim for below 59%. Above 69% is too high.",
+    ])
   })
 })

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.ts
@@ -1,10 +1,8 @@
 /**
- * The three efficiency metrics the Efficiency card shows, and the band each
- * one falls in.
+ * The headline efficiency metric and the three spend shares the card shows.
  *
- * The bands are per agent family. Codex bills a cheaper cache and a leaner
- * prompt, so its "ok" range sits lower on every scale. Any agent that is not
- * Codex reads against the Claude Code bands.
+ * The bands differ by agent family because pricing and harness behavior differ.
+ * Any agent other than Codex uses the Claude Code bands.
  */
 
 import type { SessionEfficiency } from "../types/session"
@@ -28,6 +26,8 @@ export interface EfficiencyMetrics {
   realWorkShare: EfficiencyMetric | null
   /** Share of the spend that was rewrite, in the range 0 to 1. */
   rewriteShare: EfficiencyMetric | null
+  /** Share of the spend that was carry, in the range 0 to 1. */
+  carryShare: EfficiencyMetric | null
   unpricedTurns: number
   profile: EfficiencyProfile
 }
@@ -47,6 +47,7 @@ interface ProfileEdges {
   costPerMTok: BandEdges
   rewriteShare: BandEdges
   realWorkShare: BandEdges
+  carryShare: BandEdges
 }
 
 const EDGES: Record<EfficiencyProfile, ProfileEdges> = {
@@ -54,11 +55,15 @@ const EDGES: Record<EfficiencyProfile, ProfileEdges> = {
     costPerMTok: { good: 33, bad: 80, higherIsBetter: false },
     rewriteShare: { good: 0.1, bad: 0.25, higherIsBetter: false },
     realWorkShare: { good: 0.36, bad: 0.18, higherIsBetter: true },
+    // Carry uses the overhead left when Real Work and Rewrite reach the same band.
+    carryShare: { good: 0.54, bad: 0.57, higherIsBetter: false },
   },
   codex: {
     costPerMTok: { good: 20, bad: 46, higherIsBetter: false },
     rewriteShare: { good: 0.08, bad: 0.14, higherIsBetter: false },
     realWorkShare: { good: 0.33, bad: 0.17, higherIsBetter: true },
+    // Carry uses the overhead left when Real Work and Rewrite reach the same band.
+    carryShare: { good: 0.59, bad: 0.69, higherIsBetter: false },
   },
 }
 
@@ -78,13 +83,7 @@ function bandFor(value: number, edges: BandEdges): EfficiencyBand {
   return "ok"
 }
 
-/**
- * One row's thermometer. `segments` lists the three bands in numeric order,
- * left to right. `position` is where the value sits on the track, in the
- * range 0 to 1. Each band takes one third of the track. The value maps
- * linearly inside its band: the low band runs from 0 to the first edge, the
- * high band from the second edge to twice that edge.
- */
+/** The three bands and marker position for one efficiency thermometer. */
 export interface EfficiencyThermometer {
   segments: [EfficiencyBand, EfficiencyBand, EfficiencyBand]
   position: number
@@ -108,7 +107,7 @@ function thermometerFor(value: number, edges: BandEdges): EfficiencyThermometer 
   }
 }
 
-/** The thermometer for one metric's value, read against `profile`'s bands. */
+/** Build the thermometer for one metric and agent profile. */
 export function efficiencyThermometer(
   value: number,
   metricKey: keyof ProfileEdges,
@@ -138,6 +137,7 @@ export function efficiencyMetrics(totals: SessionEfficiency, agent: string): Eff
     rewriteShare: hasSpend
       ? metric(totals.rewriteUsd / totals.totalUsd, edges.rewriteShare)
       : null,
+    carryShare: hasSpend ? metric(totals.carryUsd / totals.totalUsd, edges.carryShare) : null,
     unpricedTurns: totals.unpricedTurns,
     profile,
   }
@@ -160,6 +160,11 @@ function formatEdge(metricKey: keyof ProfileEdges, value: number): string {
   return metricKey === "costPerMTok" ? `$${value}` : `${Math.round(value * 100)}%`
 }
 
+function readableProfile(profile: EfficiencyProfile) {
+  if (profile === "claude") return "Claude"
+  if (profile === "codex") return "Codex"
+}
+
 /**
  * The band word after a value. A bad reading names its direction: a high
  * cost or rewrite share, or a low real-work share.
@@ -172,27 +177,19 @@ export function efficiencyBandWord(
   return EDGES.claude[metricKey].higherIsBetter ? "low" : "high"
 }
 
-/** What one metric measures, for a row tooltip. */
-export function efficiencyMetricDescription(metricKey: keyof ProfileEdges): string {
-  switch (metricKey) {
-    case "costPerMTok":
-      return "Cost for real work. Waste increases this cost, so high efficiency is a low number here."
-    case "realWorkShare":
-      return "How much you spent on real work. The rest of your spend was just re-reading or re-sending context."
-    case "rewriteShare":
-      return "How much you spent rewriting the cache: usually after compaction, a cache miss, or a model switch."
-  }
-}
-
-/** One sentence of thresholds for a row tooltip. */
-export function efficiencyThresholdsText(
+/** Describe the good, bad, and neutral ranges for one metric. */
+export function efficiencyThresholdGuidance(
   metricKey: keyof ProfileEdges,
   profile: EfficiencyProfile,
-): string {
+): string[] {
   const edges = EDGES[profile][metricKey]
   const fmt = (value: number) => formatEdge(metricKey, value)
   if (edges.higherIsBetter) {
-    return `[Good = over ${fmt(edges.good)}; Low = below ${fmt(edges.bad)}; otherwise OK]`
+    return [
+      `For ${readableProfile(profile)}, aim for above ${fmt(edges.good)}. Below ${fmt(edges.bad)} is too low.`,
+    ]
   }
-  return `[Good = below ${fmt(edges.good)}; High = over ${fmt(edges.bad)}; otherwise OK]`
+  return [
+    `For ${readableProfile(profile)}, aim for below ${fmt(edges.good)}. Above ${fmt(edges.bad)} is too high.`,
+  ]
 }


### PR DESCRIPTION
## Summary

- move the Efficiency card above Cost and add Carry as the third spend share
- align Real Work, Rewrite Waste, and Carry as one complete cost composition
- keep the headline $/MTok status meter and coordinate percentage rounding to 100%
- add single-open metric guidance with agent-specific thresholds and keyboard-accessible row controls

## Verification

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test` (943 tests)
- `pnpm --filter @antiburn/desktop build`
- `node scripts/check-design-drift.mjs`
- `pnpm run slop` (score 100)
- `pnpm run secrets`

## Privacy and performance

This is a local presentation change. It adds no network access, data collection, transcript reads, or unbounded work.

## Known limit

The Carry bands are derived from the remaining overhead when the existing Real Work and Rewrite bands reach the same rating. They are provisional rather than an independent empirical benchmark.