### PR TITLE
chore(release): prepare 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,40 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-01
+
+### Added
+
+- Settings now offers configurable session-data retention and removes expired
+  local transcript-derived data automatically.
+- The usage HUD remembers its position on each display.
+- Session detail now expands Efficiency and Hygiene into evidence breakdowns,
+  and its context chart identifies context rewrites.
+- Onboarding now shows agent discovery and analysis progress, previews session
+  hygiene, and explains notification and Do Not Disturb behavior before setup
+  completes.
+- Onboarding repository selection now includes one All repos switch for quickly
+  enabling or disabling every discovered repository.
+- On macOS, source discovery now includes repositories under `~/Developer`.
+
 ### Changed
 
+- Long activity lists now retain less memory while preserving keyboard
+  navigation, grouping, pinned headings, and session tooltips.
+- The app opens its popover without taking focus from the frontmost application.
 - The main popover now stays ready after its first use, so reopening it reuses
   the hidden renderer instead of rebuilding the window after 15 seconds.
+- Signed application updates now download, install, and restart antiburn
+  automatically. The automatic-update setting remains available as an opt-out.
+- Session analysis now persists bounded turn rows and serves the last completed
+  result while a newer pass runs. Drilldowns stay available during refreshes
+  and use less repeated transcript parsing.
+- Insights now recognizes more Claude, Codex, OpenCode, and Pi thread and
+  sub-agent relationships. Model, speed, cache, compaction, and repeated-context
+  findings use the expanded evidence and fail closed when required facts are
+  missing.
+- Codex cache-write usage and service tiers now contribute to the correct
+  efficiency and model-policy results.
 
 ## [0.3.0-rc.1] - 2026-09-01
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "antiburn-hud",
  "antiburn-local",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/hud", "crates/nudge", "crates/sound", "crates/trace"]
 
 [package]
 name = "antiburn"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -17,6 +17,36 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-01
+
+### Added
+
+- The row pipeline exposes `TurnRow`, `TurnRowSink`, `TurnRowStore`, turn and
+  content schema migrations, bounded batch writes, deletion helpers, and
+  row-derived metrics and evidence queries.
+- `TurnContent`, `ContentPart`, and `ContentKind` carry bounded message text,
+  thinking, tool inputs, and tool results to a separate content table.
+- `TurnFacts`, `metrics_from_rows`, and `metrics_by_source` rebuild projections
+  from a fenced persisted snapshot.
+- `ModelRegistry` and its policy contracts expose model-family, replacement,
+  effort, and speed rules used by Insights.
+
+### Changed
+
+- **Breaking:** `NormalizedRecord` gains `TurnContent`; `NormalizedEvent` gains
+  logical parent and thread identity; and the report requirement contract now
+  uses `Fact` and `FactState` instead of capability and evidence groups.
+- Vendor adapters now derive stable thread relationships for Claude, Codex,
+  OpenCode, and Pi, including delegated and sidechain turns. Codex also reads
+  service tiers and cache-write tokens.
+- Metrics and evidence reducers retain bounded derived state, account for
+  repeated context per thread, and expose row-backed chart and drilldown data.
+- Insights evaluates explicit finding and clean fact sets, preserves the last
+  published verdict during recomputation, and declines clean results when a
+  required fact is incomplete.
+- macOS repository discovery treats `~/Developer` as a common unprotected code
+  directory.
+
 ## [0.3.0-rc.1] - 2026-09-01
 
 ### Added

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "antiburn-local"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MIT"


### PR DESCRIPTION
## Summary

- set the desktop app and local engine versions to `0.3.0`
- add final `0.3.0` changelog entries, including the latest onboarding repository-selection change
- prepare the exact final-version artifacts for draft GitHub Releases and UAT

## Validation

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test` (974 tests)
- `pnpm --filter @antiburn/desktop build`
- engine `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`
- shell `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (665 tests)
- `pnpm run slop:all` (100, Healthy)
- `pnpm run secrets`
- release version verifiers for `antiburn-local-v0.3.0` and `antiburn-v0.3.0`

The release workflows will create draft GitHub Releases. Publishing remains a separate action after UAT.