### PR TITLE
scan: stop the watcher self-trigger and name every scan trigger (phase 5a)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -45,7 +45,7 @@ use crate::insights_report::ReportRequest;
 use crate::popover;
 use crate::provider_usage;
 use crate::repositories;
-use crate::scan::{self, ScanController};
+use crate::scan::{self, ScanController, ScanTrigger};
 use crate::settings;
 use crate::store::model::environment_key;
 use crate::store::{
@@ -451,7 +451,8 @@ fn apply_settings_transition(app: &tauri::AppHandle, previous: &AppSettings, sav
         || saved.activity_window_days > previous.activity_window_days
         || (previous.discovery_paused && !saved.discovery_paused);
     if wants_scan && !saved.discovery_paused {
-        app.state::<ScanController>().request();
+        app.state::<ScanController>()
+            .request(ScanTrigger::SettingsTransition);
     }
 
     // Put the first-run window away and say where the app went. Done here
@@ -1205,7 +1206,7 @@ pub async fn scan_now(
     app: tauri::AppHandle,
     activity_window_days: Option<u32>,
 ) -> CommandResult<ScanStatus> {
-    Ok(scan::run_pass(&app, activity_window_days).await)
+    Ok(scan::run_pass(&app, activity_window_days, ScanTrigger::ManualRescan).await)
 }
 
 /// Ask the scan in flight to stop at its next phase boundary.
@@ -1284,7 +1285,8 @@ pub async fn get_insights_report(app: tauri::AppHandle) -> CommandResult<Insight
     // waiting out a tick. This is a further call site of the shipped
     // on-demand trigger — the same kick the popover and the other
     // commands fire — not a new trigger class and not queue reordering.
-    app.state::<ScanController>().request();
+    app.state::<ScanController>()
+        .request(ScanTrigger::InsightsPane);
     let data_dir = app.state::<Store>().state_dir().to_path_buf();
     let request = insights_report_request(epoch_now());
     let report = app
@@ -1558,7 +1560,8 @@ pub async fn set_repository_enabled(
     // a pass so the rows come back without the reader doing anything.
     let _ = app.emit(SESSIONS_INVALIDATED_EVENT, ());
     if enabled {
-        app.state::<ScanController>().request();
+        app.state::<ScanController>()
+            .request(ScanTrigger::RepositoryToggle);
     }
     list_repositories(app)
 }
@@ -1608,7 +1611,8 @@ pub async fn add_scan_root(app: tauri::AppHandle, path: String) -> CommandResult
         store.scan_roots().map_err(fail)?
     };
     mirror_scan_roots(&app, &roots).await.map_err(fail)?;
-    app.state::<ScanController>().request();
+    app.state::<ScanController>()
+        .request(ScanTrigger::ScanRootAdded);
     Ok(roots)
 }
 
@@ -1765,7 +1769,8 @@ pub fn clear_local_index(app: tauri::AppHandle) -> CommandResult<usize> {
         .map_err(fail)?;
     // The index is empty and the popover is showing it. Refill it rather than
     // leaving a reader looking at an empty list until the next tick.
-    app.state::<ScanController>().request();
+    app.state::<ScanController>()
+        .request(ScanTrigger::IndexCleared);
     Ok(removed)
 }
 
