### PR TITLE
chore: use target-pruning aislop fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@secretlint/secretlint-rule-preset-recommend": "13.0.5",
-    "aislop": "0.15.0",
+    "aislop": "github:daveslutzkin/aislop#caa0959",
     "secretlint": "13.0.5",
     "yaml": "^2.9.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 13.0.5
         version: 13.0.5
       aislop:
-        specifier: 0.15.0
-        version: 0.15.0(@types/react@19.2.18)
+        specifier: github:daveslutzkin/aislop#caa0959
+        version: https://codeload.github.com/daveslutzkin/aislop/tar.gz/caa0959c6a22ee8c6923cbb2360a9f0729e6ebc6(@types/react@19.2.18)
       secretlint:
         specifier: 13.0.5
         version: 13.0.5
@@ -1872,8 +1872,9 @@ packages:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
     engines: {node: '>=14.0'}
 
-  aislop@0.15.0:
-    resolution: {integrity: sha512-+NsoIWymGo6YYWcVYn4XPFWa2CpqWlACj3Nh5FQ1gZk+qNQjESr1Etdv1lBvVZHo1TxmQodgncwE+m1rBj+r9Q==}
+  aislop@https://codeload.github.com/daveslutzkin/aislop/tar.gz/caa0959c6a22ee8c6923cbb2360a9f0729e6ebc6:
+    resolution: {gitHosted: true, integrity: sha512-ppNtVE1zsw6hspj09HhifyH80bVglAS2R3n1RUfNN3JROdI8DwwayLorNs8/B8lHq+7Jp6m3NGihlxBifWnu4g==, tarball: https://codeload.github.com/daveslutzkin/aislop/tar.gz/caa0959c6a22ee8c6923cbb2360a9f0729e6ebc6}
+    version: 0.16.0
     engines: {node: '>=20'}
     hasBin: true
 
@@ -5137,7 +5138,7 @@ snapshots:
 
   adm-zip@0.6.0: {}
 
-  aislop@0.15.0(@types/react@19.2.18):
+  aislop@https://codeload.github.com/daveslutzkin/aislop/tar.gz/caa0959c6a22ee8c6923cbb2360a9f0729e6ebc6(@types/react@19.2.18):
     dependencies:
       '@biomejs/biome': 2.5.11
       '@clack/prompts': 1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,9 @@ minimumReleaseAgeExclude:
   - '@secretlint/walker@13.0.5'
   - secretlint@13.0.5
 
-# No dependency is allowed to run install scripts. If a future dependency
-# needs one, add it to `onlyBuiltDependencies` deliberately, with a note
-# saying what the script does.
+# The temporary aislop fork builds its CLI from the pinned source revision.
+allowBuilds:
+  aislop@https://codeload.github.com/daveslutzkin/aislop/tar.gz/caa0959c6a22ee8c6923cbb2360a9f0729e6ebc6: true
+
+# No other dependency can run an install script.
 onlyBuiltDependencies: []


### PR DESCRIPTION
## Summary

- Pin aislop to the fork revision containing the `target` directory prune fix.
- Allow only the exact pinned Git artifact to run its source build.
- Keep all other dependency install scripts disabled.

## User impact

Codex `PostToolUse` scans no longer traverse about 55 GB of Rust build outputs. On this checkout, the hook falls from about 40 seconds, which exceeded its 30-second timeout, to about 0.79 seconds.

This is temporary until [scanaislop/aislop#382](https://github.com/scanaislop/aislop/pull/382) is merged and released.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run slop`
- `pnpm run slop:all`
- `pnpm run secrets`
- Direct `PostToolUse` hook benchmark: about 0.79 seconds

## Privacy and performance

This change does not add data collection or change product behavior. It avoids scanning generated `target` contents and substantially reduces hook CPU and filesystem work.

## Known limits

The pinned fork needs the exact `allowBuilds` entry because the Git dependency builds `dist` from source. Remove the fork pin and the allowlist entry after an upstream release includes the fix.
