### PR TITLE
Refresh model pricing from models.dev at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ See the [desktop guide](apps/desktop/README.md) for app commands and the
 
 antiburn needs no account, server, or backend operated by the project. It can
 contact coding-agent providers with credentials already held by your tools to
-read current usage. Release builds also check GitHub Releases for updates and
-can send anonymised application events. Analytics can be disabled in
+read current usage. It downloads public model prices from models.dev without
+sending session data or credentials. Release builds also check GitHub Releases
+for updates and can send anonymised application events. Analytics can be disabled in
 Settings > Privacy and never include sessions, prompts, file paths, repository
 names, or credentials. Builds from a clean checkout have no analytics endpoint.
 See the complete [analytics contract](docs/analytics.md).

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -7,9 +7,11 @@ The app discovers the coding-agent sessions already on this machine, analyzes
 them with the engine, and shows activity, per-session analysis, and
 API-equivalent cost estimates. Everything runs on the device, as you: antiburn
 needs no antiburn account, server, or backend of any kind, and nothing about
-your sessions is uploaded. It makes two calls to a service of ours, neither of
-which it depends on: the updater plugin, registered in release builds only,
-asking whether a newer version exists; and the anonymised analytics
+your sessions is uploaded. It downloads public model prices from models.dev at
+startup and hourly while running; the request contains no session data or
+credentials. It also makes two calls to a service of ours, neither of which it
+depends on: the updater plugin, registered in release builds only, asking
+whether a newer version exists; and the anonymised analytics
 channel in [`src-tauri/src/analytics`](src-tauri/src/analytics),
 which reports on the application itself in official release builds. The Ready
 screen explains it, and Settings → Privacy provides the opt-out. The analytics

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -77,8 +77,8 @@ async-trait = "0.1"
 base64 = "0.23"
 # Derives installation-scoped provider account keys without storing subjects.
 hmac = "0.12"
-# Direct provider usage fetch (`provider_usage::live::sources`): a plain
-# HTTPS request to the provider's own endpoint, with the reader's own
+# Direct provider usage and public model-pricing fetches: plain HTTPS requests
+# to the relevant public or provider endpoint, with the reader's own
 # credential — a `GET` for the usage reading itself, and, for Codex, the
 # occasional token-refresh `POST` (`form`, for its `application/`
 # `x-www-form-urlencoded` body). Blocking, so every source's `fetch` stays

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -60,13 +60,10 @@ fn fail(error: impl std::fmt::Display) -> String {
     error.to_string()
 }
 
-/// Version stamp of the engine's bundled pricing catalog (`YYYY-MM-DD`).
-///
-/// Small on purpose, and load-bearing: it is the shell's end-to-end proof that
-/// the webview, the IPC bridge, and the linked engine all work.
+/// Version stamp of the active runtime pricing catalog.
 #[tauri::command]
-pub fn engine_catalog_version() -> &'static str {
-    antiburn_local::pricing::PRICING_CATALOG_VERSION
+pub fn engine_catalog_version(app: tauri::AppHandle) -> String {
+    crate::runtime_pricing::catalog_version(&app)
 }
 
 /// Reveal a native window after its invoking renderer commits its shell.
