### PR TITLE
feat: open the popover without deactivating the frontmost app

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "smappservice-rs",
  "tauri",
  "tauri-build",
+ "tauri-nspanel",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-prevent-default",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -145,6 +145,10 @@ objc2 = "0.6"
 block2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSCell", "NSControl", "NSView", "NSResponder", "NSColor", "NSFont", "NSFontDescriptor", "NSAttributedString", "NSEvent", "block2"] }
 objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSAttributedString", "NSDictionary", "NSValue", "NSObject", "NSURL", "NSError", "NSNotification", "NSOperation", "block2"] }
+# Subclasses the popover into a non-activating NSPanel (`src/popover/panel.rs`),
+# so opening it does not deactivate the frontmost application. The rev must
+# match the nudge crate's pin so both share one plugin registration.
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "a3122e894383aa068ec5365a42994e3ac94ba1b6" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # Per-user Run-key registration. Kept in Rust so executable paths are quoted

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -37,6 +37,8 @@
 //! Whichever way it goes, it leaves through [`note_hidden`], which is also
 //! where the menu-bar item is unlit; [`note_shown`] is the other half.
 
+#[cfg(target_os = "macos")]
+mod panel;
 mod retention;
 mod timing;
 
@@ -609,6 +611,11 @@ fn build_window(app: &AppHandle, generation: u64) -> tauri::Result<WebviewWindow
 
     match builder.build() {
         Ok(window) => {
+            // Non-activating panel: opening the popover must not deactivate
+            // the frontmost application. Applied here so a rebuild after a
+            // destroy converts again.
+            #[cfg(target_os = "macos")]
+            panel::to_nonactivating_panel(&window);
             let state = app.state::<PopoverState>();
             state
                 .renderer_generation
@@ -629,6 +636,36 @@ fn build_window(app: &AppHandle, generation: u64) -> tauri::Result<WebviewWindow
             Err(error)
         }
     }
