### PR TITLE
chore(release): prepare 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,38 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-09-02
+
+### Added
+
+- Hovering or focusing a provider limit in the tray popover now opens its
+  detailed usage view beside the originating row.
+- Native Antigravity IDE and `agy` sessions now receive local analysis with
+  token, model, cache, retry, timing, and Insights evidence.
+- Settings now exports a bounded diagnostic report that omits transcript
+  content, titles, paths, repository names, and account identifiers.
+- The terminal installer now opens with an animated antiburn wordmark on
+  supported terminals while the release downloads.
+
+### Changed
+
+- Provider usage is now grouped by account for Antigravity, OpenCode, and Pi.
+  Antigravity can also show Google plan limits from the current IDE or CLI login.
+- Model pricing now refreshes from models.dev at startup and hourly, so new
+  models can receive cost estimates without an application update. The last
+  valid catalog remains available when the service cannot be reached.
+- Background scans now continue while the popover is hidden, avoid rereading
+  unchanged session sources, and show the current session list immediately when
+  the popover opens.
+
+### Fixed
+
+- Clicking the tray icon now dismisses the current notification nudge before
+  opening or closing the popover.
+- Long model and thinking-mode lists no longer extend beyond session cards.
+- The macOS terminal installer no longer requests administrator access when the
+  destination is already writable.
+
 ## [0.3.1] - 2026-09-01
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "antiburn-anchored-window",
  "antiburn-hud",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/anchored-window", "crates/hud", "crates/nudge", "crates/sound
 
 [package]
 name = "antiburn"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Summary

- set the desktop application version to `0.3.2`
- add reader-facing notes for native Antigravity support, provider usage previews and account grouping, runtime model pricing, diagnostics export, continuous scanning, installer polish, and fixes
- pin the application lockfile to the released `antiburn-local 0.4.0` engine tree
- prepare the exact final-version artifacts for a draft GitHub Release and local UAT

## Validation

- frontend format, lint, type-check, 1,047 tests, and production build
- desktop Rust format, Clippy, and 757 tests
- engine format, Clippy, full unit/integration suite, and doctests
- `pnpm run slop:all` (100, Healthy)
- `pnpm run secrets`
- third-party notices check
- app release version and engine-release verifiers
- locked Cargo metadata

The release workflow will create a draft GitHub Release. Publishing remains a separate action after UAT.