@@ -282,7 +279,7 @@ pub fn app_info(app: tauri::AppHandle) -> CommandResult<AppInfo> {
         app_version: app.package_info().version.to_string(),
         debug_build: cfg!(debug_assertions),
         arch: std::env::consts::ARCH.to_string(),
-        pricing_catalog_version: antiburn_local::pricing::PRICING_CATALOG_VERSION.to_string(),
+        pricing_catalog_version: crate::runtime_pricing::catalog_version(&app),
         schema_version: store.schema_version().map_err(fail)?,
         data_dir: store.state_dir().to_string_lossy().to_string(),
         indexed_sessions: store.session_count().map_err(fail)?,
@@ -572,6 +569,12 @@ pub fn list_recent_sessions(
     for session in sessions {
         entries.push(activity_entry(&store, &repositories, session, now).map_err(fail)?);
     }
+    if entries
+        .iter()
+        .any(|entry| entry.cost.is_none() && !entry.models.is_empty())
+    {
+        crate::runtime_pricing::request_refresh(&app);
+    }
     Ok(entries)
 }
 
@@ -734,7 +737,7 @@ fn path_is_under(path: &str, root: &str) -> bool {
 ///
 /// Nothing here contacts a provider. Every figure comes from
 /// [`crate::provider_usage`], which reads the local database and the engine's
-/// bundled pricing table and nothing else.
+/// active runtime pricing snapshot.
 #[tauri::command]
 pub fn get_provider_usage(
     app: tauri::AppHandle,
@@ -1717,6 +1720,7 @@ pub async fn export_session(
 
     let document = SessionExport::new(
         app.package_info().version.to_string(),
+        crate::runtime_pricing::catalog_version(&app),
         ExportedSession {
             agent,
             session_id,
@@ -2067,18 +2071,6 @@ mod tests {
         assert_eq!(
             request.window.end_epoch - request.window.start_epoch,
             30 * 86_400 + 1
-        );
-    }
-
-    #[test]
-    fn the_catalog_version_comes_from_the_engine_and_is_a_review_date() {
-        let version = engine_catalog_version();
-        assert_eq!(version, antiburn_local::pricing::PRICING_CATALOG_VERSION);
-        assert_eq!(version.len(), 10, "expected a YYYY-MM-DD review date");
-        assert!(
-            version
-                .split('-')
-                .all(|part| part.chars().all(|c| c.is_ascii_digit()))
         );
     }
 

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -1032,7 +1032,7 @@ pub struct AppInfo {
     pub debug_build: bool,
     /// CPU architecture this binary was compiled for, e.g. `aarch64`.
     pub arch: String,
-    /// Review date of the engine's bundled pricing catalog.
+    /// Version of the active runtime pricing catalog.
     pub pricing_catalog_version: String,
     /// Applied schema version of the local database.
     pub schema_version: i64,

--- a/apps/desktop/src-tauri/src/export.rs
+++ b/apps/desktop/src-tauri/src/export.rs
@@ -74,9 +74,8 @@ pub struct SessionExport {
     pub format_version: u32,
     pub exported_at: String,
     pub app_version: String,
-    /// Review date of the pricing catalog the cost estimate came from, so a
-    /// figure can be interpreted later.
-    pub pricing_catalog_version: &'static str,
+    /// Version of the pricing snapshot used for the cost estimate.
+    pub pricing_catalog_version: String,
     pub content_notice: &'static str,
     pub session: ExportedSession,
     /// The engine's per-session metrics, or absent when the transcript could
@@ -100,6 +99,7 @@ impl SessionExport {
     /// Assemble a document from an analysis and the session's stored metadata.
     pub fn new(
         app_version: String,
+        pricing_catalog_version: String,
         session: ExportedSession,
         analysis: &crate::analysis::SessionAnalysis,
     ) -> SessionExport {
@@ -108,7 +108,7 @@ impl SessionExport {
             format_version: FORMAT_VERSION,
             exported_at: crate::store::now_rfc3339(),
             app_version,
-            pricing_catalog_version: antiburn_local::pricing::PRICING_CATALOG_VERSION,
+            pricing_catalog_version,
             content_notice: CONTENT_NOTICE,
             session,
             metrics: analysis.metrics.clone(),
@@ -140,7 +140,12 @@ mod tests {
 
     #[test]
     fn the_document_references_the_transcript_without_copying_it() {
-        let export = SessionExport::new("0.1.0".into(), session(), &SessionAnalysis::unavailable());
+        let export = SessionExport::new(
+            "0.1.0".into(),
+            "test-catalog".into(),
+            session(),
+            &SessionAnalysis::unavailable(),
+        );
         let json = export.to_json().unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
@@ -200,7 +205,12 @@ mod tests {
 
     #[test]
     fn the_notice_travels_inside_every_document() {
-        let export = SessionExport::new("0.1.0".into(), session(), &SessionAnalysis::unavailable());
+        let export = SessionExport::new(
+            "0.1.0".into(),
+            "test-catalog".into(),
+            session(),
+            &SessionAnalysis::unavailable(),
+        );
         let value: serde_json::Value = serde_json::from_str(&export.to_json().unwrap()).unwrap();
         assert_eq!(value["contentNotice"], CONTENT_NOTICE);
     }
@@ -218,7 +228,12 @@ mod tests {
 
     #[test]
     fn an_unanalyzable_session_still_exports_its_identity() {
-        let export = SessionExport::new("0.1.0".into(), session(), &SessionAnalysis::unavailable());
+        let export = SessionExport::new(
+            "0.1.0".into(),
+            "test-catalog".into(),
+            session(),
+            &SessionAnalysis::unavailable(),
+        );
         let value: serde_json::Value = serde_json::from_str(&export.to_json().unwrap()).unwrap();
         assert_eq!(value["session"]["sessionId"], "abc");
         assert!(value["metrics"].is_null());
@@ -228,10 +243,12 @@ mod tests {
 
     #[test]
     fn the_document_carries_the_catalog_version_its_costs_came_from() {
-        let export = SessionExport::new("0.1.0".into(), session(), &SessionAnalysis::unavailable());
-        assert_eq!(
-            export.pricing_catalog_version,
-            antiburn_local::pricing::PRICING_CATALOG_VERSION
+        let export = SessionExport::new(
+            "0.1.0".into(),
+            "test-catalog".into(),
+            session(),
+            &SessionAnalysis::unavailable(),
         );
+        assert_eq!(export.pricing_catalog_version, "test-catalog");
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -41,7 +41,8 @@
 //! by default once first-run setup is complete, runs that agent so it
 //! refreshes the file — the agent goes online on its own account, exactly as
 //! it would if the reader ran it, and this crate still only reads the file it
-//! leaves behind. Notifications are antiburn's own
+//! leaves behind. The shell downloads a public pricing catalog from models.dev.
+//! The request contains no session data or credentials. Notifications are antiburn's own
 //! window, fed by a local event; nothing about one leaves the machine. The one
 //! call this crate makes to a service of ours is the updater plugin —
 //! registered in release builds only, so a development run makes no such
@@ -73,6 +74,8 @@ mod provider_accounts;
 mod provider_usage;
 mod repositories;
 mod retention;
+mod runtime_pricing;
+mod runtime_pricing_config;
 mod scan;
 mod settings;
 mod startup_registration;
@@ -184,6 +187,7 @@ pub fn run() {
             // engine's state helpers as an explicit argument.
             let data_dir = app.path().app_data_dir()?;
             app.manage(store::Store::open(&data_dir)?);
+            app.manage(runtime_pricing::PricingState::load(&data_dir));
             app.manage(insights_worker::WorkerHandle::default());
             app.manage(insights_ipc::InsightsController::default());
             if let Err(error) = app.state::<store::Store>().reconcile_evidence_revisions(
@@ -287,6 +291,7 @@ pub fn run() {
             };
             app.manage(live_usage);
             if let Some(schedulers) = app.try_state::<Schedulers>() {
+                schedulers.push(runtime_pricing::spawn_scheduler(app.handle()));
                 schedulers.push(scan::spawn_scheduler(app.handle()));
                 schedulers.push(retention::spawn_scheduler(app.handle()));
                 schedulers.push(insights_worker::spawn(app.handle()));

--- a/apps/desktop/src-tauri/src/provider_usage/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/mod.rs
@@ -5,7 +5,7 @@
 //! Exactly one place: the local database's cached session analysis. Each
 //! analyzed session carries a billable-token breakdown per model; this module
 //! attributes those models to providers ([`providers`]), sums them over three
-//! calendar windows, prices them against the engine's bundled catalog, and
+//! calendar windows, prices them against the active runtime snapshot, and
 //! reports how confident the result is.
 //!
 //! # Its ceiling, and why
@@ -206,7 +206,7 @@ struct AgentBuckets {
 #[derive(Debug, Default, Clone, Copy)]
 struct Priced {
     usd: f64,
-    /// At least one model has a price in the bundled catalog.
+    /// At least one model has a price in the runtime snapshot.
     any_priced: bool,
     /// At least one model does not, so `usd` is a floor and not a total.
     any_unpriced: bool,

--- a/apps/desktop/src-tauri/src/provider_usage/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/tests.rs
@@ -4,8 +4,7 @@
 //! nothing here depends on a clock, a scan, or a database. The two things worth
 //! stating explicitly: the anchor `1_800_000_000` is `2027-01-15T08:00:00Z`
 //! (pinned by a test below, and by `commands::tests`), and the pricing figures
-//! come from the engine's bundled catalog rather than from constants repeated
-//! here — a catalog revision should move them, not fail these tests.
+//! come from the engine's test snapshot rather than from repeated constants.
 
 use super::*;
 
@@ -13,7 +12,7 @@ use super::*;
 /// boundaries are all distinct and none of them coincides with `now`.
 const NOW: i64 = 1_800_000_000;
 
-/// A model the bundled catalog prices.
+/// A model the test snapshot prices.
 const PRICED_MODEL: &str = "claude-opus-4-6";
 /// A model it does not, and will not: the point is the shape, not the name.
 const UNPRICED_MODEL: &str = "some-unreleased-model";

--- a/apps/desktop/src-tauri/src/runtime_pricing.rs
+++ b/apps/desktop/src-tauri/src/runtime_pricing.rs
@@ -1,0 +1,607 @@
+//! Runtime model-pricing refresh and last-known-good persistence.
+
+use std::collections::{BTreeMap, HashMap};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use antiburn_local::pricing::ModelPricing;
+use anyhow::{Context, Result, anyhow, bail};
+use reqwest::StatusCode;
+use reqwest::header::{ETAG, IF_NONE_MATCH};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::Notify;
+
+const CACHE_FILE: &str = "model-pricing.json";
+const CACHE_SCHEMA: u32 = 1;
+const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_MODELS: usize = 50_000;
+const MAX_MODEL_ID_BYTES: usize = 512;
+const REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const RETRY_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const REQUEST_COOLDOWN_SECS: u64 = 15 * 60;
+
+// These provider IDs identify model creators, not price values.
+const ORIGIN_PROVIDERS: &[&str] = &[
+    "anthropic",
+    "cohere",
+    "deepseek",
+    "google",
+    "minimax",
+    "mistral",
+    "moonshotai",
+    "openai",
+    "qwen",
+    "xai",
+    "zai",
+];
+
+#[derive(Debug, Clone, Deserialize)]
+struct ModelsDevProvider {
+    #[serde(default)]
+    models: BTreeMap<String, ModelsDevModel>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ModelsDevModel {
+    #[serde(default)]
+    last_updated: Option<String>,
+    #[serde(default)]
+    cost: Option<ModelsDevCost>,
+    #[serde(default)]
+    experimental: Option<ModelsDevExperimental>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ModelsDevExperimental {
+    #[serde(default)]
+    modes: BTreeMap<String, ModelsDevMode>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ModelsDevMode {
+    #[serde(default)]
+    cost: Option<ModelsDevCost>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ModelsDevCost {
+    input: Option<f64>,
+    output: Option<f64>,
+    #[serde(default)]
+    cache_read: Option<f64>,
+    #[serde(default)]
+    cache_write: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PricingSnapshot {
+    schema: u32,
+    source: String,
+    version: String,
+    fetched_at: String,
+    etag: Option<String>,
+    models: HashMap<String, ModelPricing>,
+}
+
+/// Shared pricing refresh state managed by Tauri.
+pub struct PricingState {
+    cache_path: PathBuf,
+    version: RwLock<String>,
+    etag: Mutex<Option<String>>,
+    ready: AtomicBool,
+    ready_notify: Notify,
+    refresh_notify: Notify,
+    last_request_epoch: AtomicU64,
+}
+
+impl PricingState {
+    /// Load the last valid snapshot before background work starts.
+    pub fn load(data_dir: &Path) -> Self {
+        let state = Self {
+            cache_path: data_dir.join(CACHE_FILE),
+            version: RwLock::new("unavailable".to_string()),
+            etag: Mutex::new(None),
+            ready: AtomicBool::new(false),
+            ready_notify: Notify::new(),
+            refresh_notify: Notify::new(),
+            last_request_epoch: AtomicU64::new(0),
+        };
+
+        match read_snapshot(&state.cache_path) {
+            Ok(Some(snapshot)) => {
+                antiburn_local::analysis::install_runtime_pricing(snapshot.models);
+                *state
+                    .version
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = snapshot.version;
+                *state
+                    .etag
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = snapshot.etag;
+                state.mark_ready();
+            }
+            Ok(None) => {}
+            Err(error) => {
+                ::tracing::warn!(event = "pricing_cache_read_failed", error = %error);
+            }
+        }
+        state
+    }
+
+    pub fn version(&self) -> String {
+        self.version
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn etag(&self) -> Option<String> {
+        self.etag
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn mark_ready(&self) {
+        if !self.ready.swap(true, Ordering::Release) {
+            self.ready_notify.notify_waiters();
+        }
+    }
+
+    fn request_refresh(&self) {
+        let now = epoch_seconds();
+        let previous = self.last_request_epoch.load(Ordering::Relaxed);
+        if now.saturating_sub(previous) < REQUEST_COOLDOWN_SECS {
+            return;
+        }
+        if self
+            .last_request_epoch
+            .compare_exchange(previous, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            self.refresh_notify.notify_one();
+        }
+    }
+}
+
+/// Wait until a cache loads or the first network attempt completes.
+pub async fn wait_until_ready(app: &AppHandle) {
+    let state = app.state::<PricingState>();
+    loop {
+        let notified = state.ready_notify.notified();
+        if state.ready.load(Ordering::Acquire) {
+            return;
+        }
+        notified.await;
+    }
+}
+
+/// Request an early refresh when the UI encounters an unpriced model.
+pub fn request_refresh(app: &AppHandle) {
+    app.state::<PricingState>().request_refresh();
+}
+
+/// Return the active catalog version shown in exports and About.
+pub fn catalog_version(app: &AppHandle) -> String {
+    app.state::<PricingState>().version()
+}
+
+/// Start the hourly refresh scheduler.
+pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let success = match refresh(&app).await {
+                Ok(invalidated) => {
+                    if invalidated {
+                        let _ = app.emit(crate::commands::SESSIONS_INVALIDATED_EVENT, ());
+                    }
+                    true
+                }
+                Err(error) => {
+                    ::tracing::warn!(event = "pricing_refresh_failed", error = ?error);
+                    false
+                }
+            };
+            app.state::<PricingState>().mark_ready();
+
+            let delay = if success {
+                REFRESH_INTERVAL
+            } else {
+                RETRY_INTERVAL
+            };
+            let state = app.state::<PricingState>();
+            tokio::select! {
+                () = tokio::time::sleep(delay) => {}
+                () = state.refresh_notify.notified() => {}
+            }
+        }
+    })
+}
+
+async fn refresh(app: &AppHandle) -> Result<bool> {
+    let state = app.state::<PricingState>();
+    state
+        .last_request_epoch
+        .store(epoch_seconds(), Ordering::Relaxed);
+    let etag = state.etag();
+    let downloaded = tauri::async_runtime::spawn_blocking(move || download(etag))
+        .await
+        .context("pricing download task failed")??;
+    let Some(snapshot) = downloaded else {
+        ::tracing::debug!(event = "pricing_catalog_not_modified");
+        return Ok(false);
+    };
+
+    validate_snapshot(&snapshot)?;
+    let version_changed = app.state::<PricingState>().version() != snapshot.version;
+    let changed = antiburn_local::analysis::install_runtime_pricing(snapshot.models.clone());
+    if let Err(error) = antiburn_local::paths::state_files::write_json_atomic(
+        &app.state::<PricingState>().cache_path,
+        &snapshot,
+    )
+    .await
+    {
+        ::tracing::warn!(event = "pricing_cache_write_failed", error = %error);
+    }
+
+    let state = app.state::<PricingState>();
+    *state
+        .version
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = snapshot.version.clone();
+    *state
+        .etag
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = snapshot.etag.clone();
+    ::tracing::info!(
+        event = "pricing_catalog_refreshed",
+        version = snapshot.version,
+        models = snapshot.models.len(),
+        changed
+    );
+    Ok(changed || version_changed)
+}
+
+fn download(etag: Option<String>) -> Result<Option<PricingSnapshot>> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .user_agent(concat!("antiburn/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("failed to build the pricing client")?;
+    let mut request = client.get(crate::runtime_pricing_config::MODELS_DEV.url());
+    if let Some(etag) = etag {
+        request = request.header(IF_NONE_MATCH, etag);
+    }
+    let mut response = request.send().context("failed to download model pricing")?;
+    if response.status() == StatusCode::NOT_MODIFIED {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        bail!("models.dev returned {}", response.status());
+    }
+
+    let response_etag = response
+        .headers()
+        .get(ETAG)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let mut payload = Vec::new();
+    response
+        .by_ref()
+        .take(MAX_RESPONSE_BYTES + 1)
+        .read_to_end(&mut payload)
+        .context("failed to read the pricing response")?;
+    if payload.len() as u64 > MAX_RESPONSE_BYTES {
+        bail!("models.dev response exceeded the size limit");
+    }
+
+    let catalog: BTreeMap<String, ModelsDevProvider> =
+        serde_json::from_slice(&payload).context("failed to parse models.dev pricing")?;
+    Ok(Some(snapshot_from_catalog(catalog, response_etag)?))
+}
+
+fn snapshot_from_catalog(
+    catalog: BTreeMap<String, ModelsDevProvider>,
+    etag: Option<String>,
+) -> Result<PricingSnapshot> {
+    let mut models = HashMap::new();
+    let mut bare_candidates: BTreeMap<String, Vec<(String, ModelPricing)>> = BTreeMap::new();
+    let mut version = String::new();
+
+    for (provider_id, provider) in catalog {
+        for (model_id, model) in provider.models {
+            if let Some(last_updated) = model.last_updated.as_deref()
+                && last_updated > version.as_str()
+            {
+                version = last_updated.to_string();
+            }
+            if let Some(pricing) = model.cost.as_ref().and_then(convert_cost) {
+                add_candidate(
+                    &mut models,
+                    &mut bare_candidates,
+                    &provider_id,
+                    &model_id,
+                    pricing,
+                );
+            }
+            if let Some(experimental) = model.experimental {
+                for (mode, mode_data) in experimental.modes {
+                    if let Some(pricing) = mode_data.cost.as_ref().and_then(convert_cost) {
+                        add_candidate(
+                            &mut models,
+                            &mut bare_candidates,
+                            &provider_id,
+                            &format!("{model_id}-{mode}"),
+                            pricing,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    for (model_id, candidates) in bare_candidates {
+        if let Some(pricing) = select_bare_pricing(&candidates) {
+            models.insert(model_id, pricing);
+        }
+    }
+
+    if models.is_empty() {
+        bail!("models.dev returned no usable prices");
+    }
+    if version.is_empty() {
+        return Err(anyhow!("models.dev returned no catalog version"));
+    }
+
+    Ok(PricingSnapshot {
+        schema: CACHE_SCHEMA,
+        source: "models.dev".to_string(),
+        version,
+        fetched_at: antiburn_local::paths::state_files::now_rfc3339(),
+        etag,
+        models,
+    })
+}
+
+/// Use a creator's rate or a multi-provider consensus for a bare model ID.
+fn select_bare_pricing(candidates: &[(String, ModelPricing)]) -> Option<ModelPricing> {
+    let origins = candidates
+        .iter()
+        .filter(|(provider, _)| ORIGIN_PROVIDERS.contains(&provider.as_str()))
+        .map(|(_, pricing)| pricing)
+        .collect::<Vec<_>>();
+    if let Some(first) = origins.first() {
+        return origins
+            .iter()
+            .all(|pricing| *pricing == *first)
+            .then(|| (*first).clone());
+    }
+    if candidates.len() < 2 {
+        return None;
+    }
+    let first = &candidates.first()?.1;
+    candidates
+        .iter()
+        .all(|(_, pricing)| pricing == first)
+        .then(|| first.clone())
+}
+
+fn add_candidate(
+    models: &mut HashMap<String, ModelPricing>,
+    bare_candidates: &mut BTreeMap<String, Vec<(String, ModelPricing)>>,
+    provider_id: &str,
+    model_id: &str,
+    pricing: ModelPricing,
+) {
+    if model_id.len() > MAX_MODEL_ID_BYTES
+        || provider_id.len() + model_id.len() + 1 > MAX_MODEL_ID_BYTES
+    {
+        return;
+    }
+    let provider_id = provider_id.to_lowercase();
+    let model_id = model_id.to_lowercase();
+    models.insert(format!("{provider_id}/{model_id}"), pricing.clone());
+    models.insert(format!("{provider_id}.{model_id}"), pricing.clone());
+    bare_candidates
+        .entry(model_id)
+        .or_default()
+        .push((provider_id, pricing));
+}
+
+fn convert_cost(cost: &ModelsDevCost) -> Option<ModelPricing> {
+    let input = cost.input?;
+    let output = cost.output?;
+    let values = [
+        input,
+        output,
+        cost.cache_read.unwrap_or(input),
+        cost.cache_write.unwrap_or(0.0),
+    ];
+    if values
+        .iter()
+        .any(|value| !value.is_finite() || *value < 0.0)
+    {
+        return None;
+    }
+    Some(ModelPricing {
+        input_cost_per_token: values[0] / 1_000_000.0,
+        output_cost_per_token: values[1] / 1_000_000.0,
+        cache_read_cost_per_token: values[2] / 1_000_000.0,
+        cache_write_cost_per_token: values[3] / 1_000_000.0,
+    })
+}
+
+fn read_snapshot(path: &Path) -> Result<Option<PricingSnapshot>> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.len() > MAX_RESPONSE_BYTES => {
+            bail!("pricing cache exceeded the size limit");
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("failed to inspect the pricing cache"),
+    }
+    let payload = match std::fs::read(path) {
+        Ok(payload) => payload,
+        Err(error) => return Err(error).context("failed to read the pricing cache"),
+    };
+    let snapshot: PricingSnapshot =
+        serde_json::from_slice(&payload).context("failed to parse the pricing cache")?;
+    validate_snapshot(&snapshot)?;
+    Ok(Some(snapshot))
+}
+
+fn validate_snapshot(snapshot: &PricingSnapshot) -> Result<()> {
+    if snapshot.schema != CACHE_SCHEMA || snapshot.source != "models.dev" {
+        bail!("unsupported pricing cache format");
+    }
+    if snapshot.models.is_empty()
+        || snapshot.models.len() > MAX_MODELS
+        || !valid_catalog_version(&snapshot.version)
+    {
+        bail!("pricing cache has no usable catalog");
+    }
+    let valid = snapshot.models.iter().all(|(model, pricing)| {
+        model.len() <= MAX_MODEL_ID_BYTES
+            && [
+                pricing.input_cost_per_token,
+                pricing.output_cost_per_token,
+                pricing.cache_read_cost_per_token,
+                pricing.cache_write_cost_per_token,
+            ]
+            .iter()
+            .all(|value| value.is_finite() && *value >= 0.0)
+    });
+    if !valid {
+        bail!("pricing cache contains an invalid price");
+    }
+    Ok(())
+}
+
+fn valid_catalog_version(version: &str) -> bool {
+    let bytes = version.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(index, byte)| index == 4 || index == 7 || byte.is_ascii_digit())
+}
+
+fn epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cost(input: f64, output: f64) -> ModelsDevCost {
+        ModelsDevCost {
+            input: Some(input),
+            output: Some(output),
+            cache_read: Some(input / 10.0),
+            cache_write: None,
+        }
+    }
+
+    #[test]
+    fn origin_provider_wins_a_conflicting_bare_model_id() {
+        let catalog = BTreeMap::from([
+            (
+                "anthropic".to_string(),
+                ModelsDevProvider {
+                    models: BTreeMap::from([(
+                        "sample-model".to_string(),
+                        ModelsDevModel {
+                            last_updated: Some("2026-09-01".to_string()),
+                            cost: Some(cost(10.0, 50.0)),
+                            experimental: None,
+                        },
+                    )]),
+                },
+            ),
+            (
+                "reseller".to_string(),
+                ModelsDevProvider {
+                    models: BTreeMap::from([(
+                        "sample-model".to_string(),
+                        ModelsDevModel {
+                            last_updated: Some("2026-08-01".to_string()),
+                            cost: Some(cost(20.0, 60.0)),
+                            experimental: None,
+                        },
+                    )]),
+                },
+            ),
+        ]);
+        let snapshot = snapshot_from_catalog(catalog, Some("tag".to_string())).unwrap();
+        assert_eq!(snapshot.version, "2026-09-01");
+        assert_eq!(snapshot.models["sample-model"].input_cost_per_token, 10e-6);
+        assert_eq!(
+            snapshot.models["reseller/sample-model"].input_cost_per_token,
+            20e-6
+        );
+    }
+
+    #[test]
+    fn experimental_modes_become_model_suffixes() {
+        let catalog = BTreeMap::from([(
+            "openai".to_string(),
+            ModelsDevProvider {
+                models: BTreeMap::from([(
+                    "sample-model".to_string(),
+                    ModelsDevModel {
+                        last_updated: Some("2026-09-01".to_string()),
+                        cost: Some(cost(1.0, 2.0)),
+                        experimental: Some(ModelsDevExperimental {
+                            modes: BTreeMap::from([(
+                                "fast".to_string(),
+                                ModelsDevMode {
+                                    cost: Some(cost(3.0, 4.0)),
+                                },
+                            )]),
+                        }),
+                    },
+                )]),
+            },
+        )]);
+        let snapshot = snapshot_from_catalog(catalog, None).unwrap();
+        assert_eq!(
+            snapshot.models["sample-model-fast"].input_cost_per_token,
+            3e-6
+        );
+    }
+
+    #[test]
+    fn a_single_reseller_price_stays_provider_qualified() {
+        let candidates = vec![(
+            "reseller".to_string(),
+            convert_cost(&cost(1.0, 2.0)).unwrap(),
+        )];
+        assert!(select_bare_pricing(&candidates).is_none());
+    }
+
+    #[test]
+    fn invalid_or_incomplete_costs_are_rejected() {
+        assert!(convert_cost(&cost(f64::NAN, 1.0)).is_none());
+        assert!(
+            convert_cost(&ModelsDevCost {
+                input: Some(1.0),
+                output: None,
+                cache_read: None,
+                cache_write: None,
+            })
+            .is_none()
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/runtime_pricing_config.rs
+++ b/apps/desktop/src-tauri/src/runtime_pricing_config.rs
@@ -1,0 +1,20 @@
+//! Fixed public source for the runtime model catalog.
+
+/// The public models.dev catalog endpoint.
+pub struct CatalogEndpoint {
+    scheme: &'static str,
+    authority: &'static str,
+    path: &'static str,
+}
+
+impl CatalogEndpoint {
+    pub fn url(&self) -> String {
+        format!("{}://{}{}", self.scheme, self.authority, self.path)
+    }
+}
+
+pub const MODELS_DEV: CatalogEndpoint = CatalogEndpoint {
+    scheme: "https",
+    authority: "models.dev",
+    path: "/api.json",
+};

--- a/apps/desktop/src-tauri/src/scan.rs
+++ b/apps/desktop/src-tauri/src/scan.rs
@@ -160,6 +160,7 @@ pub(crate) fn on_demand_start(controller: &ScanController) -> bool {
 pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
+        crate::runtime_pricing::wait_until_ready(&app).await;
         // A fresh install has nothing to scan until the reader picks sources.
         if scheduled_scanning_allowed(&app) {
             run_pass(&app, None).await;

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -719,10 +719,7 @@ export async function popoverContentReady(generation: number): Promise<void> {
 }
 
 /**
- * Version stamp of the engine's bundled pricing catalog.
- *
- * The end-to-end proof that the shell links the local engine: the value
- * originates in `antiburn_local::pricing::PRICING_CATALOG_VERSION`.
+ * Version stamp of the active runtime pricing catalog.
  */
 export async function engineCatalogVersion(): Promise<string | null> {
   if (!hasShell()) return null

--- a/apps/desktop/src/views/settings/AboutPane.tsx
+++ b/apps/desktop/src/views/settings/AboutPane.tsx
@@ -92,7 +92,7 @@ export function AboutPane({ settings, update, loaded, info, onOpenPane }: AboutP
         <Card>
           <Row
             label="Pricing catalog"
-            description="Review date of the bundled price list every cost estimate is computed from. Prices are never fetched."
+            description="Latest models.dev snapshot used for cost estimates. Antiburn refreshes it hourly and keeps the last valid copy locally."
             trailing={
               <span className="type-body tabular-nums text-label-secondary">
                 {info?.pricingCatalogVersion ?? "—"}

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -174,18 +174,19 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
             There is no antiburn account, and nothing of ours you have to reach for the app to
             work. Nothing derived from your sessions — no transcript, prompt, title, file path,
             repository name, token count, or cost figure — is sent anywhere, ever. antiburn does
-            make requests of its own: it asks GitHub Releases whether a newer version exists;
-            where a source is enabled, it can ask a provider for your current plan limits using
-            the credentials your own tools already stored; and, in a released build with the
-            switch below on, it sends anonymised analytics about the application itself. Handing
-            a provider back a credential it issued you is not a disclosure — it already has it.
-            Those analytics are the one thing that goes to us; they are listed field by field
-            below, and they contain none of your work. This build
+            make requests of its own: it downloads public model prices from models.dev at
+            startup and hourly while running; it asks GitHub Releases whether a newer version
+            exists; where a source is enabled, it can ask a provider for your current plan
+            limits using the credentials your own tools already stored; and, in a released build
+            with the switch below on, it sends anonymised analytics about the application
+            itself. Handing a provider back a credential it issued you is not a disclosure — it
+            already has it. Those analytics are the one thing that goes to us; they are listed
+            field by field below, and they contain none of your work. This build
             {analyticsSupported
               ? " can send them."
               : " has no analytics endpoint, so it cannot send them at all."}
           </Disclosure>
-          <Disclosure label="One setting lets antiburn go online for current figures">
+          <Disclosure label="Provider plan-limit access is optional">
             Settings &rarr; Usage has a switch, on by default once first-run setup is complete,
             for keeping plan limits current. On, antiburn asks each provider directly for your
             current usage, using the credentials your own coding tools already have — that is

--- a/apps/desktop/src/views/settings/UpdatesSection.tsx
+++ b/apps/desktop/src/views/settings/UpdatesSection.tsx
@@ -35,8 +35,7 @@ import type { AppSettingsController } from "./useAppSettings"
  * already names the version, so the row here is the action and its status,
  * not a restatement.
  *
- * The updater plugin is the **only** network-capable surface in the whole
- * application, and `info.updatesSupported` is the shell's answer about whether
+ * `info.updatesSupported` is the shell's answer about whether
  * it actually registered — not a compile-time guess. Everything here hangs off
  * that one flag:
  *

--- a/crates/antiburn-local/src/analysis/pricing.rs
+++ b/crates/antiburn-local/src/analysis/pricing.rs
@@ -1,87 +1,111 @@
-//! On-device session cost estimation — the engine's *local estimate* layer over
-//! [`crate::pricing`].
-//!
-//! The pricing primitives — the bundled catalog, model-key normalization, and the
-//! per-model cost math — live in [`crate::pricing`]. This module is the thin
-//! analysis-side adapter over them: it holds the bundled table as a process-wide
-//! singleton that a caller may overlay with a newer snapshot
-//! ([`install_runtime_pricing`]), strips the `[..]` context-window tag some
-//! transcripts carry (which the catalog's normalization intentionally leaves to
-//! callers), and maps a [`crate::pricing::Cost`] into the analysis-facing
-//! [`SessionCost`].
-//!
-//! Every figure produced here is an estimate computed on this machine from the
-//! bundled catalog; nothing is fetched. Cost is priced **per-model**: a session
-//! that mixes models (e.g. Opus on the main thread, Haiku on subagents) is billed
-//! at each model's own rate rather than entirely at the most expensive one. When
-//! no model in a session is priceable, [`price_breakdown`] returns `None` so a
-//! caller can render "unknown" rather than a misleading `$0`.
+//! On-device session cost estimation over a caller-installed pricing snapshot.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::pricing::{ModelPricing, ModelTokens, authoritative_openai_pricing, fallback_pricing};
-
 use crate::analysis::engine::SessionCost;
+use crate::pricing::{ModelPricing, ModelTokens};
 
 static PRICING_GENERATION: AtomicU64 = AtomicU64::new(0);
 
-/// The cold-start pricing table, built once from `crate::pricing::fallback_pricing()`.
-/// Held in a `OnceLock` so lookups borrow a stable reference and the table is allocated
-/// a single time per process.
 fn pricing_table() -> &'static std::sync::RwLock<HashMap<String, ModelPricing>> {
     static TABLE: std::sync::OnceLock<std::sync::RwLock<HashMap<String, ModelPricing>>> =
         std::sync::OnceLock::new();
-    TABLE.get_or_init(|| std::sync::RwLock::new(fallback_pricing()))
+    TABLE.get_or_init(|| std::sync::RwLock::new(initial_pricing()))
 }
 
-/// Replace the process runtime overrides while retaining bundled fallback
-/// coverage. Runtime entries win on ordinary normalized model keys; verified
-/// OpenAI entries remain authoritative over downloaded snapshots.
-pub fn install_runtime_pricing(runtime: HashMap<String, ModelPricing>) {
-    let merged = merged_pricing(runtime);
-    let models = merged.len();
+#[cfg(not(any(test, feature = "test-instrumentation")))]
+fn initial_pricing() -> HashMap<String, ModelPricing> {
+    HashMap::new()
+}
+
+// These fixtures keep cost tests deterministic. Production builds start empty.
+#[cfg(any(test, feature = "test-instrumentation"))]
+fn initial_pricing() -> HashMap<String, ModelPricing> {
+    fn price(input: f64, output: f64, cache_read: f64, cache_write: f64) -> ModelPricing {
+        ModelPricing {
+            input_cost_per_token: input,
+            output_cost_per_token: output,
+            cache_read_cost_per_token: cache_read,
+            cache_write_cost_per_token: cache_write,
+        }
+    }
+
+    let opus = price(5e-6, 25e-6, 0.5e-6, 10e-6);
+    HashMap::from([
+        ("claude-opus-4-6".to_string(), opus.clone()),
+        ("claude-opus-4-7".to_string(), opus.clone()),
+        ("claude-opus-4-8".to_string(), opus),
+        (
+            "claude-sonnet-4-5".to_string(),
+            price(3e-6, 15e-6, 0.3e-6, 6e-6),
+        ),
+        (
+            "claude-sonnet-4-6".to_string(),
+            price(3e-6, 15e-6, 0.3e-6, 6e-6),
+        ),
+        (
+            "claude-3-5-haiku".to_string(),
+            price(0.8e-6, 4e-6, 0.08e-6, 1.6e-6),
+        ),
+        (
+            "claude-haiku-4-5".to_string(),
+            price(1e-6, 5e-6, 0.1e-6, 2e-6),
+        ),
+        (
+            "claude-fable-5".to_string(),
+            price(10e-6, 50e-6, 1e-6, 20e-6),
+        ),
+        ("gpt-5.4".to_string(), price(2.5e-6, 15e-6, 0.25e-6, 0.0)),
+        ("gpt-5.6".to_string(), price(5e-6, 30e-6, 0.5e-6, 6.25e-6)),
+        (
+            "gpt-5.6-sol".to_string(),
+            price(5e-6, 30e-6, 0.5e-6, 6.25e-6),
+        ),
+    ])
+}
+
+fn normalized_pricing(runtime: HashMap<String, ModelPricing>) -> HashMap<String, ModelPricing> {
+    runtime
+        .into_iter()
+        .map(|(model, pricing)| {
+            let stripped = strip_window_tag(&model);
+            let normalized = crate::pricing::normalize_model_key(stripped).to_lowercase();
+            (normalized, pricing)
+        })
+        .collect()
+}
+
+/// Replace the active runtime snapshot. Returns whether the table changed.
+pub fn install_runtime_pricing(runtime: HashMap<String, ModelPricing>) -> bool {
+    let runtime = normalized_pricing(runtime);
+    let models = runtime.len();
     let mut table = pricing_table()
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if *table == merged {
-        return;
+    if *table == runtime {
+        return false;
     }
-    *table = merged;
+    *table = runtime;
     let generation = PRICING_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
     ::tracing::info!(event = "runtime_pricing_installed", generation, models);
+    true
 }
 
-/// Monotonic process-local version used to invalidate cached cost-bearing
-/// metrics whenever a newer runtime pricing snapshot is installed.
+/// Return the process-local generation of the active pricing snapshot.
 pub fn pricing_generation() -> u64 {
     PRICING_GENERATION.load(Ordering::Relaxed)
 }
 
-fn merged_pricing(runtime: HashMap<String, ModelPricing>) -> HashMap<String, ModelPricing> {
-    let mut merged = fallback_pricing();
-    for (model, pricing) in runtime {
-        let stripped = strip_window_tag(&model);
-        let normalized = crate::pricing::normalize_model_key(stripped).to_lowercase();
-        merged.insert(normalized, pricing);
-    }
-    merged.extend(authoritative_openai_pricing());
-    merged
-}
-
-/// Strip a trailing `[..]` context-window tag (e.g. `claude-opus-4-7[1m]`) so the key
-/// matches the pricing table. [`crate::pricing::lookup_pricing`] handles lowercasing
-/// and the `-YYYYMMDD` date suffix, but leaves this transcript-side window tag to the
-/// caller.
+/// Strip a trailing context-window tag from a transcript model ID.
 pub fn strip_window_tag(model: &str) -> &str {
     match model.find('[') {
-        Some(idx) => model[..idx].trim_end(),
+        Some(index) => model[..index].trim_end(),
         None => model,
     }
 }
 
-/// Look up pricing for a model id, stripping the window tag first. Returns the
-/// catalog's [`ModelPricing`] (`*_cost_per_token` fields), or `None` for unknown models.
+/// Look up one model in the active pricing snapshot.
 pub fn lookup_pricing(model: &str) -> Option<ModelPricing> {
     let table = pricing_table()
         .read()
@@ -89,9 +113,7 @@ pub fn lookup_pricing(model: &str) -> Option<ModelPricing> {
     crate::pricing::lookup_pricing(strip_window_tag(model), &table).cloned()
 }
 
-/// Estimate the cost of a session from a per-model token breakdown, pricing each model at
-/// its own rate. Returns `None` when *no* model in the breakdown is priceable, so the UI
-/// shows no badge rather than a wrong `$0`.
+/// Estimate a complete per-model token breakdown.
 pub fn price_breakdown(breakdown: &HashMap<String, ModelTokens>) -> Option<SessionCost> {
     if breakdown.is_empty() {
         return None;
@@ -104,15 +126,15 @@ pub fn price_breakdown(breakdown: &HashMap<String, ModelTokens>) -> Option<Sessi
         for model in &result.unpriced_models {
             ::tracing::trace!(event = "model_unpriced", model);
         }
-        return None; // a partial subject total would silently undercount
+        return None;
     }
-    let c = result.cost;
+    let cost = result.cost;
     Some(SessionCost {
-        total_usd: c.total_usd,
-        input_usd: c.input_usd,
-        output_usd: c.output_usd,
-        cache_read_usd: c.cache_read_usd,
-        cache_write_usd: c.cache_write_usd,
+        total_usd: cost.total_usd,
+        input_usd: cost.input_usd,
+        output_usd: cost.output_usd,
+        cache_read_usd: cost.cache_read_usd,
+        cache_write_usd: cost.cache_write_usd,
     })
 }
 
@@ -120,133 +142,38 @@ pub fn price_breakdown(breakdown: &HashMap<String, ModelTokens>) -> Option<Sessi
 mod tests {
     use super::*;
 
-    fn tokens(input: u64, output: u64, cache_read: u64, cache_creation: u64) -> ModelTokens {
-        ModelTokens {
-            input_tokens: input,
-            output_tokens: output,
-            cache_read_tokens: cache_read,
-            cache_creation_tokens: cache_creation,
-            cache_creation_1h_tokens: 0,
-        }
+    #[test]
+    fn window_and_date_suffixes_resolve() {
+        let base = lookup_pricing("claude-opus-4-7").unwrap();
+        assert_eq!(lookup_pricing("claude-opus-4-7[1m]"), Some(base.clone()));
+        assert_eq!(lookup_pricing("claude-opus-4-7-20260301"), Some(base));
     }
 
     #[test]
-    fn strip_window_tag_drops_bracketed_suffix() {
-        assert_eq!(strip_window_tag("claude-opus-4-7[1m]"), "claude-opus-4-7");
-        assert_eq!(strip_window_tag("claude-opus-4-6"), "claude-opus-4-6");
-    }
-
-    #[test]
-    fn lookup_resolves_window_and_date_suffixes() {
-        let base = lookup_pricing("claude-opus-4-6").unwrap();
-        let windowed = lookup_pricing("claude-opus-4-7[1m]").unwrap();
-        let dated = lookup_pricing("claude-opus-4-6-20260301").unwrap();
-        // 4-7 shares the 4-6 tier; date/window variants resolve to the same rates.
-        assert_eq!(base.input_cost_per_token, windowed.input_cost_per_token);
-        assert_eq!(base.input_cost_per_token, dated.input_cost_per_token);
-    }
-
-    #[test]
-    fn unknown_model_is_not_priceable() {
-        assert!(lookup_pricing("some-unreleased-model").is_none());
-        let mut b = HashMap::new();
-        b.insert(
-            "some-unreleased-model".to_string(),
-            tokens(1000, 1000, 0, 0),
-        );
-        assert!(price_breakdown(&b).is_none());
-    }
-
-    #[test]
-    fn empty_breakdown_yields_no_estimate() {
+    fn unknown_or_partial_breakdowns_have_no_estimate() {
+        let unknown = HashMap::from([(
+            "unknown-model".to_string(),
+            ModelTokens {
+                output_tokens: 1,
+                ..Default::default()
+            },
+        )]);
+        assert!(price_breakdown(&unknown).is_none());
         assert!(price_breakdown(&HashMap::new()).is_none());
     }
 
     #[test]
-    fn single_model_sums_four_components() {
-        // Opus 4.6: in 5e-06, out 2.5e-05, cr 5e-07, cw 1e-05.
-        let mut b = HashMap::new();
-        b.insert(
-            "claude-opus-4-6".to_string(),
-            tokens(1_000_000, 1_000_000, 1_000_000, 1_000_000),
-        );
-        let c = price_breakdown(&b).unwrap();
-        assert!((c.input_usd - 5.0).abs() < 1e-9);
-        assert!((c.output_usd - 25.0).abs() < 1e-9);
-        assert!((c.cache_read_usd - 0.5).abs() < 1e-9);
-        assert!((c.cache_write_usd - 10.0).abs() < 1e-9);
-        assert!((c.total_usd - 40.5).abs() < 1e-9);
-    }
-
-    #[test]
-    fn one_hour_cache_writes_use_twice_the_input_rate() {
-        let mut model_tokens = tokens(0, 0, 0, 1_000_000);
-        model_tokens.cache_creation_1h_tokens = 1_000_000;
-        let breakdown = HashMap::from([("claude-opus-4-6".to_string(), model_tokens)]);
-
-        let cost = price_breakdown(&breakdown).unwrap();
-        assert!((cost.cache_write_usd - 10.0).abs() < 1e-9);
-        assert!((cost.total_usd - 10.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn mixed_models_price_per_model_not_at_most_expensive() {
-        // 1M output tokens on Opus (main) + 1M output tokens on Haiku (subagent).
-        let mut b = HashMap::new();
-        b.insert("claude-opus-4-6".to_string(), tokens(0, 1_000_000, 0, 0));
-        b.insert("claude-haiku-4-5".to_string(), tokens(0, 1_000_000, 0, 0));
-        let per_model = price_breakdown(&b).unwrap();
-        // Per-model: Opus output 2.5e-05 + Haiku output 5e-06 = $25 + $5 = $30.
-        assert!((per_model.total_usd - 30.0).abs() < 1e-9);
-
-        // The old behavior priced both buckets at the most-expensive model (Opus):
-        // 2M * 2.5e-05 = $50. Per-model must be strictly cheaper.
-        let mut all_opus = HashMap::new();
-        all_opus.insert("claude-opus-4-6".to_string(), tokens(0, 2_000_000, 0, 0));
-        let overstated = price_breakdown(&all_opus).unwrap();
-        assert!((overstated.total_usd - 50.0).abs() < 1e-9);
-        assert!(per_model.total_usd < overstated.total_usd);
-    }
-
-    #[test]
-    fn any_unpriced_model_suppresses_the_partial_subject_total() {
-        // One known + one unknown model must not silently price only the known
-        // portion of the addressed session.
-        let mut b = HashMap::new();
-        b.insert("claude-haiku-4-5".to_string(), tokens(0, 1_000_000, 0, 0));
-        b.insert(
-            "some-unreleased-model".to_string(),
-            tokens(0, 1_000_000, 0, 0),
-        );
-        assert!(price_breakdown(&b).is_none());
-    }
-
-    #[test]
-    fn runtime_prices_override_bundled_entries_without_erasing_fallbacks() {
-        let runtime_sonnet = ModelPricing {
-            input_cost_per_token: 9.0,
-            output_cost_per_token: 8.0,
-            cache_read_cost_per_token: 7.0,
-            cache_write_cost_per_token: 6.0,
-        };
-        let stale_gpt_56 = ModelPricing {
+    fn runtime_keys_are_normalized_before_installation() {
+        let rate = ModelPricing {
             input_cost_per_token: 1.0,
             output_cost_per_token: 2.0,
             cache_read_cost_per_token: 3.0,
             cache_write_cost_per_token: 4.0,
         };
-        let merged = merged_pricing(HashMap::from([
-            (
-                "CLAUDE-SONNET-5-20260713".to_string(),
-                runtime_sonnet.clone(),
-            ),
-            ("gpt-5.6-terra".to_string(), stale_gpt_56),
-        ]));
-        assert_eq!(merged.get("claude-sonnet-5"), Some(&runtime_sonnet));
-        assert!(merged.contains_key("claude-opus-4-6"));
-        assert_eq!(
-            merged.get("gpt-5.6-terra"),
-            authoritative_openai_pricing().get("gpt-5.6-terra"),
-        );
+        let normalized = normalized_pricing(HashMap::from([(
+            "SAMPLE-MODEL-20260301[1m]".to_string(),
+            rate.clone(),
+        )]));
+        assert_eq!(normalized.get("sample-model"), Some(&rate));
     }
 }

--- a/crates/antiburn-local/src/pricing/calc.rs
+++ b/crates/antiburn-local/src/pricing/calc.rs
@@ -1,32 +1,18 @@
 //! Per-model cost calculation.
-//!
-//! [`calculate_cost`] prices a per-model token breakdown against a pricing map,
-//! summing each model's cost independently. Models with no pricing entry are
-//! returned as data in [`CostResult::unpriced_models`]; the caller decides
-//! what to do about them, and unknown prices stay explicitly unavailable
-//! instead of appearing as partial totals. The module itself performs no
-//! I/O.
 
 use std::collections::HashMap;
 
 use crate::pricing::model::{Cost, ModelPricing, ModelTokens};
 use crate::pricing::table::lookup_pricing;
 
-/// The outcome of pricing a token breakdown: the cost plus any models that
-/// could not be priced.
+/// The calculated cost and model IDs that have no price.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CostResult {
     pub cost: Cost,
-    /// Model keys present in the breakdown with no entry in the pricing map,
-    /// sorted by model key. Includes zero-token models.
     pub unpriced_models: Vec<String>,
 }
 
-/// Calculate cache-write cost, applying the one-hour premium only to the
-/// explicitly classified subset of cache-creation tokens.
-///
-/// One-hour prompt-cache writes are priced at 2x base input. Any remaining
-/// cache-creation tokens use the model's configured default write rate.
+/// Calculate cache-write cost, including the one-hour write premium.
 pub fn calculate_cache_write_cost(tokens: &ModelTokens, pricing: &ModelPricing) -> f64 {
     let one_hour_tokens = tokens
         .cache_creation_1h_tokens
@@ -37,11 +23,7 @@ pub fn calculate_cache_write_cost(tokens: &ModelTokens, pricing: &ModelPricing) 
         + one_hour_tokens as f64 * pricing.input_cost_per_token * 2.0
 }
 
-/// Calculate total estimated cost from a per-model token breakdown.
-///
-/// Sums across all models in `breakdown`, looking up the per-token cost for
-/// each model. Models not found in the pricing map are skipped and recorded in
-/// [`CostResult::unpriced_models`].
+/// Calculate the total estimated cost from a per-model token breakdown.
 pub fn calculate_cost(
     breakdown: &HashMap<String, ModelTokens>,
     pricing_map: &HashMap<String, ModelPricing>,
@@ -79,292 +61,55 @@ pub fn calculate_cost(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pricing::table::fallback_pricing;
 
-    fn breakdown(entries: &[(&str, ModelTokens)]) -> HashMap<String, ModelTokens> {
-        entries
-            .iter()
-            .map(|(model, tokens)| (model.to_string(), tokens.clone()))
-            .collect()
+    fn pricing() -> HashMap<String, ModelPricing> {
+        HashMap::from([(
+            "sample-model".to_string(),
+            ModelPricing {
+                input_cost_per_token: 0.1,
+                output_cost_per_token: 0.2,
+                cache_read_cost_per_token: 0.03,
+                cache_write_cost_per_token: 0.04,
+            },
+        )])
     }
 
     #[test]
-    fn test_calculate_cost_sonnet() {
-        let pricing = fallback_pricing();
-        let breakdown = breakdown(&[(
-            "claude-sonnet-4-5-20250929",
-            ModelTokens {
-                input_tokens: 1_000_000,
-                output_tokens: 100_000,
-                cache_read_tokens: 0,
-                cache_creation_tokens: 0,
-                cache_creation_1h_tokens: 0,
-            },
-        )]);
-
-        let result = calculate_cost(&breakdown, &pricing);
-        // Sonnet: 1M * $3/M + 100K * $15/M = $3 + $1.5 = $4.5
-        assert!((result.cost.total_usd - 4.5).abs() < 0.001);
-        assert!((result.cost.input_usd - 3.0).abs() < 0.001);
-        assert!((result.cost.output_usd - 1.5).abs() < 0.001);
+    fn calculates_all_token_categories() {
+        let tokens = ModelTokens {
+            input_tokens: 2,
+            output_tokens: 3,
+            cache_read_tokens: 4,
+            cache_creation_tokens: 5,
+            cache_creation_1h_tokens: 0,
+        };
+        let result = calculate_cost(
+            &HashMap::from([("sample-model".to_string(), tokens)]),
+            &pricing(),
+        );
+        assert!((result.cost.total_usd - 1.12).abs() < 1e-12);
         assert!(result.unpriced_models.is_empty());
     }
 
     #[test]
-    fn test_calculate_cost_opus_46() {
-        let pricing = fallback_pricing();
-        let breakdown = breakdown(&[(
-            "claude-opus-4-6-20260301",
-            ModelTokens {
-                input_tokens: 1_000_000,
-                output_tokens: 100_000,
-                cache_read_tokens: 0,
-                cache_creation_tokens: 0,
-                cache_creation_1h_tokens: 0,
-            },
-        )]);
-
-        let result = calculate_cost(&breakdown, &pricing);
-        // Opus 4.6: 1M * $5/M + 100K * $25/M = $5 + $2.5 = $7.5
-        assert!((result.cost.total_usd - 7.5).abs() < 0.001);
+    fn one_hour_writes_cost_twice_the_input_rate() {
+        let tokens = ModelTokens {
+            cache_creation_tokens: 5,
+            cache_creation_1h_tokens: 2,
+            ..Default::default()
+        };
+        let cost = calculate_cache_write_cost(&tokens, &pricing()["sample-model"]);
+        assert!((cost - 0.52).abs() < 1e-12);
     }
 
     #[test]
-    fn test_calculate_cost_with_cache() {
-        let pricing = fallback_pricing();
-        let breakdown = breakdown(&[(
-            "claude-sonnet-4-5-20250929",
-            ModelTokens {
-                input_tokens: 500_000,
-                output_tokens: 50_000,
-                cache_read_tokens: 300_000,
-                cache_creation_tokens: 200_000,
-                cache_creation_1h_tokens: 0,
-            },
-        )]);
-
-        let result = calculate_cost(&breakdown, &pricing);
-        // Sonnet: 500K*$3/M + 50K*$15/M + 300K*$0.30/M + 200K*$6/M
-        // = $1.5 + $0.75 + $0.09 + $1.20 = $3.54
-        assert!((result.cost.total_usd - 3.54).abs() < 0.01);
-        assert!((result.cost.cache_read_usd - 0.09).abs() < 0.01);
-        assert!((result.cost.cache_write_usd - 1.20).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_calculate_cost_prices_one_hour_cache_writes_separately() {
-        let pricing = HashMap::from([(
-            "custom-model".to_string(),
-            ModelPricing {
-                input_cost_per_token: 1e-05,
-                output_cost_per_token: 0.0,
-                cache_read_cost_per_token: 0.0,
-                cache_write_cost_per_token: 1.25e-05,
-            },
-        )]);
-        let breakdown = breakdown(&[(
-            "custom-model",
-            ModelTokens {
-                input_tokens: 0,
-                output_tokens: 0,
-                cache_read_tokens: 0,
-                cache_creation_tokens: 200_000,
-                cache_creation_1h_tokens: 150_000,
-            },
-        )]);
-
-        let result = calculate_cost(&breakdown, &pricing);
-        // Custom pricing: 50K five-minute writes at $12.50/M plus 150K one-hour
-        // writes at $20/M = $0.625 + $3.00 = $3.625.
-        assert!((result.cost.cache_write_usd - 3.625).abs() < 0.001);
-        assert!((result.cost.total_usd - 3.625).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_calculate_cost_multiple_models() {
-        let pricing = fallback_pricing();
-        let breakdown = breakdown(&[
-            (
-                "claude-haiku-4-5-20251001",
-                ModelTokens {
-                    input_tokens: 1_000_000,
-                    output_tokens: 200_000,
-                    cache_read_tokens: 0,
-                    cache_creation_tokens: 0,
-                    cache_creation_1h_tokens: 0,
-                },
-            ),
-            (
-                "claude-opus-4-5-20250929",
-                ModelTokens {
-                    input_tokens: 100_000,
-                    output_tokens: 50_000,
-                    cache_read_tokens: 0,
-                    cache_creation_tokens: 0,
-                    cache_creation_1h_tokens: 0,
-                },
-            ),
+    fn reports_unpriced_models_in_stable_order() {
+        let breakdown = HashMap::from([
+            ("z-model".to_string(), ModelTokens::default()),
+            ("a-model".to_string(), ModelTokens::default()),
         ]);
-
-        let result = calculate_cost(&breakdown, &pricing);
-        // Haiku 4.5: 1M*$1/M + 200K*$5/M = $1 + $1 = $2
-        // Opus 4.5: 100K*$5/M + 50K*$25/M = $0.5 + $1.25 = $1.75
-        // Total: $3.75
-        assert!((result.cost.total_usd - 3.75).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_calculate_cost_gpt_55_fast_uses_priority_fallback() {
-        let pricing = fallback_pricing();
-        let breakdown = breakdown(&[(
-            "gpt-5.5-fast",
-            ModelTokens {
-                input_tokens: 1_000_000,
-                output_tokens: 100_000,
-                cache_read_tokens: 500_000,
-                cache_creation_tokens: 0,
-                cache_creation_1h_tokens: 0,
-            },
-        )]);
-
-        let result = calculate_cost(&breakdown, &pricing);
-        // gpt-5.5 Priority: 1M*$12.50/M + 100K*$75/M + 500K*$1.25/M.
-        assert!((result.cost.total_usd - 20.625).abs() < 0.001);
-    }
-
-    #[test]
-    fn a_multi_model_cost_does_not_depend_on_hash_map_seeding() {
-        fn sum_in_order(
-            breakdown: &HashMap<String, ModelTokens>,
-            pricing_map: &HashMap<String, ModelPricing>,
-            model_ids: &[&String],
-        ) -> Cost {
-            let mut cost = Cost::default();
-
-            for model_id in model_ids {
-                let tokens = &breakdown[*model_id];
-                let pricing = lookup_pricing(model_id, pricing_map).unwrap();
-                let input = tokens.input_tokens as f64 * pricing.input_cost_per_token;
-                let output = tokens.output_tokens as f64 * pricing.output_cost_per_token;
-                let cache_read =
-                    tokens.cache_read_tokens as f64 * pricing.cache_read_cost_per_token;
-                let cache_write = calculate_cache_write_cost(tokens, pricing);
-
-                cost.input_usd += input;
-                cost.output_usd += output;
-                cost.cache_read_usd += cache_read;
-                cost.cache_write_usd += cache_write;
-                cost.total_usd += input + output + cache_read + cache_write;
-            }
-
-            cost
-        }
-
-        fn cost_bits(cost: &Cost) -> [u64; 5] {
-            [
-                cost.total_usd.to_bits(),
-                cost.input_usd.to_bits(),
-                cost.output_usd.to_bits(),
-                cost.cache_read_usd.to_bits(),
-                cost.cache_write_usd.to_bits(),
-            ]
-        }
-
-        let pricing = fallback_pricing();
-        let priced_entries = [
-            (
-                "claude-3-5-haiku-20241022",
-                ModelTokens {
-                    input_tokens: 100,
-                    output_tokens: 10,
-                    ..ModelTokens::default()
-                },
-            ),
-            (
-                "claude-opus-4-6-20260115",
-                ModelTokens {
-                    input_tokens: 700,
-                    output_tokens: 70,
-                    ..ModelTokens::default()
-                },
-            ),
-            (
-                "claude-opus-4-7-20260115",
-                ModelTokens {
-                    input_tokens: 200,
-                    output_tokens: 20,
-                    ..ModelTokens::default()
-                },
-            ),
-        ];
-        let expected_breakdown = breakdown(&priced_entries);
-        let mut sorted_model_ids: Vec<&String> = expected_breakdown.keys().collect();
-        sorted_model_ids.sort_unstable();
-        let expected_cost = sum_in_order(&expected_breakdown, &pricing, &sorted_model_ids);
-        let mut expected_unpriced_models = vec![
-            "unknown-alpha".to_string(),
-            "unknown-beta".to_string(),
-            "unknown-gamma".to_string(),
-        ];
-        expected_unpriced_models.sort_unstable();
-        let mut saw_distinct_order = false;
-        let mut saw_unsorted_unpriced = false;
-
-        for _ in 0..1_000 {
-            let priced_breakdown = breakdown(&priced_entries);
-            let observed_model_ids: Vec<&String> = priced_breakdown.keys().collect();
-            let observed_cost = sum_in_order(&priced_breakdown, &pricing, &observed_model_ids);
-            saw_distinct_order |=
-                observed_cost.total_usd.to_bits() != expected_cost.total_usd.to_bits();
-
-            let priced_result = calculate_cost(&priced_breakdown, &pricing);
-            assert_eq!(cost_bits(&priced_result.cost), cost_bits(&expected_cost));
-
-            let mut unpriced_breakdown = HashMap::new();
-            for model_id in expected_unpriced_models.iter().rev() {
-                unpriced_breakdown.insert(model_id.clone(), ModelTokens::default());
-            }
-            let observed_unpriced_models: Vec<String> =
-                unpriced_breakdown.keys().cloned().collect();
-            saw_unsorted_unpriced |= observed_unpriced_models != expected_unpriced_models;
-
-            let unpriced_result = calculate_cost(&unpriced_breakdown, &pricing);
-            assert_eq!(unpriced_result.unpriced_models, expected_unpriced_models);
-        }
-
-        assert!(
-            saw_distinct_order,
-            "the loop did not witness an arithmetic-distinct model order"
-        );
-        assert!(
-            saw_unsorted_unpriced,
-            "the loop did not witness an unsorted unpriced-model order"
-        );
-    }
-
-    #[test]
-    fn test_calculate_cost_empty_breakdown() {
-        let pricing = fallback_pricing();
-        let result = calculate_cost(&HashMap::new(), &pricing);
-        assert_eq!(result, CostResult::default());
-    }
-
-    #[test]
-    fn test_calculate_cost_reports_unpriced_models_as_data() {
-        let pricing = fallback_pricing();
-        let breakdown = breakdown(&[(
-            "totally-unknown-model",
-            ModelTokens {
-                input_tokens: 1_000_000,
-                output_tokens: 100_000,
-                cache_read_tokens: 0,
-                cache_creation_tokens: 0,
-                cache_creation_1h_tokens: 0,
-            },
-        )]);
-
-        let result = calculate_cost(&breakdown, &pricing);
-        assert_eq!(result.cost.total_usd, 0.0);
-        assert_eq!(result.unpriced_models, vec!["totally-unknown-model"]);
+        let result = calculate_cost(&breakdown, &HashMap::new());
+        assert_eq!(result.unpriced_models, ["a-model", "z-model"]);
+        assert_eq!(result.cost, Cost::default());
     }
 }

--- a/crates/antiburn-local/src/pricing/mod.rs
+++ b/crates/antiburn-local/src/pricing/mod.rs
@@ -1,35 +1,12 @@
 //! Local, dependency-light pricing primitives.
 //!
-//! This module owns the bundled LLM pricing catalog, model-key
-//! normalization, and the per-model cost calculation. It is intentionally
-//! **std-only** — no database, async, network, or platform-specific
-//! dependencies — and performs no runtime price sourcing: the bundled
-//! catalog is the only price source, and models it cannot price are
-//! reported as explicitly unpriced rather than folded into partial totals.
-//!
-//! # Modules
-//!
-//! - [`model`] — canonical value types ([`model::ModelPricing`],
-//!   [`model::ModelTokens`], [`model::Cost`]).
-//! - [`table`] — the bundled pricing catalog plus key normalization and lookup.
-//! - [`calc`] — the per-model cost calculation ([`calc::calculate_cost`]).
+//! This module owns model-key normalization and cost calculation. The engine
+//! performs no network access and bundles no pricing catalog.
 
 pub mod calc;
 pub mod model;
 pub mod table;
 
-/// Version of the bundled pricing catalog, as a `YYYY-MM-DD` review date.
-///
-/// Prices in [`table::fallback_pricing`] are transcribed from official
-/// provider pricing pages; bump this date whenever the catalog changes.
-pub const PRICING_CATALOG_VERSION: &str = "2026-08-12";
-
-// Flat re-exports so consumers can write `pricing::calculate_cost`,
-// `pricing::ModelTokens`, `pricing::fallback_pricing()`, etc.
 pub use calc::{CostResult, calculate_cost};
 pub use model::{Cost, ModelPricing, ModelTokens};
-pub use table::{
-    ANTIGRAVITY_PLACEHOLDER_M26_MODEL_KEY, ANTIGRAVITY_PLACEHOLDER_M35_MODEL_KEY,
-    GPT_55_FAST_MODEL_KEY, authoritative_openai_pricing, canonical_model_key, fallback_pricing,
-    gpt_55_fast_priority_pricing, lookup_pricing, normalize_model_key,
-};
+pub use table::{canonical_model_key, lookup_pricing, normalize_model_key};

--- a/crates/antiburn-local/src/pricing/table.rs
+++ b/crates/antiburn-local/src/pricing/table.rs
@@ -1,34 +1,14 @@
-//! The single source of truth for the bundled pricing catalog and the
-//! model-key normalization/lookup rules.
+//! Model-key normalization and pricing lookup.
 //!
-//! [`fallback_pricing`] is the bundled catalog: prices transcribed from
-//! official provider pricing pages, reviewed at
-//! [`crate::pricing::PRICING_CATALOG_VERSION`]. The engine has no live price
-//! source.
+//! The engine does not bundle a pricing catalog. Its caller installs a current
+//! snapshot at runtime, and unknown models remain explicitly unpriced.
 
 use std::collections::HashMap;
 
 use crate::pricing::model::ModelPricing;
 
-/// OpenCode's model key for OpenAI `gpt-5.5` Priority short-context usage.
-pub const GPT_55_FAST_MODEL_KEY: &str = "gpt-5.5-fast";
-
-/// Antigravity placeholder observed for user-facing Claude Opus 4.6 Thinking usage.
-pub const ANTIGRAVITY_PLACEHOLDER_M26_MODEL_KEY: &str = "MODEL_PLACEHOLDER_M26";
-
-/// Antigravity placeholder observed for user-facing Claude Sonnet 4.6 Thinking usage.
-pub const ANTIGRAVITY_PLACEHOLDER_M35_MODEL_KEY: &str = "MODEL_PLACEHOLDER_M35";
-
-/// Strip trailing `-YYYYMMDD` date suffix from a model ID.
-///
-/// Model IDs from transcripts look like `claude-opus-4-6-20260301`.
-/// Catalog keys are typically `claude-opus-4-6` (without the date).
+/// Strip a trailing `-YYYYMMDD` date suffix from a model ID.
 pub fn normalize_model_key(model_id: &str) -> &str {
-    // Date suffixes are 8 digits preceded by a hyphen. The check runs on
-    // bytes: model IDs come from external transcript files, and slicing the
-    // string at a fixed byte offset would panic on a multi-byte character
-    // spanning it. Once the tail is confirmed to be `-` + 8 ASCII digits, the
-    // slice boundary is the ASCII hyphen, which is always a char boundary.
     let bytes = model_id.as_bytes();
     if bytes.len() > 9 {
         let (head, tail) = bytes.split_at(bytes.len() - 8);
@@ -39,16 +19,7 @@ pub fn normalize_model_key(model_id: &str) -> &str {
     model_id
 }
 
-/// Strip a leading provider or vendor namespace, apply
-/// [`normalize_model_key`], then lowercase.
-///
-/// Recognizes any prefix up to and including the first `/` (`openai/`,
-/// `anthropic/`, `google/`, ...), plus the literal `openai.` and
-/// `antigravity-` prefixes observed in session metadata. Every detector
-/// that classifies a model's family, looks up its premium or
-/// replacement-registry policy, or compares it against a dominant model
-/// uses this one canonical key (Cadence `crates/analysis/src/efficiency_findings.rs`,
-/// `SubagentTier::classify`).
+/// Strip a provider namespace, normalize the date suffix, and use lowercase.
 pub fn canonical_model_key(model: &str) -> String {
     let trimmed = model.trim();
     let without_namespace = trimmed
@@ -60,649 +31,70 @@ pub fn canonical_model_key(model: &str) -> String {
     normalize_model_key(without_namespace).to_lowercase()
 }
 
-/// Look up pricing for a model ID, trying exact match then normalized key.
+/// Look up pricing for a model ID, trying exact and normalized forms.
 pub fn lookup_pricing<'a>(
     model_id: &str,
     pricing_map: &'a HashMap<String, ModelPricing>,
 ) -> Option<&'a ModelPricing> {
-    // 1. Exact match
-    if let Some(p) = pricing_map.get(model_id) {
-        return Some(p);
+    if let Some(pricing) = pricing_map.get(model_id) {
+        return Some(pricing);
     }
-    // 2. Try with date suffix stripped
+
     let normalized = normalize_model_key(model_id);
     if normalized != model_id
-        && let Some(p) = pricing_map.get(normalized)
+        && let Some(pricing) = pricing_map.get(normalized)
     {
-        return Some(p);
+        return Some(pricing);
     }
-    // 3. Try lowercase
+
     let lower = model_id.to_lowercase();
     if lower != model_id {
-        if let Some(p) = pricing_map.get(&lower) {
-            return Some(p);
+        if let Some(pricing) = pricing_map.get(&lower) {
+            return Some(pricing);
         }
         let lower_normalized = normalize_model_key(&lower);
         if lower_normalized != lower.as_str()
-            && let Some(p) = pricing_map.get(lower_normalized)
+            && let Some(pricing) = pricing_map.get(lower_normalized)
         {
-            return Some(p);
+            return Some(pricing);
         }
     }
 
     None
 }
 
-/// Return the verified OpenAI Priority short-context pricing for `gpt-5.5-fast`.
-///
-/// OpenCode's `gpt-5.5-fast` key is treated as OpenAI `gpt-5.5` in Priority
-/// mode; this price was verified against the official OpenAI pricing table
-/// and is preferred over third-party pricing snapshots for this key.
-pub fn gpt_55_fast_priority_pricing() -> ModelPricing {
-    ModelPricing {
-        input_cost_per_token: 1.25e-05,
-        output_cost_per_token: 7.5e-05,
-        cache_read_cost_per_token: 1.25e-06,
-        cache_write_cost_per_token: 0.0,
-    }
-}
-
-/// Return OpenAI prices verified against the official OpenAI pricing table.
-///
-/// These exact model keys must override downloaded pricing. The current pricing shape
-/// represents only standard, short-context rates, so this deliberately does not add
-/// service-tier, regional, long-context, or `gpt-5.6-codex` aliases.
-pub fn authoritative_openai_pricing() -> HashMap<String, ModelPricing> {
-    let gpt_56_sol = ModelPricing {
-        input_cost_per_token: 5e-06,
-        output_cost_per_token: 3e-05,
-        cache_read_cost_per_token: 5e-07,
-        cache_write_cost_per_token: 6.25e-06,
-    };
-
-    HashMap::from([
-        (
-            GPT_55_FAST_MODEL_KEY.to_string(),
-            gpt_55_fast_priority_pricing(),
-        ),
-        ("gpt-5.6".to_string(), gpt_56_sol.clone()),
-        ("gpt-5.6-sol".to_string(), gpt_56_sol.clone()),
-        // Codex session metadata can retain the provider namespace.
-        ("openai.gpt-5.6-sol".to_string(), gpt_56_sol),
-        (
-            "gpt-5.6-terra".to_string(),
-            ModelPricing {
-                input_cost_per_token: 2.5e-06,
-                output_cost_per_token: 1.5e-05,
-                cache_read_cost_per_token: 2.5e-07,
-                cache_write_cost_per_token: 3.125e-06,
-            },
-        ),
-        (
-            "gpt-5.6-luna".to_string(),
-            ModelPricing {
-                input_cost_per_token: 1e-06,
-                output_cost_per_token: 6e-06,
-                cache_read_cost_per_token: 1e-07,
-                cache_write_cost_per_token: 1.25e-06,
-            },
-        ),
-    ])
-}
-
-/// The bundled pricing catalog.
-///
-/// Prices are sourced from official provider pricing pages and stored as
-/// per-token costs (not per-million). Because [`ModelPricing`] cannot represent
-/// long-context tiers, tiered Gemini and Grok entries use the providers'
-/// standard short-context rates.
-pub fn fallback_pricing() -> HashMap<String, ModelPricing> {
-    let mut map = HashMap::new();
-
-    // Claude cache writes default to the one-hour rate: 2x uncached input.
-    // Opus 4.5 / 4.6 / 4.7 / 4.8: $5/$25 per 1M tokens
-    let opus_new = ModelPricing {
-        input_cost_per_token: 5e-06,
-        output_cost_per_token: 2.5e-05,
-        cache_read_cost_per_token: 5e-07,
-        cache_write_cost_per_token: 1e-05,
-    };
-    map.insert("claude-opus-4-5".to_string(), opus_new.clone());
-    map.insert("claude-opus-4-6".to_string(), opus_new.clone());
-    map.insert("claude-opus-4-7".to_string(), opus_new.clone());
-    map.insert("claude-opus-4-8".to_string(), opus_new.clone());
-    map.insert("claude-opus-5".to_string(), opus_new.clone());
-    // Cursor and provider-qualified spellings observed in session metadata.
-    map.insert("claude-opus-4.6".to_string(), opus_new.clone());
-    map.insert("claude-opus-4.7".to_string(), opus_new.clone());
-    map.insert("claude-opus-4.8".to_string(), opus_new.clone());
-    map.insert("anthropic/claude-opus-4.8".to_string(), opus_new.clone());
-    map.insert(
-        "claude-opus-4-8-thinking-high".to_string(),
-        opus_new.clone(),
-    );
-    map.insert(
-        "antigravity-claude-opus-4-6-thinking".to_string(),
-        opus_new.clone(),
-    );
-    map.insert(ANTIGRAVITY_PLACEHOLDER_M26_MODEL_KEY.to_string(), opus_new);
-
-    // Fable 5 / Mythos 5: $10/$50 per 1M tokens
-    let claude_5 = ModelPricing {
-        input_cost_per_token: 1e-05,
-        output_cost_per_token: 5e-05,
-        cache_read_cost_per_token: 1e-06,
-        cache_write_cost_per_token: 2e-05,
-    };
-    map.insert("claude-fable-5".to_string(), claude_5.clone());
-    map.insert("claude-mythos-5".to_string(), claude_5.clone());
-    map.insert("claude-fable-5-thinking-high".to_string(), claude_5);
-
-    // Sonnet 5: $2/$10 per 1M tokens, cached input $0.20 / 1M.
-    map.insert(
-        "claude-sonnet-5".to_string(),
-        ModelPricing {
-            input_cost_per_token: 2e-06,
-            output_cost_per_token: 1e-05,
-            cache_read_cost_per_token: 2e-07,
-            cache_write_cost_per_token: 4e-06,
-        },
-    );
-
-    // Opus 4 / 4.1: $15/$75 per 1M tokens
-    let opus_old = ModelPricing {
-        input_cost_per_token: 1.5e-05,
-        output_cost_per_token: 7.5e-05,
-        cache_read_cost_per_token: 1.5e-06,
-        cache_write_cost_per_token: 3e-05,
-    };
-    map.insert("claude-opus-4".to_string(), opus_old.clone());
-    map.insert("claude-opus-4-1".to_string(), opus_old.clone());
-    map.insert("claude-3-opus".to_string(), opus_old);
-
-    // Sonnet: $3/$15 per 1M tokens
-    let sonnet = ModelPricing {
-        input_cost_per_token: 3e-06,
-        output_cost_per_token: 1.5e-05,
-        cache_read_cost_per_token: 3e-07,
-        cache_write_cost_per_token: 6e-06,
-    };
-    map.insert("claude-sonnet-4-6".to_string(), sonnet.clone());
-    map.insert("claude-sonnet-4.6".to_string(), sonnet.clone());
-    map.insert("claude-sonnet-4-5".to_string(), sonnet.clone());
-    map.insert("claude-sonnet-4".to_string(), sonnet.clone());
-    map.insert("claude-3-5-sonnet".to_string(), sonnet.clone());
-    map.insert(ANTIGRAVITY_PLACEHOLDER_M35_MODEL_KEY.to_string(), sonnet);
-
-    // Haiku 4.5: $1/$5 per 1M tokens
-    let haiku45 = ModelPricing {
-        input_cost_per_token: 1e-06,
-        output_cost_per_token: 5e-06,
-        cache_read_cost_per_token: 1e-07,
-        cache_write_cost_per_token: 2e-06,
-    };
-    map.insert("claude-haiku-4-5".to_string(), haiku45.clone());
-    map.insert("claude-haiku-4.5".to_string(), haiku45);
-
-    // Haiku 3.5: $0.80/$4.00 per 1M tokens
-    let haiku35 = ModelPricing {
-        input_cost_per_token: 8e-07,
-        output_cost_per_token: 4e-06,
-        cache_read_cost_per_token: 8e-08,
-        cache_write_cost_per_token: 1.6e-06,
-    };
-    map.insert("claude-3-5-haiku".to_string(), haiku35.clone());
-    map.insert("claude-haiku-3-5".to_string(), haiku35);
-
-    // Haiku 3: $0.25/$1.25 per 1M tokens
-    let haiku3 = ModelPricing {
-        input_cost_per_token: 2.5e-07,
-        output_cost_per_token: 1.25e-06,
-        cache_read_cost_per_token: 3e-08,
-        cache_write_cost_per_token: 5e-07,
-    };
-    map.insert("claude-3-haiku".to_string(), haiku3);
-
-    // GPT-5.4: $2.50 / $15.00 per 1M tokens, cached input $0.25 / 1M tokens.
-    let gpt_54 = ModelPricing {
-        input_cost_per_token: 2.5e-06,
-        output_cost_per_token: 1.5e-05,
-        cache_read_cost_per_token: 2.5e-07,
-        cache_write_cost_per_token: 0.0,
-    };
-    map.insert("gpt-5.4".to_string(), gpt_54.clone());
-    map.insert("gpt-5.4-2026-03-17".to_string(), gpt_54);
-
-    // GPT-5.4 mini: $0.75 / $4.50 per 1M tokens, cached input $0.075 / 1M tokens.
-    let gpt_54_mini = ModelPricing {
-        input_cost_per_token: 7.5e-07,
-        output_cost_per_token: 4.5e-06,
-        cache_read_cost_per_token: 7.5e-08,
-        cache_write_cost_per_token: 0.0,
-    };
-    map.insert("gpt-5.4-mini".to_string(), gpt_54_mini.clone());
-    map.insert("gpt-5.4-mini-2026-03-17".to_string(), gpt_54_mini);
-
-    // GPT-5.4 nano: $0.20 / $1.25 per 1M tokens, cached input $0.02 / 1M tokens.
-    let gpt_54_nano = ModelPricing {
-        input_cost_per_token: 2e-07,
-        output_cost_per_token: 1.25e-06,
-        cache_read_cost_per_token: 2e-08,
-        cache_write_cost_per_token: 0.0,
-    };
-    map.insert("gpt-5.4-nano".to_string(), gpt_54_nano.clone());
-    map.insert("gpt-5.4-nano-2026-03-17".to_string(), gpt_54_nano);
-
-    // GPT-5.5: $5.00 / $30.00 per 1M tokens, cached input $0.50 / 1M tokens.
-    let gpt_55 = ModelPricing {
-        input_cost_per_token: 5e-06,
-        output_cost_per_token: 3e-05,
-        cache_read_cost_per_token: 5e-07,
-        cache_write_cost_per_token: 0.0,
-    };
-    map.insert("gpt-5.5".to_string(), gpt_55);
-
-    // Cursor Composer 2.5 standard and fast rates. Cursor does not charge
-    // separately for cache writes in its published token pricing.
-    map.insert(
-        "composer-2.5".to_string(),
-        ModelPricing {
-            input_cost_per_token: 5e-07,
-            output_cost_per_token: 2.5e-06,
-            cache_read_cost_per_token: 2e-07,
-            cache_write_cost_per_token: 0.0,
-        },
-    );
-    map.insert(
-        "composer-2.5-fast".to_string(),
-        ModelPricing {
-            input_cost_per_token: 3e-06,
-            output_cost_per_token: 1.5e-05,
-            cache_read_cost_per_token: 5e-07,
-            cache_write_cost_per_token: 0.0,
-        },
-    );
-
-    let gemini_31_pro = ModelPricing {
-        input_cost_per_token: 2e-06,
-        output_cost_per_token: 1.2e-05,
-        cache_read_cost_per_token: 2e-07,
-        cache_write_cost_per_token: 0.0,
-    };
-    map.insert("gemini-3.1-pro".to_string(), gemini_31_pro.clone());
-    map.insert("gemini-3.1-pro-preview".to_string(), gemini_31_pro);
-    map.insert(
-        "grok-4.5".to_string(),
-        ModelPricing {
-            input_cost_per_token: 2e-06,
-            output_cost_per_token: 6e-06,
-            cache_read_cost_per_token: 3e-07,
-            cache_write_cost_per_token: 0.0,
-        },
-    );
-
-    // Verified GPT-5.5 Priority and GPT-5.6 standard prices are also forced
-    // over external pricing snapshots by runtime consumers.
-    map.extend(authoritative_openai_pricing());
-
-    map
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn test_pricing_map() -> HashMap<String, ModelPricing> {
-        fallback_pricing()
+    fn rate() -> ModelPricing {
+        ModelPricing {
+            input_cost_per_token: 0.1,
+            output_cost_per_token: 0.2,
+            cache_read_cost_per_token: 0.03,
+            cache_write_cost_per_token: 0.04,
+        }
     }
 
     #[test]
-    fn test_normalize_strips_date() {
-        assert_eq!(
-            normalize_model_key("claude-opus-4-6-20260301"),
-            "claude-opus-4-6"
-        );
-        assert_eq!(
-            normalize_model_key("claude-sonnet-4-5-20250929"),
-            "claude-sonnet-4-5"
-        );
-        assert_eq!(
-            normalize_model_key("claude-3-5-haiku-20241022"),
-            "claude-3-5-haiku"
-        );
-    }
-
-    #[test]
-    fn test_normalize_survives_non_ascii_model_ids() {
-        // Transcripts are external input; a multi-byte character spanning the
-        // would-be slice boundary must fall through, not panic. "€" is 3 bytes,
-        // so four of them put byte len-8 = 4 inside the second character.
-        assert_eq!(normalize_model_key("€€€€"), "€€€€");
-        assert_eq!(
-            normalize_model_key("modèle-häiku-20-àé"),
-            "modèle-häiku-20-àé"
-        );
-        // A real date suffix after non-ASCII prefix text still normalizes.
+    fn normalize_strips_only_a_date_suffix() {
+        assert_eq!(normalize_model_key("sample-model-20260301"), "sample-model");
+        assert_eq!(normalize_model_key("sample-model"), "sample-model");
         assert_eq!(normalize_model_key("modèle-4-20260301"), "modèle-4");
+        assert_eq!(normalize_model_key("€€€€"), "€€€€");
     }
 
     #[test]
-    fn test_normalize_no_date() {
-        assert_eq!(normalize_model_key("claude-opus-4-6"), "claude-opus-4-6");
-        assert_eq!(normalize_model_key("gpt-4o"), "gpt-4o");
+    fn canonical_key_removes_known_namespace_forms() {
+        assert_eq!(canonical_model_key("vendor/SAMPLE-20260301"), "sample");
+        assert_eq!(canonical_model_key("openai.SAMPLE"), "sample");
+        assert_eq!(canonical_model_key("antigravity-SAMPLE"), "sample");
     }
 
     #[test]
-    fn test_normalize_short_string() {
-        assert_eq!(normalize_model_key("short"), "short");
-        assert_eq!(normalize_model_key(""), "");
-    }
-
-    #[test]
-    fn test_canonical_model_key_strips_openai_dot_prefix() {
-        assert_eq!(canonical_model_key("openai.gpt-5.6-sol"), "gpt-5.6-sol");
-    }
-
-    #[test]
-    fn test_canonical_model_key_strips_slash_namespace() {
-        assert_eq!(
-            canonical_model_key("anthropic/claude-opus-4.8"),
-            "claude-opus-4.8"
-        );
-        assert_eq!(canonical_model_key("openai/gpt-5.6-terra"), "gpt-5.6-terra");
-        assert_eq!(
-            canonical_model_key("google/gemini-3.1-pro"),
-            "gemini-3.1-pro"
-        );
-    }
-
-    #[test]
-    fn test_canonical_model_key_strips_antigravity_prefix() {
-        assert_eq!(
-            canonical_model_key("antigravity-claude-opus-4-6-thinking"),
-            "claude-opus-4-6-thinking"
-        );
-    }
-
-    #[test]
-    fn test_canonical_model_key_normalizes_date_suffix_and_case() {
-        assert_eq!(
-            canonical_model_key("Claude-Opus-4-8-20260801"),
-            "claude-opus-4-8"
-        );
-    }
-
-    #[test]
-    fn test_canonical_model_key_passes_through_a_bare_key() {
-        assert_eq!(canonical_model_key("claude-sonnet-5"), "claude-sonnet-5");
-    }
-
-    #[test]
-    fn test_lookup_exact_match() {
-        let map = test_pricing_map();
-        assert!(lookup_pricing("claude-opus-4-6", &map).is_some());
-    }
-
-    #[test]
-    fn test_lookup_with_date_suffix() {
-        let map = test_pricing_map();
-        let p = lookup_pricing("claude-opus-4-6-20260301", &map).unwrap();
-        assert!((p.input_cost_per_token - 5e-06).abs() < 1e-10);
-    }
-
-    #[test]
-    fn test_lookup_unknown_model() {
-        let map = test_pricing_map();
-        assert!(lookup_pricing("gpt-4o", &map).is_none());
-    }
-
-    #[test]
-    fn test_lookup_does_not_alias_gpt53_codex_to_gpt52_codex() {
-        let mut map = HashMap::new();
-        map.insert(
-            "gpt-5.2-codex".to_string(),
-            ModelPricing {
-                input_cost_per_token: 1.23,
-                output_cost_per_token: 4.56,
-                cache_read_cost_per_token: 7.89,
-                cache_write_cost_per_token: 0.12,
-            },
-        );
-
-        assert!(lookup_pricing("gpt-5.3-codex", &map).is_none());
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_gpt54_mini() {
-        let map = fallback_pricing();
-        let pricing = map.get("gpt-5.4-mini").expect("missing gpt-5.4-mini");
-        assert!((pricing.input_cost_per_token - 7.5e-07).abs() < 1e-12);
-        assert!((pricing.output_cost_per_token - 4.5e-06).abs() < 1e-12);
-        assert!((pricing.cache_read_cost_per_token - 7.5e-08).abs() < 1e-12);
-        assert_eq!(pricing.cache_write_cost_per_token, 0.0);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_gpt54_nano() {
-        let map = fallback_pricing();
-        let pricing = map.get("gpt-5.4-nano").expect("missing gpt-5.4-nano");
-        assert!((pricing.input_cost_per_token - 2e-07).abs() < 1e-12);
-        assert!((pricing.output_cost_per_token - 1.25e-06).abs() < 1e-12);
-        assert!((pricing.cache_read_cost_per_token - 2e-08).abs() < 1e-12);
-        assert_eq!(pricing.cache_write_cost_per_token, 0.0);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_gpt54() {
-        let map = fallback_pricing();
-        let pricing = map.get("gpt-5.4").expect("missing gpt-5.4");
-        assert!((pricing.input_cost_per_token - 2.5e-06).abs() < 1e-12);
-        assert!((pricing.output_cost_per_token - 1.5e-05).abs() < 1e-12);
-        assert!((pricing.cache_read_cost_per_token - 2.5e-07).abs() < 1e-12);
-        assert_eq!(pricing.cache_write_cost_per_token, 0.0);
-    }
-
-    fn assert_fallback_pricing(
-        model: &str,
-        input_cost_per_token: f64,
-        output_cost_per_token: f64,
-        cache_read_cost_per_token: f64,
-        cache_write_cost_per_token: f64,
-    ) {
-        let map = fallback_pricing();
-        let pricing = map.get(model).unwrap_or_else(|| panic!("missing {model}"));
-        assert!((pricing.input_cost_per_token - input_cost_per_token).abs() < 1e-12);
-        assert!((pricing.output_cost_per_token - output_cost_per_token).abs() < 1e-12);
-        assert!((pricing.cache_read_cost_per_token - cache_read_cost_per_token).abs() < 1e-12);
-        assert!((pricing.cache_write_cost_per_token - cache_write_cost_per_token).abs() < 1e-12);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_claude_opus_47() {
-        assert_fallback_pricing("claude-opus-4-7", 5e-06, 2.5e-05, 5e-07, 1e-05);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_claude_opus_48() {
-        assert_fallback_pricing("claude-opus-4-8", 5e-06, 2.5e-05, 5e-07, 1e-05);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_claude_fable_5() {
-        assert_fallback_pricing("claude-fable-5", 1e-05, 5e-05, 1e-06, 2e-05);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_claude_mythos_5() {
-        assert_fallback_pricing("claude-mythos-5", 1e-05, 5e-05, 1e-06, 2e-05);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_claude_sonnet_5() {
-        assert_fallback_pricing("claude-sonnet-5", 2e-06, 1e-05, 2e-07, 4e-06);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_observed_claude_aliases() {
-        for model in [
-            "claude-opus-4.6",
-            "claude-opus-4.7",
-            "claude-opus-4.8",
-            "anthropic/claude-opus-4.8",
-            "claude-opus-4-8-thinking-high",
-            "antigravity-claude-opus-4-6-thinking",
-            "claude-opus-5",
-        ] {
-            assert_fallback_pricing(model, 5e-06, 2.5e-05, 5e-07, 1e-05);
-        }
-        assert_fallback_pricing("claude-fable-5-thinking-high", 1e-05, 5e-05, 1e-06, 2e-05);
-        assert_fallback_pricing("claude-sonnet-4.6", 3e-06, 1.5e-05, 3e-07, 6e-06);
-        assert_fallback_pricing("claude-haiku-4.5", 1e-06, 5e-06, 1e-07, 2e-06);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_observed_provider_models() {
-        assert_fallback_pricing("composer-2.5", 5e-07, 2.5e-06, 2e-07, 0.0);
-        assert_fallback_pricing("composer-2.5-fast", 3e-06, 1.5e-05, 5e-07, 0.0);
-        assert_fallback_pricing("gemini-3.1-pro", 2e-06, 1.2e-05, 2e-07, 0.0);
-        assert_fallback_pricing("gemini-3.1-pro-preview", 2e-06, 1.2e-05, 2e-07, 0.0);
-        assert_fallback_pricing("grok-4.5", 2e-06, 6e-06, 3e-07, 0.0);
-    }
-
-    #[test]
-    fn test_ambiguous_or_subscription_only_observed_models_remain_unpriced() {
-        let pricing = fallback_pricing();
-        for model in [
-            "gemini-default",
-            "gemma4",
-            "codex-auto-review",
-            "gpt-5.3-codex-spark",
-            "MODEL_PLACEHOLDER_M20",
-            "MODEL_PLACEHOLDER_M71",
-        ] {
-            assert!(!pricing.contains_key(model), "{model} must remain unpriced");
-        }
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_gpt55() {
-        assert_fallback_pricing("gpt-5.5", 5e-06, 3e-05, 5e-07, 0.0);
-    }
-
-    #[test]
-    fn test_fallback_pricing_starts_billing_cache_writes_at_gpt56() {
-        assert_fallback_pricing("gpt-5.6", 5e-06, 3e-05, 5e-07, 6.25e-06);
-        assert_fallback_pricing("gpt-5.6-sol", 5e-06, 3e-05, 5e-07, 6.25e-06);
-        assert_fallback_pricing("gpt-5.6-terra", 2.5e-06, 1.5e-05, 2.5e-07, 3.125e-06);
-        assert_fallback_pricing("gpt-5.6-luna", 1e-06, 6e-06, 1e-07, 1.25e-06);
-
-        let pricing = fallback_pricing();
-        for model in ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
-            let expected = pricing[model].input_cost_per_token * 1.25;
-            assert!(
-                (pricing[model].cache_write_cost_per_token - expected).abs() < 1e-15,
-                "{model} cache writes use the official 1.25x premium",
-            );
-        }
-        assert_eq!(
-            pricing["gpt-5.5"].cache_write_cost_per_token, 0.0,
-            "pre-GPT-5.6 cache writes remain free",
-        );
-    }
-
-    #[test]
-    fn test_authoritative_openai_pricing_has_only_verified_exact_keys() {
-        let pricing = authoritative_openai_pricing();
-        let mut keys = pricing.keys().map(String::as_str).collect::<Vec<_>>();
-        keys.sort_unstable();
-        assert_eq!(
-            keys,
-            [
-                "gpt-5.5-fast",
-                "gpt-5.6",
-                "gpt-5.6-luna",
-                "gpt-5.6-sol",
-                "gpt-5.6-terra",
-                "openai.gpt-5.6-sol",
-            ]
-        );
-        assert_eq!(pricing["gpt-5.6"], pricing["gpt-5.6-sol"]);
-        assert_eq!(pricing["gpt-5.6-sol"], pricing["openai.gpt-5.6-sol"]);
-    }
-
-    #[test]
-    fn test_all_canonical_claude_fallbacks_use_one_hour_write_rate() {
-        for (model, pricing) in fallback_pricing()
-            .into_iter()
-            .filter(|(model, _)| model.starts_with("claude-"))
-        {
-            assert_eq!(
-                pricing.cache_write_cost_per_token,
-                pricing.input_cost_per_token * 2.0,
-                "{model} must default cache writes to the one-hour rate",
-            );
-        }
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_gpt_55_fast_priority() {
-        let pricing = fallback_pricing();
-        let gpt_55_fast = pricing
-            .get("gpt-5.5-fast")
-            .expect("missing gpt-5.5-fast priority pricing");
-
-        assert!((gpt_55_fast.input_cost_per_token - 1.25e-05).abs() < 1e-12);
-        assert!((gpt_55_fast.output_cost_per_token - 7.5e-05).abs() < 1e-12);
-        assert!((gpt_55_fast.cache_read_cost_per_token - 1.25e-06).abs() < 1e-12);
-        assert_eq!(gpt_55_fast.cache_write_cost_per_token, 0.0);
-
-        let standard = pricing.get("gpt-5.5").expect("missing gpt-5.5 pricing");
-        assert!((standard.input_cost_per_token - 5e-06).abs() < 1e-12);
-        assert!((standard.output_cost_per_token - 3e-05).abs() < 1e-12);
-        assert!((standard.cache_read_cost_per_token - 5e-07).abs() < 1e-12);
-    }
-
-    #[test]
-    fn test_fallback_pricing_includes_antigravity_placeholder_aliases() {
-        let pricing = fallback_pricing();
-
-        let m26 = pricing
-            .get("MODEL_PLACEHOLDER_M26")
-            .expect("missing M26 placeholder pricing");
-        let opus = pricing
-            .get("claude-opus-4-6")
-            .expect("missing canonical Opus pricing");
-        assert_eq!(m26.input_cost_per_token, opus.input_cost_per_token);
-        assert_eq!(m26.output_cost_per_token, opus.output_cost_per_token);
-        assert_eq!(
-            m26.cache_read_cost_per_token,
-            opus.cache_read_cost_per_token
-        );
-        assert_eq!(
-            m26.cache_write_cost_per_token,
-            opus.cache_write_cost_per_token
-        );
-
-        let m35 = pricing
-            .get("MODEL_PLACEHOLDER_M35")
-            .expect("missing M35 placeholder pricing");
-        let sonnet = pricing
-            .get("claude-sonnet-4-6")
-            .expect("missing canonical Sonnet pricing");
-        assert_eq!(m35.input_cost_per_token, sonnet.input_cost_per_token);
-        assert_eq!(m35.output_cost_per_token, sonnet.output_cost_per_token);
-        assert_eq!(
-            m35.cache_read_cost_per_token,
-            sonnet.cache_read_cost_per_token
-        );
-        assert_eq!(
-            m35.cache_write_cost_per_token,
-            sonnet.cache_write_cost_per_token
-        );
-
-        assert!(
-            !pricing.contains_key("MODEL_PLACEHOLDER_M50"),
-            "checkpoint/shadow M50 should not be priced"
-        );
+    fn lookup_accepts_case_and_date_variants_without_guessing_aliases() {
+        let map = HashMap::from([("sample-model".to_string(), rate())]);
+        assert!(lookup_pricing("SAMPLE-MODEL-20260301", &map).is_some());
+        assert!(lookup_pricing("different-model", &map).is_none());
     }
 }

--- a/crates/antiburn-local/tests/claude_characterization.rs
+++ b/crates/antiburn-local/tests/claude_characterization.rs
@@ -19,7 +19,11 @@ use antiburn_local::insights::{
 use rusqlite::params;
 use serde_json::{Value, json};
 
+#[path = "support/pricing.rs"]
+mod pricing;
+
 fn fixture(name: &str) -> &'static str {
+    pricing::install();
     match name {
         "records_all_kinds" => {
             include_str!("fixtures/claude_characterization/records_all_kinds.jsonl")

--- a/crates/antiburn-local/tests/codex_characterization.rs
+++ b/crates/antiburn-local/tests/codex_characterization.rs
@@ -20,7 +20,11 @@ use antiburn_local::insights::{
 };
 use serde_json::{Value, json};
 
+#[path = "support/pricing.rs"]
+mod pricing;
+
 fn fixture(name: &str) -> &'static str {
+    pricing::install();
     match name {
         "records_all_kinds" => {
             include_str!("fixtures/codex_characterization/records_all_kinds.jsonl")

--- a/crates/antiburn-local/tests/pi_characterization.rs
+++ b/crates/antiburn-local/tests/pi_characterization.rs
@@ -21,7 +21,11 @@ use antiburn_local::insights::{
 use rusqlite::params;
 use serde_json::{Value, json};
 
+#[path = "support/pricing.rs"]
+mod pricing;
+
 fn fixture(name: &str) -> &'static str {
+    pricing::install();
     match name {
         "minimal_session" => include_str!("fixtures/pi_characterization/minimal_session.jsonl"),
         "role_ordering" => include_str!("fixtures/pi_characterization/role_ordering.jsonl"),

--- a/crates/antiburn-local/tests/runtime_pricing.rs
+++ b/crates/antiburn-local/tests/runtime_pricing.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use antiburn_local::analysis::{install_runtime_pricing, price_breakdown, pricing_generation};
+use antiburn_local::pricing::{ModelPricing, ModelTokens};
+
+#[test]
+fn runtime_snapshot_is_the_only_pricing_source() {
+    let breakdown = HashMap::from([(
+        "sample-model".to_string(),
+        ModelTokens {
+            input_tokens: 1,
+            ..Default::default()
+        },
+    )]);
+    assert!(price_breakdown(&breakdown).is_none());
+    let before = pricing_generation();
+    let snapshot = HashMap::from([(
+        "SAMPLE-MODEL-20260901".to_string(),
+        ModelPricing {
+            input_cost_per_token: 0.1,
+            output_cost_per_token: 0.2,
+            cache_read_cost_per_token: 0.03,
+            cache_write_cost_per_token: 0.04,
+        },
+    )]);
+
+    assert!(install_runtime_pricing(snapshot.clone()));
+    assert_eq!(pricing_generation(), before + 1);
+    assert!(price_breakdown(&breakdown).is_some());
+
+    assert!(!install_runtime_pricing(snapshot));
+    assert_eq!(pricing_generation(), before + 1);
+
+    assert!(install_runtime_pricing(HashMap::new()));
+    assert!(price_breakdown(&breakdown).is_none());
+}

--- a/crates/antiburn-local/tests/support/pricing.rs
+++ b/crates/antiburn-local/tests/support/pricing.rs
@@ -1,0 +1,50 @@
+//! Stable pricing fixtures for integration tests.
+
+use std::collections::HashMap;
+use std::sync::Once;
+
+use antiburn_local::pricing::ModelPricing;
+
+static INSTALL: Once = Once::new();
+
+pub fn install() {
+    INSTALL.call_once(|| {
+        fn rate(input: f64, output: f64, read: f64, write: f64) -> ModelPricing {
+            ModelPricing {
+                input_cost_per_token: input,
+                output_cost_per_token: output,
+                cache_read_cost_per_token: read,
+                cache_write_cost_per_token: write,
+            }
+        }
+
+        let opus = rate(5e-6, 25e-6, 0.5e-6, 10e-6);
+        antiburn_local::analysis::install_runtime_pricing(HashMap::from([
+            (
+                "claude-3-5-haiku".to_string(),
+                rate(0.8e-6, 4e-6, 0.08e-6, 1.6e-6),
+            ),
+            (
+                "claude-haiku-4-5".to_string(),
+                rate(1e-6, 5e-6, 0.1e-6, 2e-6),
+            ),
+            ("claude-opus-4-6".to_string(), opus.clone()),
+            ("claude-opus-4-7".to_string(), opus.clone()),
+            ("claude-opus-4-8".to_string(), opus),
+            (
+                "claude-sonnet-4-6".to_string(),
+                rate(3e-6, 15e-6, 0.3e-6, 6e-6),
+            ),
+            (
+                "claude-fable-5".to_string(),
+                rate(10e-6, 50e-6, 1e-6, 20e-6),
+            ),
+            ("gpt-5.4".to_string(), rate(2.5e-6, 15e-6, 0.25e-6, 0.0)),
+            ("gpt-5.5".to_string(), rate(5e-6, 30e-6, 0.5e-6, 0.0)),
+            (
+                "gpt-5.6-sol".to_string(),
+                rate(5e-6, 30e-6, 0.5e-6, 6.25e-6),
+            ),
+        ]));
+    });
+}

--- a/docs/support.md
+++ b/docs/support.md
@@ -47,11 +47,11 @@ empty chart that looks like an idle session.
 
 ## Cost estimates
 
-Costs are computed on this device from a bundled price list, against the tokens a
-transcript recorded. They are **API-equivalent estimates**, not a bill:
+Costs are computed on this device from the latest valid models.dev snapshot, against
+the tokens a transcript recorded. They are **API-equivalent estimates**, not a bill:
 
-- prices are never fetched; the bundled catalog's review date is shown in Settings →
-  About;
+- prices refresh at startup and hourly while the app runs; the snapshot date is
+  shown in Settings → About;
 - a model with no price in the catalog produces no figure rather than a wrong zero,
   and the provider's total is then labelled as a floor;
 - work done on another machine is not counted, because antiburn cannot see it.
@@ -120,7 +120,10 @@ the next time it looks.
 antiburn needs no account or backend for its main work. The connections it makes
 beyond analytics and updates are yours, not ours: reading
 a provider's own figures with your own credentials is traffic between this machine
-and a provider you already use. The application's own connection to a service of
+and a provider you already use. antiburn also downloads a public model-price catalog
+from models.dev at startup and hourly while it runs. That request sends no session
+data or credentials, and the last valid copy stays on this machine. The application's
+own connection to a service of
 ours are analytics and the updater. The updater asks GitHub Releases whether a newer
 version exists. When automatic updates are enabled, it downloads and installs the
 signed bundle and restarts antiburn. The app never depends on either connection.


### PR DESCRIPTION
## User impact

Antiburn now prices newly released models without waiting for an app release or a manual catalog update.

- Load the last valid models.dev snapshot before scanning sessions.
- Refresh at startup and hourly while the app runs, with a 15-minute retry after failures.
- Request an early refresh when the session list encounters an unpriced model.
- Reprice cached token breakdowns and invalidate open session views when rates change.
- Show and export the active models.dev catalog date.
- Remove the production pricing catalog from the engine; unavailable prices remain explicitly unknown.

If models.dev is unavailable, antiburn keeps using its last valid snapshot. A first run with no network leaves costs unavailable until a valid catalog arrives.

## Validation

- `cd crates/antiburn-local && cargo fmt --check`
- `cd crates/antiburn-local && cargo clippy --all-targets -- -D warnings`
- `cd crates/antiburn-local && cargo test`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test`
- `pnpm --filter @antiburn/desktop build`
- `cd apps/desktop/src-tauri && cargo fmt --check`
- `cd apps/desktop/src-tauri && cargo clippy --all-targets -- -D warnings`
- `cd apps/desktop/src-tauri && cargo test` (754 passed)
- `pnpm run slop:all` (score 100)
- `pnpm run secrets`

Live debug verification:

- Downloaded and installed 14,557 active prices from a 14,590-entry snapshot.
- Priced `claude-fable-5-1` at the current models.dev rates and repriced the matching session to $23.8688.
- Confirmed startup and scheduled conditional requests use ETags and accept HTTP 304 responses.
- Temporarily reduced the refresh interval to 30 seconds, observed the scheduled refresh exactly 30 seconds later, then restored the one-hour interval.

## Privacy and performance

This adds a public `GET https://models.dev/api.json` at startup and hourly while running. The request sends no credentials, session data, model IDs, or other user data. Conditional requests send only the catalog ETag.

The response is capped at 16 MiB and 50,000 usable model entries. The validated last-known-good snapshot is retained as `model-pricing.json` in the app data directory. Network work runs off the UI thread with a 20-second timeout. Unknown-model refresh requests have a 15-minute cooldown.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
