### PR TITLE
feat(analysis): snapshot resume for transcript streams (Claude)

### DIFF
--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -278,6 +278,7 @@ cfb@0.7.3 | MIT | https://github.com/mdsteele/rust-cfb
 cfg-expr@0.15.8 | MIT OR Apache-2.0 | https://github.com/EmbarkStudios/cfg-expr
 cfg-expr@0.20.9 | MIT OR Apache-2.0 | https://github.com/EmbarkStudios/cfg-expr
 cfg-if@1.0.4 | MIT OR Apache-2.0 | https://github.com/rust-lang/cfg-if
+cobs@0.3.0 | MIT OR Apache-2.0 | https://github.com/jamesmunns/cobs.rs
 concurrent-queue@2.5.0 | Apache-2.0 OR MIT | https://github.com/smol-rs/concurrent-queue
 cookie@0.18.2 | MIT OR Apache-2.0 | https://github.com/SergioBenitez/cookie-rs
 core-foundation-sys@0.8.7 | MIT OR Apache-2.0 | https://github.com/servo/core-foundation-rs
@@ -509,6 +510,7 @@ plist@1.10.0 | MIT | https://github.com/ebarnard/rust-plist/
 png@0.17.16 | MIT OR Apache-2.0 | https://github.com/image-rs/image-png
 png@0.18.1 | MIT OR Apache-2.0 | https://github.com/image-rs/image-png
 polling@3.11.0 | Apache-2.0 OR MIT | https://github.com/smol-rs/polling
+postcard@1.1.3 | MIT OR Apache-2.0 | https://github.com/jamesmunns/postcard
 potential_utf@0.1.5 | Unicode-3.0 | https://github.com/unicode-org/icu4x
 powerfmt@0.2.0 | MIT OR Apache-2.0 | https://github.com/jhpratt/powerfmt
 precomputed-hash@0.1.1 | MIT | https://github.com/emilio/precomputed-hash
@@ -2262,6 +2264,31 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+========================================
+
+Used by:
+  cobs@0.3.0
+
+Copyright (c) 2015 The cobs.rs Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ========================================
 
@@ -6796,6 +6823,37 @@ Used by:
   png@0.18.1
 
 Copyright (c) 2015 nwin
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+========================================
+
+Used by:
+  postcard@1.1.3
+
+Copyright (c) 2019 Anthony James Munns
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "libc",
+ "postcard",
  "rusqlite",
  "serde",
  "serde_json",
@@ -667,6 +668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1163,18 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -3459,6 +3481,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "filetime",
  "futures-util",
  "libc",
+ "postcard",
  "rusqlite",
  "serde",
  "serde_json",
@@ -182,6 +183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +241,18 @@ name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "errno"
@@ -517,6 +539,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +795,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -45,6 +45,10 @@ futures-util = "0.3"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Compact binary encoding for `StreamSnapshot` (see `analysis::resume`): a
+# resumed pass writes one of these on every append, so JSON's re-expanded
+# field names and string values cost too many bytes.
+postcard = { version = "1", default-features = false, features = ["use-std"] }
 time = { version = "0.3", features = ["formatting", "parsing"] }
 # Async runtime pieces used by local persistence and the bounded child-process
 # mechanism. Excludes `net`: nothing in the engine needs it yet, not that the

