### PR TITLE
Keep the main popover resident after first use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+### Changed
+
+- The main popover now stays ready after its first use, so reopening it reuses
+  the hidden renderer instead of rebuilding the window after 15 seconds.
+
 ## [0.3.0-rc.1] - 2026-09-01
 
 This is a release-candidate rehearsal build for user acceptance testing.

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -1,9 +1,8 @@
 //! The tray-anchored popover window.
 //!
-//! The popover is created lazily on the first tray click. After dismissal it
-//! stays warm for a short grace period, so a quick reopen is immediate. Once
-//! the grace period ends, the shell destroys the hidden renderer. The next
-//! open creates a new renderer from native state.
+//! The popover is created lazily on the first tray click. After its first
+//! reveal, dismissal hides the renderer but keeps it ready for the process
+//! lifetime. Each later open reuses the same renderer and its loaded state.
 //!
 //! # Geometry
 //!
@@ -342,7 +341,7 @@ pub struct PopoverState {
     pinned: AtomicBool,
     /// The generation of the current renderer.
     renderer_generation: AtomicU64,
-    /// The bounded ownership of hidden renderers and eviction callbacks.
+    /// The bounded onboarding prewarm and its eviction callbacks.
     retention: Mutex<Retention>,
     /// Content-free timing for the active menu-bar open request.
     timing: timing::PopoverTiming,
@@ -439,13 +438,12 @@ impl PopoverState {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    fn arm_hidden_retention(
+    fn arm_prewarm_retention(
         &self,
         renderer_generation: u64,
         now: Instant,
     ) -> Option<EvictionSchedule> {
-        self.retention()
-            .arm_hidden(renderer_generation, now, self.is_pinned())
+        self.retention().arm_hidden(renderer_generation, now)
     }
 
     fn arm_eviction_retry(&self, renderer_generation: u64, mode: EvictionMode) -> EvictionSchedule {
@@ -467,7 +465,7 @@ impl PopoverState {
     fn take_eviction_if_due(&self, token: EvictionToken, visible: bool) -> Option<DueEviction> {
         let renderer_generation = self.renderer_generation.load(Ordering::SeqCst);
         self.retention()
-            .take_due(token, renderer_generation, visible, self.is_pinned())
+            .take_due(token, renderer_generation, visible)
     }
 
     fn mark_prewarm(&self, generation: u64, now: Instant) {
@@ -616,7 +614,7 @@ fn build_window(app: &AppHandle, generation: u64) -> tauri::Result<WebviewWindow
                 .renderer_generation
                 .store(generation, Ordering::SeqCst);
             if state.is_prewarm(generation) {
-                schedule_idle_eviction(app);
+                schedule_prewarm_eviction(app);
             }
             Ok(window)
         }
@@ -705,7 +703,7 @@ fn replace_expired_prewarm(
     if let Err(error) = existing.destroy() {
         window_lifecycle::cancel_load::<PopoverState>(app, generation);
         let retry = state.arm_eviction_retry(expired_generation, expired.mode());
-        arm_idle_eviction(app, retry);
+        arm_prewarm_eviction(app, retry);
         return Err(error);
     }
     state.clear_prewarm_generation(expired_generation);
@@ -784,7 +782,7 @@ fn request_open_window(
                 window_lifecycle::cancel_load::<PopoverState>(app, generation);
                 if prewarmed && let Some(prewarm_generation) = prewarm_generation {
                     state.transfer_prewarm(generation, prewarm_generation);
-                    schedule_idle_eviction(app);
+                    schedule_prewarm_eviction(app);
                 }
                 return Err(error);
             }
@@ -896,7 +894,7 @@ fn request_toggle_window(app: &AppHandle, requested_at: Instant) -> tauri::Resul
                 window_lifecycle::cancel_load::<PopoverState>(app, generation);
                 if prewarmed && let Some(prewarm_generation) = prewarm_generation {
                     state.transfer_prewarm(generation, prewarm_generation);
-                    schedule_idle_eviction(app);
+                    schedule_prewarm_eviction(app);
                 }
                 return Err(error);
             }
@@ -1006,7 +1004,7 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
         WindowRequest::AwaitingBuild => return,
         WindowRequest::Cancelled => {
             note_hidden(app);
-            schedule_idle_eviction(app);
+            schedule_prewarm_eviction(app);
             return;
         }
     };
@@ -1087,23 +1085,23 @@ fn hide_window(app: &AppHandle) {
     };
     let _ = window.hide();
     note_hidden(app);
-    schedule_idle_eviction(app);
+    schedule_prewarm_eviction(app);
 }
 
-fn schedule_idle_eviction(app: &AppHandle) {
+fn schedule_prewarm_eviction(app: &AppHandle) {
     let Some(state) = app.try_state::<PopoverState>() else {
         return;
     };
     let loading_generation = state.readiness().loading_generation();
     let renderer_generation =
         loading_generation.unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
-    let Some(schedule) = state.arm_hidden_retention(renderer_generation, Instant::now()) else {
+    let Some(schedule) = state.arm_prewarm_retention(renderer_generation, Instant::now()) else {
         return;
     };
-    arm_idle_eviction(app, schedule);
+    arm_prewarm_eviction(app, schedule);
 }
 
-fn arm_idle_eviction(app: &AppHandle, schedule: EvictionSchedule) {
+fn arm_prewarm_eviction(app: &AppHandle, schedule: EvictionSchedule) {
     let Some(state) = app.try_state::<PopoverState>() else {
         return;
     };
@@ -1152,7 +1150,7 @@ fn evict_if_due(app: &AppHandle, token: EvictionToken) {
                 error = %error
             );
             let retry = state.arm_eviction_retry(due.renderer_generation(), due.mode());
-            arm_idle_eviction(app, retry);
+            arm_prewarm_eviction(app, retry);
         }
     }
 }
@@ -1343,7 +1341,7 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
         {
             let _ = window.set_focus();
         } else {
-            schedule_idle_eviction(app);
+            schedule_prewarm_eviction(app);
         }
         return;
     }
@@ -1426,7 +1424,7 @@ pub fn renderer_ready(window: &WebviewWindow, generation: u64) {
                     error = %error
                 );
                 let retry = state.arm_eviction_retry(generation, expired.mode());
-                arm_idle_eviction(app, retry);
+                arm_prewarm_eviction(app, retry);
             }
         }
         return;
@@ -1441,7 +1439,7 @@ pub fn renderer_ready(window: &WebviewWindow, generation: u64) {
     if window_lifecycle::renderer_ready::<PopoverState>(app, LABEL, generation, now) {
         reveal(window);
     } else if prewarm_became_ready {
-        schedule_idle_eviction(app);
+        schedule_prewarm_eviction(app);
     }
 }
 
@@ -1485,7 +1483,7 @@ fn reveal(window: &WebviewWindow) {
     }
     if let Err(error) = window.show() {
         ::tracing::error!(event = "window_reveal_failed", window = LABEL, error = %error);
-        schedule_idle_eviction(app);
+        schedule_prewarm_eviction(app);
         return;
     }
     let revealed_at = Instant::now();
@@ -1963,7 +1961,7 @@ mod tests {
         assert!(!state.is_prewarm(4));
         assert!(state.is_prewarm(5));
         let schedule = state
-            .arm_hidden_retention(5, started_at + Duration::from_secs(10))
+            .arm_prewarm_retention(5, started_at + Duration::from_secs(10))
             .expect("the transferred prewarm remains retained");
         assert_eq!(schedule.delay(), Duration::from_secs(55));
         assert_eq!(schedule.mode(), EvictionMode::PrewarmLoading);

--- a/apps/desktop/src-tauri/src/popover/retention.rs
+++ b/apps/desktop/src-tauri/src/popover/retention.rs
@@ -1,12 +1,10 @@
 //! The popover renderer retention policy.
 //!
-//! This module owns lease deadlines and eviction callback identity. The
-//! popover facade owns all window operations and timer scheduling.
+//! This module owns onboarding prewarm deadlines and eviction callback
+//! identity. The popover facade owns all window operations and timer
+//! scheduling.
 
 use std::time::{Duration, Instant};
-
-/// How long a hidden popover keeps its renderer after a normal dismissal.
-pub(super) const IDLE_EVICTION_DELAY: Duration = Duration::from_secs(15);
 
 /// How long onboarding keeps a hidden renderer after it becomes ready.
 pub(super) const PREWARM_READY_EVICTION_DELAY: Duration = Duration::from_secs(60);
@@ -19,7 +17,6 @@ pub(super) const EVICTION_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum EvictionMode {
-    Normal,
     PrewarmReady,
     PrewarmLoading,
 }
@@ -218,15 +215,10 @@ impl Retention {
         &mut self,
         renderer_generation: u64,
         now: Instant,
-        pinned: bool,
     ) -> Option<EvictionSchedule> {
-        let (delay, mode) = match self.prewarm.schedule(renderer_generation, now) {
-            Some(schedule) => schedule,
-            None if pinned => {
-                self.cancel_eviction();
-                return None;
-            }
-            None => (IDLE_EVICTION_DELAY, EvictionMode::Normal),
+        let Some((delay, mode)) = self.prewarm.schedule(renderer_generation, now) else {
+            self.cancel_eviction();
+            return None;
         };
         Some(self.arm(renderer_generation, delay, mode))
     }
@@ -264,13 +256,11 @@ impl Retention {
         token: EvictionToken,
         current_renderer_generation: u64,
         visible: bool,
-        pinned: bool,
     ) -> Option<DueEviction> {
         let armed = self.armed?;
         let due = armed.token == token
             && armed.renderer_generation == current_renderer_generation
-            && !visible
-            && (!pinned || armed.mode != EvictionMode::Normal);
+            && !visible;
         if !due {
             return None;
         }
@@ -309,16 +299,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normal_dismissal_keeps_the_renderer_for_fifteen_seconds() {
+    fn normal_dismissal_keeps_the_renderer_for_the_process_lifetime() {
         let now = Instant::now();
         let mut retention = Retention::default();
 
-        let schedule = retention
-            .arm_hidden(4, now, false)
-            .expect("an unpinned renderer must get an eviction schedule");
-
-        assert_eq!(schedule.delay(), Duration::from_secs(15));
-        assert_eq!(schedule.mode(), EvictionMode::Normal);
+        assert_eq!(retention.arm_hidden(4, now), None);
     }
 
     #[test]
@@ -328,7 +313,7 @@ mod tests {
         retention.begin_prewarm(4, started_at);
 
         let loading = retention
-            .arm_hidden(4, started_at, false)
+            .arm_hidden(4, started_at)
             .expect("a loading prewarm must get a fail-safe schedule");
         assert_eq!(loading.delay(), Duration::from_secs(65));
         assert_eq!(loading.mode(), EvictionMode::PrewarmLoading);
@@ -336,7 +321,7 @@ mod tests {
         let ready_at = started_at + Duration::from_secs(2);
         assert!(retention.mark_prewarm_ready(4, ready_at));
         let ready = retention
-            .arm_hidden(4, ready_at, false)
+            .arm_hidden(4, ready_at)
             .expect("a ready prewarm must keep its renderer");
         assert_eq!(ready.delay(), Duration::from_secs(60));
         assert_eq!(ready.mode(), EvictionMode::PrewarmReady);
@@ -353,7 +338,7 @@ mod tests {
         assert!(retention.is_prewarm(5));
 
         let schedule = retention
-            .arm_hidden(5, started_at + Duration::from_secs(10), false)
+            .arm_hidden(5, started_at + Duration::from_secs(10))
             .expect("the replacement must inherit the lease");
         assert_eq!(schedule.delay(), Duration::from_secs(55));
         assert_eq!(schedule.mode(), EvictionMode::PrewarmLoading);
@@ -369,12 +354,12 @@ mod tests {
 
         assert!(retention.transfer_prewarm(4, 5));
         let first = retention
-            .arm_hidden(5, ready_at + Duration::from_secs(10), false)
+            .arm_hidden(5, ready_at + Duration::from_secs(10))
             .expect("the transferred ready lease remains active");
         assert_eq!(first.delay(), Duration::from_secs(50));
 
         let rearmed = retention
-            .arm_hidden(5, ready_at + Duration::from_secs(20), false)
+            .arm_hidden(5, ready_at + Duration::from_secs(20))
             .expect("rearming keeps the original ready deadline");
         assert_eq!(rearmed.delay(), Duration::from_secs(40));
         assert_eq!(rearmed.mode(), EvictionMode::PrewarmReady);
@@ -383,11 +368,13 @@ mod tests {
     #[test]
     fn the_first_reveal_consumes_the_prewarm_lease_once() {
         let mut retention = Retention::default();
-        retention.begin_prewarm(4, Instant::now());
+        let now = Instant::now();
+        retention.begin_prewarm(4, now);
 
         assert!(retention.consume_prewarm_on_reveal(4));
         assert!(!retention.consume_prewarm_on_reveal(4));
         assert_eq!(retention.prewarm_generation(), None);
+        assert_eq!(retention.arm_hidden(4, now), None);
     }
 
     #[test]
@@ -412,36 +399,17 @@ mod tests {
     fn a_replacement_schedule_invalidates_the_old_eviction_token() {
         let now = Instant::now();
         let mut retention = Retention::default();
+        retention.begin_prewarm(4, now);
         let first = retention
-            .arm_hidden(4, now, false)
-            .expect("the first dismissal must arm eviction");
+            .arm_hidden(4, now)
+            .expect("the first prewarm schedule must arm eviction");
         let replacement = retention
-            .arm_hidden(4, now, false)
-            .expect("the repeated dismissal must replace eviction");
+            .arm_hidden(4, now)
+            .expect("the repeated prewarm schedule must replace eviction");
 
-        assert_eq!(retention.take_due(first.token(), 4, false, false), None);
+        assert_eq!(retention.take_due(first.token(), 4, false), None);
         assert_eq!(
-            retention.take_due(replacement.token(), 4, false, false),
-            Some(DueEviction {
-                renderer_generation: 4,
-                mode: EvictionMode::Normal,
-            })
-        );
-    }
-
-    #[test]
-    fn pinning_protects_normal_eviction_but_not_prewarm_expiry() {
-        let now = Instant::now();
-        let mut normal = Retention::default();
-        assert_eq!(normal.arm_hidden(4, now, true), None);
-
-        let mut prewarm = Retention::default();
-        prewarm.begin_prewarm(4, now);
-        let schedule = prewarm
-            .arm_hidden(4, now, true)
-            .expect("a pin must not make the prewarm lease unbounded");
-        assert_eq!(
-            prewarm.take_due(schedule.token(), 4, false, true),
+            retention.take_due(replacement.token(), 4, false),
             Some(DueEviction {
                 renderer_generation: 4,
                 mode: EvictionMode::PrewarmLoading,
@@ -450,25 +418,21 @@ mod tests {
     }
 
     #[test]
-    fn visibility_and_renderer_replacement_protect_a_normal_renderer() {
+    fn visibility_and_renderer_replacement_protect_a_prewarm_renderer() {
         let now = Instant::now();
         let mut visible = Retention::default();
+        visible.begin_prewarm(4, now);
         let visible_schedule = visible
-            .arm_hidden(4, now, false)
-            .expect("the dismissal must arm eviction");
-        assert_eq!(
-            visible.take_due(visible_schedule.token(), 4, true, false),
-            None
-        );
+            .arm_hidden(4, now)
+            .expect("the prewarm must arm eviction");
+        assert_eq!(visible.take_due(visible_schedule.token(), 4, true), None);
 
         let mut replaced = Retention::default();
+        replaced.begin_prewarm(4, now);
         let replaced_schedule = replaced
-            .arm_hidden(4, now, false)
-            .expect("the dismissal must arm eviction");
-        assert_eq!(
-            replaced.take_due(replaced_schedule.token(), 5, false, false),
-            None
-        );
+            .arm_hidden(4, now)
+            .expect("the prewarm must arm eviction");
+        assert_eq!(replaced.take_due(replaced_schedule.token(), 5, false), None);
     }
 
     #[test]
@@ -477,11 +441,11 @@ mod tests {
         let mut retention = Retention::default();
         retention.begin_prewarm(4, now);
         let first = retention
-            .arm_hidden(4, now, false)
+            .arm_hidden(4, now)
             .expect("the loading prewarm must arm eviction");
 
         let due = retention
-            .take_due(first.token(), 4, false, false)
+            .take_due(first.token(), 4, false)
             .expect("the deadline callback must own the matching renderer");
         let retry = retention.arm_retry(due.renderer_generation(), due.mode());
 
@@ -489,7 +453,7 @@ mod tests {
         assert_eq!(retry.mode(), EvictionMode::PrewarmLoading);
         assert!(retention.is_prewarm(4));
         assert_eq!(
-            retention.take_due(retry.token(), 4, false, true),
+            retention.take_due(retry.token(), 4, false),
             Some(DueEviction {
                 renderer_generation: 4,
                 mode: EvictionMode::PrewarmLoading,
@@ -503,11 +467,11 @@ mod tests {
         let mut retention = Retention::default();
         retention.begin_prewarm(4, now);
         let schedule = retention
-            .arm_hidden(4, now, false)
+            .arm_hidden(4, now)
             .expect("the loading prewarm must arm eviction");
 
         assert_eq!(retention.take_prewarm(), Some(4));
         retention.cancel_eviction();
-        assert_eq!(retention.take_due(schedule.token(), 4, false, false), None);
+        assert_eq!(retention.take_due(schedule.token(), 4, false), None);
     }
 }

--- a/docs/window-renderer-lifecycle.md
+++ b/docs/window-renderer-lifecycle.md
@@ -4,9 +4,9 @@ _Contributor reference for when desktop webview renderers are created, reused,
 hidden, and destroyed._
 
 The desktop shell stays resident because antiburn is a menu-bar application.
-Its webview renderers do not need the same lifetime. The shell keeps a renderer
-only while it is visible, is likely to be used again soon, or is completing a
-bounded handoff.
+The main popover renderer also stays resident after its first use, so the
+application's primary surface can reopen immediately. Other renderers remain
+bounded by their interaction or handoff.
 
 This document covers the popover, onboarding, and Settings renderers. The HUD
 and nudge windows have separate ownership rules. See [HUD states](hud-states.md)
@@ -86,45 +86,43 @@ releases the old window label. The replacement carries the pending reveal, so
 no two renderers load in parallel.
 
 A second toggle while the active renderer still loads cancels the pending
-reveal. An onboarding prewarm keeps its remaining absolute lease; other loads
-use the normal grace period.
+reveal. An onboarding prewarm keeps its remaining absolute lease. A normal
+popover load stays available for the next open request.
 
 Restarting onboarding cancels and destroys a renderer that still belongs only
 to the onboarding prewarm. This prevents a hidden post-onboarding surface from
 surviving when onboarding becomes the active application surface again.
 
-## Popover idle eviction
+## Popover residency and prewarm eviction
 
-Hiding is useful for a quick reopen, but it is not a long-term ownership model.
-The popover keeps a hidden renderer for 15 seconds after:
+After a normal popover renderer is created, ordinary dismissal only hides it.
+Focus loss, Escape, a tray toggle, reveal cancellation, and unpinning do not
+schedule destruction. The next open reuses the renderer and its loaded state.
+The renderer remains available until application shutdown or an explicit
+lifecycle reset.
 
-- an ordinary dismissal, including focus loss, Escape, or a tray toggle; or
-- cancellation of a non-prewarm reveal while the renderer is still loading.
+The onboarding prewarm keeps its renderer for 60 seconds after readiness. A
+prewarm that never becomes ready has a 65-second loading fail-safe. Cancelling
+a pending reveal does not extend or replace either absolute deadline. The
+first successful reveal consumes the one-shot lease and makes the renderer
+resident.
 
-The onboarding prewarm instead keeps its renderer for 60 seconds after
-readiness. Cancelling a pending reveal does not extend or replace that absolute
-deadline. The first reveal consumes the one-shot lease. A later dismissal uses
-the normal 15-second grace period.
-
-At the end of the grace period, the shell destroys the renderer only when all
-of these conditions still hold:
+At a prewarm deadline, the shell destroys the renderer only when all of these
+conditions still hold:
 
 - the eviction request is the current request;
 - it still names the current renderer generation;
-- the window is hidden; and
-- for the normal 15-second grace period, the popover is not pinned.
+- the window is hidden.
 
 An unrevealed onboarding prewarm expires at its absolute deadline even when
-Pin is enabled. Pin protects a renderer only after the first successful reveal.
+Pin is enabled. After the first successful reveal, there is no eviction
+deadline for Pin to change.
 
 An open request cancels the eviction before it places or reveals the window.
-Starting a newer grace period also invalidates the older timer. A stale timer
-therefore cannot destroy a reopened or replaced renderer.
-
-Pinned popovers are exempt because pinning is an explicit request to keep the
-surface available. Unpinning a hidden popover starts the normal grace period.
-After eviction, the next open starts from `Idle` and creates a fresh renderer
-from native and persisted state.
+Starting a newer prewarm schedule also invalidates the older timer. A stale
+timer therefore cannot destroy a revealed or replaced renderer. After prewarm
+eviction, the next open starts from `Idle` and creates a fresh renderer from
+native and persisted state.
 
 ## Settings teardown
 
@@ -170,15 +168,15 @@ Application shutdown uses the same native cancellation signal.
 | ---------- | ---------------------------------------------------------------------------------------------------- | -------------------------------- |
 | 1 second   | Let onboarding's final IPC response complete before destroying its renderer                          | Onboarding completion            |
 | 5 seconds  | Mark an active renderer load stale; log a warning and permit one replacement on a later open request | Renderer build start             |
-| 15 seconds | Keep a dismissed popover available for a likely near-term reopen, then make it eligible for eviction | Hidden dismissal                 |
 | 60 seconds | Keep the one post-onboarding handoff renderer available for the first menu-bar click                 | Onboarding prewarm readiness     |
 | 65 seconds | Destroy an onboarding prewarm that never reports renderer readiness                                  | Onboarding prewarm build         |
 | 5 seconds  | Refresh Insights processing status only while the pane has subscribers and remains visible           | Insights session start or resume |
 
 These values serve different purposes. The stale threshold is a recovery
-boundary, not an eviction deadline. Each eviction delay is a reuse window, not
-a guarantee that a renderer will remain alive. A lifecycle reset, onboarding
-restart, application shutdown, or build failure can end it earlier.
+boundary, not an eviction deadline. The prewarm eviction delays are bounded
+handoff windows, not guarantees that a renderer will remain alive. A lifecycle
+reset, onboarding restart, application shutdown, or build failure can end one
+earlier.
 
 ## Popover latency evidence
 
@@ -207,14 +205,14 @@ optimization.
 
 Use these principles when adding or changing desktop windows:
 
-1. **Keep the native shell resident, not every renderer.** A hidden webview has
-   a process cost even when it paints nothing.
+1. **Keep repeated primary surfaces ready.** The main popover remains resident
+   after first use; one-shot and explicitly closed renderers do not.
 2. **Create on demand by default.** Prewarm only at a clear handoff where a
    near-term interaction is likely and the work has a bounded lifetime.
 3. **Reuse one generation.** Coalesce repeated requests and turn an existing
    hidden load into a reveal rather than creating parallel renderers.
-4. **Destroy after the interaction ends.** Use a short grace period only when
-   it materially improves the next expected interaction.
+4. **Bound one-shot ownership.** Destroy handoff renderers when their lease
+   ends, and close ordinary windows when their interaction ends.
 5. **Keep durable state outside renderer lifetime.** A fresh renderer must be
    able to reconstruct the surface from native state, the local database, and
    persisted preferences.
@@ -237,7 +235,7 @@ Use these principles when adding or changing desktop windows:
 | Shared phases, generations, stale-load policy                    | [`window_readiness.rs`](../apps/desktop/src-tauri/src/window_readiness.rs)      |
 | Tauri readiness, timing, and trace adapters                      | [`window_lifecycle.rs`](../apps/desktop/src-tauri/src/window_lifecycle.rs)      |
 | Popover facade, first-click reuse, and Tauri window effects      | [`popover.rs`](../apps/desktop/src-tauri/src/popover.rs)                        |
-| Popover leases, eviction tokens, and deadline ownership          | [`retention.rs`](../apps/desktop/src-tauri/src/popover/retention.rs)            |
+| Popover prewarm leases, eviction tokens, and deadline ownership  | [`retention.rs`](../apps/desktop/src-tauri/src/popover/retention.rs)            |
 | Popover latency milestones and structured timing                 | [`timing.rs`](../apps/desktop/src-tauri/src/popover/timing.rs)                  |
 | Onboarding completion and delayed teardown                       | [`onboarding.rs`](../apps/desktop/src-tauri/src/onboarding.rs)                  |
 | Settings creation, destruction, and native Insights cancellation | [`settings.rs`](../apps/desktop/src-tauri/src/settings.rs)                      |
@@ -255,7 +253,8 @@ When a window lifecycle changes, verify all of these together:
 - repeated opens and toggles during a load;
 - a stale generation reporting readiness after replacement;
 - close or hide behavior before and after readiness;
-- delayed eviction after reopen, pin, unpin, or renderer replacement;
+- resident reuse after dismissal, reveal cancellation, and unpinning;
+- prewarm expiry after readiness, reopening, Pin, or renderer replacement;
 - destruction resetting readiness before the next build;
 - cancellation of native work when its final visible owner leaves; and
 - fresh reconstruction without relying on the previous renderer's memory.


### PR DESCRIPTION
## Summary

- keep the main popover renderer resident after its first successful reveal
- restrict renderer eviction schedules to unused onboarding prewarms
- preserve prewarm deadlines, stale-load recovery, generation guards, and retry handling
- update lifecycle documentation and the changelog

## Runtime behavior

Ordinary focus loss, Escape, tray toggling, reveal cancellation, and unpinning now hide the main popover without destroying its renderer. The next open reuses the renderer and its loaded state.

Unused onboarding prewarms remain bounded by the existing 60/65-second deadlines. The first successful reveal consumes the prewarm lease and makes that renderer resident for the application process lifetime.

## Automated validation

Run from `apps/desktop/src-tauri`:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — all 661 tests passed
- focused retention suite — all 10 tests passed

The retention tests cover:

- no eviction schedule after an ordinary dismissal
- permanent residency after the first reveal consumes a prewarm lease
- 60/65-second absolute prewarm deadlines
- replacement-token invalidation
- visibility and renderer-generation guards
- failed-destruction retry
- onboarding cancellation

## Live debug validation

1. Started the app with `pnpm --filter @antiburn/desktop dev`.
2. Opened the popover from the menu bar and recorded the renderer process identity and start time.
3. Dismissed the popover using the tray toggle.
4. Waited 17 seconds, exceeding the previous 15-second eviction deadline.
5. Confirmed the same renderer remained alive with its original start time while hidden.
6. Reopened the popover and confirmed it reused that renderer without rebuilding it.

Result: passed.

## Live release validation

1. Built and launched the optimized release binary using an isolated app identifier.
2. Completed onboarding and observed the post-onboarding popover prewarm.
3. Confirmed the first reveal reused the prewarmed renderer.
4. Dismissed the popover using the tray toggle.
5. Waited 17 seconds, exceeding the previous 15-second eviction deadline.
6. Confirmed the same renderer remained alive with its original start time while hidden.
7. Reopened the popover and confirmed it reused that renderer without reconstruction.

Result: passed.

## Test environment

A memory-pressure preflight reported 35% free memory with no throttled pages. No memory cleanup was required before the live tests.

The unused onboarding-prewarm 60/65-second expiry remains covered by automated tests; this live run exercised prewarm consumption and post-reveal residency.