### PR TITLE
fix(scan): keep scanning while hidden and describe only changed sessions

### DIFF
--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -1721,10 +1721,11 @@ fn reveal(window: &WebviewWindow) {
 /// Everything that has to happen when the popover reaches the screen, whichever
 /// way it got there.
 ///
-/// The popover *is* the view of the scanned data, so its visibility is what
-/// gates the periodic rescan (see [`crate::scan`]). Reported from here rather
-/// than inferred from window events, because a hidden window that was never
-/// shown produces no event at all.
+/// The scheduler's [`TICK`](crate::scan::TICK) already runs while the popover
+/// is hidden, so this is reconciliation, not the only path to a fresh list: it
+/// closes the gap between the last tick and the moment a reader is actually
+/// looking. Reported from here rather than inferred from window events,
+/// because a hidden window that was never shown produces no event at all.
 ///
 /// The menu-bar highlight is lit here for the same reason [`note_hidden`]
 /// clears it: both open paths already run through this one — the toggle, and a
@@ -1733,7 +1734,6 @@ fn reveal(window: &WebviewWindow) {
 /// has to remember.
 fn note_shown(app: &AppHandle) {
     if let Some(controller) = app.try_state::<crate::scan::ScanController>() {
-        controller.set_popover_visible(true);
         // Opening the popover is the one moment a reader is guaranteed to be
         // looking, so refresh immediately instead of waiting out a tick.
         controller.request();
@@ -1762,14 +1762,12 @@ fn note_shown(app: &AppHandle) {
 /// Every close path already runs through here — the toggle, the webview's
 /// Escape, dismissal on focus loss or an outside click, and the shell's
 /// suppressed window close — which is why the menu-bar highlight is cleared
-/// here rather than at each of them.
+/// here rather than at each of them. The scan scheduler does not gate on
+/// visibility, so this hook has nothing left to tell it.
 ///
 /// Unconditional: clearing a highlight that is already off costs nothing, and
 /// a state that somehow drifted out of step is corrected rather than kept.
 pub fn note_hidden(app: &AppHandle) {
-    if let Some(controller) = app.try_state::<crate::scan::ScanController>() {
-        controller.set_popover_visible(false);
-    }
     crate::tray::set_highlight(app, false);
 }
 

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -12,21 +12,22 @@
 //! antiburn is an always-running background utility. CPU time, memory, open
 //! files, and disk I/O are therefore correctness constraints, not optional
 //! optimizations: a scan must do no more work, retain no more data in memory,
-//! and run no more often than the visible feature requires.
+//! and run no more often than the visible feature requires. A pass describes
+//! a file-backed session again only when its parent and child sizes have
+//! changed since the stored record; an unchanged source is reused without
+//! opening its transcript. This is what makes the unconditional tick in the
+//! next section affordable.
 //!
 //! When a pass runs:
 //!
 //! - **At launch**, once, if onboarding is finished. A first-run install has no
 //!   sources selected yet, so scanning before the flow completes would only
 //!   spend disk on a window nobody can see.
-//! - **Every [`TICK`] while the popover is open.** The popover *is* the view of
-//!   this data; refreshing behind a closed popover would burn disk on a machine
-//!   whose owner is not looking.
-//! - **Paused entirely while the popover is hidden.** The scheduler keeps
-//!   ticking (it is one timer) but does no work, so reopening the popover
-//!   refreshes within a tick rather than after a cold start.
-//! - **The moment the popover is opened**, so a reader never looks at a stale
-//!   list while waiting out a tick.
+//! - **Every [`TICK`], unconditionally.** The popover does not gate the timer:
+//!   a pass over sources that have not changed reads no transcript, so ticking
+//!   while the popover is hidden costs stat calls, not disk reads.
+//! - **The moment the popover is opened**, as reconciliation, so a reader never
+//!   waits out a tick behind a missed event.
 //! - **On demand**, from the rescan control and after any change to the source
 //!   selection.
 //!
@@ -104,7 +105,6 @@ pub const EVENT_FINISHED: &str = "scan:finished";
 #[derive(Default)]
 pub struct ScanController {
     running: AtomicBool,
-    popover_visible: AtomicBool,
     cancel: Arc<AtomicBool>,
     status: Mutex<ScanStatus>,
     kick: Notify,
@@ -114,15 +114,6 @@ impl ScanController {
     /// Ask for a pass as soon as the scheduler can start one.
     pub fn request(&self) {
         self.kick.notify_one();
-    }
-
-    /// Record whether the popover is on screen, which is what gates the timer.
-    pub fn set_popover_visible(&self, visible: bool) {
-        self.popover_visible.store(visible, Ordering::Relaxed);
-    }
-
-    fn popover_visible(&self) -> bool {
-        self.popover_visible.load(Ordering::Relaxed)
     }
 
     /// Ask the pass in flight to stop at its next phase boundary.
@@ -157,17 +148,6 @@ impl ScanController {
     }
 }
 
-#[derive(Clone, Copy)]
-pub(crate) enum Wake {
-    Launch,
-    Tick,
-    Kick,
-}
-
-pub(crate) fn should_run_scheduled_pass(wake: Wake, popover_visible: bool, allowed: bool) -> bool {
-    allowed && (!matches!(wake, Wake::Tick) || popover_visible)
-}
-
 pub(crate) fn on_demand_start(controller: &ScanController) -> bool {
     if controller.running.swap(true, Ordering::SeqCst) {
         return false;
@@ -181,23 +161,19 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         // A fresh install has nothing to scan until the reader picks sources.
-        if should_run_scheduled_pass(Wake::Launch, false, scheduled_scanning_allowed(&app)) {
+        if scheduled_scanning_allowed(&app) {
             run_pass(&app, None).await;
         }
         loop {
             let controller = app.state::<ScanController>();
-            let wake = tokio::select! {
-                () = controller.kick.notified() => Wake::Kick,
-                () = tokio::time::sleep(TICK) => Wake::Tick,
-            };
+            tokio::select! {
+                () = controller.kick.notified() => {}
+                () = tokio::time::sleep(TICK) => {}
+            }
             // Checked after the wake-up rather than before the wait, so
             // resuming discovery takes effect at the next request or tick
             // instead of needing the app restarted.
-            if !should_run_scheduled_pass(
-                wake,
-                controller.popover_visible(),
-                scheduled_scanning_allowed(&app),
-            ) {
+            if !scheduled_scanning_allowed(&app) {
                 continue;
             }
             run_pass(&app, None).await;
@@ -2250,18 +2226,6 @@ mod tests {
     }
 
     #[test]
-    fn the_scheduled_trigger_set_is_unchanged() {
-        for wake in [Wake::Launch, Wake::Kick] {
-            assert!(should_run_scheduled_pass(wake, false, true));
-            assert!(should_run_scheduled_pass(wake, true, true));
-            assert!(!should_run_scheduled_pass(wake, true, false));
-        }
-        assert!(should_run_scheduled_pass(Wake::Tick, true, true));
-        assert!(!should_run_scheduled_pass(Wake::Tick, false, true));
-        assert!(!should_run_scheduled_pass(Wake::Tick, true, false));
-    }
-
-    #[test]
     fn an_on_demand_pass_starts_without_the_scheduler_gate() {
         let controller = ScanController::default();
         assert!(on_demand_start(&controller));
@@ -2271,11 +2235,8 @@ mod tests {
     }
 
     #[test]
-    fn the_controller_reports_the_popover_gate_and_a_clean_initial_status() {
+    fn a_fresh_controller_reports_a_clean_initial_status() {
         let controller = ScanController::default();
-        assert!(!controller.popover_visible());
-        controller.set_popover_visible(true);
-        assert!(controller.popover_visible());
 
         let status = controller.status();
         assert!(!status.running);

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -82,7 +82,7 @@ use crate::analysis;
 use crate::dto::ScanStatus;
 use crate::repositories;
 use crate::storage_health::{self, checked};
-use crate::store::{SessionActivityKey, SessionActivityState, SessionKey, SessionRecord, Store};
+use crate::store::{SessionActivityKey, SessionKey, SessionRecord, Store};
 
 /// How often the scheduler wakes up.
 pub const TICK: Duration = Duration::from_secs(60);
@@ -304,9 +304,9 @@ async fn pass(app: &AppHandle, _activity_window_days: Option<u32>) -> anyhow::Re
         )
         .await;
 
-    let activity_states = store.session_activity_states()?;
+    let previous_records = store.session_records()?;
     let Described { records, rejected } =
-        describe_with_states(logs, &home, &ignored, &activity_states).await;
+        describe_with_states(logs, &home, &ignored, &previous_records).await;
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
@@ -370,7 +370,7 @@ async fn describe_with_states(
     logs: Vec<SessionLog>,
     home: &std::path::Path,
     ignored: &std::collections::HashSet<String>,
-    activity_states: &std::collections::HashMap<SessionActivityKey, SessionActivityState>,
+    previous_records: &std::collections::HashMap<SessionActivityKey, SessionRecord>,
 ) -> Described {
     let indexed_titles = indexed_titles_for_logs(&logs).await;
     let mut records = Vec::with_capacity(logs.len());
@@ -385,11 +385,14 @@ async fn describe_with_states(
                 log.agent_type.slug(),
                 log.source_label(),
             );
-            let activity_state = activity_states.get(&activity_key).cloned();
+            let previous = previous_records.get(&activity_key).cloned();
             let indexed_title = recovered_id(&log)
                 .and_then(|session_id| indexed_titles.get(&(log.agent_type, session_id)).cloned());
             set.spawn(async move {
-                describe_one_with_activity(log, &home, indexed_title, activity_state).await
+                if let Some(reused) = reuse_unchanged_record(&log, previous.as_ref()).await {
+                    return DescribeOutcome::Session(Box::new(reused));
+                }
+                describe_one_with_activity(log, &home, indexed_title, previous).await
             });
         }
         while let Some(joined) = set.join_next().await {
@@ -447,11 +450,91 @@ enum DescribeOutcome {
     Skip,
 }
 
+/// Build the sizes-only activity cursor for one source: the parent path and
+/// size, plus each child's path and size. The format must stay byte-identical
+/// across releases — a stored row holds this string, and a format change
+/// would read as a change and re-queue evidence for every session.
+fn activity_cursor(
+    parent: &std::path::Path,
+    parent_size: u64,
+    children: &[(std::path::PathBuf, Option<u64>)],
+) -> String {
+    // Include the complete source set in the cursor. Parent + child sizes and
+    // identities make an unchanged orchestrator as cheap as a leaf while a
+    // child append naturally invalidates the gate.
+    let mut cursor_parts = vec![[
+        "parent".to_string(),
+        parent.to_string_lossy().into_owned(),
+        parent_size.to_string(),
+    ]];
+    for (child, child_size) in children {
+        cursor_parts.push([
+            "child".to_string(),
+            child.to_string_lossy().into_owned(),
+            child_size.map_or_else(|| "missing".to_string(), |size| size.to_string()),
+        ]);
+    }
+    cursor_parts.sort_unstable();
+    serde_json::to_string(&cursor_parts).expect("activity cursor is serializable")
+}
+
+/// Stat the parent and its children the same way [`semantic_activity_for_log`]
+/// does, and return the cursor those sizes produce. `None` when the source is
+/// not eligible for the unchanged-source skip: not a native file source, or a
+/// stat failed.
+async fn stat_activity_cursor(log: &SessionLog) -> Option<String> {
+    if !log.environment.is_native() {
+        // A WSL mount's stat behaviour is not trusted for this skip; describe
+        // it every pass, as today.
+        return None;
+    }
+    let SessionSource::File(path) = &log.source else {
+        return None;
+    };
+    let size = tokio::fs::metadata(path).await.ok()?.len();
+    let children = match log.agent_type {
+        AgentKind::Claude | AgentKind::Codex => {
+            Explorers::DISK
+                .list_subagents_for_transcript(&log.agent_type, path)
+                .await
+        }
+        _ => Vec::new(),
+    };
+    let mut child_sizes = Vec::with_capacity(children.len());
+    for child in &children {
+        let child_size = tokio::fs::metadata(child).await.ok().map(|meta| meta.len());
+        child_sizes.push((child.clone(), child_size));
+    }
+    Some(activity_cursor(path, size, &child_sizes))
+}
+
+/// Reuse a previous record verbatim when its source has not changed, so the
+/// pass never opens the transcript. Only a native file source with a stored
+/// record is eligible; provider-database, inline, and WSL sources always
+/// describe.
+async fn reuse_unchanged_record(
+    log: &SessionLog,
+    previous: Option<&SessionRecord>,
+) -> Option<SessionRecord> {
+    let previous = previous?;
+    let cursor = stat_activity_cursor(log).await?;
+    if cursor != previous.activity_cursor {
+        return None;
+    }
+    // An "event" row takes its activity from transcript content, and the
+    // cursor covers the sizes of that content. Any other row tracks the file
+    // mtime. A rewrite can keep the size, so such a row also needs the same
+    // discovered mtime before the pass can reuse it.
+    let mtime_matches =
+        previous.activity_source == "event" || previous.updated_at_epoch == log.updated_at;
+    mtime_matches.then(|| previous.clone())
+}
+
 /// Resolve the display timestamp from transcript events while using the
 /// persisted aggregate cursor as a cheap unchanged-source gate.
 async fn semantic_activity_for_log(
     log: &SessionLog,
-    previous: Option<&SessionActivityState>,
+    previous: Option<&SessionRecord>,
     children: &[std::path::PathBuf],
     preview: Option<&str>,
 ) -> (Option<i64>, String, String) {
@@ -463,28 +546,12 @@ async fn semantic_activity_for_log(
         return (log.updated_at, "mtime".to_string(), String::new());
     };
 
-    // Include the complete source set in the cursor. Parent + child sizes and
-    // identities make an unchanged orchestrator as cheap as a leaf while a
-    // child append naturally invalidates the gate.
-    let mut cursor_parts = vec![[
-        "parent".to_string(),
-        path.to_string_lossy().into_owned(),
-        size.to_string(),
-    ]];
+    let mut child_sizes = Vec::with_capacity(children.len());
     for child in children {
-        let child_size = tokio::fs::metadata(child)
-            .await
-            .ok()
-            .map(|meta| meta.len())
-            .map_or_else(|| "missing".to_string(), |size| size.to_string());
-        cursor_parts.push([
-            "child".to_string(),
-            child.to_string_lossy().into_owned(),
-            child_size,
-        ]);
+        let child_size = tokio::fs::metadata(child).await.ok().map(|meta| meta.len());
+        child_sizes.push((child.clone(), child_size));
     }
-    cursor_parts.sort_unstable();
-    let cursor = serde_json::to_string(&cursor_parts).expect("activity cursor is serializable");
+    let cursor = activity_cursor(path, size, &child_sizes);
 
     let unchanged_event = previous
         .is_some_and(|state| state.activity_source == "event" && state.activity_cursor == cursor);
@@ -553,7 +620,7 @@ async fn describe_one_with_activity(
     log: SessionLog,
     home: &std::path::Path,
     indexed_title: Option<ResolvedTitle>,
-    activity_state: Option<SessionActivityState>,
+    previous: Option<SessionRecord>,
 ) -> DescribeOutcome {
     let read = session_log_read(&log).await;
     let metadata = read.as_ref().map(|read| &read.metadata);
@@ -611,7 +678,7 @@ async fn describe_one_with_activity(
     let fork_parent_session_id = preview.and_then(analysis::fork_parent_from_content);
 
     let (updated_at_epoch, activity_source, activity_cursor) =
-        semantic_activity_for_log(&log, activity_state.as_ref(), &children, preview).await;
+        semantic_activity_for_log(&log, previous.as_ref(), &children, preview).await;
     let descriptor = SourceDescriptor {
         agent: log.agent_type,
         session_id: session_id.clone(),
@@ -1272,6 +1339,131 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_second_pass_over_an_unchanged_source_performs_no_head_read() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = write_claude_session(home.path(), "unchanged-source");
+        antiburn_local::discovery::track_head_reads(&path);
+        let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+
+        let first = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_800_000_000)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_records().unwrap(),
+        )
+        .await;
+        assert_eq!(first.records.len(), 1);
+        assert_eq!(antiburn_local::discovery::take_tracked_head_reads(&path), 1);
+        // `take_tracked_head_reads` deregisters the path, so each phase
+        // re-arms tracking for the read count it is about to check.
+        antiburn_local::discovery::track_head_reads(&path);
+        store
+            .upsert_sessions(&first.records, &agents::evidence_cohort())
+            .unwrap();
+
+        // Second pass, source unchanged: the stored record is reused verbatim
+        // and the transcript is never opened.
+        let second = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_800_000_100)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_records().unwrap(),
+        )
+        .await;
+        assert_eq!(second.records.len(), 1);
+        assert_eq!(second.records[0], first.records[0]);
+        assert_eq!(antiburn_local::discovery::take_tracked_head_reads(&path), 0);
+        antiburn_local::discovery::track_head_reads(&path);
+        store
+            .upsert_sessions(&second.records, &agents::evidence_cohort())
+            .unwrap();
+
+        // A genuine append changes the cursor and forces a real read.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"{\"type\":\"assistant\",\"timestamp\":\"2026-08-01T10:05:00Z\"}\n")
+            .unwrap();
+        let third = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_800_000_200)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_records().unwrap(),
+        )
+        .await;
+        assert_eq!(third.records.len(), 1);
+        assert_eq!(antiburn_local::discovery::take_tracked_head_reads(&path), 1);
+    }
+
+    #[tokio::test]
+    async fn an_mtime_row_is_described_again_when_only_its_mtime_moved() {
+        let home = tempfile::TempDir::new().unwrap();
+        let path = write_claude_session(home.path(), "mtime-source");
+        let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+
+        let first = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_800_000_000)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_records().unwrap(),
+        )
+        .await;
+        assert_eq!(first.records.len(), 1);
+        // Simulate a row whose activity fell back to the file mtime.
+        let mut stored = first.records[0].clone();
+        stored.activity_source = "mtime".into();
+        stored.updated_at_epoch = Some(1_800_000_000);
+        store
+            .upsert_sessions(&[stored], &agents::evidence_cohort())
+            .unwrap();
+
+        // Same size and same mtime: reused without a read.
+        antiburn_local::discovery::track_head_reads(&path);
+        let same = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_800_000_000)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_records().unwrap(),
+        )
+        .await;
+        assert_eq!(antiburn_local::discovery::take_tracked_head_reads(&path), 0);
+        assert_eq!(same.records[0].activity_source, "mtime");
+
+        // Same size but a newer mtime: the pass must describe it again.
+        antiburn_local::discovery::track_head_reads(&path);
+        let moved = describe_with_states(
+            vec![log(AgentKind::Claude, path.clone(), 1_800_000_100)],
+            home.path(),
+            &HashSet::new(),
+            &store.session_records().unwrap(),
+        )
+        .await;
+        assert_eq!(antiburn_local::discovery::take_tracked_head_reads(&path), 1);
+        assert_eq!(moved.records[0].activity_source, "event");
+    }
+
+    #[test]
+    fn the_activity_cursor_format_is_pinned() {
+        let parent = std::path::Path::new("/home/avery/.claude/projects/demo/session.jsonl");
+        let child_a = std::path::PathBuf::from(
+            "/home/avery/.claude/projects/demo/session/subagents/agent-a.jsonl",
+        );
+        let child_b = std::path::PathBuf::from(
+            "/home/avery/.claude/projects/demo/session/subagents/agent-b.jsonl",
+        );
+        let cursor = activity_cursor(parent, 42, &[(child_a, Some(7)), (child_b, None)]);
+        assert_eq!(
+            cursor,
+            concat!(
+                r#"[["child","/home/avery/.claude/projects/demo/session/subagents/agent-a.jsonl","7"],"#,
+                r#"["child","/home/avery/.claude/projects/demo/session/subagents/agent-b.jsonl","missing"],"#,
+                r#"["parent","/home/avery/.claude/projects/demo/session.jsonl","42"]]"#
+            )
+        );
+    }
+
+    #[tokio::test]
     async fn describing_an_opencode_provider_db_does_not_render_the_transcript() {
         let home = tempfile::TempDir::new().unwrap();
         let session_id = "opencode-provider-db";
@@ -1586,7 +1778,7 @@ mod tests {
             .upsert_sessions(&[stale], &agents::evidence_cohort())
             .unwrap();
 
-        let states = store.session_activity_states().unwrap();
+        let states = store.session_records().unwrap();
         let described = describe_with_states(
             vec![log(AgentKind::Claude, path.clone(), 1_787_155_652)],
             home.path(),
@@ -1606,7 +1798,7 @@ mod tests {
             .upsert_sessions(&described.records, &agents::evidence_cohort())
             .unwrap();
         let stored = store
-            .session_activity_states()
+            .session_records()
             .unwrap()
             .remove(&SessionActivityKey::new(
                 "native",
@@ -1633,7 +1825,7 @@ mod tests {
                 .as_bytes(),
             )
             .unwrap();
-        let states = store.session_activity_states().unwrap();
+        let states = store.session_records().unwrap();
         let touched = describe_with_states(
             vec![log(AgentKind::Claude, path.clone(), 1_800_000_000)],
             home.path(),
@@ -1649,7 +1841,7 @@ mod tests {
             store
                 .upsert_sessions(&touched.records, &agents::evidence_cohort())
                 .unwrap();
-            store.session_activity_states().unwrap()
+            store.session_records().unwrap()
         };
         let gated = describe_with_states(
             vec![log(AgentKind::Claude, path, 1_800_000_001)],
@@ -1684,7 +1876,7 @@ mod tests {
             vec![log(AgentKind::Claude, parent.clone(), 1_800_000_000)],
             home.path(),
             &HashSet::new(),
-            &store.session_activity_states().unwrap(),
+            &store.session_records().unwrap(),
         )
         .await;
         assert_eq!(first.records[0].subagent_count, 1);
@@ -1699,7 +1891,7 @@ mod tests {
             vec![log(AgentKind::Claude, parent.clone(), 1_900_000_000)],
             home.path(),
             &HashSet::new(),
-            &store.session_activity_states().unwrap(),
+            &store.session_records().unwrap(),
         )
         .await;
         assert_eq!(gated.records[0].updated_at_epoch, Some(first_epoch));
@@ -1719,7 +1911,7 @@ mod tests {
             vec![log(AgentKind::Claude, parent, 1_900_000_001)],
             home.path(),
             &HashSet::new(),
-            &store.session_activity_states().unwrap(),
+            &store.session_records().unwrap(),
         )
         .await;
         let expected = time::OffsetDateTime::parse(

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -52,8 +52,8 @@ pub use model::{
     EvidenceCompletion, EvidenceFailure, EvidenceRow, EvidenceStatus, HiddenMeters,
     MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement,
     ProjectionRevisions, PublishedEvidence, RETAIN_SESSION_DATA_FOREVER, RelationKind,
-    RelationRecord, RepositoryRecord, SessionActivityKey, SessionActivityState, SessionKey,
-    SessionRecord, SourceVersionState, ThemePreference, UsageEvidenceRecord,
+    RelationRecord, RepositoryRecord, SessionActivityKey, SessionKey, SessionRecord,
+    SourceVersionState, ThemePreference, UsageEvidenceRecord,
 };
 
 /// Evidence rows that still wait for, or sit in, processing.
@@ -766,38 +766,38 @@ impl Store {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
-    /// Return the persisted activity cursor keyed by environment,
-    /// agent, and source label. A single map keeps the scan's cheap size gate
-    /// outside the SQLite lock without allowing native/WSL rows to collide.
-    pub fn session_activity_states(
-        &self,
-    ) -> Result<HashMap<SessionActivityKey, SessionActivityState>> {
+    /// Return every session's full cached record keyed by environment, agent,
+    /// and source label. A single map keeps the scan's cheap unchanged-source
+    /// gate outside the SQLite lock without allowing native/WSL rows to
+    /// collide, and lets the scan reuse a whole previous record instead of
+    /// re-describing a source that has not changed.
+    pub fn session_records(&self) -> Result<HashMap<SessionActivityKey, SessionRecord>> {
         let connection = self.lock();
         let mut statement = connection.prepare(
-            "SELECT environment_key, agent, source_label, activity_cursor,
-                    updated_at_epoch, activity_source
-               FROM session",
+            "SELECT environment_key, agent, session_id, source_kind, source_label, wsl_distro,
+                    title, title_source, cwd, surface, updated_at_epoch,
+                    activity_cursor, activity_source, subagent_count,
+                    (SELECT related_id FROM session_relation r
+                       WHERE r.environment_key = s.environment_key
+                         AND r.agent = s.agent
+                         AND r.session_id = s.session_id
+                         AND r.kind = 'forkParent'
+                       LIMIT 1),
+                    s.source_fingerprint
+               FROM session s",
         )?;
-        let rows = statement.query_map([], |row| {
-            Ok((
-                SessionActivityKey::new(
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                ),
-                SessionActivityState {
-                    activity_cursor: row.get(3)?,
-                    updated_at_epoch: row.get(4)?,
-                    activity_source: row.get(5)?,
-                },
-            ))
-        })?;
-        let mut states = HashMap::new();
+        let rows = statement.query_map([], session_from_row)?;
+        let mut records = HashMap::new();
         for row in rows {
-            let (key, state) = row?;
-            states.insert(key, state);
+            let record = row?;
+            let key = SessionActivityKey::new(
+                record.key.environment_key.clone(),
+                record.key.agent.clone(),
+                record.source_label.clone(),
+            );
+            records.insert(key, record);
         }
-        Ok(states)
+        Ok(records)
     }
 
     /// One session's cached metadata, when it has been seen.

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -117,16 +117,6 @@ impl SessionActivityKey {
     }
 }
 
-/// Small persisted cursor used by the scanner before it reads transcript
-/// suffixes. Kept separate from [`SessionRecord`] so callers that only need
-/// the activity gate do not materialize titles, CWDs, or relationships.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SessionActivityState {
-    pub activity_cursor: String,
-    pub updated_at_epoch: Option<i64>,
-    pub activity_source: String,
-}
-
 /// Engine-derived analysis for one session, as cached.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnalysisRecord {

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1300,14 +1300,14 @@ fn activity_cursors_do_not_collide_across_environments() {
         .upsert_sessions(&[native, wsl], &crate::agents::evidence_cohort())
         .unwrap();
 
-    let states = store.session_activity_states().unwrap();
-    assert_eq!(states.len(), 2);
-    assert!(states.contains_key(&SessionActivityKey::new(
+    let records = store.session_records().unwrap();
+    assert_eq!(records.len(), 2);
+    assert!(records.contains_key(&SessionActivityKey::new(
         "native",
         "claude-code",
         "/home/avery/.claude/projects/demo/shared.jsonl",
     )));
-    assert!(states.contains_key(&SessionActivityKey::new(
+    assert!(records.contains_key(&SessionActivityKey::new(
         "wsl:ubuntu",
         "claude-code",
         "/home/avery/.claude/projects/demo/shared.jsonl",

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -855,6 +855,24 @@ describe("PopoverView", () => {
     await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument())
   })
 
+  it("refetches the session list on the shell's popover-shown signal, as a defence against a missed scan event", async () => {
+    render(<PopoverView />)
+    await screen.findByText("Wire the tray popover")
+
+    const listCallsBeforeShown = invoke.mock.calls.filter(
+      ([command]) => command === "list_recent_sessions",
+    ).length
+
+    emit("popover:shown", undefined)
+
+    await waitFor(() =>
+      expect(
+        invoke.mock.calls.filter(([command]) => command === "list_recent_sessions").length,
+      ).toBeGreaterThan(listCallsBeforeShown),
+    )
+    expect(invoke).toHaveBeenCalledWith("list_recent_sessions", { windowDays: 7 })
+  })
+
   it("never renders the first-run flow, whatever the flag says", async () => {
     // The flow has its own window now (`views/OnboardingView.tsx`), and
     // the shell sends the tray click there instead of here. A popover that

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -590,15 +590,20 @@ export class PopoverSession {
   // paused or onboarding is unfinished, and even a scan that does run can
   // take a while to finish. Neither has any bearing on a provider's own
   // stated limits, so usage gets its own refresh here rather than waiting on
-  // — or being silenced by — the scan pipeline. Entries and the repository
-  // list are already covered by `listenScanEvent` above. The open session's
-  // analysis is not: its transcript can grow while the popover is hidden,
-  // and nothing else asks for it again until the reader navigates.
+  // — or being silenced by — the scan pipeline. The open session's analysis
+  // is in the same position: its transcript can grow while the popover is
+  // hidden, and nothing else asks for it again until the reader navigates.
+  //
+  // Entries are also refetched here, even though the scan scheduler now
+  // ticks unconditionally and `listenScanEvent` above is the primary path:
+  // this is a cheap defence against a `scan:finished` event missed while the
+  // popover was hidden, so a reader never sees a stale list for a whole tick.
   private listenPopoverShown = async (generation: number): Promise<void> => {
     const unlisten = await onPopoverShown(() => {
       if (generation !== this.generation) return
       if (this.initialContentReady) this.reportContentReady(true)
       void this.restoreFloatingHud(generation)
+      void this.refreshEntries(this.windowDays()).catch(() => {})
       void this.refreshUsage()
       void this.refreshAnalysis()
     })

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -1,0 +1,174 @@
+---
+title: "Continuous session ingest: watch, resume, and replay"
+created_at: "2026-09-02"
+status: in progress
+---
+
+# Continuous session ingest
+
+- **Date:** 2026-09-02
+- **Issue:** none yet. Opened from a popover staleness report.
+
+## Problem
+
+Open the popover after a quiet stretch during which new agent sessions
+started, and the session list shows the previous list for a moment, then pops
+into the current one.
+
+The list cannot already be current, because nothing discovers sessions while
+the popover is hidden. The scan scheduler ticks every 60 seconds but skips the
+tick unless the popover is visible (`apps/desktop/src-tauri/src/scan.rs`,
+`should_run_scheduled_pass`). Showing the popover kicks a pass; the list
+refetches only when that pass emits `scan:finished`. The visible gap is one
+full pass.
+
+The gate exists because a pass is expensive. Each pass, for every session
+modified in the last 14 days, walks the agent's directories, opens the
+transcript, reads up to 16 MiB from its head, hashes it, and parses metadata
+out of it. There is no memory of the previous pass at the walk or read level.
+
+Downstream is worse. The insights worker re-parses a whole transcript from
+byte zero on every change it notices, writes every turn row again under a new
+claim fence, and on publish deletes the rows of every other fence. Turn rows
+carry no byte offset. An `AppendOnlyGuarantee` type exists but is hard-coded
+to `Absent` for every agent, because fixtures cannot prove how third-party
+writers update files.
+
+Three more findings shape the design:
+
+- Discovery, ingest, and evidence are fused. The worker's single stream fold
+  fans out to turn rows, metrics, and the evidence accumulator at once
+  (`apps/desktop/src-tauri/src/analysis.rs`, `stream_vendor_with_hooks`).
+  Metrics are replayable from rows with a parity test
+  (`crates/antiburn-local/src/analysis/replay.rs`). Evidence is not.
+- The HUD runs its own discovery walk every 60 seconds, polled every 5
+  seconds by the overlay, to produce one boolean: blink the first usage
+  segment when any transcript was written in the last 90 seconds
+  (`apps/desktop/src-tauri/src/hud.rs`, `latest_session_activity`).
+- Provider-database agents (OpenCode, Antigravity) already have per-session
+  fingerprints from max timestamp plus row count, WAL-aware change detection,
+  and ordering columns (`idx`, `time_created`, `time_updated`). Incremental
+  ingest for them is a query cursor, not a byte offset.
+
+## Target shape
+
+Two layers, split at the database.
+
+**Layer 1: continuous ingest.** One background component watches transcript
+sources, keeps the `session` table current, and appends turn rows as
+transcripts grow. It runs whether or not any window is visible. Its cost is
+proportional to what changed, not to what exists.
+
+- Change detection is tiered by activity: active sessions checked often,
+  inactive sessions rarely, new-session detection frequent but touching only
+  leaf directories. Filesystem events accelerate all three; polling remains
+  as the reconciliation path and the fallback where events are unavailable.
+- Description (the head read) runs only when the source changed.
+- Parse resumes from a persisted offset, verified each time by re-hashing a
+  window of bytes before it. A mismatch falls back to today's full pass.
+- Provider-database sources resume from a row cursor keyed on the vendor's
+  update column.
+- Active-to-idle is a backend timer keyed on the 180-second window, not a
+  file event. Every consumer, including the HUD blink, reads the same signal.
+
+**Layer 2: insights.** Detectors and the Insights report read rows, never
+files. Trigger is "rows changed for this session", debounced, promoted to
+immediate when that session's drilldown is open, plus a report recompute when
+the queue drains. Once it reads rows its cost is O(rows), so it needs no
+activity tiering of its own.
+
+## Decisions
+
+| Decision | Outcome |
+|---|---|
+| Interim fix before the full design | Yes, phase 1 ships first |
+| Filesystem events | Yes, `notify` crate, all platforms; polling stays as reconciliation |
+| CPU budget | Defaults in each phase, tuned by feel afterwards |
+| Provider-database agents | Same tiers; row cursor instead of byte offset |
+| HUD discovery walker | Folded into the shared liveness signal |
+
+## Phases
+
+Each phase is one pull request, mergeable on its own, in dependency order.
+
+### Phase 1: describe only on change, scan while hidden
+
+Goal: fix the pop-in without the new architecture.
+
+- In the scan pass, skip the head read for a file-backed session whose
+  parent and child sizes match the stored activity cursor. Reuse the stored
+  record. The cursor is already sizes-only and already trusted to skip the
+  semantic-timestamp derivation; this extends the same trust to the whole
+  description. Sessions without a stored record, and provider-database
+  sources, are described as today.
+- Remove the popover-visibility gate from the scheduler. The 60-second tick
+  runs while hidden. Showing the popover still kicks a pass as
+  reconciliation.
+- The popover refetches the session list on `popover:shown`, as a cheap
+  defence against a missed event while hidden.
+- Test: a second pass over an unchanged transcript performs no head read
+  (the discovery crate's tracked-head-read instrumentation exists for this).
+
+Known limit, accepted: a title change in a vendor index while the transcript
+size is unchanged is not picked up until the transcript grows. Phase 2
+replaces the size gate with a verified offset.
+
+### Phase 2: verified-resume ingest
+
+Goal: an appended 4 KB costs 4 KB.
+
+- Persist per source (parent and each child) the consumed byte offset and a
+  hash of the trailing window before it. On the next change, re-hash that
+  window; on match, stream from the offset and continue the turn index; on
+  mismatch, full pass.
+- Provider-database sources persist a row cursor on the vendor's update
+  column and ingest rows after it.
+- Fence semantics change: the published row set spans passes. The claim fence
+  still guards a full pass; an incremental pass appends under the published
+  fence inside one transaction. The schema revision and the
+  `published_turn_rows` contract are updated together.
+- A parser or analyzer revision bump invalidates every cursor and forces a
+  full pass.
+- Turn the `AppendOnlyGuarantee` from a static assumption into the runtime
+  verification above.
+- Test: parity. Incremental ingest over a transcript grown in steps produces
+  the same rows as one full pass over the final file, for each vendor.
+
+### Phase 3: evidence from rows
+
+Goal: layer 2 never opens a transcript.
+
+- Parse-time facts the evidence accumulator needs (unrecognized record types,
+  coverage reasons, diagnostic fields) are written by layer 1 as a small
+  per-session coverage record alongside the rows.
+- An evidence replay builds `SessionEvidence` from rows plus that record, with
+  a parity test against the live fold, mirroring the metrics replay.
+- The worker's stream fold stops accumulating evidence. Detectors run from
+  rows on a debounced "rows changed" trigger, immediate for an open
+  drilldown. The Insights report recomputes when the queue drains, as today.
+
+### Phase 4: watcher tiers, events, and the HUD fold-in
+
+Goal: layer 1 is continuous and cheap, and every consumer reads one signal.
+
+- Add `notify`. Watch each agent's roots. Classify events into "new source
+  under a root" and "known source changed". Debounce writes.
+- Polling tiers as reconciliation and fallback: active sources stat every
+  few seconds, inactive every minute, new-source leaf-directory check every
+  few seconds, full walk hourly and on demand. Per-agent leaf strategies
+  replace the unwindowed Codex tree walk and the Claude subagent sweep. WSL
+  paths get a slower tier.
+- A discovery-level per-session event to the webview carries the refreshed
+  `ActivityEntry`, so the list patches one row instead of refetching.
+- Active-to-idle expiry as a backend timer, emitted as the same event.
+- The HUD's `latest_session_activity` becomes a query on the session table
+  or a subscription to the expiry signal; its discovery walk is deleted.
+- The detail pane's 10-second fingerprint poll is replaced by the row-change
+  event.
+
+## Sequencing notes
+
+- Phase 1 stands alone and is reverted by two small edits if it misbehaves.
+- Phase 2 is the enabling work; phases 3 and 4 both depend on it and are
+  independent of each other.
+- Default cadences are set in phase 4 and reviewed after a week of use.


### PR DESCRIPTION
## Why

Opening the tray popover after a while away showed a stale session list that then "popped" into the current one. Three things caused that:

- The scan tick was gated on popover visibility, so nothing happened while the popover was hidden.
- Every pass re-read the head of every session transcript (up to 16 MiB each), even when the file had not changed.
- The list only refetched on `scan:finished`, so the popover showed the old list until the first pass after it opened finished.

## What

Phase 1 of `docs/plans/continuous-session-ingest.md` (the plan is the first commit).

- **Describe a session only when its source changed.** The pass loads the previous session records and reuses a record when the activity cursor (sizes) matches. Rows whose activity comes from the file mtime also require the same mtime. Unchanged sources perform no head read.
- **Keep scanning while the popover is hidden.** The visibility gate, `Wake`, and `should_run_scheduled_pass` are gone. The scheduler waits on a kick or the tick and then runs a pass.
- **Refetch the list when the popover is shown**, so the UI shows the current DB state immediately instead of waiting for the next pass.

Phases 2 to 4 (verified-resume ingest, evidence from rows, `notify` watcher tiers) follow in separate PRs.

## Checks

- `cargo clippy` and `cargo test --no-fail-fast` in `apps/desktop/src-tauri`
- `pnpm --filter @antiburn/desktop lint`, `typecheck`, `test`, and `prettier --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U73g2iRUFcWZ3ivhoHg8hr