--- a/crates/antiburn-local/src/analysis/efficiency.rs
+++ b/crates/antiburn-local/src/analysis/efficiency.rs
@@ -71,7 +71,7 @@ impl EfficiencyTotals {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct MessageKey {
     first: u64,
     second: u64,
@@ -94,14 +94,14 @@ fn hash_bytes(bytes: &[u8], seed: u64) -> u64 {
     })
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 enum ModelStatus {
     Missing,
     Priced(ModelPricing),
     Unpriced,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct Turn {
     creation: u64,
     ordinal: u64,
@@ -133,13 +133,13 @@ struct PricedAmounts {
     output: u64,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub(crate) struct RewriteMark {
     pub(crate) key: (i64, u64),
     pub(crate) tokens: u64,
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug, Serialize, Deserialize)]
 struct FallbackOverflow {
     growth_tokens: u64,
     output_tokens: u64,
@@ -151,7 +151,7 @@ struct FallbackOverflow {
     turns: u64,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct EfficiencyReducer {
     open: VecDeque<Turn>,
     evicted: VecDeque<MessageKey>,

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::mem::size_of;
 
+use serde::{Deserialize, Serialize};
+
 use crate::analysis::evidence::{
     CacheEvidence, ChurnCounts, CompactionEvidence, ContextEvidence, ContextSourceEvidence,
     CoverageReason, EvidenceCoverage, EvidenceSource, EvidenceValue, LoadedSource,
@@ -41,6 +43,18 @@ pub const RETAINED_EVIDENCE_BYTES_BOUND: usize = 64 * 1_024;
 /// exactly one B-tree node. This estimates one entry's node overhead —
 /// pointers and per-node slack — on top of its own key or value bytes.
 const BTREE_ENTRY_OVERHEAD_BYTES: usize = 48;
+
+/// The two fields [`SessionEvidenceAccumulator::coverage_record`] leaves
+/// out because a closed pass's record already carries their final effect.
+/// A resumed, still-open accumulator needs them back:
+/// `last_ts_ms` to keep detecting out-of-order records across the resume
+/// boundary, `seen_thread_uuids` so a later record's parent link resolves
+/// against an identity an earlier, already-processed record declared.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EvidenceResumeState {
+    pub last_ts_ms: Option<i64>,
+    pub seen_thread_uuids: HashSet<String>,
+}
 
 pub struct SessionEvidenceAccumulator {
     identity: SessionEvidenceIdentity,
@@ -502,7 +516,26 @@ impl SessionEvidenceAccumulator {
     /// carry (`last_ts_ms`, `seen_thread_uuids`) start empty: [`Self::evidence`]
     /// never reads them directly, only the `ordering` and
     /// `thread_parent_unresolved` results already folded into the record.
+    ///
+    /// This is the row-replay shape: [`crate::analysis::evidence_from_facts`]
+    /// rebuilds [`SessionEvidence`] for a *closed* pass, where the record
+    /// already carries the final effect of those two fields. A resumed
+    /// accumulator that will keep observing more records instead needs
+    /// [`Self::from_coverage_record_with_resume`].
     pub fn from_coverage_record(record: SessionCoverageRecord) -> Self {
+        Self::from_coverage_record_with_resume(record, EvidenceResumeState::default())
+    }
+
+    /// Like [`Self::from_coverage_record`], but restores the two transient
+    /// fields from `resume` instead of starting them empty. Use this to
+    /// resume a still-open accumulator: an unresumed
+    /// `seen_thread_uuids` would make a later record's parent link look
+    /// unresolved even when an earlier, already-processed record declared
+    /// it.
+    pub fn from_coverage_record_with_resume(
+        record: SessionCoverageRecord,
+        resume: EvidenceResumeState,
+    ) -> Self {
         Self {
             identity: record.identity,
             capabilities: record.capabilities,
@@ -512,7 +545,7 @@ impl SessionEvidenceAccumulator {
             diagnostics: record.diagnostics,
             record_loss_reason: record.record_loss_reason,
             session_cap_exceeded: record.session_cap_exceeded,
-            last_ts_ms: None,
+            last_ts_ms: resume.last_ts_ms,
             tools: record.tools,
             invoked_skills: record.invoked_skills,
             tools_cap_exceeded: record.tools_cap_exceeded,
@@ -523,10 +556,20 @@ impl SessionEvidenceAccumulator {
             subagent_children: record.subagent_children,
             subagent_examples: record.subagent_examples,
             subagents_cap_exceeded: record.subagents_cap_exceeded,
-            seen_thread_uuids: HashSet::new(),
+            seen_thread_uuids: resume.seen_thread_uuids,
             thread_parent_unresolved: record.thread_parent_unresolved,
             summary_observed: record.summary_observed,
             child_loss_reason: record.child_loss_reason,
+        }
+    }
+
+    /// The two transient fields [`Self::coverage_record`] leaves out,
+    /// needed to resume a still-open accumulator. See
+    /// [`Self::from_coverage_record_with_resume`].
+    pub fn resume_state(&self) -> EvidenceResumeState {
+        EvidenceResumeState {
+            last_ts_ms: self.last_ts_ms,
+            seen_thread_uuids: self.seen_thread_uuids.clone(),
         }
     }
 

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -20,10 +20,11 @@ use crate::analysis::interface::{
 };
 use crate::analysis::metrics_sink::SessionMetricsAccumulator;
 use crate::analysis::model::NormalizedEvent;
+use crate::analysis::resume::{AdapterResume, EvidenceSnapshot, StreamSnapshot};
 use crate::analysis::rows::TurnRowSink;
 use crate::analysis::{
     ANALYZER_REVISION, COVERAGE_SCHEMA_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION,
-    SessionMetrics,
+    RESUME_SNAPSHOT_REVISION, SessionMetrics,
 };
 
 /// The suffix after a skill's last `:` (e.g. `deploy` from
@@ -1116,6 +1117,13 @@ impl RecordSink for SessionEvidenceAccumulator {
     }
 }
 
+/// Metrics and evidence state as they stood immediately before the most
+/// recent [`RecordSink::finish`] mutated them. See [`CompositeSink::snapshot`].
+struct PreFinishState {
+    metrics: SessionMetricsAccumulator,
+    evidence: EvidenceSnapshot,
+}
+
 pub struct CompositeSink {
     metrics: SessionMetricsAccumulator,
     evidence: SessionEvidenceAccumulator,
@@ -1127,6 +1135,9 @@ pub struct CompositeSink {
     /// `finish` itself only borrows the summary before moving it on to
     /// `self.metrics`.
     summary: Option<SessionSummary>,
+    /// Set by [`RecordSink::finish`], `None` before the first call. See
+    /// [`Self::snapshot`].
+    pre_finish: Option<PreFinishState>,
 }
 
 impl CompositeSink {
@@ -1136,6 +1147,7 @@ impl CompositeSink {
             evidence,
             turn_rows: None,
             summary: None,
+            pre_finish: None,
         }
     }
 
@@ -1152,6 +1164,7 @@ impl CompositeSink {
             evidence,
             turn_rows: Some(turn_rows),
             summary: None,
+            pre_finish: None,
         }
     }
 
@@ -1208,10 +1221,54 @@ impl CompositeSink {
         self.turn_rows.as_ref().is_some_and(TurnRowSink::has_error)
     }
 
+    /// The fanned-out [`TurnRowSink`]'s next `turn_index`, `None` when
+    /// there is none. A caller building a resume snapshot needs this
+    /// before [`Self::into_parts`] drops the row sink.
+    pub fn turn_rows_next_index(&self) -> Option<u64> {
+        self.turn_rows.as_ref().map(TurnRowSink::next_index)
+    }
+
     pub fn into_parts(self) -> Option<(SessionMetricsAccumulator, SessionEvidenceAccumulator)> {
         self.evidence
             .can_publish()
             .then_some((self.metrics, self.evidence))
+    }
+
+    /// Assembles this source's [`StreamSnapshot`] for the next resume,
+    /// combining `resume` (the adapter's own half, from
+    /// [`crate::analysis::interface::ResumedVisit::resume`]) with this
+    /// sink's own metrics, evidence, and row-index state.
+    ///
+    /// Uses state captured just *before* the most recent `finish` mutated
+    /// it, not after. `finish` can commit a one-time decision from an
+    /// incomplete view of the session — `ProgressSlots::flip_to_active`
+    /// (`metrics_sink/slots.rs`) fixes its chart-bucket position scale on
+    /// the first `finish` that drains a record, using only what that
+    /// `finish` has seen so far — and a resumed pass calls `finish` at
+    /// every step, not only the last one. Restoring the pre-`finish` state
+    /// and running one more `finish` after every future record this
+    /// session ever sees — whether resumed again or not — reproduces
+    /// exactly what a single continuous pass computes, because a
+    /// continuous pass also calls `finish` exactly once, after the same
+    /// records. See `crates/antiburn-local/tests/resume_parity.rs`.
+    ///
+    /// `None` before the first `finish`, or under the same rule
+    /// [`Self::evidence`] returns `None` (no fanned-out [`TurnRowSink`], or
+    /// the residual cannot publish yet).
+    pub fn snapshot(&self, resume: AdapterResume) -> Option<StreamSnapshot> {
+        if !self.evidence.can_publish() {
+            return None;
+        }
+        let pre_finish = self.pre_finish.as_ref()?;
+        let next_turn_index = self.turn_rows_next_index()?;
+        Some(StreamSnapshot {
+            revision: RESUME_SNAPSHOT_REVISION,
+            resume: resume.point,
+            adapter: resume.adapter,
+            metrics: pre_finish.metrics.clone(),
+            evidence: pre_finish.evidence.clone(),
+            next_turn_index,
+        })
     }
 }
 
@@ -1225,6 +1282,18 @@ impl RecordSink for CompositeSink {
     }
 
     fn finish(&mut self, summary: SessionSummary) {
+        // `Self::snapshot` needs the state from before `finish` mutates it.
+        // Only a sink with turn rows can snapshot, so a sink without them
+        // does not pay for the clone.
+        if self.turn_rows.is_some() {
+            self.pre_finish = Some(PreFinishState {
+                metrics: self.metrics.snapshot(),
+                evidence: EvidenceSnapshot {
+                    record: self.evidence.coverage_record(),
+                    resume: self.evidence.resume_state(),
+                },
+            });
+        }
         self.evidence.observe_summary(&summary);
         if let Some(turn_rows) = &mut self.turn_rows {
             turn_rows.flush();

--- a/crates/antiburn-local/src/analysis/initial_context.rs
+++ b/crates/antiburn-local/src/analysis/initial_context.rs
@@ -28,7 +28,7 @@ use crate::model::skill::SkillUse;
 const DEFERRED_TOOL_TOKEN_ESTIMATE: u32 = 5;
 
 /// Source dimension for tokens loaded before a coding agent's first response.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum InitialContextTokenSource {
     /// Skill catalog entries or loaded skill instructions.
     Skill,
@@ -288,6 +288,7 @@ struct InitialContextTokenBreakdown {
     rows: Vec<InitialContextTokenSourceCount>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct InitialContextTokenSourceCount {
     source: InitialContextTokenSource,
     source_name: Option<String>,
@@ -454,7 +455,7 @@ mod claude_origin_rank {
     pub(super) const LISTING_NAME_SHAPE: u8 = 3;
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ClaudeContextAccumulator {
     source_rows: Vec<InitialContextTokenSourceCount>,
     skill_descriptions: HashMap<String, String>,

--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -208,7 +208,7 @@ pub(crate) fn bounded_provider_hint_value(value: &str) -> Option<String> {
 }
 
 /// Session facts that an adapter can state only after the last record.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SessionSummary {
     /// True when this adapter can observe cache-write tokens.

--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -330,11 +330,24 @@ pub enum VisitOutcome {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceChangedReason {
     IdentityMismatch,
-    ShortAtOpen { size: u64, boundary: u64 },
+    ShortAtOpen {
+        size: u64,
+        boundary: u64,
+    },
     HeadRegionMismatch,
-    ShortRead { consumed: u64, boundary: u64 },
-    TruncatedAfterRead { size: u64, boundary: u64 },
+    ShortRead {
+        consumed: u64,
+        boundary: u64,
+    },
+    TruncatedAfterRead {
+        size: u64,
+        boundary: u64,
+    },
     FingerprintMismatch,
+    /// A resumed open's file is shorter than the claimed resume offset, or
+    /// the trailing window before that offset no longer hashes to the
+    /// claimed tail hash. See [`crate::analysis::source_validity::ResumePoint`].
+    ResumeTailMismatch,
 }
 
 /// Implemented once per vendor format. Stateless and `Sync` so adapters can be

--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::analysis::framing::PartialReason;
 use crate::analysis::initial_context::InitialContextBreakdown;
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, ToolCall};
+use crate::analysis::resume::{AdapterResume, StreamSnapshot};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, SourceClaim};
 
 /// Where a session's raw bytes come from. Adapters choose how to read it.
@@ -350,6 +351,26 @@ pub enum SourceChangedReason {
     ResumeTailMismatch,
 }
 
+/// The result of a resumed streaming pass
+/// ([`VendorAdapter::visit_claimed_resumed`]).
+pub struct ResumedVisit {
+    pub outcome: VisitOutcome,
+    /// `None` when the adapter's end-of-stream state is not a safe resume
+    /// point (see the "unsettled" rule on
+    /// [`VendorAdapter::visit_claimed_resumed`]), or when `outcome` is
+    /// [`VisitOutcome::SourceChanged`].
+    ///
+    /// `Some` carries only the adapter's own half of a resume: the new
+    /// [`crate::analysis::source_validity::ResumePoint`] and the adapter's
+    /// own opaque state. The adapter streams new records into `sink`
+    /// through the same `RecordSink` interface every adapter uses, so it
+    /// never sees the sink's own accumulator types behind
+    /// `&mut dyn RecordSink` and cannot build a full [`StreamSnapshot`] on
+    /// its own. The caller combines this with its own sink's state via
+    /// [`crate::analysis::evidence_sink::CompositeSink::snapshot`].
+    pub resume: Option<AdapterResume>,
+}
+
 /// Implemented once per vendor format. Stateless and `Sync` so adapters can be
 /// stored as `&'static dyn VendorAdapter` in the registry.
 pub trait VendorAdapter: Sync {
@@ -414,5 +435,37 @@ pub trait VendorAdapter: Sync {
         _sink: &mut dyn RecordSink,
     ) -> anyhow::Result<VisitOutcome> {
         anyhow::bail!("claimed database streaming is unsupported for this adapter")
+    }
+
+    /// Streams a file from a verified [`StreamSnapshot`] instead of from the
+    /// start, then reports a new snapshot for the next resume.
+    ///
+    /// `resume.resume` (a [`crate::analysis::source_validity::ResumePoint`])
+    /// names the byte offset to read from; the adapter restores its own
+    /// whole-stream state from `resume.adapter` before it starts. Passing a
+    /// snapshot with `resume.resume.offset == 0` and a fresh adapter's
+    /// default state runs a full first pass that still produces a snapshot
+    /// for the next resume — the same [`PinnedSource::open_resumed`] path
+    /// handles an empty tail (see its offset-zero test) — so this one method
+    /// covers both the first snapshot-producing pass and every later
+    /// resumed pass, and `visit_claimed` needs no change to support resume.
+    ///
+    /// "Unsettled" rule: an adapter returns `resume: None` inside
+    /// [`ResumedVisit`] when its end-of-stream state is not a safe resume
+    /// point (a case a specific adapter's own doc comment must name — for
+    /// example, a fork whose ownership is still undetermined at EOF). The
+    /// default implementation here returns `Err`, so every adapter that
+    /// does not override this method is simply unsupported for resume.
+    ///
+    /// [`PinnedSource::open_resumed`]: crate::analysis::source_validity::PinnedSource::open_resumed
+    fn visit_claimed_resumed(
+        &self,
+        _input: &SessionInput,
+        _claim: &SourceClaim,
+        _resume: &StreamSnapshot,
+        _cancel: &dyn Fn() -> bool,
+        _sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<ResumedVisit> {
+        anyhow::bail!("resume is unsupported for this adapter")
     }
 }

--- a/crates/antiburn-local/src/analysis/metrics_sink/active.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/active.rs
@@ -1,11 +1,13 @@
 use std::mem::size_of;
 
+use serde::{Deserialize, Serialize};
+
 use crate::analysis::engine::IDLE_GAP_MS;
 
 /// The segment cap covers 1,024 distinct active-time intervals.
 pub(crate) const MAX_ACTIVE_SEGMENTS: usize = 1_024;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 struct ActiveSegment {
     start: i64,
     end: i64,
@@ -41,10 +43,15 @@ impl ActiveSegment {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub(crate) struct ActiveSegments {
     segments: Vec<ActiveSegment>,
+    /// A prefix-sum cache over `segments`, rebuilt by `Self::rebuild_prefix`
+    /// instead of serialized. `prefix_valid` starts `false` on restore, the
+    /// same state a fresh accumulator starts in.
+    #[serde(skip)]
     prefix: Vec<i64>,
+    #[serde(skip)]
     prefix_valid: bool,
     first_ts: Option<i64>,
     last_ts: Option<i64>,

--- a/crates/antiburn-local/src/analysis/metrics_sink/cache_miss.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/cache_miss.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::mem::size_of;
 
+use serde::{Deserialize, Serialize};
+
 use super::slots::CacheSlot;
 use super::tally::IdentityKey;
 
@@ -15,7 +17,7 @@ const CACHE_REHYDRATION_CONTEXT_RETENTION_RATIO: f64 = 0.8;
 const CACHE_REHYDRATION_REPLAY_RATIO: f64 = 0.5;
 const CACHE_REHYDRATION_RECOVERY_READ_RATIO: f64 = 0.5;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub(crate) struct CacheTurn {
     key: (i64, u64),
     context_tokens: u64,
@@ -36,7 +38,7 @@ pub(crate) struct CacheInput {
     pub(crate) model: Option<IdentityKey>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 struct DeferredCache {
     key: (i64, u64),
     gap: Option<u64>,
@@ -50,7 +52,7 @@ pub(crate) struct CachePatch {
     pub(crate) slot: CacheSlot,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub(crate) struct CacheReducer {
     previous_context: u64,
     previous_cache_read: u64,

--- a/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
@@ -12,6 +12,8 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
 use std::mem::size_of;
 
+use serde::{Deserialize, Serialize};
+
 use active::ActiveSegments;
 use cache_miss::{CacheInput, CachePatch, CacheReducer};
 use slots::{CompactionMark, ProgressSlots, ReorderWindow, SlotAggregate, SlotAxis, StampedName};
@@ -42,13 +44,13 @@ const MAX_DESCRIPTION_CHARS: usize = 300;
 /// Initial-context rows retain the largest named rows and overflow totals.
 const MAX_INITIAL_CONTEXT_SOURCES: usize = 64;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct MetricsIdentity {
     pub(crate) agent: String,
     pub(crate) session_id: String,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub(crate) struct OnlineTallies {
     tokens_in: u64,
     tokens_out: u64,
@@ -89,7 +91,7 @@ impl OnlineTallies {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 struct StoredSummary {
     cache_write_tokens_available: bool,
     context_window: Option<u64>,
@@ -99,7 +101,7 @@ struct StoredSummary {
     skill_descriptions: Vec<(String, String)>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 struct ModelRunMark {
     effective_ts: i64,
     ordinal: u64,
@@ -107,7 +109,7 @@ struct ModelRunMark {
     thinking_mode: Option<NameId>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SessionMetricsAccumulator {
     identity: MetricsIdentity,
     slots: ProgressSlots,
@@ -200,6 +202,37 @@ impl SessionMetricsAccumulator {
         let mut axis = self.active.clone();
         axis.rebuild_prefix();
         self.project(&axis)
+    }
+
+    /// A restorable snapshot of this accumulator's full internal state:
+    /// every reducer, interner, and pending window, not just the projected
+    /// [`SessionMetrics`]. Serializing this and feeding the result to
+    /// [`Self::restore`] reproduces this exact accumulator.
+    pub fn snapshot(&self) -> Self {
+        self.clone()
+    }
+
+    /// Restores an accumulator [`Self::snapshot`] produced. Rebuilds the
+    /// index caches serialization skips (see [`tally::Interner`],
+    /// [`active::ActiveSegments`]) so the result keeps observing records as
+    /// if it never stopped.
+    pub fn restore(snapshot: Self) -> Self {
+        let mut accumulator = snapshot;
+        accumulator.rebuild_caches();
+        accumulator
+    }
+
+    /// Rebuilds every index a snapshot restore leaves empty or invalid.
+    fn rebuild_caches(&mut self) {
+        self.interner.rebuild_index();
+        self.mcp_interner.rebuild_index();
+        self.model_interner.rebuild_index();
+        self.bucket_model_interner.rebuild_index();
+        self.thinking_interner.rebuild_index();
+        self.speed_interner.rebuild_index();
+        self.last_tool_interner.rebuild_index();
+        self.skill_names.rebuild_index();
+        self.active.rebuild_prefix();
     }
 
     pub fn earliest_ts_ms(&self) -> Option<i64> {

--- a/crates/antiburn-local/src/analysis/metrics_sink/slots.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/slots.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::mem::size_of;
 
+use serde::{Deserialize, Serialize};
+
 use crate::analysis::model::CompactionTrigger;
 
 use super::tally::NameId;
@@ -12,13 +14,13 @@ pub(crate) const SLOTS_PER_BUCKET: usize = 3;
 /// The slot grid has three times the visible chart resolution.
 pub(crate) const SLOTS: usize = crate::analysis::engine::BUCKETS * SLOTS_PER_BUCKET;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct StampedName {
     pub(crate) ordinal: u64,
     pub(crate) name: NameId,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CompactionMark {
     pub(crate) effective_ts: i64,
     pub(crate) ordinal: u64,
@@ -27,14 +29,14 @@ pub(crate) struct CompactionMark {
     pub(crate) post_tokens: Option<u64>,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CacheSlot {
     pub(crate) is_rehydration: bool,
     pub(crate) is_routing_miss: bool,
     pub(crate) rehydration_gap: Option<(u64, Option<u64>)>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct SlotAggregate {
     pub(crate) first_ordinal: u64,
     pub(crate) last_ordinal: u64,
@@ -162,7 +164,7 @@ fn merge_cache(target: &mut CacheSlot, incoming: CacheSlot) {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ReorderWindow {
     entries: VecDeque<SlotAggregate>,
     ordered: bool,
@@ -280,20 +282,20 @@ fn clamp_timestamp(slot: &mut SlotAggregate, timestamp: i64) {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum SlotAxis {
     #[default]
     Ordinal,
     Active,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct PositionedSlot {
     index: u64,
     aggregate: SlotAggregate,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub(crate) struct ProgressSlots {
     slots: Vec<PositionedSlot>,
     quantum: u64,

--- a/crates/antiburn-local/src/analysis/metrics_sink/tally.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/tally.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::mem::size_of;
 
+use serde::{Deserialize, Serialize};
+
 use crate::analysis::model::{EventSource, Usage};
 
 /// Names keep enough bytes for provider and tool identifiers.
@@ -28,10 +30,10 @@ pub(crate) const MAX_SPEEDS: usize = 64;
 /// Provisional built-in commands cannot consume the late-skill budget.
 pub(crate) const MAX_BUILTIN_LATE_CANDIDATES: usize = 64;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) struct NameId(pub(crate) u16);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct IdentityKey {
     first: u64,
     second: u64,
@@ -54,9 +56,12 @@ fn hash_bytes(bytes: &[u8], seed: u64) -> u64 {
     })
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Interner {
     names: Vec<String>,
+    /// Rebuilt from `names` on restore (`Self::rebuild_index`) instead of
+    /// serialized: it duplicates every name `names` already holds.
+    #[serde(skip)]
     ids: HashMap<String, NameId>,
     limit: usize,
     pub(crate) truncated: u64,
@@ -70,6 +75,16 @@ impl Interner {
             limit,
             truncated: 0,
         }
+    }
+
+    /// Rebuilds `ids` from `names` after a snapshot restore leaves it empty.
+    pub(crate) fn rebuild_index(&mut self) {
+        self.ids = self
+            .names
+            .iter()
+            .enumerate()
+            .map(|(index, name)| (name.clone(), NameId(index as u16)))
+            .collect();
     }
 
     pub(crate) fn intern(&mut self, name: &str) -> Option<NameId> {
@@ -114,14 +129,27 @@ impl Interner {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub(crate) struct SkillNameInterner {
     names: Vec<String>,
+    /// Rebuilt from `names` on restore (`Self::rebuild_index`) instead of
+    /// serialized: it duplicates every name `names` already holds.
+    #[serde(skip)]
     ids: HashMap<String, NameId>,
     pub(crate) truncated: u64,
 }
 
 impl SkillNameInterner {
+    /// Rebuilds `ids` from `names` after a snapshot restore leaves it empty.
+    pub(crate) fn rebuild_index(&mut self) {
+        self.ids = self
+            .names
+            .iter()
+            .enumerate()
+            .map(|(index, name)| (name.clone(), NameId(index as u16)))
+            .collect();
+    }
+
     pub(crate) fn intern(&mut self, name: &str) -> Option<NameId> {
         if name.len() <= MAX_SKILL_NAME_BYTES
             && let Some(id) = self.ids.get(name)
@@ -188,7 +216,7 @@ pub(crate) fn truncate_name(name: &str) -> String {
     format!("{}#{:016x}", &name[..end], IdentityKey::new(name).first)
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct SkillMark {
     pub(crate) ordinal: u64,
     pub(crate) tool_index: u16,
@@ -211,7 +239,7 @@ impl SkillMark {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct LateToolCandidate {
     pub(crate) ordinal: u64,
     pub(crate) source: EventSource,

--- a/crates/antiburn-local/src/analysis/metrics_sink/tests.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/tests.rs
@@ -1294,6 +1294,41 @@ fn capped_names_do_not_change_observed_turn_counts() {
 }
 
 #[test]
+fn a_snapshot_restored_through_json_keeps_observing_as_if_it_never_stopped() {
+    let events: Vec<NormalizedEvent> = (0..40)
+        .map(|index| {
+            let mut current = event(Some(index * 1_000), Role::Assistant, 5, 3);
+            current.model = Some(format!("model-{}", index % 3));
+            current.tools.push(ToolCall::new("Skill"));
+            current.tools[0].detail = Some(format!("skill-{}", index % 4));
+            current
+        })
+        .collect();
+    let (first_half, second_half) = events.split_at(20);
+
+    let mut continuous = SessionMetricsAccumulator::new("synthetic", "session");
+    for event in &events {
+        continuous.record(NormalizedRecord::MetricsEvent(Box::new(event.clone())));
+    }
+    continuous.finish(SessionSummary::default());
+
+    let mut resumed = SessionMetricsAccumulator::new("synthetic", "session");
+    for event in first_half {
+        resumed.record(NormalizedRecord::MetricsEvent(Box::new(event.clone())));
+    }
+    let json = serde_json::to_string(&resumed.snapshot()).expect("serialize snapshot");
+    let restored: SessionMetricsAccumulator =
+        serde_json::from_str(&json).expect("deserialize snapshot");
+    let mut resumed = SessionMetricsAccumulator::restore(restored);
+    for event in second_half {
+        resumed.record(NormalizedRecord::MetricsEvent(Box::new(event.clone())));
+    }
+    resumed.finish(SessionSummary::default());
+
+    assert_eq!(resumed.metrics(), continuous.metrics());
+}
+
+#[test]
 fn earliest_timestamp_is_a_minimum() {
     let accumulator = finished(
         vec![

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -80,8 +80,8 @@ pub use initial_context::{InitialContextBreakdown, InitialContextSourceCount, So
 pub use interface::{
     ContentKind, ContentPart, ContextSourceKind, EvidenceObservation, MAX_CONTENT_PART_BYTES,
     MAX_PROVIDER_HINTS, NormalizedRecord, ProviderHint, RawSource, RecordCoverage, RecordSink,
-    RelationProvenance, SessionCollector, SessionInput, SessionSummary, SourceChangedReason,
-    TurnContent, VendorAdapter, VisitOutcome,
+    RelationProvenance, ResumedVisit, SessionCollector, SessionInput, SessionSummary,
+    SourceChangedReason, TurnContent, VendorAdapter, VisitOutcome,
 };
 pub use merge::merge_subagent_events;
 pub use metrics_sink::{RETAINED_METRICS_BYTES_BOUND, SessionMetricsAccumulator, merge_metrics};

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -42,6 +42,7 @@ mod model;
 mod pricing;
 pub(crate) mod records;
 mod replay;
+mod resume;
 mod rows;
 mod source_validity;
 pub(crate) mod threads;
@@ -68,7 +69,9 @@ pub use evidence_query::{
     TurnFacts, query_model_breakdown, query_model_runs, query_turn_facts, query_turn_rows,
 };
 pub use evidence_replay::evidence_from_facts;
-pub use evidence_sink::{CompositeSink, RETAINED_EVIDENCE_BYTES_BOUND, SessionEvidenceAccumulator};
+pub use evidence_sink::{
+    CompositeSink, EvidenceResumeState, RETAINED_EVIDENCE_BYTES_BOUND, SessionEvidenceAccumulator,
+};
 pub use framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,
     SCAN_QUANTUM_BYTES,
@@ -87,6 +90,7 @@ pub use model::{
 };
 pub use pricing::{install_runtime_pricing, price_breakdown, pricing_generation};
 pub use replay::{MissingParentRows, metrics_by_source, metrics_from_rows};
+pub use resume::{AdapterResume, AdapterSnapshot, EvidenceSnapshot, StreamSnapshot};
 pub use rows::{
     MemoryTurnRowStore, SESSION_COVERAGE_SCHEMA_SQL, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE,
     TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL, TURN_SCHEMA_V3_SQL, TurnRow, TurnRowError, TurnRowSink,
@@ -164,6 +168,19 @@ pub const EVIDENCE_SCHEMA_REVISION: i64 = 12;
 /// A persisted record from an older revision cannot be trusted to replay
 /// correctly, so a reader must reparse instead of reusing it.
 pub const COVERAGE_SCHEMA_REVISION: i64 = 1;
+/// Versions [`resume::StreamSnapshot`]'s own shape. [`resume::StreamSnapshot::is_current`]
+/// rejects a persisted snapshot stamped with an older revision.
+///
+/// A bump to [`PARSER_REVISION`], [`ANALYZER_REVISION`], [`METRICS_SCHEMA_REVISION`],
+/// [`EVIDENCE_SCHEMA_REVISION`], or [`COVERAGE_SCHEMA_REVISION`] also
+/// invalidates every persisted snapshot: a snapshot's adapter and sink
+/// state was built under the old rules, and resuming it would keep
+/// producing rows, metrics, or evidence the new rules never agreed to.
+/// Phase 3b's persistence layer enforces this by checking every revision
+/// before it restores a snapshot; this constant and the rule are
+/// documented here so a future revision bump remembers to bump this one
+/// too, when the change touches resumable state.
+pub const RESUME_SNAPSHOT_REVISION: i64 = 1;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -95,7 +95,8 @@ pub use rows::{
     insert_coverage_record, insert_turn_rows, query_coverage_record, turn_row_from_event,
 };
 pub use source_validity::{
-    AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, SourceClaim, append_only_guarantee,
+    AppendOnlyGuarantee, PinnedOpen, PinnedReader, PinnedSource, RESUME_TAIL_BYTES, ResumePoint,
+    SourceClaim, append_only_guarantee,
 };
 pub use vendors::claude::ClaudeAdapter;
 pub use vendors::pi::PiAdapter;

--- a/crates/antiburn-local/src/analysis/resume.rs
+++ b/crates/antiburn-local/src/analysis/resume.rs
@@ -1,0 +1,170 @@
+//! Snapshot types for verified-resume ingest.
+//!
+//! [`StreamSnapshot`] is the unit of resume: everything a pass needs to
+//! continue a stream from a verified byte offset instead of starting over.
+//! State for one session lives in three places — the adapter (a
+//! whole-stream buffer like `ClaudeStreamState`), the metrics accumulator
+//! (a reorder window, deferred cache patches, duration heaps), and the
+//! evidence accumulator (ordering and thread-link state a row query cannot
+//! answer) — so the snapshot bundles all three, plus the row sink's next
+//! index and the [`ResumePoint`] the offset reader verifies on reopen.
+//!
+//! An adapter builds only its own half ([`AdapterResume`]); it never sees
+//! the sink's concrete accumulator types, only `&mut dyn RecordSink`. The
+//! sink's half comes from [`crate::analysis::evidence_sink::CompositeSink::snapshot`],
+//! which combines the two into a full [`StreamSnapshot`].
+//!
+//! Restoring a snapshot and streaming from its offset must reproduce
+//! exactly what a full pass over the same bytes gives. See
+//! `crates/antiburn-local/tests/resume_parity.rs` for the proof.
+
+use serde::{Deserialize, Serialize};
+
+use crate::analysis::evidence::SessionCoverageRecord;
+use crate::analysis::evidence_sink::EvidenceResumeState;
+use crate::analysis::metrics_sink::SessionMetricsAccumulator;
+use crate::analysis::source_validity::ResumePoint;
+
+/// Vendor-specific adapter state, opaque to everything but the adapter that
+/// produced it. Keeps [`StreamSnapshot`] vendor-neutral: each adapter picks
+/// its own serialization inside this envelope (`ClaudeAdapter` uses
+/// `postcard`, matching [`StreamSnapshot::encode`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdapterSnapshot(pub Vec<u8>);
+
+/// One adapter's own resume state after a streaming pass: the verified
+/// byte offset and tail hash an offset reader checks on reopen, plus the
+/// adapter's own opaque whole-stream state.
+///
+/// This is the half of a [`StreamSnapshot`] an adapter can build on its
+/// own — it never sees the sink's concrete accumulator types, only
+/// `&mut dyn RecordSink`. [`crate::analysis::evidence_sink::CompositeSink::snapshot`]
+/// combines this with the sink's own metrics, evidence, and row-index
+/// state to build the full snapshot.
+#[derive(Debug, Clone)]
+pub struct AdapterResume {
+    pub point: ResumePoint,
+    pub adapter: AdapterSnapshot,
+}
+
+/// A session's evidence-accumulator state at a pause point: the coverage
+/// record [`crate::analysis::SessionEvidenceAccumulator::coverage_record`]
+/// produces, plus the two transient fields it leaves out. See
+/// [`crate::analysis::SessionEvidenceAccumulator::from_coverage_record_with_resume`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceSnapshot {
+    pub record: SessionCoverageRecord,
+    pub resume: EvidenceResumeState,
+}
+
+/// Everything needed to resume a stream exactly where a prior pass left
+/// off: the verified byte offset, the adapter's own whole-stream state, the
+/// metrics and evidence accumulators, and the row sink's next index.
+///
+/// `SessionSummary` fields an adapter can only state after its last record
+/// (`context_window`, `model`, `initial_context`, …) need no snapshot field
+/// of their own: the adapter's own snapshot already carries the
+/// whole-stream state that produces them, and the next `finish` rebuilds
+/// them the same way a full pass would.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamSnapshot {
+    /// Must equal [`crate::analysis::RESUME_SNAPSHOT_REVISION`] — see
+    /// [`Self::is_current`].
+    pub revision: i64,
+    pub resume: ResumePoint,
+    pub adapter: AdapterSnapshot,
+    pub metrics: SessionMetricsAccumulator,
+    pub evidence: EvidenceSnapshot,
+    pub next_turn_index: u64,
+}
+
+impl StreamSnapshot {
+    /// True when `revision` matches the current
+    /// [`crate::analysis::RESUME_SNAPSHOT_REVISION`]. A caller rejects a
+    /// stale snapshot (an older revision) instead of restoring it, falling
+    /// back to a full pass — see that constant's doc comment for what else
+    /// invalidates a snapshot.
+    pub fn is_current(&self) -> bool {
+        self.revision == crate::analysis::RESUME_SNAPSHOT_REVISION
+    }
+
+    /// Encodes this snapshot as compact binary (`postcard`), the form a
+    /// caller persists. JSON re-expands this type's interned IDs and packed
+    /// slot indices into full field names and strings; `postcard` keeps
+    /// them close to their in-memory size. See
+    /// `crates/antiburn-local/tests/streaming_metrics_memory.rs` for a
+    /// measured size on the largest corpus tier.
+    pub fn encode(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).expect("a StreamSnapshot always encodes")
+    }
+
+    /// Decodes a snapshot [`Self::encode`] produced. A failure of any kind —
+    /// truncated bytes, a shape from a different revision's encoding, plain
+    /// corruption — means the snapshot is not resumable: the caller falls
+    /// back to a full pass rather than trying to interpret a partial
+    /// result. Deliberately does not distinguish failure causes; nothing
+    /// downstream of "not resumable" needs to.
+    pub fn decode(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::RESUME_SNAPSHOT_REVISION;
+    use crate::analysis::evidence::{SourceCapabilities, SourceKind};
+    use crate::analysis::evidence_sink::SessionEvidenceAccumulator;
+
+    fn sample_snapshot(revision: i64) -> StreamSnapshot {
+        let evidence = SessionEvidenceAccumulator::new(crate::analysis::evidence::EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: "s1".to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        });
+        StreamSnapshot {
+            revision,
+            resume: ResumePoint {
+                offset: 0,
+                tail_hash: 0,
+                tail_len: 0,
+            },
+            adapter: AdapterSnapshot(Vec::new()),
+            metrics: SessionMetricsAccumulator::new("claude", "s1"),
+            evidence: EvidenceSnapshot {
+                record: evidence.coverage_record(),
+                resume: EvidenceResumeState::default(),
+            },
+            next_turn_index: 0,
+        }
+    }
+
+    #[test]
+    fn a_snapshot_at_the_current_revision_is_current() {
+        assert!(sample_snapshot(RESUME_SNAPSHOT_REVISION).is_current());
+    }
+
+    #[test]
+    fn a_snapshot_at_a_stale_revision_is_not_current() {
+        assert!(!sample_snapshot(RESUME_SNAPSHOT_REVISION - 1).is_current());
+    }
+
+    #[test]
+    fn a_snapshot_round_trips_through_its_encoding() {
+        let snapshot = sample_snapshot(RESUME_SNAPSHOT_REVISION);
+        let encoded = snapshot.encode();
+        let restored = StreamSnapshot::decode(&encoded).expect("decode snapshot");
+        assert_eq!(restored.revision, snapshot.revision);
+        assert_eq!(restored.next_turn_index, snapshot.next_turn_index);
+        assert!(restored.is_current());
+    }
+
+    #[test]
+    fn decoding_truncated_bytes_fails_instead_of_panicking() {
+        let snapshot = sample_snapshot(RESUME_SNAPSHOT_REVISION);
+        let mut encoded = snapshot.encode();
+        encoded.truncate(encoded.len() / 2);
+        assert!(StreamSnapshot::decode(&encoded).is_err());
+    }
+}

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -408,6 +408,15 @@ impl TurnRowSink {
         }
     }
 
+    /// Continues `turn_index` from `index` instead of zero. A resumed sink
+    /// uses this with the `next_turn_index` a prior pass's snapshot
+    /// recorded, so its rows continue the same session's sequence instead
+    /// of restarting it.
+    pub fn with_start_index(mut self, index: u64) -> Self {
+        self.next_index = index;
+        self
+    }
+
     /// True once a write has failed. No further row reaches the store after
     /// this, but rows already accepted before the failure stay written.
     pub fn has_error(&self) -> bool {
@@ -1319,6 +1328,31 @@ mod tests {
 
         assert_eq!(writer.count(1), 10);
         assert_eq!(sink.next_index, 10);
+    }
+
+    #[test]
+    fn a_sink_restored_at_an_index_writes_the_continued_sequence() {
+        let store = MemoryTurnRowStore::new("claude", "s1");
+        let mut sink = TurnRowSink::new(Arc::clone(&store) as Arc<dyn TurnRowStore>, "s1", None)
+            .with_start_index(5);
+
+        for _ in 0..3 {
+            sink.observe(&metric_record(Role::Assistant));
+        }
+        sink.flush();
+
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "claude",
+            session_id: "s1",
+        };
+        let indices: Vec<u64> = store
+            .with_connection(|conn| crate::analysis::evidence_query::query_turn_rows(conn, &key, 1))
+            .expect("query turn rows")
+            .into_iter()
+            .map(|row| row.turn_index)
+            .collect();
+        assert_eq!(indices, vec![5, 6, 7]);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -417,6 +417,14 @@ impl TurnRowSink {
         self
     }
 
+    /// The `turn_index` this sink assigns to its next row. A caller that
+    /// pauses a stream mid-session carries this into the next pass's
+    /// snapshot, so a later [`Self::with_start_index`] continues the same
+    /// sequence.
+    pub fn next_index(&self) -> u64 {
+        self.next_index
+    }
+
     /// True once a write has failed. No further row reaches the store after
     /// this, but rows already accepted before the failure stay written.
     pub fn has_error(&self) -> bool {

--- a/crates/antiburn-local/src/analysis/source_validity.rs
+++ b/crates/antiburn-local/src/analysis/source_validity.rs
@@ -6,10 +6,32 @@ use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
 use crate::analysis::interface::SourceChangedReason;
 use crate::discovery::source_version::{
     FINGERPRINT_HEAD_BYTES, FingerprintInputs, SourceStat, head_hash_of,
 };
+
+/// Bytes of trailing window a [`ResumePoint`] hashes, ending at its
+/// `offset`. Matches [`FINGERPRINT_HEAD_BYTES`]: large enough to make a
+/// coincidental hash collision after a rewrite very unlikely, small enough
+/// to hash on every resume without a noticeable read.
+pub const RESUME_TAIL_BYTES: u64 = 64 * 1024;
+
+/// A verified point to resume a stream from: the byte offset already
+/// consumed, and a hash of the window before it.
+///
+/// [`PinnedSource::open_resumed`] trusts this offset only when the trailing
+/// window still hashes to `tail_hash` — a rewrite inside that window (not
+/// just an append after it) invalidates the resume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResumePoint {
+    pub offset: u64,
+    pub tail_hash: u64,
+    /// `min(offset, RESUME_TAIL_BYTES)`. Zero when `offset` is zero.
+    pub tail_len: u32,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceClaim {
@@ -48,6 +70,12 @@ pub type PinnedOpen = Result<PinnedSource, SourceChangedReason>;
 pub struct PinnedSource {
     file: File,
     claim: SourceClaim,
+    /// The file position [`Self::reader`] or [`Self::reader_from`] last
+    /// seeked to. Zero for [`Self::reader`]; the resumed offset for
+    /// [`Self::reader_from`]. [`Self::consumed`] counts bytes read past
+    /// this position, so a prefix recheck compares `base_offset + consumed`
+    /// against the claimed boundary.
+    base_offset: u64,
     consumed: u64,
 }
 
@@ -73,6 +101,53 @@ impl PinnedSource {
         Ok(Ok(Self {
             file,
             claim,
+            base_offset: 0,
+            consumed: 0,
+        }))
+    }
+
+    /// Opens the path and validates it the same way [`Self::open`] does,
+    /// plus a resume-specific check: the file must be at least
+    /// `resume.offset` bytes, and the window
+    /// `[resume.offset - resume.tail_len, resume.offset)` must still hash to
+    /// `resume.tail_hash`. Either failure returns
+    /// [`SourceChangedReason::ResumeTailMismatch`] — a rewrite inside the
+    /// tail window, not just an append after it, invalidates the resume.
+    pub fn open_resumed(
+        path: &Path,
+        claim: SourceClaim,
+        resume: &ResumePoint,
+    ) -> anyhow::Result<PinnedOpen> {
+        let mut file = File::open(path)?;
+        let stat = stat_from_handle(&file)?;
+        if stat.identity != claim.identity {
+            return Ok(Err(SourceChangedReason::IdentityMismatch));
+        }
+        if stat.size < claim.boundary {
+            return Ok(Err(SourceChangedReason::ShortAtOpen {
+                size: stat.size,
+                boundary: claim.boundary,
+            }));
+        }
+        let head_hash = read_head_hash(&mut file, claim.boundary)?;
+        if claim.head_hash.is_some() && claim.head_hash != Some(head_hash) {
+            return Ok(Err(SourceChangedReason::HeadRegionMismatch));
+        }
+        if stat.size < resume.offset {
+            return Ok(Err(SourceChangedReason::ResumeTailMismatch));
+        }
+        let tail_start = resume.offset - u64::from(resume.tail_len);
+        file.seek(SeekFrom::Start(tail_start))?;
+        let mut tail = vec![0_u8; resume.tail_len as usize];
+        file.read_exact(&mut tail)?;
+        if head_hash_of(&tail) != resume.tail_hash {
+            return Ok(Err(SourceChangedReason::ResumeTailMismatch));
+        }
+        file.seek(SeekFrom::Start(0))?;
+        Ok(Ok(Self {
+            file,
+            claim,
+            base_offset: 0,
             consumed: 0,
         }))
     }
@@ -87,6 +162,7 @@ impl PinnedSource {
 
     /// Reads from offset zero and delivers at most `limit` bytes.
     pub fn reader(&mut self, limit: u64) -> PinnedReader<'_> {
+        self.base_offset = 0;
         self.consumed = 0;
         let seek_error = self.file.seek(SeekFrom::Start(0)).err();
         PinnedReader {
@@ -97,10 +173,26 @@ impl PinnedSource {
         }
     }
 
+    /// Reads from `offset` and delivers at most `limit` bytes. Pairs with
+    /// [`Self::open_resumed`]: `offset` is normally the [`ResumePoint`] it
+    /// verified.
+    pub fn reader_from(&mut self, offset: u64, limit: u64) -> PinnedReader<'_> {
+        self.base_offset = offset;
+        self.consumed = 0;
+        let seek_error = self.file.seek(SeekFrom::Start(offset)).err();
+        PinnedReader {
+            file: &mut self.file,
+            consumed: &mut self.consumed,
+            remaining: limit,
+            seek_error,
+        }
+    }
+
     pub fn recheck_prefix(&mut self) -> anyhow::Result<Option<SourceChangedReason>> {
-        if self.consumed < self.claim.boundary {
+        let consumed = self.base_offset.saturating_add(self.consumed);
+        if consumed < self.claim.boundary {
             return Ok(Some(SourceChangedReason::ShortRead {
-                consumed: self.consumed,
+                consumed,
                 boundary: self.claim.boundary,
             }));
         }
@@ -116,6 +208,24 @@ impl PinnedSource {
             return Ok(Some(SourceChangedReason::HeadRegionMismatch));
         }
         Ok(None)
+    }
+
+    /// Builds a [`ResumePoint`] for the position this source has read to so
+    /// far (`base_offset` plus bytes consumed by the last reader), hashing
+    /// the [`RESUME_TAIL_BYTES`] window immediately before it. Call after a
+    /// successful read and [`Self::recheck_prefix`], the same way
+    /// [`Self::claim`] describes a validated state.
+    pub fn resume_point(&mut self) -> anyhow::Result<ResumePoint> {
+        let offset = self.base_offset.saturating_add(self.consumed);
+        let tail_len = offset.min(RESUME_TAIL_BYTES);
+        self.file.seek(SeekFrom::Start(offset - tail_len))?;
+        let mut tail = vec![0_u8; tail_len as usize];
+        self.file.read_exact(&mut tail)?;
+        Ok(ResumePoint {
+            offset,
+            tail_hash: head_hash_of(&tail),
+            tail_len: u32::try_from(tail_len).unwrap_or(u32::MAX),
+        })
     }
 
     pub fn recheck_full(&mut self) -> anyhow::Result<Option<SourceChangedReason>> {
@@ -379,5 +489,148 @@ mod tests {
             pinned.recheck_full().expect("recheck full source"),
             Some(SourceChangedReason::FingerprintMismatch)
         );
+    }
+
+    /// A claim whose boundary is `boundary`, not the whole file — the shape
+    /// [`PinnedSource::open_resumed`] expects, since the claimed prefix
+    /// covers only what the prior pass verified, not later appended bytes.
+    fn claim_for_offset(path: &Path, boundary: u64) -> SourceClaim {
+        let mut file = File::open(path).expect("open source for claim");
+        let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+        let head_hash = read_head_hash(&mut file, boundary).expect("hash source for claim");
+        SourceClaim {
+            fingerprint: String::new(),
+            identity: stat.identity,
+            boundary,
+            head_hash: Some(head_hash),
+        }
+    }
+
+    #[test]
+    fn resume_after_append_reads_only_the_suffix() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"first record\n");
+        let claim = claim_for_path(&path);
+        let mut pinned = PinnedSource::open(&path, claim.clone())
+            .expect("open pinned source")
+            .expect("matching source");
+        pinned
+            .reader(u64::MAX)
+            .read_to_end(&mut Vec::new())
+            .expect("read initial source");
+        let resume = pinned.resume_point().expect("build resume point");
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open source for append")
+            .write_all(b"second record\n")
+            .expect("append source");
+
+        let mut resumed = PinnedSource::open_resumed(&path, claim, &resume)
+            .expect("open resumed source")
+            .expect("append-only source resumes");
+        let mut suffix = Vec::new();
+        resumed
+            .reader_from(resume.offset, u64::MAX)
+            .read_to_end(&mut suffix)
+            .expect("read suffix");
+
+        assert_eq!(suffix, b"second record\n");
+        assert_eq!(resumed.recheck_prefix().expect("recheck prefix"), None);
+    }
+
+    #[test]
+    fn a_truncation_below_the_offset_is_detected() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"first record\n");
+        let claim = claim_for_path(&path);
+        let mut pinned = PinnedSource::open(&path, claim.clone())
+            .expect("open pinned source")
+            .expect("matching source");
+        pinned
+            .reader(u64::MAX)
+            .read_to_end(&mut Vec::new())
+            .expect("read initial source");
+        let resume = pinned.resume_point().expect("build resume point");
+        // A boundary-only claim (no head-hash change) so the size check below
+        // is the one that fires, not the identical existing head-hash check.
+        let claim = SourceClaim {
+            boundary: 0,
+            head_hash: None,
+            ..claim
+        };
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open source for truncation")
+            .set_len(3)
+            .expect("truncate source");
+
+        let result =
+            PinnedSource::open_resumed(&path, claim, &resume).expect("validate truncated source");
+
+        assert!(matches!(
+            result,
+            Err(SourceChangedReason::ResumeTailMismatch)
+        ));
+    }
+
+    #[test]
+    fn a_same_size_tail_rewrite_past_the_head_region_is_detected() {
+        let directory = TempDir::new().expect("tempdir");
+        let head = vec![b'a'; FINGERPRINT_HEAD_BYTES + 1024];
+        let path = write_source(&directory, "session.jsonl", &head);
+        let claim = claim_for_offset(&path, FINGERPRINT_HEAD_BYTES as u64);
+        let mut pinned = PinnedSource::open(&path, claim.clone())
+            .expect("open pinned source")
+            .expect("matching source");
+        pinned
+            .reader(u64::MAX)
+            .read_to_end(&mut Vec::new())
+            .expect("read initial source");
+        let resume = pinned.resume_point().expect("build resume point");
+        let mut writer = OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open source for rewrite");
+        // Same total size, but a byte inside the tail window (past the head
+        // region the existing head-hash check covers) changes.
+        writer
+            .seek(SeekFrom::Start(FINGERPRINT_HEAD_BYTES as u64 + 100))
+            .expect("seek into tail window");
+        writer.write_all(b"b").expect("rewrite tail window");
+        writer.sync_all().expect("sync rewrite");
+
+        let result =
+            PinnedSource::open_resumed(&path, claim, &resume).expect("validate rewritten source");
+
+        assert!(matches!(
+            result,
+            Err(SourceChangedReason::ResumeTailMismatch)
+        ));
+    }
+
+    #[test]
+    fn offset_zero_has_an_empty_tail_and_resumes_as_a_full_read() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, "session.jsonl", b"");
+        let claim = claim_for_offset(&path, 0);
+        let resume = ResumePoint {
+            offset: 0,
+            tail_hash: head_hash_of(&[]),
+            tail_len: 0,
+        };
+        std::fs::write(&path, b"first record\n").expect("grow source");
+
+        let mut resumed = PinnedSource::open_resumed(&path, claim, &resume)
+            .expect("open resumed source")
+            .expect("empty prefix resumes");
+        let mut all = Vec::new();
+        resumed
+            .reader_from(0, u64::MAX)
+            .read_to_end(&mut all)
+            .expect("read whole source");
+
+        assert_eq!(all, b"first record\n");
     }
 }

--- a/crates/antiburn-local/src/analysis/threads.rs
+++ b/crates/antiburn-local/src/analysis/threads.rs
@@ -10,6 +10,8 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 /// The most distinct uuids [`ThreadResolver`] records before it stops
 /// tracking new ones. Real Claude transcripts (measured: 76 sessions) stay
 /// orders of magnitude below this; the bound exists only to hold memory for
@@ -22,7 +24,7 @@ const MAX_THREAD_IDENTITIES: usize = 50_000;
 /// already seen. A record with no link, or with an unseen target, starts a
 /// thread named by its own uuid. A record without a uuid joins the current
 /// thread.
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ThreadResolver {
     thread_by_uuid: HashMap<String, String>,
     current: Option<String>,

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -12,12 +12,13 @@ use std::io::{BufRead, BufReader, Cursor, Read};
 use std::path::Path;
 
 use anyhow::Context;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::initial_context::ClaudeContextAccumulator;
 use crate::analysis::interface::{
-    ContextSourceKind, EvidenceObservation, NormalizedRecord, RawSource, RecordSink,
+    ContextSourceKind, EvidenceObservation, NormalizedRecord, RawSource, RecordSink, ResumedVisit,
     SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, ToolCall, Usage};
@@ -26,6 +27,7 @@ use crate::analysis::records::{
     is_inert_unrecognized, is_recognized_eventless, parse_record, record_discriminator,
     thread_identity_field,
 };
+use crate::analysis::resume::{AdapterResume, StreamSnapshot};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
 use crate::analysis::threads::ThreadResolver;
 use crate::discovery::SubagentMeta;
@@ -244,16 +246,28 @@ impl VendorAdapter for ClaudeAdapter {
         sink: &mut dyn RecordSink,
     ) -> anyhow::Result<VisitOutcome> {
         (|| -> anyhow::Result<VisitOutcome> {
-            let summary = match &input.source {
+            let state = match &input.source {
                 RawSource::File(path) => {
                     let replayed_uuids = replay_skip_uuids(path);
                     let file = File::open(path)?;
-                    self.visit_reader(BufReader::new(file), &|| false, sink, &replayed_uuids)?
+                    self.visit_reader(
+                        BufReader::new(file),
+                        &|| false,
+                        sink,
+                        &replayed_uuids,
+                        ClaudeStreamState::default(),
+                    )?
                 }
                 RawSource::Jsonl(content) => {
                     let suffix: &[u8] = if content.ends_with('\n') { b"" } else { b"\n" };
                     let source = Cursor::new(content.as_bytes()).chain(suffix);
-                    self.visit_reader(BufReader::new(source), &|| false, sink, &HashSet::new())?
+                    self.visit_reader(
+                        BufReader::new(source),
+                        &|| false,
+                        sink,
+                        &HashSet::new(),
+                        ClaudeStreamState::default(),
+                    )?
                 }
                 RawSource::Sqlite(path) => {
                     anyhow::bail!(
@@ -262,7 +276,7 @@ impl VendorAdapter for ClaudeAdapter {
                     )
                 }
             };
-            sink.finish(summary);
+            sink.finish(state.into_summary());
             Ok(VisitOutcome::Unvalidated)
         })()
         .with_context(|| format!("reading claude session {}", input.session_id))
@@ -277,6 +291,17 @@ impl VendorAdapter for ClaudeAdapter {
         sink: &mut dyn RecordSink,
     ) -> anyhow::Result<VisitOutcome> {
         ClaudeAdapter::visit_claimed(self, input, claim, guarantee, cancel, sink)
+    }
+
+    fn visit_claimed_resumed(
+        &self,
+        input: &SessionInput,
+        claim: &SourceClaim,
+        resume: &StreamSnapshot,
+        cancel: &dyn Fn() -> bool,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<ResumedVisit> {
+        ClaudeAdapter::visit_claimed_resumed(self, input, claim, resume, cancel, sink)
     }
 }
 
@@ -302,11 +327,12 @@ impl ClaudeAdapter {
                 AppendOnlyGuarantee::Evidenced => claim.boundary,
                 AppendOnlyGuarantee::Absent => u64::MAX,
             };
-            let summary = self.visit_reader(
+            let state = self.visit_reader(
                 BufReader::new(pinned.reader(limit)),
                 cancel,
                 sink,
                 &replayed_uuids,
+                ClaudeStreamState::default(),
             )?;
             let outcome = match guarantee {
                 AppendOnlyGuarantee::Evidenced => match pinned.recheck_prefix()? {
@@ -323,21 +349,111 @@ impl ClaudeAdapter {
             if matches!(outcome, VisitOutcome::SourceChanged(_)) {
                 return Ok(outcome);
             }
-            sink.finish(summary);
+            sink.finish(state.into_summary());
             Ok(outcome)
         })()
         .with_context(|| format!("reading claimed Claude session {}", input.session_id))
     }
 
+    /// Streams a file from a verified [`StreamSnapshot`], restoring
+    /// [`ClaudeStreamState`] from `resume.adapter` and reading only the
+    /// bytes past `resume.resume.offset`.
+    ///
+    /// Unlike [`Self::visit_claimed`], this always reads to the current end
+    /// of file and rechecks with [`PinnedSource::recheck_full`]: the
+    /// snapshot's `ResumePoint` already proves the claimed prefix is
+    /// unchanged (`PinnedSource::open_resumed`'s tail-hash check), so there
+    /// is no separate evidenced/absent append-only distinction to make for
+    /// the new bytes — only whether a writer changed the file during this
+    /// read.
+    ///
+    /// "Unsettled" rule: Claude has no case today where its end-of-stream
+    /// state is unsafe to resume from. Every event's usage is fully
+    /// deduplicated as it arrives ([`ClaudeStreamState::dedup_usage`]), and
+    /// `pending_commands` — resolved only in [`ClaudeStreamState::into_summary`]
+    /// — carry forward unresolved in the serialized state itself, so a
+    /// resumed pass keeps resolving them exactly as a single continuous
+    /// pass would. This method's `resume` is `None` only when `outcome`
+    /// is [`VisitOutcome::SourceChanged`].
+    pub fn visit_claimed_resumed(
+        &self,
+        input: &SessionInput,
+        claim: &SourceClaim,
+        resume: &StreamSnapshot,
+        cancel: &dyn Fn() -> bool,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<ResumedVisit> {
+        (|| -> anyhow::Result<ResumedVisit> {
+            anyhow::ensure!(
+                resume.is_current(),
+                "snapshot revision {} is not current",
+                resume.revision
+            );
+            let RawSource::File(path) = &input.source else {
+                anyhow::bail!("a claimed Claude source must be a file");
+            };
+            // Reruns on every pass: it reads the fork parent's own file, a
+            // source this snapshot does not cover. See the module doc.
+            let replayed_uuids = replay_skip_uuids(path);
+            let mut pinned = match PinnedSource::open_resumed(path, claim.clone(), &resume.resume)?
+            {
+                Ok(pinned) => pinned,
+                Err(reason) => {
+                    return Ok(ResumedVisit {
+                        outcome: VisitOutcome::SourceChanged(reason),
+                        resume: None,
+                    });
+                }
+            };
+            let initial_state: ClaudeStreamState = postcard::from_bytes(&resume.adapter.0)
+                .context("decoding Claude adapter snapshot")?;
+            let state = self.visit_reader(
+                BufReader::new(pinned.reader_from(resume.resume.offset, u64::MAX)),
+                cancel,
+                sink,
+                &replayed_uuids,
+                initial_state,
+            )?;
+            let outcome = match pinned.recheck_full()? {
+                Some(reason) => VisitOutcome::SourceChanged(reason),
+                None => VisitOutcome::AcceptedFull,
+            };
+            if matches!(outcome, VisitOutcome::SourceChanged(_)) {
+                return Ok(ResumedVisit {
+                    outcome,
+                    resume: None,
+                });
+            }
+            let adapter =
+                postcard::to_allocvec(&state).context("encoding Claude adapter snapshot")?;
+            let new_resume = pinned.resume_point()?;
+            sink.finish(state.into_summary());
+            Ok(ResumedVisit {
+                outcome,
+                resume: Some(AdapterResume {
+                    point: new_resume,
+                    adapter: crate::analysis::resume::AdapterSnapshot(adapter),
+                }),
+            })
+        })()
+        .with_context(|| format!("reading resumed Claude session {}", input.session_id))
+    }
+
+    /// Streams `reader` starting from `state`, so a resumed pass can carry
+    /// forward the state a prior pass left off with. A first pass starts
+    /// from `ClaudeStreamState::default()`. Returns the state at the end of
+    /// the stream, not yet reduced to a [`SessionSummary`]: the caller
+    /// decides whether to snapshot it before calling
+    /// [`ClaudeStreamState::into_summary`].
     fn visit_reader(
         &self,
         reader: impl BufRead,
         cancel: &dyn Fn() -> bool,
         sink: &mut dyn RecordSink,
         replayed_uuids: &HashSet<String>,
-    ) -> anyhow::Result<SessionSummary> {
+        mut state: ClaudeStreamState,
+    ) -> anyhow::Result<ClaudeStreamState> {
         let mut reader = BoundedJsonlReader::new(reader);
-        let mut state = ClaudeStreamState::default();
 
         while let Some(record) = reader.next_record(cancel) {
             match record {
@@ -448,11 +564,11 @@ impl ClaudeAdapter {
             }
         }
 
-        Ok(state.into_summary())
+        Ok(state)
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 struct ClaudeStreamState {
     max_usage_by_message_id: HashMap<String, Usage>,
     context_window: Option<u64>,
@@ -639,7 +755,12 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use super::*;
-    use crate::analysis::{PartialReason, RecordCoverage};
+    use crate::analysis::evidence::{EvidenceSource, SourceCapabilities, SourceKind};
+    use crate::analysis::evidence_sink::{EvidenceResumeState, SessionEvidenceAccumulator};
+    use crate::analysis::metrics_sink::SessionMetricsAccumulator;
+    use crate::analysis::resume::{AdapterSnapshot, EvidenceSnapshot};
+    use crate::analysis::source_validity::ResumePoint;
+    use crate::analysis::{PartialReason, RESUME_SNAPSHOT_REVISION, RecordCoverage};
     use crate::discovery::source_version::head_hash_of;
     use crate::discovery::{FingerprintInputs, SourceStat};
     use tempfile::TempDir;
@@ -804,6 +925,187 @@ mod tests {
         );
     }
 
+    /// A full [`StreamSnapshot`] around `resume` (the adapter's own half),
+    /// with fresh metrics/evidence/index state. These tests exercise only
+    /// the adapter's own offset and tail-hash behavior through
+    /// [`SessionCollector`], a sink with no `snapshot` of its own — unlike
+    /// [`crate::analysis::evidence_sink::CompositeSink::snapshot`], which a
+    /// production caller uses to carry real metrics and evidence state
+    /// forward.
+    fn snapshot_from(resume: AdapterResume) -> StreamSnapshot {
+        let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: "claimed-session".to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        });
+        StreamSnapshot {
+            revision: RESUME_SNAPSHOT_REVISION,
+            resume: resume.point,
+            adapter: resume.adapter,
+            metrics: SessionMetricsAccumulator::new("claude", "claimed-session"),
+            evidence: EvidenceSnapshot {
+                record: evidence.coverage_record(),
+                resume: EvidenceResumeState::default(),
+            },
+            next_turn_index: 0,
+        }
+    }
+
+    /// A snapshot at offset zero, ready to resume a whole file from its
+    /// start: [`PinnedSource::open_resumed`]'s offset-zero case.
+    fn fresh_snapshot() -> StreamSnapshot {
+        snapshot_from(AdapterResume {
+            point: ResumePoint {
+                offset: 0,
+                tail_hash: head_hash_of(&[]),
+                tail_len: 0,
+            },
+            adapter: AdapterSnapshot(postcard::to_allocvec(&ClaudeStreamState::default()).unwrap()),
+        })
+    }
+
+    #[test]
+    fn a_resumed_read_from_offset_zero_matches_a_full_read() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let claim = claim_for_path(&path);
+        let input = file_input(&path);
+        let mut collector = SessionCollector::new("claude", "claimed-session");
+
+        let visit = ClaudeAdapter
+            .visit_claimed_resumed(&input, &claim, &fresh_snapshot(), &|| false, &mut collector)
+            .expect("resumed visit of a fresh file");
+
+        assert_eq!(visit.outcome, VisitOutcome::AcceptedFull);
+        let resume = visit.resume.expect("a settled pass carries a resume");
+        assert_eq!(resume.point.offset, FIRST_RECORD.len() as u64);
+        assert_eq!(
+            collector
+                .into_session()
+                .expect("resumed read must publish")
+                .events
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_second_resumed_read_continues_from_the_first_snapshot() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let input = file_input(&path);
+        let mut first_pass = SessionCollector::new("claude", "claimed-session");
+        let first_claim = claim_for_path(&path);
+        let first_visit = ClaudeAdapter
+            .visit_claimed_resumed(
+                &input,
+                &first_claim,
+                &fresh_snapshot(),
+                &|| false,
+                &mut first_pass,
+            )
+            .expect("first resumed visit");
+        let resume = first_visit.resume.expect("a settled pass carries a resume");
+        let snapshot = snapshot_from(resume);
+
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open source for append")
+            .write_all(SECOND_RECORD.as_bytes())
+            .expect("append second record");
+        let second_claim = claim_for_path(&path);
+        let mut second_pass = SessionCollector::new("claude", "claimed-session");
+
+        let second_visit = ClaudeAdapter
+            .visit_claimed_resumed(
+                &input,
+                &second_claim,
+                &snapshot,
+                &|| false,
+                &mut second_pass,
+            )
+            .expect("second resumed visit");
+
+        assert_eq!(second_visit.outcome, VisitOutcome::AcceptedFull);
+        assert_eq!(
+            second_pass
+                .into_session()
+                .expect("resumed read must publish")
+                .events
+                .len(),
+            1,
+            "the resumed pass reads only the newly appended record"
+        );
+    }
+
+    #[test]
+    fn a_rewritten_tail_fails_a_resumed_read_without_a_snapshot() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let input = file_input(&path);
+        let first_claim = claim_for_path(&path);
+        let mut first_pass = SessionCollector::new("claude", "claimed-session");
+        let first_visit = ClaudeAdapter
+            .visit_claimed_resumed(
+                &input,
+                &first_claim,
+                &fresh_snapshot(),
+                &|| false,
+                &mut first_pass,
+            )
+            .expect("first resumed visit");
+        let resume = first_visit.resume.expect("a settled pass carries a resume");
+        let snapshot = snapshot_from(resume);
+
+        // Same identity, a rewritten tail: the old snapshot's offset now
+        // points past a rewritten byte instead of an append. Re-claiming
+        // against the rewritten content isolates that check from the
+        // unrelated head-region check `open_resumed` also runs.
+        std::fs::write(&path, SECOND_RECORD.as_bytes()).expect("rewrite source");
+        let rewritten_claim = claim_for_path(&path);
+        let mut second_pass = SessionCollector::new("claude", "claimed-session");
+
+        let visit = ClaudeAdapter
+            .visit_claimed_resumed(
+                &input,
+                &rewritten_claim,
+                &snapshot,
+                &|| false,
+                &mut second_pass,
+            )
+            .expect("resumed visit of a rewritten source");
+
+        assert_eq!(
+            visit.outcome,
+            VisitOutcome::SourceChanged(crate::analysis::SourceChangedReason::ResumeTailMismatch)
+        );
+        assert!(visit.resume.is_none());
+        assert!(second_pass.into_session().is_err());
+    }
+
+    #[test]
+    fn a_stale_snapshot_revision_is_rejected() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let claim = claim_for_path(&path);
+        let input = file_input(&path);
+        let mut collector = SessionCollector::new("claude", "claimed-session");
+        let mut snapshot = fresh_snapshot();
+        snapshot.revision = RESUME_SNAPSHOT_REVISION - 1;
+
+        let result = ClaudeAdapter.visit_claimed_resumed(
+            &input,
+            &claim,
+            &snapshot,
+            &|| false,
+            &mut collector,
+        );
+
+        assert!(result.is_err());
+    }
+
     #[test]
     fn a_plain_claude_read_reports_unvalidated() {
         let input = SessionInput {
@@ -877,7 +1179,13 @@ mod tests {
         let source = b"{\"type\":\"assistant\",\"message\":{\"id\":\"first\",\"role\":\"assistant\",\"content\":[]}}\n";
         let reader = BufReader::new(DataThenError::new(source));
         let mut collector = SessionCollector::new("claude", "read-failure");
-        let result = ClaudeAdapter.visit_reader(reader, &|| false, &mut collector, &HashSet::new());
+        let result = ClaudeAdapter.visit_reader(
+            reader,
+            &|| false,
+            &mut collector,
+            &HashSet::new(),
+            ClaudeStreamState::default(),
+        );
         assert!(result.is_err());
     }
 
@@ -1352,10 +1660,16 @@ mod tests {
         let reader = BufReader::new(source.as_bytes());
         let mut collector = SessionCollector::new("claude", "fork-child");
         let replayed = HashSet::from(["replayed-1".to_string()]);
-        let summary = ClaudeAdapter
-            .visit_reader(reader, &|| false, &mut collector, &replayed)
+        let state = ClaudeAdapter
+            .visit_reader(
+                reader,
+                &|| false,
+                &mut collector,
+                &replayed,
+                ClaudeStreamState::default(),
+            )
             .expect("read must succeed");
-        collector.finish(summary);
+        collector.finish(state.into_summary());
         let session = collector.into_session().expect("session must build");
         let uuids: Vec<Option<String>> = session
             .events

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -306,6 +306,19 @@ impl VendorAdapter for ClaudeAdapter {
 }
 
 impl ClaudeAdapter {
+    /// A fresh [`ClaudeStreamState`], serialized. A caller starting the
+    /// first resumable pass over a source (no snapshot from a prior pass
+    /// exists yet) uses this to build a [`StreamSnapshot`] with
+    /// [`ResumePoint::offset`] zero: see
+    /// [`VendorAdapter::visit_claimed_resumed`]'s doc comment for why that
+    /// one method covers both cases.
+    pub fn empty_adapter_snapshot() -> crate::analysis::resume::AdapterSnapshot {
+        crate::analysis::resume::AdapterSnapshot(
+            postcard::to_allocvec(&ClaudeStreamState::default())
+                .expect("a default ClaudeStreamState always encodes"),
+        )
+    }
+
     pub fn visit_claimed(
         &self,
         input: &SessionInput,
@@ -758,7 +771,7 @@ mod tests {
     use crate::analysis::evidence::{EvidenceSource, SourceCapabilities, SourceKind};
     use crate::analysis::evidence_sink::{EvidenceResumeState, SessionEvidenceAccumulator};
     use crate::analysis::metrics_sink::SessionMetricsAccumulator;
-    use crate::analysis::resume::{AdapterSnapshot, EvidenceSnapshot};
+    use crate::analysis::resume::EvidenceSnapshot;
     use crate::analysis::source_validity::ResumePoint;
     use crate::analysis::{PartialReason, RESUME_SNAPSHOT_REVISION, RecordCoverage};
     use crate::discovery::source_version::head_hash_of;
@@ -961,7 +974,7 @@ mod tests {
                 tail_hash: head_hash_of(&[]),
                 tail_len: 0,
             },
-            adapter: AdapterSnapshot(postcard::to_allocvec(&ClaudeStreamState::default()).unwrap()),
+            adapter: ClaudeAdapter::empty_adapter_snapshot(),
         })
     }
 

--- a/crates/antiburn-local/tests/resume_parity.rs
+++ b/crates/antiburn-local/tests/resume_parity.rs
@@ -1,0 +1,623 @@
+//! Parity check for verified-resume ingest (continuous ingest, phase 3a).
+//!
+//! A file grows in record-aligned steps `S0 ⊂ S1 ⊂ ... ⊂ Sn`. "Resumed at
+//! step k" — a full pass over `S0` with a snapshot, then `visit_claimed_resumed`
+//! once per later step through `k`, each time restoring the metrics and
+//! evidence accumulators and the row sink's next index from the previous
+//! step's snapshot — must equal "a full pass at `Sk`" for turn rows (every
+//! column, plus their `turn_content`), `SessionMetrics`, `SessionSummary`,
+//! `TurnFacts`, and `SessionEvidence`. See "Why a snapshot and not an
+//! offset" in `docs/plans/continuous-session-ingest.md`.
+//!
+//! [`assert_resume_parity`] is the driver every positive test below calls.
+//! Every compared value — rows, turn content, `TurnFacts`, `SessionMetrics`
+//! (including `buckets`, the chart data), `SessionSummary`, and
+//! `SessionEvidence` — is asserted exactly.
+//!
+//! The negative tests at the bottom exercise the three ways a resumed pass
+//! must refuse instead of silently reusing stale state: a rewritten tail, a
+//! truncation below the resume offset, and a stale snapshot revision.
+
+#[path = "support/claude_fixture.rs"]
+mod claude_fixture;
+#[path = "support/corpus.rs"]
+mod corpus;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use antiburn_local::analysis::{
+    AppendOnlyGuarantee, ClaudeAdapter, CompositeSink, EvidenceSnapshot, EvidenceSource,
+    MemoryTurnRowStore, RESUME_SNAPSHOT_REVISION, RawSource, ResumePoint,
+    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SourceCapabilities,
+    SourceChangedReason, SourceClaim, SourceKind, StreamSnapshot, TurnRowSink, TurnRowStore,
+    TurnSessionKey, VisitOutcome, query_turn_facts, query_turn_rows,
+};
+use antiburn_local::discovery::source_version::head_hash_of;
+use antiburn_local::discovery::{FingerprintInputs, SourceStat};
+use corpus::{SessionSpec, generate_session};
+use tempfile::TempDir;
+
+/* --------------------------------------------------------------------
+ * Helpers shared by every test below.
+ * ----------------------------------------------------------------- */
+
+/// A claim covering the file's current full content: the shape both
+/// `visit_claimed` and `visit_claimed_resumed` expect from a fresh open.
+fn claim_for(path: &Path) -> SourceClaim {
+    let file = std::fs::File::open(path).expect("open source for claim");
+    let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+    let bytes = std::fs::read(path).expect("read source for claim");
+    SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+        stat,
+        head_hash: Some(head_hash_of(&bytes)),
+    })
+}
+
+/// A [`StreamSnapshot`] ready to start the very first resumable pass over a
+/// source: [`ResumePoint`] offset zero (an empty tail, so
+/// `PinnedSource::open_resumed` resumes as a full read) and a fresh
+/// [`ClaudeAdapter`] state.
+fn fresh_snapshot(
+    agent: &str,
+    session_id: &str,
+    capabilities: SourceCapabilities,
+) -> StreamSnapshot {
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: agent.to_owned(),
+        session_id: session_id.to_owned(),
+        kind: SourceKind::Jsonl,
+        capabilities,
+    });
+    StreamSnapshot {
+        revision: RESUME_SNAPSHOT_REVISION,
+        resume: ResumePoint {
+            offset: 0,
+            tail_hash: head_hash_of(&[]),
+            tail_len: 0,
+        },
+        adapter: ClaudeAdapter::empty_adapter_snapshot(),
+        metrics: SessionMetricsAccumulator::new(agent, session_id),
+        evidence: EvidenceSnapshot {
+            record: evidence.coverage_record(),
+            resume: Default::default(),
+        },
+        next_turn_index: 0,
+    }
+}
+
+fn session_input(agent: &str, session_id: &str, path: &Path) -> SessionInput {
+    SessionInput {
+        agent: agent.to_owned(),
+        session_id: session_id.to_owned(),
+        source: RawSource::File(path.to_path_buf()),
+    }
+}
+
+/// Splits `jsonl` (one JSON record per line) into `num_steps` growing,
+/// record-aligned prefixes, the last of which is the whole input.
+/// `num_steps` must not exceed the record count.
+fn record_aligned_steps(jsonl: &str, num_steps: usize) -> Vec<String> {
+    let lines: Vec<&str> = jsonl.lines().collect();
+    assert!(
+        lines.len() >= num_steps,
+        "{} records cannot cut into {num_steps} steps",
+        lines.len()
+    );
+    (1..=num_steps)
+        .map(|step| {
+            let cut = (lines.len() * step) / num_steps;
+            let mut prefix = lines[..cut].join("\n");
+            prefix.push('\n');
+            prefix
+        })
+        .collect()
+}
+
+/// Every `turn_content` row for `key` at `claim_fence`, ordered the same way
+/// `query_turn_rows` orders its rows. `query_turn_rows` never joins this
+/// table (its `TurnRow::content` is always empty), so this is the separate
+/// content read the module doc promises.
+fn turn_content_rows(
+    store: &MemoryTurnRowStore,
+    key: &TurnSessionKey<'_>,
+    claim_fence: i64,
+) -> Vec<(String, u64, i64, String, Vec<u8>, bool)> {
+    store.with_connection(|conn| {
+        let mut statement = conn
+            .prepare(
+                "SELECT t.source_key, t.turn_index, c.part_index, c.kind, c.content, c.truncated
+                   FROM turn t JOIN turn_content c ON c.turn_rowid = t.rowid
+                  WHERE t.environment_key = ?1 AND t.agent = ?2 AND t.session_id = ?3
+                    AND t.claim_fence = ?4
+                  ORDER BY t.source_key, t.turn_index, c.part_index",
+            )
+            .expect("prepare turn_content query");
+        statement
+            .query_map(
+                rusqlite::params![key.environment_key, key.agent, key.session_id, claim_fence],
+                |row| {
+                    let truncated: i64 = row.get(5)?;
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)? as u64,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, Vec<u8>>(4)?,
+                        truncated != 0,
+                    ))
+                },
+            )
+            .expect("query turn_content rows")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect turn_content rows")
+    })
+}
+
+/// A composite sink restored from `snapshot`'s metrics, evidence, and row
+/// sink index, fanning its rows into `store`. Mirrors the restore step a
+/// desktop worker (phase 3b) will run before every resumed pass.
+fn restored_composite(
+    store: &Arc<MemoryTurnRowStore>,
+    session_id: &str,
+    snapshot: &StreamSnapshot,
+) -> CompositeSink {
+    let metrics = SessionMetricsAccumulator::restore(snapshot.metrics.clone());
+    let evidence = SessionEvidenceAccumulator::from_coverage_record_with_resume(
+        snapshot.evidence.record.clone(),
+        snapshot.evidence.resume.clone(),
+    );
+    let turn_rows = TurnRowSink::new(
+        Arc::clone(store) as Arc<dyn TurnRowStore>,
+        session_id.to_owned(),
+        None,
+    )
+    .with_start_index(snapshot.next_turn_index);
+    CompositeSink::with_turn_rows(metrics, evidence, turn_rows)
+}
+
+/// Runs the full path (one `visit_claimed` pass over `path`'s current
+/// content) and returns everything [`assert_resume_parity`] compares.
+#[allow(clippy::type_complexity)]
+fn run_full_pass(
+    agent: &str,
+    session_id: &str,
+    path: &Path,
+    capabilities: SourceCapabilities,
+) -> (
+    Vec<antiburn_local::analysis::TurnRow>,
+    Vec<(String, u64, i64, String, Vec<u8>, bool)>,
+    antiburn_local::analysis::TurnFacts,
+    antiburn_local::analysis::SessionMetrics,
+    antiburn_local::analysis::SessionSummary,
+    antiburn_local::analysis::SessionEvidence,
+) {
+    let store = MemoryTurnRowStore::new(agent, session_id);
+    let mut composite = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new(agent, session_id),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: agent.to_owned(),
+            session_id: session_id.to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities,
+        }),
+        TurnRowSink::new(
+            Arc::clone(&store) as Arc<dyn TurnRowStore>,
+            session_id.to_owned(),
+            None,
+        ),
+    );
+    let input = session_input(agent, session_id, path);
+    let claim = claim_for(path);
+    let outcome = ClaudeAdapter
+        .visit_claimed(
+            &input,
+            &claim,
+            AppendOnlyGuarantee::Absent,
+            &|| false,
+            &mut composite,
+        )
+        .expect("full pass must stream");
+    assert_eq!(outcome, VisitOutcome::AcceptedFull, "full pass outcome");
+    composite.observe_source_outcome(outcome);
+    assert!(
+        !composite.turn_row_write_failed(),
+        "full pass: turn row write must not fail"
+    );
+
+    let key = TurnSessionKey {
+        environment_key: "native",
+        agent,
+        session_id,
+    };
+    let (rows, facts) = store.with_connection(|conn| {
+        let rows = query_turn_rows(conn, &key, 1).expect("full pass rows query");
+        let facts = query_turn_facts(conn, &key, 1).expect("full pass facts query");
+        (rows, facts)
+    });
+    let content = turn_content_rows(&store, &key, 1);
+    let metrics = composite.metrics().expect("full pass must publish metrics");
+    let summary = composite.summary().cloned().expect("full pass must finish");
+    let evidence = composite
+        .evidence()
+        .expect("full pass must publish evidence");
+    (rows, content, facts, metrics, summary, evidence)
+}
+
+/// Streams `steps` (one record-aligned, growing prefix per step) into
+/// `path`, and at every step compares the resumed path (a snapshot carried
+/// forward from `S0`) against the full path (one fresh `visit_claimed` over
+/// that step's whole content).
+fn assert_resume_parity(
+    agent: &str,
+    session_id: &str,
+    capabilities: SourceCapabilities,
+    steps: &[String],
+) {
+    assert!(!steps.is_empty(), "at least one step is required");
+    let directory = TempDir::new().expect("tempdir");
+    let path = directory.path().join("session.jsonl");
+
+    let resumed_store = MemoryTurnRowStore::new(agent, session_id);
+    let mut snapshot = fresh_snapshot(agent, session_id, capabilities);
+
+    for (index, step) in steps.iter().enumerate() {
+        std::fs::write(&path, step).expect("write step content");
+        let input = session_input(agent, session_id, &path);
+        let claim = claim_for(&path);
+
+        let mut resumed = restored_composite(&resumed_store, session_id, &snapshot);
+        let visit = ClaudeAdapter
+            .visit_claimed_resumed(&input, &claim, &snapshot, &|| false, &mut resumed)
+            .unwrap_or_else(|error| {
+                panic!("{agent}/{session_id} step {index}: resumed visit failed: {error:?}")
+            });
+        assert_eq!(
+            visit.outcome,
+            VisitOutcome::AcceptedFull,
+            "{agent}/{session_id} step {index}: resumed outcome"
+        );
+        resumed.observe_source_outcome(visit.outcome);
+        assert!(
+            !resumed.turn_row_write_failed(),
+            "{agent}/{session_id} step {index}: resumed row write must not fail"
+        );
+
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent,
+            session_id,
+        };
+        let (resumed_rows, resumed_facts) = resumed_store.with_connection(|conn| {
+            let rows = query_turn_rows(conn, &key, 1).expect("resumed rows query");
+            let facts = query_turn_facts(conn, &key, 1).expect("resumed facts query");
+            (rows, facts)
+        });
+        let resumed_content = turn_content_rows(&resumed_store, &key, 1);
+        let resumed_metrics = resumed
+            .metrics()
+            .expect("resumed pass must publish metrics");
+        let resumed_summary = resumed
+            .summary()
+            .cloned()
+            .expect("resumed pass must finish");
+        let resumed_evidence = resumed
+            .evidence()
+            .expect("resumed pass must publish evidence");
+
+        let (full_rows, full_content, full_facts, full_metrics, full_summary, full_evidence) =
+            run_full_pass(agent, session_id, &path, capabilities);
+
+        assert_eq!(
+            resumed_rows, full_rows,
+            "{agent}/{session_id} step {index}: turn rows"
+        );
+        assert_eq!(
+            resumed_content, full_content,
+            "{agent}/{session_id} step {index}: turn content"
+        );
+        assert_eq!(
+            resumed_facts, full_facts,
+            "{agent}/{session_id} step {index}: TurnFacts"
+        );
+        assert_eq!(
+            resumed_metrics, full_metrics,
+            "{agent}/{session_id} step {index}: SessionMetrics"
+        );
+        assert_eq!(
+            resumed_summary, full_summary,
+            "{agent}/{session_id} step {index}: SessionSummary"
+        );
+        assert_eq!(
+            resumed_evidence, full_evidence,
+            "{agent}/{session_id} step {index}: SessionEvidence"
+        );
+
+        let resume = visit
+            .resume
+            .expect("a settled pass over a quiescent source carries a resume");
+        snapshot = resumed
+            .snapshot(resume)
+            .expect("resumed pass must publish a snapshot to carry state forward");
+    }
+}
+
+/* --------------------------------------------------------------------
+ * Positive cases: a synthetic corpus cut into 5 steps, and every Claude
+ * characterization fixture `evidence_replay_parity.rs` sweeps, cut into 3.
+ * ----------------------------------------------------------------- */
+
+#[test]
+fn a_synthetic_session_resumes_identically_at_every_step() {
+    let spec = SessionSpec::tier_s(9001, 0, 47);
+    let session = generate_session(&spec);
+    let steps = record_aligned_steps(&session.jsonl, 5);
+    assert_resume_parity(
+        "claude",
+        &session.session_id,
+        SourceCapabilities::claude(),
+        &steps,
+    );
+}
+
+fn claude_fixture_names() -> [&'static str; 28] {
+    [
+        "records_all_kinds",
+        "timestamps_repeated_and_out_of_order",
+        "malformed_between_valid",
+        "incomplete_final_record",
+        "unrecognized_type",
+        "unrecognized_role_with_usage",
+        "unrecognized_evidence_shapes",
+        "unrecognized_inert_records",
+        "unrecognized_inert_sidechain",
+        "parent_with_task_spawn",
+        "subagent_child",
+        "multi_model_session",
+        "compaction_with_cache_rehydration",
+        "inferred_cache_rehydration",
+        "mcp_and_skill_sources",
+        "reasoning_and_fast_mode",
+        "delegated_turns",
+        "delegated_models",
+        "delegated_model_missing",
+        "housekeeping_records",
+        "thread_identity_chain",
+        "thread_identity_missing_uuid",
+        "sidechain_in_parent",
+        "late_skill_metrics",
+        "two_compactions_second_without_metadata",
+        "rehydration_gap_none",
+        "disorder_ladder",
+        "subagent_single_timestamp",
+    ]
+}
+
+#[test]
+fn every_claude_characterization_fixture_resumes_identically_in_three_steps() {
+    for name in claude_fixture_names() {
+        let jsonl = claude_fixture::read_fixture(name);
+        let record_count = jsonl.lines().count();
+        let step_count = record_count.min(3);
+        let steps = record_aligned_steps(&jsonl, step_count);
+        assert_resume_parity(
+            "claude",
+            &format!("resume-{name}"),
+            SourceCapabilities::claude(),
+            &steps,
+        );
+    }
+}
+
+/* --------------------------------------------------------------------
+ * Negative cases.
+ * ----------------------------------------------------------------- */
+
+#[test]
+fn a_rewritten_tail_is_rejected_instead_of_resuming() {
+    let spec = SessionSpec::tier_s(9002, 0, 10);
+    let session = generate_session(&spec);
+    let directory = TempDir::new().expect("tempdir");
+    let path = directory.path().join("session.jsonl");
+    std::fs::write(&path, &session.jsonl).expect("write source");
+    let input = session_input("claude", &session.session_id, &path);
+
+    let first_claim = claim_for(&path);
+    let mut first_pass = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new("claude", &session.session_id),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: session.session_id.clone(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        }),
+        TurnRowSink::new(
+            MemoryTurnRowStore::new("claude", &session.session_id) as Arc<dyn TurnRowStore>,
+            session.session_id.clone(),
+            None,
+        ),
+    );
+    let visit = ClaudeAdapter
+        .visit_claimed_resumed(
+            &input,
+            &first_claim,
+            &fresh_snapshot("claude", &session.session_id, SourceCapabilities::claude()),
+            &|| false,
+            &mut first_pass,
+        )
+        .expect("first resumed visit");
+    first_pass.observe_source_outcome(visit.outcome);
+    let resume = visit.resume.expect("a settled pass carries a resume");
+    let snapshot = first_pass
+        .snapshot(resume)
+        .expect("first pass must publish a snapshot");
+
+    // Same identity, a same-size rewrite that changes bytes inside the tail
+    // window `open_resumed` hashes. A fresh claim (matching the rewritten
+    // content) isolates this from the unrelated head-region check.
+    let rewritten: Vec<u8> = session
+        .jsonl
+        .bytes()
+        .map(|byte| if byte == b'0' { b'1' } else { byte })
+        .collect();
+    assert_eq!(
+        rewritten.len(),
+        session.jsonl.len(),
+        "rewrite must not resize"
+    );
+    std::fs::write(&path, &rewritten).expect("rewrite source");
+    let rewritten_claim = claim_for(&path);
+    let second_store = MemoryTurnRowStore::new("claude", &session.session_id);
+    let mut second_composite = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new("claude", &session.session_id),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: session.session_id.clone(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        }),
+        TurnRowSink::new(
+            Arc::clone(&second_store) as Arc<dyn TurnRowStore>,
+            session.session_id.clone(),
+            None,
+        ),
+    );
+
+    let result = ClaudeAdapter
+        .visit_claimed_resumed(
+            &input,
+            &rewritten_claim,
+            &snapshot,
+            &|| false,
+            &mut second_composite,
+        )
+        .expect("resumed visit of a rewritten source");
+
+    assert_eq!(
+        result.outcome,
+        VisitOutcome::SourceChanged(SourceChangedReason::ResumeTailMismatch)
+    );
+    assert!(result.resume.is_none());
+}
+
+#[test]
+fn a_truncation_below_the_resume_offset_is_rejected_instead_of_resuming() {
+    let spec = SessionSpec::tier_s(9003, 0, 10);
+    let session = generate_session(&spec);
+    let directory = TempDir::new().expect("tempdir");
+    let path = directory.path().join("session.jsonl");
+    std::fs::write(&path, &session.jsonl).expect("write source");
+    let input = session_input("claude", &session.session_id, &path);
+
+    let first_claim = claim_for(&path);
+    let store = MemoryTurnRowStore::new("claude", &session.session_id);
+    let mut first_pass = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new("claude", &session.session_id),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: session.session_id.clone(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        }),
+        TurnRowSink::new(
+            Arc::clone(&store) as Arc<dyn TurnRowStore>,
+            session.session_id.clone(),
+            None,
+        ),
+    );
+    let visit = ClaudeAdapter
+        .visit_claimed_resumed(
+            &input,
+            &first_claim,
+            &fresh_snapshot("claude", &session.session_id, SourceCapabilities::claude()),
+            &|| false,
+            &mut first_pass,
+        )
+        .expect("first resumed visit");
+    first_pass.observe_source_outcome(visit.outcome);
+    let resume = visit.resume.expect("a settled pass carries a resume");
+    let snapshot = first_pass
+        .snapshot(resume)
+        .expect("first pass must publish a snapshot");
+
+    // Truncate below the resume offset: a new claim over the shortened
+    // file, boundary-only (no head-hash change), isolates the offset check
+    // this test exercises from the unrelated head-region check.
+    let truncated_len = snapshot.resume.offset / 2;
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .expect("open source for truncation");
+    file.set_len(truncated_len).expect("truncate source");
+    drop(file);
+    let truncated_claim = SourceClaim {
+        boundary: 0,
+        head_hash: None,
+        ..first_claim
+    };
+    let store = MemoryTurnRowStore::new("claude", &session.session_id);
+    let mut second_pass = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new("claude", &session.session_id),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: session.session_id.clone(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        }),
+        TurnRowSink::new(
+            Arc::clone(&store) as Arc<dyn TurnRowStore>,
+            session.session_id.clone(),
+            None,
+        ),
+    );
+
+    let result = ClaudeAdapter
+        .visit_claimed_resumed(
+            &input,
+            &truncated_claim,
+            &snapshot,
+            &|| false,
+            &mut second_pass,
+        )
+        .expect("resumed visit of a truncated source");
+
+    assert_eq!(
+        result.outcome,
+        VisitOutcome::SourceChanged(SourceChangedReason::ResumeTailMismatch)
+    );
+    assert!(result.resume.is_none());
+}
+
+#[test]
+fn a_stale_snapshot_revision_is_rejected_by_is_current_and_by_the_adapter() {
+    let spec = SessionSpec::tier_s(9004, 0, 10);
+    let session = generate_session(&spec);
+    let directory = TempDir::new().expect("tempdir");
+    let path = directory.path().join("session.jsonl");
+    std::fs::write(&path, &session.jsonl).expect("write source");
+    let input = session_input("claude", &session.session_id, &path);
+    let claim = claim_for(&path);
+
+    let mut stale = fresh_snapshot("claude", &session.session_id, SourceCapabilities::claude());
+    stale.revision = RESUME_SNAPSHOT_REVISION - 1;
+    assert!(!stale.is_current());
+
+    let store = MemoryTurnRowStore::new("claude", &session.session_id);
+    let mut sink = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new("claude", &session.session_id),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: session.session_id.clone(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        }),
+        TurnRowSink::new(
+            Arc::clone(&store) as Arc<dyn TurnRowStore>,
+            session.session_id.clone(),
+            None,
+        ),
+    );
+
+    let result = ClaudeAdapter.visit_claimed_resumed(&input, &claim, &stale, &|| false, &mut sink);
+    assert!(result.is_err());
+}

--- a/crates/antiburn-local/tests/streaming_metrics_memory.rs
+++ b/crates/antiburn-local/tests/streaming_metrics_memory.rs
@@ -6,14 +6,18 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use antiburn_local::analysis::{
-    BoundedJsonlReader, CompositeSink, ContextSourceKind, EvidenceObservation, EvidenceSource,
-    MemoryTurnRowStore, NormalizedEvent, NormalizedRecord, RETAINED_EVIDENCE_BYTES_BOUND,
-    RETAINED_METRICS_BYTES_BOUND, RawSource, RecordSink, RelationProvenance, Role,
-    SCAN_QUANTUM_BYTES, SessionCoverageRecord, SessionEvidenceAccumulator, SessionInput,
-    SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceKind, TURN_ROW_BATCH_SIZE,
-    ToolCall, TurnFacts, TurnRow, TurnRowError, TurnRowSink, TurnRowStore, TurnScope,
-    TurnSessionKey, Usage, adapter_for, count_turn_content_rows, count_turn_rows, merge_metrics,
+    BoundedJsonlReader, ClaudeAdapter, CompositeSink, ContextSourceKind, EvidenceObservation,
+    EvidenceSnapshot, EvidenceSource, MemoryTurnRowStore, NormalizedEvent, NormalizedRecord,
+    RESUME_SNAPSHOT_REVISION, RETAINED_EVIDENCE_BYTES_BOUND, RETAINED_METRICS_BYTES_BOUND,
+    RawSource, RecordSink, RelationProvenance, ResumePoint, Role, SCAN_QUANTUM_BYTES,
+    SessionCoverageRecord, SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator,
+    SessionSummary, SourceCapabilities, SourceClaim, SourceKind, StreamSnapshot,
+    TURN_ROW_BATCH_SIZE, ToolCall, TurnFacts, TurnRow, TurnRowError, TurnRowSink, TurnRowStore,
+    TurnScope, TurnSessionKey, Usage, adapter_for, count_turn_content_rows, count_turn_rows,
+    merge_metrics,
 };
+use antiburn_local::discovery::source_version::head_hash_of;
+use antiburn_local::discovery::{FingerprintInputs, SourceStat};
 use corpus::{SessionSpec, generate_session, generate_session_of_bytes};
 
 #[test]
@@ -562,5 +566,100 @@ fn disk_bytes_per_row_stay_bounded_with_content_enabled() {
         content_stored_bytes <= (counted.content_bytes as u64).saturating_mul(2),
         "turn_content stored {content_stored_bytes} bytes for {} fed bytes",
         counted.content_bytes
+    );
+}
+
+/// An encoded [`StreamSnapshot`] (`StreamSnapshot::encode`, `postcard`) for
+/// a full pass over the largest corpus tier this file measures elsewhere
+/// (4 MiB, same as [`disk_bytes_per_row_stay_bounded_with_content_enabled`])
+/// stays under a documented bound. `RESUMED_SNAPSHOT_BYTES_BOUND` below
+/// records the measured size this test found and explains the bound picked
+/// from it.
+#[test]
+fn a_serialized_snapshot_for_the_largest_corpus_tier_stays_bounded() {
+    /// Measured: a 4 MiB synthetic session's `StreamSnapshot` encodes to
+    /// 520,777 bytes (about 509 KiB) with `postcard`, versus 2,002,215
+    /// bytes (about 1.9 MiB) for the same snapshot as JSON — `postcard`'s
+    /// compact varint and length-prefixed encoding does not re-expand this
+    /// type's interned name IDs and packed slot indices into full field
+    /// names and strings the way JSON does. This bound rounds the measured
+    /// size up generously (over 2x), the same margin
+    /// `RETAINED_EVIDENCE_BYTES_BOUND`'s own doc comment uses.
+    const RESUMED_SNAPSHOT_BYTES_BOUND: usize = 1_100 * 1024;
+
+    let session = generate_session_of_bytes(901, 0, 4 * 1024 * 1024);
+    let directory = tempfile::TempDir::new().expect("tempdir");
+    let path = directory.path().join("session.jsonl");
+    std::fs::write(&path, &session.jsonl).expect("write source");
+    let input = SessionInput {
+        agent: "claude".to_string(),
+        session_id: session.session_id.clone(),
+        source: RawSource::File(path.clone()),
+    };
+
+    let file = std::fs::File::open(&path).expect("open source for claim");
+    let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+    let claim = SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+        stat,
+        head_hash: Some(head_hash_of(session.jsonl.as_bytes())),
+    });
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: "claude".to_owned(),
+        session_id: session.session_id.clone(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::claude(),
+    });
+    let empty_snapshot = StreamSnapshot {
+        revision: RESUME_SNAPSHOT_REVISION,
+        resume: ResumePoint {
+            offset: 0,
+            tail_hash: head_hash_of(&[]),
+            tail_len: 0,
+        },
+        adapter: ClaudeAdapter::empty_adapter_snapshot(),
+        metrics: SessionMetricsAccumulator::new("claude", &session.session_id),
+        evidence: EvidenceSnapshot {
+            record: evidence.coverage_record(),
+            resume: Default::default(),
+        },
+        next_turn_index: 0,
+    };
+
+    let store = MemoryTurnRowStore::new("claude", &session.session_id);
+    let mut composite = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new("claude", &session.session_id),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "claude".to_owned(),
+            session_id: session.session_id.clone(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::claude(),
+        }),
+        TurnRowSink::new(
+            Arc::clone(&store) as Arc<dyn TurnRowStore>,
+            session.session_id.clone(),
+            None,
+        ),
+    );
+    let visit = ClaudeAdapter
+        .visit_claimed_resumed(&input, &claim, &empty_snapshot, &|| false, &mut composite)
+        .expect("full pass over the largest corpus tier must stream");
+    assert_eq!(
+        visit.outcome,
+        antiburn_local::analysis::VisitOutcome::AcceptedFull
+    );
+    composite.observe_source_outcome(visit.outcome);
+    assert!(!composite.turn_row_write_failed());
+    let resume = visit
+        .resume
+        .expect("a settled pass over a quiescent source carries a resume");
+    let snapshot = composite
+        .snapshot(resume)
+        .expect("full pass must publish to snapshot");
+
+    let encoded = snapshot.encode();
+    assert!(
+        encoded.len() <= RESUMED_SNAPSHOT_BYTES_BOUND,
+        "encoded snapshot was {} bytes, bound is {RESUMED_SNAPSHOT_BYTES_BOUND}",
+        encoded.len()
     );
 }

--- a/crates/antiburn-local/tests/support/claude_fixture.rs
+++ b/crates/antiburn-local/tests/support/claude_fixture.rs
@@ -1,3 +1,7 @@
+//! Shared by every test that includes it through `#[path]`. Not every
+//! binary uses every helper here — the same reason `corpus.rs` allows this.
+#![allow(dead_code)]
+
 use std::sync::Arc;
 
 use antiburn_local::analysis::{

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -134,25 +134,46 @@ the full record stream, so evidence must come from rows first.
 
 Goal: an appended 4 KB costs 4 KB.
 
-- Persist per source (parent and each child) the consumed byte offset and a
-  hash of the trailing window before it. On the next change, re-hash that
-  window; on match, stream from the offset and continue the turn index; on
-  mismatch, full pass.
-- Provider-database sources persist a row cursor on the vendor's update
-  column and ingest rows after it.
-- Fence semantics change: the published row set spans passes. The claim fence
-  still guards a full pass; an incremental pass appends under the published
-  fence inside one transaction. The schema revision and the
-  `published_turn_rows` contract are updated together.
-- A parser or analyzer revision bump invalidates every cursor and forces a
-  full pass.
-- Turn the `AppendOnlyGuarantee` from a static assumption into the runtime
-  verification above.
-- Adapter stream state (for example `ClaudeStreamState`) must be persisted per
-  source alongside the offset, or be reconstructable from rows, or the resume
-  falls back to a full pass.
+- The unit of resume is a snapshot, not an offset. State lives in adapters
+  (per-stream buffers like `ClaudeStreamState`), sinks (a reorder window,
+  deferred cache patches, duration heaps), and rows (which cannot rebuild
+  every field). A snapshot bundles the adapter and sink state with the
+  verified byte offset and a hash of the trailing window before it.
+  Restoring it and streaming from the offset must equal a full pass.
+
+Deferred: provider-database sources persist no row cursor here. Their
+fingerprint already gates re-streaming, the stream is a query, and the
+Antigravity blob hash is a discovery cost that phase 4 tiers address.
+
+#### Phase 3a: snapshot resume, crate level
+
+- Snapshot types, an offset reader with tail verification, a
+  `VendorAdapter::visit_claimed_resumed` seam, and a Claude adapter
+  snapshot.
 - Test: parity. Incremental ingest over a transcript grown in steps produces
-  the same rows as one full pass over the final file, for each vendor.
+  the same rows, metrics, summary, and evidence as one full pass over the
+  final file.
+- Codex, Pi, and the provider-database adapters report resume unsupported;
+  a caller falls back to a full pass for them.
+
+#### Phase 3b: snapshot resume, desktop level
+
+- A `source_resume` table persists each source's snapshot. The worker calls
+  the new seam and falls back to a full pass when it returns unsupported or
+  the offset reader detects a change.
+- Fence semantics change: the published row set spans passes. The claim
+  fence still guards a full pass; an incremental pass appends under the
+  published fence inside one transaction. The schema revision and the
+  `published_turn_rows` contract are updated together.
+- A parser, analyzer, metrics, evidence, or coverage revision bump
+  invalidates every snapshot and forces a full pass.
+- Turn the `AppendOnlyGuarantee` from a static assumption into the runtime
+  verification phase 3a adds.
+
+#### Phase 3c: Codex and Pi snapshots
+
+- Extend `visit_claimed_resumed` to `CodexAdapter` and `PiAdapter`, covering
+  Codex's pending fork-row buffer.
 
 ### Phase 4: watcher tiers, events, and the HUD fold-in
 


### PR DESCRIPTION
## Why

Phase 3a of `docs/plans/continuous-session-ingest.md`. The insights worker re-parses a whole transcript from byte zero on every change. To make an appended 4 KB cost 4 KB, a pass must continue from where the last one stopped.

A byte offset alone is not enough. State across records lives in the adapter (Claude's usage dedup, skill names, pending commands, thread resolver), the metrics accumulator (reorder window, deferred cache patches, duration heaps), the evidence accumulator (ordering and thread-link state), and the row sink (next turn index). Some of it is retroactive, and metrics replay from rows omits tool calls and skill uses. So the unit of resume is a snapshot of all of that, taken after the last record and before `finish`. The first commit rewrites phase 3 in the plan to say so and splits it into 3a (this PR, crate only), 3b (desktop store and worker), and 3c (Codex and Pi).

## What

- **Offset reader with tail verification.** `ResumePoint` records the consumed offset plus an FNV hash of the 64 KiB before it. `PinnedSource::open_resumed` rejects a file whose identity, size, head, or tail no longer matches, with a new `ResumeTailMismatch` reason. `reader_from` streams from the offset.
- **Snapshot types.** `StreamSnapshot` bundles the resume point, an opaque adapter payload, the metrics accumulator, the evidence coverage record plus its transient state, and the next turn index. It is versioned by `RESUME_SNAPSHOT_REVISION` and encoded with `postcard`; any decode failure means "not resumable". `CompositeSink::snapshot` assembles it from the state captured before `finish`, which is what makes a resumed pass equal to a full one, chart buckets included.
- **Claude adapter.** `VendorAdapter::visit_claimed_resumed` with a default of unsupported. Claude restores its stream state, streams from the offset, and returns its half of the next snapshot. Codex, Pi, and provider databases keep the default.
- **Parity test.** For a synthetic session cut into five steps and every Claude characterization fixture cut into three, a pass resumed at each step equals a full pass over the file at that step: every turn row and its content, `TurnFacts`, `SessionMetrics` in full, `SessionSummary`, and `SessionEvidence`. Negative cases cover a rewritten tail, a truncation, and a stale revision.

Measured on the 4 MiB corpus tier, the encoded snapshot is about 520 KB, against about 2 MB as JSON. The memory test bounds it at 1100 KiB.

Nothing in `apps/desktop` changes behaviour yet. `postcard` is added with default features off so it does not pull the unmaintained `atomic-polyfill` crate; `cargo deny` stays green.

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast`, `cargo deny --locked check bans licenses advisories` in `crates/antiburn-local`
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` in `apps/desktop/src-tauri`
- `pnpm run slop:all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U73g2iRUFcWZ3ivhoHg8hr
