### PR TITLE
Rebuild onboarding around agents, hygiene, and Do Not Disturb

### DIFF
--- a/apps/desktop/src-tauri/src/analytics/event.rs
+++ b/apps/desktop/src-tauri/src/analytics/event.rs
@@ -216,6 +216,7 @@ pub enum Interaction {
 #[serde(rename_all = "snake_case")]
 pub enum OnboardingStep {
     Welcome,
+    AgentsDetected,
     SourcesAndRepos,
     Ready,
 }
@@ -287,6 +288,7 @@ impl OnboardingStep {
     fn as_str(self) -> &'static str {
         match self {
             OnboardingStep::Welcome => "welcome",
+            OnboardingStep::AgentsDetected => "agents_detected",
             OnboardingStep::SourcesAndRepos => "sources_and_repos",
             OnboardingStep::Ready => "ready",
         }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -17,7 +17,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use antiburn_local::analysis::{
     ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION, SessionEvidence, SourceAcceptance,
 };
-use antiburn_local::insights::{NotAssessedReason, ReportCatalogs, session_badges};
+use antiburn_local::insights::{
+    BadgeId, BadgeStatus, NotAssessedReason, ReportCatalogs, session_badges,
+};
 use antiburn_local::model::AgentKind;
 use antiburn_local::paths::scan_roots as engine_scan_roots;
 use antiburn_local::paths::{home_dir, protected};
@@ -31,10 +33,10 @@ use crate::agents::kind_from_slug;
 use crate::analysis;
 use crate::consent;
 use crate::dto::{
-    ActivityEntry, AgentScanState, AppInfo, DeferredPermissionDir, InsightsReportPayload,
-    InsightsStatusPayload, LiveUsageSummary, OrchestrationStatus, ProviderUsageSummary,
-    RepositoryItem, ScanStatus, SessionAnalysis, SessionHygienePayload, SessionHygieneRequest,
-    SessionIdentity, SessionRelation, SessionRelations, SubagentMember,
+    ActivityEntry, AgentScanState, AppInfo, DeferredPermissionDir, HygieneSummaryPayload,
+    InsightsReportPayload, InsightsStatusPayload, LiveUsageSummary, OrchestrationStatus,
+    ProviderUsageSummary, RepositoryItem, ScanStatus, SessionAnalysis, SessionHygienePayload,
+    SessionHygieneRequest, SessionIdentity, SessionRelation, SessionRelations, SubagentMember,
 };
 use crate::export::{ExportedSession, SessionExport};
 use crate::insights_ipc::InsightsController;
@@ -392,12 +394,20 @@ pub fn finish_onboarding(
     app: tauri::AppHandle,
     activity_window_days: u32,
     launch_at_login: bool,
+    disabled_agents: Option<Vec<String>>,
+    nudges_respect_dnd: Option<bool>,
 ) -> CommandResult<AppSettings> {
     let store = app.state::<Store>();
     let (previous, saved) = store
         .update_settings(|settings| {
             settings.activity_window_days = activity_window_days;
             settings.launch_at_login = launch_at_login;
+            if let Some(disabled) = disabled_agents {
+                settings.disabled_agents = crate::store::DisabledAgents::selected(disabled);
+            }
+            if let Some(respect) = nudges_respect_dnd {
+                settings.nudges_respect_dnd = respect;
+            }
             settings.onboarding_completed = true;
         })
         .map_err(fail)?;
@@ -471,10 +481,10 @@ fn apply_settings_transition(app: &tauri::AppHandle, previous: &AppSettings, sav
         crate::disk_monitor::refresh_title(app);
     }
 
-    // On macOS, the Focus-status authorization waits for a completed setup
-    // and the master notification switch. The function checks both itself,
-    // and repeat calls are free (the gate keeps a once-flag), so no
-    // transition edge needs to be computed here.
+    // On macOS, the Focus-status authorization waits for a completed setup,
+    // the master notification switch, and the Do Not Disturb opt-in. The
+    // function checks all three itself, and repeat calls are free (the gate
+    // keeps a once-flag), so no transition edge needs to be computed here.
     crate::notifications::maybe_initialize_authorization(app);
 
     // Consent changing is the queue's business: turning it off withdraws
@@ -534,17 +544,18 @@ pub fn list_recent_sessions(
     window_days: Option<u32>,
 ) -> CommandResult<Vec<ActivityEntry>> {
     let store = app.state::<Store>();
+    let settings = store.settings().map_err(fail)?;
     let days = match window_days {
         Some(days) => days.clamp(
             crate::store::MIN_ACTIVITY_DAYS,
             crate::store::MAX_ACTIVITY_DAYS,
         ),
-        None => store.settings().map_err(fail)?.activity_window_days,
+        None => settings.activity_window_days,
     };
     let now = scan::unix_now();
     let since = now - i64::from(days) * 86_400;
     let sessions = store
-        .recent_sessions(since, MAX_ACTIVITY_ROWS)
+        .recent_sessions_excluding(since, MAX_ACTIVITY_ROWS, &settings.disabled_agents)
         .map_err(fail)?;
     let repositories = store.repositories().map_err(fail)?;
 
@@ -1246,6 +1257,70 @@ pub fn get_insights_status(app: tauri::AppHandle) -> CommandResult<InsightsStatu
         pending: backlog.pending,
         processing: backlog.processing,
     })
+}
+
+/// The aggregate hygiene numbers for the sessions in the activity window.
+///
+/// Same window and disabled-agent filter as `list_recent_sessions`, so the
+/// summary describes the sessions the list shows.
+#[tauri::command]
+pub async fn get_hygiene_summary(app: tauri::AppHandle) -> CommandResult<HygieneSummaryPayload> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let store = app.state::<Store>();
+        let settings = store.settings().map_err(fail)?;
+        let since = scan::unix_now() - i64::from(settings.activity_window_days) * 86_400;
+        let rows = store
+            .hygiene_summary_rows(&environment_key(None), since, &settings.disabled_agents)
+            .map_err(fail)?;
+        Ok(hygiene_summary_payload(rows))
+    })
+    .await
+    .map_err(fail)?
+}
+
+fn hygiene_summary_payload(rows: Vec<crate::store::HygieneSummaryRow>) -> HygieneSummaryPayload {
+    let catalogs = ReportCatalogs::default();
+    let total_sessions = rows.len() as u64;
+    let mut settled_sessions = 0;
+    let mut analyzed_sessions = 0;
+    let mut failing_sessions = 0;
+    let mut finding_counts = [0u64; BadgeId::ALL.len()];
+    for row in rows {
+        if row.settled {
+            settled_sessions += 1;
+        }
+        let Some(evidence_json) = row.evidence_json else {
+            continue;
+        };
+        let Ok(evidence) = serde_json::from_str::<SessionEvidence>(&evidence_json) else {
+            continue;
+        };
+        analyzed_sessions += 1;
+        let mut failed = false;
+        for (index, badge) in session_badges(&evidence, &catalogs).iter().enumerate() {
+            if badge.status == BadgeStatus::Finding {
+                failed = true;
+                finding_counts[index] += 1;
+            }
+        }
+        if failed {
+            failing_sessions += 1;
+        }
+    }
+    // Ties keep the first badge in `BadgeId::ALL` order.
+    let most_common_finding = finding_counts
+        .iter()
+        .enumerate()
+        .filter(|(_, count)| **count > 0)
+        .max_by(|left, right| left.1.cmp(right.1).then(right.0.cmp(&left.0)))
+        .map(|(index, _)| crate::dto::badge_id_str(BadgeId::ALL[index]));
+    HygieneSummaryPayload {
+        total_sessions,
+        settled_sessions,
+        analyzed_sessions,
+        failing_sessions,
+        most_common_finding,
+    }
 }
 
 /// The hygiene badges for a bounded set of stored session evidence rows.

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -622,7 +622,26 @@ pub struct SessionHygienePayload {
     pub evidence_state: &'static str,
 }
 
