### PR TITLE
feat(installer): open install.sh with a doom-fire burn of the wordmark

### DIFF
--- a/docs/plans/fire-installer-plan.md
+++ b/docs/plans/fire-installer-plan.md
@@ -85,8 +85,9 @@ New gate: circle mode is 88 columns wide and Terminal.app defaults to 80.
 - Download runs in the background (`curl … & pid=$!`) while the spinner
   animates until `kill -0 $pid` fails; show percent from the growing file
   size when Content-Length is known.
-- The sudo password prompt stays a plain static line. sudo owns the cursor;
-  nothing animates while it waits.
+- When `/Applications` is not writable, explain why administrator access is
+  required before sudo asks for a password. Nothing animates while it waits.
+- When `/Applications` is writable, install directly without sudo.
 - Non-TTY falls back to plain appended lines, same words.
 
 ## Step 5 — Verification before the PR

--- a/docs/plans/fire-installer-plan.md
+++ b/docs/plans/fire-installer-plan.md
@@ -14,7 +14,7 @@ install log runs underneath. Spec comes from playground v9, signed off
 | 3. Terminal gating and fallbacks | done |
 | 4. Live-updating log | done |
 | 5. Verification matrix | done, except a real `curl \| sh` against a release (needs release assets; Keith tests) |
