### PR TITLE
Dismiss nudges when the tray icon is clicked

### DIFF
--- a/apps/desktop/src-tauri/src/nudges.rs
+++ b/apps/desktop/src-tauri/src/nudges.rs
@@ -72,6 +72,19 @@ pub fn init(app: &AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
+/// Dismiss the current nudge when the reader acknowledges it through the tray.
+pub fn dismiss(app: &AppHandle) {
+    let Some(manager) = app.try_state::<NudgeManager>() else {
+        return;
+    };
+    // A dismissed nudge can precede reveal. Spend its anchor before another nudge can take it.
+    if let Some(override_) = app.try_state::<AnchorOverride>() {
+        let _ = override_.take();
+    }
+    crate::popover::abandon_nudge_key_restoration(app);
+    manager.dismiss();
+}
+
 /// Deliver a nudge the policy layer already approved.
 ///
 /// Applies the reader's auto-dismiss preference to every nudge (the builder's

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -91,6 +91,10 @@ impl NudgeKeyHandoff {
         std::mem::take(&mut self.key_owned)
     }
 
+    fn abandon_restoration(&mut self) {
+        self.key_owned = false;
+    }
+
     fn cancel(&mut self) -> bool {
         let dismiss_now = self.key_owned && self.pending_popover_blurs == 0;
         self.clear();
@@ -495,6 +499,12 @@ impl PopoverState {
         self.nudge_key_handoff
             .lock()
             .is_ok_and(|mut handoff| handoff.on_expected_release())
+    }
+
+    fn abandon_nudge_key_restoration(&self) {
+        if let Ok(mut handoff) = self.nudge_key_handoff.lock() {
+            handoff.abandon_restoration();
+        }
     }
 
     fn cancel_nudge_key_handoff(&self) -> bool {
@@ -1197,10 +1207,9 @@ fn destroy_prewarm(app: &AppHandle) -> bool {
 }
 
 fn hide_window(app: &AppHandle) {
-    // A hidden popover has no key to take back: a nudge key release after
-    // this point must not resurrect focus.
+    // A hidden popover cannot take key back. Keep queued nudge blurs so delayed events stay suppressed.
     if let Some(state) = app.try_state::<PopoverState>() {
-        state.clear_nudge_key_handoff();
+        state.abandon_nudge_key_restoration();
     }
     let Some(window) = app.get_webview_window(LABEL) else {
         note_hidden(app);
@@ -1484,6 +1493,15 @@ pub fn refocus_after_nudge(app: &AppHandle) {
         && window.is_visible().unwrap_or(false)
     {
         let _ = window.set_focus();
+    }
+}
+
+/// Prevent a nudge release from refocusing the popover.
+///
+/// Keep queued popover blurs so delayed events remain part of the same handoff.
+pub fn abandon_nudge_key_restoration(app: &AppHandle) {
+    if let Some(state) = app.try_state::<PopoverState>() {
+        state.abandon_nudge_key_restoration();
     }
 }
 
@@ -2146,6 +2164,16 @@ mod tests {
         let mut handoff = NudgeKeyHandoff::default();
         assert!(handoff.begin_if_focused(true));
         assert!(handoff.on_expected_release());
+        assert!(handoff.on_popover_blur());
+        assert!(!handoff.on_popover_blur());
+    }
+
+    #[test]
+    fn a_tray_click_abandons_refocus_but_still_suppresses_the_queued_blur() {
+        let mut handoff = NudgeKeyHandoff::default();
+        assert!(handoff.begin_if_focused(true));
+        handoff.abandon_restoration();
+        assert!(!handoff.on_expected_release());
         assert!(handoff.on_popover_blur());
         assert!(!handoff.on_popover_blur());
     }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -18,7 +18,7 @@ use tauri::{Manager, Wry};
 
 #[cfg(debug_assertions)]
 use crate::commands;
-use crate::{popover, settings};
+use crate::{nudges, popover, settings};
 
 /// The tray item's id, and how anything else gets a handle back to it.
 pub const TRAY_ID: &str = "antiburn";
@@ -138,6 +138,8 @@ fn on_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
         ..
     } = event
     {
+        // The tray click acknowledges the nudge, even when it closes the popover.
+        nudges::dismiss(tray.app_handle());
         popover::toggle(tray.app_handle(), rect);
     }
 }


### PR DESCRIPTION
Fixes #300

## User impact

Clicking the tray icon now dismisses any current nudge before toggling the popover. This applies whether the click opens or closes the popover.

The dismissal clears the retained nudge payload so a webview reload cannot restore an acknowledged notification. On macOS, it also prevents the nudge's delayed key release from refocusing a popover the reader just closed.

Right-click menus and non-click open paths remain unchanged.

A separate follow-up PR will defer automated nudges generated while the popover is already open, then deliver fresh nudges after it closes. That proactive delivery policy is intentionally separate from this tray-click acknowledgement fix.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --release` — 674 passed
- `git diff --check`
- Built an updater-disabled release app successfully
- Manually verified on macOS that a Settings test notification dismisses when the tray icon is clicked and the popover toggles normally

## Privacy and performance

None. This changes only local window lifecycle and focus state. It adds no data access, network access, retained data, or background work.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
