### PR TITLE
feat(analysis): Codex and Pi resume snapshots (continuous ingest, phase 3c)

### DIFF
--- a/crates/antiburn-local/src/analysis/initial_context.rs
+++ b/crates/antiburn-local/src/analysis/initial_context.rs
@@ -380,7 +380,7 @@ fn parse_codex(payload: &str, catalog: &ToolCatalog) -> InitialContextTokenParse
     InitialContextTokenParseResult::Supported(normalize_breakdown(source_rows))
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct CodexContextAccumulator {
     source_rows: Vec<InitialContextTokenSourceCount>,
     skill_descriptions: HashMap<String, String>,

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -41,6 +41,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Cursor, Read};
 
 use anyhow::Context;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use super::read_source;
@@ -48,13 +49,15 @@ use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, 
 use crate::analysis::initial_context::CodexContextAccumulator;
 use crate::analysis::interface::{
     ContentKind, ContentPart, EvidenceObservation, NormalizedRecord, RawSource, RecordSink,
-    RelationProvenance, SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
+    RelationProvenance, ResumedVisit, SessionInput, SessionSummary, TurnContent, VendorAdapter,
+    VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role, ToolCall, Usage};
 use crate::analysis::records::{
     compact_json_text, concatenated_text, extract_content_parts_from_container, parse_ts,
     tool_call_from_input,
 };
+use crate::analysis::resume::{AdapterResume, StreamSnapshot};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
 
 const MAX_PENDING_FORK_ROWS: usize = 256;
