### PR TITLE
Keep the popover open during nudge key-focus handoffs

### DIFF
--- a/apps/desktop/src-tauri/crates/nudge/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/lib.rs
@@ -77,6 +77,7 @@ pub const NUDGE_HOVER_EVENT: &str = "nudge:hover";
 
 type ActionCallback = Arc<dyn Fn(NudgeActionEvent) + Send + Sync + 'static>;
 type PlacementProvider = Arc<dyn Fn() -> NudgePlacement + Send + Sync + 'static>;
+pub(crate) type KeyReleasedCallback = Arc<dyn Fn() + Send + Sync + 'static>;
 
 /// Leave enough time for a dismissing IPC command to return before destroying
 /// the webview that sent it. A replacement nudge cancels the task.
@@ -109,11 +110,14 @@ pub enum NudgePlacement {
     MenuBarAnchor { rect: tauri::Rect },
 }
 
-/// Owns the notification window and the app's on-action callback. Store one in
-/// Tauri managed state at setup.
+/// Owns the notification window and the app's callbacks (on-action, and the
+/// optional on-key-released). Store one in Tauri managed state at setup.
 pub struct NudgeManager {
     app: AppHandle,
     on_action: ActionCallback,
+    /// Runs after the notification releases key-window status it held. See
+    /// [`Self::on_key_released`].
+    on_key_released: Option<KeyReleasedCallback>,
     placement: PlacementProvider,
     /// The nudge currently meant to be on screen, if any. Retained so it can be
     /// re-delivered when the notification webview signals it is ready (its
@@ -152,11 +156,24 @@ impl NudgeManager {
         Ok(Self {
             app: app.clone(),
             on_action: Arc::new(on_action),
+            on_key_released: None,
             placement: Arc::new(placement),
             pending: Mutex::new(None),
             lifecycle: Mutex::new(()),
             teardown_generation: TeardownGeneration::default(),
         })
+    }
+
+    /// Register a callback that runs after the notification releases
+    /// key-window status it held — on mouse-leave, or on a hide while it is
+    /// key. `resignKeyWindow` hands key to no other window, so the app must
+    /// decide which of its windows takes key back; the crate stays
+    /// policy-free. The callback runs on the main thread. It never fires
+    /// outside macOS, where the notification never takes key at all.
+    #[must_use]
+    pub fn on_key_released(mut self, callback: impl Fn() + Send + Sync + 'static) -> Self {
+        self.on_key_released = Some(Arc::new(callback));
+        self
     }
 
     /// Present `nudge`: position the notification at the OS-native corner,
@@ -176,8 +193,9 @@ impl NudgeManager {
         // when a new nudge replaces one that's still on screen. This is what keeps
         // the notification from visibly resizing (wobbling) on show. The
         // notification is *revealed* via [`Self::reveal`] only after the frontend
-        // sizes it.
-        window::hide(&window);
+        // sizes it. A replaced notification can be key (hovered); this hide
+        // releases that key, so the callback fires.
+        window::hide(&window, self.on_key_released.clone());
         // Retain the payload so it can be re-delivered if the notification
         // webview's listener wasn't attached yet (see [`Self::on_nudge_ready`]).
         if let Ok(mut pending) = self.pending.lock() {
@@ -263,7 +281,7 @@ impl NudgeManager {
         #[cfg(target_os = "macos")]
         {
             if let Some(window) = self.app.get_webview_window(NUDGE_LABEL) {
-                macos::set_hovered(&window, hovered);
+                macos::set_hovered(&window, hovered, self.on_key_released.clone());
             }
         }
         #[cfg(not(target_os = "macos"))]
@@ -305,7 +323,7 @@ impl NudgeManager {
             *pending = None;
         }
         if let Some(window) = self.app.get_webview_window(NUDGE_LABEL) {
-            window::hide(&window);
+            window::hide(&window, self.on_key_released.clone());
         }
         self.schedule_teardown();
     }

--- a/apps/desktop/src-tauri/crates/nudge/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/lib.rs
@@ -77,7 +77,24 @@ pub const NUDGE_HOVER_EVENT: &str = "nudge:hover";
 
 type ActionCallback = Arc<dyn Fn(NudgeActionEvent) + Send + Sync + 'static>;
 type PlacementProvider = Arc<dyn Fn() -> NudgePlacement + Send + Sync + 'static>;
-pub(crate) type KeyReleasedCallback = Arc<dyn Fn() + Send + Sync + 'static>;
+pub(crate) type KeyCallback = Arc<dyn Fn() + Send + Sync + 'static>;
+
+#[derive(Default)]
+pub(crate) struct ExpectedKeyRelease(AtomicU64);
+
+impl ExpectedKeyRelease {
+    pub(crate) fn arm(&self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn take(&self) -> bool {
+        self.0
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |pending| {
+                pending.checked_sub(1)
+            })
+            .is_ok()
+    }
+}
 
 /// Leave enough time for a dismissing IPC command to return before destroying
 /// the webview that sent it. A replacement nudge cancels the task.
@@ -110,14 +127,15 @@ pub enum NudgePlacement {
     MenuBarAnchor { rect: tauri::Rect },
 }
 
-/// Owns the notification window and the app's callbacks (on-action, and the
-/// optional on-key-released). Store one in Tauri managed state at setup.
+/// Owns the notification window and the app's callbacks. Store one in Tauri
+/// managed state at setup.
 pub struct NudgeManager {
     app: AppHandle,
     on_action: ActionCallback,
-    /// Runs after the notification releases key-window status it held. See
-    /// [`Self::on_key_released`].
-    on_key_released: Option<KeyReleasedCallback>,
+    on_key_acquiring: Option<KeyCallback>,
+    on_key_released: Option<KeyCallback>,
+    on_unexpected_key_lost: Option<KeyCallback>,
+    expected_key_release: Arc<ExpectedKeyRelease>,
     placement: PlacementProvider,
     /// The nudge currently meant to be on screen, if any. Retained so it can be
     /// re-delivered when the notification webview signals it is ready (its
@@ -156,12 +174,26 @@ impl NudgeManager {
         Ok(Self {
             app: app.clone(),
             on_action: Arc::new(on_action),
+            on_key_acquiring: None,
             on_key_released: None,
+            on_unexpected_key_lost: None,
+            expected_key_release: Arc::new(ExpectedKeyRelease::default()),
             placement: Arc::new(placement),
             pending: Mutex::new(None),
             lifecycle: Mutex::new(()),
             teardown_generation: TeardownGeneration::default(),
         })
+    }
+
+    /// Register a callback that runs before the notification takes key.
+    ///
+    /// The app can record which window is about to yield key before AppKit
+    /// queues that window's focus-loss event. The callback runs on the main
+    /// thread and never runs outside macOS.
+    #[must_use]
+    pub fn on_key_acquiring(mut self, callback: impl Fn() + Send + Sync + 'static) -> Self {
+        self.on_key_acquiring = Some(Arc::new(callback));
+        self
     }
 
     /// Register a callback that runs after the notification releases
@@ -173,6 +205,16 @@ impl NudgeManager {
     #[must_use]
     pub fn on_key_released(mut self, callback: impl Fn() + Send + Sync + 'static) -> Self {
         self.on_key_released = Some(Arc::new(callback));
+        self
+    }
+
+    /// Register a callback for a key loss not initiated by this manager.
+    ///
+    /// The app uses this event to cancel a pending focus restoration when the
+    /// reader changes applications or AppKit selects another key window.
+    #[must_use]
+    pub fn on_unexpected_key_lost(mut self, callback: impl Fn() + Send + Sync + 'static) -> Self {
+        self.on_unexpected_key_lost = Some(Arc::new(callback));
         self
     }
 
@@ -195,7 +237,11 @@ impl NudgeManager {
         // notification is *revealed* via [`Self::reveal`] only after the frontend
         // sizes it. A replaced notification can be key (hovered); this hide
         // releases that key, so the callback fires.
-        window::hide(&window, self.on_key_released.clone());
+        window::hide(
+            &window,
+            Arc::clone(&self.expected_key_release),
+            self.on_key_released.clone(),
+        );
         // Retain the payload so it can be re-delivered if the notification
         // webview's listener wasn't attached yet (see [`Self::on_nudge_ready`]).
         if let Ok(mut pending) = self.pending.lock() {
@@ -281,12 +327,18 @@ impl NudgeManager {
         #[cfg(target_os = "macos")]
         {
             if let Some(window) = self.app.get_webview_window(NUDGE_LABEL) {
-                macos::set_hovered(&window, hovered, self.on_key_released.clone());
+                macos::set_hovered(
+                    &window,
+                    hovered,
+                    self.on_key_acquiring.clone(),
+                    Arc::clone(&self.expected_key_release),
+                    self.on_key_released.clone(),
+                );
             }
         }
         #[cfg(not(target_os = "macos"))]
         {
-            let _ = hovered;
+            let _ = (hovered, &self.on_key_acquiring);
         }
     }
 
@@ -323,7 +375,11 @@ impl NudgeManager {
             *pending = None;
         }
         if let Some(window) = self.app.get_webview_window(NUDGE_LABEL) {
-            window::hide(&window, self.on_key_released.clone());
+            window::hide(
+                &window,
+                Arc::clone(&self.expected_key_release),
+                self.on_key_released.clone(),
+            );
         }
         self.schedule_teardown();
     }
@@ -378,6 +434,19 @@ impl NudgeManager {
         self.dismiss();
     }
 
+    /// Handle the native notification window's queued focus-loss event.
+    ///
+    /// Expected events follow this manager's own resign or hide operation and
+    /// need no policy callback. Every other event reports an external key loss.
+    pub fn on_window_focus_lost(&self) {
+        if self.expected_key_release.take() {
+            return;
+        }
+        if let Some(callback) = &self.on_unexpected_key_lost {
+            callback();
+        }
+    }
+
     /// Whether the notification currently holds key-window status (macOS
     /// only; always `false` elsewhere, where the notification never takes
     /// key at all — see [`window::show`]). A live query, not an event or a
@@ -405,7 +474,26 @@ impl NudgeManager {
 
 #[cfg(test)]
 mod tests {
-    use super::TeardownGeneration;
+    use super::{ExpectedKeyRelease, TeardownGeneration};
+
+    #[test]
+    fn an_expected_key_release_matches_exactly_one_focus_loss() {
+        let expected = ExpectedKeyRelease::default();
+        assert!(!expected.take());
+        expected.arm();
+        assert!(expected.take());
+        assert!(!expected.take());
+    }
+
+    #[test]
+    fn repeated_expected_releases_match_repeated_focus_losses() {
+        let expected = ExpectedKeyRelease::default();
+        expected.arm();
+        expected.arm();
+        assert!(expected.take());
+        assert!(expected.take());
+        assert!(!expected.take());
+    }
 
     #[test]
     fn a_replacement_nudge_invalidates_the_pending_teardown() {

--- a/apps/desktop/src-tauri/crates/nudge/src/macos.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/macos.rs
@@ -9,8 +9,8 @@
 //! thread-safe, and [`crate::NudgeManager::reveal`] calls them from the IPC
 //! command thread.
 //!
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use core_foundation::base::TCFType;
@@ -143,12 +143,19 @@ pub(crate) fn show(window: &WebviewWindow) {
 pub(crate) fn set_hovered(
     window: &WebviewWindow,
     hovered: bool,
-    on_key_released: Option<crate::KeyReleasedCallback>,
+    on_key_acquiring: Option<crate::KeyCallback>,
+    expected_key_release: Arc<crate::ExpectedKeyRelease>,
+    on_key_released: Option<crate::KeyCallback>,
 ) {
     let window = window.clone();
     let _ = window.clone().run_on_main_thread(move || {
         if let Ok(panel) = window.get_webview_panel(crate::NUDGE_LABEL) {
             if hovered {
+                if !is_key(&window)
+                    && let Some(on_key_acquiring) = &on_key_acquiring
+                {
+                    on_key_acquiring();
+                }
                 let content_view = panel.content_view();
                 panel.make_first_responder(Some(&content_view));
                 panel.make_key_window();
@@ -160,6 +167,7 @@ pub(crate) fn set_hovered(
                 // responder and post a spurious `DidResignKey` for no reason.
                 // Reachable now that hover can be reported by the cursor watcher
                 // below without the panel ever having taken key.
+                expected_key_release.arm();
                 panel.resign_key_window();
                 // Key now belongs to no window. Tell the app, so it can hand
                 // key back to the window that yielded it.
@@ -339,10 +347,17 @@ pub(crate) fn animate_resize(window: &WebviewWindow, height: f64) {
 /// Hide the notification panel (order out). When the panel holds key at that
 /// moment — a dismissal or replacement while hovered — the hide releases key
 /// to no other window, so `on_key_released` runs after it.
-pub(crate) fn hide(window: &WebviewWindow, on_key_released: Option<crate::KeyReleasedCallback>) {
+pub(crate) fn hide(
+    window: &WebviewWindow,
+    expected_key_release: Arc<crate::ExpectedKeyRelease>,
+    on_key_released: Option<crate::KeyCallback>,
+) {
     let window = window.clone();
     let _ = window.clone().run_on_main_thread(move || {
         let was_key = is_key(&window);
+        if was_key {
+            expected_key_release.arm();
+        }
         match window.get_webview_panel(crate::NUDGE_LABEL) {
             Ok(panel) => panel.hide(),
             Err(_) => {

--- a/apps/desktop/src-tauri/crates/nudge/src/macos.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/macos.rs
@@ -140,7 +140,11 @@ pub(crate) fn show(window: &WebviewWindow) {
 /// explicit first responder, the window itself absorbs them, and CTA/close
 /// buttons stop responding to Tab/Enter/Space while hovered even though mouse
 /// clicks (hit-testing, independent of first-responder state) keep working.
-pub(crate) fn set_hovered(window: &WebviewWindow, hovered: bool) {
+pub(crate) fn set_hovered(
+    window: &WebviewWindow,
+    hovered: bool,
+    on_key_released: Option<crate::KeyReleasedCallback>,
+) {
     let window = window.clone();
     let _ = window.clone().run_on_main_thread(move || {
         if let Ok(panel) = window.get_webview_panel(crate::NUDGE_LABEL) {
@@ -157,6 +161,11 @@ pub(crate) fn set_hovered(window: &WebviewWindow, hovered: bool) {
                 // Reachable now that hover can be reported by the cursor watcher
                 // below without the panel ever having taken key.
                 panel.resign_key_window();
+                // Key now belongs to no window. Tell the app, so it can hand
+                // key back to the window that yielded it.
+                if let Some(on_key_released) = on_key_released {
+                    on_key_released();
+                }
             }
         }
     });
@@ -327,15 +336,21 @@ pub(crate) fn animate_resize(window: &WebviewWindow, height: f64) {
     });
 }
 
-/// Hide the notification panel (order out).
-pub(crate) fn hide(window: &WebviewWindow) {
+/// Hide the notification panel (order out). When the panel holds key at that
+/// moment — a dismissal or replacement while hovered — the hide releases key
+/// to no other window, so `on_key_released` runs after it.
+pub(crate) fn hide(window: &WebviewWindow, on_key_released: Option<crate::KeyReleasedCallback>) {
     let window = window.clone();
     let _ = window.clone().run_on_main_thread(move || {
+        let was_key = is_key(&window);
         match window.get_webview_panel(crate::NUDGE_LABEL) {
             Ok(panel) => panel.hide(),
             Err(_) => {
                 let _ = window.hide();
             }
+        }
+        if was_key && let Some(on_key_released) = on_key_released {
+            on_key_released();
         }
     });
 }

--- a/apps/desktop/src-tauri/crates/nudge/src/window.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/window.rs
@@ -12,6 +12,8 @@
 //! antiburn app, not a general-purpose plugin, so there's no need to be generic
 //! over the runtime.
 
+use std::sync::Arc;
+
 use tauri::{
     AppHandle, Manager, PhysicalPosition, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
@@ -313,15 +315,19 @@ pub(crate) fn resize(window: &WebviewWindow, content_height: f64) {
 /// Hide the notification. On macOS this orders the panel out; elsewhere a plain
 /// hide. `on_key_released` runs when the hide releases key the panel held —
 /// macOS only, because the notification never takes key elsewhere.
-pub(crate) fn hide(window: &WebviewWindow, on_key_released: Option<crate::KeyReleasedCallback>) {
+pub(crate) fn hide(
+    window: &WebviewWindow,
+    expected_key_release: Arc<crate::ExpectedKeyRelease>,
+    on_key_released: Option<crate::KeyCallback>,
+) {
     #[cfg(target_os = "macos")]
     {
         crate::macos::stop_hover_watch();
-        crate::macos::hide(window, on_key_released);
+        crate::macos::hide(window, expected_key_release, on_key_released);
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = on_key_released;
+        let _ = (expected_key_release, on_key_released);
         let _ = window.hide();
     }
 }

--- a/apps/desktop/src-tauri/crates/nudge/src/window.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/window.rs
@@ -311,15 +311,19 @@ pub(crate) fn resize(window: &WebviewWindow, content_height: f64) {
 }
 
 /// Hide the notification. On macOS this orders the panel out; elsewhere a plain
-/// hide.
-pub(crate) fn hide(window: &WebviewWindow) {
+/// hide. `on_key_released` runs when the hide releases key the panel held —
+/// macOS only, because the notification never takes key elsewhere.
+pub(crate) fn hide(window: &WebviewWindow, on_key_released: Option<crate::KeyReleasedCallback>) {
     #[cfg(target_os = "macos")]
     {
         crate::macos::stop_hover_watch();
-        crate::macos::hide(window);
+        crate::macos::hide(window, on_key_released);
     }
     #[cfg(not(target_os = "macos"))]
-    let _ = window.hide();
+    {
+        let _ = on_key_released;
+        let _ = window.hide();
+    }
 }
 
 /// Retire the hidden notification webview. The next delivery recreates it.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -537,6 +537,14 @@ fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
         WindowEvent::Focused(false) if window.label() == popover::LABEL => {
             popover::hide_on_focus_loss(window);
         }
+        WindowEvent::Focused(false) if window.label() == antiburn_nudge::NUDGE_LABEL => {
+            if let Some(manager) = window
+                .app_handle()
+                .try_state::<antiburn_nudge::NudgeManager>()
+            {
+                manager.on_window_focus_lost();
+            }
+        }
         WindowEvent::CloseRequested { api, .. } => {
             match close_policy(window.label(), onboarding::is_pending(window.app_handle())) {
                 ClosePolicy::Allow => {}

--- a/apps/desktop/src-tauri/src/nudges.rs
+++ b/apps/desktop/src-tauri/src/nudges.rs
@@ -54,11 +54,15 @@ pub fn anchor_next_to_the_tray(app: &AppHandle) {
 pub fn init(app: &AppHandle) -> tauri::Result<()> {
     let action_app = app.clone();
     let placement_app = app.clone();
+    let refocus_app = app.clone();
     let manager = NudgeManager::with_placement(
         app,
         move |event| on_action(&action_app, event),
         move || placement(&placement_app),
-    )?;
+    )?
+    // The notification resigns key without handing it to any window. Give key
+    // back to the popover when the popover yielded it to the notification.
+    .on_key_released(move || crate::popover::refocus_after_nudge(&refocus_app));
     app.manage(manager);
     app.manage(antiburn_sound::SoundPlayer::new());
     Ok(())
@@ -138,6 +142,9 @@ fn on_action(app: &AppHandle, event: NudgeActionEvent) {
     if event.action_id == "dismiss" {
         return;
     }
+    // Every other CTA opens or focuses a different window. The key release
+    // from the CTA's dismissal must not pull focus back to the popover.
+    crate::popover::clear_nudge_yield(app);
     if event.action_id == crate::notifications::NOTIFICATION_SETTINGS_ACTION_ID {
         let _ = crate::settings::open(app, Some("notifications".to_string()));
         return;

--- a/apps/desktop/src-tauri/src/nudges.rs
+++ b/apps/desktop/src-tauri/src/nudges.rs
@@ -143,16 +143,19 @@ fn placement(app: &AppHandle) -> NudgePlacement {
 /// the settings pane that can act on the nudge's subject — except the one CTA
 /// whose subject is the menu-bar item itself.
 fn on_action(app: &AppHandle, event: NudgeActionEvent) {
-    if event.action_id == "dismiss" {
+    if let Some(plan) = plan_for_notification_settings_action(&event.action_id) {
+        if plan.focus_policy == NudgeFocusPolicy::AbandonPopover {
+            crate::popover::clear_nudge_yield(app);
+        }
+        let _ = crate::settings::open(app, Some(plan.pane.to_string()));
+        return;
+    }
+    if focus_policy_for_action(&event.action_id) == NudgeFocusPolicy::RestorePopover {
         return;
     }
     // Every other CTA opens or focuses a different window. The key release
     // from the CTA's dismissal must not pull focus back to the popover.
     crate::popover::clear_nudge_yield(app);
-    if event.action_id == crate::notifications::NOTIFICATION_SETTINGS_ACTION_ID {
-        let _ = crate::settings::open(app, Some("notifications".to_string()));
-        return;
-    }
     // "Show me" opens the popover under the glyph the notification is already
     // pointing at, so the reader's first sight of it is the thing the icon
     // does rather than a settings pane about it.
@@ -193,6 +196,37 @@ fn on_action(app: &AppHandle, event: NudgeActionEvent) {
         _ => None,
     };
     let _ = crate::settings::open(app, pane.map(str::to_string));
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum NudgeFocusPolicy {
+    RestorePopover,
+    AbandonPopover,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NotificationSettingsActionPlan {
+    focus_policy: NudgeFocusPolicy,
+    pane: &'static str,
+}
+
+fn plan_for_notification_settings_action(
+    action_id: &str,
+) -> Option<NotificationSettingsActionPlan> {
+    (action_id == crate::notifications::NOTIFICATION_SETTINGS_ACTION_ID).then_some(
+        NotificationSettingsActionPlan {
+            focus_policy: NudgeFocusPolicy::AbandonPopover,
+            pane: "notifications",
+        },
+    )
+}
+
+fn focus_policy_for_action(action_id: &str) -> NudgeFocusPolicy {
+    if action_id == "dismiss" {
+        NudgeFocusPolicy::RestorePopover
+    } else {
+        NudgeFocusPolicy::AbandonPopover
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -288,5 +322,19 @@ mod tests {
         ] {
             assert_eq!(classify_update_action(&malformed), UpdateAction::OpenAbout);
         }
+    }
+
+    #[test]
+    fn a_settings_cta_opens_settings_without_restoring_popover_focus() {
+        let plan = plan_for_notification_settings_action(
+            crate::notifications::NOTIFICATION_SETTINGS_ACTION_ID,
+        )
+        .expect("the notification settings CTA must have an action plan");
+        assert_eq!(plan.focus_policy, NudgeFocusPolicy::AbandonPopover);
+        assert_eq!(plan.pane, "notifications");
+        assert_eq!(
+            focus_policy_for_action("dismiss"),
+            NudgeFocusPolicy::RestorePopover
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/nudges.rs
+++ b/apps/desktop/src-tauri/src/nudges.rs
@@ -54,15 +54,19 @@ pub fn anchor_next_to_the_tray(app: &AppHandle) {
 pub fn init(app: &AppHandle) -> tauri::Result<()> {
     let action_app = app.clone();
     let placement_app = app.clone();
+    let acquiring_app = app.clone();
     let refocus_app = app.clone();
+    let lost_app = app.clone();
     let manager = NudgeManager::with_placement(
         app,
         move |event| on_action(&action_app, event),
         move || placement(&placement_app),
     )?
+    .on_key_acquiring(move || crate::popover::begin_nudge_key_handoff(&acquiring_app))
     // The notification resigns key without handing it to any window. Give key
     // back to the popover when the popover yielded it to the notification.
-    .on_key_released(move || crate::popover::refocus_after_nudge(&refocus_app));
+    .on_key_released(move || crate::popover::refocus_after_nudge(&refocus_app))
+    .on_unexpected_key_lost(move || crate::popover::cancel_nudge_key_handoff(&lost_app));
     app.manage(manager);
     app.manage(antiburn_sound::SoundPlayer::new());
     Ok(())

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -61,6 +61,41 @@ use self::retention::{DueEviction, EvictionMode, EvictionSchedule, EvictionToken
 /// Window label. Also listed in `capabilities/default.json`.
 pub const LABEL: &str = "popover";
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct NudgeKeyHandoff {
+    pending_popover_blurs: u64,
+    key_owned: bool,
+}
+
+impl NudgeKeyHandoff {
+    fn begin(&mut self) {
+        self.pending_popover_blurs = self.pending_popover_blurs.saturating_add(1);
+        self.key_owned = true;
+    }
+
+    fn on_popover_blur(&mut self) -> bool {
+        if self.pending_popover_blurs == 0 {
+            return false;
+        }
+        self.pending_popover_blurs -= 1;
+        true
+    }
+
+    fn on_expected_release(&mut self) -> bool {
+        std::mem::take(&mut self.key_owned)
+    }
+
+    fn cancel(&mut self) -> bool {
+        let dismiss_now = self.key_owned && self.pending_popover_blurs == 0;
+        self.clear();
+        dismiss_now
+    }
+
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
+}
+
 /// Emitted the moment the popover reaches the screen, following the same
 /// `module:event` naming [`crate::scan`]'s events use. The webview listens
 /// for this to refresh live usage — see [`note_shown`] for why that refresh
@@ -341,10 +376,8 @@ pub struct PopoverState {
     /// Deliberately not persisted: a pin means "keep this on screen while I
     /// work", and a relaunch is the end of that work.
     pinned: AtomicBool,
-    /// Set when a focus loss is not acted on because the nudge notification
-    /// took key on hover. Consumed when the notification releases key, so the
-    /// popover takes key back for exactly that episode and no other.
-    yielded_key_to_nudge: AtomicBool,
+    /// Tracks one key-window handoff to the nudge notification.
+    nudge_key_handoff: Mutex<NudgeKeyHandoff>,
     /// The generation of the current renderer.
     renderer_generation: AtomicU64,
     /// The bounded onboarding prewarm and its eviction callbacks.
@@ -365,7 +398,7 @@ impl Default for PopoverState {
             resize_apply_guard: Mutex::new(()),
             focus_hold: AtomicU64::new(0),
             pinned: AtomicBool::new(false),
-            yielded_key_to_nudge: AtomicBool::new(false),
+            nudge_key_handoff: Mutex::new(NudgeKeyHandoff::default()),
             renderer_generation: AtomicU64::new(0),
             retention: Mutex::new(Retention::default()),
             timing: timing::PopoverTiming::default(),
@@ -440,17 +473,34 @@ impl PopoverState {
         self.pinned.store(pinned, Ordering::SeqCst);
     }
 
-    fn note_key_yielded_to_nudge(&self) {
-        self.yielded_key_to_nudge.store(true, Ordering::SeqCst);
+    fn begin_nudge_key_handoff(&self) {
+        if let Ok(mut handoff) = self.nudge_key_handoff.lock() {
+            handoff.begin();
+        }
     }
 
-    /// Consume the yield marker. True at most once per yielded episode.
-    fn take_key_yielded_to_nudge(&self) -> bool {
-        self.yielded_key_to_nudge.swap(false, Ordering::SeqCst)
+    fn suppress_blur_for_nudge_handoff(&self) -> bool {
+        self.nudge_key_handoff
+            .lock()
+            .is_ok_and(|mut handoff| handoff.on_popover_blur())
     }
 
-    fn clear_key_yielded_to_nudge(&self) {
-        self.yielded_key_to_nudge.store(false, Ordering::SeqCst);
+    fn release_nudge_key_handoff(&self) -> bool {
+        self.nudge_key_handoff
+            .lock()
+            .is_ok_and(|mut handoff| handoff.on_expected_release())
+    }
+
+    fn cancel_nudge_key_handoff(&self) -> bool {
+        self.nudge_key_handoff
+            .lock()
+            .is_ok_and(|mut handoff| handoff.cancel())
+    }
+
+    fn clear_nudge_key_handoff(&self) {
+        if let Ok(mut handoff) = self.nudge_key_handoff.lock() {
+            handoff.clear();
+        }
     }
 
     fn retention(&self) -> std::sync::MutexGuard<'_, Retention> {
@@ -1109,7 +1159,7 @@ fn hide_window(app: &AppHandle) {
     // A hidden popover has no key to take back: a nudge key release after
     // this point must not resurrect focus.
     if let Some(state) = app.try_state::<PopoverState>() {
-        state.clear_key_yielded_to_nudge();
+        state.clear_nudge_key_handoff();
     }
     let Some(window) = app.get_webview_window(LABEL) else {
         note_hidden(app);
@@ -1276,32 +1326,21 @@ fn apply_height(window: &WebviewWindow, height: f64) -> bool {
 /// about to take (or has taken) focus, and the popover must survive it. Also a
 /// no-op while pinned — looking away is exactly what a pin is for.
 ///
-/// Also a no-op when the nudge notification holds key right now: hovering the
-/// notification takes key for `mouseMoved` delivery (see `antiburn_nudge`),
-/// and that handoff must not read as the reader looking away. The check is a
-/// live key query and must run on the main thread — true here, because the
-/// window-event handler that calls this runs there. A hover so brief that the
-/// notification already resigned key before this queued event runs still
-/// dismisses; `NudgeManager::is_nudge_key` documents that trade.
+/// Also a no-op when the nudge notification caused this focus loss. The nudge
+/// records the handoff before it takes key, so a quick mouse leave cannot make
+/// the queued blur look like an unrelated focus change.
 ///
 /// All cases return *before* recording the dismissal: nothing was dismissed,
 /// so the next tray click is a fresh open and must not be suppressed.
 pub fn hide_on_focus_loss(window: &Window) {
     let app = window.app_handle();
-    if nudge_holds_key(app) {
-        if let Some(state) = app.try_state::<PopoverState>() {
-            state.note_key_yielded_to_nudge();
-        }
+    if app
+        .try_state::<PopoverState>()
+        .is_some_and(|state| state.suppress_blur_for_nudge_handoff())
+    {
         return;
     }
     dismiss(app);
-}
-
-/// Whether the nudge notification is the key window right now. Main thread
-/// only — the check is a live AppKit query.
-fn nudge_holds_key(app: &AppHandle) -> bool {
-    app.try_state::<antiburn_nudge::NudgeManager>()
-        .is_some_and(|manager| manager.is_nudge_key())
 }
 
 /// Hides the popover after a click somewhere else on the desktop.
@@ -1376,20 +1415,28 @@ pub fn end_focus_hold(app: &AppHandle) {
     }
 }
 
-/// Hands key back to the popover after the nudge notification releases it.
+/// Records that the focused popover is about to hand key to the nudge.
 ///
-/// The notification resigns key without giving it to any window (see
-/// `antiburn_nudge`), so without this the popover would sit visible but never
-/// key again: Escape dead, and no later focus change left to dismiss it. Only
-/// acts when [`hide_on_focus_loss`] noted that the popover yielded key to the
-/// notification, so a pinned popover left open while the reader works in
-/// another app is never re-focused over their work. Skips the refocus while a
-/// focus hold is active — a native dialog owns focus then.
+/// The callback runs before AppKit changes key windows. A popover that is only
+/// visible, such as a pinned popover behind another app, records no handoff.
+pub fn begin_nudge_key_handoff(app: &AppHandle) {
+    let focused = app
+        .get_webview_window(LABEL)
+        .is_some_and(|window| window.is_focused().unwrap_or(false));
+    if focused && let Some(state) = app.try_state::<PopoverState>() {
+        state.begin_nudge_key_handoff();
+    }
+}
+
+/// Hands key back to the popover after an expected nudge release.
+///
+/// The state keeps a pending blur after a quick release. That blur is still
+/// suppressed after focus returns, so it cannot dismiss the popover late.
 pub fn refocus_after_nudge(app: &AppHandle) {
     let Some(state) = app.try_state::<PopoverState>() else {
         return;
     };
-    if !state.take_key_yielded_to_nudge() || state.holds_focus() {
+    if !state.release_nudge_key_handoff() || state.holds_focus() {
         return;
     }
     if let Some(window) = app.get_webview_window(LABEL)
@@ -1399,12 +1446,25 @@ pub fn refocus_after_nudge(app: &AppHandle) {
     }
 }
 
+/// Cancels a handoff when AppKit removes nudge key focus unexpectedly.
+///
+/// If the popover blur already arrived, dismiss now. Otherwise, the queued
+/// blur performs the normal dismissal after the handoff marker is cleared.
+pub fn cancel_nudge_key_handoff(app: &AppHandle) {
+    let dismiss_now = app
+        .try_state::<PopoverState>()
+        .is_some_and(|state| state.cancel_nudge_key_handoff());
+    if dismiss_now {
+        dismiss(app);
+    }
+}
+
 /// Forgets that the popover yielded key to the nudge notification. Used by a
 /// notification CTA that opens another window: the key release that follows
 /// the CTA's dismissal must not pull focus back to the popover.
 pub fn clear_nudge_yield(app: &AppHandle) {
     if let Some(state) = app.try_state::<PopoverState>() {
-        state.clear_key_yielded_to_nudge();
+        state.clear_nudge_key_handoff();
     }
 }
 
@@ -2034,29 +2094,60 @@ mod tests {
     }
 
     #[test]
-    fn a_yield_to_the_nudge_is_consumed_exactly_once() {
-        let state = PopoverState::default();
-        assert!(!state.take_key_yielded_to_nudge());
-        state.note_key_yielded_to_nudge();
-        assert!(state.take_key_yielded_to_nudge());
-        assert!(!state.take_key_yielded_to_nudge());
+    fn a_normal_handoff_suppresses_blur_and_restores_focus_once() {
+        let mut handoff = NudgeKeyHandoff::default();
+        handoff.begin();
+        assert!(handoff.on_popover_blur());
+        assert!(handoff.on_expected_release());
+        assert!(!handoff.on_expected_release());
     }
 
     #[test]
-    fn clearing_a_yield_leaves_nothing_to_consume() {
-        let state = PopoverState::default();
-        state.note_key_yielded_to_nudge();
-        state.clear_key_yielded_to_nudge();
-        assert!(!state.take_key_yielded_to_nudge());
+    fn a_release_before_delayed_blur_restores_focus_and_suppresses_that_blur() {
+        let mut handoff = NudgeKeyHandoff::default();
+        handoff.begin();
+        assert!(handoff.on_expected_release());
+        assert!(handoff.on_popover_blur());
+        assert!(!handoff.on_popover_blur());
     }
 
-    /// A suppressed focus loss dismisses nothing, so it must not arm the
-    /// reopen suppression the way a real dismissal does.
     #[test]
-    fn a_yield_to_the_nudge_does_not_suppress_reopening() {
-        let state = PopoverState::default();
-        state.note_key_yielded_to_nudge();
-        assert!(!state.suppresses_reopen());
+    fn an_external_key_loss_cancels_the_handoff_without_restoring_focus() {
+        let mut handoff = NudgeKeyHandoff::default();
+        handoff.begin();
+        assert!(handoff.on_popover_blur());
+        assert!(handoff.cancel());
+        assert!(!handoff.on_expected_release());
+        assert!(!handoff.on_popover_blur());
+    }
+
+    #[test]
+    fn an_external_key_loss_before_blur_leaves_that_blur_to_dismiss() {
+        let mut handoff = NudgeKeyHandoff::default();
+        handoff.begin();
+        assert!(!handoff.cancel());
+        assert!(!handoff.on_popover_blur());
+    }
+
+    #[test]
+    fn repeated_quick_handoffs_preserve_every_queued_blur() {
+        let mut handoff = NudgeKeyHandoff::default();
+        handoff.begin();
+        assert!(handoff.on_expected_release());
+        handoff.begin();
+        assert!(handoff.on_expected_release());
+        assert!(handoff.on_popover_blur());
+        assert!(handoff.on_popover_blur());
+        assert!(!handoff.on_popover_blur());
+    }
+
+    #[test]
+    fn clearing_a_handoff_leaves_no_delayed_focus_work() {
+        let mut handoff = NudgeKeyHandoff::default();
+        handoff.begin();
+        handoff.clear();
+        assert!(!handoff.on_expected_release());
+        assert!(!handoff.on_popover_blur());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -341,6 +341,10 @@ pub struct PopoverState {
     /// Deliberately not persisted: a pin means "keep this on screen while I
     /// work", and a relaunch is the end of that work.
     pinned: AtomicBool,
+    /// Set when a focus loss is not acted on because the nudge notification
+    /// took key on hover. Consumed when the notification releases key, so the
+    /// popover takes key back for exactly that episode and no other.
+    yielded_key_to_nudge: AtomicBool,
     /// The generation of the current renderer.
     renderer_generation: AtomicU64,
     /// The bounded onboarding prewarm and its eviction callbacks.
@@ -361,6 +365,7 @@ impl Default for PopoverState {
             resize_apply_guard: Mutex::new(()),
             focus_hold: AtomicU64::new(0),
             pinned: AtomicBool::new(false),
+            yielded_key_to_nudge: AtomicBool::new(false),
             renderer_generation: AtomicU64::new(0),
             retention: Mutex::new(Retention::default()),
             timing: timing::PopoverTiming::default(),
@@ -433,6 +438,19 @@ impl PopoverState {
 
     fn set_pinned(&self, pinned: bool) {
         self.pinned.store(pinned, Ordering::SeqCst);
+    }
+
+    fn note_key_yielded_to_nudge(&self) {
+        self.yielded_key_to_nudge.store(true, Ordering::SeqCst);
+    }
+
+    /// Consume the yield marker. True at most once per yielded episode.
+    fn take_key_yielded_to_nudge(&self) -> bool {
+        self.yielded_key_to_nudge.swap(false, Ordering::SeqCst)
+    }
+
+    fn clear_key_yielded_to_nudge(&self) {
+        self.yielded_key_to_nudge.store(false, Ordering::SeqCst);
     }
 
     fn retention(&self) -> std::sync::MutexGuard<'_, Retention> {
@@ -1088,6 +1106,11 @@ fn destroy_prewarm(app: &AppHandle) -> bool {
 }
 
 fn hide_window(app: &AppHandle) {
+    // A hidden popover has no key to take back: a nudge key release after
+    // this point must not resurrect focus.
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.clear_key_yielded_to_nudge();
+    }
     let Some(window) = app.get_webview_window(LABEL) else {
         note_hidden(app);
         return;
@@ -1253,10 +1276,32 @@ fn apply_height(window: &WebviewWindow, height: f64) -> bool {
 /// about to take (or has taken) focus, and the popover must survive it. Also a
 /// no-op while pinned — looking away is exactly what a pin is for.
 ///
-/// Both cases return *before* recording the dismissal: nothing was dismissed,
+/// Also a no-op when the nudge notification holds key right now: hovering the
+/// notification takes key for `mouseMoved` delivery (see `antiburn_nudge`),
+/// and that handoff must not read as the reader looking away. The check is a
+/// live key query and must run on the main thread — true here, because the
+/// window-event handler that calls this runs there. A hover so brief that the
+/// notification already resigned key before this queued event runs still
+/// dismisses; `NudgeManager::is_nudge_key` documents that trade.
+///
+/// All cases return *before* recording the dismissal: nothing was dismissed,
 /// so the next tray click is a fresh open and must not be suppressed.
 pub fn hide_on_focus_loss(window: &Window) {
-    dismiss(window.app_handle());
+    let app = window.app_handle();
+    if nudge_holds_key(app) {
+        if let Some(state) = app.try_state::<PopoverState>() {
+            state.note_key_yielded_to_nudge();
+        }
+        return;
+    }
+    dismiss(app);
+}
+
+/// Whether the nudge notification is the key window right now. Main thread
+/// only — the check is a live AppKit query.
+fn nudge_holds_key(app: &AppHandle) -> bool {
+    app.try_state::<antiburn_nudge::NudgeManager>()
+        .is_some_and(|manager| manager.is_nudge_key())
 }
 
 /// Hides the popover after a click somewhere else on the desktop.
@@ -1328,6 +1373,38 @@ pub fn end_focus_hold(app: &AppHandle) {
         && window.is_visible().unwrap_or(false)
     {
         let _ = window.set_focus();
+    }
+}
+
+/// Hands key back to the popover after the nudge notification releases it.
+///
+/// The notification resigns key without giving it to any window (see
+/// `antiburn_nudge`), so without this the popover would sit visible but never
+/// key again: Escape dead, and no later focus change left to dismiss it. Only
+/// acts when [`hide_on_focus_loss`] noted that the popover yielded key to the
+/// notification, so a pinned popover left open while the reader works in
+/// another app is never re-focused over their work. Skips the refocus while a
+/// focus hold is active — a native dialog owns focus then.
+pub fn refocus_after_nudge(app: &AppHandle) {
+    let Some(state) = app.try_state::<PopoverState>() else {
+        return;
+    };
+    if !state.take_key_yielded_to_nudge() || state.holds_focus() {
+        return;
+    }
+    if let Some(window) = app.get_webview_window(LABEL)
+        && window.is_visible().unwrap_or(false)
+    {
+        let _ = window.set_focus();
+    }
+}
+
+/// Forgets that the popover yielded key to the nudge notification. Used by a
+/// notification CTA that opens another window: the key release that follows
+/// the CTA's dismissal must not pull focus back to the popover.
+pub fn clear_nudge_yield(app: &AppHandle) {
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.clear_key_yielded_to_nudge();
     }
 }
 
@@ -1954,6 +2031,32 @@ mod tests {
     fn a_fresh_popover_is_not_pinned() {
         let state = PopoverState::default();
         assert!(!state.is_pinned());
+    }
+
+    #[test]
+    fn a_yield_to_the_nudge_is_consumed_exactly_once() {
+        let state = PopoverState::default();
+        assert!(!state.take_key_yielded_to_nudge());
+        state.note_key_yielded_to_nudge();
+        assert!(state.take_key_yielded_to_nudge());
+        assert!(!state.take_key_yielded_to_nudge());
+    }
+
+    #[test]
+    fn clearing_a_yield_leaves_nothing_to_consume() {
+        let state = PopoverState::default();
+        state.note_key_yielded_to_nudge();
+        state.clear_key_yielded_to_nudge();
+        assert!(!state.take_key_yielded_to_nudge());
+    }
+
+    /// A suppressed focus loss dismisses nothing, so it must not arm the
+    /// reopen suppression the way a real dismissal does.
+    #[test]
+    fn a_yield_to_the_nudge_does_not_suppress_reopening() {
+        let state = PopoverState::default();
+        state.note_key_yielded_to_nudge();
+        assert!(!state.suppresses_reopen());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -68,9 +68,13 @@ struct NudgeKeyHandoff {
 }
 
 impl NudgeKeyHandoff {
-    fn begin(&mut self) {
+    fn begin_if_focused(&mut self, popover_focused: bool) -> bool {
+        if !popover_focused {
+            return false;
+        }
         self.pending_popover_blurs = self.pending_popover_blurs.saturating_add(1);
         self.key_owned = true;
+        true
     }
 
     fn on_popover_blur(&mut self) -> bool {
@@ -473,9 +477,9 @@ impl PopoverState {
         self.pinned.store(pinned, Ordering::SeqCst);
     }
 
-    fn begin_nudge_key_handoff(&self) {
+    fn begin_nudge_key_handoff(&self, popover_focused: bool) {
         if let Ok(mut handoff) = self.nudge_key_handoff.lock() {
-            handoff.begin();
+            handoff.begin_if_focused(popover_focused);
         }
     }
 
@@ -1423,8 +1427,8 @@ pub fn begin_nudge_key_handoff(app: &AppHandle) {
     let focused = app
         .get_webview_window(LABEL)
         .is_some_and(|window| window.is_focused().unwrap_or(false));
-    if focused && let Some(state) = app.try_state::<PopoverState>() {
-        state.begin_nudge_key_handoff();
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.begin_nudge_key_handoff(focused);
     }
 }
 
@@ -2094,9 +2098,9 @@ mod tests {
     }
 
     #[test]
-    fn a_normal_handoff_suppresses_blur_and_restores_focus_once() {
+    fn hovering_and_leaving_a_nudge_restores_the_open_popover() {
         let mut handoff = NudgeKeyHandoff::default();
-        handoff.begin();
+        assert!(handoff.begin_if_focused(true));
         assert!(handoff.on_popover_blur());
         assert!(handoff.on_expected_release());
         assert!(!handoff.on_expected_release());
@@ -2105,16 +2109,16 @@ mod tests {
     #[test]
     fn a_release_before_delayed_blur_restores_focus_and_suppresses_that_blur() {
         let mut handoff = NudgeKeyHandoff::default();
-        handoff.begin();
+        assert!(handoff.begin_if_focused(true));
         assert!(handoff.on_expected_release());
         assert!(handoff.on_popover_blur());
         assert!(!handoff.on_popover_blur());
     }
 
     #[test]
-    fn an_external_key_loss_cancels_the_handoff_without_restoring_focus() {
+    fn changing_applications_while_nudge_key_dismisses_without_refocus() {
         let mut handoff = NudgeKeyHandoff::default();
-        handoff.begin();
+        assert!(handoff.begin_if_focused(true));
         assert!(handoff.on_popover_blur());
         assert!(handoff.cancel());
         assert!(!handoff.on_expected_release());
@@ -2124,17 +2128,17 @@ mod tests {
     #[test]
     fn an_external_key_loss_before_blur_leaves_that_blur_to_dismiss() {
         let mut handoff = NudgeKeyHandoff::default();
-        handoff.begin();
+        assert!(handoff.begin_if_focused(true));
         assert!(!handoff.cancel());
         assert!(!handoff.on_popover_blur());
     }
 
     #[test]
-    fn repeated_quick_handoffs_preserve_every_queued_blur() {
+    fn rapid_nudge_boundary_crossings_preserve_every_queued_blur() {
         let mut handoff = NudgeKeyHandoff::default();
-        handoff.begin();
+        assert!(handoff.begin_if_focused(true));
         assert!(handoff.on_expected_release());
-        handoff.begin();
+        assert!(handoff.begin_if_focused(true));
         assert!(handoff.on_expected_release());
         assert!(handoff.on_popover_blur());
         assert!(handoff.on_popover_blur());
@@ -2144,10 +2148,19 @@ mod tests {
     #[test]
     fn clearing_a_handoff_leaves_no_delayed_focus_work() {
         let mut handoff = NudgeKeyHandoff::default();
-        handoff.begin();
+        assert!(handoff.begin_if_focused(true));
         handoff.clear();
         assert!(!handoff.on_expected_release());
         assert!(!handoff.on_popover_blur());
+    }
+
+    #[test]
+    fn a_pinned_unfocused_popover_is_never_pulled_forward() {
+        let state = PopoverState::default();
+        state.set_pinned(true);
+        state.begin_nudge_key_handoff(false);
+        assert!(state.is_pinned());
+        assert!(!state.release_nudge_key_handoff());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #321

## Symptoms

When the popover and a notification nudge are visible together, hovering the nudge makes its panel the key window. AppKit requires this so the nudge receives continuous mouse-move events for its hover expansion and controls.

The popover interpreted the resulting focus loss as the reader looking elsewhere and dismissed itself.

Two ordering cases made the problem more subtle:

- A quick hover could release the nudge before Tao delivered the popover's queued `Focused(false)` event. The delayed event then dismissed the popover.
- AppKit could remove key focus independently, such as when the reader changed applications. That left stale restoration state which could later pull focus back to the popover unexpectedly.

## Root cause

The dismissal decision relied on whether the nudge was still the key window when the queued popover blur was processed. That live query lost the causal relationship between taking key and the later event.

Focus restoration also observed only releases initiated by the nudge code. It did not reconcile the native notification window's actual focus-loss event.

## Solution

- Record a popover-to-nudge key handoff before the nudge takes key.
- Count pending popover blur events so each delayed blur is acknowledged once.
- Preserve those acknowledgements when release happens before blur delivery.
- Count expected nudge focus-loss events caused by mouse leave, dismissal, or replacement.
- Observe the nudge window's native `Focused(false)` event.
- Treat unanticipated native focus loss as an external transfer and cancel restoration state.
- Restore the popover only after an expected release and only when it originally yielded key.
- Clear restoration state when the popover hides or a notification CTA opens another window.

## Testing

Automated validation:

- `cargo fmt --all --check` in the desktop and nudge workspaces
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings` in both workspaces
- Desktop test suite: 669 passed
- Nudge test suite: 36 passed
- `git diff --check`

Deterministic Rust lifecycle coverage now includes:

- `hovering_and_leaving_a_nudge_restores_the_open_popover` — hover and leave while the popover is open.
- `rapid_nudge_boundary_crossings_preserve_every_queued_blur` — cross the nudge boundary rapidly several times.
- `changing_applications_while_nudge_key_dismisses_without_refocus` — change applications while the nudge holds key.
- `a_settings_cta_opens_settings_without_restoring_popover_focus` — open Notifications Settings from a nudge CTA without pulling the popover forward.
- `a_pinned_unfocused_popover_is_never_pulled_forward` — keep a pinned, unfocused popover behind the active application.
- Additional ordering coverage exercises release before a delayed popover blur, external key loss before and after blur, clearing a handoff, and matching expected releases to native focus-loss events.

These tests run at the Rust focus-policy and lifecycle boundary, where AppKit and Tao event order can be exercised deterministically without relying on macOS Accessibility-driven UI timing.

Manual macOS verification completed:

- [x] Hover and leave a nudge while the popover is open.
- [x] Cross the nudge boundary rapidly several times.
- [x] Change applications while the nudge holds key.
- [x] Activate a nudge CTA that opens Settings.
- [x] Confirm a pinned, unfocused popover is never pulled forward.
