### PR TITLE
feat(desktop): expand session burn checks

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1296,9 +1296,11 @@ fn hygiene_payload_from_prior_evidence(
 ) -> Option<SessionHygienePayload> {
     let evidence_json = evidence_json?;
     let evidence = serde_json::from_str::<SessionEvidence>(&evidence_json).ok()?;
+    let catalogs = ReportCatalogs::default();
     Some(SessionHygienePayload::for_evidence(
-        session_badges(&evidence, &ReportCatalogs::default()),
+        session_badges(&evidence, &catalogs),
         &evidence,
+        &catalogs,
         evidence_state,
     ))
 }
@@ -1360,9 +1362,11 @@ fn session_hygiene_payload(
             } else {
                 "ready"
             };
+            let catalogs = ReportCatalogs::default();
             SessionHygienePayload::for_evidence(
-                session_badges(&evidence, &ReportCatalogs::default()),
+                session_badges(&evidence, &catalogs),
                 &evidence,
+                &catalogs,
                 evidence_state,
             )
         }

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -11,14 +11,16 @@
 //! never labels.
 
 use antiburn_local::analysis::{
-    ActiveSessionsSummary, EfficiencyTotals, EvidenceValue, ModelRun, QuotaLimitKind,
-    RepeatedContextAccounting, SessionCost, SessionEvidence,
+    ActiveSessionsSummary, EfficiencyTotals, EvidenceValue, FAST_SPEED_KEY, ModelRun,
+    QuotaLimitKind, RepeatedContextAccounting, SessionCost, SessionEvidence,
 };
 use antiburn_local::insights::{
     BadgeId, BadgeStatus, DetectorId, DetectorStatus, EfficiencyReport, NotAssessedReason,
-    QuotaPressureSection, SessionBadge,
+    QuotaPressureSection, ReportCatalogs, SessionBadge, model_family,
 };
+use antiburn_local::pricing::canonical_model_key;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 /// One row of the popover's activity list.
 ///
@@ -548,8 +550,55 @@ pub enum SessionHygieneStatus {
     NotAssessed,
 }
 
