### PR TITLE
feat(desktop): export private diagnostic reports

### DIFF
--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,5 +1,7 @@
 include!("src/app_commands.rs");
 
+use std::fs;
+
 macro_rules! command_names {
     ($( $handler:path => $name:literal, )*) => {
         &[$($name),*]
@@ -7,6 +9,60 @@ macro_rules! command_names {
 }
 
 const APP_COMMANDS: &[&str] = with_app_commands!(command_names);
+
+fn command_permission_sources() -> Vec<String> {
+    ["capabilities", "permissions"]
+        .into_iter()
+        .flat_map(|directory| {
+            fs::read_dir(directory)
+                .unwrap_or_else(|error| panic!("failed to read {directory}: {error}"))
+        })
+        .filter_map(|entry| {
+            let path = entry
+                .expect("failed to read a permission source path")
+                .path();
+            path.is_file().then_some(path)
+        })
+        .map(|path| {
+            fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+        })
+        .collect()
+}
+
+fn contains_quoted_value(source: &str, expected: &str) -> bool {
+    source
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.starts_with('#'))
+        .any(|line| {
+            line.split('"')
+                .skip(1)
+                .step_by(2)
+                .any(|value| value == expected)
+        })
+}
+
+fn validate_command_permissions() {
+    let sources = command_permission_sources();
+    let missing = APP_COMMANDS
+        .iter()
+        .filter_map(|command| {
+            let permission = format!("allow-{}", command.replace('_', "-"));
+            (!sources
+                .iter()
+                .any(|source| contains_quoted_value(source, &permission)))
+            .then_some(*command)
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        missing.is_empty(),
+        "registered Tauri commands have no manual permission set: {}",
+        missing.join(", ")
+    );
+}
+
 fn main() {
     // `analytics::config` reads these with `option_env!`, which is
     // resolved at compile time. Cargo does not track an environment variable
@@ -19,6 +75,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=ANTIBURN_ANALYTICS_ENABLED");
     println!("cargo:rerun-if-env-changed=GOOGLE_ANTIGRAVITY_2_IDE_AGY_OAUTH_CLIENT_ID");
     println!("cargo:rerun-if-env-changed=GOOGLE_ANTIGRAVITY_2_IDE_AGY_OAUTH_CLIENT_SECRET");
+    println!("cargo:rerun-if-changed=capabilities");
+    println!("cargo:rerun-if-changed=permissions");
+    validate_command_permissions();
     let attributes = tauri_build::Attributes::new()
         .app_manifest(tauri_build::AppManifest::new().commands(APP_COMMANDS));
     tauri_build::try_build(attributes).expect("failed to build the Tauri application");

--- a/apps/desktop/src-tauri/permissions/autogenerated/export_diagnostics.toml
+++ b/apps/desktop/src-tauri/permissions/autogenerated/export_diagnostics.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-export-diagnostics"
+description = "Enables the export_diagnostics command without any pre-configured scope."
+commands.allow = ["export_diagnostics"]
+
+[[permission]]
+identifier = "deny-export-diagnostics"
+description = "Denies the export_diagnostics command without any pre-configured scope."
+commands.deny = ["export_diagnostics"]

--- a/apps/desktop/src-tauri/permissions/default.toml
+++ b/apps/desktop/src-tauri/permissions/default.toml
@@ -19,6 +19,7 @@ permissions = [
   "allow-get-consent-diagnostics",
   "allow-get-folder-permissions",
   "allow-get-hud-detail-state",
+  "allow-get-hygiene-summary",
   "allow-get-insights-report",
   "allow-get-insights-status",
   "allow-get-latest-session-activity",

--- a/apps/desktop/src-tauri/permissions/default.toml
+++ b/apps/desktop/src-tauri/permissions/default.toml
@@ -13,6 +13,7 @@ permissions = [
   "allow-delete-session-data",
   "allow-engine-catalog-version",
   "allow-end-popover-hold",
+  "allow-export-diagnostics",
   "allow-export-session",
   "allow-finish-onboarding",
   "allow-get-consent-diagnostics",

--- a/apps/desktop/src-tauri/src/app_commands.rs
+++ b/apps/desktop/src-tauri/src/app_commands.rs
@@ -13,6 +13,7 @@ macro_rules! with_app_commands {
             commands::delete_session_data => "delete_session_data",
             commands::engine_catalog_version => "engine_catalog_version",
             commands::end_popover_hold => "end_popover_hold",
+            commands::export_diagnostics => "export_diagnostics",
             commands::export_session => "export_session",
             commands::finish_onboarding => "finish_onboarding",
             commands::get_consent_diagnostics => "get_consent_diagnostics",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1655,6 +1655,24 @@ async fn mirror_scan_roots(app: &tauri::AppHandle, roots: &[String]) -> anyhow::
  * Session actions
  * ---------------------------------------------------------------------- */
 
+/// Write the privacy-scoped support diagnostics to `dest_path` as JSON.
+///
+/// The export omits transcript content, titles, paths, working directories,
+/// account keys, analytics identifiers, and every `turn_content` value.
+#[tauri::command]
+pub async fn export_diagnostics(app: tauri::AppHandle, dest_path: String) -> CommandResult<String> {
+    let data_dir = app.state::<Store>().state_dir().to_path_buf();
+    let app_version = app.package_info().version.to_string();
+    let json = tauri::async_runtime::spawn_blocking(move || {
+        crate::diagnostics_export::build(&data_dir, app_version)?.to_json()
+    })
+    .await
+    .map_err(fail)?
+    .map_err(fail)?;
+    tokio::fs::write(&dest_path, json).await.map_err(fail)?;
+    Ok(dest_path)
+}
+
 /// Write one session's derived analysis to `dest_path` as JSON.
 ///
 /// The transcript is **not** copied: the document carries a reference to where

--- a/apps/desktop/src-tauri/src/diagnostics_export.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_export.rs
@@ -1,0 +1,531 @@
+//! The privacy-scoped diagnostics export.
+//!
+//! The document carries the derived evidence needed to explain analysis and
+//! badge states. It excludes every transcript body and every location or title
+//! that could identify the reader's work. Turn rows become per-scope counts
+//! before they leave SQLite. The export never copies a turn row or content.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rusqlite::types::Type;
+use rusqlite::{Row, Transaction};
+use serde::Serialize;
+
+use crate::store::open_read_only;
+
+const EXPORT_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_EXPORTED_SESSIONS: u64 = 500;
+
+pub const FORMAT: &str = "antiburn.diagnostics-export";
+pub const FORMAT_VERSION: u32 = 1;
+pub const CONTENT_NOTICE: &str = concat!(
+    "This export contains derived diagnostics for up to 500 recent sessions in antiburn's local index. ",
+    "It includes opaque session identifiers, agent names, activity times, model and setting ",
+    "labels, tool and skill names and descriptions present in derived evidence, aggregate ",
+    "turn counts, evidence lifecycle state, revisions, and errors. It excludes transcript ",
+    "bodies, message text, tool arguments and results, file contents, session titles, source ",
+    "paths, working directories, repository names, provider-account keys, analytics ",
+    "identifiers, and turn_content. Review the file before sharing it."
+);
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticsExport {
+    format: &'static str,
+    format_version: u32,
+    exported_at: String,
+    app_version: String,
+    content_notice: &'static str,
+    database_schema_version: i64,
+    current_revisions: CurrentRevisions,
+    scope: ExportScope,
+    sessions: Vec<SessionDiagnostics>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CurrentRevisions {
+    parser: i64,
+    analyzer: i64,
+    metrics_schema: i64,
+    evidence_schema: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExportScope {
+    indexed_sessions: u64,
+    exported_sessions: u64,
+    session_limit: u64,
+    omitted_sessions: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionDiagnostics {
+    environment_key: String,
+    agent: String,
+    session_id: String,
+    source_kind: String,
+    updated_at_epoch: Option<i64>,
+    source_generation: i64,
+    evidence: Option<EvidenceDiagnostics>,
+    turn_summary: TurnSummary,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EvidenceDiagnostics {
+    status: String,
+    analyzed_generation: Option<i64>,
+    parser_revision: Option<i64>,
+    analyzer_revision: Option<i64>,
+    evidence_schema_revision: Option<i64>,
+    evidence_json: Option<serde_json::Value>,
+    evidence_json_error: Option<String>,
+    retry_count: i64,
+    analyzed_at_epoch: Option<i64>,
+    last_error: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TurnSummary {
+    main: TurnScopeSummary,
+    delegated: TurnScopeSummary,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TurnScopeSummary {
+    turns: u64,
+    assistant_turns: u64,
+    assistant_turns_with_model: u64,
+    assistant_turns_with_effort: u64,
+    assistant_turns_with_speed: u64,
+    timestamped_assistant_turns: u64,
+}
+
+type SessionIdentity = (String, String, String);
+
+/// Read one pinned database snapshot and build the diagnostics document.
+pub fn build(data_dir: &Path, app_version: String) -> Result<DiagnosticsExport> {
+    let mut connection = open_read_only(data_dir, EXPORT_BUSY_TIMEOUT)?;
+    let transaction = connection.transaction()?;
+    build_from_transaction(&transaction, app_version, crate::store::now_rfc3339())
+}
+
+impl DiagnosticsExport {
+    /// Serialize the document as one pretty-printed JSON file.
+    pub fn to_json(&self) -> Result<String> {
+        serde_json::to_string_pretty(self).context("failed to serialize the diagnostics export")
+    }
+}
+
+fn build_from_transaction(
+    transaction: &Transaction<'_>,
+    app_version: String,
+    exported_at: String,
+) -> Result<DiagnosticsExport> {
+    let database_schema_version =
+        transaction.pragma_query_value(None, "user_version", |row| row.get(0))?;
+    let indexed_sessions =
+        nonnegative_value(
+            transaction.query_row("SELECT COUNT(*) FROM session", [], |row| row.get(0))?,
+        )?;
+    let turn_summaries = read_turn_summaries(transaction)?;
+    let sessions = read_sessions(transaction, turn_summaries)?;
+    let exported_sessions = u64::try_from(sessions.len())?;
+
+    Ok(DiagnosticsExport {
+        format: FORMAT,
+        format_version: FORMAT_VERSION,
+        exported_at,
+        app_version,
+        content_notice: CONTENT_NOTICE,
+        database_schema_version,
+        current_revisions: CurrentRevisions {
+            parser: antiburn_local::analysis::PARSER_REVISION,
+            analyzer: antiburn_local::analysis::ANALYZER_REVISION,
+            metrics_schema: antiburn_local::analysis::METRICS_SCHEMA_REVISION,
+            evidence_schema: antiburn_local::analysis::EVIDENCE_SCHEMA_REVISION,
+        },
+        scope: ExportScope {
+            indexed_sessions,
+            exported_sessions,
+            session_limit: MAX_EXPORTED_SESSIONS,
+            omitted_sessions: indexed_sessions.saturating_sub(exported_sessions),
+        },
+        sessions,
+    })
+}
+
+fn read_turn_summaries(
+    transaction: &Transaction<'_>,
+) -> Result<BTreeMap<SessionIdentity, TurnSummary>> {
+    let mut statement = transaction.prepare(
+        "SELECT t.environment_key, t.agent, t.session_id,
+                t.scope, COUNT(*),
+                SUM(t.role = 'assistant'),
+                SUM(t.role = 'assistant' AND t.model IS NOT NULL),
+                SUM(t.role = 'assistant' AND t.effort IS NOT NULL),
+                SUM(t.role = 'assistant' AND t.speed IS NOT NULL),
+                SUM(t.role = 'assistant' AND t.ts_ms IS NOT NULL)
+           FROM turn t
+           JOIN session_evidence e
+             ON e.environment_key = t.environment_key
+            AND e.agent = t.agent
+            AND e.session_id = t.session_id
+            AND e.published_fence = t.claim_fence
+           JOIN (
+                SELECT environment_key, agent, session_id
+                  FROM session
+                 ORDER BY COALESCE(updated_at_epoch, 0) DESC,
+                          environment_key, agent, session_id
+                 LIMIT ?1
+           ) selected
+             ON selected.environment_key = t.environment_key
+            AND selected.agent = t.agent
+            AND selected.session_id = t.session_id
+          WHERE t.scope IN ('main', 'delegated')
+          GROUP BY t.environment_key, t.agent, t.session_id, t.scope
+          ORDER BY t.environment_key, t.agent, t.session_id, t.scope",
+    )?;
+    let rows = statement.query_map([MAX_EXPORTED_SESSIONS], |row| {
+        Ok((
+            (
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ),
+            row.get::<_, String>(3)?,
+            TurnScopeSummary {
+                turns: nonnegative_count(row, 4)?,
+                assistant_turns: nonnegative_count(row, 5)?,
+                assistant_turns_with_model: nonnegative_count(row, 6)?,
+                assistant_turns_with_effort: nonnegative_count(row, 7)?,
+                assistant_turns_with_speed: nonnegative_count(row, 8)?,
+                timestamped_assistant_turns: nonnegative_count(row, 9)?,
+            },
+        ))
+    })?;
+
+    let mut by_session = BTreeMap::<SessionIdentity, TurnSummary>::new();
+    for row in rows {
+        let (identity, scope, summary) = row?;
+        let session = by_session.entry(identity).or_default();
+        match scope.as_str() {
+            "main" => session.main = summary,
+            "delegated" => session.delegated = summary,
+            _ => {}
+        }
+    }
+    Ok(by_session)
+}
+
+fn nonnegative_count(row: &Row<'_>, index: usize) -> rusqlite::Result<u64> {
+    let count = row.get::<_, i64>(index)?;
+    u64::try_from(count).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(index, Type::Integer, Box::new(error))
+    })
+}
+
+fn nonnegative_value(value: i64) -> Result<u64> {
+    u64::try_from(value).context("SQLite returned a negative count")
+}
+
+fn read_sessions(
+    transaction: &Transaction<'_>,
+    mut turn_summaries: BTreeMap<SessionIdentity, TurnSummary>,
+) -> Result<Vec<SessionDiagnostics>> {
+    let mut statement = transaction.prepare(
+        "SELECT s.environment_key, s.agent, s.session_id, s.source_kind,
+                s.updated_at_epoch, s.source_generation,
+                e.status, e.analyzed_generation,
+                e.parser_revision, e.analyzer_revision, e.evidence_schema_revision,
+                e.evidence_json, e.retry_count, e.analyzed_at_epoch, e.last_error
+           FROM session s
+           LEFT JOIN session_evidence e
+             ON e.environment_key = s.environment_key
+            AND e.agent = s.agent
+            AND e.session_id = s.session_id
+          ORDER BY COALESCE(s.updated_at_epoch, 0) DESC,
+                   s.environment_key, s.agent, s.session_id
+          LIMIT ?1",
+    )?;
+    let rows = statement.query_map([MAX_EXPORTED_SESSIONS], |row| {
+        let identity = (
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        );
+        let evidence = match row.get::<_, Option<String>>(6)? {
+            Some(status) => {
+                let (evidence_json, evidence_json_error) =
+                    parse_evidence_json(row.get::<_, Option<String>>(11)?);
+                Some(EvidenceDiagnostics {
+                    status,
+                    analyzed_generation: row.get(7)?,
+                    parser_revision: row.get(8)?,
+                    analyzer_revision: row.get(9)?,
+                    evidence_schema_revision: row.get(10)?,
+                    evidence_json,
+                    evidence_json_error,
+                    retry_count: row.get::<_, Option<i64>>(12)?.unwrap_or_default(),
+                    analyzed_at_epoch: row.get(13)?,
+                    last_error: row.get(14)?,
+                })
+            }
+            None => None,
+        };
+        Ok((
+            identity,
+            row.get::<_, String>(3)?,
+            row.get(4)?,
+            row.get(5)?,
+            evidence,
+        ))
+    })?;
+
+    let mut sessions = Vec::new();
+    for row in rows {
+        let (identity, source_kind, updated_at_epoch, source_generation, evidence) = row?;
+        sessions.push(SessionDiagnostics {
+            environment_key: identity.0.clone(),
+            agent: identity.1.clone(),
+            session_id: identity.2.clone(),
+            source_kind,
+            updated_at_epoch,
+            source_generation,
+            evidence,
+            turn_summary: turn_summaries.remove(&identity).unwrap_or_default(),
+        });
+    }
+    Ok(sessions)
+}
+
+fn parse_evidence_json(
+    evidence_json: Option<String>,
+) -> (Option<serde_json::Value>, Option<String>) {
+    let Some(evidence_json) = evidence_json else {
+        return (None, None);
+    };
+    match serde_json::from_str(&evidence_json) {
+        Ok(value) => (Some(value), None),
+        Err(error) => (None, Some(error.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+    use rusqlite::Connection;
+
+    fn fixture_connection() -> Connection {
+        let connection = Connection::open_in_memory().expect("create the fixture database");
+        connection
+            .execute_batch(
+                "PRAGMA user_version = 27;
+                 CREATE TABLE session (
+                     environment_key TEXT NOT NULL,
+                     agent TEXT NOT NULL,
+                     session_id TEXT NOT NULL,
+                     source_kind TEXT NOT NULL,
+                     source_label TEXT NOT NULL,
+                     title TEXT,
+                     cwd TEXT,
+                     updated_at_epoch INTEGER,
+                     source_generation INTEGER NOT NULL,
+                     PRIMARY KEY (environment_key, agent, session_id)
+                 );
+                 CREATE TABLE session_evidence (
+                     environment_key TEXT NOT NULL,
+                     agent TEXT NOT NULL,
+                     session_id TEXT NOT NULL,
+                     status TEXT NOT NULL,
+                     analyzed_generation INTEGER,
+                     parser_revision INTEGER,
+                     analyzer_revision INTEGER,
+                     evidence_schema_revision INTEGER,
+                     evidence_json TEXT,
+                     retry_count INTEGER NOT NULL,
+                     analyzed_at_epoch INTEGER,
+                     last_error TEXT,
+                     published_fence INTEGER,
+                     PRIMARY KEY (environment_key, agent, session_id)
+                 );
+                 CREATE TABLE turn (
+                     environment_key TEXT NOT NULL,
+                     agent TEXT NOT NULL,
+                     session_id TEXT NOT NULL,
+                     claim_fence INTEGER NOT NULL,
+                     scope TEXT NOT NULL,
+                     role TEXT NOT NULL,
+                     model TEXT,
+                     effort TEXT,
+                     speed TEXT,
+                     ts_ms INTEGER
+                 );
+                 CREATE TABLE turn_content (
+                     turn_rowid INTEGER NOT NULL,
+                     part_index INTEGER NOT NULL,
+                     content BLOB NOT NULL
+                 );",
+            )
+            .expect("create the fixture schema");
+        connection
+    }
+
+    #[test]
+    fn the_export_contains_badge_diagnostics_without_private_session_content() {
+        let mut connection = fixture_connection();
+        connection
+            .execute(
+                "INSERT INTO session (
+                     environment_key, agent, session_id, source_kind, source_label,
+                     title, cwd, updated_at_epoch, source_generation
+                 ) VALUES ('native', 'claude-code', 'session-123', 'file',
+                           'PRIVATE-SOURCE-PATH', 'PRIVATE-TITLE', 'PRIVATE-CWD', 100, 4)",
+                [],
+            )
+            .expect("insert the fixture session");
+        connection
+            .execute(
+                "INSERT INTO session_evidence (
+                     environment_key, agent, session_id, status, analyzed_generation,
+                     parser_revision, analyzer_revision, evidence_schema_revision,
+                     evidence_json, retry_count, analyzed_at_epoch, last_error, published_fence
+                 ) VALUES ('native', 'claude-code', 'session-123', 'ready', 4,
+                           1, 2, 3, '{\"coverage\":\"complete\"}', 0, 101, NULL, 7)",
+                [],
+            )
+            .expect("insert the fixture evidence");
+        connection
+            .execute(
+                "INSERT INTO turn (
+                     environment_key, agent, session_id, claim_fence, scope, role,
+                     model, effort, speed, ts_ms
+                 ) VALUES ('native', 'claude-code', 'session-123', 7, 'main',
+                           'assistant', 'claude-opus-4-1', NULL, 'standard', 100000)",
+                [],
+            )
+            .expect("insert the fixture turn");
+        connection
+            .execute(
+                "INSERT INTO turn_content VALUES (1, 0, 'PRIVATE-TRANSCRIPT-BODY')",
+                [],
+            )
+            .expect("insert the private fixture content");
+
+        let transaction = connection
+            .transaction()
+            .expect("start the fixture snapshot");
+        let export = build_from_transaction(
+            &transaction,
+            "0.3.1".to_owned(),
+            "2026-09-02T00:00:00Z".to_owned(),
+        )
+        .expect("build the fixture export");
+        let json = export.to_json().expect("serialize the fixture export");
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("parse the fixture export");
+
+        assert_eq!(value["format"], FORMAT);
+        assert_eq!(value["databaseSchemaVersion"], 27);
+        assert_eq!(value["sessions"][0]["evidence"]["status"], "ready");
+        assert_eq!(
+            value["sessions"][0]["evidence"]["evidenceJson"]["coverage"],
+            "complete"
+        );
+        assert_eq!(value["scope"]["sessionLimit"], 500);
+        assert_eq!(value["scope"]["exportedSessions"], 1);
+        assert_eq!(
+            value["sessions"][0]["turnSummary"]["main"]["assistantTurnsWithModel"],
+            1
+        );
+        assert_eq!(
+            value["sessions"][0]["turnSummary"]["main"]["assistantTurnsWithEffort"],
+            0
+        );
+        assert_eq!(
+            value["sessions"][0]["turnSummary"]["main"]["assistantTurnsWithSpeed"],
+            1
+        );
+        assert_eq!(
+            value["sessions"][0]["turnSummary"]["main"]["timestampedAssistantTurns"],
+            1
+        );
+        for private_value in [
+            "PRIVATE-SOURCE-PATH",
+            "PRIVATE-TITLE",
+            "PRIVATE-CWD",
+            "PRIVATE-TRANSCRIPT-BODY",
+        ] {
+            assert!(!json.contains(private_value));
+        }
+    }
+
+    #[test]
+    fn malformed_evidence_is_named_without_copying_the_invalid_value() {
+        let (value, error) = parse_evidence_json(Some("PRIVATE-INVALID-EVIDENCE{".to_owned()));
+
+        assert!(value.is_none());
+        assert!(error.is_some());
+        assert!(
+            !error
+                .expect("malformed evidence must report an error")
+                .contains("PRIVATE-INVALID-EVIDENCE")
+        );
+    }
+
+    #[test]
+    fn the_export_reads_the_current_migrated_schema() {
+        let directory = tempfile::tempdir().expect("create the migrated fixture directory");
+        let _store = Store::open(directory.path()).expect("create the migrated fixture store");
+
+        let export = build(directory.path(), "0.3.1".to_owned())
+            .expect("build from the migrated fixture store");
+        let value = serde_json::to_value(export).expect("serialize the migrated export");
+
+        assert_eq!(value["scope"]["indexedSessions"], 0);
+        assert_eq!(value["sessions"].as_array().map(Vec::len), Some(0));
+    }
+
+    #[test]
+    fn the_export_bounds_sessions_to_the_most_recent_five_hundred() {
+        let mut connection = fixture_connection();
+        let transaction = connection
+            .transaction()
+            .expect("start the bounded fixture snapshot");
+        for index in 0..=MAX_EXPORTED_SESSIONS {
+            transaction
+                .execute(
+                    "INSERT INTO session (
+                         environment_key, agent, session_id, source_kind, source_label,
+                         updated_at_epoch, source_generation
+                     ) VALUES ('native', 'claude-code', ?1, 'file', 'private-path', ?2, 1)",
+                    rusqlite::params![format!("session-{index:03}"), index],
+                )
+                .expect("insert a bounded fixture session");
+        }
+
+        let export = build_from_transaction(
+            &transaction,
+            "0.3.1".to_owned(),
+            "2026-09-02T00:00:00Z".to_owned(),
+        )
+        .expect("build the bounded fixture export");
+        let value = serde_json::to_value(export).expect("serialize the bounded export");
+
+        assert_eq!(value["scope"]["indexedSessions"], 501);
+        assert_eq!(value["scope"]["exportedSessions"], 500);
+        assert_eq!(value["scope"]["omittedSessions"], 1);
+        assert_eq!(value["sessions"].as_array().map(Vec::len), Some(500));
+        assert_eq!(value["sessions"][0]["sessionId"], "session-500");
+        assert_eq!(value["sessions"][499]["sessionId"], "session-001");
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -583,6 +583,16 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
+    fn settings_can_invoke_the_diagnostics_export() {
+        let permissions = include_str!("../permissions/default.toml");
+        assert!(
+            permissions
+                .lines()
+                .any(|line| line.trim() == r#""allow-export-diagnostics","#)
+        );
+    }
+
+    #[test]
     fn a_window_close_never_quits_the_finished_menu_bar_app() {
         // Settings and the popover both close with no exit code, and the tray
         // item is the app's real lifetime.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@
 //! - [`agents`] — translating between the engine's two names for an agent.
 //! - [`analysis`] — turning a located transcript into what the views render.
 //! - [`commands`] — the IPC surface exposed to the webview.
+//! - [`diagnostics_export`] — the privacy-scoped support document.
 //! - [`disk_monitor`] — free-space polling, the tray readout, the low edge.
 //! - [`dto`] — the shapes that cross that boundary.
 //! - [`export`] — the derived-only session export document.
@@ -52,6 +53,7 @@ mod analysis;
 mod analytics;
 mod commands;
 mod consent;
+mod diagnostics_export;
 mod disk_monitor;
 mod dto;
 mod export;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -583,16 +583,6 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
-    fn settings_can_invoke_the_diagnostics_export() {
-        let permissions = include_str!("../permissions/default.toml");
-        assert!(
-            permissions
-                .lines()
-                .any(|line| line.trim() == r#""allow-export-diagnostics","#)
-        );
-    }
-
-    #[test]
     fn a_window_close_never_quits_the_finished_menu_bar_app() {
         // Settings and the popover both close with no exit code, and the tray
         // item is the app's real lifetime.

--- a/apps/desktop/src/lib/diagnosticsIpc.ts
+++ b/apps/desktop/src/lib/diagnosticsIpc.ts
@@ -1,0 +1,9 @@
+import { invoke } from "@tauri-apps/api/core"
+
+import { hasShell } from "./ipc"
+
+/** Write the privacy-scoped support diagnostics to `destPath`. */
+export async function exportDiagnostics(destPath: string): Promise<string | null> {
+  if (!hasShell()) return null
+  return invoke<string>("export_diagnostics", { destPath })
+}

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -15,6 +15,7 @@ import { SettingsView } from "./SettingsView"
 const invoke = vi.hoisted(() => vi.fn())
 const openDialog = vi.hoisted(() => vi.fn())
 const confirmDialog = vi.hoisted(() => vi.fn())
+const saveDialog = vi.hoisted(() => vi.fn())
 const closeWindow = vi.hoisted(() => vi.fn())
 /** Mutable so a test can render the macOS chrome; jsdom itself has no OS. */
 const platform = vi.hoisted(() => ({ mac: false }))
@@ -34,7 +35,7 @@ vi.mock("@tauri-apps/api/window", () => ({
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: openDialog,
   confirm: confirmDialog,
-  save: vi.fn(),
+  save: saveDialog,
 }))
 vi.mock("../lib/platform", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
@@ -165,6 +166,7 @@ describe("SettingsView", () => {
     invoke.mockReset()
     openDialog.mockReset()
     confirmDialog.mockReset()
+    saveDialog.mockReset()
     closeWindow.mockReset()
     listeners.clear()
     delete document.documentElement.dataset["theme"]
@@ -640,6 +642,45 @@ describe("SettingsView", () => {
 
     await waitFor(() => expect(confirmDialog).toHaveBeenCalledTimes(1))
     expect(invoke).not.toHaveBeenCalledWith("clear_local_index")
+  })
+
+  it("warns before exporting privacy-scoped diagnostics", async () => {
+    confirmDialog.mockResolvedValue(true)
+    saveDialog.mockResolvedValue("/tmp/antiburn-diagnostics.json")
+    mockCommands({ export_diagnostics: "/tmp/antiburn-diagnostics.json" })
+    render(<SettingsView />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Privacy" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Export…" }))
+
+    await waitFor(() => expect(confirmDialog).toHaveBeenCalledTimes(1))
+    const [message] = confirmDialog.mock.calls[0] as [string]
+    expect(message).toMatch(/excludes transcript bodies/i)
+    expect(message).toMatch(/derived model, tool, skill, timing, evidence, and error data/i)
+    await waitFor(() =>
+      expect(saveDialog).toHaveBeenCalledWith({
+        defaultPath: "antiburn-diagnostics.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      }),
+    )
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("export_diagnostics", {
+        destPath: "/tmp/antiburn-diagnostics.json",
+      }),
+    )
+    expect(await screen.findByText("Diagnostics exported.")).toBeInTheDocument()
+  })
+
+  it("does not choose a diagnostics destination when export is declined", async () => {
+    confirmDialog.mockResolvedValue(false)
+    render(<SettingsView />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Privacy" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Export…" }))
+
+    await waitFor(() => expect(confirmDialog).toHaveBeenCalledTimes(1))
+    expect(saveDialog).not.toHaveBeenCalled()
+    expect(invoke).not.toHaveBeenCalledWith("export_diagnostics", expect.anything())
   })
 
   it("defaults session retention to forever and confirms a shorter period", async () => {

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -1,4 +1,4 @@
-import { confirm } from "@tauri-apps/plugin-dialog"
+import { confirm, save } from "@tauri-apps/plugin-dialog"
 import { useCallback, useState } from "react"
 
 import { Card } from "../../components/ui/Card"
@@ -10,6 +10,7 @@ import { SectionGroup } from "../../components/ui/SectionGroup"
 import { SegmentedControl } from "../../components/ui/SegmentedControl"
 import { StatusText } from "../../components/ui/StatusText"
 import { ToggleRow } from "../../components/ui/ToggleRow"
+import { exportDiagnostics } from "../../lib/diagnosticsIpc"
 import {
   clearLocalIndex,
   openAnalyticsDocumentation,
@@ -39,6 +40,9 @@ type ClearState =
   | { kind: "cleared"; sessions: number }
   | { kind: "failed" }
 
+/** What the diagnostics export action is currently doing. */
+type DiagnosticsExportState = "idle" | "exporting" | "exported" | "failed"
+
 type RetentionValue = "30" | "90" | "-1"
 
 const RETENTION_OPTIONS: ReadonlyArray<{ value: RetentionValue; label: string }> = [
@@ -55,6 +59,8 @@ export type PrivacyPaneProps = AppSettingsController & { info: AppInfo | null }
 
 export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps) {
   const [clearState, setClearState] = useState<ClearState>({ kind: "idle" })
+  const [diagnosticsExportState, setDiagnosticsExportState] =
+    useState<DiagnosticsExportState>("idle")
   // Derived from the running build, never from a compile-time guess: a build
   // with no injected endpoint cannot send anything, and this pane's whole job
   // is to not overstate what the application does.
@@ -99,6 +105,32 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
       setClearState({ kind: "failed" })
     }
   }, [])
+
+  async function handleDiagnosticsExport() {
+    const proceed = await confirm(
+      "The export covers up to 500 recent indexed sessions. It excludes transcript bodies, titles, file paths, working directories, repository names, account identifiers, and analytics identifiers. It does include opaque session ids and derived model, tool, skill, timing, evidence, and error data. Review it before sharing.",
+      {
+        title: "Export diagnostics?",
+        kind: "warning",
+        okLabel: "Choose destination…",
+      },
+    )
+    if (!proceed) return
+
+    const destination = await save({
+      defaultPath: "antiburn-diagnostics.json",
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    })
+    if (!destination) return
+
+    setDiagnosticsExportState("exporting")
+    try {
+      await exportDiagnostics(destination)
+      setDiagnosticsExportState("exported")
+    } catch {
+      setDiagnosticsExportState("failed")
+    }
+  }
 
   return (
     <Pane title="Privacy">
@@ -356,6 +388,34 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
             // to check, and finding nothing is not an answer.
             description="antiburn cannot do this, by design. Removing a conversation is your agent’s job, in your agent’s own interface. antiburn only ever deletes records it created itself."
           />
+        </Card>
+      </SectionGroup>
+
+      <SectionGroup title="Diagnostics">
+        <Card>
+          <Row
+            label="Export diagnostics"
+            description="Create a JSON file for up to 500 recent indexed sessions, with derived evidence, processing state, revisions, errors, and aggregate turn signals. It excludes transcript bodies, titles, paths, working directories, repositories, account identifiers, analytics identifiers, and turn content. Model, tool, and skill names and descriptions can still describe real work, so review the file before sharing it."
+            trailing={
+              <PushButton
+                onClick={() => void handleDiagnosticsExport()}
+                disabled={diagnosticsExportState === "exporting"}
+              >
+                {diagnosticsExportState === "exporting" ? "Exporting…" : "Export…"}
+              </PushButton>
+            }
+          >
+            {diagnosticsExportState === "exported" && (
+              <div className="mt-1.5" aria-live="polite">
+                <StatusText tone="secondary">Diagnostics exported.</StatusText>
+              </div>
+            )}
+            {diagnosticsExportState === "failed" && (
+              <div className="mt-1.5" aria-live="polite">
+                <StatusText tone="secondary">The diagnostics could not be exported.</StatusText>
+              </div>
+            )}
+          </Row>
         </Card>
       </SectionGroup>
     </Pane>


### PR DESCRIPTION
## Summary

- add a diagnostics export action at the bottom of Privacy settings
- export a bounded JSON report with derived session evidence, timing, model, tool, skill, and error data
- omit transcript content, titles, paths, repository names, and account or analytics identifiers
- warn before export and report progress and failures in the settings UI

The export is JSON rather than ZIP so this change does not add a compression dependency.

## Verification

- `pnpm --dir apps/desktop format`
- `pnpm --dir apps/desktop lint`
- `pnpm --dir apps/desktop type-check`
- `pnpm --dir apps/desktop test`
- `pnpm --dir apps/desktop build`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `node scripts/check-design-drift.mjs`
- `pnpm run slop`
- `pnpm run secrets`