### PR TITLE
chore(release): prepare antiburn-local 0.4.0

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -17,6 +17,33 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-02
+
+### Added
+
+- `AntigravityAdapter` and `AntigravityExplorer` stream native Antigravity IDE
+  and `agy` session sources with bounded token, model, cache, retry, timing, and
+  tool evidence.
+- `SessionCoverageRecord`, `EvidenceAccumulator::coverage_record`, and
+  `evidence_from_facts` expose a serializable coverage snapshot and row-backed
+  evidence replay contract.
+- Analysis results expose bounded provider and model hints for downstream
+  account attribution.
+
+### Changed
+
+- **Breaking:** `install_runtime_pricing` now returns whether the active catalog
+  changed, and the engine no longer supplies a built-in production pricing
+  catalog. Consumers install a validated runtime catalog before calculating
+  costs.
+- **Breaking:** analysis result and row-sink contracts include coverage and
+  provider-hint data used by persisted evidence replay.
+- Antigravity discovery reads native SQLite and optional brain transcripts,
+  detects source changes, and rejects mixed snapshots instead of publishing
+  inconsistent analysis.
+- Pi, OpenCode, and Antigravity records now retain bounded provider hints for
+  provider-account grouping.
+
 ## [0.3.0] - 2026-09-01
 
 ### Added

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "antiburn-local"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MIT"


### PR DESCRIPTION
## Summary

- release the changed local engine before the desktop 0.3.2 release
- use 0.4.0 because the public analysis contracts gained fields and `install_runtime_pricing` changed its return type
- update both engine and desktop lockfiles to the same engine version
- add consumer-facing notes for native Antigravity analysis, provider hints, persisted evidence replay, and runtime pricing

## Validation

- engine format, Clippy, full unit/integration suite, and doctests
- desktop Rust format, Clippy, and 757 tests
- frontend format, lint, type-check, 1,047 tests, and production build
- `pnpm run slop:all` (100, Healthy)
- `pnpm run secrets`
- third-party notices check
- engine release version verifier and locked Cargo metadata

The engine workflow will create a draft GitHub Release. Publishing remains a separate action after review.