### PR TITLE
Head the onboarding repo list with an All repos switch

### DIFF
--- a/apps/desktop/src/views/OnboardingView.test.tsx
+++ b/apps/desktop/src/views/OnboardingView.test.tsx
@@ -472,6 +472,49 @@ describe("OnboardingView", () => {
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument())
   })
 
+  it("keeps the repository list closed while every repository is on", async () => {
+    mockCommands({ list_repositories: [REPOSITORY] })
+    render(<OnboardingView />)
+
+    await advanceToSources()
+
+    const all = await screen.findByRole("switch", { name: "Scan all repos" })
+    expect(all).toBeChecked()
+    expect(screen.queryByText("avery/widgets")).not.toBeInTheDocument()
+
+    // Opening the list is a display change. It disables no repository.
+    fireEvent.click(all)
+    expect(await screen.findByText("avery/widgets")).toBeInTheDocument()
+    expect(screen.getByRole("switch", { name: "Scan all repos" })).not.toBeChecked()
+    expect(invoke).not.toHaveBeenCalledWith("set_repository_enabled", expect.anything())
+  })
+
+  it("turns every repository back on from the All repos switch", async () => {
+    const disabled = { ...REPOSITORY, enabled: false }
+    mockCommands({
+      list_repositories: [disabled],
+      set_repository_enabled: [REPOSITORY],
+    })
+    render(<OnboardingView />)
+
+    await advanceToSources()
+
+    // One repository is off, so the list opens without being asked.
+    expect(await screen.findByText("avery/widgets")).toBeInTheDocument()
+    const all = screen.getByRole("switch", { name: "Scan all repos" })
+    expect(all).not.toBeChecked()
+
+    fireEvent.click(all)
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("set_repository_enabled", {
+        key: REPOSITORY.key,
+        enabled: true,
+      }),
+    )
+    // The list closes again once every repository is on.
+    await waitFor(() => expect(screen.queryByText("avery/widgets")).not.toBeInTheDocument())
+  })
+
   it("keeps repository rows after failure and hides retry while scanning", async () => {
     let attempts = 0
     let resolveRetry!: (status: typeof SCAN_STATUS) => void
@@ -489,6 +532,9 @@ describe("OnboardingView", () => {
 
     await advanceToSources()
     expect(await screen.findByRole("alert")).toHaveTextContent("Scan did not finish")
+    // Every repository is on, so the list starts closed. Open it to watch the
+    // rows across the retry.
+    fireEvent.click(await screen.findByRole("switch", { name: "Scan all repos" }))
     expect(screen.getByText("avery/widgets")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Try again" }))

--- a/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
+++ b/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
@@ -257,6 +257,28 @@ function SourcesAndRepos({
 }) {
   const scanFailed = !scanning && scanError !== null
 
+  // A repository that is not on this machine carries no switch, so "all" means
+  // the repositories the reader can actually turn on.
+  const toggleable = repositories.filter((item) => item.status !== "not_cloned")
+  const allEnabled = toggleable.length > 0 && toggleable.every((item) => item.enabled)
+  const [choosingRepos, setChoosingRepos] = useState(false)
+  // Every repository is on and the reader has not asked to see them, so the
+  // list stays closed.
+  const scanningAll = allEnabled && !choosingRepos
+
+  function handleScanAllRepos(next: boolean): void {
+    if (next) {
+      // Turn each repository back on, then close the list again.
+      for (const item of toggleable) {
+        if (!item.enabled) onToggleRepository(item, true)
+      }
+      setChoosingRepos(false)
+      return
+    }
+    // Turning this off opens the list. It disables no repository.
+    setChoosingRepos(true)
+  }
+
   return (
     <div className="grid h-full grid-cols-2 gap-x-8 px-8">
       <div className="col-span-full mb-4 flex flex-col gap-1.5">
@@ -265,7 +287,7 @@ function SourcesAndRepos({
         </h2>
 
         <p className="type-callout text-label-secondary">
-          antiburn won't scan sessions for any repos not enabled here.
+          antiburn will only scan sessions from repos enabled here.
         </p>
       </div>
 
@@ -406,8 +428,25 @@ function SourcesAndRepos({
             </div>
           </Card>
         ) : null}
+        {toggleable.length > 0 ? (
+          <div className="mt-2 flex items-center gap-3 border-b border-separator pb-2">
+            <div className="min-w-0 flex-1">
+              <p className="type-callout text-label">All repos</p>
+              <p className="type-caption text-label-tertiary">
+                {scanningAll
+                  ? `antiburn scans each of the ${toggleable.length} repos it found.`
+                  : "Choose the repos antiburn scans."}
+              </p>
+            </div>
+            <ToggleSwitch
+              checked={scanningAll}
+              onCheckedChange={handleScanAllRepos}
+              aria-label="Scan all repos"
+            />
+          </div>
+        ) : null}
         <div className="mt-2 min-h-0 flex-1">
-          {scanFailed && repositories.length === 0 ? (
+          {scanningAll ? null : scanFailed && repositories.length === 0 ? (
             <div className="flex h-full items-center justify-center px-6 text-center">
               <p className="type-footnote text-label-tertiary">
                 Check the scan folders and folder access, then try again.

--- a/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
+++ b/apps/desktop/src/views/onboarding/OnboardingFlow.tsx
@@ -279,8 +279,11 @@ function SourcesAndRepos({
     setChoosingRepos(true)
   }
 
+  // The rows are explicit so the heading block keeps its own height. Two
+  // automatic rows share the leftover space instead, which moves the column
+  // headings down whenever the columns hold less.
   return (
-    <div className="grid h-full grid-cols-2 gap-x-8 px-8">
+    <div className="grid h-full grid-cols-2 grid-rows-[auto_minmax(0,1fr)] gap-x-8 px-8">
       <div className="col-span-full mb-4 flex flex-col gap-1.5">
         <h2 ref={focusHeading} tabIndex={-1} className="type-title-3 text-label outline-none">
           Scan Locations: Repos

--- a/crates/antiburn-local/src/repositories/platform/macos.rs
+++ b/crates/antiburn-local/src/repositories/platform/macos.rs
@@ -8,10 +8,9 @@ use super::PlatformDiscovery;
 
 const MACOS_CODE_DIRS: &[&str] = &[
     "dev",
-    "Developer",
-    "Documents/GitHub",
     // Xcode clones into ~/Developer by default, and TCC does not guard it.
     "Developer",
+    "Documents/GitHub",
     "src",
     "code",
     "Projects",
@@ -67,6 +66,15 @@ mod tests {
     #[test]
     fn common_dirs_not_empty() {
         assert!(!MacOsPlatform.common_code_dirs().is_empty());
+    }
+
+    /// A repeated directory shows twice in the setup list and breaks the keys
+    /// the list is drawn from.
+    #[test]
+    fn common_dirs_have_no_duplicates() {
+        let dirs = MacOsPlatform.common_code_dirs();
+        let unique: std::collections::BTreeSet<&str> = dirs.iter().copied().collect();
+        assert_eq!(unique.len(), dirs.len(), "duplicate entry in {dirs:?}");
     }
 
     #[test]

--- a/docs/plans/onboarding-improvements.md
+++ b/docs/plans/onboarding-improvements.md
@@ -11,8 +11,8 @@ Branch: `claude/onboarding-improvements-8f6140` · Status: planning
 | Feature 1: Agents detected step | Built 2026-08-31 — `DisabledAgents` setting + `recent_sessions_excluding` filter (Rust), `agentsDetected` step second in the flow, Settings → Sources mirror, popover re-query, tests green. Zero-session agents seed OFF and the whole set persists (Option 1); the later-install question is still open with Keith |
 | Feature 2: Ready page stats | Built 2026-08-31 — `get_hygiene_summary` command (window + disabled-agent filter mirrors the session list; only current ready evidence counts analyzed), Ready rebuilt per v5 proto (title-1 heading, richer sentence with window + agent names, 88px slot with stats card / progress bar, plain toggle rows), `nudges_respect_dnd` setting end-to-end with the OS Focus gate now opt-in, Settings → Notifications mirror row, analytics/review-source card and read-only footnote removed from Ready. Rust 658 + frontend 938 tests green |
 | Feature 3: Nudges explained | Not started — surface confirmed: Settings → Notifications (discuss, 2026-08-31) |
-| Quick win: add `~/Developer` to `MACOS_CODE_DIRS` | Done 2026-08-31 — line + test in `crates/antiburn-local/src/repositories/platform/macos.rs`, 6/6 pass. Rides in the Feature 1 PR |
-| Feature 4: sourcesAndRepos step redesign | Design settled via proto 2026-08-31 (see section below); own PR |
+| Quick win: add `~/Developer` to `MACOS_CODE_DIRS` | Done 2026-08-31 — line + test in `crates/antiburn-local/src/repositories/platform/macos.rs`. Fixed 2026-09-01: the entry was added a second time, so the setup list drew `~/Developer` twice and React reported a duplicate key. Duplicate removed, `common_dirs_have_no_duplicates` guards it, 7/7 pass |
+| Feature 4: sourcesAndRepos step redesign | Partly built, and it diverged from the proto — see section below. Dave's `8307613` kept the two columns and added a step title and subtitle; the single vertical column and the question heading were not built |
 | Tests + manual test + screenshot | Not started |
 | PR | Not started — one PR per feature (now four); 2 stacks on 1, and 4 also touches `OnboardingFlow.tsx` so it joins that stack |
 
@@ -211,6 +211,27 @@ vertical column:
   "Nothing found yet" illustration, no explainer sentence.
 - Off-macOS the locked row and permission card never render (no consent
   concept on Windows/Linux), so the step is just summary row + results.
+
+### What is built (2026-09-01)
+
+The step keeps its two columns. Dave's `8307613` put a step title and a
+subtitle above them and made "Folders to scan" and "Repos found" the column
+headings. The single vertical column and the question heading above are **not
+built**, so the rest of this section is still a proposal.
+
+Built on top of it, from Keith's review of that screen:
+
+- Subtitle says what antiburn does, not what it refuses to do: "antiburn will
+  only scan sessions from repos enabled here."
+- **"All repos" switch** heads the "Repos found" column and hides the
+  per-repository rows while every repository is on — which is the state of a
+  fresh install, since inclusion is opt-out. Turning it off reveals the rows
+  and **disables nothing**; turning it back on re-enables each row and closes
+  the list. The list also opens on its own whenever a repository is off, so a
+  reader who returns sees their choices.
+- The switch is a `ToggleSwitch` because the app has no checkbox primitive and
+  the rows it heads are switches. Keith asked for a "check control"; revisit if
+  the switch reads wrong next to the rows.
 
 ## Locked design decisions
 


### PR DESCRIPTION
Follows Keith's review of the **Scan Locations: Repos** step.
<img width="1360" height="960" alt="Screenshot 2026-09-01 at 12-08-33" src="https://github.com/user-attachments/assets/d890ebf4-70dc-4b3b-b7c5-3e2b847d3f12" />

## What changed

**1. The subtitle says what antiburn does.** "antiburn won't scan sessions for any repos not enabled here." → "antiburn will only scan sessions from repos enabled here."

**2. An "All repos" switch heads the "Repos found" column.** Inclusion is opt-out, so a fresh install has every repository on and the old screen listed all of them anyway. The switch now hides the rows while that stays true:

- **On** (the fresh-install state) — rows hidden, subtitle reports the count.
- **Turning it off** shows the rows and **disables no repository**. It is a display change, not a data change.
- **Turning it on** enables each row again and closes the list.
- The list **opens on its own** whenever a repository is off, so a reader who comes back sees their choices rather than a switch that hides them.

It is a `ToggleSwitch` rather than a checkbox: the app has no checkbox primitive, and the rows it heads are switches. Keith asked for a "check control" — easy to swap if the switch reads wrong above the rows.

**3. Bug: `~/Developer` was listed twice.** `MACOS_CODE_DIRS` gained a second `"Developer"` entry, so the setup list drew the path twice and React logged a duplicate-key error at runtime. Duplicate removed; `common_dirs_have_no_duplicates` guards it.

## Screenshots

*(placeholder — image goes here)*

## Tests

- Frontend: 974 pass, including two new cases for the closed list and for turning every repository back on.
- Rust: full `antiburn-local` suite green (1144 + subsuites), clippy and `cargo fmt --check` clean.
- `pnpm lint`, `pnpm format`, `pnpm type-check` clean.
- Verified in a running `tauri dev` build: the duplicate-key console error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)