@@ -87,14 +90,22 @@ impl VendorAdapter for CodexAdapter {
         sink: &mut dyn RecordSink,
     ) -> anyhow::Result<VisitOutcome> {
         (|| -> anyhow::Result<VisitOutcome> {
-            let summary = match &input.source {
-                RawSource::File(path) => {
-                    self.visit_reader(BufReader::new(File::open(path)?), &|| false, sink)?
-                }
+            let state = match &input.source {
+                RawSource::File(path) => self.visit_reader(
+                    BufReader::new(File::open(path)?),
+                    &|| false,
+                    sink,
+                    CodexStreamState::default(),
+                )?,
                 RawSource::Jsonl(content) => {
                     let suffix: &[u8] = if content.ends_with('\n') { b"" } else { b"\n" };
                     let source = Cursor::new(content.as_bytes()).chain(suffix);
-                    self.visit_reader(BufReader::new(source), &|| false, sink)?
+                    self.visit_reader(
+                        BufReader::new(source),
+                        &|| false,
+                        sink,
+                        CodexStreamState::default(),
+                    )?
                 }
                 RawSource::Sqlite(path) => {
                     anyhow::bail!(
@@ -103,6 +114,7 @@ impl VendorAdapter for CodexAdapter {
                     )
                 }
             };
+            let summary = state.finish(sink);
             sink.finish(summary);
             Ok(VisitOutcome::Unvalidated)
         })()
@@ -119,9 +131,37 @@ impl VendorAdapter for CodexAdapter {
     ) -> anyhow::Result<VisitOutcome> {
         CodexAdapter::visit_claimed(self, input, claim, guarantee, cancel, sink)
     }
+
+    fn visit_claimed_resumed(
+        &self,
+        input: &SessionInput,
+        claim: &SourceClaim,
+        resume: &StreamSnapshot,
+        cancel: &dyn Fn() -> bool,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<ResumedVisit> {
+        CodexAdapter::visit_claimed_resumed(self, input, claim, resume, cancel, sink)
+    }
+
+    fn empty_resume_state(&self) -> Option<crate::analysis::resume::AdapterSnapshot> {
+        Some(CodexAdapter::empty_adapter_snapshot())
+    }
 }
 
 impl CodexAdapter {
+    /// A fresh [`CodexStreamState`], serialized. Mirrors
+    /// [`crate::analysis::vendors::claude::ClaudeAdapter::empty_adapter_snapshot`]:
+    /// pairs with a [`StreamSnapshot`] whose [`ResumePoint`][rp] offset is
+    /// zero to start the first resumable pass over a source.
+    ///
+    /// [rp]: crate::analysis::source_validity::ResumePoint
+    pub fn empty_adapter_snapshot() -> crate::analysis::resume::AdapterSnapshot {
+        crate::analysis::resume::AdapterSnapshot(
+            postcard::to_allocvec(&CodexStreamState::default())
+                .expect("a default CodexStreamState always encodes"),
+        )
+    }
+
     pub fn visit_claimed(
         &self,
         input: &SessionInput,
@@ -142,7 +182,12 @@ impl CodexAdapter {
                 AppendOnlyGuarantee::Evidenced => claim.boundary,
                 AppendOnlyGuarantee::Absent => u64::MAX,
             };
-            let summary = self.visit_reader(BufReader::new(pinned.reader(limit)), cancel, sink)?;
+            let state = self.visit_reader(
+                BufReader::new(pinned.reader(limit)),
+                cancel,
+                sink,
+                CodexStreamState::default(),
+            )?;
             let outcome = match guarantee {
                 AppendOnlyGuarantee::Evidenced => match pinned.recheck_prefix()? {
                     Some(reason) => VisitOutcome::SourceChanged(reason),
@@ -158,20 +203,119 @@ impl CodexAdapter {
             if matches!(outcome, VisitOutcome::SourceChanged(_)) {
                 return Ok(outcome);
             }
+            let summary = state.finish(sink);
             sink.finish(summary);
             Ok(outcome)
         })()
         .with_context(|| format!("reading claimed Codex session {}", input.session_id))
     }
 
+    /// Streams a file from a verified [`StreamSnapshot`], restoring
+    /// [`CodexStreamState`] from `resume.adapter` and reading only the bytes
+    /// past `resume.resume.offset`. Mirrors
+    /// [`crate::analysis::vendors::claude::ClaudeAdapter::visit_claimed_resumed`]
+    /// exactly; see its doc comment for the full read/recheck/snapshot shape.
+    ///
+    /// "Unsettled" rule: a fork sub-agent rollout's ownership can still be
+    /// [`ForkOwnership::Pending`] at end of stream — the rows in
+    /// `pending_rows` have no proven owner yet. [`CodexStreamState::finish`]
+    /// flushes them as owned so a settled read still publishes every row,
+    /// but a later full pass could resolve the same rows differently (an
+    /// `agent_message` addressed to the child might still arrive). A
+    /// snapshot taken at that point would not reproduce a full pass, so
+    /// this method reports `resume: None` whenever ownership is still
+    /// `Pending` right before `finish` — even though `outcome` is
+    /// [`VisitOutcome::AcceptedFull`] and the sink still finishes normally.
+    /// The next change to this source costs one full pass instead of a
+    /// resume.
+    pub fn visit_claimed_resumed(
+        &self,
+        input: &SessionInput,
+        claim: &SourceClaim,
+        resume: &StreamSnapshot,
+        cancel: &dyn Fn() -> bool,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<ResumedVisit> {
+        (|| -> anyhow::Result<ResumedVisit> {
+            anyhow::ensure!(
+                resume.is_current(),
+                "snapshot revision {} is not current",
+                resume.revision
+            );
+            let RawSource::File(path) = &input.source else {
+                anyhow::bail!("a claimed Codex source must be a file");
+            };
+            let mut pinned = match PinnedSource::open_resumed(path, claim.clone(), &resume.resume)?
+            {
+                Ok(pinned) => pinned,
+                Err(reason) => {
+                    return Ok(ResumedVisit {
+                        outcome: VisitOutcome::SourceChanged(reason),
+                        resume: None,
+                    });
+                }
+            };
+            let initial_state: CodexStreamState = postcard::from_bytes(&resume.adapter.0)
+                .context("decoding Codex adapter snapshot")?;
+            let state = self.visit_reader(
+                BufReader::new(pinned.reader_from(resume.resume.offset, u64::MAX)),
+                cancel,
+                sink,
+                initial_state,
+            )?;
+            let outcome = match pinned.recheck_full()? {
+                Some(reason) => VisitOutcome::SourceChanged(reason),
+                None => VisitOutcome::AcceptedFull,
+            };
+            if matches!(outcome, VisitOutcome::SourceChanged(_)) {
+                return Ok(ResumedVisit {
+                    outcome,
+                    resume: None,
+                });
+            }
+            // See the "unsettled" rule above: pending fork ownership is not
+            // a safe resume point, even though this read still finishes
+            // the sink. The `pending_rows` check is defensive: ownership
+            // stays `Pending` for as long as any row is buffered, so the
+            // two conditions coincide today, but a resume snapshot must
+            // never depend on that coincidence holding.
+            let pending =
+                state.ownership == ForkOwnership::Pending || !state.pending_rows.is_empty();
+            let settled_resume = if pending {
+                None
+            } else {
+                let adapter =
+                    postcard::to_allocvec(&state).context("encoding Codex adapter snapshot")?;
+                let point = pinned.resume_point()?;
+                Some(AdapterResume {
+                    point,
+                    adapter: crate::analysis::resume::AdapterSnapshot(adapter),
+                })
+            };
+            let summary = state.finish(sink);
+            sink.finish(summary);
+            Ok(ResumedVisit {
+                outcome,
+                resume: settled_resume,
+            })
+        })()
+        .with_context(|| format!("reading resumed Codex session {}", input.session_id))
+    }
+
+    /// Streams `reader` starting from `state`, so a resumed pass can carry
+    /// forward the state a prior pass left off with. A first pass starts
+    /// from `CodexStreamState::default()`. Returns the state at the end of
+    /// the stream, not yet reduced to a [`SessionSummary`]: the caller
+    /// decides whether to snapshot it before calling
+    /// [`CodexStreamState::finish`].
     fn visit_reader(
         &self,
         reader: impl BufRead,
         cancel: &dyn Fn() -> bool,
         sink: &mut dyn RecordSink,
-    ) -> anyhow::Result<SessionSummary> {
+        mut state: CodexStreamState,
+    ) -> anyhow::Result<CodexStreamState> {
         let mut reader = BoundedJsonlReader::new(reader);
-        let mut state = CodexStreamState::default();
 
         while let Some(record) = reader.next_record(cancel) {
             match record {
@@ -198,11 +342,11 @@ impl CodexAdapter {
             }
         }
 
-        Ok(state.finish(sink))
+        Ok(state)
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 enum ForkOwnership {
     #[default]
     TopLevel,
@@ -210,14 +354,22 @@ enum ForkOwnership {
     Owned,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 struct CodexStreamState {
     ownership: ForkOwnership,
     agent_path: Option<String>,
+    /// See [`json_text_codec`]: `postcard` cannot decode a `serde_json::Value`
+    /// directly, so this field's wire form is JSON text. Always empty at the
+    /// point [`CodexAdapter::visit_claimed_resumed`] encodes a snapshot (see
+    /// its "unsettled" rule), but the codec must not depend on that: it round
+    /// trips a populated buffer too.
+    #[serde(with = "json_text_codec")]
     pending_rows: Vec<Value>,
     pending_bytes: usize,
     pending_owned_start: Option<usize>,
     fork_attribution_incomplete: bool,
+    /// See [`json_text_codec`].
+    #[serde(with = "json_text_codec")]
     previous_token_count_key: Option<TokenCountKey>,
     previous_event_was_boundary: bool,
     previous_boundary_ts: Option<i64>,
@@ -233,6 +385,40 @@ struct CodexStreamState {
     /// [`CACHE_WRITE_ALIAS_KEYS`] key. See `usage_carries_cache_write`.
     cache_write_tokens_available: bool,
     context: CodexContextAccumulator,
+}
+
+/// Snapshot codec for a `CodexStreamState` field whose type carries
+/// `serde_json::Value` data at any depth (`pending_rows`,
+/// `previous_token_count_key`).
+///
+/// `serde_json::Value`'s `Deserialize` impl calls `deserialize_any`, a
+/// self-describing lookahead `postcard` explicitly does not implement (its
+/// wire format carries no type tags). Encoding a `Value` works either way,
+/// but decoding one back only works through a self-describing format such
+/// as JSON. This module stores the whole field as JSON text on the wire
+/// instead, parsed back through `serde_json`'s own self-describing decoder —
+/// generic over any `T`, so one codec covers every such field.
+mod json_text_codec {
+    use serde::de::DeserializeOwned;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(super) fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+        S: Serializer,
+    {
+        let text = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
+        text.serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: DeserializeOwned,
+        D: Deserializer<'de>,
+    {
+        let text = String::deserialize(deserializer)?;
+        serde_json::from_str(&text).map_err(serde::de::Error::custom)
+    }
 }
 
 impl CodexStreamState {
@@ -2402,5 +2588,359 @@ mod tests {
             .expect("visit spawn-other-name session");
 
         assert!(spawn_agent_observations(&sink).is_empty());
+    }
+
+    /* ------------------------------------------------------------------
+     * Resume snapshots.
+     * ------------------------------------------------------------------ */
+
+    mod resume_snapshots {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+        use std::path::{Path, PathBuf};
+
+        use tempfile::TempDir;
+
+        use super::*;
+        use crate::analysis::evidence::{EvidenceSource, SourceCapabilities, SourceKind};
+        use crate::analysis::evidence_sink::{EvidenceResumeState, SessionEvidenceAccumulator};
+        use crate::analysis::metrics_sink::SessionMetricsAccumulator;
+        use crate::analysis::resume::EvidenceSnapshot;
+        use crate::analysis::source_validity::ResumePoint;
+        use crate::analysis::{RESUME_SNAPSHOT_REVISION, SourceChangedReason};
+        use crate::discovery::source_version::head_hash_of;
+        use crate::discovery::{FingerprintInputs, SourceStat};
+
+        const FIRST_RECORD: &str = concat!(
+            r#"{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first"}]}}"#,
+            "\n",
+        );
+        const SECOND_RECORD: &str = concat!(
+            r#"{"timestamp":"2026-01-01T00:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"second"}]}}"#,
+            "\n",
+        );
+
+        fn file_input(path: &Path) -> SessionInput {
+            SessionInput {
+                agent: "codex".to_string(),
+                session_id: "claimed-session".to_string(),
+                source: RawSource::File(path.to_path_buf()),
+            }
+        }
+
+        fn claim_for_path(path: &Path) -> SourceClaim {
+            let file = File::open(path).expect("open source for claim");
+            let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+            let bytes = std::fs::read(path).expect("read source for claim");
+            SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+                stat,
+                head_hash: Some(head_hash_of(&bytes)),
+            })
+        }
+
+        fn write_source(directory: &TempDir, bytes: &[u8]) -> PathBuf {
+            let path = directory.path().join("session.jsonl");
+            std::fs::write(&path, bytes).expect("write source");
+            path
+        }
+
+        /// A full [`StreamSnapshot`] around `resume` (the adapter's own
+        /// half), with fresh metrics/evidence/index state. Mirrors
+        /// `claude.rs`'s test helper of the same name.
+        fn snapshot_from(resume: AdapterResume) -> StreamSnapshot {
+            let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+                agent: "codex".to_owned(),
+                session_id: "claimed-session".to_owned(),
+                kind: SourceKind::Jsonl,
+                capabilities: SourceCapabilities::codex(),
+            });
+            StreamSnapshot {
+                revision: RESUME_SNAPSHOT_REVISION,
+                resume: resume.point,
+                adapter: resume.adapter,
+                metrics: SessionMetricsAccumulator::new("codex", "claimed-session"),
+                evidence: EvidenceSnapshot {
+                    record: evidence.coverage_record(),
+                    resume: EvidenceResumeState::default(),
+                },
+                next_turn_index: 0,
+            }
+        }
+
+        /// A snapshot at offset zero, ready to resume a whole file from its
+        /// start: [`PinnedSource::open_resumed`]'s offset-zero case.
+        fn fresh_snapshot() -> StreamSnapshot {
+            snapshot_from(AdapterResume {
+                point: ResumePoint {
+                    offset: 0,
+                    tail_hash: head_hash_of(&[]),
+                    tail_len: 0,
+                },
+                adapter: CodexAdapter::empty_adapter_snapshot(),
+            })
+        }
+
+        #[test]
+        fn a_resumed_read_from_offset_zero_matches_a_full_read() {
+            let directory = TempDir::new().expect("tempdir");
+            let path = write_source(&directory, FIRST_RECORD.as_bytes());
+            let claim = claim_for_path(&path);
+            let input = file_input(&path);
+            let mut collector = SessionCollector::new("codex", "claimed-session");
+
+            let visit = CodexAdapter
+                .visit_claimed_resumed(&input, &claim, &fresh_snapshot(), &|| false, &mut collector)
+                .expect("resumed visit of a fresh file");
+
+            assert_eq!(visit.outcome, VisitOutcome::AcceptedFull);
+            let resume = visit.resume.expect("a settled pass carries a resume");
+            assert_eq!(resume.point.offset, FIRST_RECORD.len() as u64);
+            assert_eq!(
+                collector
+                    .into_session()
+                    .expect("resumed read must publish")
+                    .events
+                    .len(),
+                1
+            );
+        }
+
+        #[test]
+        fn a_second_resumed_read_continues_from_the_first_snapshot() {
+            let directory = TempDir::new().expect("tempdir");
+            let path = write_source(&directory, FIRST_RECORD.as_bytes());
+            let input = file_input(&path);
+            let mut first_pass = SessionCollector::new("codex", "claimed-session");
+            let first_claim = claim_for_path(&path);
+            let first_visit = CodexAdapter
+                .visit_claimed_resumed(
+                    &input,
+                    &first_claim,
+                    &fresh_snapshot(),
+                    &|| false,
+                    &mut first_pass,
+                )
+                .expect("first resumed visit");
+            let resume = first_visit.resume.expect("a settled pass carries a resume");
+            let snapshot = snapshot_from(resume);
+
+            OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .expect("open source for append")
+                .write_all(SECOND_RECORD.as_bytes())
+                .expect("append second record");
+            let second_claim = claim_for_path(&path);
+            let mut second_pass = SessionCollector::new("codex", "claimed-session");
+
+            let second_visit = CodexAdapter
+                .visit_claimed_resumed(
+                    &input,
+                    &second_claim,
+                    &snapshot,
+                    &|| false,
+                    &mut second_pass,
+                )
+                .expect("second resumed visit");
+
+            assert_eq!(second_visit.outcome, VisitOutcome::AcceptedFull);
+            assert_eq!(
+                second_pass
+                    .into_session()
+                    .expect("resumed read must publish")
+                    .events
+                    .len(),
+                1,
+                "the resumed pass reads only the newly appended record"
+            );
+        }
+
+        #[test]
+        fn a_rewritten_tail_fails_a_resumed_read_without_a_snapshot() {
+            let directory = TempDir::new().expect("tempdir");
+            let path = write_source(&directory, FIRST_RECORD.as_bytes());
+            let input = file_input(&path);
+            let first_claim = claim_for_path(&path);
+            let mut first_pass = SessionCollector::new("codex", "claimed-session");
+            let first_visit = CodexAdapter
+                .visit_claimed_resumed(
+                    &input,
+                    &first_claim,
+                    &fresh_snapshot(),
+                    &|| false,
+                    &mut first_pass,
+                )
+                .expect("first resumed visit");
+            let resume = first_visit.resume.expect("a settled pass carries a resume");
+            let snapshot = snapshot_from(resume);
+
+            // Same identity, a rewritten tail: the old snapshot's offset now
+            // points past a rewritten byte instead of an append. Re-claiming
+            // against the rewritten content isolates that check from the
+            // unrelated head-region check `open_resumed` also runs.
+            std::fs::write(&path, SECOND_RECORD.as_bytes()).expect("rewrite source");
+            let rewritten_claim = claim_for_path(&path);
+            let mut second_pass = SessionCollector::new("codex", "claimed-session");
+
+            let visit = CodexAdapter
+                .visit_claimed_resumed(
+                    &input,
+                    &rewritten_claim,
+                    &snapshot,
+                    &|| false,
+                    &mut second_pass,
+                )
+                .expect("resumed visit of a rewritten source");
+
+            assert_eq!(
+                visit.outcome,
+                VisitOutcome::SourceChanged(SourceChangedReason::ResumeTailMismatch)
+            );
+            assert!(visit.resume.is_none());
+            assert!(second_pass.into_session().is_err());
+        }
+
+        /// A subagent rollout whose ownership is still `Pending` at EOF (no
+        /// `agent_message` ever addresses the child): the "unsettled" rule
+        /// on `visit_claimed_resumed`. The read still settles
+        /// (`AcceptedFull`, and the sink still publishes the buffered rows
+        /// `finish` flushes), but no resume snapshot comes back — a later
+        /// full pass could still resolve those rows differently.
+        #[test]
+        fn a_pending_fork_at_eof_settles_but_carries_no_resume_snapshot() {
+            let jsonl = include_str!(
+                "../../../tests/fixtures/codex_characterization/unresolved_fork.jsonl"
+            );
+            let directory = TempDir::new().expect("tempdir");
+            let path = write_source(&directory, jsonl.as_bytes());
+            let claim = claim_for_path(&path);
+            let input = file_input(&path);
+            let mut collector = SessionCollector::new("codex", "claimed-session");
+
+            let visit = CodexAdapter
+                .visit_claimed_resumed(&input, &claim, &fresh_snapshot(), &|| false, &mut collector)
+                .expect("resumed visit of a pending fork");
+
+            assert_eq!(visit.outcome, VisitOutcome::AcceptedFull);
+            assert!(
+                visit.resume.is_none(),
+                "pending fork ownership at EOF must not carry a resume snapshot"
+            );
+            assert!(
+                !collector
+                    .into_session()
+                    .expect("a settled pass still publishes")
+                    .events
+                    .is_empty(),
+                "finish still flushes the pending rows as owned"
+            );
+        }
+
+        /// After a pending fork's first resumed pass reports no snapshot,
+        /// a later append that resolves ownership (an `agent_message`
+        /// addressed to the child) is picked up by a fresh bootstrap pass
+        /// — offset zero, a fresh adapter state — which does produce a
+        /// resume snapshot once ownership settles to `Owned`.
+        #[test]
+        fn a_later_append_that_resolves_ownership_lets_a_fresh_bootstrap_pass_snapshot() {
+            let jsonl = include_str!(
+                "../../../tests/fixtures/codex_characterization/unresolved_fork.jsonl"
+            );
+            let directory = TempDir::new().expect("tempdir");
+            let path = write_source(&directory, jsonl.as_bytes());
+            let claim = claim_for_path(&path);
+            let input = file_input(&path);
+            let mut first_pass = SessionCollector::new("codex", "claimed-session");
+            let first_visit = CodexAdapter
+                .visit_claimed_resumed(
+                    &input,
+                    &claim,
+                    &fresh_snapshot(),
+                    &|| false,
+                    &mut first_pass,
+                )
+                .expect("resumed visit of a pending fork");
+            assert!(first_visit.resume.is_none());
+
+            let resolving = concat!(
+                r#"{"timestamp":"2026-08-06T10:00:03Z","type":"event_msg","payload":{"type":"task_started"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-08-06T10:00:04Z","type":"response_item","payload":{"type":"agent_message","author":"parent","recipient":"worker","content":[{"type":"input_text","text":"Handle the synthetic task."}]}}"#,
+                "\n",
+            );
+            OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .expect("open source for append")
+                .write_all(resolving.as_bytes())
+                .expect("append resolving records");
+
+            // A fresh bootstrap pass: offset zero, a fresh adapter state —
+            // the fallback the desktop worker and the parity harness use
+            // whenever a resumed pass carries no snapshot forward.
+            let bootstrap_claim = claim_for_path(&path);
+            let mut second_pass = SessionCollector::new("codex", "claimed-session");
+            let second_visit = CodexAdapter
+                .visit_claimed_resumed(
+                    &input,
+                    &bootstrap_claim,
+                    &fresh_snapshot(),
+                    &|| false,
+                    &mut second_pass,
+                )
+                .expect("fresh bootstrap pass over the resolved fork");
+
+            assert_eq!(second_visit.outcome, VisitOutcome::AcceptedFull);
+            assert!(
+                second_visit.resume.is_some(),
+                "ownership resolved to Owned by EOF must carry a resume snapshot"
+            );
+        }
+
+        /// `pending_rows` must round-trip through a `StreamSnapshot` even
+        /// when populated: `visit_claimed_resumed` never encodes a state
+        /// whose buffer is non-empty today (see the "unsettled" rule), but
+        /// the codec itself must not depend on that invariant holding.
+        #[test]
+        fn a_populated_pending_rows_buffer_round_trips_through_a_stream_snapshot() {
+            let state = CodexStreamState {
+                ownership: ForkOwnership::Pending,
+                pending_rows: vec![
+                    serde_json::json!({
+                        "type": "session_meta",
+                        "payload": {"id": "synthetic", "thread_source": "subagent"}
+                    }),
+                    serde_json::json!({
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "token_count",
+                            "info": {"last_token_usage": {"input_tokens": 5}}
+                        }
+                    }),
+                ],
+                pending_bytes: 42,
+                ..Default::default()
+            };
+
+            let adapter_bytes =
+                postcard::to_allocvec(&state).expect("a populated CodexStreamState always encodes");
+            let snapshot = snapshot_from(AdapterResume {
+                point: ResumePoint {
+                    offset: 0,
+                    tail_hash: head_hash_of(&[]),
+                    tail_len: 0,
+                },
+                adapter: crate::analysis::resume::AdapterSnapshot(adapter_bytes),
+            });
+
+            let encoded = snapshot.encode();
+            let decoded = StreamSnapshot::decode(&encoded).expect("decode stream snapshot");
+            let decoded_state: CodexStreamState = postcard::from_bytes(&decoded.adapter.0)
+                .expect("decode codex adapter snapshot with a populated pending_rows buffer");
+
+            assert_eq!(decoded_state.ownership, ForkOwnership::Pending);
+            assert_eq!(decoded_state.pending_rows, state.pending_rows);
+            assert_eq!(decoded_state.pending_bytes, state.pending_bytes);
+        }
     }
 }

--- a/crates/antiburn-local/src/analysis/vendors/pi.rs
+++ b/crates/antiburn-local/src/analysis/vendors/pi.rs
@@ -18,18 +18,20 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Cursor, Read};
 
 use anyhow::Context;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::interface::{
     ContentPart, EvidenceObservation, NormalizedRecord, ProviderHint, RawSource, RecordSink,
-    SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
-    bounded_provider_hint_value, push_provider_hint,
+    ResumedVisit, SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter,
+    VisitOutcome, bounded_provider_hint_value, push_provider_hint,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role};
 use crate::analysis::records::{
     RecordShape, extract_content_parts, parse_record, parse_ts, thread_identity_field,
 };
+use crate::analysis::resume::{AdapterResume, StreamSnapshot};
 use crate::analysis::source_validity::{AppendOnlyGuarantee, PinnedSource, SourceClaim};
 use crate::analysis::threads::ThreadResolver;
 
@@ -53,20 +55,28 @@ impl VendorAdapter for PiAdapter {
         sink: &mut dyn RecordSink,
     ) -> anyhow::Result<VisitOutcome> {
         (|| -> anyhow::Result<VisitOutcome> {
-            let summary = match &input.source {
-                RawSource::File(path) => {
-                    self.visit_reader(BufReader::new(File::open(path)?), &|| false, sink)?
-                }
+            let state = match &input.source {
+                RawSource::File(path) => self.visit_reader(
+                    BufReader::new(File::open(path)?),
+                    &|| false,
+                    sink,
+                    PiStreamState::default(),
+                )?,
                 RawSource::Jsonl(content) => {
                     let suffix: &[u8] = if content.ends_with('\n') { b"" } else { b"\n" };
                     let source = Cursor::new(content.as_bytes()).chain(suffix);
-                    self.visit_reader(BufReader::new(source), &|| false, sink)?
+                    self.visit_reader(
+                        BufReader::new(source),
+                        &|| false,
+                        sink,
+                        PiStreamState::default(),
+                    )?
                 }
                 RawSource::Sqlite(_) => {
                     anyhow::bail!("sqlite source must be handled by the sqlite adapter")
                 }
             };
-            sink.finish(summary);
+            sink.finish(state.finish());
             Ok(VisitOutcome::Unvalidated)
         })()
         .context("reading Pi session")
@@ -82,9 +92,37 @@ impl VendorAdapter for PiAdapter {
     ) -> anyhow::Result<VisitOutcome> {
         PiAdapter::visit_claimed(self, input, claim, guarantee, cancel, sink)
     }
+
+    fn visit_claimed_resumed(
+        &self,
+        input: &SessionInput,
+        claim: &SourceClaim,
+        resume: &StreamSnapshot,
+        cancel: &dyn Fn() -> bool,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<ResumedVisit> {
+        PiAdapter::visit_claimed_resumed(self, input, claim, resume, cancel, sink)
+    }
+
+    fn empty_resume_state(&self) -> Option<crate::analysis::resume::AdapterSnapshot> {
+        Some(PiAdapter::empty_adapter_snapshot())
+    }
 }
 
 impl PiAdapter {
+    /// A fresh [`PiStreamState`], serialized. Mirrors
+    /// [`crate::analysis::vendors::claude::ClaudeAdapter::empty_adapter_snapshot`]:
+    /// pairs with a [`StreamSnapshot`] whose [`ResumePoint`][rp] offset is
+    /// zero to start the first resumable pass over a source.
+    ///
+    /// [rp]: crate::analysis::source_validity::ResumePoint
+    pub fn empty_adapter_snapshot() -> crate::analysis::resume::AdapterSnapshot {
+        crate::analysis::resume::AdapterSnapshot(
+            postcard::to_allocvec(&PiStreamState::default())
+                .expect("a default PiStreamState always encodes"),
+        )
+    }
+
     pub fn visit_claimed(
         &self,
         input: &SessionInput,
@@ -105,7 +143,12 @@ impl PiAdapter {
                 AppendOnlyGuarantee::Evidenced => claim.boundary,
                 AppendOnlyGuarantee::Absent => u64::MAX,
             };
-            let summary = self.visit_reader(BufReader::new(pinned.reader(limit)), cancel, sink)?;
+            let state = self.visit_reader(
+                BufReader::new(pinned.reader(limit)),
+                cancel,
+                sink,
+                PiStreamState::default(),
+            )?;
             let outcome = match guarantee {
                 AppendOnlyGuarantee::Evidenced => match pinned.recheck_prefix()? {
                     Some(reason) => VisitOutcome::SourceChanged(reason),
@@ -121,20 +164,96 @@ impl PiAdapter {
             if matches!(outcome, VisitOutcome::SourceChanged(_)) {
                 return Ok(outcome);
             }
-            sink.finish(summary);
+            sink.finish(state.finish());
             Ok(outcome)
         })()
         .context("reading claimed Pi session")
     }
 
+    /// Streams a file from a verified [`StreamSnapshot`], restoring
+    /// [`PiStreamState`] from `resume.adapter` and reading only the bytes
+    /// past `resume.resume.offset`. Mirrors
+    /// [`crate::analysis::vendors::claude::ClaudeAdapter::visit_claimed_resumed`]
+    /// exactly; see its doc comment for the full read/recheck/snapshot shape.
+    ///
+    /// "Unsettled" rule: Pi has no case where its end-of-stream state is
+    /// unsafe to resume from. [`PiStreamState`] is forward-only — every
+    /// field only ever advances to a later observed value — so a resumed
+    /// pass keeps building it exactly as a single continuous pass would.
+    /// This method's `resume` is `None` only when `outcome` is
+    /// [`VisitOutcome::SourceChanged`].
+    pub fn visit_claimed_resumed(
+        &self,
+        input: &SessionInput,
+        claim: &SourceClaim,
+        resume: &StreamSnapshot,
+        cancel: &dyn Fn() -> bool,
+        sink: &mut dyn RecordSink,
+    ) -> anyhow::Result<ResumedVisit> {
+        (|| -> anyhow::Result<ResumedVisit> {
+            anyhow::ensure!(
+                resume.is_current(),
+                "snapshot revision {} is not current",
+                resume.revision
+            );
+            let RawSource::File(path) = &input.source else {
+                anyhow::bail!("a claimed Pi source must be a file");
+            };
+            let mut pinned = match PinnedSource::open_resumed(path, claim.clone(), &resume.resume)?
+            {
+                Ok(pinned) => pinned,
+                Err(reason) => {
+                    return Ok(ResumedVisit {
+                        outcome: VisitOutcome::SourceChanged(reason),
+                        resume: None,
+                    });
+                }
+            };
+            let initial_state: PiStreamState =
+                postcard::from_bytes(&resume.adapter.0).context("decoding Pi adapter snapshot")?;
+            let state = self.visit_reader(
+                BufReader::new(pinned.reader_from(resume.resume.offset, u64::MAX)),
+                cancel,
+                sink,
+                initial_state,
+            )?;
+            let outcome = match pinned.recheck_full()? {
+                Some(reason) => VisitOutcome::SourceChanged(reason),
+                None => VisitOutcome::AcceptedFull,
+            };
+            if matches!(outcome, VisitOutcome::SourceChanged(_)) {
+                return Ok(ResumedVisit {
+                    outcome,
+                    resume: None,
+                });
+            }
+            let adapter = postcard::to_allocvec(&state).context("encoding Pi adapter snapshot")?;
+            let new_resume = pinned.resume_point()?;
+            sink.finish(state.finish());
+            Ok(ResumedVisit {
+                outcome,
+                resume: Some(AdapterResume {
+                    point: new_resume,
+                    adapter: crate::analysis::resume::AdapterSnapshot(adapter),
+                }),
+            })
+        })()
+        .context("reading resumed Pi session")
+    }
+
+    /// Streams `reader` starting from `state`, so a resumed pass can carry
+    /// forward the state a prior pass left off with. A first pass starts
+    /// from `PiStreamState::default()`. Returns the state at the end of the
+    /// stream, not yet reduced to a [`SessionSummary`]: the caller decides
+    /// whether to snapshot it before calling [`PiStreamState::finish`].
     fn visit_reader(
         &self,
         reader: impl BufRead,
         cancel: &dyn Fn() -> bool,
         sink: &mut dyn RecordSink,
-    ) -> anyhow::Result<SessionSummary> {
+        mut state: PiStreamState,
+    ) -> anyhow::Result<PiStreamState> {
         let mut reader = BoundedJsonlReader::new(reader);
-        let mut state = PiStreamState::default();
 
         while let Some(record) = reader.next_record(cancel) {
             match record {
@@ -161,11 +280,11 @@ impl PiAdapter {
             }
         }
 
-        Ok(state.finish())
+        Ok(state)
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 struct PiStreamState {
     model: Option<String>,
     current_model: Option<String>,
@@ -609,11 +728,213 @@ fn unknown_content_blocks(value: &Value) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
     use serde_json::json;
 
     use super::*;
+    use crate::analysis::evidence::{EvidenceSource, SourceCapabilities, SourceKind};
+    use crate::analysis::evidence_sink::{EvidenceResumeState, SessionEvidenceAccumulator};
     use crate::analysis::interface::ContentKind;
+    use crate::analysis::metrics_sink::SessionMetricsAccumulator;
     use crate::analysis::model::ToolCategory;
+    use crate::analysis::resume::EvidenceSnapshot;
+    use crate::analysis::source_validity::ResumePoint;
+    use crate::analysis::{RESUME_SNAPSHOT_REVISION, SourceChangedReason};
+    use crate::discovery::source_version::head_hash_of;
+    use crate::discovery::{FingerprintInputs, SourceStat};
+    use tempfile::TempDir;
+
+    const FIRST_RECORD: &str = concat!(
+        r#"{"type":"message","timestamp":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"first"}]}}"#,
+        "\n",
+    );
+    const SECOND_RECORD: &str = concat!(
+        r#"{"type":"message","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"second"}]}}"#,
+        "\n",
+    );
+
+    fn file_input(path: &Path) -> SessionInput {
+        SessionInput {
+            agent: "pi".to_string(),
+            session_id: "claimed-session".to_string(),
+            source: RawSource::File(path.to_path_buf()),
+        }
+    }
+
+    fn claim_for_path(path: &Path) -> SourceClaim {
+        let file = File::open(path).expect("open source for claim");
+        let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+        let bytes = std::fs::read(path).expect("read source for claim");
+        SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+            stat,
+            head_hash: Some(head_hash_of(&bytes)),
+        })
+    }
+
+    fn write_source(directory: &TempDir, bytes: &[u8]) -> PathBuf {
+        let path = directory.path().join("session.jsonl");
+        std::fs::write(&path, bytes).expect("write source");
+        path
+    }
+
+    /// A full [`StreamSnapshot`] around `resume` (the adapter's own half),
+    /// with fresh metrics/evidence/index state. Mirrors
+    /// `claude.rs`'s test helper of the same name.
+    fn snapshot_from(resume: AdapterResume) -> StreamSnapshot {
+        let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "pi".to_owned(),
+            session_id: "claimed-session".to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::pi(),
+        });
+        StreamSnapshot {
+            revision: RESUME_SNAPSHOT_REVISION,
+            resume: resume.point,
+            adapter: resume.adapter,
+            metrics: SessionMetricsAccumulator::new("pi", "claimed-session"),
+            evidence: EvidenceSnapshot {
+                record: evidence.coverage_record(),
+                resume: EvidenceResumeState::default(),
+            },
+            next_turn_index: 0,
+        }
+    }
+
+    /// A snapshot at offset zero, ready to resume a whole file from its
+    /// start: [`PinnedSource::open_resumed`]'s offset-zero case.
+    fn fresh_snapshot() -> StreamSnapshot {
+        snapshot_from(AdapterResume {
+            point: ResumePoint {
+                offset: 0,
+                tail_hash: head_hash_of(&[]),
+                tail_len: 0,
+            },
+            adapter: PiAdapter::empty_adapter_snapshot(),
+        })
+    }
+
+    #[test]
+    fn a_resumed_read_from_offset_zero_matches_a_full_read() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let claim = claim_for_path(&path);
+        let input = file_input(&path);
+        let mut collector = SessionCollector::new("pi", "claimed-session");
+
+        let visit = PiAdapter
+            .visit_claimed_resumed(&input, &claim, &fresh_snapshot(), &|| false, &mut collector)
+            .expect("resumed visit of a fresh file");
+
+        assert_eq!(visit.outcome, VisitOutcome::AcceptedFull);
+        let resume = visit.resume.expect("a settled pass carries a resume");
+        assert_eq!(resume.point.offset, FIRST_RECORD.len() as u64);
+        assert_eq!(
+            collector
+                .into_session()
+                .expect("resumed read must publish")
+                .events
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_second_resumed_read_continues_from_the_first_snapshot() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let input = file_input(&path);
+        let mut first_pass = SessionCollector::new("pi", "claimed-session");
+        let first_claim = claim_for_path(&path);
+        let first_visit = PiAdapter
+            .visit_claimed_resumed(
+                &input,
+                &first_claim,
+                &fresh_snapshot(),
+                &|| false,
+                &mut first_pass,
+            )
+            .expect("first resumed visit");
+        let resume = first_visit.resume.expect("a settled pass carries a resume");
+        let snapshot = snapshot_from(resume);
+
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open source for append")
+            .write_all(SECOND_RECORD.as_bytes())
+            .expect("append second record");
+        let second_claim = claim_for_path(&path);
+        let mut second_pass = SessionCollector::new("pi", "claimed-session");
+
+        let second_visit = PiAdapter
+            .visit_claimed_resumed(
+                &input,
+                &second_claim,
+                &snapshot,
+                &|| false,
+                &mut second_pass,
+            )
+            .expect("second resumed visit");
+
+        assert_eq!(second_visit.outcome, VisitOutcome::AcceptedFull);
+        assert_eq!(
+            second_pass
+                .into_session()
+                .expect("resumed read must publish")
+                .events
+                .len(),
+            1,
+            "the resumed pass reads only the newly appended record"
+        );
+    }
+
+    #[test]
+    fn a_rewritten_tail_fails_a_resumed_read_without_a_snapshot() {
+        let directory = TempDir::new().expect("tempdir");
+        let path = write_source(&directory, FIRST_RECORD.as_bytes());
+        let input = file_input(&path);
+        let first_claim = claim_for_path(&path);
+        let mut first_pass = SessionCollector::new("pi", "claimed-session");
+        let first_visit = PiAdapter
+            .visit_claimed_resumed(
+                &input,
+                &first_claim,
+                &fresh_snapshot(),
+                &|| false,
+                &mut first_pass,
+            )
+            .expect("first resumed visit");
+        let resume = first_visit.resume.expect("a settled pass carries a resume");
+        let snapshot = snapshot_from(resume);
+
+        // Same identity, a rewritten tail: the old snapshot's offset now
+        // points past a rewritten byte instead of an append. Re-claiming
+        // against the rewritten content isolates that check from the
+        // unrelated head-region check `open_resumed` also runs.
+        std::fs::write(&path, SECOND_RECORD.as_bytes()).expect("rewrite source");
+        let rewritten_claim = claim_for_path(&path);
+        let mut second_pass = SessionCollector::new("pi", "claimed-session");
+
+        let visit = PiAdapter
+            .visit_claimed_resumed(
+                &input,
+                &rewritten_claim,
+                &snapshot,
+                &|| false,
+                &mut second_pass,
+            )
+            .expect("resumed visit of a rewritten source");
+
+        assert_eq!(
+            visit.outcome,
+            VisitOutcome::SourceChanged(SourceChangedReason::ResumeTailMismatch)
+        );
+        assert!(visit.resume.is_none());
+        assert!(second_pass.into_session().is_err());
+    }
 
     #[derive(Default)]
     struct SummarySink {

--- a/crates/antiburn-local/tests/resume_parity.rs
+++ b/crates/antiburn-local/tests/resume_parity.rs
@@ -31,7 +31,7 @@ use antiburn_local::analysis::{
     FenceScope, MemoryTurnRowStore, RESUME_SNAPSHOT_REVISION, RawSource, ResumePoint,
     SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SourceCapabilities,
     SourceChangedReason, SourceClaim, SourceKind, StreamSnapshot, TurnRowSink, TurnRowStore,
-    TurnSessionKey, VisitOutcome, query_turn_facts, query_turn_rows,
+    TurnSessionKey, VisitOutcome, adapter_for, query_turn_facts, query_turn_rows,
 };
 use antiburn_local::discovery::source_version::head_hash_of;
 use antiburn_local::discovery::{FingerprintInputs, SourceStat};
@@ -56,8 +56,8 @@ fn claim_for(path: &Path) -> SourceClaim {
 
 /// A [`StreamSnapshot`] ready to start the very first resumable pass over a
 /// source: [`ResumePoint`] offset zero (an empty tail, so
-/// `PinnedSource::open_resumed` resumes as a full read) and a fresh
-/// [`ClaudeAdapter`] state.
+/// `PinnedSource::open_resumed` resumes as a full read) and `agent`'s own
+/// fresh adapter state.
 fn fresh_snapshot(
     agent: &str,
     session_id: &str,
@@ -76,7 +76,9 @@ fn fresh_snapshot(
             tail_hash: head_hash_of(&[]),
             tail_len: 0,
         },
-        adapter: ClaudeAdapter::empty_adapter_snapshot(),
+        adapter: adapter_for(agent)
+            .empty_resume_state()
+            .expect("adapter under test must support resume"),
         metrics: SessionMetricsAccumulator::new(agent, session_id),
         evidence: EvidenceSnapshot {
             record: evidence.coverage_record(),
@@ -209,7 +211,7 @@ fn run_full_pass(
     );
     let input = session_input(agent, session_id, path);
     let claim = claim_for(path);
-    let outcome = ClaudeAdapter
+    let outcome = adapter_for(agent)
         .visit_claimed(
             &input,
             &claim,
@@ -250,6 +252,13 @@ fn run_full_pass(
 /// `path`, and at every step compares the resumed path (a snapshot carried
 /// forward from `S0`) against the full path (one fresh `visit_claimed` over
 /// that step's whole content).
+///
+/// A step whose resumed visit carries no snapshot forward (`visit.resume`
+/// is `None` — an adapter's "unsettled" rule, such as Codex fork ownership
+/// still `Pending` at EOF) still settles and still must match the full pass
+/// for that step. The next step then starts from a fresh bootstrap pass
+/// instead of a continuation: a fresh store and a fresh, offset-zero
+/// snapshot, exactly the fallback a caller with no stored snapshot takes.
 fn assert_resume_parity(
     agent: &str,
     session_id: &str,
@@ -259,8 +268,9 @@ fn assert_resume_parity(
     assert!(!steps.is_empty(), "at least one step is required");
     let directory = TempDir::new().expect("tempdir");
     let path = directory.path().join("session.jsonl");
+    let adapter = adapter_for(agent);
 
-    let resumed_store = MemoryTurnRowStore::new(agent, session_id);
+    let mut resumed_store = MemoryTurnRowStore::new(agent, session_id);
     let mut snapshot = fresh_snapshot(agent, session_id, capabilities);
 
     for (index, step) in steps.iter().enumerate() {
@@ -269,7 +279,7 @@ fn assert_resume_parity(
         let claim = claim_for(&path);
 
         let mut resumed = restored_composite(&resumed_store, session_id, &snapshot);
-        let visit = ClaudeAdapter
+        let visit = adapter
             .visit_claimed_resumed(&input, &claim, &snapshot, &|| false, &mut resumed)
             .unwrap_or_else(|error| {
                 panic!("{agent}/{session_id} step {index}: resumed visit failed: {error:?}")
@@ -337,12 +347,19 @@ fn assert_resume_parity(
             "{agent}/{session_id} step {index}: SessionEvidence"
         );
 
-        let resume = visit
-            .resume
-            .expect("a settled pass over a quiescent source carries a resume");
-        snapshot = resumed
-            .snapshot(resume)
-            .expect("resumed pass must publish a snapshot to carry state forward");
+        match visit.resume {
+            Some(resume) => {
+                snapshot = resumed.snapshot(resume).unwrap_or_else(|| {
+                    panic!(
+                        "{agent}/{session_id} step {index}: resumed pass must publish a snapshot to carry state forward"
+                    )
+                });
+            }
+            None => {
+                resumed_store = MemoryTurnRowStore::new(agent, session_id);
+                snapshot = fresh_snapshot(agent, session_id, capabilities);
+            }
+        }
     }
 }
 
@@ -408,6 +425,72 @@ fn every_claude_characterization_fixture_resumes_identically_in_three_steps() {
             "claude",
             &format!("resume-{name}"),
             SourceCapabilities::claude(),
+            &steps,
+        );
+    }
+}
+
+/// Every `.jsonl` fixture name (without extension) directly inside
+/// `tests/fixtures/<dir>/`, sorted for a stable sweep order. Unlike
+/// `claude_fixture_names`'s curated list, the Codex and Pi sweeps below
+/// cover every fixture their directory holds.
+fn characterization_fixture_names(dir: &str) -> Vec<String> {
+    let base = format!("{}/tests/fixtures/{dir}", env!("CARGO_MANIFEST_DIR"));
+    let mut names: Vec<String> = std::fs::read_dir(&base)
+        .unwrap_or_else(|error| panic!("read fixture dir {base}: {error}"))
+        .map(|entry| entry.expect("read fixture dir entry").path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("jsonl"))
+        .map(|path| {
+            path.file_stem()
+                .expect("fixture file has a stem")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+fn characterization_fixture(dir: &str, name: &str) -> String {
+    let path = format!(
+        "{}/tests/fixtures/{dir}/{name}.jsonl",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(path).expect("fixture must be readable")
+}
+
+/// Every Codex characterization fixture, cut into three record-aligned
+/// steps. A fixture whose fork ownership is still `Pending` at some cut
+/// point exercises the "resume: None → fresh bootstrap pass" fallback in
+/// [`assert_resume_parity`]; see `unresolved_fork` and `resolved_fork`.
+#[test]
+fn every_codex_characterization_fixture_resumes_identically_in_three_steps() {
+    for name in characterization_fixture_names("codex_characterization") {
+        let jsonl = characterization_fixture("codex_characterization", &name);
+        let record_count = jsonl.lines().count();
+        let step_count = record_count.min(3);
+        let steps = record_aligned_steps(&jsonl, step_count);
+        assert_resume_parity(
+            "codex",
+            &format!("resume-{name}"),
+            SourceCapabilities::codex(),
+            &steps,
+        );
+    }
+}
+
+/// Every Pi characterization fixture, cut into three record-aligned steps.
+#[test]
+fn every_pi_characterization_fixture_resumes_identically_in_three_steps() {
+    for name in characterization_fixture_names("pi_characterization") {
+        let jsonl = characterization_fixture("pi_characterization", &name);
+        let record_count = jsonl.lines().count();
+        let step_count = record_count.min(3);
+        let steps = record_aligned_steps(&jsonl, step_count);
+        assert_resume_parity(
+            "pi",
+            &format!("resume-{name}"),
+            SourceCapabilities::pi(),
             &steps,
         );
     }

--- a/crates/antiburn-local/tests/streaming_metrics_memory.rs
+++ b/crates/antiburn-local/tests/streaming_metrics_memory.rs
@@ -695,3 +695,99 @@ fn a_serialized_snapshot_for_the_largest_corpus_tier_stays_bounded() {
         encoded.len()
     );
 }
+
+/// An encoded [`StreamSnapshot`] for a full pass over the largest Codex
+/// characterization fixture stays under a documented bound.
+///
+/// `corpus.rs` only generates Claude-shaped JSONL — see its module doc — so
+/// this test cannot build a Codex-shaped corpus the way
+/// [`a_serialized_snapshot_for_the_largest_corpus_tier_stays_bounded`] does
+/// for Claude with `generate_session_of_bytes`. It measures the largest
+/// Codex characterization fixture instead: `collab_agent_records.jsonl`
+/// (5,550 bytes), the largest Codex-shaped session this crate ships.
+#[test]
+fn a_serialized_codex_snapshot_for_the_largest_fixture_stays_bounded() {
+    /// Measured: `collab_agent_records.jsonl`'s `StreamSnapshot` encodes to
+    /// 1,335 bytes with `postcard`. This bound rounds the measured size up
+    /// generously (over 3x), the same margin `RESUMED_SNAPSHOT_BYTES_BOUND`
+    /// above uses for the Claude case.
+    const RESUMED_CODEX_SNAPSHOT_BYTES_BOUND: usize = 4 * 1024;
+
+    let jsonl = include_str!("fixtures/codex_characterization/collab_agent_records.jsonl");
+    let directory = tempfile::TempDir::new().expect("tempdir");
+    let path = directory.path().join("session.jsonl");
+    std::fs::write(&path, jsonl).expect("write source");
+    let input = SessionInput {
+        agent: "codex".to_string(),
+        session_id: "codex-snapshot-bound".to_string(),
+        source: RawSource::File(path.clone()),
+    };
+
+    let file = std::fs::File::open(&path).expect("open source for claim");
+    let stat = SourceStat::from_open_std_file(&file).expect("stat source for claim");
+    let claim = SourceClaim::from_fingerprint_inputs(&FingerprintInputs {
+        stat,
+        head_hash: Some(head_hash_of(jsonl.as_bytes())),
+    });
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: "codex".to_owned(),
+        session_id: "codex-snapshot-bound".to_owned(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::codex(),
+    });
+    let empty_snapshot = StreamSnapshot {
+        revision: RESUME_SNAPSHOT_REVISION,
+        resume: ResumePoint {
+            offset: 0,
+            tail_hash: head_hash_of(&[]),
+            tail_len: 0,
+        },
+        adapter: adapter_for("codex")
+            .empty_resume_state()
+            .expect("codex adapter must support resume"),
+        metrics: SessionMetricsAccumulator::new("codex", "codex-snapshot-bound"),
+        evidence: EvidenceSnapshot {
+            record: evidence.coverage_record(),
+            resume: Default::default(),
+        },
+        next_turn_index: 0,
+    };
+
+    let store = MemoryTurnRowStore::new("codex", "codex-snapshot-bound");
+    let mut composite = CompositeSink::with_turn_rows(
+        SessionMetricsAccumulator::new("codex", "codex-snapshot-bound"),
+        SessionEvidenceAccumulator::new(EvidenceSource {
+            agent: "codex".to_owned(),
+            session_id: "codex-snapshot-bound".to_owned(),
+            kind: SourceKind::Jsonl,
+            capabilities: SourceCapabilities::codex(),
+        }),
+        TurnRowSink::new(
+            Arc::clone(&store) as Arc<dyn TurnRowStore>,
+            "codex-snapshot-bound".to_owned(),
+            None,
+        ),
+    );
+    let visit = adapter_for("codex")
+        .visit_claimed_resumed(&input, &claim, &empty_snapshot, &|| false, &mut composite)
+        .expect("full pass over the largest Codex fixture must stream");
+    assert_eq!(
+        visit.outcome,
+        antiburn_local::analysis::VisitOutcome::AcceptedFull
+    );
+    composite.observe_source_outcome(visit.outcome);
+    assert!(!composite.turn_row_write_failed());
+    let resume = visit
+        .resume
+        .expect("a settled pass over a quiescent source carries a resume");
+    let snapshot = composite
+        .snapshot(resume)
+        .expect("full pass must publish to snapshot");
+
+    let encoded = snapshot.encode();
+    assert!(
+        encoded.len() <= RESUMED_CODEX_SNAPSHOT_BYTES_BOUND,
+        "encoded snapshot was {} bytes, bound is {RESUMED_CODEX_SNAPSHOT_BYTES_BOUND}",
+        encoded.len()
+    );
+}

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -170,10 +170,19 @@ Antigravity blob hash is a discovery cost that phase 4 tiers address.
 - Turn the `AppendOnlyGuarantee` from a static assumption into the runtime
   verification phase 3a adds.
 
-#### Phase 3c: Codex and Pi snapshots
+#### Phase 3c: Codex and Pi snapshots (done)
 
-- Extend `visit_claimed_resumed` to `CodexAdapter` and `PiAdapter`, covering
-  Codex's pending fork-row buffer.
+- Extended `visit_claimed_resumed` to `CodexAdapter` and `PiAdapter`,
+  covering Codex's pending fork-row buffer. The resume parity harness now
+  sweeps every Codex and Pi characterization fixture, not just Claude's.
+- Codex unsettled rule: a fork sub-agent rollout can still have
+  `ForkOwnership::Pending` at end of stream. `finish` still flushes those
+  buffered rows as owned, so a settled read publishes every row, but a
+  later full pass could resolve the same rows differently. So
+  `visit_claimed_resumed` reports `resume: None` whenever ownership is
+  still `Pending` right before `finish`, even though the read still
+  settles. The next change to that source costs one full pass instead of
+  a resume.
 
 ### Phase 4: watcher tiers, events, and the HUD fold-in
 


### PR DESCRIPTION
## Why

Phase 3c of `docs/plans/continuous-session-ingest.md`. Stacked on #353 (phase 3b). Phases 3a and 3b gave the engine snapshot resume and wired the desktop worker to use it for any adapter that implements it, with Claude as the only implementation. This PR adds the Codex and Pi implementations, so a growing Codex rollout or Pi session also resumes from its snapshot instead of re-reading from byte zero.

## What

- **Pi snapshot.** `PiStreamState` is serializable and threads through the record loop as state in, state out. `PiAdapter::visit_claimed_resumed` mirrors Claude: open resumed, restore state, stream from the offset, recheck the full source, encode the state, build the resume point, finish. Pi's state is forward-only, so every end of stream is a safe resume point.
- **Codex snapshot.** `CodexStreamState` is serializable, including the pending fork-row buffer and the ownership enum. Two fields carry `serde_json::Value` data, which `postcard` can encode but cannot decode because `Value` deserializes through `deserialize_any`. A small `json_text_codec` stores those fields as JSON text on the wire and parses them back through `serde_json`. A round-trip test covers a populated pending buffer.
- **Codex unsettled rule.** A fork sub-agent rollout can still have `ForkOwnership::Pending` at end of stream. `finish` flushes the buffered rows as owned, so the read still settles and publishes every row, but a later full pass could resolve them differently. `visit_claimed_resumed` therefore returns `resume: None` when ownership is `Pending` or the pending buffer is non-empty. The next change to that source costs one full pass. Tests cover the pending case and a later append that resolves ownership and produces a snapshot on the next bootstrap pass.
- **Parity harness.** `tests/resume_parity.rs` takes the adapter and fixture directory as parameters and sweeps every Codex and Pi characterization fixture in three record-aligned steps, with the same full comparison as the Claude sweep. A step whose resumed visit returns `resume: None` restarts the next step from a fresh bootstrap pass, and parity must still hold.
- **Snapshot size.** `tests/streaming_metrics_memory.rs` gains a Codex case over the largest Codex fixture, since the corpus generator only produces Claude-shaped sessions. The Codex snapshot is a few hundred bytes; the bound is 4 KiB.

Goldens are unchanged.

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast`, `cargo deny --locked check bans licenses advisories` in `crates/antiburn-local` and `apps/desktop/src-tauri`
- `pnpm run slop:all`, `pnpm notices:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U73g2iRUFcWZ3ivhoHg8hr