-| 6. PR | open |
+| 6. PR | done — [antiburn/antiburn#333](https://github.com/antiburn/antiburn/pull/333) |
 
 Follow-up, not in this change: port the same sim upgrades back to the
 tuning harness in antiburn_assets/fire-term, so the two do not drift.

--- a/docs/plans/fire-installer-plan.md
+++ b/docs/plans/fire-installer-plan.md
@@ -1,0 +1,110 @@
+# install.sh gets the fire banner
+
+`curl | sh` opens with the doom-fire burn. The flames follow the word outline,
+die down, and leave the orange **antiburn** wordmark. Then a live-updating
+install log runs underneath. Spec comes from playground v9, signed off
+2026-09-01.
+
+## Status
+
+| Step | State |
+|---|---|
+| 1. Fresh branch off origin/main | done |
+| 2. Fire sim in install.sh (contour + clearance + circles) | done |
+| 3. Terminal gating and fallbacks | done |
+| 4. Live-updating log | done |
+| 5. Verification matrix | done, except a real `curl \| sh` against a release (needs release assets; Keith tests) |
+| 6. PR | open |
+
+Follow-up, not in this change: port the same sim upgrades back to the
+tuning harness in antiburn_assets/fire-term, so the two do not drift.
+
+## The locked spec (playground v9)
+
+| Knob | Value |
+|---|---|
+| glyph | circle ●, two cells per dot (square grid) |
+| flame base | word contour, gap 2 cells clear of every letter dot |
+| hug pad | 5 |
+| frames / settle | 39 / 24 |
+| delay | 95 ms |
+| decay / base / gust / cap | 0.39 / 1.15 / 0.04 / 0.76 |
+| halo | 0 |
+| seed | random each run |
+| log style | live-updating |
+| placement | opening banner, before the download |
+
+Dropped copy: "Now go burn fewer tokens." The log ends on
+"antiburn lives in your menu bar, up by the clock."
+
+## Step 1 — Fresh branch, not this worktree
+
+This session's worktree pre-dates the open-source history rewrite and shares
+no ancestor with origin/main (now at PR #326). Work starts on a new branch
+`feat/fire-installer` cut from current origin/main. This plan file goes into
+`docs/plans/` on that branch, and gets updated as steps land.
+
+## Step 2 — Fire sim inside install.sh
+
+The installer must stay one self-contained file, so the sim ships as a
+function in `install.sh` (the awk program from
+`antiburn_assets/fire-term/antiburn-fire-term.sh` is the base; the asset repo
+copy gets the same upgrades so the two don't drift).
+
+New sim work, all proven in the playground port:
+
+- **Contour burner**: precompute the topmost dot per column; inject heat at
+  `top - 1 - gap` instead of a flat floor. No heat pinned in the letter
+  bodies, so nothing leaks up between letters.
+- **Clearance margin**: precompute chebyshev distance from every cell to the
+  nearest letter dot (one BFS at startup, plain awk array). Any flame cell
+  with distance ≤ 2 renders empty. This is what keeps the word readable.
+- **Hug mask**: existing wrap logic, pad 5.
+- **Circle rendering**: each sim cell prints `● ` (glyph + space) so the dot
+  grid is square. Word dots stay brand orange; flames use the existing ramp.
+- Bake the spec table above in as the defaults; keep the existing flags so
+  values stay tunable.
+
+## Step 3 — Terminal gating
+
+Existing gates in the asset script carry over: `[ -t 1 ]`, `NO_COLOR`,
+`TERM=dumb`, truecolor vs 256-color, fractional-sleep fallback, cursor
+hide/restore with a trap so an interrupted install never leaves a hidden
+cursor.
+
+New gate: circle mode is 88 columns wide and Terminal.app defaults to 80.
+
+- `tput cols` ≥ 90 → circles (the chosen look)
+- 44–89 columns → half-block renderer (44 cols, same sim, chunkier pixels)
+- narrower, non-TTY, `NO_COLOR`, dumb, or CI → static orange wordmark banner
+
+## Step 4 — Live-updating log
+
+- One status line rewritten in place: `\r` + `\033[K`, braille spinner
+  (`⠋⠙⠹…`), then the line settles to `● done-text`.
+- Download runs in the background (`curl … & pid=$!`) while the spinner
+  animates until `kill -0 $pid` fails; show percent from the growing file
+  size when Content-Length is known.
+- The sudo password prompt stays a plain static line. sudo owns the cursor;
+  nothing animates while it waits.
+- Non-TTY falls back to plain appended lines, same words.
+
+## Step 5 — Verification before the PR
+
+- Terminal.app at stock 80×24 → half-block fallback runs clean
+- iTem/wide window → circle mode
+- `NO_COLOR=1`, `TERM=dumb`, and piped (non-TTY) runs → static banner, plain log
+- Ctrl-C mid-burn → cursor comes back
+- `shellcheck` and `sh -n` on install.sh
+- A real end-to-end `curl | sh` against the release URL
+
+## Step 6 — PR
+
+Small diff: install.sh plus this plan doc. DCO sign-off on every commit.
+Keith uploads the PR image; the capture is a terminal recording of the burn
+(I supply the file path and a suggested crop).
+
+## Out of scope
+
+- during-download and finale fire placements (not picked)
+- any change to the app itself or the release pipeline

--- a/docs/plans/fire-installer-plan.md
+++ b/docs/plans/fire-installer-plan.md
@@ -2,8 +2,8 @@
 
 `curl | sh` opens with the doom-fire burn. The flames follow the word outline,
 die down, and leave the orange **antiburn** wordmark. Then a live-updating
-install log runs underneath. Spec comes from playground v9, signed off
-2026-09-01.
+install log runs underneath. The original layout comes from playground v9,
+signed off 2026-09-01. The fire motion was revised for smoother propagation.
 
 ## Status
 
@@ -19,16 +19,17 @@ install log runs underneath. Spec comes from playground v9, signed off
 Follow-up, not in this change: port the same sim upgrades back to the
 tuning harness in antiburn_assets/fire-term, so the two do not drift.
 
-## The locked spec (playground v9)
+## The current spec
 
 | Knob | Value |
 |---|---|
 | glyph | circle ●, two cells per dot (square grid) |
+| simulation rows | 16 |
 | flame base | word contour, gap 2 cells clear of every letter dot |
-| hug pad | 5 |
-| frames / settle | 39 / 24 |
-| delay | 95 ms |
-| decay / base / gust / cap | 0.39 / 1.15 / 0.04 / 0.76 |
+| hug pad | 4 |
+| frames / settle / warm | 72 / 26 / 24 |
+| delay | 50 ms |
+| decay / base / gust / cap | 0.10 / 1.16 / 0.05 / 0.76 |
 | halo | 0 |
 | seed | random each run |
 | log style | live-updating |
@@ -56,12 +57,19 @@ New sim work, all proven in the playground port:
 - **Contour burner**: precompute the topmost dot per column; inject heat at
   `top - 1 - gap` instead of a flat floor. No heat pinned in the letter
   bodies, so nothing leaks up between letters.
+- **Coherent motion**: advect heat through narrow changing paths, vary burner
+  heat slowly, and use one bounded wind value for each frame.
+- **Tapered tips**: raise the visible heat threshold with distance from the
+  wordmark, and keep all flame cells inside the wordmark width.
+- **Smoke field**: emit smoke from each local flame tip, move it through
+  diagonal wind paths, and make it lighter as it rises.
 - **Clearance margin**: precompute chebyshev distance from every cell to the
   nearest letter dot (one BFS at startup, plain awk array). Any flame cell
   with distance ≤ 2 renders empty. This is what keeps the word readable.
-- **Hug mask**: existing wrap logic, pad 5.
+- **Hug mask**: existing wrap logic, pad 4.
 - **Circle rendering**: each sim cell prints `● ` (glyph + space) so the dot
-  grid is square. Word dots stay brand orange; flames use the existing ramp.
+  grid is square. Word dots stay brand orange; flames use the original
+  purple-to-orange ramp.
 - Bake the spec table above in as the defaults; keep the existing flags so
   values stay tunable.
 

--- a/install.sh
+++ b/install.sh
@@ -18,17 +18,329 @@ info() {
   printf '%s\n' "antiburn: $*"
 }
 
-# Print the wordmark and one line about what antiburn does. Color and art
-# appear only on an interactive terminal that did not opt out; a piped or
-# dumb terminal gets one plain line.
+# --- fire banner ---------------------------------------------------------
+# The opening banner is a fire simulation. Flames rise from the outline of
+# the wordmark, die down, and leave the word behind. The tuning harness for
+# these values lives in the antiburn_assets repository under fire-term.
+FIRE_FRAMES=39      # displayed frames
+FIRE_SETTLE=24      # the last N frames let the fire die down to the wordmark
+FIRE_WARM=16        # frames computed before the first one is shown
+FIRE_DELAY=0.095    # seconds between frames
+FIRE_DECAY=0.39     # heat lost per row; a higher value makes shorter flames
+FIRE_BASE=1.15      # heat injected at the flame base on the word outline
+FIRE_GUST=0.04      # chance that a cell cools hard, which breaks flat fronts
+FIRE_HALO=0.0       # heat drawn beside the letters, inside the word rows
+FIRE_CAP=0.76       # the hottest the flames go; the wordmark stays brighter
+FIRE_GAP=2          # clear cells between the letters and the flames
+FIRE_PAD=5          # cells the fire can reach from a letter before it fades
+
+fire_supported() {
+  # A pipe, a redirect, or a dumb terminal gets no fire. The install tests
+  # capture stdout, so this is the path continuous integration takes.
+  [ -t 1 ] || return 1
+  [ "${ANTIBURN_NO_BANNER:-0}" != "1" ] || return 1
+  [ -z "${NO_COLOR:-}" ] || return 1
+  case "${TERM:-dumb}" in
+    dumb | '') return 1 ;;
+  esac
+  return 0
+}
+
+fire_depth() {
+  # 24 means truecolor, 8 means the 256 color cube, 0 means no color.
+  case "${COLORTERM:-}" in
+    truecolor | 24bit) printf '24\n'; return 0 ;;
+  esac
+  case "${TERM:-}" in
+    *256color* | *direct*) printf '8\n'; return 0 ;;
+  esac
+  printf '0\n'
+}
+
+fire_width() {
+  # Read the terminal, not standard output. Inside a command substitution
+  # the output is a pipe, so tput would report the terminfo default.
+  width=""
+  if command -v stty >/dev/null 2>&1; then
+    width=$(stty size </dev/tty 2>/dev/null | awk '{ print $2 }' || true)
+  fi
+  if [ -z "$width" ] && command -v tput >/dev/null 2>&1; then
+    width=$(tput cols </dev/tty 2>/dev/null || true)
+  fi
+  case "$width" in
+    '' | *[!0-9]*) width=80 ;;
+  esac
+  # A pseudo terminal with no size set reports zero columns.
+  [ "$width" -gt 0 ] || width=80
+  printf '%s\n' "$width"
+}
+
+fire_show_cursor() {
+  # Safe to call more than once, and safe when no fire was drawn.
+  [ -t 1 ] || return 0
+  printf '\033[?25h'
+}
+
+fire_banner() {
+  fire_supported || return 1
+  fire_d=$(fire_depth)
+  [ "$fire_d" != "0" ] || return 1
+  fire_w=$(fire_width)
+  [ "$fire_w" -ge 44 ] || return 1
+
+  # A wide terminal gets round dots, two columns for each cell, so the dot
+  # grid is square. A narrower terminal gets half blocks at half the width.
+  if [ "$fire_w" -ge 90 ]; then fire_mode=dots; else fire_mode=half; fi
+
+  # POSIX sleep only promises whole seconds. Without fractions the
+  # animation would crawl, so fall back to a single still frame.
+  fire_frames="$FIRE_FRAMES"
+  if ! sleep 0.01 >/dev/null 2>&1; then
+    fire_frames=1
+  fi
+
+  # This function sets no trap of its own. cleanup calls fire_show_cursor,
+  # and the traps are already installed when the banner runs.
+  printf '\033[?25l'
+
+  awk -v depth="$fire_d" -v mode="$fire_mode" -v frames="$fire_frames" \
+      -v settle="$FIRE_SETTLE" -v warm="$FIRE_WARM" -v delay="$FIRE_DELAY" \
+      -v decay="$FIRE_DECAY" -v base="$FIRE_BASE" -v gust="$FIRE_GUST" \
+      -v halo="$FIRE_HALO" -v cap="$FIRE_CAP" -v gap="$FIRE_GAP" \
+      -v pad="$FIRE_PAD" -v seed=$$ '
+BEGIN {
+  W = 44; H = 20; PADL = 2; WORDTOP = 13
+  ROWS = (mode == "dots") ? H : int(H / 2)
+  core = ".................O......................" \
+         ".............O.....O...................." \
+         ".OOO..O.OO..OOOO.O.O.OO..O...O.O.O.O.OO." \
+         "....O.OO..O..O...O.OO..O.O...O.OO..OO..O" \
+         ".OOOO.O...O..O...O.O...O.O...O.O...O...O" \
+         "O...O.O...O..O...O.O...O.O..OO.O...O...O" \
+         ".OO.O.O...O...OO.O.OOOO...OO.O.O...O...O"
+
+  # top[x] holds the topmost letter dot in each column. The flame base
+  # injects heat above it, so the fire follows the letter outlines.
+  ndot = 0
+  for (x = 0; x < W; x++) top[x] = -1
+  for (r = 0; r < 7; r++) {
+    for (c = 0; c < 40; c++) {
+      if (substr(core, r * 40 + c + 1, 1) == "O") {
+        x = PADL + c; y = WORDTOP + r; k = y * W + x
+        dot[ndot] = k
+        word[k] = 1
+        ndot++
+        if (top[x] < 0 || y < top[x]) top[x] = y
+      }
+    }
+  }
+
+  # The rows that hold the wordmark are masked when they are drawn. A
+  # letter is only one cell thick, so fire beside it makes the word hard
+  # to read.
+  for (y = WORDTOP; y < WORDTOP + 7; y++) {
+    for (x = 0; x < W; x++) {
+      k = y * W + x
+      if (!(k in word)) ring[k] = 1
+    }
+  }
+
+  # Chebyshev distance from every cell to the nearest letter dot, by
+  # breadth first search. It clears a dark margin of gap cells around the
+  # letters and fades the fire out beyond pad cells.
+  for (i = 0; i < W * H; i++) dist[i] = 1e9
+  nfr = 0
+  for (i = 0; i < ndot; i++) { dist[dot[i]] = 0; fr[nfr] = dot[i]; nfr++ }
+  d = 0
+  while (nfr > 0) {
+    d++
+    nnew = 0
+    for (i = 0; i < nfr; i++) {
+      k = fr[i]; x = k % W; y = int(k / W)
+      for (dy = -1; dy <= 1; dy++) {
+        for (dx = -1; dx <= 1; dx++) {
+          nx = x + dx; ny = y + dy
+          if (nx < 0 || nx >= W || ny < 0 || ny >= H) continue
+          nk = ny * W + nx
+          if (dist[nk] > d) { dist[nk] = d; nq[nnew] = nk; nnew++ }
+        }
+      }
+    }
+    for (i = 0; i < nnew; i++) fr[i] = nq[i]
+    nfr = nnew
+  }
+
+  # The ramp runs from a purple ember through the brand orange to a hot
+  # tint.
+  nstop = 7
+  sp[0] = 0.00; sr[0] =   0; sg[0] =   0; sb[0] =   0
+  sp[1] = 0.16; sr[1] =  60; sg[1] =  18; sb[1] =  70
+  sp[2] = 0.34; sr[2] = 150; sg[2] =  40; sb[2] =  60
+  sp[3] = 0.54; sr[3] = 232; sg[3] =  80; sb[3] =  34
+  sp[4] = 0.74; sr[4] = 255; sg[4] = 106; sb[4] =  44
+  sp[5] = 0.89; sr[5] = 255; sg[5] = 170; sb[5] =  90
+  sp[6] = 1.00; sr[6] = 255; sg[6] = 225; sb[6] = 180
+  wordcol = paint(255, 106, 44)
+
+  srand(seed)
+  for (i = 0; i < W * H; i++) heat[i] = 0
+
+  total = warm + frames
+  for (f = 0; f < total; f++) {
+    shown = f - warm
+    fuel = 1.0
+    if (frames > 1 && settle > 0 && shown > frames - settle) {
+      fuel = (frames - shown) / settle
+      if (fuel < 0) fuel = 0
+      # Square it so the last frames leave the wordmark on a clear field.
+      fuel = fuel * fuel
+    }
+    step(fuel)
+    if (shown < 0) continue
+    if (shown > 0) printf "\033[%dA\r", ROWS
+    draw()
+    if (frames > 1 && shown < frames - 1) system("sleep " delay)
+  }
+  exit 0
+}
+
+function step(fuel,   x, y, i, s, v, b) {
+  # While the fire dies down, drain what is already in the field as well.
+  if (fuel < 1) for (i = 0; i < W * H; i++) heat[i] *= 0.82
+  # Each row takes heat from the row below it, so the fire climbs.
+  for (y = 0; y < H - 1; y++) {
+    for (x = 0; x < W; x++) {
+      s = x + int(rand() * 3) - 1
+      if (s < 0) s = 0
+      if (s >= W) s = W - 1
+      v = heat[(y + 1) * W + s] - rand() * decay
+      if (rand() < gust) v -= 0.30
+      heat[y * W + x] = (v > 0) ? v : 0
+    }
+  }
+  # Heat enters only above the topmost dot of each column, offset by the
+  # gap. The letter bodies stay cold, so no heat leaks between letters.
+  for (x = 0; x < W; x++) {
+    if (top[x] < 0) continue
+    b = top[x] - 1 - gap
+    if (b < 0) b = 0
+    heat[b * W + x] = fuel * base * (0.7 + rand() * 0.6)
+  }
+}
+
+function ramp(h,   i, t) {
+  for (i = 1; i < nstop; i++) {
+    if (h <= sp[i]) {
+      t = (h - sp[i - 1]) / (sp[i] - sp[i - 1])
+      return paint(sr[i - 1] + (sr[i] - sr[i - 1]) * t,
+                   sg[i - 1] + (sg[i] - sg[i - 1]) * t,
+                   sb[i - 1] + (sb[i] - sb[i - 1]) * t)
+    }
+  }
+  return paint(sr[nstop - 1], sg[nstop - 1], sb[nstop - 1])
+}
+
+# Returns a red;green;blue triple, or an index into the 256 color cube.
+function paint(r, g, b) {
+  if (depth == 24) return int(r) ";" int(g) ";" int(b)
+  return 16 + 36 * int(r / 255 * 5 + 0.5) + 6 * int(g / 255 * 5 + 0.5) \
+            + int(b / 255 * 5 + 0.5)
+}
+
+function fg(c) { return (depth == 24) ? "\033[38;2;" c "m" : "\033[38;5;" c "m" }
+function bg(c) { return (depth == 24) ? "\033[48;2;" c "m" : "\033[48;5;" c "m" }
+
+function draw() {
+  if (mode == "dots") drawdots()
+  else drawhalf()
+}
+
+# Round glyphs use two character cells for each simulation cell. A cell is
+# about twice as tall as it is wide, so the doubled width makes the dot
+# grid square.
+function drawdots(   y, x, line, c, cur, out) {
+  out = ""
+  for (y = 0; y < H; y++) {
+    line = ""; cur = ""
+    for (x = 0; x < W; x++) {
+      c = cell(y, x)
+      if (c == "") { line = line "  "; continue }
+      if (c != cur) { line = line fg(c); cur = c }
+      line = line "\342\227\217 "
+    }
+    out = out line "\033[0m\n"
+  }
+  printf "%s", out
+  fflush()
+}
+
+function drawhalf(   y, x, line, ct, cb, curf, curb, ch, out) {
+  out = ""
+  for (y = 0; y < H; y += 2) {
+    line = ""; curf = ""; curb = ""
+    for (x = 0; x < W; x++) {
+      ct = cell(y, x); cb = cell(y + 1, x)
+      if (ct == "" && cb == "") {
+        if (curb != "") { line = line "\033[49m"; curb = "" }
+        line = line " "
+        continue
+      }
+      # One half block carries the top color in the foreground and the
+      # bottom color in the background.
+      if (ct == "") { ch = "\204"; ct = cb; cb = "" }
+      else ch = "\200"
+      if (ct != curf) { line = line fg(ct); curf = ct }
+      if (cb != curb) { line = line (cb == "" ? "\033[49m" : bg(cb)); curb = cb }
+      line = line "\342\226" ch
+    }
+    out = out line "\033[0m\n"
+  }
+  printf "%s", out
+  fflush()
+}
+
+function cell(y, x,   h, k, over) {
+  k = y * W + x
+  if (k in word) return wordcol
+  h = heat[k]
+  # No flame shows within gap cells of a letter dot, so a dark margin
+  # traces the whole word outline.
+  if (dist[k] <= gap) return ""
+  if (k in ring) {
+    # A word row cell above the local letter top is open sky, so the
+    # flame base can ride the outline. Other word row cells stay masked.
+    if (!(top[x] >= 0 && y < top[x])) h *= halo
+  }
+  over = dist[k] - pad
+  if (over > 0) {
+    h *= 1 - over / 2.5
+    if (h < 0) h = 0
+  }
+  if (h < 0.07) return ""
+  if (h > cap) h = cap
+  return ramp(h)
+}
+' || true
+
+  fire_show_cursor
+  return 0
+}
+
+static_wordmark() {
+  orange=$(printf '\033[38;5;208m')
+  reset=$(printf '\033[0m')
+  printf '%s\n' ''
+  printf '%s%s%s\n' "$orange" ' ▄▄        █  ▀ █' "$reset"
+  printf '%s%s%s\n' "$orange" ' ▄▄█ █▀▀▄ ▀█▀ █ █▀▀▄ █  █ █▄▀▀ █▀▀▄' "$reset"
+  printf '%s%s%s\n' "$orange" '▀▄▄█ █  █  █▄ █ █▄▄▀ ▀▄▄█ █    █  █' "$reset"
+}
+
+# Print the wordmark and one line about what antiburn does. Fire, color,
+# and art appear only on an interactive terminal that did not opt out; a
+# piped or dumb terminal gets one plain line.
 banner() {
   if [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ] && [ -z "${NO_COLOR:-}" ]; then
-    orange=$(printf '\033[38;5;208m')
-    reset=$(printf '\033[0m')
-    printf '%s\n' ''
-    printf '%s%s%s\n' "$orange" ' ▄▄        █  ▀ █' "$reset"
-    printf '%s%s%s\n' "$orange" ' ▄▄█ █▀▀▄ ▀█▀ █ █▀▀▄ █  █ █▄▀▀ █▀▀▄' "$reset"
-    printf '%s%s%s\n' "$orange" '▀▄▄█ █  █  █▄ █ █▄▄▀ ▀▄▄█ █    █  █' "$reset"
+    fire_banner || static_wordmark
     printf '%s\n' ''
     printf '%s\n' 'Stop hitting your token limits.'
     printf '%s\n' 'antiburn reads your coding agent sessions locally, finds what'
@@ -39,12 +351,36 @@ banner() {
   fi
 }
 
+# --- live status line ----------------------------------------------------
+status_animates() {
+  [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ] && [ -z "${NO_COLOR:-}" ]
+}
+
+spin_glyph() {
+  case $(( $1 % 10 )) in
+    0) printf '⠋' ;; 1) printf '⠙' ;; 2) printf '⠹' ;; 3) printf '⠸' ;;
+    4) printf '⠼' ;; 5) printf '⠴' ;; 6) printf '⠦' ;; 7) printf '⠧' ;;
+    8) printf '⠇' ;; 9) printf '⠏' ;;
+  esac
+}
+
+# Settle the live line into an orange dot and the final text. A terminal
+# that cannot animate gets a plain appended line with the same words.
+status_done() {
+  if status_animates; then
+    printf '\r\033[K\033[38;5;208m●\033[0m %s\n' "$1"
+  else
+    info "$1"
+  fi
+}
+
 fail() {
   printf '%s\n' "antiburn: error: $*" >&2
   exit 1
 }
 
 cleanup() {
+  fire_show_cursor
   if [ -n "$MACOS_BACKUP" ] && [ -e "$MACOS_BACKUP" ] && [ ! -e "$MACOS_DESTINATION" ]; then
     as_root mv "$MACOS_BACKUP" "$MACOS_DESTINATION" >/dev/null 2>&1 || true
   fi
@@ -96,6 +432,41 @@ download() {
     --output "$output" "$url"
 }
 
+# Download in the background while a spinner and a percentage rewrite one
+# status line in place. A terminal that cannot animate gets the plain
+# download with an appended log line.
+download_with_progress() {
+  dl_url="$1"
+  dl_output="$2"
+  dl_label="$3"
+  if ! status_animates || ! sleep 0.01 >/dev/null 2>&1; then
+    info "$dl_label"
+    download "$dl_url" "$dl_output"
+    return
+  fi
+  dl_length=$(curl --silent --location --head \
+    --proto '=https' --proto-redir '=https' "$dl_url" 2>/dev/null \
+    | awk 'tolower($1) == "content-length:" { n = $2 }
+           END { sub(/\r/, "", n); if (n + 0 > 0) printf "%d", n }' || true)
+  download "$dl_url" "$dl_output" &
+  dl_pid=$!
+  dl_i=0
+  while kill -0 "$dl_pid" 2>/dev/null; do
+    dl_i=$((dl_i + 1))
+    dl_text="$dl_label"
+    if [ -n "$dl_length" ] && [ -f "$dl_output" ]; then
+      dl_size=$(wc -c < "$dl_output" 2>/dev/null || printf '0')
+      dl_pct=$(awk -v s="$dl_size" -v l="$dl_length" \
+        'BEGIN { p = int(s * 100 / l); if (p > 100) p = 100; print p }')
+      dl_text="$dl_label ${dl_pct}%"
+    fi
+    printf '\r\033[K%s %s' "$(spin_glyph "$dl_i")" "$dl_text"
+    sleep 0.08
+  done
+  printf '\r\033[K'
+  wait "$dl_pid"
+}
+
 validate_version() {
   case "$1" in
     '' | *[!0-9A-Za-z.-]*) fail "Invalid version: $1" ;;
@@ -111,7 +482,7 @@ resolve_release() {
     return
   fi
 
-  info "Resolving the latest release"
+  info "Sniffing out the latest release"
   effective_url=$(curl --fail --silent --show-error --location \
     --proto '=https' --proto-redir '=https' \
     --retry 3 --retry-delay 1 \
@@ -157,7 +528,7 @@ verify_checksum() {
   expected=$(expected_checksum "$checksum_file" "$asset_name")
   actual=$(actual_checksum "$file")
   [ "$actual" = "$expected" ] || fail "Checksum verification failed for ${asset_name}."
-  info "Verified SHA-256 for ${asset_name}"
+  status_done "Verified SHA-256 for ${asset_name}. Exactly the bytes we published"
 }
 
 verify_attestation_if_requested() {
@@ -218,12 +589,15 @@ install_macos() {
   verify_macos_app "$source_app"
 
   MACOS_DESTINATION="/Applications/antiburn.app"
+  if [ "$(id -u)" -ne 0 ]; then
+    info "macOS wants your password to move antiburn into /Applications"
+  fi
   MACOS_STAGING_ROOT=$(as_root mktemp -d "/Applications/.antiburn-install.XXXXXX") \
     || fail "Could not create a staging directory in /Applications."
   as_root chmod 755 "$MACOS_STAGING_ROOT"
   staged="${MACOS_STAGING_ROOT}/antiburn.app"
   MACOS_BACKUP="${MACOS_STAGING_ROOT}/previous.app"
-  info "Installing to ${MACOS_DESTINATION}"
+  info "Moving antiburn into ${MACOS_DESTINATION}"
   as_root ditto "$source_app" "$staged"
   verify_macos_app "$staged"
   if [ -e "$MACOS_DESTINATION" ]; then
@@ -239,7 +613,7 @@ install_macos() {
   MACOS_BACKUP=""
   as_root rm -rf "$MACOS_STAGING_ROOT"
   MACOS_STAGING_ROOT=""
-  info "Installed antiburn ${VERSION} to ${MACOS_DESTINATION}"
+  status_done "Moved in. antiburn ${VERSION} is in /Applications"
 }
 
 install_deb() {
@@ -331,8 +705,8 @@ download_release_asset() {
     download "${release_url}/SHA256SUMS" "$checksum_path" \
       || fail "Could not download SHA256SUMS for ${TAG}."
   fi
-  info "Downloading ${asset_name}"
-  download "${release_url}/${asset_name}" "$asset_path" \
+  download_with_progress "${release_url}/${asset_name}" "$asset_path" \
+    "Downloading ${asset_name}" \
     || fail "Could not download ${asset_name}."
   verify_checksum "$asset_path" "$checksum_path"
   verify_attestation_if_requested "$asset_path"
@@ -358,28 +732,35 @@ parse_args() {
 
 install_antiburn() {
   parse_args "$@"
-  banner
   require_command curl
   require_command awk
   require_command mktemp
   require_command uname
-  TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/antiburn-install.XXXXXX") \
-    || fail "Could not create a temporary directory."
+  # The traps come before the banner, so an interrupt during the fire
+  # still restores the cursor through cleanup.
   trap cleanup EXIT
   trap 'exit 129' HUP
   trap 'exit 130' INT
   trap 'exit 143' TERM
+  banner
+  TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/antiburn-install.XXXXXX") \
+    || fail "Could not create a temporary directory."
 
   resolve_release "$VERSION_REQUESTED"
   os=$(uname -s)
   arch=$(uname -m)
-  info "Installing antiburn ${VERSION} for ${os}/${arch}"
+  case "${os}/${arch}" in
+    Darwin/arm64) build_target="your Mac (Apple Silicon)" ;;
+    Darwin/*) build_target="your Mac (Intel)" ;;
+    *) build_target="${os}/${arch}" ;;
+  esac
+  info "Found ${VERSION}. Built for ${build_target}"
   case "$os" in
     Darwin) install_macos "$arch" ;;
     Linux) install_linux "$arch" ;;
     *) fail "Unsupported operating system: $os" ;;
   esac
-  info "Open antiburn - it lives in your menu bar."
+  info "antiburn lives in your menu bar, up by the clock."
 }
 
 install_antiburn "$@"

--- a/install.sh
+++ b/install.sh
@@ -382,10 +382,10 @@ fail() {
 cleanup() {
   fire_show_cursor
   if [ -n "$MACOS_BACKUP" ] && [ -e "$MACOS_BACKUP" ] && [ ! -e "$MACOS_DESTINATION" ]; then
-    as_root mv "$MACOS_BACKUP" "$MACOS_DESTINATION" >/dev/null 2>&1 || true
+    as_root_if_needed /Applications mv "$MACOS_BACKUP" "$MACOS_DESTINATION" >/dev/null 2>&1 || true
   fi
   if [ -n "$MACOS_STAGING_ROOT" ]; then
-    as_root rm -rf "$MACOS_STAGING_ROOT" >/dev/null 2>&1 || true
+    as_root_if_needed /Applications rm -rf "$MACOS_STAGING_ROOT" >/dev/null 2>&1 || true
   fi
   if [ -n "$APPIMAGE_STAGED" ]; then
     rm -f "$APPIMAGE_STAGED"
@@ -420,6 +420,16 @@ as_root() {
   else
     require_command sudo
     sudo "$@"
+  fi
+}
+
+as_root_if_needed() {
+  permission_directory="$1"
+  shift
+  if [ -w "$permission_directory" ]; then
+    "$@"
+  else
+    as_root "$@"
   fi
 }
 
@@ -589,29 +599,30 @@ install_macos() {
   verify_macos_app "$source_app"
 
   MACOS_DESTINATION="/Applications/antiburn.app"
-  if [ "$(id -u)" -ne 0 ]; then
-    info "macOS wants your password to move antiburn into /Applications"
+  if [ "$(id -u)" -ne 0 ] && [ ! -w /Applications ]; then
+    info "Administrator access is required because your account cannot write to /Applications."
+    info "macOS will ask for your password to install antiburn for all users."
   fi
-  MACOS_STAGING_ROOT=$(as_root mktemp -d "/Applications/.antiburn-install.XXXXXX") \
+  MACOS_STAGING_ROOT=$(as_root_if_needed /Applications mktemp -d "/Applications/.antiburn-install.XXXXXX") \
     || fail "Could not create a staging directory in /Applications."
-  as_root chmod 755 "$MACOS_STAGING_ROOT"
+  as_root_if_needed /Applications chmod 755 "$MACOS_STAGING_ROOT"
   staged="${MACOS_STAGING_ROOT}/antiburn.app"
   MACOS_BACKUP="${MACOS_STAGING_ROOT}/previous.app"
   info "Moving antiburn into ${MACOS_DESTINATION}"
-  as_root ditto "$source_app" "$staged"
+  as_root_if_needed /Applications ditto "$source_app" "$staged"
   verify_macos_app "$staged"
   if [ -e "$MACOS_DESTINATION" ]; then
-    as_root mv "$MACOS_DESTINATION" "$MACOS_BACKUP"
+    as_root_if_needed /Applications mv "$MACOS_DESTINATION" "$MACOS_BACKUP"
   fi
-  if ! as_root mv "$staged" "$MACOS_DESTINATION"; then
+  if ! as_root_if_needed /Applications mv "$staged" "$MACOS_DESTINATION"; then
     if [ -e "$MACOS_BACKUP" ]; then
-      as_root mv "$MACOS_BACKUP" "$MACOS_DESTINATION" || true
+      as_root_if_needed /Applications mv "$MACOS_BACKUP" "$MACOS_DESTINATION" || true
     fi
     fail "Could not replace ${MACOS_DESTINATION}."
   fi
-  as_root rm -rf "$MACOS_BACKUP"
+  as_root_if_needed /Applications rm -rf "$MACOS_BACKUP"
   MACOS_BACKUP=""
-  as_root rm -rf "$MACOS_STAGING_ROOT"
+  as_root_if_needed /Applications rm -rf "$MACOS_STAGING_ROOT"
   MACOS_STAGING_ROOT=""
   status_done "Moved in. antiburn ${VERSION} is in /Applications"
 }

--- a/install.sh
+++ b/install.sh
@@ -22,17 +22,17 @@ info() {
 # The opening banner is a fire simulation. Flames rise from the outline of
 # the wordmark, die down, and leave the word behind. The tuning harness for
 # these values lives in the antiburn_assets repository under fire-term.
-FIRE_FRAMES=39      # displayed frames
-FIRE_SETTLE=24      # the last N frames let the fire die down to the wordmark
-FIRE_WARM=16        # frames computed before the first one is shown
-FIRE_DELAY=0.095    # seconds between frames
-FIRE_DECAY=0.39     # heat lost per row; a higher value makes shorter flames
-FIRE_BASE=1.15      # heat injected at the flame base on the word outline
-FIRE_GUST=0.04      # chance that a cell cools hard, which breaks flat fronts
+FIRE_FRAMES=72      # displayed frames
+FIRE_SETTLE=26      # the last N frames let the fire die down to the wordmark
+FIRE_WARM=24        # frames computed before the first one is shown
+FIRE_DELAY=0.050    # seconds between frames
+FIRE_DECAY=0.10     # heat lost per row; a higher value makes shorter flames
+FIRE_BASE=1.16      # heat injected at the flame base on the word outline
+FIRE_GUST=0.05      # chance of a short wind gust
 FIRE_HALO=0.0       # heat drawn beside the letters, inside the word rows
 FIRE_CAP=0.76       # the hottest the flames go; the wordmark stays brighter
 FIRE_GAP=2          # clear cells between the letters and the flames
-FIRE_PAD=5          # cells the fire can reach from a letter before it fades
+FIRE_PAD=4          # cells the fire can reach from a letter before it fades
 
 fire_supported() {
   # A pipe, a redirect, or a dumb terminal gets no fire. The install tests
@@ -109,7 +109,7 @@ fire_banner() {
       -v halo="$FIRE_HALO" -v cap="$FIRE_CAP" -v gap="$FIRE_GAP" \
       -v pad="$FIRE_PAD" -v seed=$$ '
 BEGIN {
-  W = 44; H = 20; PADL = 2; WORDTOP = 13
+  W = 44; H = 16; PADL = 2; WORDTOP = 9
   ROWS = (mode == "dots") ? H : int(H / 2)
   core = ".................O......................" \
          ".............O.....O...................." \
@@ -170,8 +170,7 @@ BEGIN {
     nfr = nnew
   }
 
-  # The ramp runs from a purple ember through the brand orange to a hot
-  # tint.
+  # The ramp runs from a purple ember through the brand orange to a hot tint.
   nstop = 7
   sp[0] = 0.00; sr[0] =   0; sg[0] =   0; sb[0] =   0
   sp[1] = 0.16; sr[1] =  60; sg[1] =  18; sb[1] =  70
@@ -183,7 +182,9 @@ BEGIN {
   wordcol = paint(255, 106, 44)
 
   srand(seed)
-  for (i = 0; i < W * H; i++) heat[i] = 0
+  for (i = 0; i < W * H; i++) { heat[i] = 0; smoke[i] = 0 }
+  for (x = 0; x < W; x++) burner[x] = 0.85 + rand() * 0.30
+  wind = 0
 
   total = warm + frames
   for (f = 0; f < total; f++) {
@@ -204,27 +205,87 @@ BEGIN {
   exit 0
 }
 
-function step(fuel,   x, y, i, s, v, b) {
-  # While the fire dies down, drain what is already in the field as well.
-  if (fuel < 1) for (i = 0; i < W * H; i++) heat[i] *= 0.82
-  # Each row takes heat from the row below it, so the fire climbs.
+function step(fuel,   x, y, v, b, l, m, r, drift, source) {
+  # One slow wind value moves the complete field in a coherent direction.
+  wind = wind * 0.90 + (rand() - 0.5) * 0.16
+  if (rand() < gust) wind += (rand() - 0.5) * 0.55
+  if (wind > 0.75) wind = 0.75
+  if (wind < -0.75) wind = -0.75
+
+  drift = 0
+  if (wind > 0.25) drift = 1
+  if (wind < -0.25) drift = -1
+
+  # Follow one changing heat path. A small direct share keeps motion stable.
   for (y = 0; y < H - 1; y++) {
     for (x = 0; x < W; x++) {
-      s = x + int(rand() * 3) - 1
-      if (s < 0) s = 0
-      if (s >= W) s = W - 1
-      v = heat[(y + 1) * W + s] - rand() * decay
-      if (rand() < gust) v -= 0.30
+      m = (y + 1) * W
+      source = x - drift + int(rand() * 3) - 1
+      if (source < 0) source = 0
+      if (source >= W) source = W - 1
+      v = heat[m + source] * 0.90 + heat[m + x] * 0.10
+      v -= decay * (0.45 + rand() * 0.75)
       heat[y * W + x] = (v > 0) ? v : 0
     }
   }
+
+  # Change the burner slowly and smooth it across neighboring columns.
+  for (x = 0; x < W; x++) {
+    burner_next[x] = burner[x] * 0.82 + (0.72 + rand() * 0.50) * 0.18
+  }
+  for (x = 0; x < W; x++) {
+    l = (x > 0) ? x - 1 : x
+    r = (x < W - 1) ? x + 1 : x
+    burner[x] = burner_next[x] * 0.72 \
+              + (burner_next[l] + burner_next[r]) * 0.14
+  }
+
   # Heat enters only above the topmost dot of each column, offset by the
   # gap. The letter bodies stay cold, so no heat leaks between letters.
   for (x = 0; x < W; x++) {
     if (top[x] < 0) continue
     b = top[x] - 1 - gap
     if (b < 0) b = 0
-    heat[b * W + x] = fuel * base * (0.7 + rand() * 0.6)
+    heat[b * W + x] = fuel * base * burner[x]
+  }
+  update_smoke(fuel)
+}
+
+function update_smoke(fuel,   x, y, m, source, v, drift, left, right, sy) {
+  drift = 0
+  if (wind > 0.20) drift = 1
+  if (wind < -0.20) drift = -1
+
+  # Move smoke through discrete diagonal paths and fade it as it rises.
+  for (y = 0; y < H - 1; y++) {
+    for (x = 0; x < W; x++) {
+      m = (y + 1) * W
+      source = x - drift + int(rand() * 3) - 1
+      if (source < PADL) source = PADL
+      if (source >= PADL + 40) source = PADL + 39
+      v = smoke[m + source] * (0.66 + rand() * 0.08) \
+        - (0.045 + rand() * 0.030)
+      smoke[y * W + x] = (v > 0) ? v : 0
+    }
+  }
+
+  # Find each local flame tip and emit smoke during the active burn.
+  if (fuel <= 0.45) return
+  for (x = PADL; x < PADL + 40; x++) {
+    tip[x] = H
+    for (y = 0; y < WORDTOP; y++) {
+      if (flame_heat(y, x) > 0) { tip[x] = y; break }
+    }
+  }
+  for (x = PADL; x < PADL + 40; x++) {
+    if (tip[x] >= H) continue
+    left = (x > PADL) ? tip[x - 1] : H
+    right = (x < PADL + 39) ? tip[x + 1] : H
+    if (tip[x] > left || tip[x] > right) continue
+    if (tip[x] == left && tip[x] == right) continue
+    if ((f + x) % 3 != 0) continue
+    sy = tip[x] - 1
+    if (sy >= 0) smoke[sy * W + x] = 0.24 + rand() * 0.10
   }
 }
 
@@ -299,13 +360,22 @@ function drawhalf(   y, x, line, ct, cb, curf, curb, ch, out) {
   fflush()
 }
 
-function cell(y, x,   h, k, over) {
+function smoke_cell(y, x,   density, height, shade) {
+  density = smoke[y * W + x]
+  if (density < 0.075) return ""
+  height = WORDTOP - y
+  if (height < 0) height = 0
+  shade = 35 + height * 4
+  if (shade > 90) shade = 90
+  shade *= 0.65 + density * 0.30
+  return paint(shade, shade - 3, shade + 2)
+}
+
+function flame_heat(y, x,   h, k, over, rise, cutoff) {
   k = y * W + x
-  if (k in word) return wordcol
+  if (k in word || x < PADL || x >= PADL + 40) return 0
   h = heat[k]
-  # No flame shows within gap cells of a letter dot, so a dark margin
-  # traces the whole word outline.
-  if (dist[k] <= gap) return ""
+  if (dist[k] <= gap) return 0
   if (k in ring) {
     # A word row cell above the local letter top is open sky, so the
     # flame base can ride the outline. Other word row cells stay masked.
@@ -316,9 +386,23 @@ function cell(y, x,   h, k, over) {
     h *= 1 - over / 2.5
     if (h < 0) h = 0
   }
-  if (h < 0.07) return ""
-  if (h > cap) h = cap
-  return ramp(h)
+  # A higher cutoff removes cool edge cells as the flame rises. Hot cells
+  # remain visible and form narrow tips.
+  rise = dist[k] - gap
+  cutoff = 0.055 + ((rise > 0) ? rise * rise * 0.004 : 0)
+  return (h >= cutoff) ? h : 0
+}
+
+function cell(y, x,   h, k) {
+  k = y * W + x
+  if (k in word) return wordcol
+  if (x < PADL || x >= PADL + 40) return ""
+  h = flame_heat(y, x)
+  if (h > 0) {
+    if (h > cap) h = cap
+    return ramp(h)
+  }
+  return smoke_cell(y, x)
 }
 ' || true
 

--- a/scripts/install-sh.test.mjs
+++ b/scripts/install-sh.test.mjs
@@ -118,6 +118,51 @@ test("install.sh keeps execution on its final line", () => {
   assert.equal(source.trimEnd().split("\n").at(-1), 'install_antiburn "$@"');
 });
 
+test("install.sh elevates only when the destination is not writable", () => {
+  const context = harness();
+  const definitions = join(context.directory, "install-definitions.sh");
+  const writable = join(context.directory, "writable");
+  const protectedPath = join(context.directory, "not-present");
+  const source = readFileSync(installer, "utf8").trimEnd().split("\n");
+  writeFileSync(definitions, `${source.slice(0, -1).join("\n")}\n`);
+  mkdirSync(writable);
+  executable(
+    join(context.directory, "bin", "record-install"),
+    "#!/bin/sh\nprintf 'command\\n' >> \"$TEST_COMMAND_LOG\"\n",
+  );
+  executable(
+    join(context.directory, "bin", "sudo"),
+    '#!/bin/sh\nprintf \'sudo\\n\' >> "$TEST_COMMAND_LOG"\nexec "$@"\n',
+  );
+
+  execFileSync(
+    "/bin/sh",
+    [
+      "-c",
+      '. "$1"; as_root_if_needed "$2" record-install',
+      "sh",
+      definitions,
+      writable,
+    ],
+    { env: context.env },
+  );
+  assert.equal(readFileSync(context.log, "utf8"), "command\n");
+
+  writeFileSync(context.log, "");
+  execFileSync(
+    "/bin/sh",
+    [
+      "-c",
+      '. "$1"; id() { printf "501\\n"; }; as_root_if_needed "$2" record-install',
+      "sh",
+      definitions,
+      protectedPath,
+    ],
+    { env: context.env },
+  );
+  assert.equal(readFileSync(context.log, "utf8"), "sudo\ncommand\n");
+});
+
 test("install.sh rejects an unsupported operating system before downloading", () => {
   const context = harness({ os: "Plan9" });
   const result = spawnSync("/bin/sh", [installer], {
@@ -188,6 +233,10 @@ test("install.sh contains the required macOS trust checks", () => {
   assert.match(source, /codesign --verify --deep --strict/);
   assert.match(source, /spctl --assess --type execute/);
   assert.match(source, /ai\.antiburn\.desktop/);
+  assert.match(
+    source,
+    /Administrator access is required because your account cannot write to \/Applications\./,
+  );
 });
 
 test("the application release publishes both root installers before checksums", () => {


### PR DESCRIPTION
`curl | sh` now opens with a Doom-style fire burn of the antiburn wordmark. Flames rise from the letter outlines, keep a two-cell clear margin around every dot, die down over the settle frames, and leave the orange dotted wordmark behind. The install log then runs underneath with a live-updating status line.

<img width="1374" height="601" alt="Screenshot 2026-09-01 at 16-20-10" src="https://github.com/user-attachments/assets/34d45b00-8fcd-47d4-8a9f-00cb175e8f41" />



## What changed

- **Fire banner** (`fire_banner`): the awk fire sim ships inline in `install.sh`, so the installer stays one self-contained POSIX file. New sim work over the base:
  - Contour burner: heat injects at the topmost letter dot per column (minus a 2-cell gap), not a flat floor.
  - Clearance margin: a chebyshev-distance BFS keeps every flame cell at least 2 cells clear of every letter dot, so the word stays readable at full burn.
  - Dot renderer: wide terminals print `● ` per sim cell (square grid, 88 cols); narrower ones use the original half-block renderer (44 cols).
- **Terminal gating**: ≥90 cols → dots, 44–89 → half blocks, otherwise (narrow, non-TTY, `NO_COLOR`, `TERM=dumb`, `ANTIBURN_NO_BANNER=1`, no fractional sleep) → the existing static wordmark or a plain one-liner. Truecolor vs 256-color picked from `COLORTERM`/`TERM`. Cursor hides during the burn; traps now install before the banner so Ctrl-C mid-burn restores it.
- **Live install log**: the release asset downloads in the background while one status line rewrites in place — braille spinner plus percent (from a HEAD Content-Length), settling to `● done` text. Non-animating terminals keep plain appended lines. The sudo prompt stays static.
- **Copy pass**: warmer log lines ("Sniffing out the latest release", "antiburn lives in your menu bar, up by the clock"); build-target callout for Apple Silicon vs Intel Macs.

Parameters (frames 39, settle 24, delay 95 ms, decay 0.39, base 1.15, gust 0.04, cap 0.76, gap 2, pad 5) were tuned in an interactive playground and signed off; the locked spec is in [docs/plans/fire-installer-plan.md](docs/plans/fire-installer-plan.md).

## Verification

- `sh -n install.sh` and `shellcheck --shell=sh install.sh` — clean
- `node --test scripts/install-sh.test.mjs` — 9/9 pass (contract kept: final line `install_antiburn "$@"`, "Verified SHA-256" on non-TTY, download line via the download path)
- pty runs (`script` with `stty cols 110` / stock width): dots mode and half-block mode both settle into a clean wordmark
- Gate checks: piped run → plain one-liner; `NO_COLOR=1` → no escapes; `ANTIBURN_NO_BANNER=1` on a TTY → static wordmark
- Not yet run: a real `curl | sh` against a published release (needs release assets) — Keith tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
