### PR TITLE
chore(release): prepare 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-01
+
+### Fixed
+
+- macOS disk images now open with the designed Finder background, window
+  layout, and application shortcut.
+- Hovering a notification nudge no longer closes the open popover or restores
+  focus after the reader changes applications or opens notification settings.
+
 ## [0.3.0] - 2026-09-01
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "antiburn-hud",
  "antiburn-local",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/hud", "crates/nudge", "crates/sound", "crates/trace"]
 
 [package]
 name = "antiburn"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary

- set the desktop app version to `0.3.1`
- add reader-facing notes for the corrected macOS DMG layout and nudge/popover focus handling
- retain `antiburn-local` at released version `0.3.0` because the engine tree is unchanged
- prepare the exact final-version artifacts for a draft GitHub Release and UAT

## Validation

- frontend format, lint, type-check, 974 tests, and production build
- desktop Rust format, Clippy, and 673 tests
- nudge crate format, Clippy, and 36 tests
- engine format, Clippy, full unit/integration suite, and doctests
- `pnpm run slop:all` (100, Healthy)
- `pnpm run secrets`
- app release version and engine-release verifiers

The release workflow will create a draft GitHub Release. Publishing remains a separate action after UAT.