### PR TITLE
feat(desktop): per-session events, idle expiry, HUD and detail-pane fold-in (continuous ingest, phase 4b)

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -477,86 +477,6 @@ pub async fn fingerprint_with_subagents(
     }
 }
 
-/// Cheap fingerprint for the open-detail poll.
-///
-/// Antigravity databases use file, WAL, and transcript metadata here. Claimed
-/// ingestion still uses the full row-content fingerprint.
-pub async fn poll_fingerprint_with_subagents(
-    agent: AgentKind,
-    session_id: &str,
-    wsl_distro: Option<&str>,
-    source: &SessionSource,
-) -> String {
-    if let SessionSource::ProviderDb {
-        agent: AgentKind::Antigravity,
-        db_path,
-        session_id,
-    } = source
-    {
-        let mut paths = vec![db_path.clone()];
-        let mut wal = db_path.as_os_str().to_os_string();
-        wal.push("-wal");
-        paths.push(std::path::PathBuf::from(wal));
-        if let Some(transcript) = antigravity_sibling_transcript(db_path, session_id) {
-            paths.push(transcript);
-        }
-        let mut subagent_paths = Explorers::DISK
-            .list_subagents_in_environment(&agent, session_id, wsl_distro)
-            .await;
-        subagent_paths.sort();
-        paths.extend(subagent_paths);
-        return poll_fingerprint_from_paths(paths);
-    }
-    fingerprint_with_subagents(agent, session_id, wsl_distro, source).await
-}
-
-fn poll_fingerprint_from_paths(paths: Vec<std::path::PathBuf>) -> String {
-    let parts = paths
-        .into_iter()
-        .map(|path| {
-            (
-                path.to_string_lossy().into_owned(),
-                fingerprint_of_path(&path),
-            )
-        })
-        .collect::<Vec<_>>();
-    serde_json::to_string(&parts)
-        .map(|fingerprint| format!("poll-v1:{fingerprint}"))
-        .unwrap_or_else(|_| MISSING_FINGERPRINT.to_string())
-}
-
-fn fingerprint_of_path(path: &std::path::Path) -> String {
-    let Ok(metadata) = std::fs::metadata(path) else {
-        return MISSING_FINGERPRINT.to_string();
-    };
-    let modified = metadata
-        .modified()
-        .ok()
-        .and_then(|at| at.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    format!("{modified}:{}", metadata.len())
-}
-
-fn antigravity_sibling_transcript(
-    db_path: &std::path::Path,
-    session_id: &str,
-) -> Option<std::path::PathBuf> {
-    let conversations = db_path.parent()?;
-    if conversations.file_name()?.to_str()? != "conversations" {
-        return None;
-    }
-    Some(
-        conversations
-            .parent()?
-            .join("brain")
-            .join(session_id)
-            .join(".system_generated")
-            .join("logs")
-            .join("transcript.jsonl"),
-    )
-}
-
 /// Build one stable fingerprint from a parent and its sorted child paths.
 fn combined_fingerprint(source: &SessionSource, subagent_paths: &[std::path::PathBuf]) -> String {
     combined_fingerprint_from_parent(fingerprint_of(source), subagent_paths)
@@ -1860,9 +1780,8 @@ pub fn analysis_from_rows(
         row_projections: None,
         agent_slug: agent_slug.to_string(),
         parent_session_id: session_id.to_string(),
-        // Rows carry no file path; the drilldown's reveal action stays
-        // unavailable for a replayed view. `get_session_analysis_fingerprint`
-        // still resolves the live path independently for the freshness poll.
+        // Rows carry no file path, so the drilldown's reveal action stays
+        // unavailable for a replayed view.
         source_path: None,
         fingerprint: record.source_fingerprint,
         analyzed_generation: record.analyzed_generation,

--- a/apps/desktop/src-tauri/src/analysis/tests.rs
+++ b/apps/desktop/src-tauri/src/analysis/tests.rs
@@ -288,45 +288,6 @@ async fn a_claimed_antigravity_database_stays_native_and_publishes() {
     assert!(!observed(&evidence.models).by_model.is_empty());
 }
 
-#[tokio::test]
-async fn antigravity_poll_fingerprint_tracks_transcript_metadata() {
-    let (_directory, path) = antigravity_database();
-    let source = SessionSource::ProviderDb {
-        agent: AgentKind::Antigravity,
-        db_path: path.clone(),
-        session_id: "root".to_owned(),
-    };
-    let transcript = antigravity_sibling_transcript(&path, "root").unwrap();
-
-    let before =
-        poll_fingerprint_with_subagents(AgentKind::Antigravity, "root", None, &source).await;
-    let mut file = std::fs::OpenOptions::new()
-        .append(true)
-        .open(transcript)
-        .unwrap();
-    std::io::Write::write_all(&mut file, b"{}\n").unwrap();
-    let after =
-        poll_fingerprint_with_subagents(AgentKind::Antigravity, "root", None, &source).await;
-
-    assert!(before.starts_with("poll-v1:"));
-    assert_ne!(before, after);
-}
-
-#[test]
-fn antigravity_poll_fingerprint_tracks_child_only_changes() {
-    let directory = tempfile::TempDir::new().unwrap();
-    let parent = directory.path().join("root.db");
-    let child = directory.path().join("child.jsonl");
-    std::fs::write(&parent, "parent").unwrap();
-    std::fs::write(&child, "child").unwrap();
-    let paths = vec![parent, child.clone()];
-
-    let before = poll_fingerprint_from_paths(paths.clone());
-    std::fs::write(&child, "child changed").unwrap();
-
-    assert_ne!(before, poll_fingerprint_from_paths(paths));
-}
-
 #[test]
 fn a_claimed_opencode_database_publishes_from_the_validated_snapshot() {
     let (_directory, path, fingerprint) = opencode_database();

--- a/apps/desktop/src-tauri/src/app_commands.rs
+++ b/apps/desktop/src-tauri/src/app_commands.rs
@@ -27,7 +27,6 @@ macro_rules! with_app_commands {
             commands::get_provider_usage => "get_provider_usage",
             commands::get_scan_status => "get_scan_status",
             commands::get_session_analysis => "get_session_analysis",
-            commands::get_session_analysis_fingerprint => "get_session_analysis_fingerprint",
             commands::get_session_hygiene => "get_session_hygiene",
             commands::get_session_limit_allocations => "get_session_limit_allocations",
             commands::get_settings => "get_settings",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -17,7 +17,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use antiburn_local::analysis::{
     ANALYZER_REVISION, EVIDENCE_SCHEMA_REVISION, PARSER_REVISION, SessionEvidence, SourceAcceptance,
 };
-use antiburn_local::discovery::SessionSource;
 use antiburn_local::insights::{
     BadgeId, BadgeStatus, NotAssessedReason, ReportCatalogs, session_badges,
 };
@@ -1017,48 +1016,6 @@ pub async fn get_session_analysis(
         analysis_pending,
         analysis_stale,
     })
-}
-
-/// The cheap fingerprint of one session's analysis inputs.
-///
-/// The session-detail popover polls this while it is open, and re-runs the
-/// full analysis only when the value changes. This command reads file
-/// metadata alone, never a transcript or database row, so a poll costs little.
-#[tauri::command]
-pub async fn get_session_analysis_fingerprint(
-    app: tauri::AppHandle,
-    agent: String,
-    session_id: String,
-    wsl_distro: Option<String>,
-) -> CommandResult<String> {
-    let Some(kind) = kind_from_slug(&agent) else {
-        return Err(format!("unknown agent {agent}"));
-    };
-    let key = SessionKey::for_session(&agent, &session_id, wsl_distro.as_deref());
-    let stored = app.state::<Store>().session(&key).map_err(fail)?;
-    let source = match stored.as_ref() {
-        Some(record) if record.source_kind == "file" => {
-            Some(SessionSource::File(PathBuf::from(&record.source_label)))
-        }
-        Some(record) if record.source_kind == "providerDb" => Some(SessionSource::ProviderDb {
-            agent: kind,
-            db_path: PathBuf::from(&record.source_label),
-            session_id: session_id.clone(),
-        }),
-        _ => analysis::locate(kind, &session_id, wsl_distro.as_deref()).await,
-    };
-    let Some(source) = source else {
-        return Ok(analysis::MISSING_FINGERPRINT.to_string());
-    };
-    Ok(
-        analysis::poll_fingerprint_with_subagents(
-            kind,
-            &session_id,
-            wsl_distro.as_deref(),
-            &source,
-        )
-        .await,
-    )
 }
 
 /// One sub-agent's own analysis, opened from the roster.

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -268,8 +268,8 @@ pub fn set_hud_detail_size(app: tauri::AppHandle, height: f64) {
 
 /// Return the newest recent transcript write as epoch seconds.
 #[tauri::command]
-pub async fn get_latest_session_activity() -> Option<i64> {
-    crate::hud::latest_session_activity().await
+pub fn get_latest_session_activity(app: tauri::AppHandle) -> Option<i64> {
+    crate::hud::latest_session_activity(&app.state::<Store>())
 }
 
 /// Where the app came from and what it is running against.

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -270,6 +270,10 @@ pub struct ScanStatus {
     /// command rather than pushed as an event (an event fires per agent, so
     /// re-reading the table for each would be pure noise).
     pub agents: Vec<AgentScanState>,
+    /// True when this pass indexed a session the list has never shown, or
+    /// evicted a rejected one. A reader's list refetches on this rather than
+    /// on every pass, since an unchanged pass patches rows in place instead.
+    pub list_changed: bool,
 }
 
 /* -------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/hud.rs
+++ b/apps/desktop/src-tauri/src/hud.rs
@@ -5,8 +5,7 @@
 //! owns where the HUD's remembered position is kept, and the watcher that
 //! reacts when a display connects or disconnects.
 
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use antiburn_hud::Placement;
 use serde::{Deserialize, Serialize};
@@ -115,30 +114,11 @@ fn promote(entries: Vec<Placement>, placement: Placement) -> Vec<Placement> {
 }
 
 /// Return the newest recent transcript write as epoch seconds.
-pub async fn latest_session_activity() -> Option<i64> {
-    static MEMO: Mutex<Option<(Instant, Option<i64>)>> = Mutex::new(None);
-    const MEMO_TTL: Duration = Duration::from_secs(60);
-
-    if let Ok(memo) = MEMO.lock()
-        && let Some((at, value)) = *memo
-        && at.elapsed() < MEMO_TTL
-    {
-        return value;
-    }
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_secs() as i64)
-        .unwrap_or(0);
-    let logs = antiburn_local::discovery::Explorers::DISK
-        .discover_recent_sessions(now, antiburn_local::discovery::ACTIVE_SESSION_WINDOW_SECS)
-        .await;
-    let latest = logs.iter().filter_map(|log| log.updated_at).max();
-
-    if let Ok(mut memo) = MEMO.lock() {
-        *memo = Some((Instant::now(), latest));
-    }
-    latest
+///
+/// One indexed query against [`Store`], so the overlay's poll costs no more
+/// than the scan pass's own writes already do — no memo needed.
+pub fn latest_session_activity(store: &Store) -> Option<i64> {
+    store.latest_session_activity().ok().flatten()
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -217,6 +217,7 @@ pub fn run() {
                 }
             }
             app.manage(scan::ScanController::default());
+            app.manage(scan::idle::IdleWake::default());
             app.manage(Schedulers::default());
             app.manage(popover::PopoverState::default());
             app.manage(popover_peek::manager());
@@ -299,6 +300,7 @@ pub fn run() {
             if let Some(schedulers) = app.try_state::<Schedulers>() {
                 schedulers.push(runtime_pricing::spawn_scheduler(app.handle()));
                 schedulers.push(scan::spawn_scheduler(app.handle()));
+                schedulers.push(scan::idle::spawn(app.handle()));
                 schedulers.push(retention::spawn_scheduler(app.handle()));
                 schedulers.push(insights_worker::spawn(app.handle()));
                 schedulers.push(updates::spawn_scheduler(app.handle()));

--- a/apps/desktop/src-tauri/src/scan/idle.rs
+++ b/apps/desktop/src-tauri/src/scan/idle.rs
@@ -1,0 +1,102 @@
+//! Idle expiry: the moment a session's active pill clears on its own.
+//!
+//! [`analysis::is_active`](crate::analysis::is_active) computes `is_active`
+//! at read time from `updated_at_epoch`, so nothing marks the instant a
+//! session crosses [`ACTIVE_SESSION_WINDOW_SECS`]. Without this task, a row
+//! already on screen would keep its active pill until the next full list
+//! refetch. This task sleeps until the next session's window ends and
+//! announces the row that just went idle, through the same
+//! `SESSION_ENTRY_CHANGED_EVENT` a fresh write announces.
+
+use std::time::Duration;
+
+use antiburn_local::discovery::ACTIVE_SESSION_WINDOW_SECS;
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::Notify;
+use tokio::time::Instant;
+
+use crate::dto::ActivityEntry;
+use crate::store::Store;
+
+/// Slack added past a session's computed deadline, so the task never wakes a
+/// moment early and finds the session still (barely) active.
+const EXPIRY_SLACK_SECS: i64 = 1;
+
+/// Rearms the idle task's deadline. [`crate::scan::pass`] notifies this after
+/// every successful upsert, so a session the task was not yet watching, or
+/// one whose activity just moved its own deadline later, is picked up
+/// immediately instead of at the task's next stale wake.
+#[derive(Default)]
+pub struct IdleWake(Notify);
+
+/// Start the idle-expiry loop. The returned handle is aborted with the rest
+/// of the schedulers on exit.
+pub fn spawn(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let store: Store = (*app.state::<Store>()).clone();
+        let announce_app = app.clone();
+        let announce = move |entry: ActivityEntry| {
+            let _ = announce_app.emit(crate::commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
+        };
+        // `now` tracks tokio's own clock rather than the wall clock directly,
+        // so a test can drive it deterministically under
+        // `tokio::time::pause()`: every `tokio::time::sleep` below advances
+        // this clock exactly as far as it advances the real one.
+        let base_epoch = crate::scan::unix_now();
+        let base_instant = Instant::now();
+        let now = move || base_epoch + base_instant.elapsed().as_secs() as i64;
+        run(&store, app.state::<IdleWake>().inner(), &now, &announce).await;
+    })
+}
+
+/// Ask the idle task to recompute its deadline now, rather than at its next
+/// wake.
+pub fn wake(app: &AppHandle) {
+    app.state::<IdleWake>().0.notify_one();
+}
+
+/// The loop [`spawn`] runs forever. Split out so a test can drive it with a
+/// temp [`Store`] and a captured `announce`, without a Tauri app.
+async fn run(
+    store: &Store,
+    wake: &IdleWake,
+    now: &(dyn Fn() -> i64 + Send + Sync),
+    announce: &(dyn Fn(ActivityEntry) + Send + Sync),
+) {
+    loop {
+        let active = store
+            .sessions_active_since(now() - ACTIVE_SESSION_WINDOW_SECS)
+            .unwrap_or_default();
+        let Some(deadline) = active
+            .iter()
+            .map(|(_, updated_at)| updated_at + ACTIVE_SESSION_WINDOW_SECS)
+            .min()
+        else {
+            // Nothing to expire: wait for a write that adds or moves one.
+            wake.0.notified().await;
+            continue;
+        };
+        let wait_secs = (deadline + EXPIRY_SLACK_SECS - now()).max(0);
+        tokio::select! {
+            () = tokio::time::sleep(Duration::from_secs(wait_secs as u64)) => {}
+            () = wake.0.notified() => {
+                // A write may have moved this deadline; re-read the active
+                // set from the top rather than trusting the stale one.
+                continue;
+            }
+        }
+        let now = now();
+        for (key, updated_at) in &active {
+            if now - updated_at < ACTIVE_SESSION_WINDOW_SECS {
+                continue;
+            }
+            if let Some(entry) = crate::insights_worker::completion_entry(store, key, now) {
+                announce(entry);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/desktop/src-tauri/src/scan/idle/tests.rs
+++ b/apps/desktop/src-tauri/src/scan/idle/tests.rs
@@ -1,0 +1,165 @@
+use super::*;
+use crate::agents;
+use crate::store::{SessionKey, SessionRecord, Store};
+use std::sync::{Arc, Mutex};
+
+fn record(session_id: &str, updated_at: i64) -> SessionRecord {
+    SessionRecord {
+        key: SessionKey::new("native", "claude-code", session_id),
+        source_kind: "file".into(),
+        source_label: format!("/tmp/{session_id}.jsonl"),
+        wsl_distro: None,
+        title: None,
+        title_source: None,
+        cwd: None,
+        surface: "cli".into(),
+        updated_at_epoch: Some(updated_at),
+        activity_cursor: String::new(),
+        activity_source: "mtime".into(),
+        subagent_count: 0,
+        fork_parent_session_id: None,
+        source_fingerprint: None,
+    }
+}
+
+/// A clock tied to tokio's own (pausable) instant, not the wall clock: every
+/// `tokio::time::sleep` this task awaits advances it exactly as far as it
+/// advances tokio's clock, so a paused test can drive it deterministically.
+fn instant_clock(base_epoch: i64) -> impl Fn() -> i64 + Send + Sync + 'static {
+    let base_instant = Instant::now();
+    move || base_epoch + base_instant.elapsed().as_secs() as i64
+}
+
+#[tokio::test(start_paused = true)]
+async fn sessions_expire_in_deadline_order_and_not_before() {
+    let home = tempfile::TempDir::new().unwrap();
+    let store = Store::open_in_memory(home.path()).unwrap();
+    let base_epoch = 1_000_000_i64;
+    store
+        .upsert_sessions(
+            &[
+                record("written-ten-seconds-ago", base_epoch - 10),
+                record("written-a-hundred-seconds-ago", base_epoch - 100),
+            ],
+            &agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    let wake = IdleWake::default();
+    let announced: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let announced_task = announced.clone();
+    let store_task = store.clone();
+    let now = instant_clock(base_epoch);
+    tokio::spawn(async move {
+        run(&store_task, &wake, &now, &move |entry: ActivityEntry| {
+            announced_task.lock().unwrap().push(entry.session_id);
+        })
+        .await;
+    });
+
+    // Neither has reached its 180s window yet: the session written 100s ago
+    // still has 79s left, the one written 10s ago has 169s left.
+    tokio::time::sleep(Duration::from_secs(79)).await;
+    assert!(
+        announced.lock().unwrap().is_empty(),
+        "nothing should expire before its own deadline"
+    );
+
+    // The session written 100s ago crosses its window first, at t=80s (plus
+    // the 1s slack).
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert_eq!(
+        *announced.lock().unwrap(),
+        vec!["written-a-hundred-seconds-ago".to_string()]
+    );
+
+    // The session written 10s ago crosses its window at t=170s.
+    tokio::time::sleep(Duration::from_secs(90)).await;
+    assert_eq!(
+        *announced.lock().unwrap(),
+        vec![
+            "written-a-hundred-seconds-ago".to_string(),
+            "written-ten-seconds-ago".to_string(),
+        ],
+        "the row written more recently expires later, and second"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_fresh_write_re_arms_an_earlier_deadline() {
+    let home = tempfile::TempDir::new().unwrap();
+    let store = Store::open_in_memory(home.path()).unwrap();
+    let base_epoch = 1_000_000_i64;
+    // 170s old: 10s from its window, the task's first deadline.
+    store
+        .upsert_sessions(
+            &[record("moving", base_epoch - 170)],
+            &agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    let wake = Arc::new(IdleWake::default());
+    let wake_task = wake.clone();
+    let announced: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let announced_task = announced.clone();
+    let store_task = store.clone();
+    let now = instant_clock(base_epoch);
+    tokio::spawn(async move {
+        run(
+            &store_task,
+            wake_task.as_ref(),
+            &now,
+            &move |entry: ActivityEntry| {
+                announced_task.lock().unwrap().push(entry.session_id);
+            },
+        )
+        .await;
+    });
+    // Give the task a chance to read the store and start sleeping on the
+    // stale 11s deadline before the write below moves it.
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    // A fresh write moves the same session's activity to "now", pushing its
+    // deadline out to a full window away, and wakes the task the way a scan
+    // pass does.
+    store
+        .upsert_sessions(&[record("moving", base_epoch)], &agents::evidence_cohort())
+        .unwrap();
+    wake.0.notify_one();
+    // Let the task observe the write before the old deadline would fire.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // The old deadline (t=11s) passes with nothing announced: the rearm won.
+    tokio::time::sleep(Duration::from_secs(15)).await;
+    assert!(
+        announced.lock().unwrap().is_empty(),
+        "the rearmed deadline should replace the stale one, not both fire"
+    );
+
+    // The rearmed deadline, a full window from the fresh write, now passes.
+    tokio::time::sleep(Duration::from_secs(180)).await;
+    assert_eq!(*announced.lock().unwrap(), vec!["moving".to_string()]);
+}
+
+#[tokio::test(start_paused = true)]
+async fn an_empty_store_emits_nothing_and_parks_instead_of_spinning() {
+    let home = tempfile::TempDir::new().unwrap();
+    let store = Store::open_in_memory(home.path()).unwrap();
+    let announced: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let announced_task = announced.clone();
+    let wake = IdleWake::default();
+    let now = instant_clock(1_000_000);
+    tokio::spawn(async move {
+        run(&store, &wake, &now, &move |entry: ActivityEntry| {
+            announced_task.lock().unwrap().push(entry.session_id);
+        })
+        .await;
+    });
+
+    // A long virtual wait resolves instantly under a paused clock; if the
+    // loop were spinning instead of parking on `Notify`, this task would
+    // never be scheduled and the sleep below would never return.
+    tokio::time::sleep(Duration::from_secs(3600)).await;
+    assert!(announced.lock().unwrap().is_empty());
+}

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -89,7 +89,8 @@ use tokio::task::JoinSet;
 
 use crate::agents;
 use crate::analysis;
-use crate::dto::ScanStatus;
+use crate::commands;
+use crate::dto::{ActivityEntry, ScanStatus};
 use crate::repositories;
 use crate::storage_health::{self, checked};
 use crate::store::{SessionActivityKey, SessionKey, SessionRecord, Store};
@@ -234,13 +235,18 @@ pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> Sca
             status.completed_agents = 0;
             status.total_agents = AgentKind::ALL.len();
             status.sessions = 0;
+            status.list_changed = false;
             status.error = None;
             status.cancelled = false;
         });
         let _ = app.emit(EVENT_STARTED, started);
     }
 
-    let outcome = pass(app, activity_window_days).await;
+    let announce_app = app.clone();
+    let announce = move |entry: ActivityEntry| {
+        let _ = announce_app.emit(commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
+    };
+    let outcome = pass(app, activity_window_days, &announce).await;
 
     let controller = app.state::<ScanController>();
     let cancelled = controller.cancelled();
@@ -249,8 +255,9 @@ pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> Sca
         status.cancelled = cancelled;
         status.finished_at = Some(crate::store::now_rfc3339());
         match &outcome {
-            Ok(sessions) => {
-                status.sessions = *sessions;
+            Ok(summary) => {
+                status.sessions = summary.sessions;
+                status.list_changed = summary.list_changed;
                 // A cancelled pass did not finish every agent, and saying it
                 // did would make the progress line lie on its last frame.
                 if !cancelled {
@@ -273,14 +280,30 @@ pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> Sca
     // all is an analytics question, and this scheduler runs a pass a minute
     // while the popover is open. `None` is a failure, which travels as a bare
     // category — an error string can hold a path.
-    crate::analytics::record_scan(app, outcome.as_ref().ok().map(|n| *n as u64));
+    crate::analytics::record_scan(
+        app,
+        outcome.as_ref().ok().map(|summary| summary.sessions as u64),
+    );
     crate::notifications::note_scan_outcome(app, &finished);
     finished
 }
 
+/// What one pass persisted, for [`run_pass`] to fold into the reported status.
+struct PassSummary {
+    sessions: usize,
+    /// True when a reader's list needs a full refetch rather than a row
+    /// patch: this pass indexed a session the list has never shown, or
+    /// evicted a rejected one.
+    list_changed: bool,
+}
+
 /// The body of one pass. Split out so [`run_pass`] owns only the in-flight
 /// bookkeeping and the events.
-async fn pass(app: &AppHandle, _activity_window_days: Option<u32>) -> anyhow::Result<usize> {
+async fn pass(
+    app: &AppHandle,
+    _activity_window_days: Option<u32>,
+    announce: &(dyn Fn(ActivityEntry) + Send + Sync),
+) -> anyhow::Result<PassSummary> {
     let store = app.state::<Store>();
     let now = unix_now();
     // Discovery always covers the widest list the UI can request, so changing
@@ -310,8 +333,12 @@ async fn pass(app: &AppHandle, _activity_window_days: Option<u32>) -> anyhow::Re
         .await;
 
     let previous_records = store.session_records()?;
-    let Described { records, rejected } =
-        describe_with_states(logs, &home, &ignored, &previous_records).await;
+    let Described {
+        records,
+        rejected,
+        changed,
+        list_changed,
+    } = describe_with_states(logs, &home, &ignored, &previous_records).await;
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
@@ -321,6 +348,8 @@ async fn pass(app: &AppHandle, _activity_window_days: Option<u32>) -> anyhow::Re
         store.upsert_sessions(&records, &agents::evidence_cohort()),
     )?;
     crate::insights_worker::wake(app);
+
+    announce_changed_rows(&store, &changed, &previous_records, now, announce);
 
     // A transcript the gate rejected may have been indexed by an earlier
     // version of the app that did not gate; the row is removed rather than
@@ -345,12 +374,41 @@ async fn pass(app: &AppHandle, _activity_window_days: Option<u32>) -> anyhow::Re
     // the reader's results and only skips the work still ahead.
     let controller = app.state::<ScanController>();
     if controller.cancelled() {
-        return Ok(records.len());
+        return Ok(PassSummary {
+            sessions: records.len(),
+            list_changed,
+        });
     }
 
     repositories::refresh(app).await?;
 
-    Ok(records.len())
+    Ok(PassSummary {
+        sessions: records.len(),
+        list_changed,
+    })
+}
+
+/// Emit `SESSION_ENTRY_CHANGED_EVENT` for every re-described row the reader's
+/// list has already shown, so a row already on screen patches in place
+/// instead of waiting for the next full refetch. A brand-new session is not
+/// announced this way: it has no row to patch, and [`Described::list_changed`]
+/// tells the list to refetch and pick it up instead.
+fn announce_changed_rows(
+    store: &Store,
+    changed: &[SessionKey],
+    previous_records: &std::collections::HashMap<SessionActivityKey, SessionRecord>,
+    now: i64,
+    announce: &(dyn Fn(ActivityEntry) + Send + Sync),
+) {
+    let previously_known = previously_known_keys(previous_records);
+    for key in changed {
+        if !previously_known.contains(key) {
+            continue;
+        }
+        if let Some(entry) = crate::insights_worker::completion_entry(store, key, now) {
+            announce(entry);
+        }
+    }
 }
 
 /// What one scan pass learned: rows for the index, and previously indexable
@@ -358,6 +416,13 @@ async fn pass(app: &AppHandle, _activity_window_days: Option<u32>) -> anyhow::Re
 struct Described {
     records: Vec<SessionRecord>,
     rejected: Vec<SessionKey>,
+    /// Keys of every record this pass re-described — new, or its cursor
+    /// moved — never a row this pass reused verbatim.
+    changed: Vec<SessionKey>,
+    /// True when a reader's list needs a full refetch rather than a row
+    /// patch: this pass indexed a session absent from `previous_records`, or
+    /// rejected a sub-agent transcript.
+    list_changed: bool,
 }
 
 /// Read metadata for every discovered log, at a bounded concurrency, and drop
@@ -380,6 +445,8 @@ async fn describe_with_states(
     let indexed_titles = indexed_titles_for_logs(&logs).await;
     let mut records = Vec::with_capacity(logs.len());
     let mut rejected = Vec::new();
+    let mut changed = Vec::new();
+    let mut list_changed = false;
     for chunk in logs.chunks(METADATA_CONCURRENCY) {
         let mut set = JoinSet::new();
         for log in chunk {
@@ -395,28 +462,61 @@ async fn describe_with_states(
                 .and_then(|session_id| indexed_titles.get(&(log.agent_type, session_id)).cloned());
             set.spawn(async move {
                 if let Some(reused) = reuse_unchanged_record(&log, previous.as_ref()).await {
-                    return DescribeOutcome::Session(Box::new(reused));
+                    return (DescribeOutcome::Session(Box::new(reused)), false);
                 }
-                describe_one_with_activity(log, &home, indexed_title, previous).await
+                let outcome = describe_one_with_activity(log, &home, indexed_title, previous).await;
+                (outcome, true)
             });
         }
         while let Some(joined) = set.join_next().await {
             match joined {
-                Ok(DescribeOutcome::Session(record)) => {
+                Ok((DescribeOutcome::Session(record), re_described)) => {
                     let cwd = record.cwd.as_deref();
                     // The engine's opt-out gate, applied once here so every
                     // surface that reads the store inherits it.
                     if cwd.is_some_and(|cwd| ignored_paths::set_contains(ignored, cwd)) {
                         continue;
                     }
+                    if re_described {
+                        changed.push(record.key.clone());
+                    }
                     records.push(*record);
                 }
-                Ok(DescribeOutcome::Subagent(key)) => rejected.push(key),
-                Ok(DescribeOutcome::Skip) | Err(_) => {}
+                Ok((DescribeOutcome::Subagent(key), _)) => rejected.push(key),
+                Ok((DescribeOutcome::Skip, _)) | Err(_) => {}
             }
         }
     }
-    Described { records, rejected }
+    // A rejected transcript's stale row, if any, is about to be evicted below
+    // `describe_with_states`'s caller — either way the list must refetch to
+    // stop showing it.
+    if !rejected.is_empty() {
+        list_changed = true;
+    }
+    let previously_known = previously_known_keys(previous_records);
+    if changed.iter().any(|key| !previously_known.contains(key)) {
+        list_changed = true;
+    }
+    Described {
+        records,
+        rejected,
+        changed,
+        list_changed,
+    }
+}
+
+/// Every session key `previous_records` already held, keyed the way
+/// [`Described::changed`] is: by session identity rather than by activity
+/// source. Shared by the `list_changed` check above and by
+/// [`announce_changed_rows`], which both ask the same question — was this
+/// key already on the reader's list — of the same map.
+fn previously_known_keys(
+    previous_records: &std::collections::HashMap<SessionActivityKey, SessionRecord>,
+) -> std::collections::HashSet<&SessionKey> {
+    previous_records
+        .values()
+        .map(|record| &record.key)
+        .collect()
 }
 
 /// Read each durable vendor title store once for the sessions in this pass.

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -95,6 +95,7 @@ use crate::repositories;
 use crate::storage_health::{self, checked};
 use crate::store::{SessionActivityKey, SessionKey, SessionRecord, Store};
 
+pub mod idle;
 pub mod watch;
 
 /// How often the scheduler wakes up.
@@ -348,6 +349,9 @@ async fn pass(
         store.upsert_sessions(&records, &agents::evidence_cohort()),
     )?;
     crate::insights_worker::wake(app);
+    // A write may have added a session the idle task was not yet watching,
+    // or moved one's deadline later; either way its sleep needs recomputing.
+    idle::wake(app);
 
     announce_changed_rows(&store, &changed, &previous_records, now, announce);
 

--- a/apps/desktop/src-tauri/src/scan/tests.rs
+++ b/apps/desktop/src-tauri/src/scan/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use antiburn_local::platform::environment::DiscoveryEnvironment;
 use std::collections::HashSet;
 use std::io::Write;
+use std::sync::Mutex;
 
 /// A synthetic Claude store: `<home>/.claude/projects/<encoded>/<id>.jsonl`.
 /// Every value is fictional; the shapes are what the engine's scanner reads.
@@ -1365,4 +1366,148 @@ fn the_scheduler_ticks_at_the_fallback_rate_when_the_watcher_is_not_healthy() {
         }),
         TICK
     );
+}
+
+#[tokio::test]
+async fn an_unchanged_pass_emits_nothing_and_reports_no_list_change() {
+    let home = tempfile::TempDir::new().unwrap();
+    let path = write_claude_session(home.path(), "steady");
+    let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+
+    let first = describe_with_states(
+        vec![log(AgentKind::Claude, path.clone(), 1_800_000_000)],
+        home.path(),
+        &HashSet::new(),
+        &store.session_records().unwrap(),
+    )
+    .await;
+    store
+        .upsert_sessions(&first.records, &agents::evidence_cohort())
+        .unwrap();
+
+    // Same size, same mtime bucket: the source is reused, so nothing changed.
+    let previous = store.session_records().unwrap();
+    let second = describe_with_states(
+        vec![log(AgentKind::Claude, path, 1_800_000_000)],
+        home.path(),
+        &HashSet::new(),
+        &previous,
+    )
+    .await;
+    assert!(second.changed.is_empty());
+    assert!(!second.list_changed);
+
+    let announced = Mutex::new(Vec::new());
+    announce_changed_rows(
+        &store,
+        &second.changed,
+        &previous,
+        1_800_000_100,
+        &|entry| {
+            announced.lock().unwrap().push(entry);
+        },
+    );
+    assert!(announced.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn a_moved_cursor_emits_exactly_one_entry_and_reports_no_list_change() {
+    let home = tempfile::TempDir::new().unwrap();
+    let path = write_claude_session(home.path(), "moving");
+    let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+
+    let first = describe_with_states(
+        vec![log(AgentKind::Claude, path.clone(), 1_800_000_000)],
+        home.path(),
+        &HashSet::new(),
+        &store.session_records().unwrap(),
+    )
+    .await;
+    store
+        .upsert_sessions(&first.records, &agents::evidence_cohort())
+        .unwrap();
+    let previous = store.session_records().unwrap();
+
+    // A genuine append moves the activity cursor: the row is known, but its
+    // source changed, so it is re-described rather than reused.
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .unwrap()
+        .write_all(b"{\"type\":\"assistant\",\"timestamp\":\"2026-08-01T10:05:00Z\"}\n")
+        .unwrap();
+    let second = describe_with_states(
+        vec![log(AgentKind::Claude, path, 1_800_000_100)],
+        home.path(),
+        &HashSet::new(),
+        &previous,
+    )
+    .await;
+    assert_eq!(second.changed.len(), 1);
+    assert!(!second.list_changed);
+    store
+        .upsert_sessions(&second.records, &agents::evidence_cohort())
+        .unwrap();
+
+    let announced = Mutex::new(Vec::new());
+    announce_changed_rows(
+        &store,
+        &second.changed,
+        &previous,
+        1_800_000_200,
+        &|entry| {
+            announced.lock().unwrap().push(entry);
+        },
+    );
+    let entries = announced.lock().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].session_id, "moving");
+}
+
+#[tokio::test]
+async fn a_new_session_emits_nothing_and_reports_a_list_change() {
+    let home = tempfile::TempDir::new().unwrap();
+    let path = write_claude_session(home.path(), "fresh");
+    let store = crate::store::Store::open_in_memory(home.path()).unwrap();
+    let previous = store.session_records().unwrap();
+
+    let described = describe_with_states(
+        vec![log(AgentKind::Claude, path, 1_800_000_000)],
+        home.path(),
+        &HashSet::new(),
+        &previous,
+    )
+    .await;
+    assert_eq!(described.changed.len(), 1);
+    assert!(described.list_changed);
+
+    // A brand-new session has no row on screen to patch; the list's own
+    // `list_changed` refetch is what picks it up, not this event.
+    let announced = Mutex::new(Vec::new());
+    announce_changed_rows(
+        &store,
+        &described.changed,
+        &previous,
+        1_800_000_100,
+        &|entry| {
+            announced.lock().unwrap().push(entry);
+        },
+    );
+    assert!(announced.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn a_rejected_transcript_reports_a_list_change() {
+    let home = tempfile::TempDir::new().unwrap();
+    let sidechain = write_claude_sidechain(home.path(), "aaaa-1111");
+
+    let described = describe(
+        vec![log(AgentKind::Claude, sidechain, 1_800_000_000)],
+        home.path(),
+        &HashSet::new(),
+    )
+    .await;
+
+    assert_eq!(described.rejected.len(), 1);
+    assert!(described.list_changed);
 }

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -733,6 +733,18 @@ impl Store {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
+    /// The newest recorded session activity, epoch seconds. `None` when no
+    /// session has one yet — an empty store, or every row still on its
+    /// filesystem-mtime fallback with a missing source.
+    pub fn latest_session_activity(&self) -> Result<Option<i64>> {
+        let connection = self.lock();
+        Ok(
+            connection.query_row("SELECT MAX(updated_at_epoch) FROM session", [], |row| {
+                row.get(0)
+            })?,
+        )
+    }
+
     /// The analysis state of every session in the activity window, for the
     /// aggregate hygiene summary.
     ///

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -179,6 +179,15 @@ const RECENT_SESSIONS_SQL: &str = "SELECT environment_key, agent, session_id, so
       ORDER BY COALESCE(updated_at_epoch, 0) DESC, session_id DESC
       LIMIT ?2";
 
+/// [`Store::sessions_active_since`]'s query, pulled out for the same reason
+/// as [`RECENT_SESSIONS_SQL`]: a schema test can pin it to the coalesced
+/// recency index.
+const SESSIONS_ACTIVE_SINCE_SQL: &str = "SELECT environment_key, agent, session_id,
+            COALESCE(updated_at_epoch, 0)
+       FROM session
+      WHERE COALESCE(updated_at_epoch, 0) >= ?1
+      ORDER BY COALESCE(updated_at_epoch, 0) ASC";
+
 impl Store {
     /// Open (creating if absent) and migrate the database under `data_dir`.
     pub fn open(data_dir: &Path) -> Result<Store> {
@@ -702,6 +711,25 @@ impl Store {
         );
         let rows =
             statement.query_map(rusqlite::params_from_iter(values.iter()), session_from_row)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    /// Sessions whose activity falls at or after `since_epoch`, earliest
+    /// activity first — the order [`crate::scan::idle`]'s expiry task wants,
+    /// so its earliest deadline is always the first row.
+    pub fn sessions_active_since(&self, since_epoch: i64) -> Result<Vec<(SessionKey, i64)>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(SESSIONS_ACTIVE_SINCE_SQL)?;
+        let rows = statement.query_map(params![since_epoch], |row| {
+            Ok((
+                SessionKey::new(
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ),
+                row.get::<_, i64>(3)?,
+            ))
+        })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -10,6 +10,7 @@ use super::model::{
 };
 use super::*;
 
+mod activity_tests;
 mod coverage_tests;
 mod reconcile_tests;
 mod resume_tests;

--- a/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
@@ -49,3 +49,31 @@ fn sessions_active_since_query_plan_uses_the_coalesced_recency_index() {
         "query plan did not use the coalesced index: {plan}"
     );
 }
+#[test]
+fn latest_session_activity_ignores_null_epochs() {
+    let store = store();
+    assert_eq!(
+        store.latest_session_activity().unwrap(),
+        None,
+        "empty store"
+    );
+
+    let mut no_heartbeat = session("no-heartbeat", 0);
+    no_heartbeat.updated_at_epoch = None;
+    store
+        .upsert_sessions(&[no_heartbeat], &crate::agents::evidence_cohort())
+        .unwrap();
+    assert_eq!(
+        store.latest_session_activity().unwrap(),
+        None,
+        "a NULL epoch is not activity"
+    );
+
+    store
+        .upsert_sessions(
+            &[session("recent", 5_000)],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    assert_eq!(store.latest_session_activity().unwrap(), Some(5_000));
+}

--- a/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
@@ -1,0 +1,51 @@
+//! Store-level tests for the session activity queries the continuous
+//! ingest surfaces read (phase 4b): the idle-expiry timer's active set and
+//! the HUD's latest-activity signal.
+
+use super::*;
+
+#[test]
+fn sessions_active_since_returns_earliest_activity_first() {
+    let store = store();
+    store
+        .upsert_sessions(&[session("old", 1_000)], &crate::agents::evidence_cohort())
+        .unwrap();
+    store
+        .upsert_sessions(&[session("mid", 2_000)], &crate::agents::evidence_cohort())
+        .unwrap();
+    store
+        .upsert_sessions(&[session("new", 3_000)], &crate::agents::evidence_cohort())
+        .unwrap();
+
+    let active = store.sessions_active_since(1_500).unwrap();
+    let ids: Vec<_> = active
+        .iter()
+        .map(|(key, _)| key.session_id.as_str())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["mid", "new"],
+        "windowed and oldest activity first"
+    );
+    assert_eq!(active[0].1, 2_000);
+    assert_eq!(active[1].1, 3_000);
+}
+
+#[test]
+fn sessions_active_since_query_plan_uses_the_coalesced_recency_index() {
+    let store = store();
+    let connection = store.lock();
+    let mut statement = connection
+        .prepare(&format!("EXPLAIN QUERY PLAN {SESSIONS_ACTIVE_SINCE_SQL}"))
+        .unwrap();
+    let plan_lines: Vec<String> = statement
+        .query_map(params![0_i64], |row| row.get::<_, String>(3))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    let plan = plan_lines.join("\n");
+    assert!(
+        plan.contains("session_recency_coalesced"),
+        "query plan did not use the coalesced index: {plan}"
+    );
+}

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -325,6 +325,8 @@ export interface ScanStatus {
   cancelled: boolean
   error: string | null
   agents: AgentScanState[]
+  /** True when this pass indexed a session the list has never shown, or evicted a rejected one. */
+  listChanged: boolean
 }
 
 /**

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -795,27 +795,6 @@ export async function getSessionAnalysis(
   })
 }
 
-/**
- * A cheap fingerprint of one session's transcript.
- *
- * A poll compares this value tick to tick instead of re-running the full
- * analysis: the fingerprint changes only when the transcript itself changes,
- * so an unchanged value proves a re-analysis would find nothing new. `"-"`
- * means the transcript is missing.
- */
-export async function getSessionAnalysisFingerprint(
-  agent: string,
-  sessionId: string,
-  wslDistro?: string | null,
-): Promise<string> {
-  if (!hasShell()) return "-"
-  return invoke<string>("get_session_analysis_fingerprint", {
-    agent,
-    sessionId,
-    wslDistro: wslDistro ?? null,
-  })
-}
-
 /** One sub-agent's own analysis. */
 export async function getSubagentAnalysis(
   agent: string,

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -1,31 +1,66 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type * as Ipc from "../../lib/ipc"
-import type { SessionAnalysisPayload } from "../../lib/ipc"
-import { ANALYSIS_POLL_MS, PopoverSession, sessionKey } from "./PopoverSession"
+import type { ActivityEntryPayload, ScanStatus, SessionAnalysisPayload } from "../../lib/ipc"
+import { PopoverSession, sessionKey } from "./PopoverSession"
 import type { SessionSubject } from "./SessionPane"
 
 const getSessionAnalysis = vi.hoisted(() => vi.fn())
-const getSessionAnalysisFingerprint = vi.hoisted(() => vi.fn())
 const getSubagentAnalysis = vi.hoisted(() => vi.fn())
 const getSessionLimitAllocations = vi.hoisted(() => vi.fn())
 const setPopoverHeight = vi.hoisted(() => vi.fn())
+const listRecentSessions = vi.hoisted(() => vi.fn())
+const onSessionEntryChanged = vi.hoisted(() => vi.fn())
+const onScanEvent = vi.hoisted(() => vi.fn())
 
-// The analysis commands are overridden. All other wrappers keep their real
-// no-shell fallback because `hasShell()` is false outside Tauri.
+// The analysis, list, and event-subscription commands are overridden. All
+// other wrappers keep their real no-shell fallback because `hasShell()` is
+// false outside Tauri.
 vi.mock("../../lib/ipc", async (importOriginal) => {
   const actual = await importOriginal<typeof Ipc>()
   return {
     ...actual,
     getSessionAnalysis,
-    getSessionAnalysisFingerprint,
     getSubagentAnalysis,
     getSessionLimitAllocations,
     setPopoverHeight,
+    listRecentSessions,
+    onSessionEntryChanged,
+    onScanEvent,
   }
 })
 
+type EntryChangedHandler = (entry: ActivityEntryPayload) => void
+type ScanEventHandler = (status: ScanStatus, phase: "started" | "progress" | "finished") => void
+
+let entryChangedHandler: EntryChangedHandler | null = null
+let scanEventHandler: ScanEventHandler | null = null
+
 beforeEach(() => {
+  entryChangedHandler = null
+  scanEventHandler = null
+  getSessionAnalysis.mockReset()
+  getSessionAnalysis.mockResolvedValue(null)
+  getSubagentAnalysis.mockReset()
+  getSubagentAnalysis.mockResolvedValue(null)
+  setPopoverHeight.mockReset()
+  setPopoverHeight.mockResolvedValue(true)
+  listRecentSessions.mockReset()
+  listRecentSessions.mockResolvedValue([])
+  onSessionEntryChanged.mockReset()
+  onSessionEntryChanged.mockImplementation(async (handler: EntryChangedHandler) => {
+    entryChangedHandler = handler
+    return () => {
+      entryChangedHandler = null
+    }
+  })
+  onScanEvent.mockReset()
+  onScanEvent.mockImplementation(async (handler: ScanEventHandler) => {
+    scanEventHandler = handler
+    return () => {
+      scanEventHandler = null
+    }
+  })
   getSessionLimitAllocations.mockReset()
   getSessionLimitAllocations.mockResolvedValue({
     generatedAt: "2027-01-15T08:00:00Z",
@@ -39,11 +74,6 @@ describe("PopoverSession surface presentation", () => {
     sessionId: "session-1",
     wslDistro: null,
   }
-
-  beforeEach(() => {
-    setPopoverHeight.mockReset()
-    setPopoverHeight.mockResolvedValue(true)
-  })
 
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -252,11 +282,11 @@ describe("sessionKey", () => {
 })
 
 /**
- * The live poll behind an open detail pane: it re-loads the analysis only
- * when the transcript's fingerprint actually moves, and it never runs
- * against an empty stack.
+ * The event-driven refresh behind an open detail pane and the activity list:
+ * `sessions:entry-changed` replaces the old fingerprint poll, and
+ * `scan:finished` is the list's own backstop when a pass reports no change.
  */
-describe("PopoverSession live analysis poll", () => {
+describe("PopoverSession event-driven refresh", () => {
   const subject: SessionSubject = {
     agent: "claude-code",
     sessionId: "session-1",
@@ -288,215 +318,53 @@ describe("PopoverSession live analysis poll", () => {
     ...overrides,
   })
 
-  const usableAnalysis = (): SessionAnalysisPayload =>
-    analysisPayload({
-      summary: {
-        sessionCount: 1,
-        avgDurationSecs: 1,
-        avgActiveSecs: 1,
-        tokensInTotal: 0,
-        tokensOutTotal: 0,
-        peakContextTokens: 0,
-        contextWindow: 0,
-        buckets: [],
-        sessions: [],
-      },
-    })
-
-  beforeEach(() => {
-    vi.useFakeTimers()
-    getSessionAnalysis.mockReset()
-    getSessionAnalysis.mockResolvedValue(null)
-    getSessionAnalysisFingerprint.mockReset()
-    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-1")
-    getSubagentAnalysis.mockReset()
-    getSubagentAnalysis.mockResolvedValue(null)
+  const entryPayload = (
+    overrides: Partial<ActivityEntryPayload> = {},
+  ): ActivityEntryPayload => ({
+    agent: "claude-code",
+    sessionId: "session-1",
+    repo: "repo",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    isActive: false,
+    surface: "cli",
+    wslDistro: null,
+    title: null,
+    hasForkParent: false,
+    forkChildCount: 0,
+    cost: null,
+    models: [],
+    modelRuns: [],
+    ...overrides,
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
+  const scanStatus = (overrides: Partial<ScanStatus> = {}): ScanStatus => ({
+    running: false,
+    completedAgents: 1,
+    totalAgents: 1,
+    sessions: 1,
+    finishedAt: "2024-01-01T00:00:00.000Z",
+    cancelled: false,
+    error: null,
+    agents: [],
+    listChanged: false,
+    ...overrides,
   })
 
-  it("re-loads the analysis when the fingerprint changes on a tick", async () => {
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    // Let `loadAnalysisFor` and the fingerprint seed that follows it settle,
-    // so the poll's own baseline is in place before the first tick.
-    await vi.advanceTimersByTimeAsync(0)
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
-
-    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-2")
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
-
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
-    unsubscribe()
-  })
-
-  it("does not re-load the analysis when the fingerprint is unchanged", async () => {
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
-
-    // The mock keeps returning "fingerprint-1" from the seed above.
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
-
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
-    unsubscribe()
-  })
-
-  it("re-loads on the next tick after an unavailable read, fingerprint unchanged", async () => {
+  it("refreshes the open analysis when a matching entry event lands", async () => {
     getSessionAnalysis.mockResolvedValue(analysisPayload())
     const session = new PopoverSession()
     const unsubscribe = session.subscribe(() => {})
     session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.waitFor(() => expect(getSessionAnalysis).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(entryChangedHandler).not.toBeNull())
 
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+    entryChangedHandler?.(entryPayload())
 
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => expect(getSessionAnalysis).toHaveBeenCalledTimes(2))
     unsubscribe()
   })
 
-  it("re-loads on every tick while the drilldown is pending, fingerprint unchanged", async () => {
-    getSessionAnalysis.mockResolvedValue(analysisPayload({ analysisPending: true }))
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
-
-    // Unbounded, unlike the unavailable-analysis retry budget below: a
-    // pending drilldown keeps refetching every tick until the worker
-    // actually publishes something, however many ticks that takes.
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(6)
-    unsubscribe()
-  })
-
-  it("stops re-loading once a pending drilldown resolves", async () => {
-    getSessionAnalysis
-      .mockResolvedValueOnce(analysisPayload({ analysisPending: true }))
-      .mockResolvedValueOnce(analysisPayload({ analysisPending: true }))
-      .mockResolvedValue(usableAnalysis())
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
-
-    // 1 initial load + 2 pending re-loads, then the third re-load lands
-    // usable and the poll goes back to comparing fingerprints alone.
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(3)
-    unsubscribe()
-  })
-
-  it("re-loads a pending sub-agent drilldown too, unlike the unavailable-analysis retry", async () => {
-    getSubagentAnalysis.mockResolvedValue(analysisPayload({ analysisPending: true }))
-    const subagent: SessionSubject = {
-      ...subject,
-      subagent: { parentSessionId: subject.sessionId, subagentId: "subagent-1" },
-    }
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subagent)
-    await vi.advanceTimersByTimeAsync(0)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 2)
-
-    expect(getSubagentAnalysis).toHaveBeenCalledTimes(3)
-    unsubscribe()
-  })
-
-  it("re-loads on every tick while the analysis is stale, fingerprint unchanged", async () => {
-    getSessionAnalysis.mockResolvedValue({ ...usableAnalysis(), analysisStale: true })
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
-
-    // Unbounded, the same as a pending drilldown: a stale analysis keeps
-    // refetching every tick until the fresher pass the worker already
-    // queued or is already running actually publishes.
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(6)
-    unsubscribe()
-  })
-
-  it("stops re-loading once a stale analysis comes back fresh", async () => {
-    getSessionAnalysis
-      .mockResolvedValueOnce({ ...usableAnalysis(), analysisStale: true })
-      .mockResolvedValueOnce({ ...usableAnalysis(), analysisStale: true })
-      .mockResolvedValue(usableAnalysis())
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 5)
-
-    // 1 initial load + 2 stale re-loads, then the third re-load lands fresh
-    // and the poll goes back to comparing fingerprints alone.
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(3)
-    unsubscribe()
-  })
-
-  it("stops retrying once a usable analysis lands", async () => {
-    getSessionAnalysis
-      .mockResolvedValueOnce(analysisPayload())
-      .mockResolvedValue(usableAnalysis())
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 4)
-
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
-    unsubscribe()
-  })
-
-  it("latches after three unavailable retries", async () => {
-    getSessionAnalysis.mockResolvedValue(analysisPayload())
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 12)
-
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(4)
-    unsubscribe()
-  })
-
-  it("re-arms the budget after a usable analysis settles", async () => {
-    getSessionAnalysis
-      .mockResolvedValueOnce(analysisPayload())
-      .mockResolvedValueOnce(usableAnalysis())
-      .mockResolvedValueOnce(analysisPayload())
-      .mockResolvedValue(usableAnalysis())
-    const session = new PopoverSession()
-    const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
-    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-2")
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
-
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(4)
-    unsubscribe()
-  })
-
-  it("does not retry a sub-agent subject", async () => {
+  it("refreshes a sub-agent subject's analysis on its parent's entry event", async () => {
     getSubagentAnalysis.mockResolvedValue(analysisPayload())
     const subagent: SessionSubject = {
       ...subject,
@@ -505,56 +373,122 @@ describe("PopoverSession live analysis poll", () => {
     const session = new PopoverSession()
     const unsubscribe = session.subscribe(() => {})
     session.openSession(subagent)
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.waitFor(() => expect(getSubagentAnalysis).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(entryChangedHandler).not.toBeNull())
 
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 3)
-    expect(getSubagentAnalysis).toHaveBeenCalledTimes(1)
+    entryChangedHandler?.(entryPayload({ sessionId: subject.sessionId }))
 
-    getSessionAnalysisFingerprint.mockResolvedValue("fingerprint-2")
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
-
-    expect(getSubagentAnalysis).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => expect(getSubagentAnalysis).toHaveBeenCalledTimes(2))
     unsubscribe()
   })
 
-  it("does not retry when the agent does not support analysis", async () => {
-    getSessionAnalysis.mockResolvedValue(analysisPayload({ supportsAnalysis: false }))
+  it("does not refresh the open analysis when the entry event names a different session", async () => {
+    getSessionAnalysis.mockResolvedValue(analysisPayload())
     const session = new PopoverSession()
     const unsubscribe = session.subscribe(() => {})
     session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.waitFor(() => expect(getSessionAnalysis).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(entryChangedHandler).not.toBeNull())
 
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 2)
+    entryChangedHandler?.(entryPayload({ sessionId: "another-session" }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(getSessionAnalysis).toHaveBeenCalledTimes(1)
     unsubscribe()
   })
 
-  it("retries a rejected read", async () => {
-    getSessionAnalysis.mockRejectedValueOnce(new Error("read failed"))
-    getSessionAnalysis.mockResolvedValue(usableAnalysis())
+  it("coalesces two matching events that land during one in-flight refresh into exactly one more", async () => {
+    getSessionAnalysis.mockResolvedValue(analysisPayload())
     const session = new PopoverSession()
     const unsubscribe = session.subscribe(() => {})
     session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.waitFor(() => expect(getSessionAnalysis).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(entryChangedHandler).not.toBeNull())
 
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS)
+    const pendingResolvers: ((payload: SessionAnalysisPayload) => void)[] = []
+    getSessionAnalysis.mockImplementationOnce(
+      () =>
+        new Promise<SessionAnalysisPayload>((resolve) => {
+          pendingResolvers.push(resolve)
+        }),
+    )
+    const matching = entryPayload()
+    entryChangedHandler?.(matching)
+    await vi.waitFor(() => expect(getSessionAnalysis).toHaveBeenCalledTimes(2))
 
-    expect(getSessionAnalysis).toHaveBeenCalledTimes(2)
+    // Both land while the refresh above is still in flight.
+    entryChangedHandler?.(matching)
+    entryChangedHandler?.(matching)
+
+    pendingResolvers.shift()?.(analysisPayload())
+    await vi.waitFor(() => expect(getSessionAnalysis).toHaveBeenCalledTimes(3))
+
+    // No further call follows the coalesced one.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(getSessionAnalysis).toHaveBeenCalledTimes(3)
     unsubscribe()
   })
 
-  it("stops polling once the detail pane closes", async () => {
+  it("refetches the list once for an entry event whose session is not on screen", async () => {
     const session = new PopoverSession()
     const unsubscribe = session.subscribe(() => {})
-    session.openSession(subject)
-    await vi.advanceTimersByTimeAsync(0)
-    getSessionAnalysisFingerprint.mockClear()
+    await vi.waitFor(() => expect(listRecentSessions).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(entryChangedHandler).not.toBeNull())
 
-    session.goBack()
-    await vi.advanceTimersByTimeAsync(ANALYSIS_POLL_MS * 3)
+    entryChangedHandler?.(entryPayload({ sessionId: "unknown-session" }))
 
-    expect(getSessionAnalysisFingerprint).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(listRecentSessions).toHaveBeenCalledTimes(2))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(listRecentSessions).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("does not refetch on a scan:finished within the reconcile interval when the list did not change", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() => expect(listRecentSessions).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(scanEventHandler).not.toBeNull())
+
+    scanEventHandler?.(scanStatus({ listChanged: true }), "finished")
+    await vi.waitFor(() => expect(listRecentSessions).toHaveBeenCalledTimes(2))
+
+    scanEventHandler?.(scanStatus({ listChanged: false }), "finished")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(listRecentSessions).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("re-sorts a revived session to the top of the list", async () => {
+    const older = entryPayload({
+      sessionId: "session-old",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    })
+    const newer = entryPayload({
+      sessionId: "session-new",
+      timestamp: "2024-01-02T00:00:00.000Z",
+    })
+    listRecentSessions.mockResolvedValue([newer, older])
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() =>
+      expect(session.getSnapshot().entries?.map((entry) => entry.sessionId)).toEqual([
+        "session-new",
+        "session-old",
+      ]),
+    )
+    await vi.waitFor(() => expect(entryChangedHandler).not.toBeNull())
+
+    entryChangedHandler?.(
+      entryPayload({ sessionId: "session-old", timestamp: "2024-01-03T00:00:00.000Z" }),
+    )
+
+    await vi.waitFor(() =>
+      expect(session.getSnapshot().entries?.map((entry) => entry.sessionId)).toEqual([
+        "session-old",
+        "session-new",
+      ]),
+    )
     unsubscribe()
   })
 })

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -12,7 +12,6 @@ import {
   getProviderUsage,
   getSessionLimitAllocations,
   getSessionAnalysis,
-  getSessionAnalysisFingerprint,
   getSettings,
   getStorageHealth,
   getSubagentAnalysis,
@@ -33,6 +32,7 @@ import {
   scanNow,
   setPopoverHeight,
   setSettings,
+  type ActivityEntryPayload,
   type AppSettings,
   type LiveUsageSummaryPayload,
   type ProviderUsageSummaryPayload,
@@ -73,45 +73,6 @@ type PopoverAnalysisState = {
   payload: SessionAnalysisPayload | null
   error: boolean
 } | null
-
-/** Whether the settled analysis for `key` has nothing usable. */
-function isUnavailableAnalysis(state: PopoverAnalysisState, key: string): boolean {
-  if (state === null || state.key !== key) return false
-  if (state.error) return true
-  return (
-    state.payload !== null &&
-    state.payload.supportsAnalysis &&
-    state.payload.summary === null &&
-    state.payload.cost === null
-  )
-}
-
-/**
- * Whether the settled analysis for `key` reports the drilldown as still
- * pending: the worker has not published a row set for this session yet, so
- * the shell served a placeholder payload rather than a real read.
- */
-function isAnalysisPending(state: PopoverAnalysisState, key: string): boolean {
-  return (
-    state !== null &&
-    state.key === key &&
-    state.payload !== null &&
-    state.payload.analysisPending
-  )
-}
-
-/**
- * Whether the settled analysis for `key` reports itself as stale: it comes
- * from a published fence a fresher pass is already queued or running
- * behind, or whose transcript has since moved on. The data on screen is
- * real, so this does not gate what renders — it only keeps the poll running
- * so the fresh pass swaps in once the worker publishes it.
- */
-function isAnalysisStale(state: PopoverAnalysisState, key: string): boolean {
-  return (
-    state !== null && state.key === key && state.payload !== null && state.payload.analysisStale
-  )
-}
 
 export interface PopoverSnapshot {
   appVersion: string | null
@@ -196,28 +157,33 @@ async function loadAnalysis(subject: SessionSubject): Promise<SessionAnalysisPay
 }
 
 /**
- * Fetch one subject's transcript fingerprint, for the live-detail poll.
- *
- * The parent fingerprint covers the parent transcript and every sub-agent
- * transcript, so a sub-agent subject fingerprints its parent session.
- */
-async function loadAnalysisFingerprint(subject: SessionSubject): Promise<string> {
-  const sessionId = subject.subagent?.parentSessionId ?? subject.sessionId
-  return getSessionAnalysisFingerprint(subject.agent, sessionId, subject.wslDistro)
-}
-
-/** How often the open detail pane checks its transcript for new activity. */
-export const ANALYSIS_POLL_MS = 10_000
-
-/** How many times a subject can re-read an unavailable analysis. */
-const MAX_UNAVAILABLE_ANALYSIS_RETRIES = 3
-
-/**
  * How often the store forces a snapshot change while a detail pane is open,
  * so the header's relative-time text ("last just now") stays current even
  * when nothing else about the session has changed.
  */
 const NOW_TICK_MS = 30_000
+
+/**
+ * How long the list can go without a full refetch before `listenScanEvent`
+ * forces one, even though the pass reported `listChanged: false`. The
+ * backstop for a signal this session missed or got wrong; matches the
+ * backend scheduler's own tick, so reconciliation never lags a full cycle
+ * behind the pass that produced it.
+ */
+const LIST_RECONCILE_MS = 60_000
+
+/**
+ * Order list rows the way the backend does: newest activity first, and a
+ * revived session's own id breaking a tie. `listenSessionEntryChanged`
+ * re-sorts with this after patching one row in place, so a session whose
+ * activity just moved reliably lands where a full re-list would put it.
+ */
+function compareByRecency(a: SessionListEntry, b: SessionListEntry): number {
+  if (a.timestamp !== b.timestamp) return a.timestamp > b.timestamp ? -1 : 1
+  const aId = a.sessionId ?? ""
+  const bId = b.sessionId ?? ""
+  return aId > bId ? -1 : aId < bId ? 1 : 0
+}
 
 /** Narrow the shell's status string to the repository list's union. */
 function repositoryStatus(status: string): LocalRepositoryStatus {
@@ -249,6 +215,14 @@ export class PopoverSession {
   private usageRefreshCount = 0
   /** How many `refreshAnalysis` calls are in flight; see `usageRefreshCount`. */
   private analysisRefreshCount = 0
+  /**
+   * Set when a matching `sessions:entry-changed` event lands while a
+   * `refreshAnalysis` call is already in flight. Coalesced to one extra run,
+   * not one per event: the in-flight call's own result is already stale by
+   * the time it lands, so every event that arrives before it finishes is
+   * asking for the same thing.
+   */
+  private pendingAnalysisRefresh = false
   private liveUsageRevision = 0
   private sessionLimitAllocationRequested = 0
   private sessionLimitAllocationRefresh: Promise<void> | null = null
@@ -258,18 +232,16 @@ export class PopoverSession {
   private contentReadyReportInFlightGeneration: number | null = null
   private contentReadyRetryGeneration: number | null = null
 
+  /** Set while a coalesced `refreshEntries` call is in flight; see `pendingAnalysisRefresh`. */
+  private entriesRefreshInFlight = false
+  private entriesRefreshQueued = false
   /**
-   * The key of the subject the poll's fingerprint belongs to, and the last
-   * fingerprint fetched for it. `null` fingerprint means no baseline has
-   * landed yet, so a poll tick must not treat it as a change.
+   * When `listenScanEvent` last refetched the full list. Read against
+   * `LIST_RECONCILE_MS` so a pass that never sets `listChanged` still gets
+   * reconciled eventually.
    */
-  private analysisFingerprintKey: string | null = null
-  private analysisFingerprint: string | null = null
-  private analysisRetryKey: string | null = null
-  private analysisRetryCount = 0
-  /** Set while a poll tick's fetch is in flight, so ticks never overlap. */
-  private analysisPollInFlight = false
-  private analysisPollTimer: ReturnType<typeof setInterval> | null = null
+  private lastListReconcileAt = 0
+
   private nowTickTimer: ReturnType<typeof setInterval> | null = null
 
   private stopSettingsListening: (() => void) | null = null
@@ -329,8 +301,6 @@ export class PopoverSession {
     if (top) {
       this.openAnalysis(top)
     } else {
-      this.analysisFingerprintKey = null
-      this.analysisFingerprint = null
       this.syncDetailTimers()
     }
   }
@@ -418,14 +388,7 @@ export class PopoverSession {
 
     // A stack carried over from a previous start (the window never really
     // unmounts, but the listener count can still hit zero and come back)
-    // needs a fresh fingerprint baseline before the poll resumes on it.
-    const top = this.snapshot.stack.at(-1)
-    if (top) {
-      const key = sessionKey(top)
-      this.analysisFingerprintKey = key
-      this.analysisFingerprint = null
-      this.seedAnalysisFingerprint(top, generation, key)
-    }
+    // still needs its relative-time ticker running again.
     this.syncDetailTimers()
   }
 
@@ -446,13 +409,8 @@ export class PopoverSession {
     this.stopPopoverShownListening = null
     this.stopLiveUsageListening?.()
     this.stopLiveUsageListening = null
-    this.stopAnalysisPolling()
     this.stopNowTicking()
     this.stopSessionLimitAllocationExpiryTimer()
-    this.analysisFingerprintKey = null
-    this.analysisFingerprint = null
-    this.analysisRetryKey = null
-    this.analysisRetryCount = 0
     window.removeEventListener("keydown", this.onWindowKeyDown)
   }
 
@@ -535,27 +493,14 @@ export class PopoverSession {
   // Opening a session computes its analysis and the shell caches it, but a
   // cache write alone does not change what a scan already put in the list.
   // The shell pushes the one changed row here so the pills stay current
-  // without a full re-query.
+  // without a full re-query, and — since this is also the scan pass's own
+  // per-session signal, not only the worker's — this also refreshes an open
+  // detail pane's analysis when the changed session is the one on screen.
   private listenSessionEntryChanged = async (generation: number): Promise<void> => {
     const unlisten = await onSessionEntryChanged((entry) => {
       if (generation !== this.generation) return
-      const entries = this.snapshot.entries
-      if (!entries) return
-      const index = indexOfSession(entries, entry.agent, entry.sessionId, entry.wslDistro)
-      // A session outside the current window is the next scan's business, so
-      // an entry with no match here is not inserted.
-      if (index === -1) return
-      // The cohort for the high-cost flag is the list on screen, with the
-      // replaced row's own cost swapped in — the same set `toActivityEntries`
-      // would see on a full re-list.
-      const threshold = costOutlierThreshold(
-        entries
-          .map((row, i) => (i === index ? entry.cost?.totalUsd : row.cost?.totalUsd))
-          .filter((usd): usd is number => typeof usd === "number"),
-      )
-      const next = [...entries]
-      next[index] = toActivityEntry(entry, threshold)
-      this.update({ entries: next })
+      this.patchOrRefetchEntry(entry)
+      this.refreshOpenAnalysisIfMatching(entry)
       void this.refreshSessionLimitAllocations()
     })
     if (generation !== this.generation) {
@@ -563,6 +508,90 @@ export class PopoverSession {
       return
     }
     this.stopSessionEntryChangedListening = unlisten
+  }
+
+  /**
+   * Patch the one row `entry` describes in place, re-sorted the way the
+   * backend orders the list so a revived session moves back to the top. A
+   * session not already on screen — one that just re-entered the window, or
+   * one the popover has never listed — triggers a coalesced full refetch
+   * instead of being dropped.
+   */
+  private patchOrRefetchEntry(entry: ActivityEntryPayload): void {
+    const entries = this.snapshot.entries
+    if (!entries) return
+    const index = indexOfSession(entries, entry.agent, entry.sessionId, entry.wslDistro)
+    if (index === -1) {
+      this.requestEntriesRefresh()
+      return
+    }
+    // The cohort for the high-cost flag is the list on screen, with the
+    // replaced row's own cost swapped in — the same set `toActivityEntries`
+    // would see on a full re-list.
+    const threshold = costOutlierThreshold(
+      entries
+        .map((row, i) => (i === index ? entry.cost?.totalUsd : row.cost?.totalUsd))
+        .filter((usd): usd is number => typeof usd === "number"),
+    )
+    const next = [...entries]
+    next[index] = toActivityEntry(entry, threshold)
+    next.sort(compareByRecency)
+    this.update({ entries: next })
+  }
+
+  /**
+   * Refresh `refreshEntries` at most once at a time: a burst of
+   * `sessions:entry-changed` events for sessions outside the current list
+   * (a watcher-driven scan describing several new sessions in one pass, say)
+   * must not start a refetch per event.
+   */
+  private requestEntriesRefresh = (): void => {
+    if (this.entriesRefreshInFlight) {
+      this.entriesRefreshQueued = true
+      return
+    }
+    this.entriesRefreshInFlight = true
+    void this.refreshEntries(this.windowDays())
+      .catch(() => {})
+      .finally(() => {
+        this.entriesRefreshInFlight = false
+        if (this.entriesRefreshQueued) {
+          this.entriesRefreshQueued = false
+          this.requestEntriesRefresh()
+        }
+      })
+  }
+
+  /**
+   * Refresh the open detail pane's analysis when `entry` describes the
+   * subject on top of the stack — its own session, or for a sub-agent
+   * subject its parent's session, in the same environment.
+   */
+  private refreshOpenAnalysisIfMatching(entry: ActivityEntryPayload): void {
+    const subject = this.snapshot.stack.at(-1)
+    if (!subject) return
+    const sessionId = subject.subagent?.parentSessionId ?? subject.sessionId
+    if (
+      entry.agent !== subject.agent ||
+      entry.sessionId !== sessionId ||
+      (entry.wslDistro ?? null) !== (subject.wslDistro ?? null)
+    ) {
+      return
+    }
+    this.requestAnalysisRefresh()
+  }
+
+  /**
+   * Refresh the open analysis, coalesced: a matching event that lands while
+   * a refresh is already in flight schedules exactly one more, run after the
+   * in-flight one settles, rather than a second overlapping load.
+   */
+  private requestAnalysisRefresh = (): void => {
+    if (this.analysisRefreshCount > 0) {
+      this.pendingAnalysisRefresh = true
+      return
+    }
+    void this.refreshAnalysis()
   }
 
   // Storage health changes rarely and matters immediately, so it is pushed
@@ -588,14 +617,21 @@ export class PopoverSession {
   // The scan is the only thing that changes what is on screen behind the
   // reader's back, so that is what the list listens for rather than polling.
   // Only `finished` matters here: no surface in this window draws a pass in
-  // progress, so the intermediate phases have nothing to say.
+  // progress, so the intermediate phases have nothing to say. A full refetch
+  // of entries and repositories only runs when the pass says the list needs
+  // one, or the reconcile interval has elapsed — `sessions:entry-changed`
+  // already keeps individual rows current in between.
   private listenScanEvent = async (generation: number): Promise<void> => {
-    const unlisten = await onScanEvent((_status, phase) => {
+    const unlisten = await onScanEvent((status, phase) => {
       if (generation !== this.generation) return
       if (phase !== "finished") return
-      void this.refreshEntries(this.windowDays()).catch(() => {})
+      const now = Date.now()
+      if (status.listChanged || now - this.lastListReconcileAt >= LIST_RECONCILE_MS) {
+        this.lastListReconcileAt = now
+        void this.refreshEntries(this.windowDays()).catch(() => {})
+        void this.refreshRepositoryList()
+      }
       void this.refreshUsage()
-      void this.refreshRepositoryList()
     })
     if (generation !== this.generation) {
       unlisten()
@@ -819,120 +855,19 @@ export class PopoverSession {
     })
   }
 
-  /**
-   * Load a subject's analysis, then seed the live poll's fingerprint baseline
-   * from the freshly-loaded transcript, and make sure the poll and the
-   * relative-time ticker are running — a detail pane is now open.
-   *
-   * The baseline is fetched only after `loadAnalysisFor` settles, not next to
-   * it: that way the poll's first tick compares against a transcript state at
-   * least as new as what is already on screen, and never fires a refresh on
-   * data the reader has not even seen yet.
-   */
+  /** Load a subject's analysis and make sure the relative-time ticker is running — a detail pane is now open. */
   private openAnalysis(subject: SessionSubject): void {
-    const generation = this.generation
-    const key = sessionKey(subject)
-    this.analysisFingerprintKey = key
-    this.analysisFingerprint = null
-    this.analysisRetryKey = key
-    this.analysisRetryCount = 0
-    void this.loadAnalysisFor(subject).then(() => {
-      if (generation !== this.generation || key !== this.analysisFingerprintKey) return
-      this.seedAnalysisFingerprint(subject, generation, key)
-    })
+    void this.loadAnalysisFor(subject)
     this.syncDetailTimers()
   }
 
-  private seedAnalysisFingerprint(
-    subject: SessionSubject,
-    generation: number,
-    key: string,
-  ): void {
-    void loadAnalysisFingerprint(subject)
-      .then((fingerprint) => {
-        if (generation !== this.generation || key !== this.analysisFingerprintKey) return
-        this.analysisFingerprint = fingerprint
-      })
-      .catch(() => {})
-  }
-
-  /**
-   * One poll tick: fetch the open subject's fingerprint and, if it moved
-   * since the last tick (or the seed), re-load the analysis. Overlapping
-   * ticks are dropped rather than queued — a slow fetch is left to finish on
-   * its own, and the next interval simply tries again.
-   *
-   * A pending analysis (the worker has not published rows for this session
-   * yet) or a stale one (rows are published, but a fresher pass is queued or
-   * running behind them) re-loads on every tick, unbounded, whether or not
-   * the fingerprint moved: there is nothing newer to compare against until
-   * the worker's next pass lands, and that pass is what this poll is
-   * waiting for. That check runs before, and short-circuits, the bounded
-   * unavailable-analysis retry below, which answers a different question —
-   * a published pass that turned up nothing to show.
-   */
-  private tickAnalysisPoll = (): void => {
-    if (this.analysisPollInFlight) return
-    const subject = this.snapshot.stack.at(-1)
-    if (!subject) return
-    const generation = this.generation
-    const key = sessionKey(subject)
-    this.analysisPollInFlight = true
-    void loadAnalysisFingerprint(subject)
-      .then((fingerprint) => {
-        if (generation !== this.generation || key !== this.analysisFingerprintKey) return
-        const previous = this.analysisFingerprint
-        this.analysisFingerprint = fingerprint
-        if (previous !== null && fingerprint !== previous) {
-          void this.refreshAnalysis()
-          return
-        }
-        if (
-          isAnalysisPending(this.snapshot.analysis, key) ||
-          isAnalysisStale(this.snapshot.analysis, key)
-        ) {
-          void this.refreshAnalysis()
-          return
-        }
-        if (subject.subagent) return
-        if (key !== this.analysisRetryKey) {
-          this.analysisRetryKey = key
-          this.analysisRetryCount = 0
-        }
-        if (
-          isUnavailableAnalysis(this.snapshot.analysis, key) &&
-          this.analysisRetryCount < MAX_UNAVAILABLE_ANALYSIS_RETRIES
-        ) {
-          this.analysisRetryCount += 1
-          void this.refreshAnalysis()
-        }
-      })
-      .catch(() => {})
-      .finally(() => {
-        this.analysisPollInFlight = false
-      })
-  }
-
-  /** Start or stop the poll and the relative-time ticker to match whether a detail pane is open. */
+  /** Start or stop the relative-time ticker to match whether a detail pane is open. */
   private syncDetailTimers(): void {
     if (this.snapshot.stack.length > 0) {
-      this.startAnalysisPolling()
       this.startNowTicking()
     } else {
-      this.stopAnalysisPolling()
       this.stopNowTicking()
     }
-  }
-
-  private startAnalysisPolling(): void {
-    if (this.analysisPollTimer !== null) return
-    this.analysisPollTimer = setInterval(this.tickAnalysisPoll, ANALYSIS_POLL_MS)
-  }
-
-  private stopAnalysisPolling(): void {
-    if (this.analysisPollTimer === null) return
-    clearInterval(this.analysisPollTimer)
-    this.analysisPollTimer = null
   }
 
   private startNowTicking(): void {
@@ -954,10 +889,6 @@ export class PopoverSession {
       .then((payload) => {
         if (generation !== this.generation || token !== this.analysisToken) return
         this.update({ analysis: { key, payload, error: false } })
-        if (!isUnavailableAnalysis(this.snapshot.analysis, key)) {
-          this.analysisRetryKey = key
-          this.analysisRetryCount = 0
-        }
       })
       .catch(() => {
         if (generation !== this.generation || token !== this.analysisToken) return
@@ -970,6 +901,10 @@ export class PopoverSession {
    * result stays on screen until the new one lands: `loading` is derived from
    * a key mismatch, and the key does not change here, so the reader sees the
    * header spinner rather than the skeleton.
+   *
+   * A matching `sessions:entry-changed` event that lands while this is
+   * already running is not dropped: `requestAnalysisRefresh` queues exactly
+   * one more call, picked up here once this one settles.
    */
   private refreshAnalysis = async (): Promise<void> => {
     const top = this.snapshot.stack.at(-1)
@@ -981,6 +916,10 @@ export class PopoverSession {
     } finally {
       this.analysisRefreshCount -= 1
       this.update({ analysisRefreshing: this.analysisRefreshCount > 0 })
+      if (this.analysisRefreshCount === 0 && this.pendingAnalysisRefresh) {
+        this.pendingAnalysisRefresh = false
+        void this.refreshAnalysis()
+      }
     }
   }
 

--- a/apps/desktop/src/views/popover/ScanStatusBar.test.tsx
+++ b/apps/desktop/src/views/popover/ScanStatusBar.test.tsx
@@ -22,6 +22,7 @@ function status(overrides: Partial<ScanStatus> = {}): ScanStatus {
     cancelled: false,
     error: null,
     agents: [],
+    listChanged: false,
     ...overrides,
   }
 }

--- a/apps/desktop/src/views/settings/GeneralPane.test.ts
+++ b/apps/desktop/src/views/settings/GeneralPane.test.ts
@@ -13,6 +13,7 @@ function status(overrides: Partial<ScanStatus> = {}): ScanStatus {
     cancelled: false,
     error: null,
     agents: [],
+    listChanged: false,
     ...overrides,
   }
 }

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -1790,35 +1790,8 @@ impl Explorers {
     }
 
     /// Collect every agent's recent session logs, native and WSL, deduped.
-    ///
-    /// Quiet counterpart to [`Self::discover_recent_sessions_with_progress`] for
-    /// callers that report their own progress (or none).
-    pub async fn discover_recent_sessions(&self, now: i64, since_secs: i64) -> Vec<SessionLog> {
-        // One spawn per agent, driven off the `AgentKind::ALL` registry so a new
-        // agent is wired up in exactly one place rather than in each fan-out's
-        // hand-written roster. Order is irrelevant: `collect_discovered_sessions`
-        // merges the per-agent batches.
-        let mut set = tokio::task::JoinSet::new();
-        for t in AgentKind::ALL {
-            let explorer = self.get(t);
-            set.spawn(async move { explorer.discover_recent(now, since_secs).await });
-        }
-        let mut per_agent_logs: Vec<Vec<SessionLog>> = Vec::new();
-        while let Some(result) = set.join_next().await {
-            if let Ok(logs) = result {
-                per_agent_logs.push(logs);
-            }
-        }
-
-        let mut logs = collect_discovered_sessions(per_agent_logs);
-        logs.extend(self.discover_wsl_file_sessions(now, since_secs).await);
-        dedupe_environment_sessions(&mut logs);
-        logs
-    }
-
-    /// Like [`Self::discover_recent_sessions`] but calls `on_agent_done`
-    /// each time an agent explorer completes, enabling per-agent progress
-    /// reporting.
+    /// Calls `on_agent_done` each time an agent explorer completes, enabling
+    /// per-agent progress reporting.
     ///
     /// The callback receives `(agent_name, sessions_found, completed_count, total_agents)`.
     pub async fn discover_recent_sessions_with_progress(

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -207,15 +207,41 @@ Goal: layer 1 is continuous and cheap, and every consumer reads one signal.
   pays for the full walk underneath. Needs the same date- or mtime-gated
   pruning the other three agents got in 4a.
 
-#### Phase 4b: per-session event, idle expiry, HUD fold-in (not started)
+#### Phase 4b: per-session event, idle expiry, HUD fold-in (done)
 
-- A discovery-level per-session event to the webview carries the refreshed
-  `ActivityEntry`, so the list patches one row instead of refetching.
-- Active-to-idle expiry as a backend timer, emitted as the same event.
-- The HUD's `latest_session_activity` becomes a query on the session table
-  or a subscription to the expiry signal; its discovery walk is deleted.
-- The detail pane's 10-second fingerprint poll is replaced by the row-change
-  event.
+- A scan pass now tracks which sessions it actually re-described versus
+  reused, in `scan::describe_with_states`, and announces each changed one
+  through the existing `sessions:entry-changed` event
+  (`SESSION_ENTRY_CHANGED_EVENT`) instead of leaving the popover to find out
+  on its next full refetch. `ScanStatus` gained `list_changed`, true when a
+  pass indexed a session the list has never shown or evicted a rejected one,
+  so a consumer can tell "the set of rows changed" from "a row's fields
+  changed" without diffing the list itself.
+- Active-to-idle expiry is a backend task (`scan/idle.rs`): it sleeps until
+  the soonest active session's window ends, then announces every session
+  that crossed it through the same `sessions:entry-changed` event. An
+  `IdleWake` notify lets `scan::pass` re-arm the task's deadline immediately
+  after a write, rather than waiting for a stale wake.
+  `Store::sessions_active_since` backs the task's read of the active set.
+- `hud::latest_session_activity` is now one call to
+  `Store::latest_session_activity` — a single `SELECT MAX(updated_at_epoch)`
+  query — replacing the discovery walk and its in-memory memoization.
+  `get_latest_session_activity` is a sync command now that it no longer
+  awaits a walk.
+- The popover's detail pane no longer polls a fingerprint. It refreshes,
+  coalesced to one extra run per burst, when `sessions:entry-changed` names
+  its open subject (or, for a sub-agent, its parent). The activity list
+  patches the one row an event describes in place and re-sorts it; a row not
+  already on screen triggers a coalesced full refetch instead. `scan:finished`
+  drives the list too: `list_changed` refetches immediately, and a pass that
+  never sets it still gets reconciled every `LIST_RECONCILE_MS` (60 s, the
+  scheduler's own healthy-watcher tick) as a backstop. The
+  `get_session_analysis_fingerprint` command, `poll_fingerprint_with_subagents`,
+  and their tests are deleted along with the poll.
+- Left out: Cursor's `collect_agent_transcript_dirs` and
+  `collect_cursor_chat_metadata` are still unwindowed recursive walks — the
+  4a follow-up noted above, unrelated to 4b's event and expiry work, and
+  still open.
 
 ## Sequencing notes
 


### PR DESCRIPTION
## Why

Phase 4b of `docs/plans/continuous-session-ingest.md`, the last phase. Stacked on #355 (phase 4a). With the watcher in place a scan pass runs within seconds of a transcript write, so every surface can now read one signal instead of polling or walking discovery on its own.

## What

- **The scan pass announces the rows it changed.** `describe_with_states` tracks which sessions it re-described versus reused. After the upsert, each re-described session that was already indexed is emitted through the existing `sessions:entry-changed` event, so a row on screen patches in place. `ScanStatus` gains `list_changed`, true when a pass indexed a session the list has never shown or evicted a rejected one.
- **Idle expiry is a backend timer.** New `scan/idle.rs` sleeps until the soonest active session's 180 s window ends and emits the same event for every session that crossed it. A pass re-arms it after every upsert. The active set comes from a new `Store::sessions_active_since` over the recency index. Tests run under paused tokio time against a temp store.
- **The HUD reads the store.** `hud::latest_session_activity` is one `MAX(updated_at_epoch)` query. The discovery walk and its 60 s memo are gone, and with them the crate's unwindowed `discover_recent_sessions`, which had no other caller. One behaviour change to note: while discovery is paused the scan does not run, so the HUD's live signal now follows the pause instead of walking on its own.
- **The detail pane listens instead of polling.** The 10 s fingerprint poll, its pending, stale, and unavailable retry loops, the `get_session_analysis_fingerprint` command, and `poll_fingerprint_with_subagents` are deleted. The open analysis refreshes when an entry event names the subject, or a sub-agent subject's parent, coalesced to one extra run per burst. The worker's publish event covers pending and stale analyses; the refresh on `popover:shown` remains the reconciliation for an event that landed before the listener registered.
- **The list patches rows and refetches only when the set changed.** A matching event replaces the row and re-sorts by recency so a revived session moves up. An event for a session not on screen triggers one coalesced refetch. `scan:finished` refetches entries and repositories only when `list_changed` is set or 60 s have passed since the last full refetch; usage refresh is unchanged.
- **Tests.** Scan tests cover the four announce and `list_changed` cases. Popover tests replace the seventeen timer-driven poll cases with seven event-driven ones.

Cursor's unwindowed walks stay as the follow-up recorded in 4a.

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast`, `cargo deny --locked check bans licenses advisories` in `crates/antiburn-local` and `apps/desktop/src-tauri`
- `pnpm lint`, `pnpm type-check`, `pnpm test`, `pnpm exec prettier --check src` in `apps/desktop`
- `pnpm run slop:all`, `pnpm notices:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U73g2iRUFcWZ3ivhoHg8hr
