### PR TITLE
popover usage refresh floor and depth-bounded Cursor walks (phase 5c)

### DIFF
--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type * as Ipc from "../../lib/ipc"
-import type { ActivityEntryPayload, ScanStatus, SessionAnalysisPayload } from "../../lib/ipc"
+import {
+  EMPTY_PROVIDER_USAGE,
+  type ActivityEntryPayload,
+  type ScanStatus,
+  type SessionAnalysisPayload,
+} from "../../lib/ipc"
 import { PopoverSession, sessionKey } from "./PopoverSession"
 import type { SessionSubject } from "./SessionPane"
 
 const getSessionAnalysis = vi.hoisted(() => vi.fn())
 const getSubagentAnalysis = vi.hoisted(() => vi.fn())
 const getSessionLimitAllocations = vi.hoisted(() => vi.fn())
+const getProviderUsage = vi.hoisted(() => vi.fn())
 const setPopoverHeight = vi.hoisted(() => vi.fn())
 const listRecentSessions = vi.hoisted(() => vi.fn())
 const onSessionEntryChanged = vi.hoisted(() => vi.fn())
@@ -23,6 +29,7 @@ vi.mock("../../lib/ipc", async (importOriginal) => {
     getSessionAnalysis,
     getSubagentAnalysis,
     getSessionLimitAllocations,
+    getProviderUsage,
     setPopoverHeight,
     listRecentSessions,
     onSessionEntryChanged,
@@ -66,6 +73,8 @@ beforeEach(() => {
     generatedAt: "2027-01-15T08:00:00Z",
     allocations: [],
   })
+  getProviderUsage.mockReset()
+  getProviderUsage.mockResolvedValue(EMPTY_PROVIDER_USAGE)
 })
 
 describe("PopoverSession surface presentation", () => {
@@ -457,6 +466,47 @@ describe("PopoverSession event-driven refresh", () => {
 
     expect(listRecentSessions).toHaveBeenCalledTimes(2)
     unsubscribe()
+  })
+
+  // F1: `scan:finished` refreshes usage on its own floor
+  // (`USAGE_REFRESH_MIN_MS`), separate from the list reconcile interval
+  // above — a scan pass finishing is not by itself a reason to recompute
+  // 30-day usage totals on every one of an active session's rapid passes.
+  it("refreshes usage on a floor, bypassed by a reported list change", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(scanEventHandler).not.toBeNull()
+    const baseline = getProviderUsage.mock.calls.length
+
+    // First scan:finished always refreshes: nothing has refreshed usage
+    // from this handler yet.
+    scanEventHandler?.(scanStatus({ listChanged: false }), "finished")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
+
+    // A second event 1 s later, still no list change, lands inside the
+    // floor and refreshes nothing further.
+    await vi.advanceTimersByTimeAsync(1_000)
+    scanEventHandler?.(scanStatus({ listChanged: false }), "finished")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
+
+    // A reported list change bypasses the floor.
+    scanEventHandler?.(scanStatus({ listChanged: true }), "finished")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 2)
+
+    // Once the floor elapses, an unchanged list refreshes again too.
+    await vi.advanceTimersByTimeAsync(30_000)
+    scanEventHandler?.(scanStatus({ listChanged: false }), "finished")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 3)
+
+    unsubscribe()
+    vi.useRealTimers()
   })
 
   it("re-sorts a revived session to the top of the list", async () => {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -173,6 +173,17 @@ const NOW_TICK_MS = 30_000
 const LIST_RECONCILE_MS = 60_000
 
 /**
+ * Floor between `scan:finished`-triggered usage refreshes that report no
+ * list change. A pass finishing is not, by itself, a reason to recompute
+ * 30-day usage totals and resolve both live provider accounts (F1): an
+ * active session's row updates every few seconds, and a usage refresh on
+ * every one of those would cost as much as the list rebuild it was meant to
+ * avoid. `listChanged` still forces an immediate refresh, since that means a
+ * session was discovered or removed.
+ */
+const USAGE_REFRESH_MIN_MS = 30_000
+
+/**
  * Order list rows the way the backend does: newest activity first, and a
  * revived session's own id breaking a tie. `listenSessionEntryChanged`
  * re-sorts with this after patching one row in place, so a session whose
@@ -241,6 +252,13 @@ export class PopoverSession {
    * reconciled eventually.
    */
   private lastListReconcileAt = 0
+
+  /**
+   * When `listenScanEvent` last triggered a usage refresh. Read against
+   * `USAGE_REFRESH_MIN_MS` (F1) so a quiet stream of `scan:finished` events
+   * with no list change refreshes usage on a floor, not on every event.
+   */
+  private lastUsageRefreshAt = 0
 
   private nowTickTimer: ReturnType<typeof setInterval> | null = null
 
@@ -620,7 +638,9 @@ export class PopoverSession {
   // progress, so the intermediate phases have nothing to say. A full refetch
   // of entries and repositories only runs when the pass says the list needs
   // one, or the reconcile interval has elapsed — `sessions:entry-changed`
-  // already keeps individual rows current in between.
+  // already keeps individual rows current in between. Usage follows the
+  // same shape on its own floor (F1): `listChanged` forces an immediate
+  // refresh, and every other pass waits for `USAGE_REFRESH_MIN_MS`.
   private listenScanEvent = async (generation: number): Promise<void> => {
     const unlisten = await onScanEvent((status, phase) => {
       if (generation !== this.generation) return
@@ -631,7 +651,10 @@ export class PopoverSession {
         void this.refreshEntries(this.windowDays()).catch(() => {})
         void this.refreshRepositoryList()
       }
-      void this.refreshUsage()
+      if (status.listChanged || now - this.lastUsageRefreshAt >= USAGE_REFRESH_MIN_MS) {
+        this.lastUsageRefreshAt = now
+        void this.refreshUsage()
+      }
     })
     if (generation !== this.generation) {
       unlisten()

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -46,8 +46,9 @@ version and refuses the release if there is none.
   inside the recency window, Claude's sub-agent sweep skips a session whose
   parent is not recent and whose `subagents` directory is old, and
   Antigravity checks a database's mtime before opening it. Cursor's
-  `agent-transcripts` and `chats` walks now skip a directory whose mtime is
-  older than the recency window before descending into it.
+  `agent-transcripts` and `chats` walks are now bounded by depth to the
+  documented layout, rather than mtime-gated, so a rediscovery no longer
+  reads a project's other subdirectories.
 
 ## [0.4.0] - 2026-09-02
 

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -45,7 +45,9 @@ version and refuses the release if there is none.
 - Discovery prunes before it stats: Codex walks only the date directories
   inside the recency window, Claude's sub-agent sweep skips a session whose
   parent is not recent and whose `subagents` directory is old, and
-  Antigravity checks a database's mtime before opening it.
+  Antigravity checks a database's mtime before opening it. Cursor's
+  `agent-transcripts` and `chats` walks now skip a directory whose mtime is
+  older than the recency window before descending into it.
 
 ## [0.4.0] - 2026-09-02
 

--- a/crates/antiburn-local/src/discovery/agents/cursor.rs
+++ b/crates/antiburn-local/src/discovery/agents/cursor.rs
@@ -214,50 +214,31 @@ async fn log_dirs_in(home: &Path) -> Vec<PathBuf> {
         .join("workspaceStorage");
     dirs.extend(find_chat_session_dirs(&ws_root).await);
 
-    // A generous window: this helper's callers build fixtures with fresh
-    // mtimes, so the F2 gate below must never prune them.
-    let now = current_epoch_secs();
     let projects_dir = home.join(".cursor").join("projects");
-    dirs.extend(collect_agent_transcript_dirs(&projects_dir, now, now).await);
+    dirs.extend(collect_agent_transcript_dirs(&projects_dir).await);
 
     dirs
 }
 
-#[cfg(test)]
-fn current_epoch_secs() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as i64
-}
-
-/// A directory's mtime as Unix epoch seconds, or `None` when `stat` fails.
-/// F2: the caller falls back to descending on `None`, so unreadable
-/// metadata never hides a subtree.
-async fn dir_mtime_epoch(path: &Path) -> Option<i64> {
-    let metadata = tokio::fs::metadata(path).await.ok()?;
-    metadata
-        .modified()
-        .ok()?
-        .duration_since(UNIX_EPOCH)
-        .ok()
-        .map(|duration| duration.as_secs() as i64)
-}
-
-/// Collect `agent-transcripts` directories under `root`.
+/// How many directory levels [`collect_agent_transcript_dirs`] enters below
+/// `root`. Cursor's CLI layout puts `agent-transcripts` two levels below the
+/// projects root: `projects/<project>/agent-transcripts`. The walk never
+/// enters a directory past this depth, so it never reads a project's other
+/// subdirectories, such as `canvases`.
 ///
-/// F2: a directory's mtime moves whenever an entry inside it is added or
-/// removed, so a directory that gained a session file within the window
-/// (`now - since_secs`) is always inside the window. Skipping a stale
-/// directory before descending turns a rediscovery into a handful of stats
-/// instead of a full recursive walk. The `root` itself is always walked,
-/// so a stale top-level projects directory never hides a fresh child.
-async fn collect_agent_transcript_dirs(root: &Path, now: i64, since_secs: i64) -> Vec<PathBuf> {
-    let cutoff = now - since_secs;
-    let mut out = Vec::new();
-    let mut stack = vec![root.to_path_buf()];
+/// A directory's mtime cannot gate this walk instead (F2): a new session
+/// file bumps only its immediate parent, `agent-transcripts/`, never the
+/// project directory above it. An mtime gate on the project directory would
+/// hide every session added to an old project from then on.
+const MAX_TRANSCRIPT_WALK_DEPTH: usize = 2;
 
-    while let Some(dir) = stack.pop() {
+/// Collect `agent-transcripts` directories under `root`, entering a
+/// directory no deeper than [`MAX_TRANSCRIPT_WALK_DEPTH`].
+async fn collect_agent_transcript_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![(root.to_path_buf(), 0usize)];
+
+    while let Some((dir, depth)) = stack.pop() {
         let mut entries = match tokio::fs::read_dir(&dir).await {
             Ok(entries) => entries,
             Err(_) => continue,
@@ -282,18 +263,15 @@ async fn collect_agent_transcript_dirs(root: &Path, now: i64, since_secs: i64) -
                 continue;
             }
 
-            if let Some(mtime) = dir_mtime_epoch(&path).await
-                && mtime < cutoff
-            {
-                continue;
-            }
-
             if name == "agent-transcripts" {
                 out.push(path);
                 continue;
             }
 
-            stack.push(path);
+            let entry_depth = depth + 1;
+            if entry_depth < MAX_TRANSCRIPT_WALK_DEPTH {
+                stack.push((path, entry_depth));
+            }
         }
     }
 
@@ -307,9 +285,9 @@ async fn discover_agent_transcripts(
 ) -> Vec<CursorDiscoveredSession> {
     let cutoff = now - since_secs;
     let projects_dir = home.join(".cursor").join("projects");
-    let transcript_dirs = collect_agent_transcript_dirs(&projects_dir, now, since_secs).await;
+    let transcript_dirs = collect_agent_transcript_dirs(&projects_dir).await;
     let workspace_map = collect_workspace_paths(home).await;
-    let chat_metadata = collect_cursor_chat_metadata(home, now, since_secs).await;
+    let chat_metadata = collect_cursor_chat_metadata(home).await;
     let mut workspace_decode_cache: HashMap<String, Option<String>> = HashMap::new();
     let mut out = Vec::new();
 
@@ -417,19 +395,19 @@ async fn discover_agent_transcripts(
     out
 }
 
-/// Collect `meta.json` sidecars under `~/.cursor/chats`.
-///
-/// F2: the same mtime gate as [`collect_agent_transcript_dirs`], applied per
-/// chat directory before any file inside it is opened.
-async fn collect_cursor_chat_metadata(
-    home: &Path,
-    now: i64,
-    since_secs: i64,
-) -> HashMap<String, CursorChatMetadata> {
-    let cutoff = now - since_secs;
+/// How many directory levels [`collect_cursor_chat_metadata`] enters below
+/// `~/.cursor/chats`. The layout is `chats/<workspace>/<chat>/meta.json`: a
+/// workspace directory is depth 1, a chat directory is depth 2, and
+/// `meta.json` is read from inside the chat directory. The walk never enters
+/// a directory past this depth.
+const MAX_CHAT_WALK_DEPTH: usize = 2;
+
+/// Collect `meta.json` sidecars under `~/.cursor/chats`, entering a
+/// directory no deeper than [`MAX_CHAT_WALK_DEPTH`].
+async fn collect_cursor_chat_metadata(home: &Path) -> HashMap<String, CursorChatMetadata> {
     let mut out = HashMap::new();
-    let mut stack = vec![home.join(".cursor").join("chats")];
-    while let Some(dir) = stack.pop() {
+    let mut stack = vec![(home.join(".cursor").join("chats"), 0usize)];
+    while let Some((dir, depth)) = stack.pop() {
         let mut entries = match tokio::fs::read_dir(&dir).await {
             Ok(entries) => entries,
             Err(_) => continue,
@@ -440,12 +418,10 @@ async fn collect_cursor_chat_metadata(
                 continue;
             };
             if file_type.is_dir() {
-                if let Some(mtime) = dir_mtime_epoch(&path).await
-                    && mtime < cutoff
-                {
-                    continue;
+                let entry_depth = depth + 1;
+                if entry_depth <= MAX_CHAT_WALK_DEPTH {
+                    stack.push((path, entry_depth));
                 }
-                stack.push(path);
                 continue;
             }
             if path.file_name().and_then(|name| name.to_str()) != Some("meta.json") {
@@ -2573,33 +2549,44 @@ mod tests {
         assert!(dirs.is_empty());
     }
 
-    // F2: a project directory whose mtime is older than the recency window
-    // is skipped, so a Cursor rediscovery does not pay for a full walk. A
-    // fresh sibling directory is still walked.
+    // F2: the walk never enters a directory past the documented depth, so a
+    // project's other subdirectories (`canvases`, and anything else it
+    // accumulates) are never read.
     #[tokio::test]
-    async fn test_collect_agent_transcript_dirs_skips_stale_project_dir() {
+    async fn test_collect_agent_transcript_dirs_ignores_agent_transcripts_one_level_too_deep() {
         let home = TempDir::new().unwrap();
         let projects_dir = home.path().join(".cursor").join("projects");
 
-        let stale_transcripts = projects_dir.join("stale-project").join("agent-transcripts");
-        tokio::fs::create_dir_all(&stale_transcripts).await.unwrap();
+        let too_deep = projects_dir
+            .join("some-project")
+            .join("canvases")
+            .join("agent-transcripts");
+        tokio::fs::create_dir_all(&too_deep).await.unwrap();
 
-        let fresh_transcripts = projects_dir.join("fresh-project").join("agent-transcripts");
-        tokio::fs::create_dir_all(&fresh_transcripts).await.unwrap();
+        let dirs = collect_agent_transcript_dirs(&projects_dir).await;
 
-        let now: i64 = 1_700_000_000;
-        let since_secs: i64 = 86_400;
-        // Backdate only the stale project dir. The fresh sibling keeps its
-        // real (recent) mtime.
-        crate::discovery::set_file_mtime(
-            &projects_dir.join("stale-project"),
-            now - (since_secs + 10),
-        );
+        assert!(!dirs.contains(&too_deep));
+    }
 
-        let dirs = collect_agent_transcript_dirs(&projects_dir, now, since_secs).await;
+    // Regression guard: an mtime gate on the project directory is wrong here
+    // (see `MAX_TRANSCRIPT_WALK_DEPTH`'s doc comment) because a new session
+    // file never touches it — only `agent-transcripts/` itself. A project
+    // last used outside any recency window must still surface a session
+    // added to it since.
+    #[tokio::test]
+    async fn test_collect_agent_transcript_dirs_finds_transcripts_under_an_old_project_dir() {
+        let home = TempDir::new().unwrap();
+        let projects_dir = home.path().join(".cursor").join("projects");
 
-        assert!(!dirs.contains(&stale_transcripts));
-        assert!(dirs.contains(&fresh_transcripts));
+        let project_dir = projects_dir.join("old-project");
+        let transcripts = project_dir.join("agent-transcripts");
+        tokio::fs::create_dir_all(&transcripts).await.unwrap();
+        // 30 days old — well outside any recency window this agent uses.
+        crate::discovery::set_file_mtime(&project_dir, 1_700_000_000 - 30 * 86_400);
+
+        let dirs = collect_agent_transcript_dirs(&projects_dir).await;
+
+        assert!(dirs.contains(&transcripts));
     }
 
     #[tokio::test]

--- a/crates/antiburn-local/src/discovery/agents/cursor.rs
+++ b/crates/antiburn-local/src/discovery/agents/cursor.rs
@@ -214,13 +214,46 @@ async fn log_dirs_in(home: &Path) -> Vec<PathBuf> {
         .join("workspaceStorage");
     dirs.extend(find_chat_session_dirs(&ws_root).await);
 
+    // A generous window: this helper's callers build fixtures with fresh
+    // mtimes, so the F2 gate below must never prune them.
+    let now = current_epoch_secs();
     let projects_dir = home.join(".cursor").join("projects");
-    dirs.extend(collect_agent_transcript_dirs(&projects_dir).await);
+    dirs.extend(collect_agent_transcript_dirs(&projects_dir, now, now).await);
 
     dirs
 }
 
-async fn collect_agent_transcript_dirs(root: &Path) -> Vec<PathBuf> {
+#[cfg(test)]
+fn current_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+/// A directory's mtime as Unix epoch seconds, or `None` when `stat` fails.
+/// F2: the caller falls back to descending on `None`, so unreadable
+/// metadata never hides a subtree.
+async fn dir_mtime_epoch(path: &Path) -> Option<i64> {
+    let metadata = tokio::fs::metadata(path).await.ok()?;
+    metadata
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs() as i64)
+}
+
+/// Collect `agent-transcripts` directories under `root`.
+///
+/// F2: a directory's mtime moves whenever an entry inside it is added or
+/// removed, so a directory that gained a session file within the window
+/// (`now - since_secs`) is always inside the window. Skipping a stale
+/// directory before descending turns a rediscovery into a handful of stats
+/// instead of a full recursive walk. The `root` itself is always walked,
+/// so a stale top-level projects directory never hides a fresh child.
+async fn collect_agent_transcript_dirs(root: &Path, now: i64, since_secs: i64) -> Vec<PathBuf> {
+    let cutoff = now - since_secs;
     let mut out = Vec::new();
     let mut stack = vec![root.to_path_buf()];
 
@@ -249,6 +282,12 @@ async fn collect_agent_transcript_dirs(root: &Path) -> Vec<PathBuf> {
                 continue;
             }
 
+            if let Some(mtime) = dir_mtime_epoch(&path).await
+                && mtime < cutoff
+            {
+                continue;
+            }
+
             if name == "agent-transcripts" {
                 out.push(path);
                 continue;
@@ -268,9 +307,9 @@ async fn discover_agent_transcripts(
 ) -> Vec<CursorDiscoveredSession> {
     let cutoff = now - since_secs;
     let projects_dir = home.join(".cursor").join("projects");
-    let transcript_dirs = collect_agent_transcript_dirs(&projects_dir).await;
+    let transcript_dirs = collect_agent_transcript_dirs(&projects_dir, now, since_secs).await;
     let workspace_map = collect_workspace_paths(home).await;
-    let chat_metadata = collect_cursor_chat_metadata(home).await;
+    let chat_metadata = collect_cursor_chat_metadata(home, now, since_secs).await;
     let mut workspace_decode_cache: HashMap<String, Option<String>> = HashMap::new();
     let mut out = Vec::new();
 
@@ -378,7 +417,16 @@ async fn discover_agent_transcripts(
     out
 }
 
-async fn collect_cursor_chat_metadata(home: &Path) -> HashMap<String, CursorChatMetadata> {
+/// Collect `meta.json` sidecars under `~/.cursor/chats`.
+///
+/// F2: the same mtime gate as [`collect_agent_transcript_dirs`], applied per
+/// chat directory before any file inside it is opened.
+async fn collect_cursor_chat_metadata(
+    home: &Path,
+    now: i64,
+    since_secs: i64,
+) -> HashMap<String, CursorChatMetadata> {
+    let cutoff = now - since_secs;
     let mut out = HashMap::new();
     let mut stack = vec![home.join(".cursor").join("chats")];
     while let Some(dir) = stack.pop() {
@@ -392,6 +440,11 @@ async fn collect_cursor_chat_metadata(home: &Path) -> HashMap<String, CursorChat
                 continue;
             };
             if file_type.is_dir() {
+                if let Some(mtime) = dir_mtime_epoch(&path).await
+                    && mtime < cutoff
+                {
+                    continue;
+                }
                 stack.push(path);
                 continue;
             }
@@ -2518,6 +2571,35 @@ mod tests {
 
         let dirs = log_dirs_in(home.path()).await;
         assert!(dirs.is_empty());
+    }
+
+    // F2: a project directory whose mtime is older than the recency window
+    // is skipped, so a Cursor rediscovery does not pay for a full walk. A
+    // fresh sibling directory is still walked.
+    #[tokio::test]
+    async fn test_collect_agent_transcript_dirs_skips_stale_project_dir() {
+        let home = TempDir::new().unwrap();
+        let projects_dir = home.path().join(".cursor").join("projects");
+
+        let stale_transcripts = projects_dir.join("stale-project").join("agent-transcripts");
+        tokio::fs::create_dir_all(&stale_transcripts).await.unwrap();
+
+        let fresh_transcripts = projects_dir.join("fresh-project").join("agent-transcripts");
+        tokio::fs::create_dir_all(&fresh_transcripts).await.unwrap();
+
+        let now: i64 = 1_700_000_000;
+        let since_secs: i64 = 86_400;
+        // Backdate only the stale project dir. The fresh sibling keeps its
+        // real (recent) mtime.
+        crate::discovery::set_file_mtime(
+            &projects_dir.join("stale-project"),
+            now - (since_secs + 10),
+        );
+
+        let dirs = collect_agent_transcript_dirs(&projects_dir, now, since_secs).await;
+
+        assert!(!dirs.contains(&stale_transcripts));
+        assert!(dirs.contains(&fresh_transcripts));
     }
 
     #[tokio::test]

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -415,9 +415,9 @@ scheduler task, so passes never overlap and the store sees one writer.
 ## Follow-ups
 
 - Cursor's `collect_agent_transcript_dirs` and `collect_cursor_chat_metadata`
-  are still unwindowed recursive walks. Scheduled as phase 5c (F2); done by
-  bounding the walk's depth to the documented layout, not by mtime, since a
-  new session file bumps only its immediate parent's mtime.
+  were unbounded recursive walks. Done in phase 5c (F2) by bounding each
+  walk's depth to the documented layout, not by mtime, since a new session
+  file bumps only its immediate parent's mtime.
 - `AppendOnlyGuarantee` is still hard-coded to `Absent`. The resumed path no
   longer needs it; either evidence it per agent or remove it and let a full
   read always re-check its whole prefix.

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -288,25 +288,136 @@ Goal: layer 1 is continuous and cheap, and every consumer reads one signal.
   `get_session_analysis_fingerprint` command, `poll_fingerprint_with_subagents`,
   and their tests are deleted along with the poll.
 
+### Phase 5: scoped passes (in progress)
+
+Goal: a watcher event costs work proportional to what changed, not a
+whole-machine pass. Found on 2026-09-03 after phase 4 had run for a day:
+the log showed a full pass every 1.5 s for over an hour, and antiburn sat at
+55 to 80 percent of a core.
+
+Two causes, one bug and one design gap:
+
+- Bug: every pass opens Cursor's `state.vscdb` databases read-only. They are
+  in WAL mode, and a WAL reader takes read marks in the `state.vscdb-shm`
+  sidecar, which bumps its mtime. That sidecar sits under a recursive Cursor
+  watch root, `is_relevant` only drops `Access` events, so the pass kicked
+  itself: modify, 1.5 s quiet, pass, modify. The gap histogram made it
+  unambiguous: about 2240 of roughly 2550 consecutive gaps were exactly the
+  quiet window, and one gap in the hour exceeded 6 s.
+- Design gap: a watcher kick ran the same pass as the 60 s tick. That pass
+  walks all 11 agents, loads every stored record, stats every source, upserts
+  every row, refreshes the repository list, and its `scan:finished` makes the
+  popover refetch the list, recompute 30-day usage totals, and resolve both
+  live provider accounts. An active Claude Code session writing sub-agent
+  transcripts every couple of seconds keeps that going at the 1.5 s to 5 s
+  cadence with no bug involved.
+
+The wanted behaviour, from the original planning discussion:
+
+- An active session's row updates often: every 5 to 20 s, not every 1.5 s.
+- An inactive session costs nothing until it becomes active again.
+- A new session is detected when it is created.
+
+None of that needs full discovery. The event path names the session or the
+agent, and the pieces to act on it narrowly already exist: per-row patching
+through `sessions:entry-changed`, fingerprint reuse in
+`reuse_unchanged_record`, per-agent `discover_recent`, `list_changed`, and
+`Explorers::infer_agent_and_surface` to map a path to its agent.
+
+#### Phase 5a: stop the self-trigger, name every trigger
+
+- W1. `is_relevant` in `scan/watch.rs` drops an event whose every path ends
+  in `-shm`. That sidecar is the WAL index, which readers modify; `-wal` is
+  written only by a real writer and stays relevant, because a WAL database's
+  committed rows live there until a checkpoint. Provider database opens are
+  left as they are: `immutable=1` would hide un-checkpointed rows and
+  `locking_mode=EXCLUSIVE` would hold a shared lock against the vendor.
+- W2. The debounce loop collects the relevant paths of each burst and hands
+  them to the kick, deduplicated, instead of a bare `()`. Phase 5b consumes
+  them; 5a logs them.
+- W3. Every pass request carries a `ScanTrigger`: launch, tick, watcher
+  (with the burst's path count and a bounded sample of paths), popover shown,
+  settings transition, insights pane, repository toggle, scan root added,
+  folder access granted, index cleared, manual rescan. The scheduler logs
+  `scan_pass_requested` with the trigger at debug, and `run_pass` logs
+  `scan_pass_started` and `scan_pass_finished` with the trigger, duration in
+  milliseconds, sessions persisted, rows re-described, and `list_changed`.
+  This is the instrumentation that was missing when the loop was diagnosed
+  from `repo_discovery_agent_done` lines alone.
+- W4. A request that arrives while a pass is running is still dropped, but
+  the drop is logged with its trigger, so a hidden feedback loop shows up as
+  a stream of drops rather than silence.
+
+#### Phase 5b: targeted refresh and per-agent rediscovery
+
+The watcher's burst is classified path by path, and each class runs the
+narrowest pass that answers it. All passes stay serialized through the
+scheduler task, so passes never overlap and the store sees one writer.
+
+- T1. Known session. A path that equals a stored native file session's
+  `source_label`, or whose ancestor directory `D` has `D.jsonl` as a stored
+  `source_label` (the sub-agent layout), names that session. The targeted
+  pass builds the `SessionLog` from the stored record, runs
+  `describe_with_states` over just those logs with just their previous
+  records, upserts the resulting rows, announces the re-described ones
+  through `sessions:entry-changed`, and wakes the insights worker and the
+  idle task. It does not run discovery, does not refresh repositories, does
+  not rewrite per-agent scan bookkeeping, and does not emit `scan:started`
+  or `scan:finished`.
+- T2. Per-session floor. A session re-described at `t` is not re-described
+  again before `t + TARGETED_MIN_INTERVAL` (10 s). Events inside the floor
+  are coalesced into one deferred refresh at the floor's end, never dropped,
+  so a session that keeps writing is refreshed every 10 s and a session that
+  writes once is refreshed once.
+- T3. New session. A path under an agent's watch root that matches no stored
+  session means that agent has a session the store has never seen. The
+  agent-scoped pass runs `discover_recent` for that one agent, describes the
+  result against the stored records, upserts, and goes through the normal
+  `run_pass` status machinery, so `scan:finished` with `list_changed` makes
+  the popover refetch the list. Discovery for the other ten agents does not
+  run.
+- T4. Per-agent floor. Agent-scoped rediscovery for one agent runs at most
+  once per `AGENT_REDISCOVER_MIN_INTERVAL` (20 s), coalesced the same way as
+  T2.
+- T5. Database-backed agents. For Cursor, OpenCode, Antigravity, Windsurf,
+  and Kiro the changed path is a database, not a session, so every event
+  under their roots is a T3 rediscovery of that agent, with a longer floor,
+  `DB_AGENT_REDISCOVER_MIN_INTERVAL` (30 s).
+- T6. Unclassified paths (no agent root claims them) are ignored; the 60 s
+  tick reconciles. The tick, the popover-shown kick, the manual rescan, and
+  every command kick keep running the full pass exactly as before.
+- T7. A burst that arrives while a pass is in flight is held, merged with any
+  later bursts, and processed when the scheduler is free, rather than dropped.
+
+#### Phase 5c: refresh scaling and the Cursor walks
+
+- F1. The popover's `scan:finished` handler refreshes usage at most once per
+  `USAGE_REFRESH_MIN_MS` (30 s) unless the pass reported `list_changed`.
+  Row patches from `sessions:entry-changed` never trigger a usage refresh.
+- F2. Cursor's `collect_agent_transcript_dirs` and
+  `collect_cursor_chat_metadata` get the mtime-gated pruning the other agents
+  got in 4a, so a T5 rediscovery of Cursor does not pay for a full walk.
+
 ## Sequencing notes
 
 - Phase 1 stands alone and is reverted by two small edits if it misbehaves.
 - Phase 2 depends only on phase 1.
 - Phase 3 is the enabling work for phase 4.
 - Default cadences are set in phase 4 and reviewed after a week of use.
+- Phase 5a stands alone. 5b stacks on 5a (it consumes the burst paths 5a
+  passes through). 5c's two items are independent of each other and of 5b.
 
 ## Follow-ups
 
 - Cursor's `collect_agent_transcript_dirs` and `collect_cursor_chat_metadata`
-  are still unwindowed recursive walks. A Cursor watch delivers change
-  notifications, but the kicked pass pays for the full walk underneath. They
-  need the same date- or mtime-gated pruning the other agents got in 4a.
+  are still unwindowed recursive walks. Scheduled as phase 5c (F2).
 - `AppendOnlyGuarantee` is still hard-coded to `Absent`. The resumed path no
   longer needs it; either evidence it per agent or remove it and let a full
   read always re-check its whole prefix.
 - Provider-database agents (OpenCode, Antigravity) persist no row cursor. A
   change still costs a full re-stream of the session's rows.
-- Review the phase 4 cadences (60 s tick, 15 s fallback, 1.5 s / 5 s
-  debounce, 60 s list reconcile) after a week of use.
+- The phase 4 cadences were reviewed after a day, not a week; the result is
+  phase 5. The 60 s tick, 15 s fallback, 1.5 s / 5 s burst coalescing, and
+  60 s list reconcile stay; the per-session and per-agent floors are new.
 - While discovery is paused the scan does not run, so the HUD's live signal
   now follows the pause. Decide whether that is the wanted behaviour.

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -395,8 +395,13 @@ scheduler task, so passes never overlap and the store sees one writer.
   `USAGE_REFRESH_MIN_MS` (30 s) unless the pass reported `list_changed`.
   Row patches from `sessions:entry-changed` never trigger a usage refresh.
 - F2. Cursor's `collect_agent_transcript_dirs` and
-  `collect_cursor_chat_metadata` get the mtime-gated pruning the other agents
-  got in 4a, so a T5 rediscovery of Cursor does not pay for a full walk.
+  `collect_cursor_chat_metadata` bound their walk by depth to the documented
+  layout (`projects/<project>/agent-transcripts`,
+  `chats/<workspace>/<chat>/meta.json`) instead of the mtime-gated pruning
+  the other agents got in 4a, so a T5 rediscovery of Cursor does not pay for
+  a full walk. Mtime gating is wrong here: a new session file bumps only its
+  immediate parent's mtime, so an old project directory would hide every
+  session added to it since.
 
 ## Sequencing notes
 
@@ -410,7 +415,9 @@ scheduler task, so passes never overlap and the store sees one writer.
 ## Follow-ups
 
 - Cursor's `collect_agent_transcript_dirs` and `collect_cursor_chat_metadata`
-  are still unwindowed recursive walks. Scheduled as phase 5c (F2).
+  are still unwindowed recursive walks. Scheduled as phase 5c (F2); done by
+  bounding the walk's depth to the documented layout, not by mtime, since a
+  new session file bumps only its immediate parent's mtime.
 - `AppendOnlyGuarantee` is still hard-coded to `Absent`. The resumed path no
   longer needs it; either evidence it per agent or remove it and let a full
   read always re-check its whole prefix.


### PR DESCRIPTION
## Summary

Phase 5c of the continuous-ingest plan (see `docs/plans/continuous-session-ingest.md`, "Phase 5"). Independent of #361; the plan doc commit is shared.

- **F1:** the popover's `scan:finished` handler refreshes usage at most once per 30 s unless the pass reported `list_changed`. Every reader-driven usage refresh (popover shown, settings, initial load) is unchanged. Previously every pass recomputed 30-day totals and resolved both live provider accounts, which with an active session meant every couple of seconds.
- **F2:** Cursor's `collect_agent_transcript_dirs` and `collect_cursor_chat_metadata` no longer recurse into every subdirectory of every project; they are bounded by depth to the documented layouts (`projects/<project>/agent-transcripts`, `chats/<workspace>/<chat>/meta.json`). A directory-mtime gate was tried first and rejected: a new session file bumps only its immediate parent's mtime, so an mtime gate on the project directory would hide every session added to a project older than the window. A regression test covers that case.

## Test plan

- `crates/antiburn-local`: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p antiburn-local --no-fail-fast` (17 result lines, all ok). New tests: `agent-transcripts` one level too deep is ignored; an old project directory's `agent-transcripts` is still found.
- `apps/desktop`: `pnpm lint`, `pnpm type-check`, `pnpm test` (1055 passed), `prettier --check .` clean. New test: two finishes 1 s apart refresh usage once, `listChanged` refreshes immediately, the floor elapsing refreshes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1ir9iHoiRvkdSQnY8wsy2