### PR TITLE
feat: continuous ingest phase 5b (scoped passes)

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1150,7 +1150,13 @@ pub async fn scan_now(
     app: tauri::AppHandle,
     activity_window_days: Option<u32>,
 ) -> CommandResult<ScanStatus> {
-    Ok(scan::run_pass(&app, activity_window_days, ScanTrigger::ManualRescan).await)
+    Ok(scan::run_pass(
+        &app,
+        activity_window_days,
+        ScanTrigger::ManualRescan,
+        scan::PassScope::Full,
+    )
+    .await)
 }
 
 /// Ask the scan in flight to stop at its next phase boundary.

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -97,6 +97,7 @@ use crate::storage_health::{self, checked};
 use crate::store::{SessionActivityKey, SessionKey, SessionRecord, Store};
 
 pub mod idle;
+pub mod scoped;
 pub mod watch;
 
 /// How often the scheduler wakes up.

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -73,7 +73,6 @@
 //! the process.
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -126,15 +125,6 @@ pub enum ScanTrigger {
     Launch,
     /// The scheduler's unconditional [`TICK`].
     Tick,
-    /// A filesystem change the watcher's debouncer coalesced into one burst.
-    Watcher {
-        /// Relevant events folded into the burst, including any past the
-        /// stored path sample's bound.
-        events: usize,
-        /// The burst's deduplicated paths, in first-seen order, bounded at a
-        /// fixed constant — see [`watch::WatchBurst`].
-        paths: Vec<PathBuf>,
-    },
     /// T3/T5: a burst named one or more agents to rediscover, with no full
     /// discovery walk over the rest.
     WatcherAgents {
@@ -166,7 +156,6 @@ impl ScanTrigger {
         match self {
             ScanTrigger::Launch => "launch",
             ScanTrigger::Tick => "tick",
-            ScanTrigger::Watcher { .. } => "watcher",
             ScanTrigger::WatcherAgents { .. } => "watcher_agents",
             ScanTrigger::PopoverShown => "popover_shown",
             ScanTrigger::SettingsTransition => "settings_transition",
@@ -205,6 +194,11 @@ pub struct ScanController {
     /// rather than queued, because the waiting request already covers
     /// "scan again soon".
     pending_trigger: Mutex<Option<ScanTrigger>>,
+    /// Watcher bursts waiting for the scheduler loop to classify them. A
+    /// `Vec` rather than a channel: the scheduler drains every burst at once
+    /// per wake, and classification needs the whole batch together to fold
+    /// correctly into one [`scoped::ScopedWork`] (T7).
+    burst_inbox: Mutex<Vec<watch::WatchBurst>>,
 }
 
 impl ScanController {
@@ -238,6 +232,28 @@ impl ScanController {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take()
+    }
+
+    /// Hand the scheduler loop a debounced burst, and wake it. Called from
+    /// the watcher's own task, not the scheduler's, so this only queues the
+    /// burst — classification and admission happen on the scheduler's loop.
+    fn push_burst(&self, burst: watch::WatchBurst) {
+        self.burst_inbox
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(burst);
+        self.kick.notify_one();
+    }
+
+    /// Take every burst queued since the last drain, for the scheduler to
+    /// classify together.
+    fn take_bursts(&self) -> Vec<watch::WatchBurst> {
+        std::mem::take(
+            &mut self
+                .burst_inbox
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
     }
 
     /// Ask the pass in flight to stop at its next phase boundary.
@@ -280,6 +296,16 @@ pub(crate) fn on_demand_start(controller: &ScanController) -> bool {
     true
 }
 
+/// Which `tokio::select!` arm woke the scheduler loop. The loop needs to
+/// tell its own unconditional [`TICK`] apart from a burst-triggered or
+/// retry-triggered wake, since only the tick (or an explicit request) runs a
+/// full pass; a plain burst or retry wake only advances scoped work.
+enum Wake {
+    Kick,
+    Tick,
+    Deferred,
+}
+
 /// Start the scheduler. The returned handle is aborted when the app exits.
 pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> {
     let app = app.clone();
@@ -292,26 +318,162 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
         if scheduled_scanning_allowed(&app) {
             run_pass(&app, None, ScanTrigger::Launch, PassScope::Full).await;
         }
+
+        // T1-T7: the backlog a watcher burst can answer without a full
+        // discovery walk. `pending_work` is floor-gated (T2/T4/T5, T7);
+        // `retry_work` already cleared its floor but found a command's pass
+        // running, and is retried directly at `scoped::SCOPED_RETRY` — see
+        // the `scoped` module doc.
+        let mut floors = scoped::Floors::default();
+        let mut pending_work = scoped::ScopedWork::default();
+        let mut retry_work = scoped::ScopedWork::default();
+        let mut deferred_due: Option<tokio::time::Instant> = None;
+
         loop {
             let controller = app.state::<ScanController>();
-            tokio::select! {
-                () = controller.kick.notified() => {}
-                () = tokio::time::sleep(tick) => {}
-            }
+            let woke = tokio::select! {
+                () = controller.kick.notified() => Wake::Kick,
+                () = tokio::time::sleep(tick) => Wake::Tick,
+                () = sleep_until_due(deferred_due) => Wake::Deferred,
+            };
             // Checked after the wake-up rather than before the wait, so
             // resuming discovery takes effect at the next request or tick
             // instead of needing the app restarted.
             if !scheduled_scanning_allowed(&app) {
+                let dropped = controller.take_bursts();
+                if !dropped.is_empty() {
+                    ::tracing::debug!(
+                        event = "scan_bursts_dropped_while_paused",
+                        bursts = dropped.len(),
+                    );
+                }
+                // `Floors` keeps real last-run timestamps, so admission
+                // recomputes correct due times once scanning resumes. A
+                // stale `deferred_due` left set here would otherwise wake
+                // this loop again immediately, on every iteration, for as
+                // long as discovery stays paused.
+                deferred_due = None;
                 continue;
             }
-            // A trigger is pending unless this woke from the sleep arm with
-            // nothing requested, which is the unconditional tick itself.
-            let trigger = controller
-                .take_pending_trigger()
-                .unwrap_or(ScanTrigger::Tick);
-            run_pass(&app, None, trigger, PassScope::Full).await;
+
+            // Fold in any bursts queued since the last wake before deciding
+            // what runs: a full pass below covers them for free, and a
+            // scoped wake needs them for admission.
+            let bursts = controller.take_bursts();
+            if !bursts.is_empty() {
+                let home = home_dir().unwrap_or_default();
+                let store = app.state::<Store>();
+                for burst in bursts {
+                    let work = scoped::classify_burst(&burst.paths, &home, &|label: &str| {
+                        store
+                            .session_record_by_source_label(label)
+                            .ok()
+                            .flatten()
+                            .map(|(key, _)| key)
+                    });
+                    pending_work.merge(work);
+                }
+            }
+
+            // A trigger is pending unless this woke from the tick's own
+            // sleep arm with nothing requested. Either way a full pass
+            // supersedes every floor-gated or retrying scoped item: it
+            // re-describes everything they would have, so their floors are
+            // stamped as satisfied rather than left to run again soon.
+            let full_trigger = controller.take_pending_trigger();
+            if full_trigger.is_some() || matches!(woke, Wake::Tick) {
+                let trigger = full_trigger.unwrap_or(ScanTrigger::Tick);
+                run_pass(&app, None, trigger, PassScope::Full).await;
+                let now = tokio::time::Instant::now();
+                floors.stamp(&pending_work, now);
+                floors.stamp(&retry_work, now);
+                pending_work = scoped::ScopedWork::default();
+                retry_work = scoped::ScopedWork::default();
+                deferred_due = None;
+                continue;
+            }
+
+            // T7: retry work a prior admission already stamped as run, but
+            // that found a command's pass in the way, before admitting more
+            // — it does not need to clear its floor again, only wait for
+            // the pass that was busy.
+            if !retry_work.is_empty() {
+                retry_work = run_admitted_work(&app, std::mem::take(&mut retry_work)).await;
+            }
+
+            let now = tokio::time::Instant::now();
+            let (run_now, deferred, earliest_due) =
+                floors.admit(std::mem::take(&mut pending_work), now);
+            pending_work = deferred;
+            if !run_now.is_empty() {
+                let busy = run_admitted_work(&app, run_now).await;
+                retry_work.merge(busy);
+            }
+
+            deferred_due = match (earliest_due, retry_work.is_empty()) {
+                (Some(due), true) => Some(due),
+                (Some(due), false) => Some(due.min(now + scoped::SCOPED_RETRY)),
+                (None, true) => None,
+                (None, false) => Some(now + scoped::SCOPED_RETRY),
+            };
         }
     })
+}
+
+/// Sleep until `due`, or forever when nothing is due. A `tokio::select!` arm
+/// with nothing pending must never fire, so this never resolves on `None`
+/// rather than resolving immediately.
+async fn sleep_until_due(due: Option<tokio::time::Instant>) {
+    match due {
+        Some(instant) => tokio::time::sleep_until(instant).await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Run one wake's admitted [`scoped::ScopedWork`]: [`scoped::refresh_sessions`]
+/// for the sessions (T1), [`scoped::rediscover_agents`] for the plain and
+/// database-backed agents together (T3/T5) — both floors lead to the same
+/// rediscovery call, so one combined set avoids running it twice. Returns the
+/// part that found a command's pass already running, for the caller to retry
+/// (T7) without re-admitting it through [`scoped::Floors`].
+async fn run_admitted_work(app: &AppHandle, work: scoped::ScopedWork) -> scoped::ScopedWork {
+    let mut busy = scoped::ScopedWork::default();
+
+    if !work.sessions.is_empty() {
+        match scoped::refresh_sessions(app, &work.sessions).await {
+            Ok(Some(summary)) => {
+                ::tracing::debug!(
+                    event = "scan_targeted_admitted",
+                    sessions = work.sessions.len(),
+                    re_described = summary.re_described,
+                );
+            }
+            Ok(None) => busy.sessions = work.sessions,
+            Err(error) => {
+                ::tracing::debug!(event = "scan_targeted_failed", error = %error);
+            }
+        }
+    }
+
+    let rediscover: BTreeSet<AgentKind> = work
+        .agents
+        .iter()
+        .chain(work.db_agents.iter())
+        .copied()
+        .collect();
+    if !rediscover.is_empty() {
+        let labels: Vec<&'static str> = rediscover.iter().map(|agent| agent.slug()).collect();
+        let trigger = ScanTrigger::WatcherAgents { agents: labels };
+        if scoped::rediscover_agents(app, &rediscover, trigger)
+            .await
+            .is_none()
+        {
+            busy.agents = work.agents;
+            busy.db_agents = work.db_agents;
+        }
+    }
+
+    busy
 }
 
 /// The scheduler's fixed poll interval for this run, chosen once from the
@@ -467,21 +629,6 @@ pub(crate) async fn try_run_pass(
 /// picked up (see [`ScanController::request`]).
 fn log_scan_pass_requested(trigger: &ScanTrigger) {
     match trigger {
-        ScanTrigger::Watcher { events, paths } => {
-            let sample = paths
-                .iter()
-                .take(8)
-                .map(|path| path.to_string_lossy())
-                .collect::<Vec<_>>()
-                .join(",");
-            ::tracing::debug!(
-                event = "scan_pass_requested",
-                trigger = trigger.label(),
-                events,
-                paths = %sample,
-                path_count = paths.len(),
-            );
-        }
         ScanTrigger::WatcherAgents { agents } => {
             ::tracing::debug!(
                 event = "scan_pass_requested",

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -140,6 +140,9 @@ pub enum ScanTrigger {
         /// The rediscovered agents' slugs, for the log line.
         agents: Vec<&'static str>,
     },
+    /// A burst reached [`watch::MAX_BURST_PATHS`] and may have dropped
+    /// paths, so only a full pass can be sure to cover it.
+    WatcherOverflow,
     /// The popover reached the screen.
     PopoverShown,
     /// A settings save that finished onboarding, widened the activity
@@ -166,6 +169,7 @@ impl ScanTrigger {
             ScanTrigger::Launch => "launch",
             ScanTrigger::Tick => "tick",
             ScanTrigger::WatcherAgents { .. } => "watcher_agents",
+            ScanTrigger::WatcherOverflow => "watcher_overflow",
             ScanTrigger::PopoverShown => "popover_shown",
             ScanTrigger::SettingsTransition => "settings_transition",
             ScanTrigger::InsightsPane => "insights_pane",
@@ -337,14 +341,21 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
         let mut pending_work = scoped::ScopedWork::default();
         let mut retry_work = scoped::ScopedWork::default();
         let mut deferred_due: Option<tokio::time::Instant> = None;
+        // The tick is a fixed deadline, not a sleep restarted on every
+        // wake. A scoped wake every few seconds must not push the
+        // reconciliation pass back forever.
+        let mut next_tick = tokio::time::Instant::now() + tick;
 
         loop {
             let controller = app.state::<ScanController>();
             let woke = tokio::select! {
                 () = controller.kick.notified() => Wake::Kick,
-                () = tokio::time::sleep(tick) => Wake::Tick,
+                () = tokio::time::sleep_until(next_tick) => Wake::Tick,
                 () = sleep_until_due(deferred_due) => Wake::Deferred,
             };
+            if matches!(woke, Wake::Tick) {
+                next_tick = tokio::time::Instant::now() + tick;
+            }
             // Checked after the wake-up rather than before the wait, so
             // resuming discovery takes effect at the next request or tick
             // instead of needing the app restarted.
@@ -369,10 +380,22 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
             // what runs: a full pass below covers them for free, and a
             // scoped wake needs them for admission.
             let bursts = controller.take_bursts();
+            let mut overflowed = false;
             if !bursts.is_empty() {
                 let home = home_dir().unwrap_or_default();
                 let store = app.state::<Store>();
                 for burst in bursts {
+                    // A burst at the path bound may have dropped paths, so a
+                    // scoped pass could miss one. Only a full pass is safe.
+                    if burst.paths.len() >= watch::MAX_BURST_PATHS {
+                        ::tracing::debug!(
+                            event = "scan_burst_overflowed",
+                            events = burst.events,
+                            path_count = burst.paths.len(),
+                        );
+                        overflowed = true;
+                        continue;
+                    }
                     let work = scoped::classify_burst(&burst.paths, &home, &|label: &str| {
                         store
                             .session_record_by_source_label(label)
@@ -390,8 +413,12 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
             // re-describes everything they would have, so their floors are
             // stamped as satisfied rather than left to run again soon.
             let full_trigger = controller.take_pending_trigger();
-            if full_trigger.is_some() || matches!(woke, Wake::Tick) {
-                let trigger = full_trigger.unwrap_or(ScanTrigger::Tick);
+            if full_trigger.is_some() || overflowed || matches!(woke, Wake::Tick) {
+                let trigger = full_trigger.unwrap_or(if overflowed {
+                    ScanTrigger::WatcherOverflow
+                } else {
+                    ScanTrigger::Tick
+                });
                 run_pass(&app, None, trigger, PassScope::Full).await;
                 let now = tokio::time::Instant::now();
                 floors.stamp(&pending_work, now);
@@ -399,6 +426,9 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
                 pending_work = scoped::ScopedWork::default();
                 retry_work = scoped::ScopedWork::default();
                 deferred_due = None;
+                // A full pass just ran, so the next tick can wait a whole
+                // interval.
+                next_tick = now + tick;
                 continue;
             }
 

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -30,13 +30,22 @@
 //!   waits out a tick behind a missed event.
 //! - **On demand**, from the rescan control and after any change to the source
 //!   selection.
-//! - **Shortly after a watched file changes.** [`watch::spawn_watcher`] starts
-//!   an OS filesystem watcher over every agent's watch roots
-//!   (`AgentExplorer::watch_roots`), debounces the events it sees, and
-//!   requests a pass after a quiet period — see the `watch` module doc for
-//!   the debounce shape. [`TICK`] stays as reconciliation for what the
-//!   watcher cannot cover (a root the OS refuses to watch, a change the
-//!   debounce window swallowed). When the watcher is not fully healthy the
+//! - **Shortly after a watched file changes — narrowly, not as a full pass.**
+//!   [`watch::spawn_watcher`] starts an OS filesystem watcher over every
+//!   agent's watch roots (`AgentExplorer::watch_roots`), debounces the events
+//!   it sees, and hands the scheduler's loop one [`watch::WatchBurst`] after
+//!   each quiet period — see the `watch` module doc for the debounce shape.
+//!   The `scoped` module classifies that burst into up to three lanes: a
+//!   known session refreshed directly with no discovery walk, a plain
+//!   agent rediscovered on its own, or a database-backed agent rediscovered
+//!   at a longer floor because every write near its store looks like a new
+//!   session. Each lane has its own minimum re-run interval, and a burst
+//!   that arrives inside one is folded into the next admitted run rather
+//!   than dropped — see the `scoped` module doc for the full contract.
+//!   [`TICK`] stays as reconciliation for what the watcher cannot cover (a
+//!   root the OS refuses to watch, a change the debounce window swallowed),
+//!   and it runs a full pass, which supersedes any scoped work still
+//!   waiting on its floor. When the watcher is not fully healthy the
 //!   scheduler ticks at [`watch::FALLBACK_TICK`] instead, so polling alone
 //!   still finds new sessions at a reasonable cadence.
 //!

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -72,6 +72,7 @@
 //! scheduler is a single handle the app aborts on exit, so nothing outlives
 //! the process.
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -134,6 +135,12 @@ pub enum ScanTrigger {
         /// fixed constant — see [`watch::WatchBurst`].
         paths: Vec<PathBuf>,
     },
+    /// T3/T5: a burst named one or more agents to rediscover, with no full
+    /// discovery walk over the rest.
+    WatcherAgents {
+        /// The rediscovered agents' slugs, for the log line.
+        agents: Vec<&'static str>,
+    },
     /// The popover reached the screen.
     PopoverShown,
     /// A settings save that finished onboarding, widened the activity
@@ -160,6 +167,7 @@ impl ScanTrigger {
             ScanTrigger::Launch => "launch",
             ScanTrigger::Tick => "tick",
             ScanTrigger::Watcher { .. } => "watcher",
+            ScanTrigger::WatcherAgents { .. } => "watcher_agents",
             ScanTrigger::PopoverShown => "popover_shown",
             ScanTrigger::SettingsTransition => "settings_transition",
             ScanTrigger::InsightsPane => "insights_pane",
@@ -170,6 +178,18 @@ impl ScanTrigger {
             ScanTrigger::ManualRescan => "manual_rescan",
         }
     }
+}
+
+/// What one pass discovers: every agent, or only a burst-named subset.
+///
+/// T3/T5: an agent-scoped pass reuses [`run_pass`] and [`pass`] wholesale —
+/// same status machinery, same events — so the only thing it changes is which
+/// agents discovery asks and which agents' rows the upsert and per-agent scan
+/// bookkeeping touch.
+#[derive(Debug, Clone)]
+pub enum PassScope {
+    Full,
+    Agents(BTreeSet<AgentKind>),
 }
 
 /// The scheduler's shared state, registered as Tauri managed state.
@@ -270,7 +290,7 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
         let tick = tick_for(&watch::spawn_watcher(&app));
         // A fresh install has nothing to scan until the reader picks sources.
         if scheduled_scanning_allowed(&app) {
-            run_pass(&app, None, ScanTrigger::Launch).await;
+            run_pass(&app, None, ScanTrigger::Launch, PassScope::Full).await;
         }
         loop {
             let controller = app.state::<ScanController>();
@@ -289,7 +309,7 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
             let trigger = controller
                 .take_pending_trigger()
                 .unwrap_or(ScanTrigger::Tick);
-            run_pass(&app, None, trigger).await;
+            run_pass(&app, None, trigger, PassScope::Full).await;
         }
     })
 }
@@ -325,7 +345,24 @@ pub async fn run_pass(
     app: &AppHandle,
     activity_window_days: Option<u32>,
     trigger: ScanTrigger,
+    scope: PassScope,
 ) -> ScanStatus {
+    try_run_pass(app, activity_window_days, trigger, scope)
+        .await
+        .unwrap_or_else(|| app.state::<ScanController>().status())
+}
+
+/// [`run_pass`]'s body, returning `None` rather than a stale status when
+/// [`on_demand_start`] finds one already running. The scoped lanes in
+/// `scoped.rs` use this directly to tell "ran" from "skipped, retry soon"
+/// (T7) — a distinction [`run_pass`]'s callers do not need, since they always
+/// treat "already running" as "nothing more to do here".
+pub(crate) async fn try_run_pass(
+    app: &AppHandle,
+    activity_window_days: Option<u32>,
+    trigger: ScanTrigger,
+    scope: PassScope,
+) -> Option<ScanStatus> {
     log_scan_pass_requested(&trigger);
     {
         let controller = app.state::<ScanController>();
@@ -335,7 +372,7 @@ pub async fn run_pass(
             // the tick. Logging the trigger turns that into a visible stream
             // of drops instead.
             ::tracing::debug!(event = "scan_request_dropped", trigger = trigger.label());
-            return controller.status();
+            return None;
         }
         let started = controller.update(|status| {
             status.running = true;
@@ -355,7 +392,7 @@ pub async fn run_pass(
     let announce = move |entry: ActivityEntry| {
         let _ = announce_app.emit(commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
     };
-    let outcome = pass(app, activity_window_days, &announce).await;
+    let outcome = pass(app, activity_window_days, &scope, &announce).await;
 
     let controller = app.state::<ScanController>();
     let cancelled = controller.cancelled();
@@ -420,7 +457,7 @@ pub async fn run_pass(
         outcome.as_ref().ok().map(|summary| summary.sessions as u64),
     );
     crate::notifications::note_scan_outcome(app, &finished);
-    finished
+    Some(finished)
 }
 
 /// Log `scan_pass_requested`. Every call to [`run_pass`] gets one, whether it
@@ -445,6 +482,14 @@ fn log_scan_pass_requested(trigger: &ScanTrigger) {
                 path_count = paths.len(),
             );
         }
+        ScanTrigger::WatcherAgents { agents } => {
+            ::tracing::debug!(
+                event = "scan_pass_requested",
+                trigger = trigger.label(),
+                agents = %agents.join(","),
+                agent_count = agents.len(),
+            );
+        }
         other => {
             ::tracing::debug!(event = "scan_pass_requested", trigger = other.label());
         }
@@ -465,9 +510,14 @@ struct PassSummary {
 
 /// The body of one pass. Split out so [`run_pass`] owns only the in-flight
 /// bookkeeping and the events.
+///
+/// `scope` narrows discovery, the upsert's evidence cohort, and per-agent
+/// scan bookkeeping to a burst-named subset of agents (T3/T5); everything
+/// else runs exactly as a full pass. See [`PassScope`].
 async fn pass(
     app: &AppHandle,
     _activity_window_days: Option<u32>,
+    scope: &PassScope,
     announce: &(dyn Fn(ActivityEntry) + Send + Sync),
 ) -> anyhow::Result<PassSummary> {
     let store = app.state::<Store>();
@@ -480,45 +530,66 @@ async fn pass(
     let ignored = ignored_paths::load_ignored(store.state_dir(), IGNORE_SCOPE);
     let home = home_dir().unwrap_or_default();
 
-    let progress_app = app.clone();
-    let logs = Explorers::DISK
-        .discover_recent_sessions_with_progress(
-            now,
-            since_secs,
-            move |agent, found, completed, total| {
-                let controller = progress_app.state::<ScanController>();
-                let status = controller.update(|status| {
-                    status.completed_agents = completed;
-                    status.total_agents = total;
-                    status.sessions += found;
-                });
-                let _ = progress_app.emit(EVENT_PROGRESS, status);
-                let _ = agent;
-            },
-        )
-        .await;
+    let logs = match scope {
+        PassScope::Full => {
+            let progress_app = app.clone();
+            Explorers::DISK
+                .discover_recent_sessions_with_progress(
+                    now,
+                    since_secs,
+                    move |agent, found, completed, total| {
+                        let controller = progress_app.state::<ScanController>();
+                        let status = controller.update(|status| {
+                            status.completed_agents = completed;
+                            status.total_agents = total;
+                            status.sessions += found;
+                        });
+                        let _ = progress_app.emit(EVENT_PROGRESS, status);
+                        let _ = agent;
+                    },
+                )
+                .await
+        }
+        PassScope::Agents(agents) => discover_scoped_agents(app, agents, now, since_secs).await,
+    };
 
     let previous_records = store.session_records()?;
+    let scoped_previous_records;
+    let previous_records_for_pass = match scope {
+        PassScope::Full => &previous_records,
+        PassScope::Agents(agents) => {
+            scoped_previous_records = previous_records
+                .iter()
+                .filter(|(key, _)| agents.iter().any(|agent| agent.slug() == key.agent))
+                .map(|(key, record)| (key.clone(), record.clone()))
+                .collect();
+            &scoped_previous_records
+        }
+    };
     let Described {
         records,
         rejected,
         changed,
         list_changed,
-    } = describe_with_states(logs, &home, &ignored, &previous_records).await;
+    } = describe_with_states(logs, &home, &ignored, previous_records_for_pass).await;
+    let evidence_agents: Vec<&str> = match scope {
+        PassScope::Full => agents::evidence_cohort(),
+        PassScope::Agents(agents) => agents.iter().map(|agent| agent.slug()).collect(),
+    };
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
     checked(
         app,
         "The session index",
-        store.upsert_sessions(&records, &agents::evidence_cohort()),
+        store.upsert_sessions(&records, &evidence_agents),
     )?;
     crate::insights_worker::wake(app);
     // A write may have added a session the idle task was not yet watching,
     // or moved one's deadline later; either way its sleep needs recomputing.
     idle::wake(app);
 
-    announce_changed_rows(&store, &changed, &previous_records, now, announce);
+    announce_changed_rows(&store, &changed, previous_records_for_pass, now, announce);
 
     // A transcript the gate rejected may have been indexed by an earlier
     // version of the app that did not gate; the row is removed rather than
@@ -531,6 +602,8 @@ async fn pass(
         )?;
     }
 
+    // `records` already holds only the scoped agents' sessions when `scope`
+    // is [`PassScope::Agents`], since discovery itself was scoped.
     for (agent, seen, cursor) in per_agent_totals(&records) {
         checked(
             app,
@@ -550,13 +623,51 @@ async fn pass(
         });
     }
 
-    repositories::refresh(app).await?;
+    // A full pass always refreshes the repository list. An agent-scoped pass
+    // only pays for it when a session's arrival or eviction could plausibly
+    // have introduced a new cwd.
+    if matches!(scope, PassScope::Full) || list_changed {
+        repositories::refresh(app).await?;
+    }
 
     Ok(PassSummary {
         sessions: records.len(),
         list_changed,
         re_described: changed.len(),
     })
+}
+
+/// [`PassScope::Agents`]'s discovery: only the named agents, concurrently,
+/// with no WSL file-session walk — WSL sessions are a full-pass concern; a
+/// scoped pass exists because a native watch root fired.
+async fn discover_scoped_agents(
+    app: &AppHandle,
+    agents: &BTreeSet<AgentKind>,
+    now: i64,
+    since_secs: i64,
+) -> Vec<SessionLog> {
+    let mut set = JoinSet::new();
+    for agent in agents {
+        let explorer = Explorers::DISK.get(agent);
+        set.spawn(async move { explorer.discover_recent(now, since_secs).await });
+    }
+    let total = agents.len();
+    let mut completed = 0;
+    let mut logs = Vec::new();
+    while let Some(result) = set.join_next().await {
+        completed += 1;
+        if let Ok(found) = result {
+            let controller = app.state::<ScanController>();
+            let status = controller.update(|status| {
+                status.completed_agents = completed;
+                status.total_agents = total;
+                status.sessions += found.len();
+            });
+            let _ = app.emit(EVENT_PROGRESS, status);
+            logs.extend(found);
+        }
+    }
+    logs
 }
 
 /// Emit `SESSION_ENTRY_CHANGED_EVENT` for every re-described row the reader's

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -7,22 +7,27 @@
 //! database-backed session appeared under their root (T3, T5), or paths
 //! nothing claims (T6). [`Floors`] then admits the part of that work that has
 //! not run too recently, per session and per agent (T2, T4, T5), and defers
-//! the rest without dropping it (T7). [`rediscover_agents`] runs the
-//! agent-scoped lane.
+//! the rest without dropping it (T7). [`refresh_sessions`] and
+//! [`rediscover_agents`] run the two admitted lanes.
 
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use antiburn_local::discovery::{Explorers, WatchRoot};
+use antiburn_local::discovery::{Explorers, SessionLog, SessionSource, WatchRoot};
 use antiburn_local::model::AgentKind;
-use tauri::AppHandle;
+use antiburn_local::paths::{home_dir, ignored_paths};
+use antiburn_local::platform::environment::DiscoveryEnvironment;
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::time::Instant;
 
-use crate::dto::ScanStatus;
-use crate::store::SessionActivityKey;
+use crate::agents;
+use crate::dto::{ActivityEntry, ScanStatus};
+use crate::storage_health::checked;
+use crate::store::{SessionActivityKey, SessionRecord, Store};
 
-use super::{PassScope, ScanTrigger};
+use super::{PassScope, ScanController, ScanTrigger};
 
 /// T2: a re-described session is not re-described again before this many
 /// seconds pass.
@@ -35,6 +40,10 @@ pub const AGENT_REDISCOVER_MIN_INTERVAL: Duration = Duration::from_secs(20);
 /// than [`AGENT_REDISCOVER_MIN_INTERVAL`] because every write under such an
 /// agent's root looks like a new session to the classifier.
 pub const DB_AGENT_REDISCOVER_MIN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// T7: how long the scheduler waits before retrying admitted work that found
+/// a command's pass already holding the running flag.
+pub const SCOPED_RETRY: Duration = Duration::from_millis(500);
 
 /// File name suffixes the classifier treats as a database-backed agent's
 /// store (T5): the vendor extensions themselves, plus their SQLite WAL and
@@ -301,6 +310,118 @@ impl<K: Ord> Admission<'_, K> {
             }
         }
     }
+}
+
+/// What one targeted or agent-scoped pass persisted, for the caller's log
+/// line.
+pub struct ScopedSummary {
+    pub sessions: usize,
+    pub re_described: usize,
+}
+
+/// T1: refresh exactly the sessions named in `keys`, without discovery,
+/// without touching repositories or per-agent scan bookkeeping, and without
+/// the `scan:started` / `scan:finished` events a full or agent-scoped pass
+/// emits.
+///
+/// Returns `Ok(None)` rather than attempting the refresh when a command's
+/// [`super::run_pass`] already holds the running flag — the caller keeps the
+/// keys pending and retries (T7) instead of losing them.
+pub(super) async fn refresh_sessions(
+    app: &AppHandle,
+    keys: &BTreeSet<SessionActivityKey>,
+) -> anyhow::Result<Option<ScopedSummary>> {
+    if keys.is_empty() {
+        return Ok(Some(ScopedSummary {
+            sessions: 0,
+            re_described: 0,
+        }));
+    }
+    let controller = app.state::<ScanController>();
+    if !super::on_demand_start(&controller) {
+        return Ok(None);
+    }
+    let started_at = std::time::Instant::now();
+    let outcome = refresh_sessions_locked(app, keys).await;
+    controller.running.store(false, Ordering::SeqCst);
+    controller.cancel.store(false, Ordering::SeqCst);
+    let summary = outcome?;
+    ::tracing::debug!(
+        event = "scan_targeted_finished",
+        sessions = summary.sessions,
+        re_described = summary.re_described,
+        duration_ms = started_at.elapsed().as_millis() as u64,
+    );
+    Ok(Some(summary))
+}
+
+async fn refresh_sessions_locked(
+    app: &AppHandle,
+    keys: &BTreeSet<SessionActivityKey>,
+) -> anyhow::Result<ScopedSummary> {
+    let store = app.state::<Store>();
+    let now = super::unix_now();
+    let home = home_dir().unwrap_or_default();
+    let ignored = ignored_paths::load_ignored(store.state_dir(), super::IGNORE_SCOPE);
+
+    let mut previous_map: HashMap<SessionActivityKey, SessionRecord> = HashMap::new();
+    let mut logs = Vec::new();
+    for key in keys {
+        let Some((activity_key, record)) =
+            store.session_record_by_source_label(&key.source_label)?
+        else {
+            continue;
+        };
+        // Only a native file source can be reused this way; a provider-database
+        // or inline session has no path to re-describe from.
+        if record.source_kind != "file" {
+            continue;
+        }
+        let Some(agent) = AgentKind::from_slug(&record.key.agent) else {
+            continue;
+        };
+        let path = PathBuf::from(&record.source_label);
+        if !path.exists() {
+            // The tick's full pass evicts a session whose source vanished;
+            // a targeted refresh only skips it.
+            ::tracing::debug!(event = "scan_targeted_source_missing", source_label = %record.source_label);
+            continue;
+        }
+        logs.push(SessionLog {
+            agent_type: agent,
+            source: SessionSource::File(path),
+            updated_at: record.updated_at_epoch,
+            environment: DiscoveryEnvironment::Native,
+        });
+        previous_map.insert(activity_key, record);
+    }
+
+    let announce_app = app.clone();
+    let announce = move |entry: ActivityEntry| {
+        let _ = announce_app.emit(crate::commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
+    };
+
+    let described = super::describe_with_states(logs, &home, &ignored, &previous_map).await;
+    checked(
+        app,
+        "The session index",
+        store.upsert_sessions(&described.records, &agents::evidence_cohort()),
+    )?;
+    crate::insights_worker::wake(app);
+    super::idle::wake(app);
+    super::announce_changed_rows(&store, &described.changed, &previous_map, now, &announce);
+    for key in &described.rejected {
+        checked(
+            app,
+            "The session index",
+            store.delete_session(key).map(|_| ()),
+        )?;
+    }
+
+    Ok(ScopedSummary {
+        sessions: described.records.len(),
+        re_described: described.changed.len(),
+    })
 }
 
 /// T3, T5: rediscover exactly `agents`, reusing [`super::run_pass`] scoped to

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -51,6 +51,9 @@ pub const SCOPED_RETRY: Duration = Duration::from_millis(500);
 const DATABASE_EXTENSIONS: [&str; 4] = ["vscdb", "db", "sqlite", "sqlite3"];
 const DATABASE_SIDECAR_SUFFIXES: [&str; 2] = ["-wal", "-journal"];
 
+/// How many of a burst's paths the classification log line shows.
+const LOG_PATH_SAMPLE: usize = 8;
+
 /// What one path in a burst means for the scheduler, in the classification
 /// order T1, T5, T3, T6 apply.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -118,12 +121,20 @@ pub fn classify_burst(
     // database-triggered rediscovery: both lead to the same
     // `discover_recent` call, and the shorter T3 floor already covers it.
     work.db_agents.retain(|agent| !work.agents.contains(agent));
+    let sample = paths
+        .iter()
+        .take(LOG_PATH_SAMPLE)
+        .map(|path| path.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(",");
     ::tracing::debug!(
         event = "scan_burst_classified",
         sessions = work.sessions.len(),
         agents = work.agents.len(),
         db_agents = work.db_agents.len(),
         ignored,
+        paths = %sample,
+        path_count = paths.len(),
     );
     work
 }

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -7,7 +7,8 @@
 //! database-backed session appeared under their root (T3, T5), or paths
 //! nothing claims (T6). [`Floors`] then admits the part of that work that has
 //! not run too recently, per session and per agent (T2, T4, T5), and defers
-//! the rest without dropping it (T7).
+//! the rest without dropping it (T7). [`rediscover_agents`] runs the
+//! agent-scoped lane.
 
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -15,9 +16,13 @@ use std::time::Duration;
 
 use antiburn_local::discovery::{Explorers, WatchRoot};
 use antiburn_local::model::AgentKind;
+use tauri::AppHandle;
 use tokio::time::Instant;
 
+use crate::dto::ScanStatus;
 use crate::store::SessionActivityKey;
+
+use super::{PassScope, ScanTrigger};
 
 /// T2: a re-described session is not re-described again before this many
 /// seconds pass.
@@ -296,6 +301,20 @@ impl<K: Ord> Admission<'_, K> {
             }
         }
     }
+}
+
+/// T3, T5: rediscover exactly `agents`, reusing [`super::run_pass`] scoped to
+/// them so `scan:started` / `scan:finished` and the log lines it already
+/// emits come for free.
+///
+/// Returns `None` when [`super::on_demand_start`] finds a pass already
+/// running — the caller keeps `agents` pending and retries (T7).
+pub(super) async fn rediscover_agents(
+    app: &AppHandle,
+    agents: &BTreeSet<AgentKind>,
+    trigger: ScanTrigger,
+) -> Option<ScanStatus> {
+    super::try_run_pass(app, None, trigger, PassScope::Agents(agents.clone())).await
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -1,0 +1,570 @@
+//! Scoped passes: the narrow work a watcher burst can answer without a full
+//! discovery walk. See `docs/plans/continuous-session-ingest.md`, "Phase 5b",
+//! rules T1 to T7, for the contract this module implements.
+//!
+//! [`classify_burst`] sorts a burst's paths into a [`ScopedWork`]: known
+//! sessions to refresh directly (T1), agents to rediscover because a new or
+//! database-backed session appeared under their root (T3, T5), or paths
+//! nothing claims (T6). [`Floors`] then admits the part of that work that has
+//! not run too recently, per session and per agent (T2, T4, T5), and defers
+//! the rest without dropping it (T7).
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use antiburn_local::discovery::{Explorers, WatchRoot};
+use antiburn_local::model::AgentKind;
+use tokio::time::Instant;
+
+use crate::store::SessionActivityKey;
+
+/// T2: a re-described session is not re-described again before this many
+/// seconds pass.
+pub const TARGETED_MIN_INTERVAL: Duration = Duration::from_secs(10);
+
+/// T4: an agent's rediscovery runs at most this often.
+pub const AGENT_REDISCOVER_MIN_INTERVAL: Duration = Duration::from_secs(20);
+
+/// T5: a database-backed agent's rediscovery runs at most this often — longer
+/// than [`AGENT_REDISCOVER_MIN_INTERVAL`] because every write under such an
+/// agent's root looks like a new session to the classifier.
+pub const DB_AGENT_REDISCOVER_MIN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// File name suffixes the classifier treats as a database-backed agent's
+/// store (T5): the vendor extensions themselves, plus their SQLite WAL and
+/// rollback-journal sidecars.
+const DATABASE_EXTENSIONS: [&str; 4] = ["vscdb", "db", "sqlite", "sqlite3"];
+const DATABASE_SIDECAR_SUFFIXES: [&str; 2] = ["-wal", "-journal"];
+
+/// What one path in a burst means for the scheduler, in the classification
+/// order T1, T5, T3, T6 apply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClassifiedPath {
+    Session(SessionActivityKey),
+    DatabaseAgent(AgentKind),
+    Agent(AgentKind),
+    Ignored,
+}
+
+/// A burst's classifications, folded together. Sets rather than counts: the
+/// scheduler merges bursts across wakes (T7), and a repeated path or agent
+/// must not be double-counted or double-admitted.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ScopedWork {
+    pub sessions: BTreeSet<SessionActivityKey>,
+    pub agents: BTreeSet<AgentKind>,
+    pub db_agents: BTreeSet<AgentKind>,
+}
+
+impl ScopedWork {
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty() && self.agents.is_empty() && self.db_agents.is_empty()
+    }
+
+    /// Fold another burst's work in, dropping nothing (T7).
+    pub fn merge(&mut self, other: ScopedWork) {
+        self.sessions.extend(other.sessions);
+        self.agents.extend(other.agents);
+        self.db_agents.extend(other.db_agents);
+    }
+}
+
+/// Classify every path in a burst against `home` and `lookup`, and fold the
+/// result into one [`ScopedWork`]. Pure over its arguments — no I/O beyond
+/// what `lookup` does — so a test can drive it with a fake lookup and a
+/// synthetic home.
+///
+/// `lookup` answers "is this string form a stored native file session's
+/// `source_label`", the store query [`crate::store::Store::session_record_by_source_label`]
+/// backs in production.
+pub fn classify_burst(
+    paths: &[PathBuf],
+    home: &Path,
+    lookup: &dyn Fn(&str) -> Option<SessionActivityKey>,
+) -> ScopedWork {
+    let roots = all_agent_roots(home);
+    let mut work = ScopedWork::default();
+    let mut ignored = 0usize;
+    for path in paths {
+        match classify_path(path, &roots, lookup) {
+            ClassifiedPath::Session(key) => {
+                work.sessions.insert(key);
+            }
+            ClassifiedPath::DatabaseAgent(agent) => {
+                work.db_agents.insert(agent);
+            }
+            ClassifiedPath::Agent(agent) => {
+                work.agents.insert(agent);
+            }
+            ClassifiedPath::Ignored => ignored += 1,
+        }
+    }
+    // An agent already admitted on its own file evidence needs no separate
+    // database-triggered rediscovery: both lead to the same
+    // `discover_recent` call, and the shorter T3 floor already covers it.
+    work.db_agents.retain(|agent| !work.agents.contains(agent));
+    ::tracing::debug!(
+        event = "scan_burst_classified",
+        sessions = work.sessions.len(),
+        agents = work.agents.len(),
+        db_agents = work.db_agents.len(),
+        ignored,
+    );
+    work
+}
+
+fn classify_path(
+    path: &Path,
+    roots: &[(AgentKind, WatchRoot)],
+    lookup: &dyn Fn(&str) -> Option<SessionActivityKey>,
+) -> ClassifiedPath {
+    if let Some(key) = lookup(&path.to_string_lossy()) {
+        return ClassifiedPath::Session(key);
+    }
+    // T1's sub-agent form: `<dir>/<sessionId>/subagents/agent-*.jsonl` names
+    // its parent transcript as `<dir>/<sessionId>.jsonl`. Walk ancestors
+    // while they stay under an agent's watch root, stopping at the first
+    // ancestor whose `.jsonl` sibling is a stored session.
+    let mut current = path.parent();
+    while let Some(dir) = current {
+        if !roots.iter().any(|(_, root)| dir.starts_with(&root.path)) {
+            break;
+        }
+        let candidate = dir.with_extension("jsonl");
+        if let Some(key) = lookup(&candidate.to_string_lossy()) {
+            return ClassifiedPath::Session(key);
+        }
+        current = dir.parent();
+    }
+    if is_database_path(path)
+        && let Some(agent) = owning_agent(path, roots)
+    {
+        return ClassifiedPath::DatabaseAgent(agent);
+    }
+    match owning_agent(path, roots) {
+        Some(agent) => ClassifiedPath::Agent(agent),
+        None => ClassifiedPath::Ignored,
+    }
+}
+
+/// T5: whether `path`'s file name is one of the database extensions, or a
+/// `-wal` / `-journal` sidecar of one.
+fn is_database_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if let Some(extension) = path.extension().and_then(|ext| ext.to_str())
+        && DATABASE_EXTENSIONS
+            .iter()
+            .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+    {
+        return true;
+    }
+    DATABASE_SIDECAR_SUFFIXES.iter().any(|suffix| {
+        name.strip_suffix(suffix).is_some_and(|stem| {
+            Path::new(stem)
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| {
+                    DATABASE_EXTENSIONS
+                        .iter()
+                        .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+                })
+        })
+    })
+}
+
+/// The agent whose watch root is the longest matching prefix of `path`, or
+/// `None` when no watch root claims it.
+///
+/// T3: watch-root prefix matching, not [`Explorers::infer_agent_and_surface`]
+/// — the watch roots are exactly what the watcher registered, so this
+/// classification cannot disagree with what was watched.
+pub fn owning_agent(path: &Path, roots: &[(AgentKind, WatchRoot)]) -> Option<AgentKind> {
+    roots
+        .iter()
+        .filter(|(_, root)| path.starts_with(&root.path))
+        .max_by_key(|(_, root)| root.path.as_os_str().len())
+        .map(|(agent, _)| *agent)
+}
+
+/// Every agent's watch roots, resolved against `home`, paired with the agent
+/// that owns each — the same roots the watcher registered, built fresh per
+/// classification since a burst is rare enough that caching is not worth the
+/// staleness risk of an agent installed after start-up.
+fn all_agent_roots(home: &Path) -> Vec<(AgentKind, WatchRoot)> {
+    AgentKind::ALL
+        .iter()
+        .flat_map(|agent| {
+            Explorers::DISK
+                .watch_roots_for(agent, home)
+                .into_iter()
+                .map(move |root| (*agent, root))
+        })
+        .collect()
+}
+
+/// Tracks the last admitted run per session and per agent, so the scheduler
+/// can enforce T2, T4, and T5's floors without dropping the work a floor
+/// defers (T7).
+#[derive(Debug, Default)]
+pub struct Floors {
+    sessions: HashMap<SessionActivityKey, Instant>,
+    agents: HashMap<AgentKind, Instant>,
+}
+
+impl Floors {
+    /// Split `work` into the part whose floor has elapsed (admitted, and
+    /// stamped here as run at `now`) and the part still inside its floor
+    /// (deferred, unstamped). Returns the deferred part's earliest due
+    /// instant, for the scheduler's sleep arm.
+    pub fn admit(
+        &mut self,
+        work: ScopedWork,
+        now: Instant,
+    ) -> (ScopedWork, ScopedWork, Option<Instant>) {
+        let mut run_now = ScopedWork::default();
+        let mut deferred = ScopedWork::default();
+        let mut earliest_due = None;
+
+        for key in work.sessions {
+            let last_run = self.sessions.get(&key).copied();
+            let mut outcome = Admission {
+                run_now: &mut run_now.sessions,
+                deferred: &mut deferred.sessions,
+                earliest_due: &mut earliest_due,
+            };
+            outcome.admit(key, last_run, TARGETED_MIN_INTERVAL, now);
+        }
+        for agent in work.agents {
+            let last_run = self.agents.get(&agent).copied();
+            let mut outcome = Admission {
+                run_now: &mut run_now.agents,
+                deferred: &mut deferred.agents,
+                earliest_due: &mut earliest_due,
+            };
+            outcome.admit(agent, last_run, AGENT_REDISCOVER_MIN_INTERVAL, now);
+        }
+        for agent in work.db_agents {
+            let last_run = self.agents.get(&agent).copied();
+            let mut outcome = Admission {
+                run_now: &mut run_now.db_agents,
+                deferred: &mut deferred.db_agents,
+                earliest_due: &mut earliest_due,
+            };
+            outcome.admit(agent, last_run, DB_AGENT_REDISCOVER_MIN_INTERVAL, now);
+        }
+
+        self.stamp(&run_now, now);
+        (run_now, deferred, earliest_due)
+    }
+
+    /// Stamp every item in `work` as run at `now`, without deciding anything.
+    /// A full pass re-describes everything a scoped pass would have, so it
+    /// supersedes and satisfies every floor for the work it displaced.
+    pub fn stamp(&mut self, work: &ScopedWork, now: Instant) {
+        for key in &work.sessions {
+            self.sessions.insert(key.clone(), now);
+        }
+        for agent in work.agents.iter().chain(work.db_agents.iter()) {
+            self.agents.insert(*agent, now);
+        }
+    }
+}
+
+/// One floor's decision output, bundled so [`Floors::admit`] can hand it to
+/// [`Admission::admit`] as a single argument per item kind.
+struct Admission<'a, K: Ord> {
+    run_now: &'a mut BTreeSet<K>,
+    deferred: &'a mut BTreeSet<K>,
+    earliest_due: &'a mut Option<Instant>,
+}
+
+impl<K: Ord> Admission<'_, K> {
+    /// Admit `item` now when its floor has elapsed since `last_run`, or
+    /// defer it and widen `earliest_due` to cover when it will.
+    fn admit(&mut self, item: K, last_run: Option<Instant>, floor: Duration, now: Instant) {
+        match last_run.map(|last| last + floor) {
+            Some(due) if due > now => {
+                self.deferred.insert(item);
+                *self.earliest_due =
+                    Some(self.earliest_due.map_or(due, |current| current.min(due)));
+            }
+            _ => {
+                self.run_now.insert(item);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root(path: &str, recursive: bool) -> WatchRoot {
+        let path = PathBuf::from(path);
+        if recursive {
+            WatchRoot::recursive(path)
+        } else {
+            WatchRoot::shallow(path)
+        }
+    }
+
+    fn key(source_label: &str) -> SessionActivityKey {
+        SessionActivityKey::new("native", "claude-code", source_label)
+    }
+
+    /// Cursor's real watch root for `home`, so a `classify_burst` test (which
+    /// resolves roots through the actual [`Explorers::DISK`] registry, not a
+    /// fake) exercises a path the classifier would really see — the root's
+    /// shape differs by platform.
+    fn cursor_watch_root(home: &Path) -> PathBuf {
+        Explorers::DISK
+            .watch_roots_for(&AgentKind::Cursor, home)
+            .into_iter()
+            .next()
+            .expect("Cursor has at least one watch root")
+            .path
+    }
+
+    #[test]
+    fn a_path_equal_to_a_stored_source_label_is_a_known_session() {
+        let home = PathBuf::from("/home/avery");
+        let session_path = home.join(".claude/projects/demo/abc.jsonl");
+        let expected = key(&session_path.to_string_lossy());
+        let lookup_key = expected.clone();
+        let lookup =
+            move |label: &str| (label == lookup_key.source_label).then(|| lookup_key.clone());
+
+        let work = classify_burst(&[session_path], &home, &lookup);
+        assert_eq!(work.sessions, BTreeSet::from([expected]));
+        assert!(work.agents.is_empty());
+        assert!(work.db_agents.is_empty());
+    }
+
+    #[test]
+    fn a_subagent_transcript_resolves_to_its_parent_sessions_jsonl_sibling() {
+        let home = PathBuf::from("/home/avery");
+        let parent = home.join(".claude/projects/demo/abc.jsonl");
+        let subagent = home.join(".claude/projects/demo/abc/subagents/agent-1.jsonl");
+        let expected = key(&parent.to_string_lossy());
+        let lookup_key = expected.clone();
+        let lookup =
+            move |label: &str| (label == lookup_key.source_label).then(|| lookup_key.clone());
+
+        let work = classify_burst(&[subagent], &home, &lookup);
+        assert_eq!(work.sessions, BTreeSet::from([expected]));
+    }
+
+    #[test]
+    fn a_database_path_under_an_agents_root_is_a_database_agent() {
+        let home = PathBuf::from("/home/avery");
+        let db_path = home.join(".cursor/state.vscdb");
+        let roots = [(AgentKind::Cursor, root("/home/avery/.cursor", true))];
+        let lookup = |_: &str| None;
+
+        assert_eq!(
+            classify_path(&db_path, &roots, &lookup),
+            ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
+        );
+        let wal = home.join(".cursor/state.vscdb-wal");
+        assert_eq!(
+            classify_path(&wal, &roots, &lookup),
+            ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
+        );
+        let journal = home.join(".cursor/state.vscdb-journal");
+        assert_eq!(
+            classify_path(&journal, &roots, &lookup),
+            ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
+        );
+    }
+
+    #[test]
+    fn a_non_database_path_under_an_agents_root_is_a_plain_agent() {
+        let home = PathBuf::from("/home/avery");
+        let path = home.join(".codex/sessions/2026/08/01/rollout.jsonl");
+        let roots = [(AgentKind::Codex, root("/home/avery/.codex", true))];
+        let lookup = |_: &str| None;
+
+        assert_eq!(
+            classify_path(&path, &roots, &lookup),
+            ClassifiedPath::Agent(AgentKind::Codex)
+        );
+    }
+
+    #[test]
+    fn an_unclaimed_path_is_ignored() {
+        let path = PathBuf::from("/home/avery/Downloads/random.txt");
+        let roots: [(AgentKind, WatchRoot); 0] = [];
+        let lookup = |_: &str| None;
+
+        assert_eq!(
+            classify_path(&path, &roots, &lookup),
+            ClassifiedPath::Ignored
+        );
+    }
+
+    #[test]
+    fn a_burst_folds_into_all_three_buckets_and_counts_ignored() {
+        let home = PathBuf::from("/home/avery");
+        let session_path = home.join(".claude/projects/demo/known.jsonl");
+        let db_path = cursor_watch_root(&home).join("state.vscdb");
+        let agent_path = home.join(".codex/sessions/2026/08/01/rollout.jsonl");
+        let unclaimed = PathBuf::from("/home/avery/Downloads/random.txt");
+
+        let expected_key = key(&session_path.to_string_lossy());
+        let lookup_key = expected_key.clone();
+        let lookup =
+            move |label: &str| (label == lookup_key.source_label).then(|| lookup_key.clone());
+
+        let work = classify_burst(
+            &[session_path, db_path, agent_path, unclaimed],
+            &home,
+            &lookup,
+        );
+        assert_eq!(work.sessions, BTreeSet::from([expected_key]));
+        assert_eq!(work.agents, BTreeSet::from([AgentKind::Codex]));
+        assert_eq!(work.db_agents, BTreeSet::from([AgentKind::Cursor]));
+    }
+
+    #[test]
+    fn an_agent_with_both_plain_and_database_evidence_keeps_only_the_plain_classification() {
+        let home = PathBuf::from("/home/avery");
+        let cursor_root = cursor_watch_root(&home);
+        let db_path = cursor_root.join("state.vscdb");
+        let plain_path = cursor_root.join("some-other-file.json");
+        let lookup = |_: &str| None;
+
+        let work = classify_burst(&[db_path, plain_path], &home, &lookup);
+        assert_eq!(work.agents, BTreeSet::from([AgentKind::Cursor]));
+        assert!(work.db_agents.is_empty());
+    }
+
+    #[test]
+    fn owning_agent_picks_the_longest_matching_root() {
+        let roots = [
+            (AgentKind::Cline, root("/home/avery/.config/Code", true)),
+            (
+                AgentKind::Cline,
+                root("/home/avery/.config/Code/User/globalStorage/cline", true),
+            ),
+        ];
+        let path =
+            PathBuf::from("/home/avery/.config/Code/User/globalStorage/cline/tasks/1/api.json");
+        assert_eq!(owning_agent(&path, &roots), Some(AgentKind::Cline));
+
+        let outside = PathBuf::from("/home/avery/.config/Code/User/settings.json");
+        assert_eq!(owning_agent(&outside, &roots), Some(AgentKind::Cline));
+
+        let unrelated = PathBuf::from("/home/avery/.codex/sessions/x.jsonl");
+        assert_eq!(owning_agent(&unrelated, &roots), None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_session_is_deferred_inside_its_floor_and_admitted_after() {
+        let mut floors = Floors::default();
+        let session_key = key("/home/avery/.claude/projects/demo/x.jsonl");
+        let mut work = ScopedWork::default();
+        work.sessions.insert(session_key.clone());
+
+        let t0 = Instant::now();
+        let (run_now, deferred, _due) = floors.admit(work.clone(), t0);
+        assert_eq!(run_now.sessions, BTreeSet::from([session_key.clone()]));
+        assert!(deferred.sessions.is_empty());
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let (run_now, deferred, due) = floors.admit(work.clone(), Instant::now());
+        assert!(run_now.sessions.is_empty(), "still inside the 10s floor");
+        assert_eq!(deferred.sessions, BTreeSet::from([session_key.clone()]));
+        assert_eq!(due, Some(t0 + TARGETED_MIN_INTERVAL));
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let (run_now, deferred, _due) = floors.admit(work, Instant::now());
+        assert_eq!(run_now.sessions, BTreeSet::from([session_key]));
+        assert!(deferred.sessions.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_agent_uses_the_twenty_second_floor() {
+        let mut floors = Floors::default();
+        let mut work = ScopedWork::default();
+        work.agents.insert(AgentKind::Codex);
+
+        let t0 = Instant::now();
+        floors.admit(work.clone(), t0);
+
+        tokio::time::advance(AGENT_REDISCOVER_MIN_INTERVAL - Duration::from_secs(1)).await;
+        let (run_now, deferred, _due) = floors.admit(work.clone(), Instant::now());
+        assert!(run_now.agents.is_empty());
+        assert_eq!(deferred.agents, BTreeSet::from([AgentKind::Codex]));
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let (run_now, _deferred, _due) = floors.admit(work, Instant::now());
+        assert_eq!(run_now.agents, BTreeSet::from([AgentKind::Codex]));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_database_agent_uses_the_thirty_second_floor() {
+        let mut floors = Floors::default();
+        let mut work = ScopedWork::default();
+        work.db_agents.insert(AgentKind::Cursor);
+
+        let t0 = Instant::now();
+        floors.admit(work.clone(), t0);
+
+        tokio::time::advance(AGENT_REDISCOVER_MIN_INTERVAL).await;
+        let (run_now, deferred, _due) = floors.admit(work.clone(), Instant::now());
+        assert!(
+            run_now.db_agents.is_empty(),
+            "the 20s agent floor must not admit a database agent early"
+        );
+        assert_eq!(deferred.db_agents, BTreeSet::from([AgentKind::Cursor]));
+
+        tokio::time::advance(DB_AGENT_REDISCOVER_MIN_INTERVAL - AGENT_REDISCOVER_MIN_INTERVAL)
+            .await;
+        let (run_now, _deferred, _due) = floors.admit(work, Instant::now());
+        assert_eq!(run_now.db_agents, BTreeSet::from([AgentKind::Cursor]));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deferred_work_merges_with_newly_classified_work() {
+        let mut floors = Floors::default();
+        let session_a = key("/home/avery/.claude/projects/demo/a.jsonl");
+        let session_b = key("/home/avery/.claude/projects/demo/b.jsonl");
+
+        let mut first = ScopedWork::default();
+        first.sessions.insert(session_a.clone());
+        let t0 = Instant::now();
+        floors.admit(first.clone(), t0);
+
+        // A second burst for the same session inside its floor is deferred,
+        // not dropped.
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let (run_now, deferred_a, _due) = floors.admit(first, Instant::now());
+        assert!(run_now.sessions.is_empty(), "still inside the 10s floor");
+        assert_eq!(deferred_a.sessions, BTreeSet::from([session_a.clone()]));
+
+        // The deferred session merges with a newly classified one.
+        let mut pending = ScopedWork::default();
+        pending.merge(deferred_a);
+        let mut second = ScopedWork::default();
+        second.sessions.insert(session_b.clone());
+        pending.merge(second);
+
+        assert_eq!(
+            pending.sessions,
+            BTreeSet::from([session_a.clone(), session_b.clone()])
+        );
+
+        // Once session_a's floor elapses, both are admitted together: the
+        // never-before-seen session_b was never inside a floor at all.
+        tokio::time::advance(TARGETED_MIN_INTERVAL - Duration::from_secs(1)).await;
+        let (run_now, deferred, _due) = floors.admit(pending, Instant::now());
+        assert!(
+            deferred.sessions.is_empty(),
+            "b was never admitted before, so it is due immediately"
+        );
+        assert_eq!(run_now.sessions, BTreeSet::from([session_a, session_b]));
+    }
+}

--- a/apps/desktop/src-tauri/src/scan/watch.rs
+++ b/apps/desktop/src-tauri/src/scan/watch.rs
@@ -87,11 +87,10 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherStatus {
     };
     let app = app.clone();
     spawn_watcher_over(home, move |burst: WatchBurst| {
-        app.state::<crate::scan::ScanController>()
-            .request(crate::scan::ScanTrigger::Watcher {
-                events: burst.events,
-                paths: burst.paths,
-            });
+        // Phase 5b: a burst is classified and admitted on the scheduler's own
+        // loop (see `scoped` and `super::spawn_scheduler`), not requested as
+        // a full pass here.
+        app.state::<crate::scan::ScanController>().push_burst(burst);
     })
 }
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -817,19 +817,7 @@ impl Store {
     /// re-describing a source that has not changed.
     pub fn session_records(&self) -> Result<HashMap<SessionActivityKey, SessionRecord>> {
         let connection = self.lock();
-        let mut statement = connection.prepare(
-            "SELECT environment_key, agent, session_id, source_kind, source_label, wsl_distro,
-                    title, title_source, cwd, surface, updated_at_epoch,
-                    activity_cursor, activity_source, subagent_count,
-                    (SELECT related_id FROM session_relation r
-                       WHERE r.environment_key = s.environment_key
-                         AND r.agent = s.agent
-                         AND r.session_id = s.session_id
-                         AND r.kind = 'forkParent'
-                       LIMIT 1),
-                    s.source_fingerprint
-               FROM session s",
-        )?;
+        let mut statement = connection.prepare(SESSION_SELECT_SQL)?;
         let rows = statement.query_map([], session_from_row)?;
         let mut records = HashMap::new();
         for row in rows {
@@ -847,26 +835,43 @@ impl Store {
     /// One session's cached metadata, when it has been seen.
     pub fn session(&self, key: &SessionKey) -> Result<Option<SessionRecord>> {
         let connection = self.lock();
-        let mut statement = connection.prepare(
-            "SELECT environment_key, agent, session_id, source_kind, source_label, wsl_distro,
-                    title, title_source, cwd, surface, updated_at_epoch,
-                    activity_cursor, activity_source, subagent_count,
-                    (SELECT related_id FROM session_relation r
-                       WHERE r.environment_key = s.environment_key
-                         AND r.agent = s.agent
-                         AND r.session_id = s.session_id
-                         AND r.kind = 'forkParent'
-                       LIMIT 1),
-                    s.source_fingerprint
-               FROM session s
-              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3",
-        )?;
+        let mut statement = connection.prepare(&format!(
+            "{SESSION_SELECT_SQL}
+              WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3"
+        ))?;
         Ok(statement
             .query_row(
                 params![key.environment_key, key.agent, key.session_id],
                 session_from_row,
             )
             .optional()?)
+    }
+
+    /// One native file session's cached record, addressed by its
+    /// `source_label` (the transcript path) rather than its session id.
+    ///
+    /// T1: the watcher names a changed path, not a session id, so the scoped
+    /// scan classifies a burst's paths against `source_label` before it can
+    /// build a targeted refresh.
+    pub fn session_record_by_source_label(
+        &self,
+        source_label: &str,
+    ) -> Result<Option<(SessionActivityKey, SessionRecord)>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(&format!(
+            "{SESSION_SELECT_SQL}\n              WHERE source_label = ?1"
+        ))?;
+        let record = statement
+            .query_row(params![source_label], session_from_row)
+            .optional()?;
+        Ok(record.map(|record| {
+            let key = SessionActivityKey::new(
+                record.key.environment_key.clone(),
+                record.key.agent.clone(),
+                record.source_label.clone(),
+            );
+            (key, record)
+        }))
     }
 
     /// One session's persisted source version and optional start time.
@@ -2813,6 +2818,24 @@ fn evidence_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EvidenceRow> {
         published_fence: row.get(17)?,
     })
 }
+
+/// Column list and join shared by every reader of the `session` table:
+/// [`Store::session_records`], [`Store::session`], and
+/// [`Store::session_record_by_source_label`]. One copy means a schema change
+/// updates every reader together, and [`session_from_row`] stays the single
+/// row mapper for all three.
+const SESSION_SELECT_SQL: &str =
+    "SELECT environment_key, agent, session_id, source_kind, source_label, wsl_distro,
+                    title, title_source, cwd, surface, updated_at_epoch,
+                    activity_cursor, activity_source, subagent_count,
+                    (SELECT related_id FROM session_relation r
+                       WHERE r.environment_key = s.environment_key
+                         AND r.agent = s.agent
+                         AND r.session_id = s.session_id
+                         AND r.kind = 'forkParent'
+                       LIMIT 1),
+                    s.source_fingerprint
+               FROM session s";
 
 fn session_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> {
     Ok(SessionRecord {

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -97,7 +97,11 @@ pub struct SourceVersionState {
 
 /// Identity of one persisted activity cursor. The source label alone is not
 /// enough: native and WSL environments can expose the same provider path.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+///
+/// `Ord` gives a stable order for a `BTreeSet<SessionActivityKey>`, which the
+/// scoped scan passes use to keep a burst's admitted sessions deterministic
+/// (phase 5b).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SessionActivityKey {
     pub environment_key: String,
     pub agent: String,

--- a/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
@@ -77,3 +77,32 @@ fn latest_session_activity_ignores_null_epochs() {
         .unwrap();
     assert_eq!(store.latest_session_activity().unwrap(), Some(5_000));
 }
+
+#[test]
+fn session_record_by_source_label_round_trips() {
+    let store = store();
+    let record = session("by-label", 4_000);
+    store
+        .upsert_sessions(
+            std::slice::from_ref(&record),
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    let (key, found) = store
+        .session_record_by_source_label(&record.source_label)
+        .unwrap()
+        .expect("a stored session is found by its source label");
+    assert_eq!(key.environment_key, "native");
+    assert_eq!(key.agent, "claude-code");
+    assert_eq!(key.source_label, record.source_label);
+    assert_eq!(found.key.session_id, "by-label");
+
+    assert!(
+        store
+            .session_record_by_source_label("/nowhere/unknown.jsonl")
+            .unwrap()
+            .is_none(),
+        "an unknown source label finds nothing"
+    );
+}

--- a/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
@@ -106,3 +106,41 @@ fn session_record_by_source_label_round_trips() {
         "an unknown source label finds nothing"
     );
 }
+
+#[test]
+fn an_agent_scoped_upsert_leaves_another_agents_rows_intact() {
+    let store = store();
+    let claude = session("claude-session", 1_000);
+    let codex = SessionRecord {
+        key: SessionKey::new("native", "codex", "codex-session"),
+        source_label: "/home/avery/.codex/sessions/codex-session.jsonl".into(),
+        ..session("codex-session", 2_000)
+    };
+    store
+        .upsert_sessions(
+            &[claude.clone(), codex.clone()],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    // An agent-scoped pass upserts only Claude's row, naming Claude alone as
+    // the evidence cohort for this pass.
+    let renamed_claude = SessionRecord {
+        title: Some("Renamed during a scoped pass".into()),
+        ..claude.clone()
+    };
+    store
+        .upsert_sessions(&[renamed_claude], &["claude-code"])
+        .unwrap();
+
+    let stored_claude = store.session(&claude.key).unwrap().expect("claude row");
+    assert_eq!(
+        stored_claude.title.as_deref(),
+        Some("Renamed during a scoped pass")
+    );
+    let stored_codex = store
+        .session(&codex.key)
+        .unwrap()
+        .expect("codex row is untouched by a Claude-scoped pass");
+    assert_eq!(stored_codex.key.session_id, "codex-session");
+}

--- a/crates/antiburn-local/src/model/agent.rs
+++ b/crates/antiburn-local/src/model/agent.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// Contains only the ratified v1 discovery agents. Serialization uses the
 /// stable kebab-case slug (e.g. `"claude-code"`, `"amp-code"`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// `Ord` gives a stable order for a `BTreeSet<AgentKind>`, which the scoped
+/// scan passes use to keep a burst's admitted agents deterministic (phase 5b).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum AgentKind {
     #[serde(rename = "claude-code")]
     Claude,

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -288,7 +288,7 @@ Goal: layer 1 is continuous and cheap, and every consumer reads one signal.
   `get_session_analysis_fingerprint` command, `poll_fingerprint_with_subagents`,
   and their tests are deleted along with the poll.
 
-### Phase 5: scoped passes (in progress)
+### Phase 5: scoped passes (5a and 5c merged 2026-09-03; 5b in review)
 
 Goal: a watcher event costs work proportional to what changed, not a
 whole-machine pass. Found on 2026-09-03 after phase 4 had run for a day:
@@ -411,6 +411,9 @@ scheduler task, so passes never overlap and the store sees one writer.
 - Default cadences are set in phase 4 and reviewed after a week of use.
 - Phase 5a stands alone. 5b stacks on 5a (it consumes the burst paths 5a
   passes through). 5c's two items are independent of each other and of 5b.
+- 5b keeps the tick as a fixed deadline that only a full pass resets, so
+  scoped wakes every few seconds cannot starve reconciliation. A burst at
+  the watcher's path bound forces a full pass, since paths were dropped.
 
 ## Follow-ups
 


### PR DESCRIPTION
## Summary

Phase 5b of `docs/plans/continuous-session-ingest.md`: a watcher burst now costs work proportional to what changed instead of a whole-machine pass.

- **T1/T2** A path that matches a stored session's `source_label` (or a Claude sub-agent transcript under one) gets a targeted re-describe of that session only, emitting `sessions:entry-changed` and nothing else, with a 10 s per-session floor.
- **T3/T4** An unknown path under an agent's watch root triggers `discover_recent` for that agent alone via `run_pass` with `PassScope::Agents`, with a 20 s per-agent floor. The pass touches only that agent's rows and skips `repositories::refresh` unless the list changed.
- **T5** A database path (`.vscdb`, `.db`, `.sqlite`, plus `-wal`/`-journal` sidecars) counts as agent rediscovery with a 30 s floor.
- **T6/T7** Unclaimed paths are ignored. Work inside a floor is deferred and merged, never dropped. A burst arriving while a command's pass holds the running flag is retried after 500 ms. A full pass (tick, popover, manual) supersedes all pending scoped work and stamps its floors.
- The tick is a fixed deadline that only a full pass resets, so a busy session cannot starve reconciliation. A burst at `MAX_BURST_PATHS` forces a full pass because paths were dropped.
- `ScanTrigger::Watcher` is gone (bursts no longer request full passes); `WatcherAgents` and `WatcherOverflow` replace it.

New module `scan/scoped.rs` holds the classifier, floors, and both scoped lanes, with pure unit tests. `Store::session_record_by_source_label` shares its SELECT with the other session readers.

## Test plan

- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` (desktop workspace)
- [x] `cargo test -p antiburn --no-fail-fast`: 820 passed, 0 failed
- [x] `cargo test --no-fail-fast` in `crates/antiburn-local`: 17 result lines, all ok
- [ ] Run the app with an active Claude session and confirm the log shows `scan_targeted_finished` about every 10 s and no `repo_discovery_agent_done` lines between ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1ir9iHoiRvkdSQnY8wsy2
