### PR TITLE
feat(evidence): build session evidence from persisted rows and a coverage record

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -23,8 +23,8 @@ use antiburn_local::analysis::{
     SessionEvidence, SessionEvidenceAccumulator, SessionInput, SessionMetrics,
     SessionMetricsAccumulator, SessionSummary, SkillUse, SourceCapabilities, SourceClaim,
     SourceKind, TurnRow, TurnRowSink, TurnRowStore, TurnScope, VisitOutcome, adapter_for,
-    aggregate_metrics, append_only_guarantee, merge_metrics, metrics_by_source, metrics_from_rows,
-    price_breakdown, pricing_generation,
+    aggregate_metrics, append_only_guarantee, evidence_from_facts, merge_metrics,
+    metrics_by_source, metrics_from_rows, price_breakdown, pricing_generation,
 };
 use antiburn_local::discovery::{
     ACTIVE_SESSION_WINDOW_SECS, Explorers, FORK_OBSERVATION_KEY, FingerprintInputs,
@@ -874,21 +874,40 @@ fn stream_vendor_with_hooks(
         .map(|child| (child.metrics(), child.started_at_ms().map(|ts| ts / 1000)))
         .collect();
     let merged = merge_metrics(parent, children);
-    // A pass without a row store publishes no evidence: the residual alone
-    // cannot build a `SessionEvidence`, since every row-derived group comes
-    // from `TurnFacts`. A row query failure fails the whole pass, the same
-    // way a turn-row write failure does above — published metrics must
-    // never disagree with rows this pass could not read back. The same
-    // fail-the-pass rule covers `row_projections`: `inclusive_model_breakdown`
-    // and `model_runs` must never publish out of step with the rows this
-    // pass itself wrote.
+    // A pass without a row store publishes no evidence. Rows and a coverage
+    // record are both required. Neither exists without a store. A query or
+    // write failure fails the whole pass. This matches the turn-row write
+    // failure above: published metrics must never disagree with rows this
+    // pass could not read back. The same fail-the-pass rule covers
+    // `row_projections`: `inclusive_model_breakdown` and `model_runs` must
+    // never publish out of step with the rows this pass itself wrote.
     let (evidence, row_projections) = match turn_row_store {
         Some(store) => {
-            let facts = match store.query_turn_facts() {
-                Ok(facts) => facts,
-                Err(_) => return StreamOutcome::ParentUnreadable,
+            // The worker never builds `SessionEvidence` from its own
+            // in-memory fold. It writes the fold's `SessionCoverageRecord`
+            // under this pass's claim fence. Then it reads the facts back
+            // through the store's own SQL query and reads the record back
+            // too. It replays both with `evidence_from_facts`. A resumed
+            // pass with no live fold needs the same rebuild, so the worker
+            // exercises it on every publish.
+            let evidence = match parent_residual {
+                Some(residual) => {
+                    let record = residual.coverage_record();
+                    if store.write_coverage_record(&record).is_err() {
+                        return StreamOutcome::ParentUnreadable;
+                    }
+                    let facts = match store.query_turn_facts() {
+                        Ok(facts) => facts,
+                        Err(_) => return StreamOutcome::ParentUnreadable,
+                    };
+                    let record = match store.query_coverage_record() {
+                        Ok(Some(record)) => record,
+                        Ok(None) | Err(_) => return StreamOutcome::ParentUnreadable,
+                    };
+                    Some(evidence_from_facts(&facts, &record))
+                }
+                None => None,
             };
-            let evidence = parent_residual.map(|residual| residual.evidence(&facts));
             let model_breakdown = match store.query_model_breakdown() {
                 Ok(model_breakdown) => model_breakdown,
                 Err(_) => return StreamOutcome::ParentUnreadable,

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -37,10 +37,11 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use antiburn_local::analysis::{
-    ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, ModelRun, PARSER_REVISION, TurnFacts, TurnRow,
-    TurnRowError, TurnRowStore, TurnSessionKey, count_turn_rows, delete_turn_rows,
-    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
-    query_model_breakdown, query_model_runs, query_turn_facts, query_turn_rows,
+    ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, ModelRun, PARSER_REVISION, SessionCoverageRecord,
+    TurnFacts, TurnRow, TurnRowError, TurnRowStore, TurnSessionKey, count_turn_rows,
+    delete_turn_rows, delete_turn_rows_except_fence, delete_turn_rows_for_fence,
+    insert_coverage_record, insert_turn_rows, query_coverage_record, query_model_breakdown,
+    query_model_runs, query_turn_facts, query_turn_rows,
 };
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
@@ -1232,6 +1233,7 @@ impl Store {
         tx.execute("DELETE FROM session_analysis", [])?;
         tx.execute("DELETE FROM session_evidence", [])?;
         tx.execute("DELETE FROM turn_content", [])?;
+        tx.execute("DELETE FROM session_coverage", [])?;
         tx.execute("DELETE FROM turn", [])?;
         let sessions = tx.execute("DELETE FROM session", [])?;
         tx.execute("DELETE FROM provider_account_seen", [])?;
@@ -1445,6 +1447,39 @@ impl Store {
             &turn_session_key(key),
             published_fence,
         )?))
+    }
+
+    /// One session's last published [`SessionCoverageRecord`], or `None`
+    /// when this session has never published.
+    ///
+    /// Mirrors [`Self::published_turn_rows`]'s contract exactly, over
+    /// `session_coverage` instead of `turn`: `published_fence` names a
+    /// complete coverage record for the same reason it names a complete row
+    /// set, and the evidence lookup and the record query run under one
+    /// lock for the same race-free guarantee.
+    pub fn published_coverage_record(
+        &self,
+        key: &SessionKey,
+    ) -> Result<Option<SessionCoverageRecord>> {
+        let connection = self.lock();
+        let Some(evidence) = connection
+            .query_row(
+                EVIDENCE_BY_KEY_SQL,
+                params![key.environment_key, key.agent, key.session_id],
+                evidence_from_row,
+            )
+            .optional()?
+        else {
+            return Ok(None);
+        };
+        let Some(published_fence) = evidence.published_fence else {
+            return Ok(None);
+        };
+        Ok(query_coverage_record(
+            &connection,
+            &turn_session_key(key),
+            published_fence,
+        )?)
     }
 
     /// Write one session's analysis columns directly, without the evidence
@@ -2332,10 +2367,10 @@ fn delete_session_in(connection: &Connection, key: &SessionKey) -> Result<bool> 
           WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         parameters,
     )?;
-    // Same reasoning as `session_evidence` above: the v15 cascades from
-    // `session` cover `turn` and `turn_content`, but this stays explicit and
-    // pragma-independent. `turn_content` has no direct session key, so it is
-    // deleted through `turn`'s rowid.
+    // Same reasoning as `session_evidence` above: the v15 and v28 cascades
+    // from `session` cover `turn`, `turn_content`, and `session_coverage`,
+    // but this stays explicit and pragma-independent. `turn_content` has no
+    // direct session key, so it is deleted through `turn`'s rowid.
     delete_turn_rows_in(connection, key)?;
     let removed = connection.execute(
         "DELETE FROM session WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
@@ -2512,6 +2547,26 @@ impl TurnRowStore for FencedTurnRowStore {
     fn query_model_runs(&self) -> Result<Vec<ModelRun>, TurnRowError> {
         let connection = self.store.lock();
         Ok(query_model_runs(
+            &connection,
+            &turn_session_key(&self.key),
+            self.claim_fence,
+        )?)
+    }
+
+    fn write_coverage_record(&self, record: &SessionCoverageRecord) -> Result<(), TurnRowError> {
+        let connection = self.store.lock();
+        insert_coverage_record(
+            &connection,
+            &turn_session_key(&self.key),
+            self.claim_fence,
+            record,
+        )?;
+        Ok(())
+    }
+
+    fn query_coverage_record(&self) -> Result<Option<SessionCoverageRecord>, TurnRowError> {
+        let connection = self.store.lock();
+        Ok(query_coverage_record(
             &connection,
             &turn_session_key(&self.key),
             self.claim_fence,

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -12,7 +12,7 @@
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
     V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,
-    V22, V23, V24, V25, V26, V27,
+    V22, V23, V24, V25, V26, V27, V28,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -447,6 +447,12 @@ ON CONFLICT(environment_key, agent, session_id) DO NOTHING;
 /// backfill gives every session `publish_projections` has already reached
 /// its own last winning fence, the only fence whose rows are still on disk
 /// for a `ready` or `unsupported` row.
+///
+/// Since [`V28`], `published_fence` names a complete `turn` row set and its
+/// `session_coverage` record together: [`antiburn_local::analysis::delete_turn_rows_except_fence`]
+/// and [`antiburn_local::analysis::delete_turn_rows_for_fence`] delete from
+/// both tables under the same fence, so the two are never on disk one
+/// without the other.
 const V21: &str = r#"
 ALTER TABLE session_evidence ADD COLUMN published_fence INTEGER;
 UPDATE session_evidence SET published_fence = claim_fence WHERE status IN ('ready','unsupported');
@@ -528,3 +534,16 @@ ADD COLUMN last_seen_epoch INTEGER NOT NULL DEFAULT 0;
 UPDATE provider_account_seen
    SET last_seen_epoch = first_seen_epoch;
 "#;
+
+/// v28 adds the `session_coverage` table. Each row holds one serialized
+/// `SessionCoverageRecord`, keyed by `(environment_key, agent, session_id,
+/// claim_fence)`. A pass writes its record under this key alongside its
+/// `turn` rows, under the same fence. The record carries the accumulator
+/// fields `evidence_from_facts` needs that never become a `TurnRow`: the
+/// tools catalog, skills and MCP sources, subagent spawn observations,
+/// diagnostics counters, and coverage and loss reasons.
+///
+/// `antiburn_local::analysis::SESSION_COVERAGE_SCHEMA_SQL` owns the column
+/// list, for the same reason [`V15`] re-exports `TURN_SCHEMA_SQL` instead of
+/// stating its own DDL.
+const V28: &str = antiburn_local::analysis::SESSION_COVERAGE_SCHEMA_SQL;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -10,6 +10,7 @@ use super::model::{
 };
 use super::*;
 
+mod coverage_tests;
 mod reconcile_tests;
 
 fn store() -> Store {
@@ -334,7 +335,7 @@ fn provider_hints_migration_keeps_old_analysis_unknown() {
         .unwrap()
         .expect("legacy analysis survives");
 
-    assert_eq!(store.schema_version().unwrap(), 27);
+    assert_eq!(store.schema_version().unwrap(), 28);
     assert_eq!(analysis.provider_hints_json, None);
 }
 
@@ -3709,10 +3710,10 @@ fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pinned so this test fails loudly if a future migration is appended
     // without also being counted here — the number is the whole point of
     // the assertion, not an incidental detail.
-    assert_eq!(super::schema::MIGRATIONS.len(), 27);
+    assert_eq!(super::schema::MIGRATIONS.len(), 28);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 27);
+    assert_eq!(store.schema_version().unwrap(), 28);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/store/tests/coverage_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/coverage_tests.rs
@@ -1,0 +1,143 @@
+use antiburn_local::analysis::{
+    EvidenceSource, SessionCoverageRecord, SessionEvidenceAccumulator, SourceCapabilities,
+    SourceKind, TurnRowStore,
+};
+
+use super::*;
+
+fn coverage_record(session_id: &str) -> SessionCoverageRecord {
+    SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: "claude-code".into(),
+        session_id: session_id.into(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::claude(),
+    })
+    .coverage_record()
+}
+
+#[test]
+fn a_fenced_coverage_writer_writes_a_record_the_store_can_read() {
+    let store = store();
+    let mut record = session("coverage-writer", 1_000);
+    record.source_fingerprint = Some("sv1:coverage-writer".into());
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    let key = record.key.clone();
+
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), 7);
+    let written = coverage_record("coverage-writer");
+    writer.write_coverage_record(&written).unwrap();
+
+    let connection = store.lock();
+    assert_eq!(
+        query_coverage_record(&connection, &turn_session_key(&key), 7).unwrap(),
+        Some(written)
+    );
+    assert_eq!(
+        query_coverage_record(&connection, &turn_session_key(&key), 8).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn publishing_evidence_keeps_only_the_current_fence_coverage_record() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "publish-current-fence-coverage", 100, 60);
+    let key = record.key.clone();
+
+    // A record left over from an earlier, superseded pass under a stale fence.
+    {
+        let connection = store.lock();
+        insert_coverage_record(
+            &connection,
+            &turn_session_key(&key),
+            claim.claim_fence - 1,
+            &coverage_record("publish-current-fence-coverage"),
+        )
+        .unwrap();
+    }
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    let current = coverage_record("publish-current-fence-coverage");
+    writer.write_coverage_record(&current).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    let connection = store.lock();
+    assert_eq!(
+        query_coverage_record(&connection, &turn_session_key(&key), claim.claim_fence - 1).unwrap(),
+        None,
+        "the superseded fence's coverage record must be gone"
+    );
+    assert_eq!(
+        query_coverage_record(&connection, &turn_session_key(&key), claim.claim_fence).unwrap(),
+        Some(current)
+    );
+    drop(connection);
+    assert_eq!(
+        store.published_coverage_record(&key).unwrap(),
+        Some(coverage_record("publish-current-fence-coverage")),
+        "the published record must survive and be readable through Store::published_coverage_record"
+    );
+}
+
+#[test]
+fn a_lost_publish_race_deletes_only_its_own_fences_coverage_record() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "lost-race-coverage", 100, 60);
+    let key = record.key.clone();
+    // A record from a still-current, earlier pass. A lost race must not
+    // touch a record it does not own.
+    {
+        let connection = store.lock();
+        insert_coverage_record(
+            &connection,
+            &turn_session_key(&key),
+            claim.claim_fence - 1,
+            &coverage_record("lost-race-coverage"),
+        )
+        .unwrap();
+    }
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer
+        .write_coverage_record(&coverage_record("lost-race-coverage"))
+        .unwrap();
+    // Bumping the source generation makes the fenced UPDATE inside
+    // `publish_projections` affect zero rows — the same "lost the race"
+    // shape the turn-row equivalent of this test exercises.
+    store
+        .lock()
+        .execute(
+            "UPDATE session SET source_generation = source_generation + 1
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+
+    assert!(
+        !store
+            .publish_projections(&record, None, &completion, &[])
+            .unwrap()
+    );
+
+    let connection = store.lock();
+    assert_eq!(
+        query_coverage_record(&connection, &turn_session_key(&key), claim.claim_fence).unwrap(),
+        None,
+        "the losing pass's own coverage record must be gone"
+    );
+    assert_eq!(
+        query_coverage_record(&connection, &turn_session_key(&key), claim.claim_fence - 1).unwrap(),
+        Some(coverage_record("lost-race-coverage")),
+        "a record the lost race does not own must be untouched"
+    );
+}

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -855,6 +855,57 @@ pub struct EvidenceSource {
     pub capabilities: SourceCapabilities,
 }
 
+/// The bounded, per-session residual [`super::evidence_sink::
+/// SessionEvidenceAccumulator`] observed directly from records that never
+/// become [`super::rows::TurnRow`]s — an `Observation`, an `Unusable`
+/// record, or the end-of-stream [`super::interface::SessionSummary`].
+///
+/// [`super::evidence_replay::evidence_from_facts`] combines this with the
+/// row-derived [`super::evidence_query::TurnFacts`] to rebuild
+/// [`SessionEvidence`] without opening the transcript again. Every field
+/// here mirrors an accumulator field one for one; `coverage_record` on the
+/// accumulator builds this, and building [`SessionEvidence`] needs nothing
+/// else the accumulator held — the two transient fields the accumulator
+/// keeps only to compute `ordering` and `thread_parent_unresolved` live
+/// (`last_ts_ms`, `seen_thread_uuids`) are not carried, since only their
+/// already-folded results are.
+///
+/// Bounded the same way [`super::evidence_sink::SessionEvidenceAccumulator::
+/// retained_bytes`] bounds the accumulator: every collection here is one
+/// the accumulator already caps (`tools`, `skills`, `mcp_servers`,
+/// `subagent_children`, `subagent_examples`, and `diagnostics`'s own
+/// capped sets), so this record's serialized size is bounded the same way.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCoverageRecord {
+    pub coverage_schema_revision: i64,
+    pub identity: SessionEvidenceIdentity,
+    pub capabilities: SourceCapabilities,
+    pub source_kind: SourceKind,
+    pub source_acceptance: SourceAcceptance,
+    pub ordering: OrderingObservation,
+    pub diagnostics: ParseDiagnostics,
+    pub record_loss_reason: Option<CoverageReason>,
+    pub session_cap_exceeded: bool,
+    pub tools: BTreeMap<String, ToolUse>,
+    pub invoked_skills: BTreeSet<String>,
+    pub tools_cap_exceeded: bool,
+    pub skills: BTreeMap<String, LoadedSource>,
+    pub mcp_servers: BTreeMap<String, LoadedSource>,
+    pub context_sources_cap_exceeded: bool,
+    pub subagent_spawn_count: u64,
+    pub subagent_children: Vec<SubagentChild>,
+    pub subagent_examples: Vec<SubagentExample>,
+    pub subagents_cap_exceeded: bool,
+    /// A `ThreadLink` observation's `parent_uuid` named an identity this
+    /// source never declared. Distinct from [`super::evidence_query::
+    /// TurnFacts::thread_identity_missing`]: that flags a counted turn with
+    /// no `uuid` at all; this flags a `uuid` that does not resolve.
+    pub thread_parent_unresolved: bool,
+    pub summary_observed: bool,
+    pub child_loss_reason: Option<CoverageReason>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionEvidence {

--- a/crates/antiburn-local/src/analysis/evidence_replay.rs
+++ b/crates/antiburn-local/src/analysis/evidence_replay.rs
@@ -1,0 +1,20 @@
+//! Rebuilds `SessionEvidence` from persisted facts and a coverage record
+//! alone.
+//!
+//! [`evidence_from_facts`] combines [`TurnFacts`] (read with SQL through
+//! [`evidence_query::query_turn_facts`]) and a [`SessionCoverageRecord`] (the
+//! bounded residual [`SessionEvidenceAccumulator::coverage_record`] captures,
+//! for the facts a row query can never answer) to rebuild [`SessionEvidence`]
+//! with no transcript or live fold involved. See
+//! `crates/antiburn-local/tests/evidence_replay_parity.rs` for the proof.
+
+use crate::analysis::evidence::{SessionCoverageRecord, SessionEvidence};
+use crate::analysis::evidence_query::TurnFacts;
+use crate::analysis::evidence_sink::SessionEvidenceAccumulator;
+
+/// Rebuilds [`SessionEvidence`] from a session's [`TurnFacts`] and its
+/// [`SessionCoverageRecord`], with no transcript, store, or live fold
+/// involved.
+pub fn evidence_from_facts(facts: &TurnFacts, record: &SessionCoverageRecord) -> SessionEvidence {
+    SessionEvidenceAccumulator::from_coverage_record(record.clone()).evidence(facts)
+}

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -6,10 +6,10 @@ use crate::analysis::evidence::{
     CoverageReason, EvidenceCoverage, EvidenceSource, EvidenceValue, LoadedSource,
     MAX_CONTEXT_SOURCES, MAX_EVIDENCE_EXAMPLES, MAX_SUBAGENT_CHILDREN, MAX_TOOL_NAMES,
     MAX_UNRECOGNIZED_TYPES, ModelEvidence, OrderingObservation, ParseDiagnostics,
-    RelationConfidence, RepeatedContext, RepeatedContextAccounting, SessionEvidence,
-    SessionEvidenceIdentity, SessionProvenance, SourceAcceptance, SourceCapabilities, SourceKind,
-    SubagentChild, SubagentEvidence, SubagentExample, ToolClass, ToolEvidence, ToolUse, cap_string,
-    insert_diagnostic_field, record_diagnostic_set_cap,
+    RelationConfidence, RepeatedContext, RepeatedContextAccounting, SessionCoverageRecord,
+    SessionEvidence, SessionEvidenceIdentity, SessionProvenance, SourceAcceptance,
+    SourceCapabilities, SourceKind, SubagentChild, SubagentEvidence, SubagentExample, ToolClass,
+    ToolEvidence, ToolUse, cap_string, insert_diagnostic_field, record_diagnostic_set_cap,
 };
 use crate::analysis::evidence_query::TurnFacts;
 use crate::analysis::interface::{
@@ -20,7 +20,8 @@ use crate::analysis::metrics_sink::SessionMetricsAccumulator;
 use crate::analysis::model::NormalizedEvent;
 use crate::analysis::rows::TurnRowSink;
 use crate::analysis::{
-    ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION, SessionMetrics,
+    ANALYZER_REVISION, COVERAGE_SCHEMA_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION,
+    SessionMetrics,
 };
 
 /// The suffix after a skill's last `:` (e.g. `deploy` from
@@ -460,6 +461,73 @@ impl SessionEvidenceAccumulator {
             self.set_record_loss_reason(CoverageReason::PinnedPrefix);
         }
         self.source_acceptance = SourceAcceptance::from(outcome);
+    }
+
+    /// Snapshots every field [`Self::evidence`] reads from `self` (every
+    /// field but the two transient ones, `last_ts_ms` and
+    /// `seen_thread_uuids`, that exist only to compute `ordering` and
+    /// `thread_parent_unresolved` live) into a [`SessionCoverageRecord`].
+    /// [`crate::analysis::evidence_replay::evidence_from_facts`] combines the
+    /// record this returns with row-derived [`TurnFacts`] to rebuild
+    /// [`SessionEvidence`] without a live fold.
+    pub fn coverage_record(&self) -> SessionCoverageRecord {
+        SessionCoverageRecord {
+            coverage_schema_revision: COVERAGE_SCHEMA_REVISION,
+            identity: self.identity.clone(),
+            capabilities: self.capabilities,
+            source_kind: self.source_kind,
+            source_acceptance: self.source_acceptance,
+            ordering: self.ordering,
+            diagnostics: self.diagnostics.clone(),
+            record_loss_reason: self.record_loss_reason,
+            session_cap_exceeded: self.session_cap_exceeded,
+            tools: self.tools.clone(),
+            invoked_skills: self.invoked_skills.clone(),
+            tools_cap_exceeded: self.tools_cap_exceeded,
+            skills: self.skills.clone(),
+            mcp_servers: self.mcp_servers.clone(),
+            context_sources_cap_exceeded: self.context_sources_cap_exceeded,
+            subagent_spawn_count: self.subagent_spawn_count,
+            subagent_children: self.subagent_children.clone(),
+            subagent_examples: self.subagent_examples.clone(),
+            subagents_cap_exceeded: self.subagents_cap_exceeded,
+            thread_parent_unresolved: self.thread_parent_unresolved,
+            summary_observed: self.summary_observed,
+            child_loss_reason: self.child_loss_reason,
+        }
+    }
+
+    /// Rebuilds an accumulator from a [`SessionCoverageRecord`] a prior pass
+    /// produced. The two transient fields [`Self::coverage_record`] does not
+    /// carry (`last_ts_ms`, `seen_thread_uuids`) start empty: [`Self::evidence`]
+    /// never reads them directly, only the `ordering` and
+    /// `thread_parent_unresolved` results already folded into the record.
+    pub fn from_coverage_record(record: SessionCoverageRecord) -> Self {
+        Self {
+            identity: record.identity,
+            capabilities: record.capabilities,
+            source_kind: record.source_kind,
+            source_acceptance: record.source_acceptance,
+            ordering: record.ordering,
+            diagnostics: record.diagnostics,
+            record_loss_reason: record.record_loss_reason,
+            session_cap_exceeded: record.session_cap_exceeded,
+            last_ts_ms: None,
+            tools: record.tools,
+            invoked_skills: record.invoked_skills,
+            tools_cap_exceeded: record.tools_cap_exceeded,
+            skills: record.skills,
+            mcp_servers: record.mcp_servers,
+            context_sources_cap_exceeded: record.context_sources_cap_exceeded,
+            subagent_spawn_count: record.subagent_spawn_count,
+            subagent_children: record.subagent_children,
+            subagent_examples: record.subagent_examples,
+            subagents_cap_exceeded: record.subagents_cap_exceeded,
+            seen_thread_uuids: HashSet::new(),
+            thread_parent_unresolved: record.thread_parent_unresolved,
+            summary_observed: record.summary_observed,
+            child_loss_reason: record.child_loss_reason,
+        }
     }
 
     /// Builds this session's [`SessionEvidence`] from the row-derived
@@ -1073,6 +1141,17 @@ impl CompositeSink {
             Ok(facts) => Some(self.evidence.evidence(&facts)),
             Err(_) => None,
         }
+    }
+
+    /// This residual's [`SessionCoverageRecord`] snapshot, once it can
+    /// publish — `None` under the same rule [`Self::evidence`] returns
+    /// `None`. A caller that persists a coverage record alongside turn rows
+    /// calls this instead of [`Self::evidence`], since evidence itself now
+    /// comes from replaying rows against the persisted record.
+    pub fn coverage_record(&self) -> Option<SessionCoverageRecord> {
+        self.evidence
+            .can_publish()
+            .then(|| self.evidence.coverage_record())
     }
 
     pub fn observe_source_outcome(&mut self, outcome: VisitOutcome) {

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -88,11 +88,11 @@ pub use model::{
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
 pub use replay::{MissingParentRows, metrics_by_source, metrics_from_rows};
 pub use rows::{
-    MemoryTurnRowStore, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL,
-    TURN_SCHEMA_V3_SQL, TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope,
-    TurnSessionKey, count_turn_content_rows, count_turn_rows, delete_turn_rows,
-    delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_turn_rows,
-    turn_row_from_event,
+    MemoryTurnRowStore, SESSION_COVERAGE_SCHEMA_SQL, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE,
+    TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL, TURN_SCHEMA_V3_SQL, TurnRow, TurnRowError, TurnRowSink,
+    TurnRowStore, TurnScope, TurnSessionKey, count_turn_content_rows, count_turn_rows,
+    delete_turn_rows, delete_turn_rows_except_fence, delete_turn_rows_for_fence,
+    insert_coverage_record, insert_turn_rows, query_coverage_record, turn_row_from_event,
 };
 pub use source_validity::{
     AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -31,6 +31,7 @@ mod efficiency;
 mod engine;
 mod evidence;
 mod evidence_query;
+mod evidence_replay;
 mod evidence_sink;
 mod framing;
 mod initial_context;
@@ -58,14 +59,15 @@ pub use evidence::{
     EvidenceCoverage, EvidenceSource, EvidenceValue, FAST_SPEED_KEY, LoadedSource, ModelEvidence,
     ModelTokens, ModelTransition, OrderingObservation, ParseDiagnostics, QuotaConfidence,
     QuotaHitSeverity, QuotaIncident, QuotaLimitKind, RelationConfidence, RepeatedContext,
-    RepeatedContextAccounting, SessionEvidence, SessionEvidenceIdentity, SessionProvenance,
-    SessionQuotaEvidence, SessionTimeRange, SignalCoverage, SourceAcceptance, SourceCapabilities,
-    SourceKind, SubagentChild, SubagentEvidence, SubagentExample, ToolClass, ToolEvidence, ToolUse,
-    TurnCounts,
+    RepeatedContextAccounting, SessionCoverageRecord, SessionEvidence, SessionEvidenceIdentity,
+    SessionProvenance, SessionQuotaEvidence, SessionTimeRange, SignalCoverage, SourceAcceptance,
+    SourceCapabilities, SourceKind, SubagentChild, SubagentEvidence, SubagentExample, ToolClass,
+    ToolEvidence, ToolUse, TurnCounts,
 };
 pub use evidence_query::{
     TurnFacts, query_model_breakdown, query_model_runs, query_turn_facts, query_turn_rows,
 };
+pub use evidence_replay::evidence_from_facts;
 pub use evidence_sink::{CompositeSink, RETAINED_EVIDENCE_BYTES_BOUND, SessionEvidenceAccumulator};
 pub use framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,
@@ -155,6 +157,12 @@ pub const METRICS_SCHEMA_REVISION: i64 = 4;
 // +1 more for `RepeatedContext::paid_tokens` (part F).
 // +1 more for `SourceCapabilities::linear_record_order`.
 pub const EVIDENCE_SCHEMA_REVISION: i64 = 12;
+/// Versions [`evidence::SessionCoverageRecord`]'s own shape, separately
+/// from [`EVIDENCE_SCHEMA_REVISION`]: the record is an internal input to
+/// evidence replay, not the published `SessionEvidence` shape itself.
+/// A persisted record from an older revision cannot be trusted to replay
+/// correctly, so a reader must reparse instead of reusing it.
+pub const COVERAGE_SCHEMA_REVISION: i64 = 1;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -4,14 +4,16 @@
 //! query the durable rows instead of streaming an accumulator, and lets a
 //! catalog or policy change requery rows instead of reparsing a transcript.
 //!
-//! This module owns only the `turn` and `turn_content` DDL and the read/write
-//! functions over a borrowed [`rusqlite::Connection`]. The crate does not open
-//! the app database and does not know any other app table.
+//! This module owns only the `turn`, `turn_content`, and `session_coverage`
+//! DDL and the read/write functions over a borrowed [`rusqlite::Connection`].
+//! The crate does not open the app database and does not know any other app
+//! table.
 
 use std::sync::{Arc, Mutex};
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 
+use crate::analysis::evidence::SessionCoverageRecord;
 use crate::analysis::evidence_query::{TurnFacts, query_turn_facts};
 use crate::analysis::interface::{ContentPart, NormalizedRecord, RecordSink, SessionSummary};
 use crate::analysis::model::{CompactionTrigger, EventSource, NormalizedEvent, Role};
@@ -100,13 +102,44 @@ ALTER TABLE turn ADD COLUMN last_tool TEXT;
 ALTER TABLE turn ADD COLUMN subagent_launches INTEGER NOT NULL DEFAULT 0;
 "#;
 
-/// Every migration that builds the `turn` and `turn_content` schema, in
-/// order. A caller that creates this schema from scratch (a test, an
-/// in-memory store) applies every entry in order; the app applies
-/// [`TURN_SCHEMA_SQL`], [`TURN_SCHEMA_V2_SQL`], and [`TURN_SCHEMA_V3_SQL`] as
-/// its own separately numbered migrations instead, since [`TURN_SCHEMA_SQL`]
-/// is already applied on user machines.
-pub const TURN_MIGRATIONS: &[&str] = &[TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL, TURN_SCHEMA_V3_SQL];
+/// DDL for the `session_coverage` table: one row per `(environment_key,
+/// agent, session_id, claim_fence)`, holding the serialized
+/// [`SessionCoverageRecord`] a pass wrote alongside its turn rows under the
+/// same fence.
+///
+/// Carries the same `ON DELETE CASCADE` foreign key to `session` that `turn`
+/// does, for the same reason: deleting a session must not leave an orphaned
+/// coverage record behind. [`delete_turn_rows_except_fence`] and
+/// [`delete_turn_rows_for_fence`] delete from this table too — the published
+/// fence covers rows and the coverage record together, never one without the
+/// other.
+pub const SESSION_COVERAGE_SCHEMA_SQL: &str = r#"
+CREATE TABLE session_coverage (
+    environment_key TEXT NOT NULL,
+    agent TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    claim_fence INTEGER NOT NULL,
+    coverage_json TEXT NOT NULL,
+    coverage_schema_revision INTEGER NOT NULL,
+    PRIMARY KEY (environment_key, agent, session_id, claim_fence),
+    FOREIGN KEY (environment_key, agent, session_id)
+      REFERENCES session (environment_key, agent, session_id) ON DELETE CASCADE
+) STRICT;
+"#;
+
+/// Every migration that builds the `turn`, `turn_content`, and
+/// `session_coverage` schema, in order. A caller that creates this schema
+/// from scratch (a test, an in-memory store) applies every entry in order;
+/// the app applies [`TURN_SCHEMA_SQL`], [`TURN_SCHEMA_V2_SQL`],
+/// [`TURN_SCHEMA_V3_SQL`], and [`SESSION_COVERAGE_SCHEMA_SQL`] as its own
+/// separately numbered migrations instead, since [`TURN_SCHEMA_SQL`] is
+/// already applied on user machines.
+pub const TURN_MIGRATIONS: &[&str] = &[
+    TURN_SCHEMA_SQL,
+    TURN_SCHEMA_V2_SQL,
+    TURN_SCHEMA_V3_SQL,
+    SESSION_COVERAGE_SCHEMA_SQL,
+];
 
 /// Number of rows a [`TurnRowSink`] buffers before it writes them, unless the
 /// caller picks a different size with [`TurnRowSink::with_batch_size`].
@@ -311,6 +344,14 @@ pub trait TurnRowStore: Send + Sync {
     /// its own session key and fence, parent runs first. See
     /// [`crate::analysis::query_model_runs`].
     fn query_model_runs(&self) -> Result<Vec<crate::analysis::model::ModelRun>, TurnRowError>;
+
+    /// Writes this session's [`SessionCoverageRecord`] under this store's own
+    /// session key and fence, replacing any record already written under it.
+    fn write_coverage_record(&self, record: &SessionCoverageRecord) -> Result<(), TurnRowError>;
+
+    /// Reads the coverage record this store wrote under its own session key
+    /// and fence. `None` when nothing has written one yet under this fence.
+    fn query_coverage_record(&self) -> Result<Option<SessionCoverageRecord>, TurnRowError>;
 }
 
 /// A [`RecordSink`] that turns `MetricsEvent` records into [`TurnRow`]s,
@@ -535,7 +576,8 @@ pub fn insert_turn_rows(
 ///
 /// Used after a pass publishes: rows from every earlier, superseded pass are
 /// dropped, keeping only the rows the just-published evidence was built
-/// from. Returns the number of `turn` rows removed.
+/// from. Also deletes any `session_coverage` record stamped with a fence
+/// other than `keep_fence`. Returns the number of `turn` rows removed.
 pub fn delete_turn_rows_except_fence(
     conn: &Connection,
     key: &TurnSessionKey<'_>,
@@ -547,6 +589,12 @@ pub fn delete_turn_rows_except_fence(
               WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
                 AND claim_fence != ?4
          )",
+        params![key.environment_key, key.agent, key.session_id, keep_fence],
+    )?;
+    conn.execute(
+        "DELETE FROM session_coverage
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+            AND claim_fence != ?4",
         params![key.environment_key, key.agent, key.session_id, keep_fence],
     )?;
     conn.execute(
@@ -562,7 +610,8 @@ pub fn delete_turn_rows_except_fence(
 /// Used when a pass loses the publish race (its claim fence no longer
 /// matches): the rows it wrote never became part of any published evidence,
 /// so they are cleaned up under their own fence rather than left to
-/// accumulate. Returns the number of `turn` rows removed.
+/// accumulate. Also deletes any `session_coverage` record stamped with
+/// `claim_fence`. Returns the number of `turn` rows removed.
 pub fn delete_turn_rows_for_fence(
     conn: &Connection,
     key: &TurnSessionKey<'_>,
@@ -577,6 +626,12 @@ pub fn delete_turn_rows_for_fence(
         params![key.environment_key, key.agent, key.session_id, claim_fence],
     )?;
     conn.execute(
+        "DELETE FROM session_coverage
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+            AND claim_fence = ?4",
+        params![key.environment_key, key.agent, key.session_id, claim_fence],
+    )?;
+    conn.execute(
         "DELETE FROM turn
           WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
             AND claim_fence = ?4",
@@ -584,14 +639,77 @@ pub fn delete_turn_rows_for_fence(
     )
 }
 
-/// Deletes every row for `key`. Used by session delete and
-/// clear-local-session-data paths.
+const UPSERT_SESSION_COVERAGE_SQL: &str = "INSERT INTO session_coverage (
+    environment_key, agent, session_id, claim_fence,
+    coverage_json, coverage_schema_revision
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+ON CONFLICT (environment_key, agent, session_id, claim_fence) DO UPDATE SET
+    coverage_json = excluded.coverage_json,
+    coverage_schema_revision = excluded.coverage_schema_revision";
+
+/// Writes `record` for `key` under `claim_fence`, replacing any record
+/// already written under that same key and fence.
+pub fn insert_coverage_record(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+    record: &SessionCoverageRecord,
+) -> rusqlite::Result<()> {
+    let coverage_json = serde_json::to_string(record)
+        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
+    conn.execute(
+        UPSERT_SESSION_COVERAGE_SQL,
+        params![
+            key.environment_key,
+            key.agent,
+            key.session_id,
+            claim_fence,
+            coverage_json,
+            record.coverage_schema_revision,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Reads the [`SessionCoverageRecord`] written for `key` under
+/// `claim_fence`. `None` when nothing has been written under that key and
+/// fence.
+pub fn query_coverage_record(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> rusqlite::Result<Option<SessionCoverageRecord>> {
+    let coverage_json: Option<String> = conn
+        .query_row(
+            "SELECT coverage_json FROM session_coverage
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
+                AND claim_fence = ?4",
+            params![key.environment_key, key.agent, key.session_id, claim_fence],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(coverage_json) = coverage_json else {
+        return Ok(None);
+    };
+    let record = serde_json::from_str(&coverage_json).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+    })?;
+    Ok(Some(record))
+}
+
+/// Deletes every row, and every `session_coverage` record, for `key`. Used
+/// by session delete and clear-local-session-data paths.
 pub fn delete_turn_rows(conn: &Connection, key: &TurnSessionKey<'_>) -> rusqlite::Result<usize> {
     conn.execute(
         "DELETE FROM turn_content WHERE turn_rowid IN (
              SELECT rowid FROM turn
               WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3
          )",
+        params![key.environment_key, key.agent, key.session_id],
+    )?;
+    conn.execute(
+        "DELETE FROM session_coverage
+          WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
         params![key.environment_key, key.agent, key.session_id],
     )?;
     conn.execute(
@@ -745,6 +863,18 @@ impl TurnRowStore for MemoryTurnRowStore {
             self.claim_fence,
         )
         .map_err(TurnRowError::from)
+    }
+
+    fn write_coverage_record(&self, record: &SessionCoverageRecord) -> Result<(), TurnRowError> {
+        let connection = self.connection.lock().expect("lock");
+        insert_coverage_record(&connection, &self.key(), self.claim_fence, record)
+            .map_err(TurnRowError::from)
+    }
+
+    fn query_coverage_record(&self) -> Result<Option<SessionCoverageRecord>, TurnRowError> {
+        let connection = self.connection.lock().expect("lock");
+        query_coverage_record(&connection, &self.key(), self.claim_fence)
+            .map_err(TurnRowError::from)
     }
 }
 
@@ -983,6 +1113,17 @@ mod tests {
         fn query_model_runs(&self) -> Result<Vec<crate::analysis::model::ModelRun>, TurnRowError> {
             Err(TurnRowError("not readable".to_owned()))
         }
+
+        fn write_coverage_record(
+            &self,
+            _record: &SessionCoverageRecord,
+        ) -> Result<(), TurnRowError> {
+            Err(TurnRowError("boom".to_owned()))
+        }
+
+        fn query_coverage_record(&self) -> Result<Option<SessionCoverageRecord>, TurnRowError> {
+            Err(TurnRowError("not readable".to_owned()))
+        }
     }
 
     /// A store over a real connection, so batching tests can assert on rows
@@ -1105,6 +1246,38 @@ mod tests {
         fn query_model_runs(&self) -> Result<Vec<crate::analysis::model::ModelRun>, TurnRowError> {
             let conn = self.conn.lock().expect("lock");
             crate::analysis::evidence_query::query_model_runs(
+                &conn,
+                &TurnSessionKey {
+                    environment_key: "native",
+                    agent: "claude",
+                    session_id: &self.key,
+                },
+                1,
+            )
+            .map_err(TurnRowError::from)
+        }
+
+        fn write_coverage_record(
+            &self,
+            record: &SessionCoverageRecord,
+        ) -> Result<(), TurnRowError> {
+            let conn = self.conn.lock().expect("lock");
+            insert_coverage_record(
+                &conn,
+                &TurnSessionKey {
+                    environment_key: "native",
+                    agent: "claude",
+                    session_id: &self.key,
+                },
+                1,
+                record,
+            )
+            .map_err(TurnRowError::from)
+        }
+
+        fn query_coverage_record(&self) -> Result<Option<SessionCoverageRecord>, TurnRowError> {
+            let conn = self.conn.lock().expect("lock");
+            query_coverage_record(
                 &conn,
                 &TurnSessionKey {
                     environment_key: "native",

--- a/crates/antiburn-local/tests/evidence_replay_parity.rs
+++ b/crates/antiburn-local/tests/evidence_replay_parity.rs
@@ -1,0 +1,864 @@
+//! Parity check between the live pipeline's `SessionEvidence` and the same
+//! evidence rebuilt from a `SessionCoverageRecord` read back through a
+//! store. Modelled on `turn_row_replay_parity.rs`. See phase 2, "evidence
+//! from rows", in `docs/plans/continuous-session-ingest.md`.
+//!
+//! For every vendor characterization fixture `turn_facts_parity.rs` sweeps,
+//! this streams the fixture once through a `CompositeSink` (metrics +
+//! evidence + `TurnRowSink` into a `MemoryTurnRowStore`), writes the
+//! coverage record the fold produced, reads the facts and the coverage
+//! record back through the store, rebuilds evidence with
+//! `evidence_from_facts`, and asserts the result equals the live
+//! accumulator's own `SessionEvidence` field by field. The write and read
+//! back put the coverage record's JSON round trip under test, which is the
+//! part this file needs to prove.
+//!
+//! Two scenarios below build their rows and accumulators by hand instead of
+//! through a characterization fixture: a parent with a discovered child
+//! transcript (`observe_child_coverage`), and a parent with a discovered
+//! child that could not be read at all (`observe_child_unreadable`). Neither
+//! shape appears in the crate's own characterization fixtures — a
+//! discovered child is a separate file the desktop app's own
+//! `stream_vendor_with_hooks` folds in, which this crate does not depend on
+//! — so this file exercises `SessionEvidenceAccumulator`'s public API
+//! directly, the same way `evidence_sink.rs`'s own unit tests do.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use antiburn_local::analysis::{
+    CompositeSink, EvidenceSource, MemoryTurnRowStore, NormalizedEvent, NormalizedRecord,
+    RawSource, Role, SessionEvidence, SessionEvidenceAccumulator, SessionInput,
+    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceKind, TurnRowSink,
+    TurnRowStore, TurnScope, TurnSessionKey, VisitOutcome, adapter_for, evidence_from_facts,
+    query_coverage_record, query_turn_facts,
+};
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+/// Records a mismatch when the replayed `SessionEvidence` and the live
+/// accumulator's own `SessionEvidence` differ for one field of one fixture.
+fn diff<T: std::fmt::Debug + PartialEq>(
+    mismatches: &mut Vec<Mismatch>,
+    fixture: &str,
+    field: &str,
+    replayed: T,
+    live: T,
+) {
+    if replayed != live {
+        mismatches.push(Mismatch {
+            detail: format!(
+                "fixture={fixture} field={field}\n  replayed = {replayed:?}\n  live     = {live:?}"
+            ),
+        });
+    }
+}
+
+struct Mismatch {
+    detail: String,
+}
+
+fn assert_no_mismatches(vendor: &str, mismatches: Vec<Mismatch>) {
+    let details: Vec<&str> = mismatches
+        .iter()
+        .map(|mismatch| mismatch.detail.as_str())
+        .collect();
+    assert!(
+        details.is_empty(),
+        "{vendor}: {} mismatch(es) between evidence_from_facts and the live accumulator:\n\n{}",
+        details.len(),
+        details.join("\n\n")
+    );
+}
+
+/// Compares every top-level `SessionEvidence` field, for one fixture,
+/// pushing each mismatch found into `mismatches`.
+fn compare_evidence(
+    mismatches: &mut Vec<Mismatch>,
+    fixture: &str,
+    live: &SessionEvidence,
+    replayed: &SessionEvidence,
+) {
+    diff(
+        mismatches,
+        fixture,
+        "schemaRevision",
+        replayed.schema_revision,
+        live.schema_revision,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "identity",
+        replayed.identity.clone(),
+        live.identity.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "context",
+        replayed.context.clone(),
+        live.context.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "capabilities",
+        replayed.capabilities,
+        live.capabilities,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "coverage",
+        replayed.coverage,
+        live.coverage,
+    );
+    diff(
+        mismatches,
+        fixture,
+        "provenance",
+        replayed.provenance.clone(),
+        live.provenance.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "diagnostics",
+        replayed.diagnostics.clone(),
+        live.diagnostics.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "timeRange",
+        replayed.time_range.clone(),
+        live.time_range.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "eligibility",
+        replayed.eligibility.clone(),
+        live.eligibility.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "tools",
+        replayed.tools.clone(),
+        live.tools.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "contextSources",
+        replayed.context_sources.clone(),
+        live.context_sources.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "models",
+        replayed.models.clone(),
+        live.models.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "subagents",
+        replayed.subagents.clone(),
+        live.subagents.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "cache",
+        replayed.cache.clone(),
+        live.cache.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "compactions",
+        replayed.compactions.clone(),
+        live.compactions.clone(),
+    );
+    diff(
+        mismatches,
+        fixture,
+        "quotaIncidents",
+        replayed.quota_incidents.clone(),
+        live.quota_incidents.clone(),
+    );
+}
+
+/// Streams `input` through the real adapter and the real evidence and
+/// turn-row pipeline, then rebuilds `SessionEvidence` from the facts and
+/// coverage record read back through the store. Returns `(live, replayed)`.
+fn run_fixture_and_replay(
+    agent: &str,
+    fixture: &str,
+    input: &SessionInput,
+    capabilities: SourceCapabilities,
+) -> (SessionEvidence, SessionEvidence) {
+    let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: input.agent.clone(),
+        session_id: input.session_id.clone(),
+        kind: SourceKind::from(&input.source),
+        capabilities,
+    });
+    let store = MemoryTurnRowStore::new(input.agent.clone(), input.session_id.clone());
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        input.session_id.clone(),
+        None,
+    );
+    let mut composite = CompositeSink::with_turn_rows(metrics, evidence, turn_rows);
+    let outcome = adapter_for(agent)
+        .visit(input, &mut composite)
+        .expect("fixture must stream");
+    composite.observe_source_outcome(outcome);
+    assert!(
+        !composite.turn_row_write_failed(),
+        "fixture {fixture}: turn row write must not fail"
+    );
+    let live = composite
+        .evidence()
+        .expect("finished source must publish evidence");
+    let record = composite
+        .coverage_record()
+        .expect("finished source must publish a coverage record");
+
+    let key = TurnSessionKey {
+        environment_key: "native",
+        agent,
+        session_id: &input.session_id,
+    };
+    store
+        .write_coverage_record(&record)
+        .expect("coverage record must write");
+    let (facts, record) = store.with_connection(|conn| {
+        let facts = query_turn_facts(conn, &key, 1).expect("query facts must succeed");
+        let record = query_coverage_record(conn, &key, 1)
+            .expect("query coverage record must succeed")
+            .expect("coverage record must have been written");
+        (facts, record)
+    });
+    let replayed = evidence_from_facts(&facts, &record);
+    (live, replayed)
+}
+
+fn run_fixture(
+    agent: &str,
+    fixture: &str,
+    jsonl: &str,
+    capabilities: SourceCapabilities,
+) -> (SessionEvidence, SessionEvidence) {
+    let input = SessionInput {
+        agent: agent.to_owned(),
+        session_id: fixture.to_owned(),
+        source: RawSource::Jsonl(jsonl.to_owned()),
+    };
+    run_fixture_and_replay(agent, fixture, &input, capabilities)
+}
+
+/* --------------------------------------------------------------------
+ * Claude fixtures. Same fixture set `turn_facts_parity.rs` sweeps.
+ * ----------------------------------------------------------------- */
+
+fn claude_fixture(name: &str) -> &'static str {
+    match name {
+        "records_all_kinds" => {
+            include_str!("fixtures/claude_characterization/records_all_kinds.jsonl")
+        }
+        "timestamps_repeated_and_out_of_order" => include_str!(
+            "fixtures/claude_characterization/timestamps_repeated_and_out_of_order.jsonl"
+        ),
+        "malformed_between_valid" => {
+            include_str!("fixtures/claude_characterization/malformed_between_valid.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/claude_characterization/incomplete_final_record.jsonl")
+        }
+        "unrecognized_type" => {
+            include_str!("fixtures/claude_characterization/unrecognized_type.jsonl")
+        }
+        "unrecognized_role_with_usage" => {
+            include_str!("fixtures/claude_characterization/unrecognized_role_with_usage.jsonl")
+        }
+        "unrecognized_evidence_shapes" => {
+            include_str!("fixtures/claude_characterization/unrecognized_evidence_shapes.jsonl")
+        }
+        "unrecognized_inert_records" => {
+            include_str!("fixtures/claude_characterization/unrecognized_inert_records.jsonl")
+        }
+        "unrecognized_inert_sidechain" => {
+            include_str!("fixtures/claude_characterization/unrecognized_inert_sidechain.jsonl")
+        }
+        "parent_with_task_spawn" => {
+            include_str!("fixtures/claude_characterization/parent_with_task_spawn.jsonl")
+        }
+        "subagent_child" => include_str!("fixtures/claude_characterization/subagent_child.jsonl"),
+        "multi_model_session" => {
+            include_str!("fixtures/claude_characterization/multi_model_session.jsonl")
+        }
+        "compaction_with_cache_rehydration" => {
+            include_str!("fixtures/claude_characterization/compaction_with_cache_rehydration.jsonl")
+        }
+        "inferred_cache_rehydration" => {
+            include_str!("fixtures/claude_characterization/inferred_cache_rehydration.jsonl")
+        }
+        "mcp_and_skill_sources" => {
+            include_str!("fixtures/claude_characterization/mcp_and_skill_sources.jsonl")
+        }
+        "reasoning_and_fast_mode" => {
+            include_str!("fixtures/claude_characterization/reasoning_and_fast_mode.jsonl")
+        }
+        "delegated_turns" => {
+            include_str!("fixtures/claude_characterization/delegated_turns.jsonl")
+        }
+        "delegated_models" => {
+            include_str!("fixtures/claude_characterization/delegated_models.jsonl")
+        }
+        "delegated_model_missing" => {
+            include_str!("fixtures/claude_characterization/delegated_model_missing.jsonl")
+        }
+        "housekeeping_records" => {
+            include_str!("fixtures/claude_characterization/housekeeping_records.jsonl")
+        }
+        "thread_identity_chain" => {
+            include_str!("fixtures/claude_characterization/thread_identity_chain.jsonl")
+        }
+        "thread_identity_missing_uuid" => {
+            include_str!("fixtures/claude_characterization/thread_identity_missing_uuid.jsonl")
+        }
+        "sidechain_in_parent" => {
+            include_str!("fixtures/claude_characterization/sidechain_in_parent.jsonl")
+        }
+        "late_skill_metrics" => {
+            include_str!("fixtures/claude_characterization/late_skill_metrics.jsonl")
+        }
+        "two_compactions_second_without_metadata" => include_str!(
+            "fixtures/claude_characterization/two_compactions_second_without_metadata.jsonl"
+        ),
+        "rehydration_gap_none" => {
+            include_str!("fixtures/claude_characterization/rehydration_gap_none.jsonl")
+        }
+        "disorder_ladder" => {
+            include_str!("fixtures/claude_characterization/disorder_ladder.jsonl")
+        }
+        "subagent_single_timestamp" => {
+            include_str!("fixtures/claude_characterization/subagent_single_timestamp.jsonl")
+        }
+        _ => panic!("unknown Claude characterization fixture: {name}"),
+    }
+}
+
+fn claude_fixture_names() -> [&'static str; 28] {
+    [
+        "records_all_kinds",
+        "timestamps_repeated_and_out_of_order",
+        "malformed_between_valid",
+        "incomplete_final_record",
+        "unrecognized_type",
+        "unrecognized_role_with_usage",
+        "unrecognized_evidence_shapes",
+        "unrecognized_inert_records",
+        "unrecognized_inert_sidechain",
+        "parent_with_task_spawn",
+        "subagent_child",
+        "multi_model_session",
+        "compaction_with_cache_rehydration",
+        "inferred_cache_rehydration",
+        "mcp_and_skill_sources",
+        "reasoning_and_fast_mode",
+        "delegated_turns",
+        "delegated_models",
+        "delegated_model_missing",
+        "housekeeping_records",
+        "thread_identity_chain",
+        "thread_identity_missing_uuid",
+        "sidechain_in_parent",
+        "late_skill_metrics",
+        "two_compactions_second_without_metadata",
+        "rehydration_gap_none",
+        "disorder_ladder",
+        "subagent_single_timestamp",
+    ]
+}
+
+#[test]
+fn claude_evidence_from_facts_matches_the_live_accumulator_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in claude_fixture_names() {
+        let (live, replayed) = run_fixture(
+            "claude",
+            name,
+            claude_fixture(name),
+            SourceCapabilities::claude(),
+        );
+        compare_evidence(&mut mismatches, name, &live, &replayed);
+    }
+    assert_no_mismatches("claude", mismatches);
+}
+
+/* --------------------------------------------------------------------
+ * Codex fixtures. Same fixture set `turn_facts_parity.rs` sweeps —
+ * `resolved_fork` and `fork_developer_lookbehind` exercise a Codex
+ * sub-agent (a `collab_agent_spawn_begin` thread inline in the same file).
+ * ----------------------------------------------------------------- */
+
+fn codex_fixture(name: &str) -> &'static str {
+    match name {
+        "records_all_kinds" => {
+            include_str!("fixtures/codex_characterization/records_all_kinds.jsonl")
+        }
+        "malformed_between_valid" => {
+            include_str!("fixtures/codex_characterization/malformed_between_valid.jsonl")
+        }
+        "unrecognized_type" => {
+            include_str!("fixtures/codex_characterization/unrecognized_type.jsonl")
+        }
+        "absent_model_and_effort" => {
+            include_str!("fixtures/codex_characterization/absent_model_and_effort.jsonl")
+        }
+        "resolved_fork" => include_str!("fixtures/codex_characterization/resolved_fork.jsonl"),
+        "fork_developer_lookbehind" => {
+            include_str!("fixtures/codex_characterization/fork_developer_lookbehind.jsonl")
+        }
+        "fork_disputed_window" => {
+            include_str!("fixtures/codex_characterization/fork_disputed_window.jsonl")
+        }
+        "unresolved_fork" => {
+            include_str!("fixtures/codex_characterization/unresolved_fork.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/codex_characterization/incomplete_final_record.jsonl")
+        }
+        _ => panic!("unknown Codex characterization fixture: {name}"),
+    }
+}
+
+fn codex_fixture_names() -> [&'static str; 9] {
+    [
+        "records_all_kinds",
+        "malformed_between_valid",
+        "unrecognized_type",
+        "absent_model_and_effort",
+        "resolved_fork",
+        "fork_developer_lookbehind",
+        "fork_disputed_window",
+        "unresolved_fork",
+        "incomplete_final_record",
+    ]
+}
+
+#[test]
+fn codex_evidence_from_facts_matches_the_live_accumulator_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in codex_fixture_names() {
+        let (live, replayed) = run_fixture(
+            "codex",
+            name,
+            codex_fixture(name),
+            SourceCapabilities::codex(),
+        );
+        compare_evidence(&mut mismatches, name, &live, &replayed);
+    }
+    assert_no_mismatches("codex", mismatches);
+}
+
+/* --------------------------------------------------------------------
+ * Pi fixtures. Same fixture set `turn_facts_parity.rs` sweeps.
+ * ----------------------------------------------------------------- */
+
+fn pi_fixture(name: &str) -> &'static str {
+    match name {
+        "minimal_session" => include_str!("fixtures/pi_characterization/minimal_session.jsonl"),
+        "role_ordering" => include_str!("fixtures/pi_characterization/role_ordering.jsonl"),
+        "content_blocks" => include_str!("fixtures/pi_characterization/content_blocks.jsonl"),
+        "usage_all_buckets" => {
+            include_str!("fixtures/pi_characterization/usage_all_buckets.jsonl")
+        }
+        "usage_subset_keys" => {
+            include_str!("fixtures/pi_characterization/usage_subset_keys.jsonl")
+        }
+        "model_change" => include_str!("fixtures/pi_characterization/model_change.jsonl"),
+        "thinking_level_change" => {
+            include_str!("fixtures/pi_characterization/thinking_level_change.jsonl")
+        }
+        "compaction_and_inert" => {
+            include_str!("fixtures/pi_characterization/compaction_and_inert.jsonl")
+        }
+        "unknown_row_type" => {
+            include_str!("fixtures/pi_characterization/unknown_row_type.jsonl")
+        }
+        "unknown_content_block" => {
+            include_str!("fixtures/pi_characterization/unknown_content_block.jsonl")
+        }
+        "custom_rows" => include_str!("fixtures/pi_characterization/custom_rows.jsonl"),
+        "malformed_middle" => {
+            include_str!("fixtures/pi_characterization/malformed_middle.jsonl")
+        }
+        "incomplete_final_record" => {
+            include_str!("fixtures/pi_characterization/incomplete_final_record.jsonl")
+        }
+        "header_only" => include_str!("fixtures/pi_characterization/header_only.jsonl"),
+        "unsupported_version" => {
+            include_str!("fixtures/pi_characterization/unsupported_version.jsonl")
+        }
+        "fork_hazard_parent" => {
+            include_str!("fixtures/pi_characterization/fork_hazard_parent.jsonl")
+        }
+        "fork_hazard_child" => {
+            include_str!("fixtures/pi_characterization/fork_hazard_child.jsonl")
+        }
+        "fork_no_inherited" => {
+            include_str!("fixtures/pi_characterization/fork_no_inherited.jsonl")
+        }
+        "timestamp_disagreement" => {
+            include_str!("fixtures/pi_characterization/timestamp_disagreement.jsonl")
+        }
+        "image_block" => include_str!("fixtures/pi_characterization/image_block.jsonl"),
+        "bash_execution_role" => {
+            include_str!("fixtures/pi_characterization/bash_execution_role.jsonl")
+        }
+        "bash_execution_with_usage" => {
+            include_str!("fixtures/pi_characterization/bash_execution_with_usage.jsonl")
+        }
+        "mixed_api" => include_str!("fixtures/pi_characterization/mixed_api.jsonl"),
+        "skill_tool_privacy" => {
+            include_str!("fixtures/pi_characterization/skill_tool_privacy.jsonl")
+        }
+        "inert_signal_guard" => {
+            include_str!("fixtures/pi_characterization/inert_signal_guard.jsonl")
+        }
+        "non_turn_timestamp_ordering" => {
+            include_str!("fixtures/pi_characterization/non_turn_timestamp_ordering.jsonl")
+        }
+        "session_start" => include_str!("fixtures/pi_characterization/session_start.jsonl"),
+        "headerless_tools" => {
+            include_str!("fixtures/pi_characterization/headerless_tools.jsonl")
+        }
+        "headerless_usage" => {
+            include_str!("fixtures/pi_characterization/headerless_usage.jsonl")
+        }
+        _ => panic!("unknown Pi characterization fixture: {name}"),
+    }
+}
+
+fn pi_fixture_names() -> [&'static str; 28] {
+    [
+        "minimal_session",
+        "role_ordering",
+        "content_blocks",
+        "usage_all_buckets",
+        "usage_subset_keys",
+        "model_change",
+        "thinking_level_change",
+        "compaction_and_inert",
+        "unknown_row_type",
+        "unknown_content_block",
+        "custom_rows",
+        "malformed_middle",
+        "header_only",
+        "unsupported_version",
+        "fork_hazard_parent",
+        "fork_hazard_child",
+        "fork_no_inherited",
+        "timestamp_disagreement",
+        "image_block",
+        "bash_execution_role",
+        "bash_execution_with_usage",
+        "mixed_api",
+        "skill_tool_privacy",
+        "inert_signal_guard",
+        "non_turn_timestamp_ordering",
+        "session_start",
+        "headerless_tools",
+        "headerless_usage",
+    ]
+}
+
+#[test]
+fn pi_evidence_from_facts_matches_the_live_accumulator_for_every_fixture() {
+    let mut mismatches = Vec::new();
+    for name in pi_fixture_names() {
+        let (live, replayed) = run_fixture("pi", name, pi_fixture(name), SourceCapabilities::pi());
+        compare_evidence(&mut mismatches, name, &live, &replayed);
+    }
+    assert_no_mismatches("pi", mismatches);
+}
+
+/* --------------------------------------------------------------------
+ * OpenCode: a provider-database source. Reuses two of
+ * `turn_facts_parity.rs`'s own scenarios — the SQLite `session`/`message`/
+ * `part` schema is synthetic test fixture data, so mirroring its minimal
+ * helpers here is acceptable (that file's own module comment makes the
+ * same call for `opencode_characterization.rs`).
+ * ----------------------------------------------------------------- */
+
+fn opencode_create_database() -> (TempDir, std::path::PathBuf) {
+    let directory = TempDir::new().expect("tempdir");
+    let path = directory.path().join("opencode.db");
+    let connection = Connection::open(&path).expect("database");
+    connection
+        .execute_batch(
+            "CREATE TABLE session (
+                 id TEXT PRIMARY KEY, parent_id TEXT, title TEXT,
+                 time_created INTEGER, time_updated INTEGER
+             );
+             CREATE TABLE message (
+                 id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER,
+                 time_updated INTEGER, data TEXT
+             );
+             CREATE TABLE part (
+                 id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+                 time_created INTEGER, time_updated INTEGER, data TEXT
+             );",
+        )
+        .expect("schema");
+    drop(connection);
+    (directory, path)
+}
+
+fn opencode_insert_session(
+    connection: &Connection,
+    id: &str,
+    parent: Option<&str>,
+    timestamp: i64,
+) {
+    connection
+        .execute(
+            "INSERT INTO session (id, parent_id, title, time_created, time_updated)
+             VALUES (?1, ?2, NULL, ?3, ?3)",
+            params![id, parent, timestamp],
+        )
+        .expect("session");
+}
+
+fn opencode_insert_message(
+    connection: &Connection,
+    id: &str,
+    session_id: &str,
+    timestamp: i64,
+    data: &str,
+) {
+    connection
+        .execute(
+            "INSERT INTO message VALUES (?1, ?2, ?3, ?3, ?4)",
+            params![id, session_id, timestamp, data],
+        )
+        .expect("message");
+}
+
+fn opencode_sqlite_input(path: &Path, session_id: &str) -> SessionInput {
+    SessionInput {
+        agent: "opencode".to_owned(),
+        session_id: session_id.to_owned(),
+        source: RawSource::Sqlite(path.to_owned()),
+    }
+}
+
+/// A root session with a delegated child session and a model transition.
+/// Exercises `subagents`, `models.byModel`, and the cache group's
+/// model-transition and idle-gap fields, over a real provider-database
+/// source.
+fn opencode_fixture_subagent_delegation_with_model_transition() -> (TempDir, SessionInput) {
+    let (directory, path) = opencode_create_database();
+    let connection = Connection::open(&path).expect("database");
+    opencode_insert_session(&connection, "root", None, 10);
+    opencode_insert_message(
+        &connection,
+        "r1",
+        "root",
+        10,
+        r#"{"role":"assistant","modelID":"model-a","tokens":{"input":1,"output":1}}"#,
+    );
+    opencode_insert_session(&connection, "child", Some("root"), 20);
+    opencode_insert_message(
+        &connection,
+        "c1",
+        "child",
+        20,
+        r#"{"role":"assistant","modelID":"model-b","tokens":{"input":2,"output":2}}"#,
+    );
+    opencode_insert_message(
+        &connection,
+        "r2",
+        "root",
+        60,
+        r#"{"role":"assistant","modelID":"model-c","tokens":{"input":1,"output":1}}"#,
+    );
+    drop(connection);
+    let input = opencode_sqlite_input(&path, "root");
+    (directory, input)
+}
+
+#[test]
+fn opencode_evidence_from_facts_matches_the_live_accumulator_for_a_provider_database_source() {
+    let mut mismatches = Vec::new();
+    let (_directory, input) = opencode_fixture_subagent_delegation_with_model_transition();
+    let (live, replayed) = run_fixture_and_replay(
+        "opencode",
+        "subagent_delegation_with_model_transition",
+        &input,
+        SourceCapabilities::opencode(),
+    );
+    compare_evidence(
+        &mut mismatches,
+        "subagent_delegation_with_model_transition",
+        &live,
+        &replayed,
+    );
+    assert_no_mismatches("opencode", mismatches);
+}
+
+/* --------------------------------------------------------------------
+ * Discovered children: a separate transcript the desktop app's own
+ * `stream_vendor_with_hooks` folds in through `observe_child_coverage` /
+ * `observe_child_unreadable`. Built by hand — see this file's module
+ * comment.
+ * ----------------------------------------------------------------- */
+
+fn one_turn_row(model: &str, ts_ms: i64, uuid: &str) -> NormalizedEvent {
+    let mut event = NormalizedEvent::new(Role::Assistant);
+    event.ts_ms = Some(ts_ms);
+    event.model = Some(model.to_owned());
+    event.usage.input_tokens = 10;
+    event.usage.output_tokens = 5;
+    event.uuid = Some(uuid.to_owned());
+    event
+}
+
+#[test]
+fn a_parent_with_a_discovered_child_matches_evidence_from_facts() {
+    let store = MemoryTurnRowStore::new("claude", "parent-1");
+
+    let mut parent_evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: "claude".to_owned(),
+        session_id: "parent-1".to_owned(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::claude(),
+    });
+    let mut parent_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        "parent-1".to_owned(),
+        None,
+    );
+    let parent_record =
+        NormalizedRecord::MetricsEvent(Box::new(one_turn_row("claude-opus-4-6", 1_000, "p-1")));
+    parent_evidence.observe(&parent_record);
+    parent_rows.observe(&parent_record);
+    parent_rows.flush();
+    parent_evidence.observe_source_outcome(VisitOutcome::AcceptedFull);
+    parent_evidence.observe_summary(&SessionSummary::default());
+
+    let mut child_evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: "claude".to_owned(),
+        session_id: "child-1".to_owned(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::claude(),
+    });
+    let mut child_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        "child-1".to_owned(),
+        Some(TurnScope::Delegated),
+    );
+    let child_record =
+        NormalizedRecord::MetricsEvent(Box::new(one_turn_row("claude-haiku-4-6", 2_000, "c-1")));
+    child_evidence.observe(&child_record);
+    child_rows.observe(&child_record);
+    child_rows.flush();
+    child_evidence.observe_source_outcome(VisitOutcome::AcceptedFull);
+    child_evidence.observe_summary(&SessionSummary::default());
+
+    parent_evidence.observe_child_coverage(&child_evidence);
+
+    let facts = store.query_turn_facts().expect("query facts must succeed");
+    let live = parent_evidence.evidence(&facts);
+    let record = parent_evidence.coverage_record();
+
+    let key = TurnSessionKey {
+        environment_key: "native",
+        agent: "claude",
+        session_id: "parent-1",
+    };
+    store
+        .write_coverage_record(&record)
+        .expect("coverage record must write");
+    let (facts, record) = store.with_connection(|conn| {
+        let facts = query_turn_facts(conn, &key, 1).expect("query facts must succeed");
+        let record = query_coverage_record(conn, &key, 1)
+            .expect("query coverage record must succeed")
+            .expect("coverage record must have been written");
+        (facts, record)
+    });
+    let replayed = evidence_from_facts(&facts, &record);
+
+    let mut mismatches = Vec::new();
+    compare_evidence(
+        &mut mismatches,
+        "parent_with_discovered_child",
+        &live,
+        &replayed,
+    );
+    assert_no_mismatches("parent_with_discovered_child", mismatches);
+}
+
+#[test]
+fn a_parent_with_an_unreadable_child_matches_evidence_from_facts() {
+    let store = MemoryTurnRowStore::new("codex", "parent-2");
+
+    let mut parent_evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: "codex".to_owned(),
+        session_id: "parent-2".to_owned(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::codex(),
+    });
+    let mut parent_rows = TurnRowSink::new(
+        Arc::clone(&store) as Arc<dyn TurnRowStore>,
+        "parent-2".to_owned(),
+        None,
+    );
+    let parent_record =
+        NormalizedRecord::MetricsEvent(Box::new(one_turn_row("gpt-5-codex", 1_000, "p-1")));
+    parent_evidence.observe(&parent_record);
+    parent_rows.observe(&parent_record);
+    parent_rows.flush();
+    parent_evidence.observe_source_outcome(VisitOutcome::AcceptedFull);
+    parent_evidence.observe_summary(&SessionSummary::default());
+    parent_evidence.observe_child_unreadable();
+
+    let facts = store.query_turn_facts().expect("query facts must succeed");
+    let live = parent_evidence.evidence(&facts);
+    let record = parent_evidence.coverage_record();
+
+    let key = TurnSessionKey {
+        environment_key: "native",
+        agent: "codex",
+        session_id: "parent-2",
+    };
+    store
+        .write_coverage_record(&record)
+        .expect("coverage record must write");
+    let (facts, record) = store.with_connection(|conn| {
+        let facts = query_turn_facts(conn, &key, 1).expect("query facts must succeed");
+        let record = query_coverage_record(conn, &key, 1)
+            .expect("query coverage record must succeed")
+            .expect("coverage record must have been written");
+        (facts, record)
+    });
+    let replayed = evidence_from_facts(&facts, &record);
+
+    let mut mismatches = Vec::new();
+    compare_evidence(
+        &mut mismatches,
+        "parent_with_unreadable_child",
+        &live,
+        &replayed,
+    );
+    assert_no_mismatches("parent_with_unreadable_child", mismatches);
+}

--- a/crates/antiburn-local/tests/streaming_metrics_memory.rs
+++ b/crates/antiburn-local/tests/streaming_metrics_memory.rs
@@ -9,10 +9,10 @@ use antiburn_local::analysis::{
     BoundedJsonlReader, CompositeSink, ContextSourceKind, EvidenceObservation, EvidenceSource,
     MemoryTurnRowStore, NormalizedEvent, NormalizedRecord, RETAINED_EVIDENCE_BYTES_BOUND,
     RETAINED_METRICS_BYTES_BOUND, RawSource, RecordSink, RelationProvenance, Role,
-    SCAN_QUANTUM_BYTES, SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator,
-    SessionSummary, SourceCapabilities, SourceKind, TURN_ROW_BATCH_SIZE, ToolCall, TurnFacts,
-    TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope, TurnSessionKey, Usage,
-    adapter_for, count_turn_content_rows, count_turn_rows, merge_metrics,
+    SCAN_QUANTUM_BYTES, SessionCoverageRecord, SessionEvidenceAccumulator, SessionInput,
+    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceKind, TURN_ROW_BATCH_SIZE,
+    ToolCall, TurnFacts, TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope,
+    TurnSessionKey, Usage, adapter_for, count_turn_content_rows, count_turn_rows, merge_metrics,
 };
 use corpus::{SessionSpec, generate_session, generate_session_of_bytes};
 
@@ -159,6 +159,14 @@ impl TurnRowStore for CountingWriter {
     }
 
     fn query_model_runs(&self) -> Result<Vec<antiburn_local::analysis::ModelRun>, TurnRowError> {
+        Err(TurnRowError("not readable".to_owned()))
+    }
+
+    fn write_coverage_record(&self, _record: &SessionCoverageRecord) -> Result<(), TurnRowError> {
+        Ok(())
+    }
+
+    fn query_coverage_record(&self) -> Result<Option<SessionCoverageRecord>, TurnRowError> {
         Err(TurnRowError("not readable".to_owned()))
     }
 }
@@ -444,6 +452,14 @@ impl TurnRowStore for CountingRealStore {
 
     fn query_model_runs(&self) -> Result<Vec<antiburn_local::analysis::ModelRun>, TurnRowError> {
         self.inner.query_model_runs()
+    }
+
+    fn write_coverage_record(&self, record: &SessionCoverageRecord) -> Result<(), TurnRowError> {
+        self.inner.write_coverage_record(record)
+    }
+
+    fn query_coverage_record(&self) -> Result<Option<SessionCoverageRecord>, TurnRowError> {
+        self.inner.query_coverage_record()
     }
 }
 

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -110,10 +110,27 @@ Goal: fix the pop-in without the new architecture.
   (the discovery crate's tracked-head-read instrumentation exists for this).
 
 Known limit, accepted: a title change in a vendor index while the transcript
-size is unchanged is not picked up until the transcript grows. Phase 2
+size is unchanged is not picked up until the transcript grows. Phase 3
 replaces the size gate with a verified offset.
 
-### Phase 2: verified-resume ingest
+### Phase 2: evidence from rows
+
+Goal: layer 2 never opens a transcript.
+
+Phase 2 and phase 3 swap order from the original plan. Verified-resume ingest
+cannot skip the transcript prefix while `SessionEvidence` is still folded from
+the full record stream, so evidence must come from rows first.
+
+- Parse-time facts the evidence accumulator needs (unrecognized record types,
+  coverage reasons, diagnostic fields) are written by layer 1 as a small
+  per-session coverage record alongside the rows.
+- An evidence replay builds `SessionEvidence` from rows plus that record, with
+  a parity test against the live fold, mirroring the metrics replay.
+- The worker's stream fold stops accumulating evidence. Detectors run from
+  rows on a debounced "rows changed" trigger, immediate for an open
+  drilldown. The Insights report recomputes when the queue drains, as today.
+
+### Phase 3: verified-resume ingest
 
 Goal: an appended 4 KB costs 4 KB.
 
@@ -131,21 +148,11 @@ Goal: an appended 4 KB costs 4 KB.
   full pass.
 - Turn the `AppendOnlyGuarantee` from a static assumption into the runtime
   verification above.
+- Adapter stream state (for example `ClaudeStreamState`) must be persisted per
+  source alongside the offset, or be reconstructable from rows, or the resume
+  falls back to a full pass.
 - Test: parity. Incremental ingest over a transcript grown in steps produces
   the same rows as one full pass over the final file, for each vendor.
-
-### Phase 3: evidence from rows
-
-Goal: layer 2 never opens a transcript.
-
-- Parse-time facts the evidence accumulator needs (unrecognized record types,
-  coverage reasons, diagnostic fields) are written by layer 1 as a small
-  per-session coverage record alongside the rows.
-- An evidence replay builds `SessionEvidence` from rows plus that record, with
-  a parity test against the live fold, mirroring the metrics replay.
-- The worker's stream fold stops accumulating evidence. Detectors run from
-  rows on a debounced "rows changed" trigger, immediate for an open
-  drilldown. The Insights report recomputes when the queue drains, as today.
 
 ### Phase 4: watcher tiers, events, and the HUD fold-in
 
@@ -169,6 +176,6 @@ Goal: layer 1 is continuous and cheap, and every consumer reads one signal.
 ## Sequencing notes
 
 - Phase 1 stands alone and is reverted by two small edits if it misbehaves.
-- Phase 2 is the enabling work; phases 3 and 4 both depend on it and are
-  independent of each other.
+- Phase 2 depends only on phase 1.
+- Phase 3 is the enabling work for phase 4.
 - Default cadences are set in phase 4 and reviewed after a week of use.


### PR DESCRIPTION
## Why

Phase 2 of `docs/plans/continuous-session-ingest.md`. The insights worker folded `SessionEvidence` from the full record stream on every pass. Verified-resume ingest (the next phase) cannot skip a transcript prefix while that fold still needs every record. So evidence has to come from persisted data first. The plan's phases 2 and 3 are swapped to reflect that; the first commit updates the doc.

## What

- **Coverage record.** `SessionCoverageRecord` snapshots the bounded per-session residual the evidence accumulator observes from records that never become turn rows: capabilities, source acceptance, ordering, parse diagnostics, loss reasons, the tools catalog, loaded skills and MCP servers, and subagent spawn observations. It carries its own `COVERAGE_SCHEMA_REVISION`. No `TurnRow` column was added; every per-turn fact the evidence needs was already a row column.
- **Replay.** `evidence_from_facts(&TurnFacts, &SessionCoverageRecord)` rebuilds `SessionEvidence` from the store's existing SQL facts query plus the record. A new parity test proves it equals the live fold for every Claude, Codex, and Pi characterization fixture, an OpenCode provider-database source, a parent with a discovered child, and a parent with an unreadable child.
- **Persistence.** Schema v28 adds `session_coverage`, keyed by session and claim fence, with the same cascade as `turn`. The fence deletes on publish and on a lost race cover it. `Store::published_coverage_record` mirrors `published_turn_rows`.
- **Worker.** On publish the worker writes the record under its claim fence, reads the facts and the record back, and publishes the replayed evidence. The in-memory fold's `evidence()` is no longer called on the worker path. No `ANALYZER_REVISION` bump: the parity test proves the published document is unchanged.

The live `evidence()` derivation stays as the reference the parity test compares against; many integration tests call it and gating it behind `cfg(test)` would not compile for them.

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` in `crates/antiburn-local` and `apps/desktop/src-tauri`
- `pnpm run slop:all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U73g2iRUFcWZ3ivhoHg8hr