+}
+
+/// Give the popover keyboard focus.
+///
+/// On macOS this goes through the non-activating panel, so the frontmost
+/// application stays active and keeps its full visual state. The plain
+/// `set_focus` fallback covers a window the panel plugin never converted.
+fn focus_popover(window: &WebviewWindow) {
+    #[cfg(target_os = "macos")]
+    if panel::focus_without_activation(window) {
+        return;
+    }
+    if let Err(error) = window.set_focus() {
+        ::tracing::warn!(event = "window_focus_failed", window = LABEL, error = %error);
+    }
+}
+
+/// Destroy the popover window.
+///
+/// On macOS the panel class must return to its original window class first
+/// (see [`panel::prepare_for_destroy`]); a failed restore aborts the destroy,
+/// and the caller's existing error path keeps the window and retries.
+fn destroy_window(window: &WebviewWindow) -> tauri::Result<()> {
+    #[cfg(target_os = "macos")]
+    if !panel::prepare_for_destroy(window) {
+        return Err(tauri::Error::Io(std::io::Error::other(
+            "the popover panel could not be restored to a window before destroy",
+        )));
+    }
+    window.destroy()
 }
 
 enum WindowRequest {
@@ -700,7 +737,7 @@ fn replace_expired_prewarm(
     };
 
     state.readiness().defer_build_until_destroyed(generation);
-    if let Err(error) = existing.destroy() {
+    if let Err(error) = destroy_window(&existing) {
         window_lifecycle::cancel_load::<PopoverState>(app, generation);
         let retry = state.arm_eviction_retry(expired_generation, expired.mode());
         arm_prewarm_eviction(app, retry);
@@ -778,7 +815,7 @@ fn request_open_window(
             if !state.readiness().defer_build_until_destroyed(generation) {
                 return Ok(WindowRequest::AwaitingBuild);
             }
-            if let Err(error) = existing.destroy() {
+            if let Err(error) = destroy_window(&existing) {
                 window_lifecycle::cancel_load::<PopoverState>(app, generation);
                 if prewarmed && let Some(prewarm_generation) = prewarm_generation {
                     state.transfer_prewarm(generation, prewarm_generation);
@@ -890,7 +927,7 @@ fn request_toggle_window(app: &AppHandle, requested_at: Instant) -> tauri::Resul
             if !state.readiness().defer_build_until_destroyed(generation) {
                 return Ok(WindowRequest::AwaitingBuild);
             }
-            if let Err(error) = existing.destroy() {
+            if let Err(error) = destroy_window(&existing) {
                 window_lifecycle::cancel_load::<PopoverState>(app, generation);
                 if prewarmed && let Some(prewarm_generation) = prewarm_generation {
                     state.transfer_prewarm(generation, prewarm_generation);
@@ -978,7 +1015,7 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
             if let Err(error) = anchor_to(&window, anchor) {
                 ::tracing::warn!(event = "popover_anchor_failed", error = %error);
             }
-            let _ = window.set_focus();
+            focus_popover(&window);
             return;
         }
         hide_window(app);
@@ -1069,7 +1106,7 @@ fn destroy_prewarm(app: &AppHandle) -> bool {
     let Some(window) = app.get_webview_window(LABEL) else {
         return true;
     };
-    match window.destroy() {
+    match destroy_window(&window) {
         Ok(()) => true,
         Err(error) => {
             ::tracing::warn!(event = "popover_prewarm_cancel_failed", error = %error);
@@ -1138,7 +1175,7 @@ fn evict_if_due(app: &AppHandle, token: EvictionToken) {
     let Some(due) = state.take_eviction_if_due(token, visible) else {
         return;
     };
-    match window.destroy() {
+    match destroy_window(&window) {
         Ok(()) => {
             state.clear_prewarm_generation(due.renderer_generation());
             ::tracing::info!(event = "window_renderer_evicted", window = LABEL);
@@ -1301,7 +1338,7 @@ pub fn end_focus_hold(app: &AppHandle) {
     if let Some(window) = app.get_webview_window(LABEL)
         && window.is_visible().unwrap_or(false)
     {
-        let _ = window.set_focus();
+        focus_popover(&window);
     }
 }
 
@@ -1339,7 +1376,7 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
         if let Some(window) = app.get_webview_window(LABEL)
             && window.is_visible().unwrap_or(false)
         {
-            let _ = window.set_focus();
+            focus_popover(&window);
         } else {
             schedule_prewarm_eviction(app);
         }
@@ -1398,7 +1435,7 @@ pub fn set_pinned(app: &AppHandle, pinned: bool) {
     // Guarded exactly as `end_focus_hold` is: focusing a hidden window would
     // order it front, and an unpin is not a request to open anything.
     if window.is_visible().unwrap_or(false) {
-        let _ = window.set_focus();
+        focus_popover(&window);
     }
 }
 
@@ -1412,7 +1449,7 @@ pub fn renderer_ready(window: &WebviewWindow, generation: u64) {
     {
         state.cancel_eviction();
         prepare_expired_renderer_retirement(&state, generation, now);
-        match window.destroy() {
+        match destroy_window(window) {
             Ok(()) => {
                 state.clear_prewarm_generation(generation);
                 ::tracing::info!(event = "window_renderer_evicted", window = LABEL);
@@ -1492,9 +1529,7 @@ fn reveal(window: &WebviewWindow) {
         state.timing.revealed(generation, revealed_at);
     }
     ::tracing::info!(event = "window_revealed", window = LABEL, generation);
-    if let Err(error) = window.set_focus() {
-        ::tracing::warn!(event = "window_focus_failed", window = LABEL, error = %error);
-    }
+    focus_popover(window);
     note_shown(app);
 }
 

--- a/apps/desktop/src-tauri/src/popover/panel.rs
+++ b/apps/desktop/src-tauri/src/popover/panel.rs
@@ -1,0 +1,105 @@
+//! macOS: subclass the popover window into a non-activating `NSPanel` via
+//! `tauri-nspanel`.
+//!
+//! A plain `set_focus` activates the application. macOS then deactivates the
+//! frontmost application, which dims its title bar and traffic lights. Native
+//! menu-bar extras do not do this. The `NonactivatingPanel` style mask splits
+//! the two states: the panel becomes the key window and receives keyboard
+//! input, while the previous application stays active.
+//!
+//! Window operations must run on the main thread. Each public function here
+//! marshals its work through [`tauri::WebviewWindow::run_on_main_thread`],
+//! except [`prepare_for_destroy`], which its callers already run there.
+
+use tauri::{Manager, WebviewWindow};
+use tauri_nspanel::objc2_app_kit::NSWindowStyleMask;
+use tauri_nspanel::objc2_foundation::NSThread;
+use tauri_nspanel::{ManagerExt, WebviewPanelManager, WebviewWindowExt};
+
+tauri_nspanel::tauri_panel! {
+    panel!(PopoverPanel {
+        config: {
+            can_become_key_window: true,
+            can_become_main_window: false
+        }
+    })
+}
+
+/// Convert the popover window into a non-activating panel. Requires the
+/// nspanel plugin (registered via `antiburn_nudge::register`); a no-op if it
+/// isn't present. Safe to call from any thread — the work is marshaled onto
+/// the main thread.
+///
+/// Only the style mask changes. The window keeps the level that
+/// `always_on_top` set and the default collection behavior, so the popover
+/// stays a surface of the current Space.
+pub(super) fn to_nonactivating_panel(window: &WebviewWindow) {
+    if window
+        .try_state::<WebviewPanelManager<tauri::Wry>>()
+        .is_none()
+    {
+        return;
+    }
+    let window = window.clone();
+    let _ = window.clone().run_on_main_thread(move || {
+        let Ok(panel) = window.to_panel::<PopoverPanel>() else {
+            return;
+        };
+        // Borderless + never activate the application on key.
+        panel.set_style_mask(NSWindowStyleMask::NonactivatingPanel);
+    });
+}
+
+/// Give the popover key-window status without activating the application.
+///
+/// Orders the panel front, makes the content view first responder, then makes
+/// the panel key. `makeKeyWindow` alone does not hand keyboard events to the
+/// embedded WKWebView: without an explicit first responder the window itself
+/// absorbs them, and typing and Escape stop reaching the views even though
+/// mouse clicks (hit-testing, independent of first-responder state) keep
+/// working.
+///
+/// Returns `false` when the nspanel plugin is not registered or the closure
+/// cannot be marshaled; the caller falls back to a plain `set_focus`. Inside
+/// the closure an unconverted window (a cold-start race with
+/// [`to_nonactivating_panel`]) gets the same fallback.
+pub(super) fn focus_without_activation(window: &WebviewWindow) -> bool {
+    if window
+        .try_state::<WebviewPanelManager<tauri::Wry>>()
+        .is_none()
+    {
+        return false;
+    }
+    let window = window.clone();
+    window
+        .clone()
+        .run_on_main_thread(move || match window.get_webview_panel(super::LABEL) {
+            Ok(panel) => {
+                panel.order_front_regardless();
+                let content_view = panel.content_view();
+                panel.make_first_responder(Some(&content_view));
+                panel.make_key_window();
+            }
+            Err(_) => {
+                let _ = window.set_focus();
+            }
+        })
+        .is_ok()
+}
+
+/// Convert the popover panel back to its original window class and remove the
+/// retained panel handle before Tauri destroys the webview. The pinned
+/// nspanel revision owns the class restoration in `Panel::to_window`. Skipping
+/// this makes AppKit terminate the process while it unregisters WebKit's
+/// window-visibility observer. Returns `false` if a registered panel cannot
+/// be converted safely.
+pub(super) fn prepare_for_destroy(window: &WebviewWindow) -> bool {
+    debug_assert!(
+        NSThread::isMainThread_class(),
+        "popover::panel::prepare_for_destroy called off the main thread — AppKit calls are undefined behavior there"
+    );
+    match window.get_webview_panel(super::LABEL) {
+        Ok(panel) => panel.to_window().is_some(),
+        Err(_) => true,
+    }
+}


### PR DESCRIPTION
## User impact

Fixes #319.

Opening the popover no longer deactivates the frontmost application, so its
title bar, traffic lights, and shadows keep their active state — the same
behaviour as native menu-bar extras.

The popover window is now a non-activating `NSPanel`, converted through
`tauri-nspanel` (already in the tree for the nudge window, pinned to the same
rev so both share one plugin registration). Reveal takes key-window status
with `orderFrontRegardless` + `makeKeyWindow` and makes the content view
first responder so the WKWebView keeps receiving keystrokes. The panel class
is restored to `NSWindow` before every destroy, and a deferred rebuild
re-converts inside `build_window`. Dismissal, pinning, and the focus hold
keep their existing paths. Windows and Linux behaviour is unchanged.

Known tradeoff (from the issue): antiburn never activates, so it never
installs a menu bar and Cmd-shortcuts route to the app behind the popover —
matching native menu-bar extras.

Related: #177 tracks nudge focus behaviour; #321 covers the popover being
dismissed when a nudge takes key on hover (pre-existing, not addressed here).

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 661 tests passed
- Dev app launch on macOS: plugin wiring and panel conversion run without a crash
- Manual check on macOS: opening the popover over an active app no longer dims its title bar or traffic lights

## Privacy and performance

No change to data access, network access, or retained data. The panel
conversion is a one-time class swap per window build; no new threads,
timers, or resident cost.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)