-fn badge_id_str(id: BadgeId) -> &'static str {
+/// The aggregate hygiene numbers for the sessions in the activity window.
+///
+/// The onboarding Ready step reads this: a progress state while
+/// `settled_sessions` trails `total_sessions`, a results card after.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HygieneSummaryPayload {
+    /// Sessions in the window, after the disabled-agent display filter.
+    pub total_sessions: u64,
+    /// Sessions whose analysis reached a terminal state.
+    pub settled_sessions: u64,
+    /// Sessions with current ready evidence, so the checks ran.
+    pub analyzed_sessions: u64,
+    /// Analyzed sessions with at least one finding.
+    pub failing_sessions: u64,
+    /// Badge id of the most frequent finding, when any session fails.
+    pub most_common_finding: Option<&'static str>,
+}
+
+pub(crate) fn badge_id_str(id: BadgeId) -> &'static str {
     match id {
         BadgeId::SessionOverdepth => "sessionOverdepth",
         BadgeId::ModelOverthinking => "modelOverthinking",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -148,6 +148,7 @@ pub fn run() {
             commands::refresh_live_usage,
             commands::get_scan_status,
             commands::get_insights_report,
+            commands::get_hygiene_summary,
             commands::get_insights_status,
             commands::get_session_hygiene,
             commands::cancel_insights_report,

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -23,11 +23,13 @@
 //! - **Only the shell posts one.** The webview is granted no notification
 //!   permission (`capabilities/default.json`), so "what is worth interrupting
 //!   someone for" is decided in one place, in this file.
-//! - **The operating system gets the last word** for automated kinds.
-//!   Immediately before an automated notification shows, [`deliver`] asks the
-//!   OS whether interruptions are welcome right now — Focus and Do Not Disturb
-//!   on macOS, fullscreen/presentation/toasts-off states on Windows, DND on
-//!   GNOME and Plasma ([`antiburn_nudge::NotificationGate`]). A suppressed
+//! - **The operating system gets the last word** for automated kinds, when
+//!   the reader opts in (`nudges_respect_dnd`, off by default because the
+//!   macOS Focus check needs its own authorization prompt). Immediately
+//!   before an automated notification shows, [`deliver`] asks the OS whether
+//!   interruptions are welcome right now — Focus and Do Not Disturb on macOS,
+//!   fullscreen/presentation/toasts-off states on Windows, DND on GNOME and
+//!   Plasma ([`antiburn_nudge::NotificationGate`]). A suppressed
 //!   notification is dropped and its trigger stays consumed, so ending Focus
 //!   does not release a backlog of stale notifications. Unknown OS state fails
 //!   open. Preview kinds bypass the gate for the same reason they bypass the
@@ -200,9 +202,19 @@ enum Delivery {
 
 /// Ask the OS whether an automated notification may interrupt right now.
 ///
-/// A missing gate fails open: the gate is managed at setup, so its absence
-/// means a test harness, not a policy answer.
+/// The check runs only when the reader opted in (`nudges_respect_dnd`):
+/// on macOS it depends on a Focus-status authorization prompt, which must
+/// follow a choice rather than precede one. A missing gate fails open: the
+/// gate is managed at setup, so its absence means a test harness, not a
+/// policy answer.
 fn os_gate_allows(app: &AppHandle) -> bool {
+    let respect = app
+        .try_state::<Store>()
+        .and_then(|store| store.settings().ok())
+        .is_some_and(|settings| settings.nudges_respect_dnd);
+    if !respect {
+        return true;
+    }
     app.try_state::<antiburn_nudge::NotificationGate>()
         .is_none_or(|gate| gate.delivery_allowed())
 }
@@ -579,16 +591,22 @@ pub fn note_sample(app: &AppHandle, kind: Kind) {
 
 /// Request the macOS Focus-status authorization, at most once per process.
 ///
-/// The request runs only when setup is complete and the master notification
-/// preference is on, so the permission sheet cannot appear over the first-run
-/// window. Repeat calls are free: the gate keeps a once-flag. The other
-/// platforms need no authorization. The gate self-skips for unbundled dev
-/// binaries, which cannot hold the signed entitlement.
+/// The request runs only when setup is complete, the master notification
+/// preference is on, and the reader opted in to the Focus check — so the
+/// permission sheet cannot appear over the first-run window, and never
+/// appears for a reader who did not ask for the check. Repeat calls are
+/// free: the gate keeps a once-flag. The other platforms need no
+/// authorization. The gate self-skips for unbundled dev binaries, which
+/// cannot hold the signed entitlement.
 pub fn maybe_initialize_authorization(app: &AppHandle) {
     let ready = app
         .try_state::<Store>()
         .and_then(|store| store.settings().ok())
-        .is_some_and(|settings| settings.onboarding_completed && settings.notifications_enabled);
+        .is_some_and(|settings| {
+            settings.onboarding_completed
+                && settings.notifications_enabled
+                && settings.nudges_respect_dnd
+        });
     if !ready {
         return;
     }

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -37,8 +37,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use antiburn_local::analysis::{
-    ModelRun, TurnFacts, TurnRow, TurnRowError, TurnRowStore, TurnSessionKey, count_turn_rows,
-    delete_turn_rows, delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
+    ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, ModelRun, PARSER_REVISION, TurnFacts, TurnRow,
+    TurnRowError, TurnRowStore, TurnSessionKey, count_turn_rows, delete_turn_rows,
+    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
     query_model_breakdown, query_model_runs, query_turn_facts, query_turn_rows,
 };
 use anyhow::{Context, Result};
@@ -47,12 +48,12 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use crate::dto::DeferredPermissionDir;
 
 pub use model::{
-    AnalysisRecord, AppSettings, DiskSpaceDisplay, EvidenceClaim, EvidenceCompletion,
-    EvidenceFailure, EvidenceRow, EvidenceStatus, HiddenMeters, MAX_ACTIVITY_DAYS,
-    MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement, ProjectionRevisions,
-    PublishedEvidence, RETAIN_SESSION_DATA_FOREVER, RelationKind, RelationRecord, RepositoryRecord,
-    SessionActivityKey, SessionActivityState, SessionKey, SessionRecord, SourceVersionState,
-    ThemePreference, UsageEvidenceRecord,
+    AnalysisRecord, AppSettings, DisabledAgents, DiskSpaceDisplay, EvidenceClaim,
+    EvidenceCompletion, EvidenceFailure, EvidenceRow, EvidenceStatus, HiddenMeters,
+    MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement,
+    ProjectionRevisions, PublishedEvidence, RETAIN_SESSION_DATA_FOREVER, RelationKind,
+    RelationRecord, RepositoryRecord, SessionActivityKey, SessionActivityState, SessionKey,
+    SessionRecord, SourceVersionState, ThemePreference, UsageEvidenceRecord,
 };
 
 /// Evidence rows that still wait for, or sit in, processing.
@@ -605,9 +606,116 @@ impl Store {
 
     /// Sessions whose activity falls at or after `since_epoch`, newest first.
     pub fn recent_sessions(&self, since_epoch: i64, limit: usize) -> Result<Vec<SessionRecord>> {
+        self.recent_sessions_excluding(since_epoch, limit, &DisabledAgents::default())
+    }
+
+    /// [`Self::recent_sessions`], without the sessions of the excluded agents.
+    ///
+    /// This is the display filter for [`DisabledAgents`]. Scan and analysis
+    /// callers use [`Self::recent_sessions`], because a disabled agent stays
+    /// indexed and analyzed.
+    pub fn recent_sessions_excluding(
+        &self,
+        since_epoch: i64,
+        limit: usize,
+        excluded_agents: &DisabledAgents,
+    ) -> Result<Vec<SessionRecord>> {
+        let excluded = excluded_agents.slugs();
+        let exclusion_predicate = if excluded.is_empty() {
+            String::new()
+        } else {
+            // Parameters 1 and 2 are the window and the limit, so the agent
+            // list binds from parameter 3.
+            let placeholders = (0..excluded.len())
+                .map(|index| format!("?{}", index + 3))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" AND agent NOT IN ({placeholders})")
+        };
         let connection = self.lock();
-        let mut statement = connection.prepare(RECENT_SESSIONS_SQL)?;
-        let rows = statement.query_map(params![since_epoch, limit as i64], session_from_row)?;
+        // Splice the agent exclusion into the shared SQL. The base query and
+        // the plan test keep one constant.
+        let sql = RECENT_SESSIONS_SQL.replace(
+            "WHERE COALESCE(updated_at_epoch, 0) >= ?1",
+            &format!("WHERE COALESCE(updated_at_epoch, 0) >= ?1{exclusion_predicate}"),
+        );
+        let mut statement = connection.prepare(&sql)?;
+        let mut values: Vec<rusqlite::types::Value> = vec![
+            rusqlite::types::Value::Integer(since_epoch),
+            rusqlite::types::Value::Integer(limit as i64),
+        ];
+        values.extend(
+            excluded
+                .iter()
+                .map(|agent| rusqlite::types::Value::Text(agent.clone())),
+        );
+        let rows =
+            statement.query_map(rusqlite::params_from_iter(values.iter()), session_from_row)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    /// The analysis state of every session in the activity window, for the
+    /// aggregate hygiene summary.
+    ///
+    /// The window and the agent exclusion match
+    /// [`Self::recent_sessions_excluding`], so the summary describes the
+    /// same sessions the list shows. A row carries its evidence JSON only
+    /// when the evidence is `ready` for the current source generation and
+    /// revisions — the same currency rule `insights_report.rs` applies.
+    pub fn hygiene_summary_rows(
+        &self,
+        environment_key: &str,
+        since_epoch: i64,
+        excluded_agents: &DisabledAgents,
+    ) -> Result<Vec<HygieneSummaryRow>> {
+        let excluded = excluded_agents.slugs();
+        let exclusion_predicate = if excluded.is_empty() {
+            String::new()
+        } else {
+            // Parameters 1-5 are the scope, window and revisions, so the
+            // agent list binds from parameter 6.
+            let placeholders = (0..excluded.len())
+                .map(|index| format!("?{}", index + 6))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" AND s.agent NOT IN ({placeholders})")
+        };
+        let current_ready = "e.status = 'ready'
+                 AND NOT (e.analyzed_generation IS NOT s.source_generation)
+                 AND NOT (e.parser_revision IS NOT ?3)
+                 AND NOT (e.analyzer_revision IS NOT ?4)
+                 AND NOT (e.evidence_schema_revision IS NOT ?5)";
+        let connection = self.lock();
+        let mut statement = connection.prepare(&format!(
+            "SELECT COALESCE(e.status IN ('failed', 'unsupported')
+                             OR ({current_ready}), 0),
+                    CASE WHEN {current_ready} THEN e.evidence_json END
+               FROM session s
+               LEFT JOIN session_evidence e
+                 ON e.environment_key = s.environment_key
+                AND e.agent = s.agent
+                AND e.session_id = s.session_id
+              WHERE s.environment_key = ?1
+                AND COALESCE(s.updated_at_epoch, 0) >= ?2{exclusion_predicate}",
+        ))?;
+        let mut values: Vec<rusqlite::types::Value> = vec![
+            rusqlite::types::Value::Text(environment_key.to_owned()),
+            rusqlite::types::Value::Integer(since_epoch),
+            rusqlite::types::Value::Integer(PARSER_REVISION),
+            rusqlite::types::Value::Integer(ANALYZER_REVISION),
+            rusqlite::types::Value::Integer(EVIDENCE_SCHEMA_REVISION),
+        ];
+        values.extend(
+            excluded
+                .iter()
+                .map(|agent| rusqlite::types::Value::Text(agent.clone())),
+        );
+        let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+            Ok(HygieneSummaryRow {
+                settled: row.get::<_, bool>(0)?,
+                evidence_json: row.get::<_, Option<String>>(1)?,
+            })
+        })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
@@ -1604,6 +1712,15 @@ impl Store {
 }
 
 /// Read every preference through one already-held connection or transaction.
+/// One session's analysis state, as [`Store::hygiene_summary_rows`] reads it.
+#[derive(Debug, Clone)]
+pub struct HygieneSummaryRow {
+    /// True when analysis reached a terminal state for the current source.
+    pub settled: bool,
+    /// Current ready evidence JSON, when the session has one.
+    pub evidence_json: Option<String>,
+}
+
 fn read_settings(connection: &Connection) -> Result<AppSettings> {
     let mut statement = connection.prepare("SELECT key, value FROM setting")?;
     let rows = statement.query_map([], |row| {
@@ -1669,6 +1786,10 @@ fn read_settings(connection: &Connection) -> Result<AppSettings> {
             .get("notificationSound")
             .map(|value| value == "true")
             .unwrap_or(defaults.notification_sound),
+        nudges_respect_dnd: stored
+            .get("nudgesRespectDnd")
+            .map(|value| value == "true")
+            .unwrap_or(defaults.nudges_respect_dnd),
         disk_space_display: stored
             .get("diskSpaceDisplay")
             .and_then(|value| DiskSpaceDisplay::parse(value))
@@ -1697,6 +1818,10 @@ fn read_settings(connection: &Connection) -> Result<AppSettings> {
             .get("liveUsageHiddenProviders")
             .map(|value| HiddenMeters::parse(value))
             .unwrap_or(defaults.live_usage_hidden_providers.clone()),
+        disabled_agents: stored
+            .get("disabledAgents")
+            .map(|value| DisabledAgents::parse(value))
+            .unwrap_or(defaults.disabled_agents.clone()),
         // No stored answer means this database predates the setting. A fresh
         // install takes the default. An install that already finished setup
         // stays off until the reader enables it.
@@ -1768,6 +1893,10 @@ fn write_settings(connection: &Connection, settings: &AppSettings) -> Result<()>
         bool_text(settings.notification_sound)
     ])?;
     put.execute(params![
+        "nudgesRespectDnd",
+        bool_text(settings.nudges_respect_dnd)
+    ])?;
+    put.execute(params![
         "diskSpaceDisplay",
         settings.disk_space_display.as_str()
     ])?;
@@ -1795,6 +1924,7 @@ fn write_settings(connection: &Connection, settings: &AppSettings) -> Result<()>
         "liveUsageHiddenProviders",
         settings.live_usage_hidden_providers.as_str()
     ])?;
+    put.execute(params!["disabledAgents", settings.disabled_agents.as_str()])?;
     put.execute(params![
         "analyticsEnabled",
         bool_text(settings.analytics_enabled)

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -537,6 +537,57 @@ impl HiddenMeters {
     }
 }
 
+/// The coding agents whose sessions the reader turned off, by discovery slug.
+///
+/// Stores the *disabled* set, not the enabled set. An agent a later build
+/// adds shows by default, and a slug an older build wrote stays harmless.
+///
+/// Disabled is a display filter: the agent's sessions stay indexed and
+/// analyzed, but the session list does not show them. The reader can turn
+/// the agent back on and see everything the index kept.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DisabledAgents(Vec<String>);
+
+impl DisabledAgents {
+    pub fn selected(values: impl IntoIterator<Item = String>) -> Self {
+        Self(values.into_iter().collect()).normalized()
+    }
+
+    pub fn as_str(&self) -> String {
+        self.0.join(",")
+    }
+
+    pub fn parse(value: &str) -> Self {
+        Self::selected(value.split(',').map(str::to_string))
+    }
+
+    pub fn contains(&self, agent: &str) -> bool {
+        let agent = agent.trim().to_ascii_lowercase();
+        self.0.binary_search(&agent).is_ok()
+    }
+
+    pub fn slugs(&self) -> &[String] {
+        &self.0
+    }
+
+    pub fn any(&self) -> bool {
+        !self.0.is_empty()
+    }
+
+    fn normalized(mut self) -> Self {
+        for value in &mut self.0 {
+            *value = value.trim().to_ascii_lowercase();
+        }
+        // An empty slug matches no agent and would hide nothing. Drop it, so
+        // that a stray comma in the stored value cannot survive a round trip.
+        self.0.retain(|value| !value.is_empty());
+        self.0.sort_unstable();
+        self.0.dedup();
+        self
+    }
+}
+
 /// Narrowest and widest activity windows the settings pane offers, in days.
 /// These control presentation and recent discovery, not storage: sessions
 /// already indexed follow the separate retention setting.
@@ -601,6 +652,12 @@ pub struct AppSettings {
     pub nudge_auto_dismiss_secs: u32,
     /// Whether a nudge may play the notification chime.
     pub notification_sound: bool,
+    /// Whether Focus and Do Not Disturb suppress automated nudges.
+    ///
+    /// Off by default: the OS Focus-status check needs its own macOS
+    /// authorization prompt, so the check is an opt-in. Off means an
+    /// automated nudge shows even while Focus is on.
+    pub nudges_respect_dnd: bool,
     /// When the menu bar shows the free-disk-space number.
     pub disk_space_display: DiskSpaceDisplay,
     /// Free space, in binary GB, below which the disk counts as low.
@@ -628,6 +685,10 @@ pub struct AppSettings {
     /// provider, this one stops the named provider. Both stop requests, so a
     /// hidden provider also stops its milestone notifications.
     pub live_usage_hidden_providers: HiddenMeters,
+    /// The coding agents whose sessions the reader turned off. See
+    /// [`DisabledAgents`]. A display filter only: indexing and analysis
+    /// continue for a disabled agent.
+    pub disabled_agents: DisabledAgents,
     /// The analytics opt-out. On by default for a new install and preserved
     /// when an existing install has explicitly disabled it.
     pub analytics_enabled: bool,
@@ -658,6 +719,9 @@ impl Default for AppSettings {
             nudge_placement: NudgePlacement::default(),
             nudge_auto_dismiss_secs: DEFAULT_NUDGE_AUTO_DISMISS_SECS,
             notification_sound: true,
+            // Off: honoring Focus needs a macOS authorization prompt, and
+            // that prompt should follow a choice the reader made.
+            nudges_respect_dnd: false,
             disk_space_display: DiskSpaceDisplay::default(),
             disk_space_threshold_gb: DEFAULT_DISK_THRESHOLD_GB,
             notify_disk_space_low: true,
@@ -672,6 +736,9 @@ impl Default for AppSettings {
             // Empty: every provider antiburn can meter is metered. A reader
             // who wants fewer meters says so one provider at a time.
             live_usage_hidden_providers: HiddenMeters::default(),
+            // Empty: every agent with sessions shows. Onboarding and the
+            // Sources pane write slugs here when the reader turns one off.
+            disabled_agents: DisabledAgents::default(),
             // Official analytics-capable builds start enabled. Source builds
             // omit the client unless the builder selects its Cargo feature.
             // `settings_from` keeps older completed installs disabled.
@@ -765,6 +832,33 @@ mod tests {
         // A provider a later build adds must be metered without the reader
         // asking. Storing the hidden set is what makes that true.
         assert!(!AppSettings::default().live_usage_hidden_providers.any());
+    }
+
+    #[test]
+    fn disabled_agents_survive_a_round_trip_through_their_stored_text() {
+        let disabled = DisabledAgents::parse("windsurf,kiro");
+        assert_eq!(disabled.as_str(), "kiro,windsurf");
+        assert!(disabled.contains("windsurf"));
+        assert_eq!(disabled.slugs(), ["kiro", "windsurf"]);
+        assert!(disabled.any());
+    }
+
+    #[test]
+    fn disabled_agents_tolerate_what_a_hand_edited_database_can_hold() {
+        // Whitespace, case, duplicates, and a stray comma. Each one must
+        // resolve to the same set rather than to a row that hides nothing.
+        let disabled = DisabledAgents::parse(" Kiro , kiro,, ");
+        assert_eq!(disabled.as_str(), "kiro");
+        assert!(disabled.contains("KIRO"));
+        assert!(!DisabledAgents::parse("").any());
+    }
+
+    #[test]
+    fn every_agent_is_shown_by_default() {
+        // An agent a later build detects must surface without the reader
+        // asking. Storing the disabled set is what makes that true.
+        assert!(!AppSettings::default().disabled_agents.any());
+        assert!(!DisabledAgents::parse("some-future-agent").contains("claude-code"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -428,6 +428,9 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     assert!(defaults.notifications_enabled);
     assert!(defaults.notify_update_available);
     assert!(defaults.notify_scan_failure);
+    // Off by default: the Focus-status check needs its own macOS
+    // authorization prompt, so the reader opts in first.
+    assert!(!defaults.nudges_respect_dnd);
 
     let saved = store
         .save_settings(&AppSettings {
@@ -444,6 +447,7 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
             nudge_placement: NudgePlacement::TopRight,
             nudge_auto_dismiss_secs: 25,
             notification_sound: false,
+            nudges_respect_dnd: true,
             disk_space_display: DiskSpaceDisplay::Always,
             disk_space_threshold_gb: 100,
             notify_disk_space_low: false,
@@ -451,6 +455,7 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
             milestones_weekly: Milestones::none(),
             live_usage_enabled: true,
             live_usage_hidden_providers: HiddenMeters::default(),
+            disabled_agents: DisabledAgents::parse("windsurf,kiro"),
             analytics_enabled: false,
             overview_limits_expanded: false,
         })
@@ -471,6 +476,8 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     assert!(!saved.milestones_weekly.any());
     assert!(saved.milestones_5h.contains(75) && !saved.milestones_5h.contains(50));
     assert!(saved.live_usage_enabled);
+    // The disabled-agent set survives normalized to sorted slugs.
+    assert_eq!(saved.disabled_agents.as_str(), "kiro,windsurf");
     assert!(!saved.overview_limits_expanded);
     assert!(saved.onboarding_completed);
     assert!(saved.discovery_paused);
@@ -1307,6 +1314,37 @@ fn recent_sessions_query_plan_uses_the_coalesced_recency_index() {
         plan.contains("session_recency_coalesced"),
         "query plan did not use the coalesced index: {plan}"
     );
+}
+
+#[test]
+fn a_disabled_agent_leaves_the_recent_list_but_not_the_index() {
+    let store = store();
+    let mut codex = session("codex-session", 2_000);
+    codex.key = SessionKey::new("native", "codex", "codex-session");
+    store
+        .upsert_sessions(
+            &[session("claude-session", 3_000), codex],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    let disabled = DisabledAgents::parse("codex");
+    let shown = store.recent_sessions_excluding(0, 100, &disabled).unwrap();
+    let ids: Vec<_> = shown
+        .iter()
+        .map(|record| record.key.agent.as_str())
+        .collect();
+    assert_eq!(ids, vec!["claude-code"], "the disabled agent is filtered");
+
+    // The filter is display-only: the unfiltered read still sees both, so
+    // re-enabling the agent brings its sessions straight back.
+    assert_eq!(store.recent_sessions(0, 100).unwrap().len(), 2);
+
+    // An empty set filters nothing.
+    let all = store
+        .recent_sessions_excluding(0, 100, &DisabledAgents::default())
+        .unwrap();
+    assert_eq!(all.len(), 2);
 }
 
 #[test]

--- a/apps/desktop/src/lib/insightsIpc.ts
+++ b/apps/desktop/src/lib/insightsIpc.ts
@@ -166,6 +166,23 @@ export interface SessionHygienePayload {
 }
 
 /**
+ * Aggregate hygiene numbers for the sessions in the activity window.
+ * Mirrors Rust `HygieneSummaryPayload`.
+ */
+export interface HygieneSummary {
+  /** Sessions in the window, after the disabled-agent display filter. */
+  totalSessions: number
+  /** Sessions whose analysis reached a terminal state. */
+  settledSessions: number
+  /** Sessions with current ready evidence, so the checks ran. */
+  analyzedSessions: number
+  /** Analyzed sessions with at least one finding. */
+  failingSessions: number
+  /** Badge id of the most frequent finding, when any session fails. */
+  mostCommonFinding: SessionHygieneBadgeId | null
+}
+
+/**
  * The thirty-day insights report, computed on this machine.
  *
  * Opening the pane calls this; the shell deduplicates concurrent calls
@@ -181,6 +198,12 @@ export async function getInsightsReport(): Promise<InsightsReportPayload | null>
 export async function getInsightsStatus(): Promise<InsightsStatusPayload | null> {
   if (!hasShell()) return null
   return invoke<InsightsStatusPayload>("get_insights_status")
+}
+
+/** The aggregate hygiene numbers for the sessions in the activity window. */
+export async function getHygieneSummary(): Promise<HygieneSummary | null> {
+  if (!hasShell()) return null
+  return invoke<HygieneSummary>("get_hygiene_summary")
 }
 
 /** The hygiene badges reduced from a bounded set of stored evidence rows. */

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -77,6 +77,12 @@ export interface AppSettings {
   nudgeAutoDismissSecs: number
   /** Whether a nudge may play the notification chime. */
   notificationSound: boolean
+  /**
+   * Whether Focus and Do Not Disturb suppress automated nudges. Off by
+   * default: the macOS Focus check needs its own authorization prompt, so
+   * the check is an opt-in.
+   */
+  nudgesRespectDnd: boolean
   /** When the menu bar shows the free-disk-space number. */
   diskSpaceDisplay: DiskSpaceDisplay
   /** Free space, in GB, below which the disk counts as low (5–2000). */
@@ -108,6 +114,15 @@ export interface AppSettings {
    * also stops its milestone notifications.
    */
   liveUsageHiddenProviders: string[]
+  /**
+   * Discovery slugs of the coding agents the reader turned off.
+   *
+   * A display filter only: a disabled agent's sessions stay indexed and
+   * analyzed, but the session list does not show them. An agent absent from
+   * this list shows by default, so a newly detected agent surfaces on its
+   * own.
+   */
+  disabledAgents: string[]
   /**
    * The consented analytics channel.
    *
@@ -666,6 +681,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   nudgePlacement: "menuBar",
   nudgeAutoDismissSecs: 10,
   notificationSound: true,
+  nudgesRespectDnd: false,
   diskSpaceDisplay: "whenLow",
   diskSpaceThresholdGb: 50,
   notifyDiskSpaceLow: true,
@@ -673,6 +689,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   milestonesWeekly: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
   liveUsageEnabled: true,
   liveUsageHiddenProviders: [],
+  disabledAgents: [],
   analyticsEnabled: true,
   overviewLimitsExpanded: true,
 }
@@ -927,7 +944,7 @@ export async function openPrivacyPolicy(): Promise<void> {
 export type Interaction =
   | {
       kind: "onboardingStepViewed"
-      step: "welcome" | "sources_and_repos" | "ready"
+      step: "welcome" | "agents_detected" | "sources_and_repos" | "ready"
     }
   | { kind: "sessionOpened"; agent: string; environment: "native" | "wsl" }
   | {
@@ -956,16 +973,25 @@ export function noteInteraction(interaction: Interaction): void {
 export async function finishOnboarding(
   activityWindowDays: number,
   launchAtLogin: boolean,
+  disabledAgents: string[],
+  nudgesRespectDnd: boolean,
 ): Promise<AppSettings> {
   if (!hasShell()) {
     return {
       ...DEFAULT_SETTINGS,
       activityWindowDays,
       launchAtLogin,
+      disabledAgents,
+      nudgesRespectDnd,
       onboardingCompleted: true,
     }
   }
-  return invoke<AppSettings>("finish_onboarding", { activityWindowDays, launchAtLogin })
+  return invoke<AppSettings>("finish_onboarding", {
+    activityWindowDays,
+    launchAtLogin,
+    disabledAgents,
+    nudgesRespectDnd,
+  })
 }
 
 /** The sessions to show in the popover, newest first. */

--- a/apps/desktop/src/lib/presentation/sessionHygiene.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.ts
@@ -139,6 +139,11 @@ export const INITIAL_SESSION_HYGIENE: SessionHygienePayload = {
   evidenceState: "pending",
 }
 
+/** The reader-facing name of one check, with no verdict attached. */
+export function sessionHygieneCheckName(id: SessionHygieneBadgeId): string {
+  return CHECKS.find((check) => check.id === id)?.name ?? id
+}
+
 /** Add reader copy and semantic ink to the engine badge identifiers. */
 export function sessionHygieneChecks(payload: SessionHygienePayload): SessionHygieneCheck[] {
   return CHECKS.map((definition) => {

--- a/apps/desktop/src/lib/scanStatusStore.ts
+++ b/apps/desktop/src/lib/scanStatusStore.ts
@@ -14,5 +14,16 @@ import { getScanStatus, onScanEvent, type ScanStatus } from "./ipc"
 export const scanStatusStore = createExternalStore<ScanStatus | null>({
   initial: null,
   load: () => getScanStatus().catch(() => null),
-  subscribe: (set) => onScanEvent((status) => set(status)),
+  subscribe: (set) => onScanEvent((status) => set(withKnownAgents(status))),
 })
+
+/**
+ * Keep the per-agent list across updates that do not carry one. Scan events
+ * and `scan_now` return an empty `agents` array by design; only
+ * `get_scan_status` fills it. Use for every write into `scanStatusStore`.
+ */
+export function withKnownAgents(status: ScanStatus): ScanStatus {
+  const previous = scanStatusStore.getSnapshot()
+  if (status.agents.length > 0 || !previous || previous.agents.length === 0) return status
+  return { ...status, agents: previous.agents }
+}

--- a/apps/desktop/src/views/OnboardingView.test.tsx
+++ b/apps/desktop/src/views/OnboardingView.test.tsx
@@ -137,9 +137,9 @@ async function advanceToReady() {
 /** Move from Welcome past the agents step to the search-locations step. */
 async function advanceToSources() {
   fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
-  await screen.findByRole("heading", { name: "Tell us about your Coding agents" })
+  await screen.findByRole("heading", { name: "Scan Locations: Agents" })
   fireEvent.click(screen.getByRole("button", { name: "Continue" }))
-  await screen.findByRole("heading", { name: "Repo search locations" })
+  await screen.findByRole("heading", { name: "Scan Locations: Repos" })
 }
 
 describe("OnboardingView", () => {
@@ -200,7 +200,7 @@ describe("OnboardingView", () => {
 
     // 2 — Coding agents. Discovery starts on leaving Welcome.
     expect(
-      await screen.findByRole("heading", { name: "Tell us about your Coding agents" }),
+      await screen.findByRole("heading", { name: "Scan Locations: Agents" }),
     ).toBeInTheDocument()
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("scan_now", { activityWindowDays: 7 }),
@@ -209,7 +209,7 @@ describe("OnboardingView", () => {
 
     // 3 — Search locations and repositories share the discovery pass.
     expect(
-      await screen.findByRole("heading", { name: "Repo search locations" }),
+      await screen.findByRole("heading", { name: "Scan Locations: Repos" }),
     ).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Repos found" })).toBeInTheDocument()
     expect(screen.getByText("/home/avery/code")).toBeInTheDocument()
@@ -255,7 +255,7 @@ describe("OnboardingView", () => {
     render(<OnboardingView />)
 
     fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
-    await screen.findByRole("heading", { name: "Tell us about your Coding agents" })
+    await screen.findByRole("heading", { name: "Scan Locations: Agents" })
 
     // Detected agents lead with their evidence and start switched on.
     expect(screen.getByText("304 sessions")).toBeInTheDocument()
@@ -266,7 +266,7 @@ describe("OnboardingView", () => {
     fireEvent.click(screen.getByRole("switch", { name: "Show Codex sessions" }))
 
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
-    await screen.findByRole("heading", { name: "Repo search locations" })
+    await screen.findByRole("heading", { name: "Scan Locations: Repos" })
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
     await screen.findByRole("heading", { name: "Ready" })
     fireEvent.click(screen.getByRole("button", { name: "Start using antiburn" }))
@@ -297,7 +297,7 @@ describe("OnboardingView", () => {
     render(<OnboardingView />)
     await advanceToReady()
     fireEvent.click(screen.getByRole("button", { name: "Back" }))
-    await screen.findByRole("heading", { name: "Repo search locations" })
+    await screen.findByRole("heading", { name: "Scan Locations: Repos" })
 
     for (const step of ["welcome", "agents_detected", "sources_and_repos", "ready"]) {
       expect(invoke).toHaveBeenCalledWith("note_interaction", {
@@ -414,14 +414,14 @@ describe("OnboardingView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
 
     const agents = await screen.findByRole("heading", {
-      name: "Tell us about your Coding agents",
+      name: "Scan Locations: Agents",
     })
     await waitFor(() => expect(agents).toHaveFocus())
     expect(screen.getByText("Step 2 of 4")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
 
-    const locations = await screen.findByRole("heading", { name: "Repo search locations" })
+    const locations = await screen.findByRole("heading", { name: "Scan Locations: Repos" })
     await waitFor(() => expect(locations).toHaveFocus())
     expect(screen.getByText("Step 3 of 4")).toBeInTheDocument()
   })

--- a/apps/desktop/src/views/OnboardingView.test.tsx
+++ b/apps/desktop/src/views/OnboardingView.test.tsx
@@ -5,7 +5,6 @@ import { OnboardingView } from "./OnboardingView"
 
 const invoke = vi.hoisted(() => vi.fn())
 const openDialog = vi.hoisted(() => vi.fn())
-const clipboardWrite = vi.hoisted(() => vi.fn())
 const listeners = vi.hoisted(() => new Map<string, ((event: { payload: unknown }) => void)[]>())
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }))
@@ -31,6 +30,17 @@ const SETTINGS = {
   autoUpdate: true,
   discoveryPaused: false,
   analyticsEnabled: true,
+  disabledAgents: [],
+  nudgesRespectDnd: false,
+}
+
+/** A finished analysis pass over the four scanned sessions. */
+const HYGIENE_SUMMARY = {
+  totalSessions: 4,
+  settledSessions: 4,
+  analyzedSessions: 4,
+  failingSessions: 1,
+  mostCommonFinding: "modelOverthinking",
 }
 
 /** An analytics-capable official build. Source builds use the unsupported case. */
@@ -98,6 +108,8 @@ function mockCommands(overrides: Record<string, unknown> = {}) {
         return Promise.resolve((args as Record<string, unknown> | undefined)?.["settings"])
       case "finish_onboarding":
         return Promise.resolve({ ...SETTINGS, onboardingCompleted: true })
+      case "get_hygiene_summary":
+        return Promise.resolve(HYGIENE_SUMMARY)
       case "list_scan_roots":
       case "default_scan_roots":
       case "list_repositories":
@@ -116,10 +128,18 @@ function mockCommands(overrides: Record<string, unknown> = {}) {
 
 async function advanceToReady() {
   await screen.findByRole("heading", { name: "Stop hitting your token limits." })
-  for (let step = 0; step < 2; step += 1) {
+  for (let step = 0; step < 3; step += 1) {
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
   }
   await screen.findByRole("heading", { name: "Ready" })
+}
+
+/** Move from Welcome past the agents step to the search-locations step. */
+async function advanceToSources() {
+  fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
+  await screen.findByRole("heading", { name: "Tell us about your Coding agents" })
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+  await screen.findByRole("heading", { name: "Repo search locations" })
 }
 
 describe("OnboardingView", () => {
@@ -127,12 +147,6 @@ describe("OnboardingView", () => {
     invoke.mockReset()
     openDialog.mockReset()
     listeners.clear()
-    clipboardWrite.mockReset()
-    clipboardWrite.mockResolvedValue(undefined)
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText: clipboardWrite },
-    })
     mockCommands()
   })
 
@@ -173,7 +187,7 @@ describe("OnboardingView", () => {
     })
   })
 
-  it("runs the three-step first-run flow and records that it finished", async () => {
+  it("runs the four-step first-run flow and records that it finished", async () => {
     mockCommands({ default_scan_roots: ["/home/avery/code"] })
     render(<OnboardingView />)
 
@@ -184,39 +198,99 @@ describe("OnboardingView", () => {
     expect(screen.getByText(/nothing from your sessions is ever uploaded/i)).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
 
-    // 2 — Search locations and repositories share the discovery pass.
+    // 2 — Coding agents. Discovery starts on leaving Welcome.
     expect(
-      await screen.findByRole("heading", { name: "Repo search locations" }),
+      await screen.findByRole("heading", { name: "Tell us about your Coding agents" }),
     ).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Repos found" })).toBeInTheDocument()
-    expect(screen.getByText("/home/avery/code")).toBeInTheDocument()
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("scan_now", { activityWindowDays: 7 }),
     )
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
 
-    // 3 — Ready.
+    // 3 — Search locations and repositories share the discovery pass.
+    expect(
+      await screen.findByRole("heading", { name: "Repo search locations" }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Repos found" })).toBeInTheDocument()
+    expect(screen.getByText("/home/avery/code")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+
+    // 4 — Ready. The analysis numbers arrive from the summary poll.
     expect(await screen.findByRole("heading", { name: "Ready" })).toBeInTheDocument()
-    expect(screen.getByText(/repositories are never modified/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "4 sessions from the last 7 days are indexed and waiting in the menu bar.",
+      ),
+    ).toBeInTheDocument()
+    expect(await screen.findByText("sessions analyzed")).toBeInTheDocument()
+    expect(screen.getByText("75%")).toBeInTheDocument()
+    expect(screen.getByText("Model overthinking")).toBeInTheDocument()
     expect(screen.getByRole("switch", { name: "Launch antiburn on startup" })).toBeChecked()
+    expect(
+      screen.getByRole("switch", { name: "Nudges respect Do Not Disturb" }),
+    ).not.toBeChecked()
     fireEvent.click(screen.getByRole("button", { name: "Start using antiburn" }))
 
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("finish_onboarding", {
         activityWindowDays: 7,
         launchAtLogin: true,
+        disabledAgents: [],
+        nudgesRespectDnd: false,
       }),
     )
   })
 
-  it("discloses analytics on the Ready step without offering a switch", async () => {
+  it("lists detected agents and persists switched-off agents on finish", async () => {
+    mockCommands({
+      get_scan_status: {
+        ...SCAN_STATUS,
+        agents: [
+          { agent: "claude-code", lastCompletedAt: null, sessionsSeen: 304 },
+          { agent: "codex", lastCompletedAt: null, sessionsSeen: 41 },
+          { agent: "cursor", lastCompletedAt: null, sessionsSeen: 12 },
+        ],
+      },
+    })
+    render(<OnboardingView />)
+
+    fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
+    await screen.findByRole("heading", { name: "Tell us about your Coding agents" })
+
+    // Detected agents lead with their evidence and start switched on.
+    expect(screen.getByText("304 sessions")).toBeInTheDocument()
+    expect(screen.getByRole("switch", { name: "Show Claude Code sessions" })).toBeChecked()
+    // An agent with no sessions starts switched off.
+    expect(screen.getByRole("switch", { name: "Show Windsurf sessions" })).not.toBeChecked()
+
+    fireEvent.click(screen.getByRole("switch", { name: "Show Codex sessions" }))
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+    await screen.findByRole("heading", { name: "Repo search locations" })
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+    await screen.findByRole("heading", { name: "Ready" })
+    fireEvent.click(screen.getByRole("button", { name: "Start using antiburn" }))
+
+    await waitFor(() =>
+      expect(invoke.mock.calls.some(([command]) => command === "finish_onboarding")).toBe(true),
+    )
+    const call = invoke.mock.calls.find(([command]) => command === "finish_onboarding")
+    const disabled = (call?.[1] as { disabledAgents: string[] }).disabledAgents
+    expect(disabled).toContain("codex")
+    expect(disabled).toContain("windsurf")
+    expect(disabled).not.toContain("claude-code")
+    expect(disabled).not.toContain("cursor")
+  })
+
+  it("keeps analytics and privacy copy off the Ready step", async () => {
+    // The v5 redesign moved this disclosure out of onboarding. Settings →
+    // Privacy still carries the switch and the copy.
     render(<OnboardingView />)
     await advanceToReady()
 
     expect(screen.queryByRole("switch", { name: /analytics/i })).not.toBeInTheDocument()
-    expect(screen.getByText(/Never prompts, sessions/i)).toBeInTheDocument()
-    expect(screen.getByText(/check what leaves your computer/i)).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Copy prompt" })).toBeInTheDocument()
+    expect(screen.queryByText(/Never prompts, sessions/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Copy prompt" })).not.toBeInTheDocument()
   })
 
   it("records each onboarding step once", async () => {
@@ -225,81 +299,68 @@ describe("OnboardingView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Back" }))
     await screen.findByRole("heading", { name: "Repo search locations" })
 
-    for (const step of ["welcome", "sources_and_repos", "ready"]) {
+    for (const step of ["welcome", "agents_detected", "sources_and_repos", "ready"]) {
       expect(invoke).toHaveBeenCalledWith("note_interaction", {
         interaction: { kind: "onboardingStepViewed", step },
       })
     }
     expect(
       invoke.mock.calls.filter(([command]) => command === "note_interaction"),
-    ).toHaveLength(3)
+    ).toHaveLength(4)
   })
 
-  it("omits analytics disclosure from a build without analytics", async () => {
+  it("skips step analytics for a build without analytics", async () => {
     mockCommands({ app_info: { ...APP_INFO, analyticsSupported: false } })
     render(<OnboardingView />)
 
-    expect(await screen.findByText(/This build has no analytics endpoint/i)).toBeInTheDocument()
-
     await advanceToReady()
 
-    expect(screen.queryByText(/Never prompts, sessions/i)).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Copy prompt" })).not.toBeInTheDocument()
     expect(
       invoke.mock.calls.filter(([command]) => command === "note_interaction"),
     ).toHaveLength(0)
   })
 
-  it("explains the process override without hiding analytics support", async () => {
+  it("skips step analytics when the environment disables analytics", async () => {
     mockCommands({ app_info: { ...APP_INFO, analyticsEnvironmentDisabled: true } })
     render(<OnboardingView />)
 
-    expect(
-      await screen.findByText(/Analytics is disabled for this launch by/i),
-    ).toHaveTextContent("ANTIBURN_ANALYTICS_ENABLED=false")
-    expect(screen.queryByText(/This build has no analytics endpoint/i)).not.toBeInTheDocument()
-
     await advanceToReady()
 
-    expect(screen.getByText(/Off for this launch/i)).toHaveTextContent(
-      "ANTIBURN_ANALYTICS_ENABLED=false. Remove it to use the setting in Settings → Privacy.",
-    )
     expect(
       invoke.mock.calls.filter(([command]) => command === "note_interaction"),
     ).toHaveLength(0)
   })
 
-  it("copies the optional privacy prompt for an AI agent", async () => {
+  it("shows analysis progress while sessions are still settling", async () => {
+    mockCommands({
+      get_hygiene_summary: { ...HYGIENE_SUMMARY, settledSessions: 2, analyzedSessions: 2 },
+    })
     render(<OnboardingView />)
     await advanceToReady()
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }))
-
-    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument()
-    expect(clipboardWrite).toHaveBeenCalledWith(
-      expect.stringContaining("Explain in plain language what stays on my computer"),
-    )
-    await waitFor(
-      () => expect(screen.getByRole("button", { name: "Copy prompt" })).toBeInTheDocument(),
-      { timeout: 3_000 },
-    )
+    expect(await screen.findByText("Analyzing sessions")).toBeInTheDocument()
+    expect(screen.getByText("2 of 4")).toBeInTheDocument()
+    expect(screen.queryByText("sessions analyzed")).not.toBeInTheDocument()
   })
 
-  it("persists a startup opt-out before finishing onboarding", async () => {
+  it("persists the startup and Do Not Disturb drafts before finishing onboarding", async () => {
     render(<OnboardingView />)
     await advanceToReady()
 
     const launchAtLogin = screen.getByRole("switch", { name: "Launch antiburn on startup" })
     expect(launchAtLogin).toBeChecked()
     fireEvent.click(launchAtLogin)
-    // The choice is a draft until Finish, so there is no earlier settings
-    // round-trip for this click to race.
+    fireEvent.click(screen.getByRole("switch", { name: "Nudges respect Do Not Disturb" }))
+    // The choices are drafts until Finish, so there is no earlier settings
+    // round-trip for these clicks to race.
     fireEvent.click(screen.getByRole("button", { name: "Start using antiburn" }))
 
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("finish_onboarding", {
         activityWindowDays: 7,
         launchAtLogin: false,
+        disabledAgents: [],
+        nudgesRespectDnd: true,
       }),
     )
   })
@@ -348,13 +409,21 @@ describe("OnboardingView", () => {
       name: "Stop hitting your token limits.",
     })
     await waitFor(() => expect(welcome).toHaveFocus())
-    expect(screen.getByText("Step 1 of 3")).toBeInTheDocument()
+    expect(screen.getByText("Step 1 of 4")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+
+    const agents = await screen.findByRole("heading", {
+      name: "Tell us about your Coding agents",
+    })
+    await waitFor(() => expect(agents).toHaveFocus())
+    expect(screen.getByText("Step 2 of 4")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Continue" }))
 
     const locations = await screen.findByRole("heading", { name: "Repo search locations" })
     await waitFor(() => expect(locations).toHaveFocus())
-    expect(screen.getByText("Step 2 of 3")).toBeInTheDocument()
+    expect(screen.getByText("Step 3 of 4")).toBeInTheDocument()
   })
 
   it("queues a follow-up scan when a folder is added during discovery", async () => {
@@ -366,11 +435,11 @@ describe("OnboardingView", () => {
     openDialog.mockResolvedValue("/home/avery/work")
     render(<OnboardingView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
+    await advanceToSources()
     await waitFor(() =>
       expect(invoke.mock.calls.filter(([command]) => command === "scan_now")).toHaveLength(1),
     )
-    fireEvent.click(await screen.findByRole("button", { name: /Add a folder/ }))
+    fireEvent.click(await screen.findByRole("button", { name: /Add Locations/ }))
     await waitFor(() => expect(invoke).toHaveBeenCalledWith("add_scan_root", expect.anything()))
 
     resolveScan(SCAN_STATUS)
@@ -390,7 +459,7 @@ describe("OnboardingView", () => {
     })
     render(<OnboardingView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
+    await advanceToSources()
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Scan did not finish")
     expect(screen.getByRole("alert")).toHaveTextContent("Could not read ~/.claude/projects.")
@@ -418,7 +487,7 @@ describe("OnboardingView", () => {
     })
     render(<OnboardingView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
+    await advanceToSources()
     expect(await screen.findByRole("alert")).toHaveTextContent("Scan did not finish")
     expect(screen.getByText("avery/widgets")).toBeInTheDocument()
 
@@ -441,7 +510,7 @@ describe("OnboardingView", () => {
     mockCommands({ list_scan_roots: ["/home/avery/work"] })
     render(<OnboardingView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
+    await advanceToSources()
     await waitFor(() =>
       expect(invoke.mock.calls.filter(([command]) => command === "scan_now")).toHaveLength(1),
     )
@@ -463,8 +532,8 @@ describe("OnboardingView", () => {
     openDialog.mockResolvedValue("/home/avery/work")
     render(<OnboardingView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: "Continue" }))
-    fireEvent.click(await screen.findByRole("button", { name: /Add a folder/ }))
+    await advanceToSources()
+    fireEvent.click(await screen.findByRole("button", { name: /Add Locations/ }))
 
     await waitFor(() => expect(invoke).toHaveBeenCalledWith("add_scan_root", expect.anything()))
     expect(invoke).not.toHaveBeenCalledWith("begin_popover_hold")

--- a/apps/desktop/src/views/OnboardingView.tsx
+++ b/apps/desktop/src/views/OnboardingView.tsx
@@ -65,10 +65,15 @@ export function OnboardingView() {
         onToggleRepository={session.toggleRepository}
         onDiscover={session.rescan}
         scanStatus={state.scanStatus}
+        disabledAgents={state.disabledAgents}
+        onAgentEnabledChange={session.setAgentEnabled}
         launchAtLogin={state.launchAtLogin}
         onLaunchAtLoginChange={session.setLaunchAtLogin}
-        analyticsSupported={state.analyticsSupported}
-        analyticsEnvironmentDisabled={state.analyticsEnvironmentDisabled}
+        nudgesRespectDnd={state.nudgesRespectDnd}
+        onNudgesRespectDndChange={session.setNudgesRespectDnd}
+        activityWindowDays={state.activityWindowDays}
+        hygieneSummary={state.hygieneSummary}
+        onReadyEntered={session.beginHygienePolling}
         onStepViewed={session.noteOnboardingStep}
         finishing={state.finishing}
         finishError={state.finishError}

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -60,6 +60,7 @@ const SETTINGS = {
   nudgePlacement: "menuBar" as const,
   nudgeAutoDismissSecs: 10,
   notificationSound: true,
+  nudgesRespectDnd: false,
   diskSpaceDisplay: "whenLow" as const,
   diskSpaceThresholdGb: 50,
   notifyDiskSpaceLow: true,
@@ -69,6 +70,7 @@ const SETTINGS = {
   liveUsageHiddenProviders: [],
   analyticsEnabled: true,
   overviewLimitsExpanded: true,
+  disabledAgents: [] as string[],
 }
 
 const INFO = {

--- a/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
+++ b/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
@@ -137,12 +137,10 @@ function Welcome() {
 
 function AgentsDetected({
   scanStatus,
-  scanning,
   disabledAgents,
   onAgentEnabledChange,
 }: {
   scanStatus: ScanStatus | null
-  scanning: boolean
   disabledAgents: readonly string[]
   onAgentEnabledChange: (slug: string, enabled: boolean) => void
 }) {
@@ -153,21 +151,14 @@ function AgentsDetected({
   const quiet = AGENT_SLUGS.filter((slug) => !detectedSlugs.has(slug))
   const isEnabled = (slug: string) => !disabledAgents.includes(slug)
 
-  const summary =
-    detected.length > 0
-      ? `antiburn found sessions from ${detected.length} coding ${
-          detected.length === 1 ? "agent" : "agents"
-        }.`
-      : scanning
-        ? "Looking for coding agent sessions…"
-        : "No agent sessions found yet — antiburn keeps looking as you work."
-
   return (
     <div className="flex h-full min-h-0 flex-col px-8">
       <h2 ref={focusHeading} tabIndex={-1} className="type-title-3 text-label outline-none">
-        Tell us about your Coding agents
+        Scan Locations: Agents
       </h2>
-      <p className="mt-1.5 type-callout text-label-secondary">{summary}</p>
+      <p className="mt-1.5 type-callout text-label-secondary">
+        antiburn does constant background session scans from agents you enable.
+      </p>
 
       <ScrollPane className="mt-3" viewportClassName="pr-1">
         {detected.length > 0 ? (
@@ -267,13 +258,23 @@ function SourcesAndRepos({
   const scanFailed = !scanning && scanError !== null
 
   return (
-    <div className="grid grid-cols-2 h-full">
-      <div className="flex min-h-0 flex-col px-8">
+    <div className="grid h-full grid-cols-2 gap-x-8 px-8">
+      <div className="col-span-full mb-4 flex flex-col gap-1.5">
         <h2 ref={focusHeading} tabIndex={-1} className="type-title-3 text-label outline-none">
-          Repo search locations
+          Scan Locations: Repos
         </h2>
 
-        <ScrollPane className="mt-3" viewportClassName="pr-1">
+        <p className="type-callout text-label-secondary">
+          antiburn won't scan sessions for any repos not enabled here.
+        </p>
+      </div>
+
+      <div className="flex min-h-0 flex-col">
+        <h3 className="border-b border-separator pb-1 type-body-large" tabIndex={-1}>
+          Folders to scan
+        </h3>
+
+        <ScrollPane className="mt-2.5" viewportClassName="pr-1">
           {defaultRoots.length > 0 && (
             <>
               <p className="pb-1 type-footnote font-semibold! text-label-tertiary">Defaults</p>
@@ -354,8 +355,11 @@ function SourcesAndRepos({
         </ScrollPane>
       </div>
 
-      <div className="flex min-h-0 flex-col px-8">
-        <h2 className="type-title-3 text-label">Repos found</h2>
+      <div className="flex min-h-0 flex-col">
+        <h3 className="border-b border-separator pb-1 type-body-large" tabIndex={-1}>
+          Repos found
+        </h3>
+
         {permissions.supported && permissions.deferred.length > 0 ? (
           <div className="mt-2">
             <FolderPermissionNotice
@@ -654,7 +658,6 @@ export function OnboardingFlow({
         {step === "agentsDetected" && (
           <AgentsDetected
             scanStatus={scanStatus}
-            scanning={running}
             disabledAgents={disabledAgents}
             onAgentEnabledChange={onAgentEnabledChange}
           />

--- a/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
+++ b/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Check, Copy, FolderPlus, Lock, X } from "lucide-react"
+import { AlertTriangle, Check, FolderPlus, Lock, X } from "lucide-react"
 
 import appIcon from "../../assets/app-icon.png"
 import { useState } from "react"
@@ -10,10 +10,13 @@ import { FolderPermissionNotice } from "../../components/repositories/FolderPerm
 import { LocalRepositoryList } from "../../components/repositories/LocalRepositoryList"
 import { Card } from "../../components/ui/Card"
 import { PushButton } from "../../components/ui/PushButton"
-import { Row } from "../../components/ui/Row"
 import { ScrollPane } from "../../components/ui/ScrollPane"
-import { ToggleRow } from "../../components/ui/ToggleRow"
+import { ToggleSwitch } from "../../components/ui/ToggleSwitch"
+import { renderAgentIcon } from "../../lib/agentIcon"
+import { AGENT_SLUGS, agentDisplayName } from "../../lib/presentation/agents"
+import { sessionHygieneCheckName } from "../../lib/presentation/sessionHygiene"
 import { getConsentDiagnostics, openFolderAccessSettings, type ScanStatus } from "../../lib/ipc"
+import type { HygieneSummary } from "../../lib/insightsIpc"
 import type { FolderPermissions, LocalRepositoryItem } from "../../lib/types/repository"
 import type { FolderPermissionFlow } from "../../lib/useFolderPermissionFlow"
 import type { OnboardingStep } from "./OnboardingSession"
@@ -47,14 +50,23 @@ export interface OnboardingFlowProps {
   onDiscover: () => void
   /** The shell's scan status, or null before the first read. */
   scanStatus: ScanStatus | null
+  /** Draft of the disabled-agent display filter. Persisted on finish. */
+  disabledAgents: readonly string[]
+  /** Show or hide one agent's sessions. Sessions stay indexed either way. */
+  onAgentEnabledChange: (slug: string, enabled: boolean) => void
   /** Whether the installed app should start after the reader signs in. */
   launchAtLogin: boolean
   onLaunchAtLoginChange: (enabled: boolean) => void
-  /** Whether this build can send analytics at all. False in development and
-   *  in any build from a clean checkout. */
-  analyticsSupported: boolean
-  /** Whether the process environment disables analytics for this launch. */
-  analyticsEnvironmentDisabled: boolean
+  /** Draft of the Do Not Disturb opt-in. Persisted on finish. */
+  nudgesRespectDnd: boolean
+  onNudgesRespectDndChange: (enabled: boolean) => void
+  /** The activity window, in days, that scopes the session numbers. */
+  activityWindowDays: number
+  /** Aggregate analysis numbers for the Ready step, or null before the
+   *  first read. */
+  hygieneSummary: HygieneSummary | null
+  /** The Ready step is now visible. The session starts summary polling. */
+  onReadyEntered: () => void
   /** Count one step. The session deduplicates repeated navigation. */
   onStepViewed: (step: OnboardingStep) => void
   /** Finish: records the flag and enters the activity view. */
@@ -63,17 +75,15 @@ export interface OnboardingFlowProps {
   finishError: string | null
 }
 
-const STEPS = ["welcome", "sourcesAndRepos", "ready"] as const
+const STEPS = ["welcome", "agentsDetected", "sourcesAndRepos", "ready"] as const
 type Step = (typeof STEPS)[number]
 
 const ANALYTICS_STEP: Record<Step, OnboardingStep> = {
   welcome: "welcome",
+  agentsDetected: "agents_detected",
   sourcesAndRepos: "sources_and_repos",
   ready: "ready",
 }
-
-const PRIVACY_REVIEW_PROMPT =
-  "Review Antiburn's public source code: https://github.com/antiburn/antiburn. Explain in plain language what stays on my computer, what data leaves it, when analytics starts, and how I can turn analytics off. Cite the files that support each answer."
 
 function focusHeading(heading: HTMLHeadingElement | null): void {
   heading?.focus()
@@ -98,21 +108,7 @@ function StepDots({ step }: { step: Step }) {
 
 const CENTRED_COLUMN = "mx-auto flex max-w-[440px] flex-col items-center"
 
-function Welcome({
-  analyticsSupported,
-  analyticsEnvironmentDisabled,
-}: {
-  analyticsSupported: boolean
-  analyticsEnvironmentDisabled: boolean
-}) {
-  // This sentence is part of the network surface. A new outbound call means
-  // a change here. Settings → Privacy is the long form.
-  const networkCopy = !analyticsSupported
-    ? "It only goes online for your provider’s usage figures and a version check. This build has no analytics endpoint, so it sends nothing about itself."
-    : analyticsEnvironmentDisabled
-      ? "It only goes online for your provider’s usage figures and a version check. Analytics is disabled for this launch by ANTIBURN_ANALYTICS_ENABLED=false."
-      : "It only goes online for your provider’s usage figures, a version check, and anonymised analytics about the app. You can opt out of the analytics."
-
+function Welcome() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-8 text-center overflow-y-auto">
       <div className={CENTRED_COLUMN}>
@@ -125,17 +121,115 @@ function Welcome({
           className="mb-5 h-24 w-24 select-none drop-shadow-md"
           draggable={false}
         />
-        <h2 ref={focusHeading} tabIndex={-1} className="type-title-3 text-label outline-none">
+        <h2 ref={focusHeading} tabIndex={-1} className="type-title-1 text-label outline-none">
           Stop hitting your token limits.
         </h2>
-        <p className="mt-2 text-balance type-callout text-label-secondary">
+        <p className="mt-2.5 text-balance type-body text-label-secondary">
           antiburn reads your coding agent session logs and analyses them locally.
         </p>
-        <p className="mt-2 text-balance type-callout text-label-secondary">
+        <p className="mt-2 text-balance type-body text-label-secondary">
           No account needed, and nothing from your sessions is ever uploaded.
         </p>
-        <p className="mt-2 text-balance type-callout text-label-secondary">{networkCopy}</p>
       </div>
+    </div>
+  )
+}
+
+function AgentsDetected({
+  scanStatus,
+  scanning,
+  disabledAgents,
+  onAgentEnabledChange,
+}: {
+  scanStatus: ScanStatus | null
+  scanning: boolean
+  disabledAgents: readonly string[]
+  onAgentEnabledChange: (slug: string, enabled: boolean) => void
+}) {
+  const detected = (scanStatus?.agents ?? [])
+    .filter((entry) => entry.sessionsSeen > 0)
+    .sort((a, b) => b.sessionsSeen - a.sessionsSeen)
+  const detectedSlugs = new Set(detected.map((entry) => entry.agent))
+  const quiet = AGENT_SLUGS.filter((slug) => !detectedSlugs.has(slug))
+  const isEnabled = (slug: string) => !disabledAgents.includes(slug)
+
+  const summary =
+    detected.length > 0
+      ? `antiburn found sessions from ${detected.length} coding ${
+          detected.length === 1 ? "agent" : "agents"
+        }.`
+      : scanning
+        ? "Looking for coding agent sessions…"
+        : "No agent sessions found yet — antiburn keeps looking as you work."
+
+  return (
+    <div className="flex h-full min-h-0 flex-col px-8">
+      <h2 ref={focusHeading} tabIndex={-1} className="type-title-3 text-label outline-none">
+        Tell us about your Coding agents
+      </h2>
+      <p className="mt-1.5 type-callout text-label-secondary">{summary}</p>
+
+      <ScrollPane className="mt-3" viewportClassName="pr-1">
+        {detected.length > 0 ? (
+          <Card>
+            {detected.map((entry) => (
+              <div key={entry.agent} className="flex items-center gap-2.5 px-3 py-1.5">
+                <span className="flex w-5 shrink-0 justify-center">
+                  {renderAgentIcon(entry.agent, 16)}
+                </span>
+                <span className="type-callout font-semibold! text-label">
+                  {agentDisplayName(entry.agent)}
+                </span>
+                <span className="flex-1 type-footnote text-label-tertiary">
+                  {entry.sessionsSeen} {entry.sessionsSeen === 1 ? "session" : "sessions"}
+                </span>
+                <ToggleSwitch
+                  checked={isEnabled(entry.agent)}
+                  onCheckedChange={(next) => onAgentEnabledChange(entry.agent, next)}
+                  aria-label={`Show ${agentDisplayName(entry.agent)} sessions`}
+                />
+              </div>
+            ))}
+          </Card>
+        ) : null}
+
+        {quiet.length > 0 ? (
+          <>
+            <p
+              className={cn(
+                "pb-1.5 type-footnote font-semibold! text-label-tertiary",
+                detected.length > 0 ? "mt-3.5" : "mt-1",
+              )}
+            >
+              No sessions found
+            </p>
+            <Card className="grid grid-cols-2 divide-y-0">
+              {quiet.map((slug, position) => (
+                <div
+                  key={slug}
+                  className={cn(
+                    "flex items-center gap-2.5 border-separator px-3 py-1",
+                    position >= 2 && "border-t",
+                    position % 2 === 0 && "border-r",
+                  )}
+                >
+                  <span className="flex w-5 shrink-0 justify-center">
+                    {renderAgentIcon(slug, 14)}
+                  </span>
+                  <span className="flex-1 truncate type-footnote text-label-secondary">
+                    {agentDisplayName(slug)}
+                  </span>
+                  <ToggleSwitch
+                    checked={isEnabled(slug)}
+                    onCheckedChange={(next) => onAgentEnabledChange(slug, next)}
+                    aria-label={`Show ${agentDisplayName(slug)} sessions`}
+                  />
+                </div>
+              ))}
+            </Card>
+          </>
+        ) : null}
+      </ScrollPane>
     </div>
   )
 }
@@ -228,7 +322,7 @@ function SourcesAndRepos({
 
             <PushButton className="gap-1.5" onClick={onAddScanRoot}>
               <FolderPlus size={12} aria-hidden="true" />
-              Add a folder…
+              Add Locations…
             </PushButton>
           </div>
           {scanRoots.length === 0 ? (
@@ -330,86 +424,135 @@ function SourcesAndRepos({
   )
 }
 
+/** "Claude Code, Codex and Cursor" from a display-name list. */
+function joinNames(names: readonly string[]): string {
+  if (names.length <= 1) return names[0] ?? ""
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`
+}
+
+/**
+ * The fixed-height slot between the Ready sentence and the toggle rows.
+ *
+ * The results card and the analyzing bar render at the same height, so the
+ * heading and the toggles never move when analysis finishes.
+ */
+function ReadyStatSlot({ summary }: { summary: HygieneSummary | null }) {
+  const content = () => {
+    if (summary === null || summary.totalSessions === 0) return null
+    if (summary.settledSessions < summary.totalSessions) {
+      const progress = Math.round((summary.settledSessions / summary.totalSessions) * 100)
+      return (
+        <div className="mx-auto w-full max-w-[300px]">
+          <div className="flex items-baseline gap-2">
+            <p className="type-footnote text-label-secondary">Analyzing sessions</p>
+            <span className="flex-1" />
+            <p className="font-mono type-footnote text-label-tertiary">
+              {summary.settledSessions} of {summary.totalSessions}
+            </p>
+          </div>
+          <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-surface-secondary">
+            <div
+              className="h-full rounded-full bg-accent-fill"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      )
+    }
+    const passing =
+      summary.analyzedSessions > 0
+        ? Math.round(
+            ((summary.analyzedSessions - summary.failingSessions) / summary.analyzedSessions) *
+              100,
+          )
+        : null
+    return (
+      <Card className="grid w-full grid-cols-[1fr_1fr_1.5fr] divide-x divide-y-0 divide-separator">
+        <div className="flex flex-col items-center justify-center px-3 py-2.5">
+          <p className="font-mono type-title-2 text-label">{summary.analyzedSessions}</p>
+          <p className="mt-0.5 type-footnote text-label-tertiary">sessions analyzed</p>
+        </div>
+        <div className="flex flex-col items-center justify-center px-3 py-2.5">
+          <p className="font-mono type-title-2 text-accent">
+            {passing === null ? "–" : `${passing}%`}
+          </p>
+          <p className="mt-0.5 type-footnote text-label-tertiary">pass the session checks</p>
+        </div>
+        <div className="flex flex-col items-center justify-center px-3 py-2.5">
+          <p className="text-balance type-headline text-label">
+            {summary.mostCommonFinding === null
+              ? "None"
+              : sessionHygieneCheckName(summary.mostCommonFinding)}
+          </p>
+          <p className="mt-0.5 type-footnote text-label-tertiary">most common failure</p>
+        </div>
+      </Card>
+    )
+  }
+  return <div className="mt-4 flex h-[88px] w-full items-center">{content()}</div>
+}
+
 function Ready({
   sessions,
+  windowDays,
+  agentNames,
+  hygieneSummary,
   launchAtLogin,
   onLaunchAtLoginChange,
-  analyticsSupported,
-  analyticsEnvironmentDisabled,
+  nudgesRespectDnd,
+  onNudgesRespectDndChange,
   finishError,
 }: {
   sessions: number
+  windowDays: number
+  agentNames: readonly string[]
+  hygieneSummary: HygieneSummary | null
   launchAtLogin: boolean
   onLaunchAtLoginChange: (enabled: boolean) => void
-  analyticsSupported: boolean
-  analyticsEnvironmentDisabled: boolean
+  nudgesRespectDnd: boolean
+  onNudgesRespectDndChange: (enabled: boolean) => void
   finishError: string | null
 }) {
-  const [copied, setCopied] = useState(false)
-
-  const copyReviewPrompt = () => {
-    void navigator.clipboard
-      .writeText(PRIVACY_REVIEW_PROMPT)
-      .then(() => {
-        setCopied(true)
-        window.setTimeout(() => setCopied(false), 2_000)
-      })
-      .catch(() => setCopied(false))
-  }
+  const dayClause = windowDays === 1 ? "the last day" : `the last ${windowDays} days`
+  const agentClause = agentNames.length > 0 ? ` across ${joinNames(agentNames)}` : ""
+  const sentence =
+    sessions > 0
+      ? `${sessions} ${sessions === 1 ? "session" : "sessions"} from ${dayClause}${agentClause} ${
+          sessions === 1 ? "is" : "are"
+        } indexed and waiting in the menu bar.`
+      : "Looking for coding sessions…"
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-8 text-center">
-      <div className={CENTRED_COLUMN}>
-        <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-surface-secondary text-label-secondary">
+      <div className={cn(CENTRED_COLUMN, "w-full")}>
+        <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-surface-secondary text-label-secondary">
           <Check size={22} strokeWidth={2} aria-hidden="true" />
         </div>
-        <h2
-          ref={focusHeading}
-          tabIndex={-1}
-          className="type-title-3 text-label outline-none mt-1"
-        >
+        <h2 ref={focusHeading} tabIndex={-1} className="type-title-1 text-label outline-none">
           Ready
         </h2>
-        <p className="mt-2 text-balance type-callout text-label-secondary">
-          {sessions > 0
-            ? `${sessions} ${sessions === 1 ? "session is" : "sessions are"} indexed and waiting in the menu bar.`
-            : "Nothing is indexed yet — antiburn keeps looking in the background as you work."}
-        </p>
-        <p className="mt-2 text-balance type-footnote text-label-tertiary">
-          Session files are read only; your repositories are never modified.
-        </p>
-        <Card className="mt-12 w-full text-left">
-          <ToggleRow
-            label="Launch antiburn on startup"
-            description="Starts automatically in the menu bar. Change anytime in Settings."
-            checked={launchAtLogin}
-            onChange={onLaunchAtLoginChange}
-          />
-        </Card>
-        {analyticsSupported ? (
-          <Card className="mt-3 w-full text-left">
-            <Row
-              label="Anonymised analytics"
-              description={
-                analyticsEnvironmentDisabled
-                  ? "Off for this launch because ANTIBURN_ANALYTICS_ENABLED=false. Remove it to use the setting in Settings → Privacy."
-                  : "Sends app launches, onboarding progress, feature use, and error categories. Never prompts, sessions, source code, filenames, or paths. Turn it off in Settings → Privacy."
-              }
+        <p className="mt-2.5 text-balance type-body text-label-secondary">{sentence}</p>
+        <ReadyStatSlot summary={hygieneSummary} />
+        <div className="mt-4 flex w-full flex-col gap-2 text-left">
+          <div className="flex items-center gap-3">
+            <span className="type-callout text-label">Launch antiburn on startup</span>
+            <span className="flex-1" />
+            <ToggleSwitch
+              checked={launchAtLogin}
+              onCheckedChange={onLaunchAtLoginChange}
+              aria-label="Launch antiburn on startup"
             />
-            <Row
-              label="Review the source code"
-              trailing={
-                <PushButton onClick={copyReviewPrompt} trailingIcon={Copy} disabled={copied}>
-                  {copied ? "Copied" : "Copy prompt"}
-                </PushButton>
-              }
-            >
-              <p className="mt-1 type-footnote text-label-secondary">
-                Copy a prompt for your AI agent to check what leaves your computer.
-              </p>
-            </Row>
-          </Card>
-        ) : null}
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="type-callout text-label">Nudges respect Do Not Disturb</span>
+            <span className="flex-1" />
+            <ToggleSwitch
+              checked={nudgesRespectDnd}
+              onCheckedChange={onNudgesRespectDndChange}
+              aria-label="Nudges respect Do Not Disturb"
+            />
+          </div>
+        </div>
         {finishError ? (
           <p className="mt-3 type-footnote text-system-red" role="alert">
             {finishError}
@@ -434,10 +577,15 @@ export function OnboardingFlow({
   onToggleRepository,
   onDiscover,
   scanStatus,
+  disabledAgents,
+  onAgentEnabledChange,
   launchAtLogin,
   onLaunchAtLoginChange,
-  analyticsSupported,
-  analyticsEnvironmentDisabled,
+  nudgesRespectDnd,
+  onNudgesRespectDndChange,
+  activityWindowDays,
+  hygieneSummary,
+  onReadyEntered,
   onStepViewed,
   onFinish,
   finishing,
@@ -453,10 +601,11 @@ export function OnboardingFlow({
 
   const advance = () => {
     const next = STEPS[index + 1] ?? "ready"
-    if (next === "sourcesAndRepos" && !scanSucceeded && !running && !discoveryRequested) {
+    if (next === "agentsDetected" && !scanSucceeded && !running && !discoveryRequested) {
       setDiscoveryRequested(true)
       onDiscover()
     }
+    if (next === "ready") onReadyEntered()
     onStepViewed(ANALYTICS_STEP[next])
     setStep(next)
   }
@@ -500,11 +649,14 @@ export function OnboardingFlow({
         </p>
       </header>
 
-      <div className={cn("min-h-0", step != "sourcesAndRepos" && "self-center")}>
-        {step === "welcome" && (
-          <Welcome
-            analyticsSupported={analyticsSupported}
-            analyticsEnvironmentDisabled={analyticsEnvironmentDisabled}
+      <div className={cn("min-h-0", (step === "welcome" || step === "ready") && "self-center")}>
+        {step === "welcome" && <Welcome />}
+        {step === "agentsDetected" && (
+          <AgentsDetected
+            scanStatus={scanStatus}
+            scanning={running}
+            disabledAgents={disabledAgents}
+            onAgentEnabledChange={onAgentEnabledChange}
           />
         )}
         {step === "sourcesAndRepos" && (
@@ -530,9 +682,15 @@ export function OnboardingFlow({
             finishError={finishError}
             launchAtLogin={launchAtLogin}
             sessions={scanStatus?.sessions ?? 0}
+            windowDays={activityWindowDays}
+            agentNames={(scanStatus?.agents ?? [])
+              .filter((entry) => entry.sessionsSeen > 0)
+              .sort((a, b) => b.sessionsSeen - a.sessionsSeen)
+              .map((entry) => agentDisplayName(entry.agent))}
+            hygieneSummary={hygieneSummary}
             onLaunchAtLoginChange={onLaunchAtLoginChange}
-            analyticsSupported={analyticsSupported}
-            analyticsEnvironmentDisabled={analyticsEnvironmentDisabled}
+            nudgesRespectDnd={nudgesRespectDnd}
+            onNudgesRespectDndChange={onNudgesRespectDndChange}
           />
         )}
       </div>

--- a/apps/desktop/src/views/onboarding/OnboardingSession.ts
+++ b/apps/desktop/src/views/onboarding/OnboardingSession.ts
@@ -22,6 +22,7 @@ import {
   type RepositoryItemPayload,
   type ScanStatus,
 } from "../../lib/ipc"
+import { getHygieneSummary, type HygieneSummary } from "../../lib/insightsIpc"
 import type {
   FolderPermissions,
   LocalRepositoryItem,
@@ -32,6 +33,7 @@ import type {
   FolderPermissionFlow,
   FolderVerdict,
 } from "../../lib/useFolderPermissionFlow"
+import { AGENT_SLUGS } from "../../lib/presentation/agents"
 
 const EMPTY_PERMISSIONS: FolderPermissions = {
   deferred: [],
@@ -57,6 +59,15 @@ export type OnboardingSnapshot = {
   permissions: FolderPermissions
   repositories: LocalRepositoryItem[]
   scanStatus: ScanStatus | null
+  /**
+   * Draft of the disabled-agent set, persisted by `finish`. Seeded once from
+   * scan results: agents with sessions start on, the rest start off.
+   */
+  disabledAgents: string[]
+  /** Draft of the Do Not Disturb opt-in, persisted by `finish`. */
+  nudgesRespectDnd: boolean
+  /** The aggregate check numbers the Ready step shows. Null until fetched. */
+  hygieneSummary: HygieneSummary | null
   recheckingPermissions: boolean
   finishing: boolean
   finishError: string | null
@@ -96,6 +107,8 @@ export class OnboardingSession {
   private permissionTimer: ReturnType<typeof setTimeout> | null = null
   private rescanInFlight = false
   private rescanQueued = false
+  private agentChoicesTouched = false
+  private hygieneTimer: ReturnType<typeof setInterval> | null = null
   private analyticsSteps = new Set<OnboardingStep>()
 
   private snapshot: OnboardingSnapshot
@@ -113,6 +126,9 @@ export class OnboardingSession {
       permissions: EMPTY_PERMISSIONS,
       repositories: [],
       scanStatus: null,
+      disabledAgents: [],
+      nudgesRespectDnd: false,
+      hygieneSummary: null,
       recheckingPermissions: false,
       finishing: false,
       finishError: null,
@@ -139,6 +155,43 @@ export class OnboardingSession {
 
   setLaunchAtLogin = (enabled: boolean): void => {
     this.update({ launchAtLogin: enabled, finishError: null })
+  }
+
+  setNudgesRespectDnd = (enabled: boolean): void => {
+    this.update({ nudgesRespectDnd: enabled, finishError: null })
+  }
+
+  /**
+   * Fetch the check numbers now and re-fetch each second until analysis
+   * settles. The flow calls this when the reader reaches the Ready step,
+   * so the poll never runs behind an earlier step.
+   */
+  beginHygienePolling = (): void => {
+    if (this.hygieneTimer !== null) return
+    this.hygieneTimer = setInterval(() => void this.refreshHygieneSummary(), 1_000)
+    void this.refreshHygieneSummary()
+  }
+
+  private refreshHygieneSummary = async (): Promise<void> => {
+    const generation = this.generation
+    const summary = await getHygieneSummary().catch(() => null)
+    if (summary === null || generation !== this.generation) return
+    this.update({ hygieneSummary: summary })
+    if (summary.settledSessions >= summary.totalSessions) this.stopHygienePolling()
+  }
+
+  private stopHygienePolling(): void {
+    if (this.hygieneTimer === null) return
+    clearInterval(this.hygieneTimer)
+    this.hygieneTimer = null
+  }
+
+  setAgentEnabled = (slug: string, enabled: boolean): void => {
+    this.agentChoicesTouched = true
+    const disabled = new Set(this.snapshot.disabledAgents)
+    if (enabled) disabled.delete(slug)
+    else disabled.add(slug)
+    this.update({ disabledAgents: [...disabled].sort(), finishError: null })
   }
 
   noteOnboardingStep = (step: OnboardingStep): void => {
@@ -175,7 +228,7 @@ export class OnboardingSession {
       do {
         this.rescanQueued = false
         const status = await scanNow(this.snapshot.activityWindowDays).catch(() => null)
-        if (status) this.update({ scanStatus: status })
+        if (status) this.applyScanStatus(status)
         const permissions = await getFolderPermissions().catch(() => null)
         if (permissions) this.update({ permissions })
       } while (this.rescanQueued)
@@ -206,7 +259,12 @@ export class OnboardingSession {
     if (this.snapshot.finishing) return
     this.update({ finishing: true, finishError: null })
     try {
-      await finishOnboarding(this.snapshot.activityWindowDays, this.snapshot.launchAtLogin)
+      await finishOnboarding(
+        this.snapshot.activityWindowDays,
+        this.snapshot.launchAtLogin,
+        this.snapshot.disabledAgents,
+        this.snapshot.nudgesRespectDnd,
+      )
     } catch (error) {
       this.update({
         finishing: false,
@@ -222,8 +280,11 @@ export class OnboardingSession {
     const pendingScanListener = onScanEvent((status, phase) => {
       if (generation !== this.generation) return
       this.scanEventVersion += 1
-      this.update({ scanStatus: status })
-      if (phase === "finished") void this.refreshRepositories()
+      this.applyScanStatus(status)
+      if (phase === "finished") {
+        void this.refreshRepositories()
+        void this.refreshScanStatus()
+      }
     })
 
     try {
@@ -255,14 +316,15 @@ export class OnboardingSession {
         loadError: null,
         activityWindowDays: settings.activityWindowDays,
         launchAtLogin: settings.launchAtLogin,
+        nudgesRespectDnd: settings.nudgesRespectDnd,
         analyticsSupported: info?.analyticsSupported ?? false,
         analyticsEnvironmentDisabled: info?.analyticsEnvironmentDisabled ?? false,
         scanRoots,
         defaultRoots,
         permissions,
         repositories: toRepositories(repositories),
-        ...(scanVersion === this.scanEventVersion ? { scanStatus } : {}),
       })
+      if (scanVersion === this.scanEventVersion && scanStatus) this.applyScanStatus(scanStatus)
       this.noteOnboardingStep("welcome")
     } catch (error) {
       if (generation !== this.generation) return
@@ -278,12 +340,54 @@ export class OnboardingSession {
     this.generation += 1
     this.stopScanListening?.()
     this.stopScanListening = null
+    this.stopHygienePolling()
     this.cancelPermissionFlow()
   }
 
   private refreshRepositories = async (): Promise<void> => {
     const payloads = await listRepositories().catch(() => [])
     this.update({ repositories: toRepositories(payloads) })
+  }
+
+  /**
+   * Apply a scan status while it keeps the known agent list. Scan events carry
+   * an empty `agents` array, so an event must not erase the fetched list.
+   */
+  private applyScanStatus(status: ScanStatus): void {
+    const previous = this.snapshot.scanStatus
+    const agents = status.agents.length > 0 ? status.agents : (previous?.agents ?? [])
+    const merged = { ...status, agents }
+    this.update({ scanStatus: merged })
+    this.seedAgentChoices(merged)
+  }
+
+  /** Fetch the per-agent scan state, which scan events do not carry. */
+  private refreshScanStatus = async (): Promise<void> => {
+    const version = this.scanEventVersion
+    const fetched = await getScanStatus().catch(() => null)
+    if (!fetched) return
+    if (version === this.scanEventVersion) {
+      this.applyScanStatus(fetched)
+      return
+    }
+    // A newer scan event arrived during the fetch. Keep the event's counters
+    // and take only the agent list from the fetched status.
+    const current = this.snapshot.scanStatus
+    if (current === null || fetched.agents.length === 0) return
+    const merged = { ...current, agents: fetched.agents }
+    this.update({ scanStatus: merged })
+    this.seedAgentChoices(merged)
+  }
+
+  /**
+   * Seed the draft toggles from scan results until the user touches one.
+   * Agents with sessions start on; agents with none start off.
+   */
+  private seedAgentChoices(status: ScanStatus): void {
+    if (this.agentChoicesTouched || status.agents.length === 0) return
+    const sessions = new Map(status.agents.map((entry) => [entry.agent, entry.sessionsSeen]))
+    const disabled = AGENT_SLUGS.filter((slug) => (sessions.get(slug) ?? 0) === 0)
+    this.update({ disabledAgents: disabled })
   }
 
   private startPermissionFlow = (): void => {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -473,9 +473,13 @@ export class PopoverSession {
     const unlisten = await onSettingsChanged((settings) => {
       if (generation !== this.generation) return
       const previousDays = this.windowDays()
+      const previousDisabled = (this.snapshot.settings?.disabledAgents ?? []).join(",")
       applyTheme(settings.theme)
       this.update({ settings })
-      if (settings.activityWindowDays !== previousDays) {
+      if (
+        settings.activityWindowDays !== previousDays ||
+        settings.disabledAgents.join(",") !== previousDisabled
+      ) {
         void this.refreshEntries(settings.activityWindowDays).catch(() => {})
       }
     })

--- a/apps/desktop/src/views/settings/NotificationsPane.tsx
+++ b/apps/desktop/src/views/settings/NotificationsPane.tsx
@@ -166,6 +166,14 @@ export function NotificationsPane({ settings, update }: NotificationsPaneProps) 
             dimmed={!on}
             disabled={!on}
           />
+          <ToggleRow
+            label="Respect Do Not Disturb"
+            description="Automated nudges stay quiet while Focus or Do Not Disturb is on. macOS asks once for permission to read the Focus state."
+            checked={settings.nudgesRespectDnd}
+            onChange={(next) => void update({ nudgesRespectDnd: next })}
+            dimmed={!on}
+            disabled={!on}
+          />
           <Row
             label="Auto-dismiss time"
             description="How long a notification stays before it fades. Hovering pauses the timer."

--- a/apps/desktop/src/views/settings/SourcesPane.tsx
+++ b/apps/desktop/src/views/settings/SourcesPane.tsx
@@ -8,12 +8,16 @@ import { PaneHeader } from "../../components/ui/Pane"
 import { PushButton } from "../../components/ui/PushButton"
 import { SectionGroup } from "../../components/ui/SectionGroup"
 import { StatusText } from "../../components/ui/StatusText"
+import { ToggleSwitch } from "../../components/ui/ToggleSwitch"
+import { renderAgentIcon } from "../../lib/agentIcon"
 import { openFolderAccessSettings, scanNow } from "../../lib/ipc"
-import { scanStatusStore } from "../../lib/scanStatusStore"
+import { AGENT_SLUGS, agentDisplayName } from "../../lib/presentation/agents"
+import { scanStatusStore, withKnownAgents } from "../../lib/scanStatusStore"
 import type { LocalRepositoryItem } from "../../lib/types/repository"
 import { useFolderPermissionFlow } from "../../lib/useFolderPermissionFlow"
 import { scanStatusLabel } from "../popover/ScanStatusBar"
 import { SourcesSession } from "./SourcesSession"
+import { useAppSettings } from "./useAppSettings"
 
 /**
  * Sources: which repositories antiburn watches, and where it looks for them.
@@ -46,7 +50,7 @@ export function SourcesPane({ discoveryPaused }: SourcesPaneProps) {
 
   const handleRescanSessions = useCallback(async () => {
     const status = await scanNow().catch(() => null)
-    if (status) scanStatusStore.set(status)
+    if (status) scanStatusStore.set(withKnownAgents(status))
   }, [])
 
   // Granting is the one path that can add repositories the reader is waiting
@@ -73,6 +77,27 @@ export function SourcesPane({ discoveryPaused }: SourcesPaneProps) {
   const handleLocate = useCallback(() => session.locate(), [session])
 
   const handleRemoveRoot = useCallback((path: string) => session.removeRoot(path), [session])
+
+  const { settings, update } = useAppSettings()
+  const disabledAgents = settings.disabledAgents
+
+  const setAgentEnabled = useCallback(
+    (slug: string, enabled: boolean) => {
+      const next = new Set(disabledAgents)
+      if (enabled) next.delete(slug)
+      else next.add(slug)
+      void update({ disabledAgents: [...next].sort() })
+    },
+    [disabledAgents, update],
+  )
+
+  // Detected agents lead, ordered by evidence; the rest keep registry order.
+  const sessionsByAgent = new Map(
+    (scanStatus?.agents ?? []).map((entry) => [entry.agent, entry.sessionsSeen]),
+  )
+  const agentRows = [...AGENT_SLUGS].sort(
+    (a, b) => (sessionsByAgent.get(b) ?? 0) - (sessionsByAgent.get(a) ?? 0),
+  )
 
   return (
     <>
@@ -116,6 +141,36 @@ export function SourcesPane({ discoveryPaused }: SourcesPaneProps) {
                 {scanStatus?.running ? "Scanning…" : "Rescan"}
               </PushButton>
             </div>
+          </Card>
+        </SectionGroup>
+
+        <SectionGroup title="Coding agents">
+          <Card>
+            <p className="px-4 pt-3 pb-1 type-footnote text-label-secondary">
+              A switched-off agent keeps its sessions indexed, but the session list and reports
+              leave them out.
+            </p>
+            {agentRows.map((slug) => {
+              const sessions = sessionsByAgent.get(slug) ?? 0
+              return (
+                <div key={slug} className="flex items-center gap-2.5 px-4 py-2">
+                  <span className="flex w-5 shrink-0 justify-center">
+                    {renderAgentIcon(slug, 15)}
+                  </span>
+                  <span className="type-callout text-label">{agentDisplayName(slug)}</span>
+                  <span className="flex-1 type-footnote text-label-tertiary">
+                    {sessions > 0
+                      ? `${sessions} ${sessions === 1 ? "session" : "sessions"}`
+                      : ""}
+                  </span>
+                  <ToggleSwitch
+                    checked={!disabledAgents.includes(slug)}
+                    onCheckedChange={(next) => setAgentEnabled(slug, next)}
+                    aria-label={`Show ${agentDisplayName(slug)} sessions`}
+                  />
+                </div>
+              )
+            })}
           </Card>
         </SectionGroup>
 

--- a/crates/antiburn-local/src/repositories/platform/macos.rs
+++ b/crates/antiburn-local/src/repositories/platform/macos.rs
@@ -10,6 +10,8 @@ const MACOS_CODE_DIRS: &[&str] = &[
     "dev",
     "Developer",
     "Documents/GitHub",
+    // Xcode clones into ~/Developer by default, and TCC does not guard it.
+    "Developer",
     "src",
     "code",
     "Projects",
@@ -65,6 +67,16 @@ mod tests {
     #[test]
     fn common_dirs_not_empty() {
         assert!(!MacOsPlatform.common_code_dirs().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn developer_dir_is_searched_and_unprotected() {
+        assert!(MacOsPlatform.common_code_dirs().contains(&"Developer"));
+        if let Some(home) = home_dir() {
+            let xcode_clone = home.join("Developer").join("repo");
+            assert!(!MacOsPlatform.is_access_protected(&xcode_clone));
+        }
     }
 
     #[test]

--- a/docs/plans/onboarding-improvements.md
+++ b/docs/plans/onboarding-improvements.md
@@ -1,0 +1,246 @@
+# Onboarding improvements: agents detected, a useful Ready page, nudges explained
+
+Branch: `claude/onboarding-improvements-8f6140` · Status: planning
+
+## Status
+
+| Step | State |
+| --- | --- |
+| Explore current code, verify data sources | Done |
+| Agree this plan with Keith | Done 2026-08-31 — all questions answered except one u-3 sub-question (do OFF-by-default agents stay silently watched?) |
+| Feature 1: Agents detected step | Built 2026-08-31 — `DisabledAgents` setting + `recent_sessions_excluding` filter (Rust), `agentsDetected` step second in the flow, Settings → Sources mirror, popover re-query, tests green. Zero-session agents seed OFF and the whole set persists (Option 1); the later-install question is still open with Keith |
+| Feature 2: Ready page stats | Built 2026-08-31 — `get_hygiene_summary` command (window + disabled-agent filter mirrors the session list; only current ready evidence counts analyzed), Ready rebuilt per v5 proto (title-1 heading, richer sentence with window + agent names, 88px slot with stats card / progress bar, plain toggle rows), `nudges_respect_dnd` setting end-to-end with the OS Focus gate now opt-in, Settings → Notifications mirror row, analytics/review-source card and read-only footnote removed from Ready. Rust 658 + frontend 938 tests green |
+| Feature 3: Nudges explained | Not started — surface confirmed: Settings → Notifications (discuss, 2026-08-31) |
+| Quick win: add `~/Developer` to `MACOS_CODE_DIRS` | Done 2026-08-31 — line + test in `crates/antiburn-local/src/repositories/platform/macos.rs`, 6/6 pass. Rides in the Feature 1 PR |
+| Feature 4: sourcesAndRepos step redesign | Design settled via proto 2026-08-31 (see section below); own PR |
+| Tests + manual test + screenshot | Not started |
+| PR | Not started — one PR per feature (now four); 2 stacks on 1, and 4 also touches `OnboardingFlow.tsx` so it joins that stack |
+
+## Where things stand today
+
+The onboarding window is a fixed 680×480 flow of three steps —
+`welcome → sourcesAndRepos → ready` — driven by a plain step tuple in
+[OnboardingFlow.tsx:66](../../apps/desktop/src/views/onboarding/OnboardingFlow.tsx).
+Discovery kicks off when the reader advances past Welcome, so by the Ready
+step a scan has usually finished.
+
+Three facts shape all three features:
+
+1. **Per-agent detection data exists end to end and is never rendered.**
+   `ScanStatus.agents` carries `{ agent, lastCompletedAt, sessionsSeen }` per
+   agent ([dto.rs:256](../../apps/desktop/src-tauri/src/dto.rs)), and the
+   frontend has a full display registry (names, icons) in
+   `lib/presentation/agents.ts`. No component reads it. One caveat: the
+   `agents` array is only filled when status is read through the
+   `get_scan_status` **command** — scan **events** omit it by design — so any
+   step that shows it must fetch, not just read the pushed snapshot.
+2. **Detection means "sessions found", not "app installed".** There is no
+   is-this-binary-installed probe. Copy must say "found 304 Claude Code
+   sessions", never "Claude Code is installed".
+3. **Burn checks are real now — and measured fast on first run.** Each
+   session gets 3 burn checks, computed by a background evidence worker that
+   drains a queue newest-first (see
+   [session-check-states.md](session-check-states.md)). The plan originally
+   assumed a fresh install leaves most rows at "Computing checks…" when the
+   reader reaches Ready. **Measured 2026-08-31** on Keith's machine (cold
+   dev-build run, fresh debug store): all 323 sessions in the 14-day window
+   analyzed in 46 seconds — 175 in the first 15s, 269 by 30s; the last-7-days
+   cohort ~80% done within 25s. So on this hardware, real check results exist
+   by Ready. Caveat: one fast Mac, one dataset — a slow disk or giant
+   transcripts would stretch it, so progress-shaped copy ("Checked X of Y")
+   degrades more gracefully than a bare count.
+
+## Feature 1: "Agents detected" step
+
+A new step that shows which coding agents antiburn found sessions for, with
+per-agent session counts.
+
+**Position changed 2026-08-31 (v3 proto round): the step comes second**,
+right after Welcome — `welcome → agentsDetected → sourcesAndRepos → ready`.
+Discovery kicks on leaving Welcome, so the reader may watch counts fill in
+live on this step; the component already plans for that ("rows appearing as
+agents complete"). The intro line is just "antiburn found sessions from N
+agents on this Mac." — no toggle-explainer sentence (cut in the same round).
+
+**What it shows** (decided in discuss, 2026-08-31): a checklist — one row per
+agent with icon + display name (from `lib/presentation/agents.ts`) and a
+toggle. Detected agents show "N sessions" and default ON; zero-session agents
+are included but default OFF. This implies a new per-agent enabled setting
+that does not exist today (the only `enabled` column is per-repository, and
+the analysis cohort is compile-time): a persisted setting, scan/discovery
+gating in Rust, and a mirror in Settings so the choice stays editable.
+Toggle semantics, first half answered (chat, 2026-08-31): OFF hides the
+agent's already-indexed sessions, not just future scans — so the setting can
+be a display/report filter over data that stays indexed, which keeps the
+Rust surface small. Still open: should OFF-by-default agents stay silently
+watched so a later install still surfaces?
+
+**Mechanics** (the flow was built to scale off the tuple, so this is small):
+
+- Add `"agentsDetected"` to `STEPS` and `ANALYTICS_STEP` in
+  `OnboardingFlow.tsx`, plus a render branch and an `AgentsDetected`
+  component.
+- On entry, call `getScanStatus()` to get the filled `agents` array (caveat 1
+  above). While the scan is still running, show the rows appearing as agents
+  complete, or a short "Still looking…" state.
+- Add the step's data to `OnboardingSession` snapshot if needed.
+- Analytics: the `onStepViewed` plumbing handles the new step for free once
+  it's in `ANALYTICS_STEP`.
+
+**Constraint**: the window is fixed 680×480 and `onboarding.rs` pins the body
+height budget with compile-time asserts. Eleven agents can't all fit as fat
+rows; a compact list or two-column grid, capped with the detected ones first.
+
+## Feature 2: Ready page tells the reader something useful
+
+Today Ready says "N sessions are indexed and waiting in the menu bar."
+Keith's sketch: "304 sessions detected … 40 sessions failed checks".
+
+**The honesty problem**: burn checks won't have run yet (fact 3). Two honest
+shapes, in order of preference:
+
+- **Option A — report what's true now, point at what's coming.** Keep the
+  session count, add the per-agent breakdown ("304 sessions across Claude
+  Code, Codex and Cursor"), and add one forward-looking line: "Burn checks
+  are running in the background — results appear on each session in the menu
+  bar." No fake numbers, no waiting.
+- **Option B — live counter.** Ready polls check progress and the line
+  updates in place: "Checked 61 of 304 sessions so far — 9 have burn
+  findings." Real numbers, more moving parts: needs a new aggregate-hygiene
+  Rust command (current `get_session_hygiene` is per-listed-row, and the
+  Insights report is a 30-day reduction that is `pending` at first run), plus
+  polling in a window the reader may close at any moment.
+
+Plan assumed **Option A** for this PR and filed Option B as a follow-up once
+an aggregate hygiene count exists — that command is also what a future
+"weekly summary" nudge would need, so it earns its keep twice. If Feature 1's
+step already shows the per-agent breakdown, Ready's version compresses to
+one sentence so the two steps don't repeat a table.
+
+**Reopened and decided 2026-08-31** after the throughput measurement (fact
+3) showed the whole 14-day window analyzed in ~46s. Keith's call (chat):
+show **real analysis, stylized attractively, in its own card** —
+
+> 234 Sessions analyzed
+> 80% pass the session checks
+> Most common failure: Overpowered subagents
+
+("Overpowered subagents" was illustrative; the card uses the real check
+names — reasoning overkill, excess cache rehydration, bloated initial
+context.) While results are not yet available, the card shows a **progress
+bar over the number of sessions** ("Analyzing sessions", checked X of Y).
+Only if real progress turns out too hard, fall back to a faked ~10-second
+bar. Real progress should not be hard: the same aggregate-hygiene command
+that powers the card can report checked/total, so the fake bar is a
+last-resort fallback, not the plan.
+
+Consequences: the aggregate-hygiene Rust command moves **into scope** for
+this PR (it also serves the future weekly-summary nudge), and Ready needs a
+light poll while the bar is showing. Option A's plain sentence survives as
+the zero-sessions state.
+
+**v4 proto refinements (2026-08-31)**: stat figures use the mono font
+(`fonts.mono`), matching the app's number styling; the analyzing state is a
+bare lightweight bar (no card); the launch-at-login toggle is a plain
+single line, not a card, joined by a new **"Nudges respect Do Not Disturb"**
+line, default OFF (Focus-status authorization — `notifications.rs` already
+has the plumbing; the "requires permissions" label was cut in the v5 round —
+the permission prompt appears on first toggle instead).
+
+**v5 layout rule**: the results stat card and the analyzing progress bar
+render inside a fixed-height slot (88px in the proto), so the Ready heading
+and toggle rows sit at identical positions in both states — no reflow when
+analysis finishes. Verified pixel-identical in the v5 screenshot. Welcome and
+Ready hero headings move up the documented scale to `type-title-1` with
+`type-body` copy. Removed from onboarding entirely in the v3/v4 review
+rounds: Welcome's network/analytics paragraph, Ready's analytics +
+review-source card, and Ready's nudges one-liner (Feature 3's onboarding
+tie-in is dead; the pane explainer stands alone). Flag: analytics now has
+no pre-consent disclosure anywhere in onboarding — raised with Keith
+2026-08-31, unresolved.
+
+## Feature 3: Explain nudges as a feature
+
+Keith's note says "on the alerts page" — **there is no alerts page**. The
+closest surface is Settings → Notifications
+([NotificationsPane.tsx](../../apps/desktop/src/views/settings/NotificationsPane.tsx)),
+which already lists every notification kind, placement, auto-dismiss, and a
+debug-only sample row. See the open question below; assuming the
+Notifications pane is the place:
+
+- Add a short explainer at the top of the pane: what a nudge is (antiburn's
+  own small notification window, not a macOS notification), when one
+  appears (only for the listed kinds — nothing else interrupts), and that
+  each kind can be turned off individually.
+- Promote the "Sample notifications" row from debug-only to always-on for
+  one representative kind ("Show me one") so a reader can see a nudge
+  before deciding what to allow. The debug row keeps the full kind list.
+- Optional tie-in to onboarding: one sentence on the Ready step ("antiburn
+  nudges you when a session burns hot — choose what interrupts you in
+  Settings → Notifications"). Cheap, and it makes the feature discoverable
+  at the moment the reader is deciding what this app does.
+
+## Feature 4: sourcesAndRepos step redesign (progressive disclosure)
+
+Added 2026-08-31 after a proto round (three variants, then two single-column
+revisions; final: `scratchpad proto repo-search-disclosure/single-v3.html`,
+picked "A as a single vertical"). The current two-column step becomes one
+vertical column:
+
+- **Heading is a question (Keith, chat 2026-08-31)**: "Where should antiburn
+  look for your Claude Code, Codex and Cursor repos?" — detected agent names
+  joined naturally, "your repos" when none are detected. The step follows the
+  agents step, so the names are already known. Voice stays "antiburn", not
+  "we", matching the rest of the flow.
+
+- The 8 readable default roots collapse to one disclosure row: "Searching 8
+  standard code folders ▸" (expands to the path list). Individual paths are
+  never shown at rest.
+- **v5 round (2026-08-31)**: the search-location rows (the disclosure
+  summary, the expanded path list, and the locked row) use the mono font
+  with leading check glyphs, styled like the app's session-check rows. The
+  locked row swaps its check for a lock glyph until access is granted.
+- The locked `~/Documents/GitHub` row stays visible on its own line ("needs
+  permission"), with the "Add a folder…" button inline on the same row. The
+  "Added by you" section header is gone; user-added folders appear as rows
+  under the summary.
+- "Repos found" and its permission card sit below and take the rest of the
+  window; found repositories fill that space.
+- The "Repositories appear once a coding session has run in one." explainer
+  is **cut entirely** (v5 round) — the empty state is just the
+  "Nothing found yet" illustration, no explainer sentence.
+- Off-macOS the locked row and permission card never render (no consent
+  concept on Windows/Linux), so the step is just summary row + results.
+
+## Locked design decisions
+
+- Copy says "found N sessions", never "installed" (fact 2).
+- No fabricated or premature check numbers on Ready (fact 3). Mock hygiene
+  data is gone from the codebase and stays gone.
+- The new step derives everything (dots, step count, Back) from the `STEPS`
+  tuple — no parallel bookkeeping.
+- Design tokens per `apps/desktop/design.md`; agent icons only via the
+  `renderAgentIcon` slot.
+
+## Out of scope
+
+- ~~Aggregate hygiene count command + live Ready counter (Option B)~~ —
+  moved into Feature 2's scope 2026-08-31.
+- Live per-agent scan progress (Rust drops agent identity in the scan
+  progress callback today); the step fetches after completion instead.
+- Any new nudge kinds (e.g. a "weekly burn summary" nudge) — separate
+  feature.
+- A standalone "Alerts" page, unless the open question says otherwise.
+
+## Open questions for Keith
+
+1. **"Alerts page"** — answered (discuss, 2026-08-31): (a) Settings →
+   Notifications. The one-line Ready-step pointer stays unless Keith cuts it.
+2. Ready page — answered (discuss, 2026-08-31): Option A for this PR;
+   Option B and its aggregate-hygiene command stay in Out of scope.
+3. Agents-detected step — answered (discuss, 2026-08-31): include
+   zero-session agents, OFF by default, as toggles. Two follow-up questions
+   pending on thread u-3: what OFF means for already-indexed sessions, and
+   whether OFF agents stay silently watched.
+4. PR split — answered (discuss, 2026-08-31): three PRs, one per feature;
+   Feature 2 stacks on Feature 1 since both touch `OnboardingFlow.tsx`.

--- a/install.ps1
+++ b/install.ps1
@@ -14,6 +14,29 @@ function Write-InstallerInfo {
     Write-Information "antiburn: $Message" -InformationAction Continue
 }
 
+# Print the wordmark and one line about what antiburn does. Art and color
+# appear only on an interactive host that did not opt out.
+function Write-InstallerBanner {
+    if ($env:NO_COLOR -or [Console]::IsOutputRedirected) {
+        Write-InstallerInfo 'Stop hitting your token limits - antiburn finds what burns tokens in your coding agent sessions.'
+        return
+    }
+    $wordmark = @(
+        ' ▄▄        █  ▀ █'
+        ' ▄▄█ █▀▀▄ ▀█▀ █ █▀▀▄ █  █ █▄▀▀ █▀▀▄'
+        '▀▄▄█ █  █  █▄ █ █▄▄▀ ▀▄▄█ █    █  █'
+    )
+    Write-Host ''
+    foreach ($line in $wordmark) {
+        Write-Host $line -ForegroundColor DarkYellow
+    }
+    Write-Host ''
+    Write-Host 'Stop hitting your token limits.'
+    Write-Host 'antiburn reads your coding agent sessions locally, finds what'
+    Write-Host 'burns tokens, and nudges you before you hit a limit.'
+    Write-Host ''
+}
+
 function Get-AntiburnRelease {
     param([string] $RequestedVersion)
 
@@ -129,6 +152,7 @@ function Invoke-AntiburnInstall {
         [Net.ServicePointManager]::SecurityProtocol = $protocol -bor [Net.SecurityProtocolType]::Tls12
     }
 
+    Write-InstallerBanner
     Test-WindowsArchitecture
     $release = Get-AntiburnRelease -RequestedVersion $RequestedVersion
     $assetName = "antiburn_$($release.Version)_x64-setup.exe"
@@ -167,6 +191,7 @@ function Invoke-AntiburnInstall {
             throw "The installer completed, but antiburn was not found at $installedApplication."
         }
         Write-InstallerInfo "Installed antiburn $($release.Version)"
+        Write-InstallerInfo 'Open antiburn - it lives in your menu bar.'
     }
     finally {
         Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,27 @@ info() {
   printf '%s\n' "antiburn: $*"
 }
 
+# Print the wordmark and one line about what antiburn does. Color and art
+# appear only on an interactive terminal that did not opt out; a piped or
+# dumb terminal gets one plain line.
+banner() {
+  if [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ] && [ -z "${NO_COLOR:-}" ]; then
+    orange=$(printf '\033[38;5;208m')
+    reset=$(printf '\033[0m')
+    printf '%s\n' ''
+    printf '%s%s%s\n' "$orange" ' ▄▄        █  ▀ █' "$reset"
+    printf '%s%s%s\n' "$orange" ' ▄▄█ █▀▀▄ ▀█▀ █ █▀▀▄ █  █ █▄▀▀ █▀▀▄' "$reset"
+    printf '%s%s%s\n' "$orange" '▀▄▄█ █  █  █▄ █ █▄▄▀ ▀▄▄█ █    █  █' "$reset"
+    printf '%s\n' ''
+    printf '%s\n' 'Stop hitting your token limits.'
+    printf '%s\n' 'antiburn reads your coding agent sessions locally, finds what'
+    printf '%s\n' 'burns tokens, and nudges you before you hit a limit.'
+    printf '%s\n' ''
+  else
+    info "Stop hitting your token limits - antiburn finds what burns tokens in your coding agent sessions."
+  fi
+}
+
 fail() {
   printf '%s\n' "antiburn: error: $*" >&2
   exit 1
@@ -337,6 +358,7 @@ parse_args() {
 
 install_antiburn() {
   parse_args "$@"
+  banner
   require_command curl
   require_command awk
   require_command mktemp
@@ -357,6 +379,7 @@ install_antiburn() {
     Linux) install_linux "$arch" ;;
     *) fail "Unsupported operating system: $os" ;;
   esac
+  info "Open antiburn - it lives in your menu bar."
 }
 
 install_antiburn "$@"


### PR DESCRIPTION
## What this does

Rebuilds the onboarding flow per `docs/plans/onboarding-improvements.md` (included), reviewed screen-by-screen in a design pass focused on anchoring each step to the core value: stopping needless token burn.

- **New agentsDetected step** — detected coding agents with session counts and per-agent show/hide toggles, plus a quiet grid for agents with no sessions yet. Disabled agents are filtered from the recent-sessions list (display-only; they stay indexed and analyzed).
- **Ready step rebuilt** — a hygiene stats card (sessions analyzed, pass rate, most common failure) fed by the new `get_hygiene_summary` command, with a fixed-height progress slot while sessions settle (1s polling; the heading never moves).
- **`nudges_respect_dnd` setting end to end** — opt-in toggle on Ready, mirror row in Settings → Notifications, and an OS Focus gate behind it. macOS Focus authorization is only requested in bundled builds, after onboarding finishes with the toggle on.
- **Removed from Ready** — the analytics card and the review-source footnote.
- **Copy fixes from the review pass** — zero-state line is now "Looking for coding sessions…"; the add button is "Add Locations…".
- **Install scripts** — explain what antiburn does before installing.

## Screenshots

*(placeholder — image goes here)*

## Testing

- Rust: 664 tests pass (`cargo test --workspace`), clippy and fmt clean.
- Frontend: 954 tests pass (`pnpm test`), eslint, prettier, and `tsc` clean.
- Onboarding walked end to end in `tauri dev` across all four steps, including the agents-empty and Ready analyzing/zero states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)