### PR TITLE
fix(desktop): constrain session model metadata

### DIFF
--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -162,7 +162,7 @@ function SessionRow({ entry, hygiene, onOpen, renderAgentIcon, wslIcon }: Sessio
     <div
       className={cn(
         "group relative",
-        "w-full grid grid-cols-[14px_1fr] gap-x-2 gap-y-1",
+        "w-full grid grid-cols-[14px_minmax(0,1fr)] gap-x-2 gap-y-1",
         "items-center",
         "rounded-[var(--radius-popover)] bg-surface-card px-3 py-3",
         "transition-colors duration-[var(--duration-fast)] ease-out",
@@ -239,9 +239,9 @@ function SessionRow({ entry, hygiene, onOpen, renderAgentIcon, wslIcon }: Sessio
       </div>
 
       {modelPairs.length > 0 && (
-        <div className="col-2 space-y-px">
+        <div className="col-2 min-w-0 space-y-px">
           <div
-            className="min-w-0 truncate type-callout text-label-tertiary"
+            className="min-w-0 max-w-full truncate type-callout text-label-tertiary"
             title={modelRunNames(modelRuns).join("\n")}
           >
             {modelPairs.map((pair, index) => (


### PR DESCRIPTION
## Summary

- keep the session card flexible grid column within the popover width
- allow the model metadata row to shrink so its existing ellipsis takes effect

## User impact

Long model and thinking-mode lists no longer render beyond the session card or popover edge.

## Verification

- pnpm --filter @antiburn/desktop exec prettier --check src/components/session/SessionList.tsx
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop test
- pnpm --filter @antiburn/desktop build
- pnpm run slop:all
- pnpm run secrets

## Privacy and performance

Presentation-only layout change. It adds no data access, network traffic, retained state, or meaningful runtime work.

## Known limits

None.