### PR TITLE
chore(desktop): add hover intent to usage previews

### DIFF
--- a/apps/desktop/src/lib/anchoredTrigger.test.ts
+++ b/apps/desktop/src/lib/anchoredTrigger.test.ts
@@ -18,6 +18,7 @@ function harness(
     target,
     retargetCommitRequired: false,
   })),
+  hoverDelayMs = 0,
 ) {
   let lifecycle: ((event: AnchoredWindowLifecycleEvent<Target>) => void) | null = null
   const bridge: AnchoredTriggerBridge<Target> = {
@@ -33,6 +34,7 @@ function harness(
     "detail",
     (left, right) => left.id === right.id,
     bridge,
+    { hoverDelayMs },
   )
   const unsubscribe = controller.subscribe(() => undefined)
   return {
@@ -58,6 +60,155 @@ function state(generation: number, target: Target | null) {
 }
 
 describe("AnchoredTriggerController", () => {
+  it("delays the first hover until intent is clear", async () => {
+    vi.useFakeTimers()
+    const request = vi.fn(async (target: Target) => ({
+      generation: 1,
+      target,
+      retargetCommitRequired: false,
+    }))
+    const { controller, unsubscribe } = harness(request, 150)
+
+    try {
+      const hover = controller.hover({ id: "alpha" }, ANCHOR)
+
+      await vi.advanceTimersByTimeAsync(149)
+      expect(request).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      await hover
+      expect(request).toHaveBeenCalledOnce()
+    } finally {
+      unsubscribe()
+      vi.useRealTimers()
+    }
+  })
+
+  it("cancels a delayed hover when the pointer leaves", async () => {
+    vi.useFakeTimers()
+    const request = vi.fn(async (target: Target) => ({
+      generation: 1,
+      target,
+      retargetCommitRequired: false,
+    }))
+    const { controller, unsubscribe } = harness(request, 150)
+
+    try {
+      const hover = controller.hover({ id: "alpha" }, ANCHOR)
+      await vi.advanceTimersByTimeAsync(100)
+      await controller.leave()
+      await vi.advanceTimersByTimeAsync(50)
+      await hover
+
+      expect(request).not.toHaveBeenCalled()
+    } finally {
+      unsubscribe()
+      vi.useRealTimers()
+    }
+  })
+
+  it("restarts the delay with the latest hover target and presentation", async () => {
+    vi.useFakeTimers()
+    const request = vi.fn(
+      async (target: Target, _anchor: AnchorRegion, _presentation: string | undefined) => ({
+        generation: 1,
+        target,
+        retargetCommitRequired: false,
+      }),
+    )
+    const bridge: AnchoredTriggerBridge<Target, string> = {
+      request,
+      conceal: vi.fn(async () => undefined),
+      listen: vi.fn(async () => () => undefined),
+      state: vi.fn(async () => state(0, null)),
+    }
+    const controller = new AnchoredTriggerController(
+      "detail",
+      (left: Target, right: Target) => left.id === right.id,
+      bridge,
+      { hoverDelayMs: 150 },
+    )
+    const unsubscribe = controller.subscribe(() => undefined)
+
+    try {
+      const first = controller.hover({ id: "first" }, ANCHOR, "first presentation")
+      await vi.advanceTimersByTimeAsync(100)
+      const secondAnchor = { top: 48, height: 24 }
+      const second = controller.hover({ id: "second" }, secondAnchor, "second presentation")
+      await first
+
+      await vi.advanceTimersByTimeAsync(149)
+      expect(request).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+      await second
+
+      expect(request).toHaveBeenCalledOnce()
+      expect(request).toHaveBeenCalledWith(
+        { id: "second" },
+        secondAnchor,
+        "second presentation",
+      )
+    } finally {
+      unsubscribe()
+      vi.useRealTimers()
+    }
+  })
+
+  it("retargets immediately while an anchored window is active", async () => {
+    vi.useFakeTimers()
+    const request = vi.fn(async (target: Target) => ({
+      generation: target.id === "first" ? 1 : 2,
+      target,
+      retargetCommitRequired: false,
+    }))
+    const { controller, unsubscribe } = harness(request, 150)
+
+    try {
+      const first = controller.hover({ id: "first" }, ANCHOR)
+      await vi.advanceTimersByTimeAsync(150)
+      await first
+
+      const second = controller.hover({ id: "second" }, ANCHOR)
+      expect(request).toHaveBeenCalledTimes(2)
+      await second
+      expect(controller.getSnapshot()).toMatchObject({
+        activation: "hovered",
+        target: { id: "second" },
+      })
+    } finally {
+      unsubscribe()
+      vi.useRealTimers()
+    }
+  })
+
+  it("keeps selection immediate and clears delayed hover on unsubscribe", async () => {
+    vi.useFakeTimers()
+    const request = vi.fn(async (target: Target) => ({
+      generation: 1,
+      target,
+      retargetCommitRequired: false,
+    }))
+    const { controller, emit, unsubscribe } = harness(request, 150)
+
+    try {
+      const hover = controller.hover({ id: "hover" }, ANCHOR)
+      const selection = controller.select({ id: "selected" }, ANCHOR)
+
+      expect(request).toHaveBeenCalledWith({ id: "selected" }, ANCHOR, undefined)
+      await selection
+      await hover
+
+      emit(state(2, null))
+      const abandoned = controller.hover({ id: "abandoned" }, ANCHOR)
+      unsubscribe()
+      await vi.advanceTimersByTimeAsync(150)
+      await abandoned
+      expect(request).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("keeps each queued presentation paired with its target", async () => {
     const pending = new Map<
       string,

--- a/apps/desktop/src/lib/anchoredTrigger.ts
+++ b/apps/desktop/src/lib/anchoredTrigger.ts
@@ -33,6 +33,10 @@ export interface AnchoredTriggerSnapshot<T> {
   generation: number
 }
 
+export interface AnchoredTriggerOptions {
+  hoverDelayMs?: number
+}
+
 export interface AnchoredTriggerBridge<T, P = undefined> {
   request: (
     target: T,
@@ -52,6 +56,13 @@ interface ScheduledRequest<T, P> {
   resolve: () => void
 }
 
+interface DelayedHover<T, P> {
+  target: T
+  anchor: AnchorRegion
+  presentation: P | undefined
+  resolve: () => void
+}
+
 const LISTENER_RETRY_MS = 250
 
 /** Retains one trigger's activation while its anchored window remains active. */
@@ -65,6 +76,8 @@ export class AnchoredTriggerController<T, P = undefined> {
   private stopListening: (() => void) | null = null
   private listenerGeneration = 0
   private retryTimer: ReturnType<typeof setTimeout> | null = null
+  private hoverTimer: ReturnType<typeof setTimeout> | null = null
+  private delayedHover: DelayedHover<T, P> | null = null
   private requestRevision = 0
   private lastLeaveRevision = 0
   private activeRequest: ScheduledRequest<T, P> | null = null
@@ -73,15 +86,19 @@ export class AnchoredTriggerController<T, P = undefined> {
   private readonly companionLabel: string
   private readonly sameTarget: (left: T, right: T) => boolean
   private readonly bridge: AnchoredTriggerBridge<T, P>
+  private readonly hoverDelayMs: number
 
   constructor(
     companionLabel: string,
     sameTarget: (left: T, right: T) => boolean,
     bridge: AnchoredTriggerBridge<T, P>,
+    options: AnchoredTriggerOptions = {},
   ) {
     this.companionLabel = companionLabel
     this.sameTarget = sameTarget
     this.bridge = bridge
+    const hoverDelayMs = options.hoverDelayMs ?? 0
+    this.hoverDelayMs = Number.isFinite(hoverDelayMs) && hoverDelayMs > 0 ? hoverDelayMs : 0
   }
 
   getSnapshot = (): AnchoredTriggerSnapshot<T> => this.snapshot
@@ -100,6 +117,13 @@ export class AnchoredTriggerController<T, P = undefined> {
       this.matchesSnapshot(target) && this.snapshot.activation === "selected"
         ? "selected"
         : "hovered"
+    if (
+      activation === "hovered" &&
+      this.snapshot.activation === "idle" &&
+      this.hoverDelayMs > 0
+    ) {
+      return this.delayHover(target, anchor, presentation)
+    }
     return this.activate(target, anchor, activation, presentation)
   }
 
@@ -108,8 +132,34 @@ export class AnchoredTriggerController<T, P = undefined> {
   }
 
   leave(): Promise<void> {
+    this.cancelDelayedHover()
     this.lastLeaveRevision = this.requestRevision
     return this.bridge.conceal().catch(() => undefined)
+  }
+
+  private delayHover(
+    target: T,
+    anchor: AnchorRegion,
+    presentation: P | undefined,
+  ): Promise<void> {
+    this.cancelDelayedHover()
+    return new Promise((resolve) => {
+      const delayedHover = { target, anchor, presentation, resolve }
+      this.delayedHover = delayedHover
+      this.hoverTimer = setTimeout(() => {
+        if (this.delayedHover !== delayedHover) return
+        this.delayedHover = null
+        this.hoverTimer = null
+        void this.activate(target, anchor, "hovered", presentation).then(resolve)
+      }, this.hoverDelayMs)
+    })
+  }
+
+  private cancelDelayedHover(): void {
+    if (this.hoverTimer != null) clearTimeout(this.hoverTimer)
+    this.hoverTimer = null
+    this.delayedHover?.resolve()
+    this.delayedHover = null
   }
 
   private activate(
@@ -118,6 +168,7 @@ export class AnchoredTriggerController<T, P = undefined> {
     activation: Exclude<AnchoredTriggerActivation, "idle">,
     presentation: P | undefined,
   ): Promise<void> {
+    this.cancelDelayedHover()
     const revision = ++this.requestRevision
     this.setSnapshot({ ...this.snapshot, activation, target })
     return new Promise((resolve) => {
@@ -225,6 +276,7 @@ export class AnchoredTriggerController<T, P = undefined> {
 
   private stop(): void {
     this.listenerGeneration += 1
+    this.cancelDelayedHover()
     if (this.retryTimer != null) clearTimeout(this.retryTimer)
     this.retryTimer = null
     this.stopListening?.()

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -739,25 +739,53 @@ describe("PopoverView", () => {
     expect(screen.getByRole("button", { name: "Codex at 40 percent" })).toBeInTheDocument()
   })
 
-  it("requests a provider preview directly on pointer entry", async () => {
+  it("requests a provider preview after the pointer rests on its trigger", async () => {
     render(<PopoverView />)
 
     const trigger = await screen.findByRole("button", { name: "Codex at 40 percent" })
-    fireEvent.mouseEnter(trigger)
-    expect(trigger).toHaveAttribute("data-state", "hovered")
-    expect(invoke).toHaveBeenCalledWith("show_popover_peek", {
-      target: {
-        kind: "provider",
-        provider: "openai",
-        utcOffsetMinutes: -new Date().getTimezoneOffset(),
-      },
-      anchor: expect.any(Object),
-      initialPresentation: {
-        kind: "provider",
-        summary: { ...PROVIDER_USAGE, providers: [] },
-        live: LIVE_USAGE,
-      },
-    })
+    vi.useFakeTimers()
+    try {
+      fireEvent.mouseEnter(trigger)
+
+      await act(() => vi.advanceTimersByTimeAsync(149))
+      expect(invoke).not.toHaveBeenCalledWith("show_popover_peek", expect.anything())
+
+      await act(() => vi.advanceTimersByTimeAsync(1))
+      expect(invoke).toHaveBeenCalledWith("show_popover_peek", {
+        target: {
+          kind: "provider",
+          provider: "openai",
+          utcOffsetMinutes: -new Date().getTimezoneOffset(),
+        },
+        anchor: expect.any(Object),
+        initialPresentation: {
+          kind: "provider",
+          summary: { ...PROVIDER_USAGE, providers: [] },
+          live: LIVE_USAGE,
+        },
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("cancels a pending provider preview when its click opens Usage", async () => {
+    render(<PopoverView />)
+
+    const trigger = await screen.findByRole("button", { name: "Codex at 40 percent" })
+    vi.useFakeTimers()
+    try {
+      fireEvent.mouseEnter(trigger)
+      fireEvent.click(trigger)
+
+      expect(screen.getByRole("heading", { name: "Usage" })).toBeInTheDocument()
+      expect(invoke).toHaveBeenCalledWith("hide_popover_peek")
+
+      await act(() => vi.advanceTimersByTimeAsync(150))
+      expect(invoke).not.toHaveBeenCalledWith("show_popover_peek", expect.anything())
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("conceals an active provider preview before expanding the limits bar", async () => {

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -53,13 +53,18 @@ function createPopoverPeekTriggers(): AnchoredTriggerController<
   PopoverPeekTarget,
   PopoverPeekData
 > {
-  return new AnchoredTriggerController(POPOVER_PEEK_LABEL, samePopoverPeekTarget, {
-    request: (target, anchor, presentation) =>
-      showPopoverPeek(target, anchor, presentation ?? null),
-    conceal: hidePopoverPeek,
-    listen: onPopoverPeekLifecycle,
-    state: getPopoverPeekAnchorState,
-  })
+  return new AnchoredTriggerController(
+    POPOVER_PEEK_LABEL,
+    samePopoverPeekTarget,
+    {
+      request: (target, anchor, presentation) =>
+        showPopoverPeek(target, anchor, presentation ?? null),
+      conceal: hidePopoverPeek,
+      listen: onPopoverPeekLifecycle,
+      state: getPopoverPeekAnchorState,
+    },
+    { hoverDelayMs: 150 },
+  )
 }
 
 function selectedProviderPresentation(
@@ -398,7 +403,7 @@ export function PopoverView() {
               }}
               refreshing={state.usageRefreshing}
               onViewAll={() => {
-                void hidePopoverPeek().catch(() => undefined)
+                void peekTriggers.leave()
                 // A provider pill is the one place the reader asks for the full
                 // Usage view from the activity surface. Counts and a three-value
                 // evidence label, never a per-provider list.
@@ -445,7 +450,7 @@ export function PopoverView() {
               days={windowDays}
               onOpenSession={(entry) => {
                 if (!entry.sessionId) return
-                void hidePopoverPeek().catch(() => undefined)
+                void peekTriggers.leave()
                 // The card click, not the traversal inside a session — the
                 // question is how often the list leads anywhere, and the
                 // newer/older arrows would drown that out. Instrumented here


### PR DESCRIPTION
## User impact

Anchored usage previews now wait 150 ms before opening on initial hover. Quick cursor passes no longer flash the preview, while moving between providers after a preview opens remains immediate.

Clicks and keyboard-driven navigation remain immediate. The existing 300 ms conceal grace is unchanged.

## Validation

- Desktop formatting check passed.
- ESLint passed.
- TypeScript type-check passed.
- Focused tests passed: 62/62.
- Full desktop tests passed: 1060/1060.
- Production desktop build passed.
- Development application built and launched successfully.
- Cross-platform review found no actionable regressions; Windows and Linux native smoke validation remains for CI.

## Privacy and performance

No changes to data access, network access, retained data, or background work.

The interaction uses one cancellable 150 ms in-process timer while an initial provider hover is pending.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

## Screenshots
<img width="400" alt="Screen Recording 2026-09-03 at 10 50 23 am" src="https://github.com/user-attachments/assets/b6ea3469-0081-48f0-9f7b-4a3d8348af9b" />

