### PR TITLE
Fix replayed Claude cache classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ CI changes, and documentation that no user acts on stay out — see
 - Context charts now distinguish provider cache misses from cache rehydration
   after meaningful user inactivity, using provider-specific timing.
 
+### Fixed
+
+- Claude session details now apply the Claude inactivity threshold when they
+  rebuild metrics from stored rows, and name provider cache misses consistently.
+
 ## [0.3.2] - 2026-09-02
 
 ### Added

--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -1710,8 +1710,9 @@ pub fn analysis_from_rows(
     store: &Store,
     key: &SessionKey,
     session_id: &str,
-    agent_slug: &str,
+    agent: AgentKind,
 ) -> Option<SessionAnalysis> {
+    let metrics_agent = vendor_label(agent);
     let rows = store.published_turn_rows(key).ok().flatten()?;
     let record = store.analysis(key).ok().flatten()?;
     let source_summaries_json = record.source_summaries_json.as_deref()?;
@@ -1728,7 +1729,7 @@ pub fn analysis_from_rows(
             .cloned()
             .unwrap_or_default()
     };
-    let mut by_source = metrics_by_source(agent_slug, session_id, &rows, summary_for);
+    let mut by_source = metrics_by_source(metrics_agent, session_id, &rows, summary_for);
     let mut parent_metrics = by_source.remove(session_id)?;
     // `metrics_by_source` replays each source's own tool-call history from
     // its rows' last-tool-only summary (`replay.rs`'s module doc comment),
@@ -1741,7 +1742,7 @@ pub fn analysis_from_rows(
     if let Some(initial_context) = initial_context {
         parent_metrics.initial_context = Some(initial_context);
     }
-    let merged = metrics_from_rows(agent_slug, session_id, &rows, summary_for).ok()?;
+    let merged = metrics_from_rows(metrics_agent, session_id, &rows, summary_for).ok()?;
 
     let by_id: HashMap<String, (SessionMetrics, Option<i64>)> = by_source
         .into_iter()
@@ -1778,7 +1779,7 @@ pub fn analysis_from_rows(
         // no separate row-store query to reconcile against here, unlike
         // the worker pass's own `RowProjections`.
         row_projections: None,
-        agent_slug: agent_slug.to_string(),
+        agent_slug: agent.slug().to_string(),
         parent_session_id: session_id.to_string(),
         // Rows carry no file path, so the drilldown's reveal action stays
         // unavailable for a replayed view.
@@ -1979,8 +1980,9 @@ pub fn subagent_analysis_from_rows(
     parent_key: &SessionKey,
     parent_session_id: &str,
     subagent_id: &str,
-    agent_slug: &str,
+    agent: AgentKind,
 ) -> Option<SessionAnalysis> {
+    let metrics_agent = vendor_label(agent);
     let rows = store.published_turn_rows(parent_key).ok().flatten()?;
     let record = store.analysis(parent_key).ok().flatten()?;
     let source_summaries_json = record.source_summaries_json.as_deref()?;
@@ -1993,13 +1995,13 @@ pub fn subagent_analysis_from_rows(
             .cloned()
             .unwrap_or_default()
     };
-    let mut by_source = metrics_by_source(agent_slug, parent_session_id, &rows, summary_for);
+    let mut by_source = metrics_by_source(metrics_agent, parent_session_id, &rows, summary_for);
     let metrics = by_source.remove(subagent_id)?;
     let started_at_epoch = source_started_at_epoch(&source_summaries, &rows, subagent_id);
 
     Some(standalone_session_analysis(
         metrics,
-        agent_slug.to_string(),
+        agent.slug().to_string(),
         None,
         record.source_fingerprint,
         started_at_epoch,

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -960,7 +960,7 @@ pub async fn get_session_analysis(
     // — so this command never caches one itself or emits
     // `SESSION_ENTRY_CHANGED_EVENT` for it.
     let (analysis, analysis_pending, analysis_stale) =
-        match analysis::analysis_from_rows(&store, &key, &session_id, &agent) {
+        match analysis::analysis_from_rows(&store, &key, &session_id, kind) {
             Some(replayed) => {
                 let fingerprint_mismatch = nudge_if_evidence_stale(
                     &app,
@@ -1042,7 +1042,7 @@ pub async fn get_subagent_analysis(
         &parent_key,
         &parent_session_id,
         &subagent_id,
-        &agent,
+        kind,
     ) {
         Some(replayed) => {
             let evidence_status = store

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -4,6 +4,7 @@ use antiburn_local::analysis::{
     ContentKind, ContentPart, MemoryTurnRowStore, TurnRowStore, TurnScope, count_turn_content_rows,
     count_turn_rows,
 };
+use antiburn_local::model::AgentKind;
 
 use super::model::{
     PublishedEvidence, SESSION_DATA_RETENTION_DAYS_30, SESSION_DATA_RETENTION_DAYS_90,
@@ -2533,7 +2534,10 @@ async fn analysis_from_rows_serves_a_published_pass_without_reading_a_transcript
                 agent: "claude".into(),
                 session_id: record.key.session_id.clone(),
                 source: antiburn_local::analysis::RawSource::Jsonl(
-                    r#"{"type":"assistant","timestamp":100,"message":{"id":"m","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":2,"output_tokens":3},"content":[]}}
+                    r#"{"type":"user","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"start"}}
+{"type":"assistant","timestamp":"2026-01-01T00:00:01Z","message":{"id":"m1","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":100,"cache_read_input_tokens":30000,"output_tokens":3},"content":[]}}
+{"type":"user","timestamp":"2026-01-01T02:00:00Z","message":{"role":"user","content":"resume"}}
+{"type":"assistant","timestamp":"2026-01-01T02:00:01Z","message":{"id":"m2","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":100,"cache_read_input_tokens":5000,"cache_creation_input_tokens":25000,"output_tokens":3},"content":[]}}
 "#
                     .into(),
                 ),
@@ -2567,11 +2571,13 @@ async fn analysis_from_rows_serves_a_published_pass_without_reading_a_transcript
         &store,
         &record.key,
         &record.key.session_id,
-        "claude-code",
+        AgentKind::Claude,
     )
     .expect("a ready, published pass replays from rows");
 
-    assert!(replayed.metrics.is_some());
+    let metrics = replayed.metrics.as_ref().expect("replayed metrics");
+    assert_eq!(metrics.cache_rehydration_count, 1);
+    assert_eq!(metrics.cache_routing_miss_count, 0);
     assert_eq!(replayed.fingerprint, "sv1:rows-replay-parent");
     assert_eq!(replayed.cost, replayed.top_level_cost);
     assert!(replayed.source_path.is_none());
@@ -2648,7 +2654,7 @@ async fn analysis_from_rows_still_serves_a_published_pass_after_a_requeue() {
         &store,
         &record.key,
         &record.key.session_id,
-        "claude-code",
+        AgentKind::Claude,
     )
     .expect("a requeued session still replays its last published rows");
 
@@ -2678,7 +2684,7 @@ fn analysis_from_rows_returns_none_before_anything_was_ever_published() {
             &store,
             &claim.key,
             &claim.key.session_id,
-            "claude-code"
+            AgentKind::Claude,
         )
         .is_none()
     );
@@ -2712,7 +2718,7 @@ fn analysis_from_rows_serves_a_pass_published_unsupported() {
     );
 
     let replayed =
-        crate::analysis::analysis_from_rows(&store, &key, &key.session_id, "claude-code")
+        crate::analysis::analysis_from_rows(&store, &key, &key.session_id, AgentKind::Claude)
             .expect("an unsupported, published pass still replays from rows");
 
     assert!(replayed.metrics.is_some());

--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -230,7 +230,7 @@ describe("SessionDetailPresentation — chrome", () => {
       cost: cost(),
       summary: summary({ sessions: [metrics({ cacheRoutingMissCount: 2 })] }),
     })
-    expect(screen.getByText(/2 routing misses/)).toBeTruthy()
+    expect(screen.getByText(/2 provider cache misses/)).toBeTruthy()
   })
 
   it("omits the Cost card when nothing priced the session", () => {

--- a/apps/desktop/src/components/session/tokensCard.test.ts
+++ b/apps/desktop/src/components/session/tokensCard.test.ts
@@ -60,16 +60,16 @@ describe("tokensCardModel", () => {
     )
   })
 
-  it("adds the routing-miss count to the hint, pluralized", () => {
+  it("adds the provider-cache-miss count to the hint, pluralized", () => {
     expect(tokensCardModel({ ...base, cacheRoutingMissCount: 1 }).hint).toBe(
-      "1.2M in · 34.0k out · 1 routing miss",
+      "1.2M in · 34.0k out · 1 provider cache miss",
     )
     expect(tokensCardModel({ ...base, cacheRoutingMissCount: 2 }).hint).toBe(
-      "1.2M in · 34.0k out · 2 routing misses",
+      "1.2M in · 34.0k out · 2 provider cache misses",
     )
     expect(
       tokensCardModel({ ...base, cacheRehydrationCount: 1, cacheRoutingMissCount: 2 }).hint,
-    ).toBe("1.2M in · 34.0k out · 1 rehydration · 2 routing misses")
+    ).toBe("1.2M in · 34.0k out · 1 rehydration · 2 provider cache misses")
   })
 
   it("keeps a null cost total when nothing was priced", () => {

--- a/apps/desktop/src/components/session/tokensCard.ts
+++ b/apps/desktop/src/components/session/tokensCard.ts
@@ -33,11 +33,11 @@ export interface TokensCardModel {
    * the headline. Mixing subjects would produce rows that do not add up.
    */
   split: TokensCostSplit | null
-  /** Right-hand hint: token counts, then compactions and rehydrations when any. */
+  /** Right-hand hint: token counts, then compactions and cache events when any. */
   hint: string
 }
 
-/** "3 compactions", "1 compaction", "2 routing misses". */
+/** "3 compactions", "1 compaction", "2 provider cache misses". */
 function countLabel(count: number, noun: string): string {
   if (count === 1) return `${count} ${noun}`
   return `${count} ${noun}${noun.endsWith("s") ? "es" : "s"}`
@@ -105,7 +105,9 @@ export function tokensCardModel(input: {
   const parts = [`${formatCompact(tokensInTotal)} in`, `${formatCompact(tokensOutTotal)} out`]
   if (compactionCount > 0) parts.push(countLabel(compactionCount, "compaction"))
   if (cacheRehydrationCount > 0) parts.push(countLabel(cacheRehydrationCount, "rehydration"))
-  if (cacheRoutingMissCount > 0) parts.push(countLabel(cacheRoutingMissCount, "routing miss"))
+  if (cacheRoutingMissCount > 0) {
+    parts.push(countLabel(cacheRoutingMissCount, "provider cache miss"))
+  }
 
   return { costTotal, split, hint: parts.join(" · ") }
 }


### PR DESCRIPTION
## Summary
- pass typed agent identity into stored-row replay and derive the canonical metrics vendor label
- preserve the storage slug in session-detail output
- call cache misses provider cache misses in the Context summary
- cover a two-hour Claude resume through persisted-row replay

## Testing
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop test
- pnpm --filter @antiburn/desktop build
- pnpm run slop:all
- pnpm run secrets