-/// One session hygiene badge with identifiers only.
-#[derive(Debug, Clone, Copy, Serialize)]
+/// The stored facts that caused one session hygiene finding.
+#[derive(Debug, Clone, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum SessionHygieneFindingEvidencePayload {
+    SessionOverdepth {
+        max_request_context_tokens: u64,
+        depth_cap_tokens: u64,
+    },
+    ModelOverthinking {
+        tiers: Vec<HygieneEffortTierPayload>,
+    },
+    OverpoweredSubagents {
+        main_models: Vec<String>,
+        delegated_models: Vec<String>,
+    },
+    ObsoleteModel {
+        models: Vec<HygieneObsoleteModelPayload>,
+    },
+    FastModeOveruse {
+        delegated_turns: u64,
+    },
+    ExcessCacheRehydration {
+        repeated_tokens: u64,
+        paid_tokens: u64,
+        threshold_multiple: f64,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HygieneEffortTierPayload {
+    pub tier: String,
+    pub main_loop_turns: u64,
+    pub delegated_turns: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HygieneObsoleteModelPayload {
+    pub model: String,
+    pub replacement: String,
+}
+
+/// One session hygiene badge with the facts behind a finding.
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionHygieneBadgePayload {
     pub id: &'static str,
@@ -560,6 +609,9 @@ pub struct SessionHygieneBadgePayload {
     /// `repeated_context` marker.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accounting: Option<&'static str>,
+    /// Present only when stored evidence explains a finding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finding_evidence: Option<SessionHygieneFindingEvidencePayload>,
 }
 
 /// The session badge set and its stored evidence state.
@@ -582,7 +634,11 @@ fn badge_id_str(id: BadgeId) -> &'static str {
 }
 
 impl SessionHygieneBadgePayload {
-    fn from_badge(badge: SessionBadge, accounting: Option<&'static str>) -> Self {
+    fn from_badge(
+        badge: SessionBadge,
+        accounting: Option<&'static str>,
+        finding_evidence: Option<SessionHygieneFindingEvidencePayload>,
+    ) -> Self {
         let (status, not_assessed_reason) = match badge.status {
             BadgeStatus::Finding => (SessionHygieneStatus::Finding, None),
             BadgeStatus::Clean => (SessionHygieneStatus::Clean, None),
@@ -603,6 +659,145 @@ impl SessionHygieneBadgePayload {
             status,
             not_assessed_reason,
             accounting,
+            finding_evidence,
+        }
+    }
+}
+
+fn observed<T>(evidence: &EvidenceValue<T>) -> Option<&T> {
+    match evidence {
+        EvidenceValue::Complete(observed) | EvidenceValue::Partial { observed, .. } => {
+            Some(observed)
+        }
+        EvidenceValue::Unsupported => None,
+    }
+}
+
+fn model_is_premium(model: &str, catalogs: &ReportCatalogs) -> bool {
+    let Some(policy) = catalogs.families.get(&model_family(model)) else {
+        return false;
+    };
+    policy.premium.reviewed && policy.premium.is_premium(&canonical_model_key(model))
+}
+
+fn finding_evidence(
+    id: BadgeId,
+    evidence: &SessionEvidence,
+    catalogs: &ReportCatalogs,
+) -> Option<SessionHygieneFindingEvidencePayload> {
+    match id {
+        BadgeId::SessionOverdepth => {
+            let context = observed(&evidence.context)?;
+            Some(SessionHygieneFindingEvidencePayload::SessionOverdepth {
+                max_request_context_tokens: context.max_request_context_tokens,
+                depth_cap_tokens: catalogs.depth_cap_tokens,
+            })
+        }
+        BadgeId::ModelOverthinking => {
+            let models = observed(&evidence.models)?;
+            let families = models
+                .by_model
+                .keys()
+                .map(|model| model_family(model))
+                .collect::<BTreeSet<_>>();
+            let tiers = models
+                .effort_tiers
+                .iter()
+                .filter_map(|(tier, turns)| {
+                    let normalized = tier.trim().to_lowercase();
+                    let above_cap = families.iter().any(|family| {
+                        catalogs
+                            .families
+                            .get(family)
+                            .is_some_and(|policy| policy.effort.above_cap.contains(&normalized))
+                    });
+                    above_cap.then(|| HygieneEffortTierPayload {
+                        tier: tier.clone(),
+                        main_loop_turns: turns.main_loop,
+                        delegated_turns: turns.delegated,
+                    })
+                })
+                .collect();
+            Some(SessionHygieneFindingEvidencePayload::ModelOverthinking { tiers })
+        }
+        BadgeId::OverpoweredSubagents => {
+            let subagents = observed(&evidence.subagents)?;
+            let models = observed(&evidence.models);
+            let main_models = models
+                .and_then(|models| models.dominant_main_model.as_ref())
+                .filter(|model| model_is_premium(model, catalogs))
+                .cloned()
+                .into_iter()
+                .chain(
+                    subagents
+                        .children
+                        .iter()
+                        .filter_map(|child| child.parent_model.as_ref())
+                        .filter(|model| model_is_premium(model, catalogs))
+                        .cloned(),
+                )
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            let delegated_models = subagents
+                .delegated_models
+                .iter()
+                .filter(|model| model_is_premium(model, catalogs))
+                .cloned()
+                .collect();
+            Some(SessionHygieneFindingEvidencePayload::OverpoweredSubagents {
+                main_models,
+                delegated_models,
+            })
+        }
+        BadgeId::ObsoleteModel => {
+            let models = observed(&evidence.models)?;
+            let models = models
+                .by_model
+                .iter()
+                .filter_map(|(model, tokens)| {
+                    let replacement = catalogs.model_replacements.lookup(model)?;
+                    (tokens.turns > 0 && tokens.last_ts_ms >= replacement.available_since_ts_ms)
+                        .then(|| HygieneObsoleteModelPayload {
+                            model: model.clone(),
+                            replacement: replacement.replacement.clone(),
+                        })
+                })
+                .collect();
+            Some(SessionHygieneFindingEvidencePayload::ObsoleteModel { models })
+        }
+        BadgeId::FastModeOveruse => {
+            let models = observed(&evidence.models)?;
+            let delegated_turns = models
+                .fast_modes
+                .iter()
+                .filter(|(label, turns)| {
+                    label.trim().eq_ignore_ascii_case(FAST_SPEED_KEY)
+                        && turns.delegated >= catalogs.fast_mode_delegated_turns_threshold
+                })
+                .map(|(_, turns)| turns.delegated)
+                .sum();
+            Some(SessionHygieneFindingEvidencePayload::FastModeOveruse { delegated_turns })
+        }
+        BadgeId::ExcessCacheRehydration => {
+            let cache = observed(&evidence.cache)?;
+            let repeated_context = observed(&cache.repeated_context)?;
+            let models = observed(&evidence.models)?;
+            let model = models
+                .dominant_main_model
+                .as_ref()
+                .or_else(|| models.by_model.keys().next())?;
+            let threshold_multiple = catalogs
+                .families
+                .get(&model_family(model))?
+                .cache_overpay_multiple_threshold;
+            Some(
+                SessionHygieneFindingEvidencePayload::ExcessCacheRehydration {
+                    repeated_tokens: repeated_context.repeated_tokens,
+                    paid_tokens: repeated_context.paid_tokens,
+                    threshold_multiple,
+                },
+            )
         }
     }
 }
@@ -637,7 +832,7 @@ impl SessionHygienePayload {
         Self {
             badges: badges
                 .into_iter()
-                .map(|badge| SessionHygieneBadgePayload::from_badge(badge, accounting))
+                .map(|badge| SessionHygieneBadgePayload::from_badge(badge, accounting, None))
                 .collect(),
             evidence_state,
         }
@@ -646,13 +841,24 @@ impl SessionHygienePayload {
     pub fn for_evidence(
         badges: [SessionBadge; 6],
         evidence: &SessionEvidence,
+        catalogs: &ReportCatalogs,
         evidence_state: &'static str,
     ) -> Self {
-        Self::from_badges(
-            badges,
-            repeated_context_accounting_str(evidence),
+        let accounting = repeated_context_accounting_str(evidence);
+        Self {
+            badges: badges
+                .into_iter()
+                .map(|badge| {
+                    let details = if matches!(badge.status, BadgeStatus::Finding) {
+                        finding_evidence(badge.id, evidence, catalogs)
+                    } else {
+                        None
+                    };
+                    SessionHygieneBadgePayload::from_badge(badge, accounting, details)
+                })
+                .collect(),
             evidence_state,
-        )
+        }
     }
 
     pub fn not_assessed(evidence_state: &'static str, reason: NotAssessedReason) -> Self {
@@ -1050,9 +1256,14 @@ mod tests {
     mod insights {
         use std::collections::{BTreeMap, BTreeSet};
 
+        use antiburn_local::analysis::{
+            ContextEvidence, EvidenceSource, ModelTokens, RelationConfidence, RelationProvenance,
+            RepeatedContext, SessionEvidenceAccumulator, SourceCapabilities, SourceKind,
+            SubagentChild, TurnCounts, TurnFacts,
+        };
         use antiburn_local::insights::{
             CoverageCounts, DetectorFindings, EfficiencyReportAccumulator, QuotaPressureFindings,
-            ReportContext, ReportWindow,
+            ReportContext, ReportWindow, session_badges,
         };
 
         use super::*;
@@ -1292,6 +1503,123 @@ mod tests {
                         {"id": "excessCacheRehydration", "status": "clean", "notAssessedReason": null}
                     ],
                     "evidenceState": "ready"
+                })
+            );
+        }
+
+        #[test]
+        fn the_session_hygiene_payload_serializes_finding_evidence() {
+            let mut evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+                agent: "claude-code".to_owned(),
+                session_id: "finding-details".to_owned(),
+                kind: SourceKind::File,
+                capabilities: SourceCapabilities::claude(),
+            })
+            .evidence(&TurnFacts::default());
+            let catalogs = ReportCatalogs::default();
+
+            evidence.context = EvidenceValue::Complete(ContextEvidence {
+                max_request_context_tokens: catalogs.depth_cap_tokens + 50_000,
+                top_depth_examples: Vec::new(),
+            });
+            let EvidenceValue::Complete(models) = &mut evidence.models else {
+                panic!("synthetic model evidence must be complete");
+            };
+            models.dominant_main_model = Some("claude-opus-4-6".to_owned());
+            models.by_model.insert(
+                "claude-opus-4-6".to_owned(),
+                ModelTokens {
+                    turns: 2,
+                    last_ts_ms: i64::MAX,
+                    ..ModelTokens::default()
+                },
+            );
+            models.effort_tiers.insert(
+                "max".to_owned(),
+                TurnCounts {
+                    main_loop: 2,
+                    delegated: 0,
+                },
+            );
+            models.fast_modes.insert(
+                FAST_SPEED_KEY.to_owned(),
+                TurnCounts {
+                    main_loop: 0,
+                    delegated: 2,
+                },
+            );
+
+            let EvidenceValue::Complete(subagents) = &mut evidence.subagents else {
+                panic!("synthetic subagent evidence must be complete");
+            };
+            subagents.spawn_count = 1;
+            subagents.delegated_turns = 2;
+            subagents
+                .delegated_models
+                .insert("claude-opus-4-6".to_owned());
+            subagents.children.push(SubagentChild {
+                ordinal: 1,
+                parent_model: Some("claude-opus-4-6".to_owned()),
+                child_model: EvidenceValue::Unsupported,
+                confidence: RelationConfidence::Observed,
+                provenance: RelationProvenance::TaskToolUse,
+            });
+
+            let EvidenceValue::Complete(cache) = &mut evidence.cache else {
+                panic!("synthetic cache evidence must be complete");
+            };
+            cache.repeated_context = EvidenceValue::Complete(RepeatedContext {
+                accounting: RepeatedContextAccounting::CacheWrite,
+                repeated_tokens: 135,
+                paid_tokens: 235,
+                pairs_considered: 1,
+                pairs_skipped: 0,
+            });
+
+            let payload = SessionHygienePayload::for_evidence(
+                session_badges(&evidence, &catalogs),
+                &evidence,
+                &catalogs,
+                "ready",
+            );
+            let value = serde_json::to_value(payload).unwrap();
+
+            assert_eq!(
+                value["badges"][0]["findingEvidence"],
+                serde_json::json!({
+                    "kind": "sessionOverdepth",
+                    "maxRequestContextTokens": 450_000,
+                    "depthCapTokens": 400_000
+                })
+            );
+            assert_eq!(
+                value["badges"][1]["findingEvidence"]["kind"],
+                "modelOverthinking"
+            );
+            assert_eq!(
+                value["badges"][1]["findingEvidence"]["tiers"][0]["tier"],
+                "max"
+            );
+            assert_eq!(
+                value["badges"][2]["findingEvidence"]["kind"],
+                "overpoweredSubagents"
+            );
+            assert_eq!(
+                value["badges"][3]["findingEvidence"]["kind"],
+                "obsoleteModel"
+            );
+            assert_eq!(
+                value["badges"][3]["findingEvidence"]["models"][0]["replacement"],
+                "claude-opus-5"
+            );
+            assert_eq!(value["badges"][4]["findingEvidence"]["delegatedTurns"], 2);
+            assert_eq!(
+                value["badges"][5]["findingEvidence"],
+                serde_json::json!({
+                    "kind": "excessCacheRehydration",
+                    "repeatedTokens": 135,
+                    "paidTokens": 235,
+                    "thresholdMultiple": 2.35
                 })
             );
         }

--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -155,7 +155,7 @@ describe("SessionDetailPresentation — chrome", () => {
     expect(screen.getByText("Cost")).toBeTruthy()
   })
 
-  it("renders a distinct not-assessed hygiene pip with an accessible label", () => {
+  it("renders every hygiene check with a distinct verdict", () => {
     view({
       hygiene: {
         badges: [
@@ -194,12 +194,35 @@ describe("SessionDetailPresentation — chrome", () => {
       },
     })
 
-    const pip = screen.getByLabelText("Session overdepth not assessed")
-    expect(pip.textContent).toBe("?")
-    expect(pip.className).toContain("border-dashed")
-    expect(pip.className).toContain("text-label-tertiary")
-    expect(screen.getByLabelText("No model overthinking detected").textContent).toBe("✓")
-    expect(screen.getByLabelText("Overpowered subagents detected").textContent).toBe("×")
+    const hygiene = screen.getByLabelText("Session hygiene checks")
+    expect(hygiene.children).toHaveLength(2)
+    const summary = screen.getByRole("button", {
+      name: "4/5 passing, 1 not assessed",
+    })
+    expect(
+      screen.getByRole("button", { name: "Overpowered subagents details" }),
+    ).toHaveTextContent("failing")
+
+    fireEvent.click(summary)
+
+    expect(screen.getByRole("button", { name: "Session overdepth details" })).toHaveTextContent(
+      "not assessed",
+    )
+    expect(
+      screen.getByRole("button", { name: "Model overthinking details" }),
+    ).toHaveTextContent("passing")
+  })
+
+  it("shows the hygiene evidence state in the card header", () => {
+    view({
+      hygiene: {
+        ...INITIAL_SESSION_HYGIENE,
+        evidenceState: "stale",
+      },
+    })
+
+    expect(screen.getByText("Burn Checks")).toBeTruthy()
+    expect(screen.getByText("Refreshing")).toBeTruthy()
   })
 
   it("adds the routing-miss count from the session metrics to the Context hint", () => {
@@ -288,13 +311,16 @@ describe("SessionDetailPresentation — chrome", () => {
     expect(detailRow).toHaveTextContent("last 11m ago")
     expect(detailRow).toHaveTextContent("5.6-sol/high")
     const hygiene = screen.getByLabelText("Session hygiene checks")
-    expect(hygiene.children).toHaveLength(6)
-    expect(screen.getByLabelText("No session overdepth detected")).toBeTruthy()
-    expect(screen.getByLabelText("No model overthinking detected")).toBeTruthy()
-    expect(screen.getByLabelText("No overpowered subagents detected")).toBeTruthy()
-    expect(screen.getByLabelText("No obsolete model detected")).toBeTruthy()
-    expect(screen.getByLabelText("No fast mode overuse detected")).toBeTruthy()
-    expect(screen.getByLabelText("No excess cache rehydration detected")).toBeTruthy()
+    expect(hygiene.children).toHaveLength(1)
+    fireEvent.click(screen.getByRole("button", { name: "6/6 passing" }))
+    expect(screen.getByRole("button", { name: "Session overdepth details" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Model overthinking details" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Overpowered subagents details" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Obsolete model details" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Fast mode overuse details" })).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "Excess cache rehydration details" }),
+    ).toBeTruthy()
   })
 
   it("names the back control for what it does, not for the view it leaves", () => {

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -50,6 +50,7 @@ import { Skeleton } from "../ui/Skeleton"
 import { CostBreakdown } from "./analysis/CostBreakdown"
 import { ContextTokensChart } from "./analysis/ContextTokensChart"
 import { EfficiencyBreakdown } from "./analysis/EfficiencyBreakdown"
+import { HygieneBreakdown } from "./analysis/HygieneBreakdown"
 import { SkillsMcpChart } from "./analysis/SkillsMcpChart"
 import { SessionCostBadge } from "./metrics/SessionCostBadge"
 import type { AgentIconRenderer } from "./orchestration/SubagentRosterRow"
@@ -629,7 +630,6 @@ export function SessionDetailPresentation({
 
         {ready && !error && !empty && summary && (
           <>
-            {/* Header */}
             <div className="w-full flex flex-col gap-y-2 px-4 pb-3">
               <div className="flex items-center gap-x-2" aria-label="Session summary">
                 <span className="shrink-0">{renderAgentIcon(session.agent, 20)}</span>
@@ -739,34 +739,8 @@ export function SessionDetailPresentation({
                   lines={3}
                 />
               </div>
-
-              <div className="flex items-center gap-x-2">
-                <span className="type-footnote text-label-tertiary">
-                  Hygiene checks{hygieneStateLabel ? ` · ${hygieneStateLabel}` : ""}:
-                </span>
-                <div className="flex items-center gap-x-2" aria-label="Session hygiene checks">
-                  {hygieneChecks.map((check) => (
-                    <span
-                      key={check.id}
-                      className={cn(
-                        "inline-flex size-5 items-center justify-center rounded-control bg-surface-secondary type-footnote leading-none transition-opacity duration-[var(--duration-fast)] hover:opacity-80",
-                        check.status === "clean" && "text-system-green opacity-50",
-                        check.status === "finding" && "text-system-red-text opacity-70",
-                        check.status === "notAssessed" &&
-                          "border border-dashed border-separator text-label-tertiary opacity-70",
-                      )}
-                      title={check.title}
-                      aria-label={check.title}
-                    >
-                      {check.status === "clean" ? "✓" : check.status === "finding" ? "×" : "?"}
-                    </span>
-                  ))}
-                </div>
-              </div>
             </div>
 
-            {/* Provenance: mark a sub-agent view as an autonomous worker and
-                link up to the orchestrator that launched it. */}
             {subagent && (
               <SubagentBadge
                 parentAgent={session.agent}
@@ -784,6 +758,13 @@ export function SessionDetailPresentation({
                 <EfficiencyBreakdown metrics={efficiencyCard} />
               </Card>
             )}
+
+            <Card
+              title="Burn Checks"
+              {...(hygieneStateLabel ? { hint: hygieneStateLabel } : {})}
+            >
+              <HygieneBreakdown checks={hygieneChecks} />
+            </Card>
 
             {tokensCard && (
               <Card title="Context" subtitle={tokensCard.hint}>

--- a/apps/desktop/src/components/session/analysis/HygieneBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/HygieneBreakdown.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import type { SessionHygienePayload } from "../../../lib/insightsIpc"
+import { sessionHygieneChecks } from "../../../lib/presentation/sessionHygiene"
+import { HygieneBreakdown } from "./HygieneBreakdown"
+
+afterEach(cleanup)
+
+const PAYLOAD: SessionHygienePayload = {
+  badges: [
+    {
+      id: "sessionOverdepth",
+      status: "finding",
+      notAssessedReason: null,
+      findingEvidence: {
+        kind: "sessionOverdepth",
+        maxRequestContextTokens: 475_000,
+        depthCapTokens: 400_000,
+      },
+    },
+    { id: "modelOverthinking", status: "clean", notAssessedReason: null },
+    {
+      id: "overpoweredSubagents",
+      status: "notAssessed",
+      notAssessedReason: "incompleteEvidence",
+    },
+    { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+    { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+    { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+  ],
+  evidenceState: "ready",
+}
+
+function view() {
+  return render(<HygieneBreakdown checks={sessionHygieneChecks(PAYLOAD)} />)
+}
+
+describe("HygieneBreakdown", () => {
+  it("rolls passing and unassessed checks into a summary", () => {
+    view()
+
+    const summary = screen.getByRole("button", {
+      name: "4/5 passing, 1 not assessed",
+    })
+    expect(summary.getAttribute("aria-expanded")).toBe("false")
+    expect(screen.getByLabelText("Session hygiene checks").children).toHaveLength(2)
+    expect(screen.getByText("Session overdepth")).toBeTruthy()
+    expect(screen.getByText("failing")).toBeTruthy()
+    expect(screen.queryByText("Model overthinking")).toBeNull()
+
+    fireEvent.click(summary)
+
+    expect(summary.getAttribute("aria-expanded")).toBe("true")
+    expect(screen.getByText("Model overthinking")).toBeTruthy()
+    expect(screen.getByText("Overpowered subagents")).toBeTruthy()
+    expect(screen.getByText("Obsolete model")).toBeTruthy()
+    expect(screen.getByText("Fast mode overuse")).toBeTruthy()
+    expect(screen.getByText("Excess cache rehydration")).toBeTruthy()
+    expect(screen.getAllByText("passing")).toHaveLength(4)
+    expect(screen.getByText("not assessed")).toBeTruthy()
+  })
+
+  it("opens the documentation for one check at a time", () => {
+    view()
+
+    fireEvent.click(screen.getByRole("button", { name: "Session overdepth details" }))
+    expect(
+      screen.getByRole("region", { name: "Session overdepth guidance" }),
+    ).toHaveTextContent("Deep context burns more tokens with each request")
+    expect(
+      screen.getByRole("region", { name: "Session overdepth guidance" }),
+    ).toHaveTextContent("475,000 tokens")
+    expect(
+      screen.getByRole("region", { name: "Session overdepth guidance" }),
+    ).toHaveTextContent("reviewed limit is 400,000")
+
+    fireEvent.click(screen.getByRole("button", { name: "4/5 passing, 1 not assessed" }))
+    fireEvent.click(screen.getByRole("button", { name: "Model overthinking details" }))
+    expect(screen.queryByRole("region", { name: "Session overdepth guidance" })).toBeNull()
+    expect(
+      screen.getByRole("region", { name: "Model overthinking guidance" }),
+    ).toHaveTextContent("Keep thinking/reasoning/effort below xhigh")
+  })
+
+  it("explains why a check was not assessed", () => {
+    view()
+
+    fireEvent.click(screen.getByRole("button", { name: "4/5 passing, 1 not assessed" }))
+    fireEvent.click(screen.getByRole("button", { name: "Overpowered subagents details" }))
+    expect(
+      screen.getByRole("region", { name: "Overpowered subagents guidance" }),
+    ).toHaveTextContent("couldn't read the whole session log")
+  })
+
+  it("keeps failing checks visible when the rollup closes", () => {
+    view()
+
+    const summary = screen.getByRole("button", { name: "4/5 passing, 1 not assessed" })
+    fireEvent.click(summary)
+    fireEvent.click(screen.getByRole("button", { name: "Model overthinking details" }))
+    fireEvent.click(summary)
+
+    expect(screen.queryByRole("region", { name: "Model overthinking guidance" })).toBeNull()
+    expect(screen.getByRole("button", { name: "Session overdepth details" })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/session/analysis/HygieneBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/HygieneBreakdown.tsx
@@ -1,0 +1,191 @@
+import { Check, ChevronRight, CircleDashed, X, type LucideIcon } from "lucide-react"
+import { useId, useState } from "react"
+
+import { cn } from "../../../lib/cn"
+import {
+  notAssessedReasonLabel,
+  sessionHygieneDocumentation,
+  type SessionHygieneCheck,
+} from "../../../lib/presentation/sessionHygiene"
+
+export interface HygieneBreakdownProps {
+  checks: SessionHygieneCheck[]
+}
+
+interface HygieneStatusPresentation {
+  Icon: LucideIcon
+  iconSize: number
+  label: string
+  strokeWidth: number
+  textClass: string
+}
+
+const STATUS_PRESENTATION: Record<SessionHygieneCheck["status"], HygieneStatusPresentation> = {
+  finding: {
+    Icon: X,
+    iconSize: 12,
+    label: "failing",
+    strokeWidth: 2.5,
+    textClass: "text-system-red-text",
+  },
+  clean: {
+    Icon: Check,
+    iconSize: 12,
+    label: "passing",
+    strokeWidth: 2.5,
+    textClass: "text-system-green",
+  },
+  notAssessed: {
+    Icon: CircleDashed,
+    iconSize: 10,
+    label: "not assessed",
+    strokeWidth: 2,
+    textClass: "text-label-tertiary",
+  },
+}
+
+function HygieneGuidance({ check }: { check: SessionHygieneCheck }) {
+  const documentation = sessionHygieneDocumentation(check)
+
+  return (
+    <div className="space-y-1 rounded-control border-x border-b border-separator px-3 pb-3 text-pretty type-footnote text-label-secondary">
+      {documentation.findingDetails.length > 0 && (
+        <div className="mb-2">
+          {documentation.findingDetails.map((sentence) => (
+            <p key={sentence} className="type-footnote font-semibold! text-system-red-text">
+              {sentence}
+            </p>
+          ))}
+        </div>
+      )}
+      <p className="type-footnote font-semibold! text-label-secondary">
+        {documentation.summary}
+      </p>
+      {check.status === "notAssessed" && check.notAssessedReason && (
+        <p className="italic">
+          Not assessed: {notAssessedReasonLabel(check.notAssessedReason)}.
+        </p>
+      )}
+      {documentation.guidance.length > 0 && (
+        <ul className="mt-2 list-disc space-y-0.5 pl-5 text-sm/5">
+          {documentation.guidance.map((sentence) => (
+            <li key={sentence} className="mt-1">
+              {sentence}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function HygieneRow({
+  check,
+  open,
+  onToggle,
+}: {
+  check: SessionHygieneCheck
+  open: boolean
+  onToggle: () => void
+}) {
+  const bodyId = useId()
+  const status = STATUS_PRESENTATION[check.status]
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={`${check.name} details`}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={onToggle}
+        className="-mx-1 grid grid-cols-[minmax(0,1fr)_max-content] items-center gap-x-3 rounded-control px-1 py-1 text-left type-caption transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover active:transform-none active:opacity-100"
+      >
+        <span className="truncate text-label-tertiary">{check.name}</span>
+        <span className={cn("inline-flex items-center gap-1", status.textClass)}>
+          <status.Icon
+            size={status.iconSize}
+            strokeWidth={status.strokeWidth}
+            aria-hidden="true"
+          />
+          <span>{status.label}</span>
+        </span>
+      </button>
+
+      {open && (
+        <div
+          id={bodyId}
+          role="region"
+          aria-label={`${check.name} guidance`}
+          className="px-1 pb-2"
+        >
+          <HygieneGuidance check={check} />
+        </div>
+      )}
+    </>
+  )
+}
+
+export function HygieneBreakdown({ checks }: HygieneBreakdownProps) {
+  const [rollupOpen, setRollupOpen] = useState(false)
+  const [openCheck, setOpenCheck] = useState<SessionHygieneCheck["id"] | null>(null)
+  const passing = checks.filter((check) => check.status === "clean")
+  const notAssessed = checks.filter((check) => check.status === "notAssessed")
+  const findings = checks.filter((check) => check.status === "finding")
+  const rolledChecks = checks.filter((check) => check.status !== "finding")
+  const assessedCount = passing.length + findings.length
+  const rollupLabel = `${passing.length}/${assessedCount} passing${
+    notAssessed.length > 0 ? `, ${notAssessed.length} not assessed` : ""
+  }`
+
+  const toggleCheck = (checkId: SessionHygieneCheck["id"]) => {
+    setOpenCheck((current) => (current === checkId ? null : checkId))
+  }
+
+  const toggleRollup = () => {
+    if (rollupOpen && rolledChecks.some((check) => check.id === openCheck)) {
+      setOpenCheck(null)
+    }
+    setRollupOpen((current) => !current)
+  }
+
+  return (
+    <div className="grid gap-y-1" aria-label="Session hygiene checks">
+      <button
+        type="button"
+        aria-expanded={rollupOpen}
+        onClick={toggleRollup}
+        className="-mx-1 flex items-center justify-between gap-x-3 rounded-control px-1 py-1 text-left type-caption text-label-tertiary cursor-pointer! transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover active:transform-none active:opacity-100"
+      >
+        <span>{rollupLabel}</span>
+        <ChevronRight
+          size={14}
+          aria-hidden="true"
+          className={cn(
+            "shrink-0 transition-transform duration-[var(--duration-fast)] ease-out",
+            rollupOpen && "rotate-90",
+          )}
+        />
+      </button>
+
+      {rollupOpen &&
+        rolledChecks.map((check) => (
+          <HygieneRow
+            key={check.id}
+            check={check}
+            open={openCheck === check.id}
+            onToggle={() => toggleCheck(check.id)}
+          />
+        ))}
+
+      {findings.map((check) => (
+        <HygieneRow
+          key={check.id}
+          check={check}
+          open={openCheck === check.id}
+          onToggle={() => toggleCheck(check.id)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/lib/insightsIpc.ts
+++ b/apps/desktop/src/lib/insightsIpc.ts
@@ -108,6 +108,43 @@ export type SessionHygieneBadgeId =
   | "fastModeOveruse"
   | "excessCacheRehydration"
 
+export type SessionHygieneFindingEvidence =
+  | {
+      kind: "sessionOverdepth"
+      maxRequestContextTokens: number
+      depthCapTokens: number
+    }
+  | {
+      kind: "modelOverthinking"
+      tiers: Array<{
+        tier: string
+        mainLoopTurns: number
+        delegatedTurns: number
+      }>
+    }
+  | {
+      kind: "overpoweredSubagents"
+      mainModels: string[]
+      delegatedModels: string[]
+    }
+  | {
+      kind: "obsoleteModel"
+      models: Array<{
+        model: string
+        replacement: string
+      }>
+    }
+  | {
+      kind: "fastModeOveruse"
+      delegatedTurns: number
+    }
+  | {
+      kind: "excessCacheRehydration"
+      repeatedTokens: number
+      paidTokens: number
+      thresholdMultiple: number
+    }
+
 export interface SessionHygieneBadgePayload {
   id: SessionHygieneBadgeId
   status: "finding" | "clean" | "notAssessed"
@@ -116,6 +153,8 @@ export interface SessionHygieneBadgePayload {
    *  verdict. Absent for every other badge and for old evidence with no
    *  `repeated_context` marker. */
   accounting?: "cacheWrite" | "uncachedInput"
+  /** The stored facts that caused a finding. Absent for every other status. */
+  findingEvidence?: SessionHygieneFindingEvidence
 }
 
 export type SessionHygieneEvidenceState =

--- a/apps/desktop/src/lib/presentation/sessionHygiene.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.test.ts
@@ -5,6 +5,7 @@ import {
   INITIAL_SESSION_HYGIENE,
   notAssessedReasonLabel,
   sessionHygieneChecks,
+  sessionHygieneDocumentation,
   sessionHygieneStateLabel,
 } from "./sessionHygiene"
 
@@ -27,17 +28,17 @@ const PAYLOAD: SessionHygienePayload = {
 describe("sessionHygieneChecks", () => {
   it("maps every engine identifier to reader copy in a stable order", () => {
     expect(sessionHygieneChecks(PAYLOAD).map(({ id, title }) => ({ id, title }))).toEqual([
-      { id: "sessionOverdepth", title: "Session overdepth detected" },
-      { id: "modelOverthinking", title: "No model overthinking detected" },
+      { id: "sessionOverdepth", title: "Session went too deep" },
+      { id: "modelOverthinking", title: "Thinking/reasoning modes ok" },
       {
         id: "overpoweredSubagents",
-        title: "Overpowered subagents not assessed",
+        title: "Subagent models not assessed",
       },
-      { id: "obsoleteModel", title: "No obsolete model detected" },
-      { id: "fastModeOveruse", title: "No fast mode overuse detected" },
+      { id: "obsoleteModel", title: "All models up to date" },
+      { id: "fastModeOveruse", title: "Fast mode not overused" },
       {
         id: "excessCacheRehydration",
-        title: "No excess cache rehydration detected",
+        title: "Cache rehydration under control",
       },
     ])
   })
@@ -48,8 +49,8 @@ describe("sessionHygieneChecks", () => {
       "Model overthinking",
       "Overpowered subagents",
       "Obsolete model",
-      "Fast-mode overuse",
-      "Excess context reprocessing",
+      "Fast mode overuse",
+      "Excess cache rehydration",
     ])
   })
 
@@ -58,6 +59,65 @@ describe("sessionHygieneChecks", () => {
       expect(check.name.toLowerCase()).not.toContain("detected")
       expect(check.name.toLowerCase()).not.toContain("not assessed")
     }
+  })
+
+  it("provides an explanation and guidance for every check", () => {
+    for (const check of sessionHygieneChecks(PAYLOAD)) {
+      const documentation = sessionHygieneDocumentation(check)
+      expect(documentation.summary.length).toBeGreaterThan(0)
+      expect(documentation.guidance.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("describes the stored evidence that caused a finding", () => {
+    const payload: SessionHygienePayload = {
+      ...PAYLOAD,
+      badges: PAYLOAD.badges.map((badge) =>
+        badge.id === "modelOverthinking"
+          ? {
+              ...badge,
+              status: "finding" as const,
+              findingEvidence: {
+                kind: "modelOverthinking" as const,
+                tiers: [{ tier: "max", mainLoopTurns: 2, delegatedTurns: 1 }],
+              },
+            }
+          : badge,
+      ),
+    }
+    const check = sessionHygieneChecks(payload).find(
+      (candidate) => candidate.id === "modelOverthinking",
+    )!
+
+    expect(sessionHygieneDocumentation(check).findingDetails).toEqual([
+      "The session used max reasoning for 3 turns.",
+    ])
+  })
+
+  it("uses concise model names in finding details", () => {
+    const payload: SessionHygienePayload = {
+      ...PAYLOAD,
+      badges: PAYLOAD.badges.map((badge) =>
+        badge.id === "overpoweredSubagents"
+          ? {
+              ...badge,
+              status: "finding" as const,
+              findingEvidence: {
+                kind: "overpoweredSubagents" as const,
+                mainModels: ["claude-fable-5"],
+                delegatedModels: ["claude-fable-5", "claude-opus-5"],
+              },
+            }
+          : badge,
+      ),
+    }
+    const check = sessionHygieneChecks(payload).find(
+      (candidate) => candidate.id === "overpoweredSubagents",
+    )!
+
+    expect(sessionHygieneDocumentation(check).findingDetails).toEqual([
+      "fable-5 used premium subagents (fable-5 and opus-5).",
+    ])
   })
 
   it("names the not-assessed obsolete-model check without its verdict", () => {
@@ -108,6 +168,9 @@ describe("sessionHygieneChecks", () => {
       (candidate) => candidate.id === "excessCacheRehydration",
     )
     expect(check?.detail).toBe("Reduce repeated cache writes")
+    expect(check && sessionHygieneDocumentation(check).guidance[0]).toBe(
+      "Reduce repeated cache writes",
+    )
   })
 
   it("names the accounting-specific detail copy for an uncached-input finding", () => {

--- a/apps/desktop/src/lib/presentation/sessionHygiene.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.ts
@@ -5,6 +5,7 @@ import type {
   SessionHygieneEvidenceState,
   SessionHygienePayload,
 } from "../insightsIpc"
+import { modelShortName } from "./models"
 
 type SessionHygieneInk = "system-green" | "system-red-text" | "label-tertiary"
 
@@ -12,6 +13,7 @@ export interface SessionHygieneCheck {
   id: SessionHygieneBadgeId
   status: SessionHygieneBadgePayload["status"]
   notAssessedReason: InsightsNotAssessedReason | null
+  findingEvidence?: SessionHygieneBadgePayload["findingEvidence"]
   title: string
   /**
    * The check name alone, with no verdict. Use it where a separate line
@@ -34,55 +36,87 @@ interface HygieneCheckDefinition {
   cleanTitle: string
   findingTitle: string
   notAssessedTitle: string
+  summary: string
+  guidance: readonly string[]
 }
 
 const CHECKS: readonly HygieneCheckDefinition[] = [
   {
     id: "sessionOverdepth",
     name: "Session overdepth",
-    cleanTitle: "No session overdepth detected",
-    findingTitle: "Session overdepth detected",
-    notAssessedTitle: "Session overdepth not assessed",
+    cleanTitle: "Session didn't get too deep",
+    findingTitle: "Session went too deep",
+    notAssessedTitle: "Session depth not assessed",
+    summary:
+      "Deep context burns more tokens with each request, directly affecting cost and quality.",
+    guidance: [
+      "Compaction works now, use it over about 200k tokens.",
+      "Use subagents to preserve parent context.",
+    ],
   },
   {
     id: "modelOverthinking",
     name: "Model overthinking",
-    cleanTitle: "No model overthinking detected",
-    findingTitle: "Model overthinking detected",
-    notAssessedTitle: "Model overthinking not assessed",
+    cleanTitle: "Thinking/reasoning modes ok",
+    findingTitle: "Thinking/reasoning modes too high",
+    notAssessedTitle: "Thinking/reasoning modes not assessed",
+    summary: "Higher thinking modes burn more tokens without giving better quality.",
+    guidance: [
+      "Keep thinking/reasoning/effort below xhigh.",
+      "Default to high for most tasks.",
+    ],
   },
   {
     id: "overpoweredSubagents",
     name: "Overpowered subagents",
-    cleanTitle: "No overpowered subagents detected",
-    findingTitle: "Overpowered subagents detected",
-    notAssessedTitle: "Overpowered subagents not assessed",
+    cleanTitle: "Subagent models ok",
+    findingTitle: "Subagent models too powerful",
+    notAssessedTitle: "Subagent models not assessed",
+    summary:
+      "Subagents have to reorient themselves. Using premium subagents gets expensive fast.",
+    guidance: ["Get your premium main agent to delegate to cheaper subagents."],
   },
   {
     id: "obsoleteModel",
     name: "Obsolete model",
-    cleanTitle: "No obsolete model detected",
-    findingTitle: "Obsolete model detected",
-    notAssessedTitle: "Obsolete model not assessed",
+    cleanTitle: "All models up to date",
+    findingTitle: "Old model usage detected",
+    notAssessedTitle: "Model obsolescence not assessed",
+    summary: "Newer models usually give better output at the same or cheaper cost.",
+    guidance: [
+      "Manually switch to the current replacement.",
+      "Update the agent's default model in config.",
+    ],
   },
   {
     id: "fastModeOveruse",
-    name: "Fast-mode overuse",
-    cleanTitle: "No fast mode overuse detected",
-    findingTitle: "Fast mode overuse detected",
-    notAssessedTitle: "Fast mode overuse not assessed",
+    name: "Fast mode overuse",
+    cleanTitle: "Fast mode not overused",
+    findingTitle: "Fast mode overused",
+    notAssessedTitle: "Fast mode not assessed",
+    summary: "Fast mode costs a lot more for a little extra speed.",
+    guidance: ["Use standard speed by default.", "Rarely use fast mode for subagents."],
   },
   {
     id: "excessCacheRehydration",
-    // This name diverges from the title wording on purpose. "Excess cache
-    // rehydration" names the mechanism; "Excess context reprocessing"
-    // names the check in reader terms.
-    name: "Excess context reprocessing",
-    cleanTitle: "No excess cache rehydration detected",
-    findingTitle: "Excess cache rehydration detected",
-    notAssessedTitle: "Excess cache rehydration not assessed",
+    name: "Excess cache rehydration",
+    cleanTitle: "Cache rehydration under control",
+    findingTitle: "Cache rehydration out of control",
+    notAssessedTitle: "Cache rehydration not assessed",
+    summary: "Spending tokens to refresh the server-side cache is a waste of money/quota.",
+    guidance: [
+      "Avoid long breaks in sessions.",
+      "If you have a long break, compact before or even after it.",
+      "Avoid switching models with a large context accumulated.",
+    ],
   },
 ]
+
+export interface SessionHygieneDocumentation {
+  summary: string
+  findingDetails: readonly string[]
+  guidance: readonly string[]
+}
 
 const NOT_ASSESSED: SessionHygieneBadgePayload = {
   id: "sessionOverdepth",
@@ -142,6 +176,73 @@ export function sessionHygieneChecks(payload: SessionHygienePayload): SessionHyg
       ink: "label-tertiary" as const,
     }
   })
+}
+
+/** Return the explanation and guidance for one hygiene check. */
+export function sessionHygieneDocumentation(
+  check: SessionHygieneCheck,
+): SessionHygieneDocumentation {
+  const definition = CHECKS.find((candidate) => candidate.id === check.id)!
+  const guidance = check.detail ? [check.detail, ...definition.guidance] : definition.guidance
+  return {
+    summary: definition.summary,
+    findingDetails: sessionHygieneFindingDetails(check),
+    guidance,
+  }
+}
+
+function readableCount(value: number, noun: string): string {
+  return `${value.toLocaleString()} ${value === 1 ? noun : `${noun}s`}`
+}
+
+function readableModels(models: readonly string[]): string {
+  const shortNames = [...new Set(models.map(modelShortName))]
+  return new Intl.ListFormat(undefined, { style: "long", type: "conjunction" }).format(
+    shortNames,
+  )
+}
+
+/** Describe the stored facts that caused one finding. */
+function sessionHygieneFindingDetails(check: SessionHygieneCheck): string[] {
+  const evidence = check.findingEvidence
+  if (check.status !== "finding" || !evidence) return []
+
+  switch (evidence.kind) {
+    case "sessionOverdepth":
+      return [
+        `The deepest request carried ${evidence.maxRequestContextTokens.toLocaleString()} tokens. The reviewed limit is ${evidence.depthCapTokens.toLocaleString()}.`,
+      ]
+    case "modelOverthinking":
+      return evidence.tiers.map(({ tier, mainLoopTurns, delegatedTurns }) => {
+        const turns = mainLoopTurns + delegatedTurns
+        return `The session used ${tier} reasoning for ${readableCount(turns, "turn")}.`
+      })
+    case "overpoweredSubagents":
+      return [
+        `${readableModels(evidence.mainModels)} used premium subagents (${readableModels(evidence.delegatedModels)}).`,
+      ]
+    case "obsoleteModel":
+      return evidence.models.map(
+        ({ model, replacement }) =>
+          `${modelShortName(model)} was still in use after ${modelShortName(replacement)} became available.`,
+      )
+    case "fastModeOveruse":
+      return [
+        `Fast mode was used for ${readableCount(evidence.delegatedTurns, "delegated turn")}.`,
+      ]
+    case "excessCacheRehydration": {
+      const uniqueTokens = evidence.paidTokens - evidence.repeatedTokens
+      if (uniqueTokens <= 0) {
+        return [
+          `All ${evidence.paidTokens.toLocaleString()} paid context tokens repeated. The finding threshold is ${evidence.thresholdMultiple.toLocaleString()}×.`,
+        ]
+      }
+      const observedMultiple = evidence.paidTokens / uniqueTokens
+      return [
+        `${evidence.repeatedTokens.toLocaleString()} of ${evidence.paidTokens.toLocaleString()} paid context tokens repeated. This raised paid context to ${observedMultiple.toLocaleString(undefined, { maximumFractionDigits: 2 })}× the unique context; the finding threshold is ${evidence.thresholdMultiple.toLocaleString()}×.`,
+      ]
+    }
+  }
 }
 
 /** Name a non-ready evidence state without implying a clean result. */


### PR DESCRIPTION
## User impact

Replaces the compact session hygiene pips with a Burn Checks card. Passing and unassessed checks roll up behind a disclosure row, while failing checks remain visible and expand to show the stored facts that triggered them plus concise guidance.

Finding details include context depth, reasoning tiers, premium subagent models, obsolete model replacements, delegated fast-mode turns, and repeated-context accounting. Model IDs use the desktop's concise display names.

## Validation

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## Privacy and performance

No new data access, network access, retained data, or background work. The card presents bounded facts already stored in local session evidence.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
