### PR TITLE
fix(release): apply the DMG Finder layout in CI builds

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -589,6 +589,9 @@ jobs:
           # The updater's detached signature. Required on every target.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # The bundler skips the Finder layout step when CI is set, so the
+          # DMG ships without its background. This flag keeps the step on.
+          TAURI_BUNDLER_DMG_IGNORE_CI: "true"
           # Read by the bundler on macOS only, and empty everywhere else.
           APPLE_CERTIFICATE: ${{ runner.os == 'macOS' && steps.signing.outputs.platform_signing == 'developer-id' && secrets.APPLE_CERTIFICATE || '' }}
           APPLE_CERTIFICATE_PASSWORD: ${{ runner.os == 'macOS' && steps.signing.outputs.platform_signing == 'developer-id' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}


### PR DESCRIPTION
## User impact

The 0.3.0 release DMG mounts as a plain white Finder window even though the designed background from #95 is inside the image at `.background/background.tiff`. Cause: tauri-bundler passes `--skip-jenkins` to `bundle_dmg.sh` whenever the `CI` environment variable is set ([dmg/mod.rs](https://github.com/tauri-apps/tauri/blob/dev/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs#L172-L178)), which skips the Finder AppleScript that writes the `.DS_Store` carrying the background, window size, and icon positions. GitHub Actions always sets `CI`, so every released DMG shipped without its layout — while local builds looked correct.

This sets `TAURI_BUNDLER_DMG_IGNORE_CI: "true"` in the release build env so the layout step runs on the GitHub macOS runners, which do have a GUI session. Known limit: the AppleScript becomes a live step in release builds; if it fails, the build fails rather than shipping a plain DMG.

📷 *Placeholder: screenshot of the mounted DMG with the designed background (locally built, shows the intended result).*

## Validation

- Mounted the released `antiburn_0.3.0_aarch64.dmg`: `.background/background.tiff` present, `.DS_Store` absent — confirming the layout step never ran.
- Release run 33462907592 (macOS ARM64 log): `bundle_dmg.sh` completed with no AppleScript activity or errors.
- Confirmed the skip logic and the `TAURI_BUNDLER_DMG_IGNORE_CI` escape hatch in tauri-bundler source.
- YAML parses (`python3 yaml.safe_load`). End-to-end verification needs the next release/rc run since the behavior is CI-only.

## Privacy and performance

None.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