@@ -1863,7 +1868,8 @@ pub async fn request_folder_access(
     recorded.map_err(fail)?;
 
     if matches!(outcome, consent::ProbeOutcome::Granted { .. }) {
-        app.state::<ScanController>().request();
+        app.state::<ScanController>()
+            .request(ScanTrigger::FolderAccessGranted);
     }
 
     Ok(FolderAccessOutcome {
@@ -1944,7 +1950,8 @@ pub async fn recheck_folder_permissions(app: tauri::AppHandle) -> CommandResult<
     };
 
     if !discovered.is_empty() {
-        app.state::<ScanController>().request();
+        app.state::<ScanController>()
+            .request(ScanTrigger::FolderAccessGranted);
     }
     let mut discovered: Vec<String> = discovered.into_iter().collect();
     discovered.sort();

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -1736,7 +1736,7 @@ fn note_shown(app: &AppHandle) {
     if let Some(controller) = app.try_state::<crate::scan::ScanController>() {
         // Opening the popover is the one moment a reader is guaranteed to be
         // looking, so refresh immediately instead of waiting out a tick.
-        controller.request();
+        controller.request(crate::scan::ScanTrigger::PopoverShown);
     }
     // A separate signal from the scan kick just above, on purpose, rather
     // than something the webview infers from `scan:finished`. Two things

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -72,9 +72,10 @@
 //! scheduler is a single handle the app aborts on exit, so nothing outlives
 //! the process.
 
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use antiburn_local::discovery::scanner::{self, TitleSource};
 use antiburn_local::discovery::{
@@ -114,6 +115,62 @@ pub const EVENT_STARTED: &str = "scan:started";
 pub const EVENT_PROGRESS: &str = "scan:progress";
 pub const EVENT_FINISHED: &str = "scan:finished";
 
+/// W3: why a pass was requested. Every request site names its own purpose, so
+/// a log line answers "why is the machine scanning right now" without having
+/// to correlate timestamps against reader actions after the fact.
+#[derive(Debug, Clone)]
+pub enum ScanTrigger {
+    /// The one pass run at startup, after onboarding has finished.
+    Launch,
+    /// The scheduler's unconditional [`TICK`].
+    Tick,
+    /// A filesystem change the watcher's debouncer coalesced into one burst.
+    Watcher {
+        /// Relevant events folded into the burst, including any past the
+        /// stored path sample's bound.
+        events: usize,
+        /// The burst's deduplicated paths, in first-seen order, bounded at a
+        /// fixed constant — see [`watch::WatchBurst`].
+        paths: Vec<PathBuf>,
+    },
+    /// The popover reached the screen.
+    PopoverShown,
+    /// A settings save that finished onboarding, widened the activity
+    /// window, or resumed discovery.
+    SettingsTransition,
+    /// The Insights pane was opened.
+    InsightsPane,
+    /// A repository was included or ignored.
+    RepositoryToggle,
+    /// A scan root was added.
+    ScanRootAdded,
+    /// A protected folder's access was granted or discovered.
+    FolderAccessGranted,
+    /// The local index was cleared.
+    IndexCleared,
+    /// The reader asked for a rescan explicitly.
+    ManualRescan,
+}
+
+impl ScanTrigger {
+    /// A stable snake_case name for logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ScanTrigger::Launch => "launch",
+            ScanTrigger::Tick => "tick",
+            ScanTrigger::Watcher { .. } => "watcher",
+            ScanTrigger::PopoverShown => "popover_shown",
+            ScanTrigger::SettingsTransition => "settings_transition",
+            ScanTrigger::InsightsPane => "insights_pane",
+            ScanTrigger::RepositoryToggle => "repository_toggle",
+            ScanTrigger::ScanRootAdded => "scan_root_added",
+            ScanTrigger::FolderAccessGranted => "folder_access_granted",
+            ScanTrigger::IndexCleared => "index_cleared",
+            ScanTrigger::ManualRescan => "manual_rescan",
+        }
+    }
+}
+
 /// The scheduler's shared state, registered as Tauri managed state.
 #[derive(Default)]
 pub struct ScanController {
@@ -121,12 +178,45 @@ pub struct ScanController {
     cancel: Arc<AtomicBool>,
     status: Mutex<ScanStatus>,
     kick: Notify,
+    /// The trigger for the next pass the scheduler will run, set by
+    /// [`ScanController::request`] and taken by the scheduler loop when it
+    /// wakes. W3: a second request while one is already pending is coalesced
+    /// rather than queued, because the waiting request already covers
+    /// "scan again soon".
+    pending_trigger: Mutex<Option<ScanTrigger>>,
 }
 
 impl ScanController {
-    /// Ask for a pass as soon as the scheduler can start one.
-    pub fn request(&self) {
+    /// Ask for a pass as soon as the scheduler can start one, naming why.
+    ///
+    /// If a trigger is already pending, the earlier one is kept: the pending
+    /// trigger already means a pass is coming, so the second ask changes
+    /// nothing about when that happens, only which label would explain it.
+    pub fn request(&self, trigger: ScanTrigger) {
+        let mut pending = self
+            .pending_trigger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match pending.as_ref() {
+            Some(existing) => {
+                ::tracing::debug!(
+                    event = "scan_request_coalesced",
+                    kept = existing.label(),
+                    dropped = trigger.label(),
+                );
+            }
+            None => *pending = Some(trigger),
+        }
+        drop(pending);
         self.kick.notify_one();
+    }
+
+    /// Take the pending trigger, if any, for the scheduler to run next.
+    fn take_pending_trigger(&self) -> Option<ScanTrigger> {
+        self.pending_trigger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
     }
 
     /// Ask the pass in flight to stop at its next phase boundary.
@@ -179,7 +269,7 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
         let tick = tick_for(&watch::spawn_watcher(&app));
         // A fresh install has nothing to scan until the reader picks sources.
         if scheduled_scanning_allowed(&app) {
-            run_pass(&app, None).await;
+            run_pass(&app, None, ScanTrigger::Launch).await;
         }
         loop {
             let controller = app.state::<ScanController>();
@@ -193,7 +283,12 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
             if !scheduled_scanning_allowed(&app) {
                 continue;
             }
-            run_pass(&app, None).await;
+            // A trigger is pending unless this woke from the sleep arm with
+            // nothing requested, which is the unconditional tick itself.
+            let trigger = controller
+                .take_pending_trigger()
+                .unwrap_or(ScanTrigger::Tick);
+            run_pass(&app, None, trigger).await;
         }
     })
 }
@@ -225,10 +320,20 @@ fn scheduled_scanning_allowed(app: &AppHandle) -> bool {
 }
 
 /// Run one pass, unless one is already in flight.
-pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> ScanStatus {
+pub async fn run_pass(
+    app: &AppHandle,
+    activity_window_days: Option<u32>,
+    trigger: ScanTrigger,
+) -> ScanStatus {
+    log_scan_pass_requested(&trigger);
     {
         let controller = app.state::<ScanController>();
         if !on_demand_start(&controller) {
+            // W4: a request dropped here is otherwise silent, and a hidden
+            // feedback loop then shows up only as a wall of full passes on
+            // the tick. Logging the trigger turns that into a visible stream
+            // of drops instead.
+            ::tracing::debug!(event = "scan_request_dropped", trigger = trigger.label());
             return controller.status();
         }
         let started = controller.update(|status| {
@@ -242,6 +347,8 @@ pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> Sca
         });
         let _ = app.emit(EVENT_STARTED, started);
     }
+    ::tracing::debug!(event = "scan_pass_started", trigger = trigger.label());
+    let pass_started_at = Instant::now();
 
     let announce_app = app.clone();
     let announce = move |entry: ActivityEntry| {
@@ -276,6 +383,32 @@ pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> Sca
     if outcome.is_ok() {
         storage_health::note_ok(app);
     }
+    let duration_ms = pass_started_at.elapsed().as_millis() as u64;
+    match &outcome {
+        Ok(summary) => {
+            ::tracing::debug!(
+                event = "scan_pass_finished",
+                trigger = trigger.label(),
+                duration_ms,
+                sessions = summary.sessions,
+                re_described = summary.re_described,
+                list_changed = summary.list_changed,
+                cancelled,
+            );
+        }
+        Err(error) => {
+            ::tracing::debug!(
+                event = "scan_pass_finished",
+                trigger = trigger.label(),
+                duration_ms,
+                sessions = 0,
+                re_described = 0,
+                list_changed = false,
+                cancelled,
+                error = %error,
+            );
+        }
+    }
     let _ = app.emit(EVENT_FINISHED, finished.clone());
     // The outcome, not a shaped event: whether this pass is worth reporting at
     // all is an analytics question, and this scheduler runs a pass a minute
@@ -289,6 +422,34 @@ pub async fn run_pass(app: &AppHandle, activity_window_days: Option<u32>) -> Sca
     finished
 }
 
+/// Log `scan_pass_requested`. Every call to [`run_pass`] gets one, whether it
+/// goes on to run or is dropped by [`on_demand_start`] — the drop is a
+/// separate `scan_request_dropped` line (W4), and a coalesced ask never
+/// reaches here at all: it never became a pending trigger a scheduler wake
+/// picked up (see [`ScanController::request`]).
+fn log_scan_pass_requested(trigger: &ScanTrigger) {
+    match trigger {
+        ScanTrigger::Watcher { events, paths } => {
+            let sample = paths
+                .iter()
+                .take(8)
+                .map(|path| path.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(",");
+            ::tracing::debug!(
+                event = "scan_pass_requested",
+                trigger = trigger.label(),
+                events,
+                paths = %sample,
+                path_count = paths.len(),
+            );
+        }
+        other => {
+            ::tracing::debug!(event = "scan_pass_requested", trigger = other.label());
+        }
+    }
+}
+
 /// What one pass persisted, for [`run_pass`] to fold into the reported status.
 struct PassSummary {
     sessions: usize,
@@ -296,6 +457,9 @@ struct PassSummary {
     /// patch: this pass indexed a session the list has never shown, or
     /// evicted a rejected one.
     list_changed: bool,
+    /// [`Described::changed`]'s length: rows this pass re-described, new or
+    /// with a moved cursor, never a row reused verbatim.
+    re_described: usize,
 }
 
 /// The body of one pass. Split out so [`run_pass`] owns only the in-flight
@@ -381,6 +545,7 @@ async fn pass(
         return Ok(PassSummary {
             sessions: records.len(),
             list_changed,
+            re_described: changed.len(),
         });
     }
 
@@ -389,6 +554,7 @@ async fn pass(
     Ok(PassSummary {
         sessions: records.len(),
         list_changed,
+        re_described: changed.len(),
     })
 }
 

--- a/apps/desktop/src-tauri/src/scan/tests.rs
+++ b/apps/desktop/src-tauri/src/scan/tests.rs
@@ -1332,6 +1332,30 @@ fn a_fresh_controller_reports_a_clean_initial_status() {
     assert!(!status.cancelled);
 }
 
+#[tokio::test(start_paused = true)]
+async fn a_second_request_before_the_scheduler_wakes_is_coalesced() {
+    let controller = ScanController::default();
+    controller.request(ScanTrigger::PopoverShown);
+    controller.request(ScanTrigger::ManualRescan);
+
+    {
+        let pending = controller
+            .pending_trigger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(
+            matches!(pending.as_ref(), Some(ScanTrigger::PopoverShown)),
+            "the first trigger is kept, the second is dropped"
+        );
+    }
+
+    // The two requests notify only once: this consumes that single permit...
+    controller.kick.notified().await;
+    // ...and a second wait finds nothing further queued.
+    let second = tokio::time::timeout(Duration::from_millis(0), controller.kick.notified()).await;
+    assert!(second.is_err(), "only one notify should have been queued");
+}
+
 #[test]
 fn a_cancel_request_only_applies_while_a_pass_is_running() {
     let controller = ScanController::default();

--- a/apps/desktop/src-tauri/src/scan/watch.rs
+++ b/apps/desktop/src-tauri/src/scan/watch.rs
@@ -86,7 +86,9 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherStatus {
         return WatcherStatus::default();
     };
     let app = app.clone();
-    spawn_watcher_over(home, move || {
+    // The burst is threaded through in full starting here (W2); the next
+    // change wires its paths and event count into a named request trigger.
+    spawn_watcher_over(home, move |_burst: WatchBurst| {
         app.state::<crate::scan::ScanController>().request();
     })
 }
@@ -106,7 +108,7 @@ fn all_watch_roots(home: &Path) -> Vec<WatchRoot> {
 /// tests, under `tokio::time::pause()`, without a running app.
 fn spawn_watcher_over(
     home: PathBuf,
-    on_relevant_change: impl Fn() + Send + Sync + 'static,
+    on_relevant_change: impl Fn(WatchBurst) + Send + Sync + 'static,
 ) -> WatcherStatus {
     let roots = all_watch_roots(&home);
     let (tx, rx) = unbounded_channel::<Event>();
@@ -187,25 +189,65 @@ async fn run_root_recheck_loop(
     }
 }
 
+/// W2: the paths a debounce burst that stores has become this large stops
+/// growing. A pass request still names the trigger and its event count past
+/// this point; only the path sample is capped, so a runaway burst cannot grow
+/// the debouncer's memory with the size of the change.
+const MAX_BURST_PATHS: usize = 64;
+
+/// One coalesced run of relevant filesystem events, handed to
+/// `on_relevant_change` after the burst's quiet period ends.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct WatchBurst {
+    /// Relevant paths seen in this burst, deduplicated, in first-seen order,
+    /// bounded at [`MAX_BURST_PATHS`].
+    pub paths: Vec<PathBuf>,
+    /// Every relevant event coalesced into this burst. Counts past
+    /// [`MAX_BURST_PATHS`] even after the path sample stops growing.
+    pub events: usize,
+}
+
+impl WatchBurst {
+    /// Fold one relevant event's paths into the burst.
+    fn record(&mut self, event: &Event) {
+        self.events += 1;
+        for path in &event.paths {
+            if self.paths.len() >= MAX_BURST_PATHS {
+                break;
+            }
+            if !self.paths.contains(path) {
+                self.paths.push(path.clone());
+            }
+        }
+    }
+}
+
 /// Consume events until the channel closes, requesting one pass after each
 /// quiet period. See the module doc for the debounce shape.
-async fn run_debounce_loop(mut events: UnboundedReceiver<Event>, on_relevant_change: impl Fn()) {
+async fn run_debounce_loop(
+    mut events: UnboundedReceiver<Event>,
+    on_relevant_change: impl Fn(WatchBurst),
+) {
     while let Some(first) = events.recv().await {
         if !is_relevant(&first) {
             continue;
         }
-        wait_for_quiet(&mut events, QUIET_WINDOW, MAX_WAIT).await;
-        on_relevant_change();
+        let mut burst = WatchBurst::default();
+        burst.record(&first);
+        wait_for_quiet(&mut events, QUIET_WINDOW, MAX_WAIT, &mut burst).await;
+        on_relevant_change(burst);
     }
 }
 
 /// After a relevant event, keep consuming events while more relevant ones
 /// keep arriving inside the quiet window, up to the maximum wait. Only a
-/// relevant event resets the quiet window; noise never extends it.
+/// relevant event resets the quiet window; noise never extends it. Every
+/// relevant event folds its paths into `burst` (W2).
 async fn wait_for_quiet(
     events: &mut UnboundedReceiver<Event>,
     quiet: Duration,
     max_wait: Duration,
+    burst: &mut WatchBurst,
 ) {
     let deadline = Instant::now() + max_wait;
     let mut quiet_deadline = Instant::now() + quiet;
@@ -217,6 +259,7 @@ async fn wait_for_quiet(
                     return;
                 };
                 if is_relevant(&event) {
+                    burst.record(&event);
                     quiet_deadline = Instant::now() + quiet;
                 }
                 if Instant::now() >= deadline {
@@ -230,9 +273,17 @@ async fn wait_for_quiet(
     }
 }
 
-/// Drop `Access`-only events (including antiburn's own reads) and events
-/// whose every path sits under a WSL mount — WSL sessions run through the
-/// tick's own discovery walk, not this watcher.
+/// Drop `Access`-only events (including antiburn's own reads), events whose
+/// every path sits under a WSL mount — WSL sessions run through the tick's
+/// own discovery walk, not this watcher — and events whose every path is a
+/// SQLite `-shm` sidecar.
+///
+/// W1: a WAL reader takes read marks in the `-shm` file, which bumps its
+/// mtime. antiburn's own read-only open of a vendor database (Cursor's
+/// `state.vscdb`) therefore modifies `-shm` on every pass, and without this
+/// rule the watcher would re-kick a pass the moment the previous one finished
+/// reading. `-wal` stays relevant: only a real writer appends to it, and a
+/// WAL database's committed rows live there until a checkpoint.
 fn is_relevant(event: &Event) -> bool {
     if matches!(event.kind, EventKind::Access(_)) {
         return false;
@@ -240,11 +291,20 @@ fn is_relevant(event: &Event) -> bool {
     if event.paths.is_empty() {
         return true;
     }
+    if event.paths.iter().all(|path| is_shm_sidecar_path(path)) {
+        return false;
+    }
     !event.paths.iter().all(|path| is_wsl_mount_path(path))
 }
 
 fn is_wsl_mount_path(path: &Path) -> bool {
     environment_from_mounted_path(path).is_some()
+}
+
+fn is_shm_sidecar_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with("-shm"))
 }
 
 #[cfg(test)]
@@ -267,7 +327,7 @@ mod tests {
         let (tx, rx) = unbounded_channel();
         let fires = Arc::new(AtomicUsize::new(0));
         let counter = fires.clone();
-        tokio::spawn(run_debounce_loop(rx, move || {
+        tokio::spawn(run_debounce_loop(rx, move |_burst: WatchBurst| {
             counter.fetch_add(1, Ordering::SeqCst);
         }));
 
@@ -298,7 +358,7 @@ mod tests {
         let (tx, rx) = unbounded_channel();
         let fires = Arc::new(AtomicUsize::new(0));
         let counter = fires.clone();
-        tokio::spawn(run_debounce_loop(rx, move || {
+        tokio::spawn(run_debounce_loop(rx, move |_burst: WatchBurst| {
             counter.fetch_add(1, Ordering::SeqCst);
         }));
 
@@ -320,13 +380,33 @@ mod tests {
         let (tx, rx) = unbounded_channel();
         let fires = Arc::new(AtomicUsize::new(0));
         let counter = fires.clone();
-        tokio::spawn(run_debounce_loop(rx, move || {
+        tokio::spawn(run_debounce_loop(rx, move |_burst: WatchBurst| {
             counter.fetch_add(1, Ordering::SeqCst);
         }));
 
         tx.send(access_event(Path::new("/tmp/a"))).unwrap();
         tokio::time::sleep(MAX_WAIT + Duration::from_secs(1)).await;
         assert_eq!(fires.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn two_events_for_the_same_path_yield_one_path_and_two_events() {
+        let (tx, rx) = unbounded_channel();
+        let bursts: Arc<std::sync::Mutex<Vec<WatchBurst>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let collected = bursts.clone();
+        tokio::spawn(run_debounce_loop(rx, move |burst: WatchBurst| {
+            collected.lock().unwrap().push(burst);
+        }));
+
+        tx.send(modify_event(Path::new("/tmp/a"))).unwrap();
+        tx.send(modify_event(Path::new("/tmp/a"))).unwrap();
+        tokio::time::sleep(QUIET_WINDOW + Duration::from_millis(100)).await;
+
+        let bursts = bursts.lock().unwrap();
+        assert_eq!(bursts.len(), 1);
+        assert_eq!(bursts[0].paths, vec![PathBuf::from("/tmp/a")]);
+        assert_eq!(bursts[0].events, 2);
     }
 
     #[test]
@@ -338,6 +418,26 @@ mod tests {
 
         let native = modify_event(Path::new("/home/avery/.claude/projects/p/s.jsonl"));
         assert!(is_relevant(&native));
+    }
+
+    #[test]
+    fn an_event_confined_to_shm_sidecars_is_not_relevant() {
+        let shm_only = modify_event(Path::new("/home/avery/.cursor/state.vscdb-shm"));
+        assert!(!is_relevant(&shm_only));
+    }
+
+    #[test]
+    fn an_event_with_one_shm_path_and_one_relevant_path_is_relevant() {
+        let mixed = Event::new(EventKind::Modify(ModifyKind::Any))
+            .add_path(PathBuf::from("/home/avery/.cursor/state.vscdb-shm"))
+            .add_path(PathBuf::from("/home/avery/.claude/projects/p/s.jsonl"));
+        assert!(is_relevant(&mixed));
+    }
+
+    #[test]
+    fn a_wal_event_is_relevant() {
+        let wal = modify_event(Path::new("/home/avery/.cursor/state.vscdb-wal"));
+        assert!(is_relevant(&wal));
     }
 
     #[test]
@@ -392,7 +492,7 @@ mod tests {
 
         let fired = Arc::new(AtomicUsize::new(0));
         let counter = fired.clone();
-        let status = spawn_watcher_over(home.path().to_path_buf(), move || {
+        let status = spawn_watcher_over(home.path().to_path_buf(), move |_burst: WatchBurst| {
             counter.fetch_add(1, Ordering::SeqCst);
         });
         assert!(status.active);

--- a/apps/desktop/src-tauri/src/scan/watch.rs
+++ b/apps/desktop/src-tauri/src/scan/watch.rs
@@ -86,10 +86,12 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherStatus {
         return WatcherStatus::default();
     };
     let app = app.clone();
-    // The burst is threaded through in full starting here (W2); the next
-    // change wires its paths and event count into a named request trigger.
-    spawn_watcher_over(home, move |_burst: WatchBurst| {
-        app.state::<crate::scan::ScanController>().request();
+    spawn_watcher_over(home, move |burst: WatchBurst| {
+        app.state::<crate::scan::ScanController>()
+            .request(crate::scan::ScanTrigger::Watcher {
+                events: burst.events,
+                paths: burst.paths,
+            });
     })
 }
 

--- a/apps/desktop/src-tauri/src/scan/watch.rs
+++ b/apps/desktop/src-tauri/src/scan/watch.rs
@@ -191,11 +191,11 @@ async fn run_root_recheck_loop(
     }
 }
 
-/// W2: the paths a debounce burst that stores has become this large stops
-/// growing. A pass request still names the trigger and its event count past
-/// this point; only the path sample is capped, so a runaway burst cannot grow
-/// the debouncer's memory with the size of the change.
-const MAX_BURST_PATHS: usize = 64;
+/// W2: the most paths one burst stores. Past this bound the burst keeps
+/// counting events but stops storing paths, so a runaway burst cannot grow
+/// the debouncer's memory with the size of the change. A consumer that sees
+/// a full sample must treat the burst as possibly incomplete.
+pub const MAX_BURST_PATHS: usize = 64;
 
 /// One coalesced run of relevant filesystem events, handed to
 /// `on_relevant_change` after the burst's quiet period ends.

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -288,25 +288,136 @@ Goal: layer 1 is continuous and cheap, and every consumer reads one signal.
   `get_session_analysis_fingerprint` command, `poll_fingerprint_with_subagents`,
   and their tests are deleted along with the poll.
 
+### Phase 5: scoped passes (in progress)
+
+Goal: a watcher event costs work proportional to what changed, not a
+whole-machine pass. Found on 2026-09-03 after phase 4 had run for a day:
+the log showed a full pass every 1.5 s for over an hour, and antiburn sat at
+55 to 80 percent of a core.
+
+Two causes, one bug and one design gap:
+
+- Bug: every pass opens Cursor's `state.vscdb` databases read-only. They are
+  in WAL mode, and a WAL reader takes read marks in the `state.vscdb-shm`
+  sidecar, which bumps its mtime. That sidecar sits under a recursive Cursor
+  watch root, `is_relevant` only drops `Access` events, so the pass kicked
+  itself: modify, 1.5 s quiet, pass, modify. The gap histogram made it
+  unambiguous: about 2240 of roughly 2550 consecutive gaps were exactly the
+  quiet window, and one gap in the hour exceeded 6 s.
+- Design gap: a watcher kick ran the same pass as the 60 s tick. That pass
+  walks all 11 agents, loads every stored record, stats every source, upserts
+  every row, refreshes the repository list, and its `scan:finished` makes the
+  popover refetch the list, recompute 30-day usage totals, and resolve both
+  live provider accounts. An active Claude Code session writing sub-agent
+  transcripts every couple of seconds keeps that going at the 1.5 s to 5 s
+  cadence with no bug involved.
+
+The wanted behaviour, from the original planning discussion:
+
+- An active session's row updates often: every 5 to 20 s, not every 1.5 s.
+- An inactive session costs nothing until it becomes active again.
+- A new session is detected when it is created.
+
+None of that needs full discovery. The event path names the session or the
+agent, and the pieces to act on it narrowly already exist: per-row patching
+through `sessions:entry-changed`, fingerprint reuse in
+`reuse_unchanged_record`, per-agent `discover_recent`, `list_changed`, and
+`Explorers::infer_agent_and_surface` to map a path to its agent.
+
+#### Phase 5a: stop the self-trigger, name every trigger
+
+- W1. `is_relevant` in `scan/watch.rs` drops an event whose every path ends
+  in `-shm`. That sidecar is the WAL index, which readers modify; `-wal` is
+  written only by a real writer and stays relevant, because a WAL database's
+  committed rows live there until a checkpoint. Provider database opens are
+  left as they are: `immutable=1` would hide un-checkpointed rows and
+  `locking_mode=EXCLUSIVE` would hold a shared lock against the vendor.
+- W2. The debounce loop collects the relevant paths of each burst and hands
+  them to the kick, deduplicated, instead of a bare `()`. Phase 5b consumes
+  them; 5a logs them.
+- W3. Every pass request carries a `ScanTrigger`: launch, tick, watcher
+  (with the burst's path count and a bounded sample of paths), popover shown,
+  settings transition, insights pane, repository toggle, scan root added,
+  folder access granted, index cleared, manual rescan. The scheduler logs
+  `scan_pass_requested` with the trigger at debug, and `run_pass` logs
+  `scan_pass_started` and `scan_pass_finished` with the trigger, duration in
+  milliseconds, sessions persisted, rows re-described, and `list_changed`.
+  This is the instrumentation that was missing when the loop was diagnosed
+  from `repo_discovery_agent_done` lines alone.
+- W4. A request that arrives while a pass is running is still dropped, but
+  the drop is logged with its trigger, so a hidden feedback loop shows up as
+  a stream of drops rather than silence.
+
+#### Phase 5b: targeted refresh and per-agent rediscovery
+
+The watcher's burst is classified path by path, and each class runs the
+narrowest pass that answers it. All passes stay serialized through the
+scheduler task, so passes never overlap and the store sees one writer.
+
+- T1. Known session. A path that equals a stored native file session's
+  `source_label`, or whose ancestor directory `D` has `D.jsonl` as a stored
+  `source_label` (the sub-agent layout), names that session. The targeted
+  pass builds the `SessionLog` from the stored record, runs
+  `describe_with_states` over just those logs with just their previous
+  records, upserts the resulting rows, announces the re-described ones
+  through `sessions:entry-changed`, and wakes the insights worker and the
+  idle task. It does not run discovery, does not refresh repositories, does
+  not rewrite per-agent scan bookkeeping, and does not emit `scan:started`
+  or `scan:finished`.
+- T2. Per-session floor. A session re-described at `t` is not re-described
+  again before `t + TARGETED_MIN_INTERVAL` (10 s). Events inside the floor
+  are coalesced into one deferred refresh at the floor's end, never dropped,
+  so a session that keeps writing is refreshed every 10 s and a session that
+  writes once is refreshed once.
+- T3. New session. A path under an agent's watch root that matches no stored
+  session means that agent has a session the store has never seen. The
+  agent-scoped pass runs `discover_recent` for that one agent, describes the
+  result against the stored records, upserts, and goes through the normal
+  `run_pass` status machinery, so `scan:finished` with `list_changed` makes
+  the popover refetch the list. Discovery for the other ten agents does not
+  run.
+- T4. Per-agent floor. Agent-scoped rediscovery for one agent runs at most
+  once per `AGENT_REDISCOVER_MIN_INTERVAL` (20 s), coalesced the same way as
+  T2.
+- T5. Database-backed agents. For Cursor, OpenCode, Antigravity, Windsurf,
+  and Kiro the changed path is a database, not a session, so every event
+  under their roots is a T3 rediscovery of that agent, with a longer floor,
+  `DB_AGENT_REDISCOVER_MIN_INTERVAL` (30 s).
+- T6. Unclassified paths (no agent root claims them) are ignored; the 60 s
+  tick reconciles. The tick, the popover-shown kick, the manual rescan, and
+  every command kick keep running the full pass exactly as before.
+- T7. A burst that arrives while a pass is in flight is held, merged with any
+  later bursts, and processed when the scheduler is free, rather than dropped.
+
+#### Phase 5c: refresh scaling and the Cursor walks
+
+- F1. The popover's `scan:finished` handler refreshes usage at most once per
+  `USAGE_REFRESH_MIN_MS` (30 s) unless the pass reported `list_changed`.
+  Row patches from `sessions:entry-changed` never trigger a usage refresh.
+- F2. Cursor's `collect_agent_transcript_dirs` and
+  `collect_cursor_chat_metadata` get the mtime-gated pruning the other agents
+  got in 4a, so a T5 rediscovery of Cursor does not pay for a full walk.
+
 ## Sequencing notes
 
 - Phase 1 stands alone and is reverted by two small edits if it misbehaves.
 - Phase 2 depends only on phase 1.
 - Phase 3 is the enabling work for phase 4.
 - Default cadences are set in phase 4 and reviewed after a week of use.
+- Phase 5a stands alone. 5b stacks on 5a (it consumes the burst paths 5a
+  passes through). 5c's two items are independent of each other and of 5b.
 
 ## Follow-ups
 
 - Cursor's `collect_agent_transcript_dirs` and `collect_cursor_chat_metadata`
-  are still unwindowed recursive walks. A Cursor watch delivers change
-  notifications, but the kicked pass pays for the full walk underneath. They
-  need the same date- or mtime-gated pruning the other agents got in 4a.
+  are still unwindowed recursive walks. Scheduled as phase 5c (F2).
 - `AppendOnlyGuarantee` is still hard-coded to `Absent`. The resumed path no
   longer needs it; either evidence it per agent or remove it and let a full
   read always re-check its whole prefix.
 - Provider-database agents (OpenCode, Antigravity) persist no row cursor. A
   change still costs a full re-stream of the session's rows.
-- Review the phase 4 cadences (60 s tick, 15 s fallback, 1.5 s / 5 s
-  debounce, 60 s list reconcile) after a week of use.
+- The phase 4 cadences were reviewed after a day, not a week; the result is
+  phase 5. The 60 s tick, 15 s fallback, 1.5 s / 5 s burst coalescing, and
+  60 s list reconcile stay; the per-session and per-agent floors are new.
 - While discovery is paused the scan does not run, so the HUD's live signal
   now follows the pause. Decide whether that is the wanted behaviour.


### PR DESCRIPTION
## Summary

Phase 5a of the continuous-ingest plan. After a day of phase 4, the debug log showed a full scan pass every 1.5 s for over an hour and the app sat at 55 to 80 percent of a core.

- **Bug:** every pass opens Cursor's `state.vscdb` read-only. In WAL mode a reader takes read marks in the `-shm` sidecar, bumping its mtime under a recursive watch root. The watcher only dropped `Access` events, so each pass re-kicked itself after the 1.5 s quiet window. The pass-gap histogram had ~2240 of ~2550 gaps at exactly the quiet window.
- **W1:** `is_relevant` drops events whose every path is a `-shm` sidecar. `-wal` stays relevant since committed rows live there until a checkpoint.
- **W2:** the debounce loop hands each burst's deduplicated paths (bounded at 64) to the kick, so phase 5b can scope a pass to what changed.
- **W3/W4:** every pass request carries a `ScanTrigger`; `run_pass` logs `scan_pass_requested`, `scan_pass_started`, `scan_pass_finished` (duration, sessions, rows re-described, `list_changed`) and `scan_request_dropped`, all at debug. This was the missing instrumentation when the loop had to be diagnosed from `repo_discovery_agent_done` lines alone.

The plan doc gains a "Phase 5" section covering 5a, 5b (targeted refresh and per-agent rediscovery) and 5c (usage refresh floor, Cursor walk pruning).

## Test plan

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p antiburn --no-fail-fast` (817 passed).
- New unit tests: `-shm`-only events dropped, mixed events kept, `-wal` kept; bursts dedupe paths and count events; a second `request` before the scheduler wakes is coalesced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1ir9iHoiRvkdSQnY8wsy2