### PR TITLE
Fix AppImage startup on newer Linux graphics stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test the CI control plane
-        run: node --test scripts/build-tool-catalog.test.mjs scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/mem-report.test.mjs scripts/third-party-notices.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
+        run: node --test scripts/build-tool-catalog.test.mjs scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/mem-report.test.mjs scripts/verify-linux-appimage.test.mjs scripts/third-party-notices.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
 
       # The drift guard runs here, not in a classified job. It reads the
       # contract, the stylesheets, and the popover window's own corner

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -581,6 +581,26 @@ jobs:
           test -f apps/desktop/src-tauri/icons/icon.icns
           test -f apps/desktop/src-tauri/icons/icon.ico
 
+      # Tauri 2.11.4 caches a 2024 linuxdeploy build that bundles libwayland-client.
+      # This pinned build follows the AppImage graphics-library exclusions.
+      - name: Install the pinned Linux AppImage bundler
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          LINUXDEPLOY_ASSET_ID: "538917371"
+          LINUXDEPLOY_SHA256: "36a2d7e274d12e1050d0e9ecfe11d339ed54720b2bec464c286d53f8b07f5c62"
+        run: |
+          set -euo pipefail
+          tools="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+          destination="${tools}/linuxdeploy-x86_64.AppImage"
+          mkdir -p "$tools"
+          curl --fail --location --retry 3 \
+            --header 'Accept: application/octet-stream' \
+            "https://api.github.com/repos/linuxdeploy/linuxdeploy/releases/assets/${LINUXDEPLOY_ASSET_ID}" \
+            --output "$destination"
+          echo "${LINUXDEPLOY_SHA256}  ${destination}" | sha256sum --check --strict
+          chmod +x "$destination"
+
       - name: Build and sign
         shell: bash
         env:
@@ -635,6 +655,22 @@ jobs:
             pnpm --filter @antiburn/desktop exec tauri build \
               --features distribution,analytics --target "$TARGET" --bundles "$BUNDLES"
           fi
+
+      # Host graphics drivers must use the host Wayland client ABI.
+      - name: Verify the Linux AppImage graphics boundary
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          bundle="apps/desktop/src-tauri/target/${TARGET}/release/bundle/appimage"
+          mapfile -t images < <(find "$bundle" -maxdepth 1 -type f -name '*.AppImage' | sort)
+          if [[ "${#images[@]}" -ne 1 ]]; then
+            echo "::error::Expected one AppImage to verify, found ${#images[@]}."
+            exit 1
+          fi
+          node scripts/verify-linux-appimage.mjs "${images[0]}"
 
       # Signing that is not verified is a claim, not a fact.
       - name: Verify the macOS signature and notarization ticket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ CI changes, and documentation that no user acts on stay out — see
 - Context charts now distinguish provider cache misses from cache rehydration
   after meaningful user inactivity, using provider-specific timing.
 
+### Fixed
+
+- Linux AppImages now use the host Wayland client library, preventing WebKit
+  renderer startup failures on newer graphics stacks.
+
 ## [0.3.2] - 2026-09-02
 
 ### Added

--- a/scripts/verify-linux-appimage.mjs
+++ b/scripts/verify-linux-appimage.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import process from "node:process";
+
+const HOST_LIBRARY = "usr/lib/libwayland-client.so.0";
+
+async function exists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function main() {
+  const [input] = process.argv.slice(2);
+  if (!input) throw new Error("Usage: verify-linux-appimage.mjs <AppImage>");
+
+  const appImage = resolve(input);
+  await stat(appImage);
+  const work = await mkdtemp(join(tmpdir(), "antiburn-appimage-check-"));
+  try {
+    const result = spawnSync(appImage, ["--appimage-extract"], {
+      cwd: work,
+      env: { ...process.env, APPIMAGE_EXTRACT_AND_RUN: "1" },
+      stdio: "ignore",
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        `${basename(appImage)} extraction failed with status ${result.status ?? "unknown"}`,
+      );
+    }
+    if (await exists(join(work, "squashfs-root", HOST_LIBRARY))) {
+      throw new Error(`${basename(appImage)} bundles ${HOST_LIBRARY}`);
+    }
+    console.log(`${basename(appImage)} uses the host Wayland client library`);
+  } finally {
+    await rm(work, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/verify-linux-appimage.test.mjs
+++ b/scripts/verify-linux-appimage.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "verify-linux-appimage.mjs",
+);
+
+async function appImageFixture(bundled) {
+  const directory = await mkdtemp(join(tmpdir(), "antiburn-appimage-test-"));
+  const appImage = join(directory, "antiburn.AppImage");
+  await writeFile(
+    appImage,
+    `#!/bin/sh
+set -eu
+test "\${1:-}" = --appimage-extract
+mkdir -p squashfs-root/usr/lib
+${bundled ? "printf bundled > squashfs-root/usr/lib/libwayland-client.so.0" : ":"}
+`,
+  );
+  await chmod(appImage, 0o755);
+  return { appImage, directory };
+}
+
+test("accepts an AppImage that uses the host Wayland client", async (t) => {
+  const subject = await appImageFixture(false);
+  t.after(() => rm(subject.directory, { recursive: true, force: true }));
+
+  const output = execFileSync(process.execPath, [SCRIPT, subject.appImage], {
+    encoding: "utf8",
+  });
+
+  assert.match(output, /uses the host Wayland client library/);
+});
+
+test("rejects an AppImage that bundles the Wayland client", async (t) => {
+  const subject = await appImageFixture(true);
+  t.after(() => rm(subject.directory, { recursive: true, force: true }));
+
+  const result = spawnSync(process.execPath, [SCRIPT, subject.appImage], {
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /bundles usr\/lib\/libwayland-client\.so\.0/);
+});


### PR DESCRIPTION
## What this fixes

The Linux AppImage includes an old graphics library that conflicts with newer Linux systems. Antiburn starts, but its interface never appears. This change makes the AppImage use the computer's compatible library instead and adds a test to prevent the problem from returning.

## How

- Pin a newer `linuxdeploy` build by GitHub asset ID and SHA-256.
- Verify every release AppImage excludes `usr/lib/libwayland-client.so.0`.
- Keep the Debian package, macOS and Windows release paths unchanged.

Tauri 2.11.4 otherwise downloads its cached 2024 `linuxdeploy` build. The pinned build follows the AppImage graphics-library exclusions, so host graphics drivers resolve the host Wayland client ABI.

## Reproduction and verification

I reproduced this with the checksum-verified v0.3.2 AppImage on Arch Linux under Wayland and Hyprland. The stock AppImage emitted `EGL_BAD_PARAMETER`, and its WebKit renderer did not become ready. Removing only the bundled Wayland client fixed startup.

I then built the AppImage from this branch with the pinned bundler. The artifact passed the new package boundary check and its onboarding renderer became ready successfully.

Checks run:

- 94 CI control-plane tests
- `pnpm run secrets`
- `pnpm run slop` — score 100
- Local Tauri debug AppImage build and launch
- Boundary check against both the failing official artifact and the corrected artifact

## Privacy and performance

This changes only the Linux release packaging path. It does not read or transmit credentials, sessions, analytics, or other user data. Application runtime behavior and resource use are unchanged. The Linux release job downloads one checksum-pinned bundler artifact before building.
