### PR TITLE
feat: continuous ingest phase 5d (tick and popover stop being the freshness path)

### DIFF
--- a/apps/desktop/src-tauri/src/analytics/mod.rs
+++ b/apps/desktop/src-tauri/src/analytics/mod.rs
@@ -243,15 +243,17 @@ mod enabled {
     ///
     /// `Some(count)` is a completed pass; `None` is a failed one.
     ///
-    /// The scheduler runs a pass every [`crate::scan::TICK`] for as long as the
-    /// popover is open, so reporting each one would put an event a minute, all
-    /// day, into a channel whose other events are counted in ones — swamping the
-    /// queue's own bound and every other event with it. It would also be the wrong
-    /// measurement twice over: what is worth knowing is roughly how large an
-    /// install's history is and whether scanning works at all, and a repetition
-    /// answers neither better than the first report did. A machine stuck failing
-    /// every pass would additionally report that failure some six hundred times a
-    /// day, which is not more information about one broken install.
+    /// The scheduler runs a full pass every [`crate::scan::TICK`], plus a
+    /// scoped pass on every watcher burst — as often as every few seconds
+    /// while a session is active — so reporting each one would put far more
+    /// events into a channel whose other events are counted in ones,
+    /// swamping the queue's own bound and every other event with it. It
+    /// would also be the wrong measurement twice over: what is worth knowing
+    /// is roughly how large an install's history is and whether scanning
+    /// works at all, and a repetition answers neither better than the first
+    /// report did. A machine stuck failing every pass would additionally
+    /// report that same failure over and over, which is not more information
+    /// about one broken install.
     ///
     /// So the bucket, or the failure category, is compared against the last one
     /// reported and an unchanged outcome is dropped. What survives is the first
@@ -721,7 +723,7 @@ mod enabled {
             reset_session();
         }
 
-        /// A pass a minute is the scheduler's business; a pass a minute in the
+        /// A frequent pass is the scheduler's business; a frequent event in the
         /// payload is not. Only a changed outcome survives, and recovering from a
         /// failure counts as a change.
         #[test]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -772,13 +772,13 @@ pub async fn get_session_limit_allocations(
 
 /// How fresh a reading the refresh command asks each source's cooldown for.
 ///
-/// This command is called from the popover, which polls it roughly once a
-/// minute for as long as the popover stays visible — see
-/// `scan::TICK` and `popover::note_shown`. Fifty seconds sits just under that
-/// polling interval, so an open popover's own ordinary polling is what keeps
-/// the reading current: every visible tick is close enough to the cooldown's
-/// edge to trigger a real fetch, without this command itself running a timer
-/// or a background task. The aggressive freshness is bounded by someone
+/// This command is called from the popover, which polls it on its own 60 s
+/// visible interval for as long as the popover stays visible (R6,
+/// `USAGE_VISIBLE_POLL_MS` in `PopoverSession.ts`). Fifty seconds sits just
+/// under that polling interval, so an open popover's own ordinary polling is
+/// what keeps the reading current: every visible tick is close enough to the
+/// cooldown's edge to trigger a real fetch, without this command itself
+/// running a timer or a background task. The aggressive freshness is bounded by someone
 /// actually looking — once the popover closes, nothing here keeps polling on
 /// its behalf, and the background monitor's own, much longer, `max_age`
 /// takes back over (see `usage_alerts::BACKGROUND_MAX_AGE`).

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -778,10 +778,10 @@ pub async fn get_session_limit_allocations(
 /// under that polling interval, so an open popover's own ordinary polling is
 /// what keeps the reading current: every visible tick is close enough to the
 /// cooldown's edge to trigger a real fetch, without this command itself
-/// running a timer or a background task. The aggressive freshness is bounded by someone
-/// actually looking — once the popover closes, nothing here keeps polling on
-/// its behalf, and the background monitor's own, much longer, `max_age`
-/// takes back over (see `usage_alerts::BACKGROUND_MAX_AGE`).
+/// running a timer or a background task. The aggressive freshness is bounded
+/// by someone actually looking — once the popover closes, nothing here keeps
+/// polling on its behalf, and the background monitor's own, much longer,
+/// `max_age` takes back over (see `usage_alerts::BACKGROUND_MAX_AGE`).
 const POPOVER_LIVE_USAGE_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(50);
 
 /// Return the last provider limit snapshot without reading a provider.

--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -273,6 +273,11 @@ pub struct ScanStatus {
     /// evicted a rejected one. A reader's list refetches on this rather than
     /// on every pass, since an unchanged pass patches rows in place instead.
     pub list_changed: bool,
+    /// R5: how many sessions the last pass re-described — new, or a moved
+    /// cursor — never a row it reused verbatim. Lets a reader tell an idle
+    /// pass from a productive one without inferring it from `list_changed`
+    /// alone.
+    pub re_described: usize,
 }
 
 /* -------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -161,11 +161,12 @@ impl NotificationCopy {
 impl NotificationState {
     /// Claim the right to report a scan failure, once per run.
     ///
-    /// Returns true exactly once. A scan runs every minute while the popover is
-    /// open, and whatever broke the first pass — an unreadable directory, a
-    /// full disk — is overwhelmingly likely to break the next sixty as well;
-    /// one notification per run says the same thing without becoming the
-    /// reason someone quits the app.
+    /// Returns true exactly once. The scheduler's tick and the watcher both
+    /// keep passing over this machine for as long as it runs, and whatever
+    /// broke the first pass — an unreadable directory, a full disk — is
+    /// overwhelmingly likely to break every later one too; one notification
+    /// per run says the same thing without becoming the reason someone quits
+    /// the app.
     pub fn claim_scan_failure(&self) -> bool {
         !self.scan_failure_reported.swap(true, Ordering::SeqCst)
     }
@@ -825,7 +826,7 @@ mod tests {
         for _ in 0..60 {
             assert!(
                 !state.claim_scan_failure(),
-                "a scan runs every minute; the failure is announced once"
+                "a scan can run again at any time; the failure is announced once"
             );
         }
     }

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -1721,11 +1721,11 @@ fn reveal(window: &WebviewWindow) {
 /// Everything that has to happen when the popover reaches the screen, whichever
 /// way it got there.
 ///
-/// The scheduler's [`TICK`](crate::scan::TICK) already runs while the popover
-/// is hidden, so this is reconciliation, not the only path to a fresh list: it
-/// closes the gap between the last tick and the moment a reader is actually
-/// looking. Reported from here rather than inferred from window events,
-/// because a hidden window that was never shown produces no event at all.
+/// R1: this does not ask for a scan. [`crate::scan::TICK`] and the watcher
+/// keep the store fresh on their own, so a reader is never waiting out a
+/// missed pass; this function only announces the moment and lights the tray.
+/// Reported from here rather than inferred from window events, because a
+/// hidden window that was never shown produces no event at all.
 ///
 /// The menu-bar highlight is lit here for the same reason [`note_hidden`]
 /// clears it: both open paths already run through this one — the toggle, and a
@@ -1733,25 +1733,12 @@ fn reveal(window: &WebviewWindow) {
 /// highlight with visibility is structural rather than something each caller
 /// has to remember.
 fn note_shown(app: &AppHandle) {
-    if let Some(controller) = app.try_state::<crate::scan::ScanController>() {
-        // Opening the popover is the one moment a reader is guaranteed to be
-        // looking, so refresh immediately instead of waiting out a tick.
-        controller.request(crate::scan::ScanTrigger::PopoverShown);
-    }
-    // A separate signal from the scan kick just above, on purpose, rather
-    // than something the webview infers from `scan:finished`. Two things
-    // about the scan kick make it the wrong vehicle for a usage refresh:
-    // `request()` itself always wakes the scheduler loop, but the pass that
-    // wake-up would run is silently skipped whenever discovery is paused or
-    // onboarding has not finished (`scheduled_scanning_allowed` in
-    // `crate::scan`), which would leave usage silently stuck too even
-    // though nothing about reading a provider's own limits depends on
-    // whether local disk discovery is allowed to run; and even when a scan
-    // does run, it is a full disk walk, so gating the usage refresh on its
-    // completion would make "reopen the popover" mean "wait out a scan" for
-    // a figure that has nothing to do with what is on disk. Emitting this
-    // unconditionally, the instant the popover is on screen, keeps the two
-    // refreshes independent the way the data they show already is.
+    // R6: usage freshness while the popover is visible is this event's own
+    // signal, not something that rides on a scan. A provider's own stated
+    // limits have nothing to do with whether local disk discovery runs, or
+    // with how long a disk walk takes, so the webview starts its visible-only
+    // usage poll straight off this event instead of waiting on the scan
+    // pipeline.
     let _ = app.emit(EVENT_SHOWN, ());
     crate::tray::set_highlight(app, true);
 }

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -108,9 +108,13 @@ impl NudgeKeyHandoff {
 
 /// Emitted the moment the popover reaches the screen, following the same
 /// `module:event` naming [`crate::scan`]'s events use. The webview listens
-/// for this to refresh live usage — see [`note_shown`] for why that refresh
-/// does not simply ride the scan events this same function also kicks.
+/// for this to start its visible-only usage polling (R6) — see [`note_shown`]
+/// for why usage freshness does not ride on a scan pass.
 pub const EVENT_SHOWN: &str = "popover:shown";
+
+/// Emitted the moment the popover leaves the screen. The webview listens for
+/// this to stop its visible-only usage polling (R6) — see [`note_hidden`].
+pub const EVENT_HIDDEN: &str = "popover:hidden";
 
 /// Popover width in logical pixels. Fixed: the views size themselves to it.
 const WIDTH: f64 = 380.0;
@@ -1750,11 +1754,14 @@ fn note_shown(app: &AppHandle) {
 /// Escape, dismissal on focus loss or an outside click, and the shell's
 /// suppressed window close — which is why the menu-bar highlight is cleared
 /// here rather than at each of them. The scan scheduler does not gate on
-/// visibility, so this hook has nothing left to tell it.
+/// visibility, so this hook has nothing to tell it; it tells the popover's own
+/// visible-only usage poll instead (R6).
 ///
 /// Unconditional: clearing a highlight that is already off costs nothing, and
 /// a state that somehow drifted out of step is corrected rather than kept.
 pub fn note_hidden(app: &AppHandle) {
+    // R6: the popover stops its visible-only usage polling on this.
+    let _ = app.emit(EVENT_HIDDEN, ());
     crate::tray::set_highlight(app, false);
 }
 

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -23,11 +23,12 @@
 //! - **At launch**, once, if onboarding is finished. A first-run install has no
 //!   sources selected yet, so scanning before the flow completes would only
 //!   spend disk on a window nobody can see.
-//! - **Every [`TICK`], unconditionally.** The popover does not gate the timer:
-//!   a pass over sources that have not changed reads no transcript, so ticking
-//!   while the popover is hidden costs stat calls, not disk reads.
-//! - **The moment the popover is opened**, as reconciliation, so a reader never
-//!   waits out a tick behind a missed event.
+//! - **Every [`TICK`], unconditionally.** R1/R2: the watcher is the primary
+//!   freshness path now, so the tick is 5 minutes of reconciliation for what
+//!   it cannot see — a WSL session (never watched) or a rare dropped OS
+//!   event — not the path a reader waits on. A pass over sources that have
+//!   not changed reads no transcript, so ticking while the popover is hidden
+//!   costs stat calls, not disk reads.
 //! - **On demand**, from the rescan control and after any change to the source
 //!   selection.
 //! - **Shortly after a watched file changes — narrowly, not as a full pass.**
@@ -52,8 +53,8 @@
 //! # Pausing
 //!
 //! `AppSettings::discovery_paused` stops every *scheduled* pass — the launch
-//! pass, the tick, and the passes requested when the popover opens or the
-//! sources change. It deliberately does not stop [`run_pass`] itself, so the
+//! pass, the tick, and the passes requested after a source selection change.
+//! It deliberately does not stop [`run_pass`] itself, so the
 //! rescan control still works while discovery is paused and the popover keeps
 //! browsing everything already indexed. "Paused" is a statement about
 //! background work, not a lock on the app.
@@ -109,8 +110,14 @@ pub mod idle;
 pub mod scoped;
 pub mod watch;
 
-/// How often the scheduler wakes up.
-pub const TICK: Duration = Duration::from_secs(60);
+/// How often the scheduler wakes up for its unconditional full pass.
+///
+/// R2: 5 minutes. The watcher is the primary freshness path (T1-T7 in the
+/// `scoped` module), so this tick only has to reconcile what it cannot see —
+/// a WSL session, or a rare dropped OS event — not answer for an active
+/// session's own row updates. [`watch::FALLBACK_TICK`] stays 15 seconds for a
+/// degraded watcher, where polling really is the only freshness path.
+pub const TICK: Duration = Duration::from_secs(300);
 
 /// How many session logs have their metadata read at once. Bounds open files
 /// and blocking-pool pressure during a whole-machine pass.
@@ -143,8 +150,6 @@ pub enum ScanTrigger {
     /// A burst reached [`watch::MAX_BURST_PATHS`] and may have dropped
     /// paths, so only a full pass can be sure to cover it.
     WatcherOverflow,
-    /// The popover reached the screen.
-    PopoverShown,
     /// A settings save that finished onboarding, widened the activity
     /// window, or resumed discovery.
     SettingsTransition,
@@ -170,7 +175,6 @@ impl ScanTrigger {
             ScanTrigger::Tick => "tick",
             ScanTrigger::WatcherAgents { .. } => "watcher_agents",
             ScanTrigger::WatcherOverflow => "watcher_overflow",
-            ScanTrigger::PopoverShown => "popover_shown",
             ScanTrigger::SettingsTransition => "settings_transition",
             ScanTrigger::InsightsPane => "insights_pane",
             ScanTrigger::RepositoryToggle => "repository_toggle",
@@ -650,9 +654,10 @@ pub(crate) async fn try_run_pass(
     }
     let _ = app.emit(EVENT_FINISHED, finished.clone());
     // The outcome, not a shaped event: whether this pass is worth reporting at
-    // all is an analytics question, and this scheduler runs a pass a minute
-    // while the popover is open. `None` is a failure, which travels as a bare
-    // category — an error string can hold a path.
+    // all is an analytics question, and this scheduler runs a full pass every
+    // five minutes plus a scoped pass on every watcher burst. `None` is a
+    // failure, which travels as a bare category — an error string can hold a
+    // path.
     crate::analytics::record_scan(
         app,
         outcome.as_ref().ok().map(|summary| summary.sessions as u64),

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -612,6 +612,7 @@ pub(crate) async fn try_run_pass(
             status.total_agents = AgentKind::ALL.len();
             status.sessions = 0;
             status.list_changed = false;
+            status.re_described = 0;
             status.error = None;
             status.cancelled = false;
         });
@@ -636,6 +637,8 @@ pub(crate) async fn try_run_pass(
             Ok(summary) => {
                 status.sessions = summary.sessions;
                 status.list_changed = summary.list_changed;
+                // R5: lets a reader tell an idle pass from a productive one.
+                status.re_described = summary.re_described;
                 // A cancelled pass did not finish every agent, and saying it
                 // did would make the progress line lie on its last frame.
                 if !cancelled {
@@ -643,7 +646,10 @@ pub(crate) async fn try_run_pass(
                 }
                 status.error = None;
             }
-            Err(error) => status.error = Some(error.to_string()),
+            Err(error) => {
+                status.error = Some(error.to_string());
+                status.re_described = 0;
+            }
         }
     });
     controller.running.store(false, Ordering::SeqCst);

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -184,6 +184,33 @@ impl ScanTrigger {
             ScanTrigger::ManualRescan => "manual_rescan",
         }
     }
+
+    /// R4: whether a full pass should pay to refresh the repository list for
+    /// this trigger, on top of the `list_changed` check every trigger gets.
+    ///
+    /// The tick and the watcher triggers cannot plausibly have introduced a
+    /// repository the list has not already seen — a new `cwd` only arrives
+    /// through a session's own upsert, and `list_changed` already covers
+    /// that case for them. Every other trigger names an action that can
+    /// change the repository set directly (a toggle, a new scan root, a
+    /// settings transition), so it refreshes unconditionally. Matched
+    /// exhaustively, with no `_` arm, so a new variant forces this decision
+    /// rather than defaulting into it silently.
+    pub fn refreshes_repositories(&self) -> bool {
+        match self {
+            ScanTrigger::Tick
+            | ScanTrigger::WatcherAgents { .. }
+            | ScanTrigger::WatcherOverflow => false,
+            ScanTrigger::Launch
+            | ScanTrigger::SettingsTransition
+            | ScanTrigger::InsightsPane
+            | ScanTrigger::RepositoryToggle
+            | ScanTrigger::ScanRootAdded
+            | ScanTrigger::FolderAccessGranted
+            | ScanTrigger::IndexCleared
+            | ScanTrigger::ManualRescan => true,
+        }
+    }
 }
 
 /// What one pass discovers: every agent, or only a burst-named subset.
@@ -597,7 +624,7 @@ pub(crate) async fn try_run_pass(
     let announce = move |entry: ActivityEntry| {
         let _ = announce_app.emit(commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
     };
-    let outcome = pass(app, activity_window_days, &scope, &announce).await;
+    let outcome = pass(app, activity_window_days, &trigger, &scope, &announce).await;
 
     let controller = app.state::<ScanController>();
     let cancelled = controller.cancelled();
@@ -704,10 +731,13 @@ struct PassSummary {
 ///
 /// `scope` narrows discovery, the upsert's evidence cohort, and per-agent
 /// scan bookkeeping to a burst-named subset of agents (T3/T5); everything
-/// else runs exactly as a full pass. See [`PassScope`].
+/// else runs exactly as a full pass. See [`PassScope`]. `trigger` decides
+/// only whether this pass refreshes the repository list (R4); it plays no
+/// other part here.
 async fn pass(
     app: &AppHandle,
     _activity_window_days: Option<u32>,
+    trigger: &ScanTrigger,
     scope: &PassScope,
     announce: &(dyn Fn(ActivityEntry) + Send + Sync),
 ) -> anyhow::Result<PassSummary> {
@@ -767,13 +797,24 @@ async fn pass(
         PassScope::Full => agents::evidence_cohort(),
         PassScope::Agents(agents) => agents.iter().map(|agent| agent.slug()).collect(),
     };
+    // R3: an idle pass writes nothing. A row this pass reused verbatim is
+    // byte-identical to what is already stored, and `last_seen_at` is only
+    // retention's fallback for a row with no activity epoch, so rewriting an
+    // unchanged row buys nothing. `returned` is the one exception: its row
+    // may also be unchanged, but its evidence last failed on a missing
+    // source, and only a write re-runs `upsert_sessions`'s own
+    // `source_returned` check to re-queue it.
+    let returned = store.sessions_with_missing_source()?;
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
     checked(
         app,
         "The session index",
-        store.upsert_sessions(&records, &evidence_agents),
+        store.upsert_sessions(
+            &records_to_persist(&records, &changed, &returned),
+            &evidence_agents,
+        ),
     )?;
     crate::insights_worker::wake(app);
     // A write may have added a session the idle task was not yet watching,
@@ -814,10 +855,13 @@ async fn pass(
         });
     }
 
-    // A full pass always refreshes the repository list. An agent-scoped pass
-    // only pays for it when a session's arrival or eviction could plausibly
-    // have introduced a new cwd.
-    if matches!(scope, PassScope::Full) || list_changed {
+    // R4: repositories refresh only when it can matter. `list_changed`
+    // covers every trigger, since a session's arrival or eviction can
+    // introduce a new cwd regardless of what asked for the pass;
+    // `refreshes_repositories` additionally covers triggers that name an
+    // action which can change the repository set on its own — a toggle, a
+    // new scan root — even on a pass that redescribed nothing.
+    if trigger.refreshes_repositories() || list_changed {
         repositories::refresh(app).await?;
     }
 
@@ -826,6 +870,28 @@ async fn pass(
         list_changed,
         re_described: changed.len(),
     })
+}
+
+/// R3: which of this pass's records are actually worth writing.
+///
+/// A record earns a write by being in `changed` (this pass re-described it —
+/// new, or its cursor moved) or in `returned` (its evidence last failed on a
+/// missing source, so even an unchanged row needs a write to re-queue it).
+/// Every other record is a row reused verbatim, and rewriting it would only
+/// cost a write for no observable change. Order follows `records`, and a key
+/// named by both `changed` and `returned` still yields one copy.
+fn records_to_persist(
+    records: &[SessionRecord],
+    changed: &[SessionKey],
+    returned: &[SessionKey],
+) -> Vec<SessionRecord> {
+    let worth_writing: std::collections::HashSet<&SessionKey> =
+        changed.iter().chain(returned).collect();
+    records
+        .iter()
+        .filter(|record| worth_writing.contains(&record.key))
+        .cloned()
+        .collect()
 }
 
 /// [`PassScope::Agents`]'s discovery: only the named agents, concurrently,

--- a/apps/desktop/src-tauri/src/scan/tests.rs
+++ b/apps/desktop/src-tauri/src/scan/tests.rs
@@ -1450,7 +1450,7 @@ fn a_fresh_controller_reports_a_clean_initial_status() {
 #[tokio::test(start_paused = true)]
 async fn a_second_request_before_the_scheduler_wakes_is_coalesced() {
     let controller = ScanController::default();
-    controller.request(ScanTrigger::PopoverShown);
+    controller.request(ScanTrigger::InsightsPane);
     controller.request(ScanTrigger::ManualRescan);
 
     {
@@ -1459,7 +1459,7 @@ async fn a_second_request_before_the_scheduler_wakes_is_coalesced() {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         assert!(
-            matches!(pending.as_ref(), Some(ScanTrigger::PopoverShown)),
+            matches!(pending.as_ref(), Some(ScanTrigger::InsightsPane)),
             "the first trigger is kept, the second is dropped"
         );
     }

--- a/apps/desktop/src-tauri/src/scan/tests.rs
+++ b/apps/desktop/src-tauri/src/scan/tests.rs
@@ -1338,6 +1338,38 @@ fn record(agent: &str, session_id: &str, updated_at: Option<i64>) -> SessionReco
 }
 
 #[test]
+fn records_to_persist_keeps_only_changed_or_returned_rows() {
+    let a = record("claude-code", "a", Some(1_000));
+    let b = record("claude-code", "b", Some(2_000));
+    let c = record("codex", "c", Some(3_000));
+    let records = vec![a.clone(), b.clone(), c.clone()];
+
+    assert_eq!(records_to_persist(&records, &[], &[]), Vec::new());
+
+    assert_eq!(
+        records_to_persist(&records, std::slice::from_ref(&a.key), &[]),
+        vec![a.clone()],
+        "changed only"
+    );
+
+    assert_eq!(
+        records_to_persist(&records, &[], std::slice::from_ref(&c.key)),
+        vec![c.clone()],
+        "returned only"
+    );
+
+    assert_eq!(
+        records_to_persist(
+            &records,
+            &[a.key.clone(), b.key.clone()],
+            std::slice::from_ref(&b.key),
+        ),
+        vec![a, b],
+        "a key named by both changed and returned still yields one copy"
+    );
+}
+
+#[test]
 fn per_agent_totals_count_sessions_and_keep_the_newest_activity() {
     let records = vec![
         record("claude-code", "a", Some(1_000)),
@@ -1469,6 +1501,44 @@ async fn a_second_request_before_the_scheduler_wakes_is_coalesced() {
     // ...and a second wait finds nothing further queued.
     let second = tokio::time::timeout(Duration::from_millis(0), controller.kick.notified()).await;
     assert!(second.is_err(), "only one notify should have been queued");
+}
+
+/// R4: the tick and the watcher triggers cannot plausibly have introduced a
+/// repository the list has not already seen, so they alone skip the refresh.
+#[test]
+fn refreshes_repositories_is_false_only_for_the_tick_and_the_watcher_triggers() {
+    let cheap = [
+        ScanTrigger::Tick,
+        ScanTrigger::WatcherAgents {
+            agents: vec!["claude-code"],
+        },
+        ScanTrigger::WatcherOverflow,
+    ];
+    for trigger in &cheap {
+        assert!(
+            !trigger.refreshes_repositories(),
+            "{} should not refresh repositories",
+            trigger.label()
+        );
+    }
+
+    let refreshing = [
+        ScanTrigger::Launch,
+        ScanTrigger::SettingsTransition,
+        ScanTrigger::InsightsPane,
+        ScanTrigger::RepositoryToggle,
+        ScanTrigger::ScanRootAdded,
+        ScanTrigger::FolderAccessGranted,
+        ScanTrigger::IndexCleared,
+        ScanTrigger::ManualRescan,
+    ];
+    for trigger in &refreshing {
+        assert!(
+            trigger.refreshes_repositories(),
+            "{} should refresh repositories",
+            trigger.label()
+        );
+    }
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/storage_health.rs
+++ b/apps/desktop/src-tauri/src/storage_health.rs
@@ -140,7 +140,7 @@ mod tests {
         );
         assert!(
             health.replace(failing.clone()).is_none(),
-            "a scan runs every minute; the same failure is not news sixty times"
+            "a scan can run again soon; the same failure is not news every time"
         );
 
         // A *different* failure is news again, because it names something else.

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -874,6 +874,35 @@ impl Store {
         }))
     }
 
+    /// Keys of every session whose evidence last failed because its source
+    /// was missing.
+    ///
+    /// R3: a full pass reuses an unchanged row without rewriting it, which
+    /// would otherwise leave a session stuck once its source returns —
+    /// nothing else would notice and re-queue its evidence. The scan pass
+    /// persists these rows through `upsert_sessions` even when the row
+    /// itself is unchanged, so its own `source_returned` check runs and
+    /// clears the failure.
+    pub fn sessions_with_missing_source(&self) -> Result<Vec<SessionKey>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(
+            "SELECT environment_key, agent, session_id
+               FROM session_evidence
+              WHERE status = 'failed' AND last_error = ?1",
+        )?;
+        let rows = statement.query_map(
+            params![crate::insights_worker::EVIDENCE_ERROR_SOURCE_MISSING],
+            |row| {
+                Ok(SessionKey::new(
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
     /// One session's persisted source version and optional start time.
     pub fn session_source_state(&self, key: &SessionKey) -> Result<Option<SourceVersionState>> {
         let connection = self.lock();

--- a/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
@@ -144,3 +144,42 @@ fn an_agent_scoped_upsert_leaves_another_agents_rows_intact() {
         .expect("codex row is untouched by a Claude-scoped pass");
     assert_eq!(stored_codex.key.session_id, "codex-session");
 }
+
+/// R3: only a `source-missing` failure marks a session for a forced rewrite.
+/// A different failure reason, or a session with no failure at all, must not
+/// come back from this query.
+#[test]
+fn sessions_with_missing_source_returns_only_that_failure_reason() {
+    let store = store();
+    store
+        .upsert_sessions(
+            &[
+                session("returned", 1_000),
+                session("other-failure", 2_000),
+                session("healthy", 3_000),
+            ],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    {
+        let connection = store.lock();
+        connection
+            .execute(
+                "UPDATE session_evidence SET status = 'failed', last_error = ?1
+                  WHERE session_id = 'returned'",
+                params![crate::insights_worker::EVIDENCE_ERROR_SOURCE_MISSING],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE session_evidence SET status = 'failed', last_error = 'source-unreadable'
+                  WHERE session_id = 'other-failure'",
+                [],
+            )
+            .unwrap();
+    }
+
+    let missing = store.sessions_with_missing_source().unwrap();
+    let ids: Vec<_> = missing.iter().map(|key| key.session_id.as_str()).collect();
+    assert_eq!(ids, vec!["returned"]);
+}

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -327,6 +327,12 @@ export interface ScanStatus {
   agents: AgentScanState[]
   /** True when this pass indexed a session the list has never shown, or evicted a rejected one. */
   listChanged: boolean
+  /**
+   * R5: how many sessions the last pass re-described — new, or a moved
+   * cursor — never a row it reused verbatim. Tells an idle pass from a
+   * productive one without inferring it from `listChanged` alone.
+   */
+  reDescribed: number
 }
 
 /**

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1267,11 +1267,11 @@ export async function onSessionEntryChanged(
  * Event the shell emits the instant the popover reaches the screen. Mirrors
  * `popover::EVENT_SHOWN` in `src-tauri/src/popover.rs`.
  *
- * Deliberately not folded into `onScanEvent`: the scan it also kicks is
- * gated on discovery being unpaused and can take as long as a full disk
- * walk, neither of which has anything to do with a provider's own stated
- * limits. This is what a view subscribes to when what it wants is "the
- * popover just opened," full stop.
+ * Deliberately not folded into `onScanEvent`: opening the popover no longer
+ * asks for a scan at all (R1), and a provider's own stated limits have
+ * nothing to do with a scan pass anyway. This is what a view subscribes to
+ * when what it wants is "the popover just opened," full stop — including
+ * starting the visible-only usage poll (R6).
  */
 export const POPOVER_SHOWN_EVENT = "popover:shown"
 
@@ -1279,6 +1279,20 @@ export const POPOVER_SHOWN_EVENT = "popover:shown"
 export async function onPopoverShown(handler: () => void): Promise<UnlistenFn> {
   if (!hasShell()) return noShellUnlisten
   return listen(POPOVER_SHOWN_EVENT, () => handler())
+}
+
+/**
+ * Event the shell emits the instant the popover leaves the screen. Mirrors
+ * `popover::EVENT_HIDDEN` in `src-tauri/src/popover.rs`.
+ *
+ * R6: this is what stops the visible-only usage poll `onPopoverShown` starts.
+ */
+export const POPOVER_HIDDEN_EVENT = "popover:hidden"
+
+/** Subscribe to the popover leaving the screen. The result unsubscribes. */
+export async function onPopoverHidden(handler: () => void): Promise<UnlistenFn> {
+  if (!hasShell()) return noShellUnlisten
+  return listen(POPOVER_HIDDEN_EVENT, () => handler())
 }
 
 /** Event the shell emits after it refreshes the cached live-usage snapshot. */

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -18,6 +18,8 @@ const setPopoverHeight = vi.hoisted(() => vi.fn())
 const listRecentSessions = vi.hoisted(() => vi.fn())
 const onSessionEntryChanged = vi.hoisted(() => vi.fn())
 const onScanEvent = vi.hoisted(() => vi.fn())
+const onPopoverShown = vi.hoisted(() => vi.fn())
+const onPopoverHidden = vi.hoisted(() => vi.fn())
 
 // The analysis, list, and event-subscription commands are overridden. All
 // other wrappers keep their real no-shell fallback because `hasShell()` is
@@ -34,6 +36,8 @@ vi.mock("../../lib/ipc", async (importOriginal) => {
     listRecentSessions,
     onSessionEntryChanged,
     onScanEvent,
+    onPopoverShown,
+    onPopoverHidden,
   }
 })
 
@@ -42,10 +46,14 @@ type ScanEventHandler = (status: ScanStatus, phase: "started" | "progress" | "fi
 
 let entryChangedHandler: EntryChangedHandler | null = null
 let scanEventHandler: ScanEventHandler | null = null
+let popoverShownHandler: (() => void) | null = null
+let popoverHiddenHandler: (() => void) | null = null
 
 beforeEach(() => {
   entryChangedHandler = null
   scanEventHandler = null
+  popoverShownHandler = null
+  popoverHiddenHandler = null
   getSessionAnalysis.mockReset()
   getSessionAnalysis.mockResolvedValue(null)
   getSubagentAnalysis.mockReset()
@@ -66,6 +74,20 @@ beforeEach(() => {
     scanEventHandler = handler
     return () => {
       scanEventHandler = null
+    }
+  })
+  onPopoverShown.mockReset()
+  onPopoverShown.mockImplementation(async (handler: () => void) => {
+    popoverShownHandler = handler
+    return () => {
+      popoverShownHandler = null
+    }
+  })
+  onPopoverHidden.mockReset()
+  onPopoverHidden.mockImplementation(async (handler: () => void) => {
+    popoverHiddenHandler = handler
+    return () => {
+      popoverHiddenHandler = null
     }
   })
   getSessionLimitAllocations.mockReset()
@@ -516,6 +538,76 @@ describe("PopoverSession event-driven refresh", () => {
     scanEventHandler?.(scanStatus({ listChanged: false, reDescribed: 1 }), "finished")
     await vi.advanceTimersByTimeAsync(0)
     expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 3)
+
+    unsubscribe()
+    vi.useRealTimers()
+  })
+
+  // R6: usage freshness while the popover is visible is its own poll,
+  // independent of any scan. The session starts visible (see `visible`'s
+  // doc comment), so polling starts immediately; `popover:hidden` stops it
+  // and `popover:shown` resumes it.
+  it("polls usage on its own interval while visible, stopping and resuming with the popover", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(popoverHiddenHandler).not.toBeNull()
+    const baseline = getProviderUsage.mock.calls.length
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 2)
+
+    popoverHiddenHandler?.()
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 2)
+
+    popoverShownHandler?.()
+    await vi.advanceTimersByTimeAsync(0)
+    // `popover:shown` also runs its own immediate usage refresh, independent
+    // of the poll it resumes.
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 3)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 4)
+
+    unsubscribe()
+    vi.useRealTimers()
+  })
+
+  // R6: `sessions:entry-changed` shares the scan's usage floor while the
+  // popover is visible, so an active session's totals stay current between
+  // scans; hidden, it does nothing, since nobody is looking.
+  it("refreshes usage from sessions:entry-changed at most once per floor, only while visible", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(entryChangedHandler).not.toBeNull()
+    const baseline = getProviderUsage.mock.calls.length
+
+    entryChangedHandler?.(entryPayload())
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
+
+    // A second event 1 s later lands inside the floor and refreshes nothing
+    // further.
+    await vi.advanceTimersByTimeAsync(1_000)
+    entryChangedHandler?.(entryPayload())
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
+
+    // Hidden, even past the floor, an entry change refreshes nothing.
+    popoverHiddenHandler?.()
+    await vi.advanceTimersByTimeAsync(30_000)
+    entryChangedHandler?.(entryPayload())
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
 
     unsubscribe()
     vi.useRealTimers()

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -356,6 +356,7 @@ describe("PopoverSession event-driven refresh", () => {
     error: null,
     agents: [],
     listChanged: false,
+    reDescribed: 0,
     ...overrides,
   })
 
@@ -468,11 +469,12 @@ describe("PopoverSession event-driven refresh", () => {
     unsubscribe()
   })
 
-  // F1: `scan:finished` refreshes usage on its own floor
-  // (`USAGE_REFRESH_MIN_MS`), separate from the list reconcile interval
-  // above — a scan pass finishing is not by itself a reason to recompute
-  // 30-day usage totals on every one of an active session's rapid passes.
-  it("refreshes usage on a floor, bypassed by a reported list change", async () => {
+  // R5: `scan:finished` only refreshes usage when the pass re-described at
+  // least one session, floored by `USAGE_REFRESH_MIN_MS`, or reported a list
+  // change — an idle pass (`reDescribed: 0`) refreshes nothing, no matter
+  // how stale the last refresh is, since the watcher (not this event) is now
+  // what keeps an active session's own rows current.
+  it("refreshes usage only on a re-described pass, floored, bypassed by a list change", async () => {
     vi.useFakeTimers()
     vi.setSystemTime("2027-01-15T08:00:00Z")
     const session = new PopoverSession()
@@ -481,27 +483,37 @@ describe("PopoverSession event-driven refresh", () => {
     expect(scanEventHandler).not.toBeNull()
     const baseline = getProviderUsage.mock.calls.length
 
-    // First scan:finished always refreshes: nothing has refreshed usage
-    // from this handler yet.
-    scanEventHandler?.(scanStatus({ listChanged: false }), "finished")
+    // An idle pass refreshes nothing, even though nothing has refreshed yet.
+    scanEventHandler?.(scanStatus({ listChanged: false, reDescribed: 0 }), "finished")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline)
+
+    // A re-described pass refreshes, and stamps the floor.
+    scanEventHandler?.(scanStatus({ listChanged: false, reDescribed: 1 }), "finished")
     await vi.advanceTimersByTimeAsync(0)
     expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
 
-    // A second event 1 s later, still no list change, lands inside the
-    // floor and refreshes nothing further.
+    // Another re-described pass 1 s later lands inside the floor and
+    // refreshes nothing further.
     await vi.advanceTimersByTimeAsync(1_000)
-    scanEventHandler?.(scanStatus({ listChanged: false }), "finished")
+    scanEventHandler?.(scanStatus({ listChanged: false, reDescribed: 1 }), "finished")
     await vi.advanceTimersByTimeAsync(0)
     expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 1)
 
-    // A reported list change bypasses the floor.
-    scanEventHandler?.(scanStatus({ listChanged: true }), "finished")
+    // A reported list change bypasses the floor, even with nothing
+    // re-described.
+    scanEventHandler?.(scanStatus({ listChanged: true, reDescribed: 0 }), "finished")
     await vi.advanceTimersByTimeAsync(0)
     expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 2)
 
-    // Once the floor elapses, an unchanged list refreshes again too.
+    // Once the floor elapses, an idle pass still refreshes nothing...
     await vi.advanceTimersByTimeAsync(30_000)
-    scanEventHandler?.(scanStatus({ listChanged: false }), "finished")
+    scanEventHandler?.(scanStatus({ listChanged: false, reDescribed: 0 }), "finished")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 2)
+
+    // ...but a re-described pass does.
+    scanEventHandler?.(scanStatus({ listChanged: false, reDescribed: 1 }), "finished")
     await vi.advanceTimersByTimeAsync(0)
     expect(getProviderUsage).toHaveBeenCalledTimes(baseline + 3)
 

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -19,6 +19,7 @@ import {
   hidePopover,
   listRecentSessions,
   listRepositories,
+  onPopoverHidden,
   onPopoverShown,
   onLiveUsageChanged,
   onScanEvent,
@@ -173,15 +174,24 @@ const NOW_TICK_MS = 30_000
 const LIST_RECONCILE_MS = 60_000
 
 /**
- * Floor between `scan:finished`-triggered usage refreshes that report no
- * list change. A pass finishing is not, by itself, a reason to recompute
- * 30-day usage totals and resolve both live provider accounts (F1): an
- * active session's row updates every few seconds, and a usage refresh on
- * every one of those would cost as much as the list rebuild it was meant to
- * avoid. `listChanged` still forces an immediate refresh, since that means a
- * session was discovered or removed.
+ * Floor shared by `scan:finished` and `sessions:entry-changed` usage
+ * refreshes that report no list change. A re-described pass or a patched row
+ * is not, by itself, a reason to recompute 30-day usage totals and resolve
+ * both live provider accounts (F1, R6): an active session's row updates
+ * every few seconds, and a usage refresh on every one of those would cost as
+ * much as the list rebuild it was meant to avoid. `listChanged` still forces
+ * an immediate refresh, since that means a session was discovered or
+ * removed.
  */
 const USAGE_REFRESH_MIN_MS = 30_000
+
+/**
+ * How often usage is polled while the popover is visible, independent of any
+ * scan (R6). The backend's `POPOVER_LIVE_USAGE_MAX_AGE` (50 s) is tuned to
+ * sit just under this, so an open popover's own polling is what keeps a
+ * live reading current.
+ */
+const USAGE_VISIBLE_POLL_MS = 60_000
 
 /**
  * Order list rows the way the backend does: newest activity first, and a
@@ -254,13 +264,28 @@ export class PopoverSession {
   private lastListReconcileAt = 0
 
   /**
-   * When `listenScanEvent` last triggered a usage refresh. Read against
-   * `USAGE_REFRESH_MIN_MS` (F1) so a quiet stream of `scan:finished` events
-   * with no list change refreshes usage on a floor, not on every event.
+   * When a usage refresh last ran from `listenScanEvent` or
+   * `listenSessionEntryChanged`. Read against `USAGE_REFRESH_MIN_MS` (F1, R6)
+   * so a quiet stream of events with no list change refreshes usage on a
+   * shared floor, not on every event.
    */
   private lastUsageRefreshAt = 0
 
+  /**
+   * Whether the popover is currently on screen. R6: gates the
+   * `sessions:entry-changed` usage refresh and whether the visible-only poll
+   * is running.
+   *
+   * Defaults `true` rather than `false`: the session can start after the
+   * shell's first `popover:shown` already fired, before this class's own
+   * listener was registered to hear it, and a wrongly-`false` default would
+   * then never start the poll until the popover cycled hidden and shown again.
+   */
+  private visible = true
+
   private nowTickTimer: ReturnType<typeof setInterval> | null = null
+  /** The visible-only usage poll (R6); see `startUsagePolling`/`stopUsagePolling`. */
+  private usagePollTimer: ReturnType<typeof setInterval> | null = null
 
   private stopSettingsListening: (() => void) | null = null
   private stopSessionsInvalidatedListening: (() => void) | null = null
@@ -268,6 +293,7 @@ export class PopoverSession {
   private stopStorageHealthListening: (() => void) | null = null
   private stopScanListening: (() => void) | null = null
   private stopPopoverShownListening: (() => void) | null = null
+  private stopPopoverHiddenListening: (() => void) | null = null
   private stopLiveUsageListening: (() => void) | null = null
 
   private snapshot: PopoverSnapshot = {
@@ -395,6 +421,7 @@ export class PopoverSession {
     void this.listenStorageHealth(generation)
     void this.listenScanEvent(generation)
     void this.listenPopoverShown(generation)
+    void this.listenPopoverHidden(generation)
     void this.listenLiveUsage(generation)
 
     // ⌘, opens Settings — the platform's standard preferences shortcut, which
@@ -408,6 +435,11 @@ export class PopoverSession {
     // unmounts, but the listener count can still hit zero and come back)
     // still needs its relative-time ticker running again.
     this.syncDetailTimers()
+
+    // R6: the session starts visible (see `visible`'s doc comment), so its
+    // usage poll starts immediately rather than waiting for a `popover:shown`
+    // that may already have fired.
+    this.startUsagePolling()
   }
 
   private stop(): void {
@@ -425,9 +457,12 @@ export class PopoverSession {
     this.stopScanListening = null
     this.stopPopoverShownListening?.()
     this.stopPopoverShownListening = null
+    this.stopPopoverHiddenListening?.()
+    this.stopPopoverHiddenListening = null
     this.stopLiveUsageListening?.()
     this.stopLiveUsageListening = null
     this.stopNowTicking()
+    this.stopUsagePolling()
     this.stopSessionLimitAllocationExpiryTimer()
     window.removeEventListener("keydown", this.onWindowKeyDown)
   }
@@ -514,12 +549,23 @@ export class PopoverSession {
   // without a full re-query, and — since this is also the scan pass's own
   // per-session signal, not only the worker's — this also refreshes an open
   // detail pane's analysis when the changed session is the one on screen.
+  //
+  // R6: while the popover is visible, this is also a usage-refresh signal,
+  // on the same `USAGE_REFRESH_MIN_MS` floor `listenScanEvent` uses — an
+  // active session's row updates faster than a full pass re-describes it, so
+  // waiting for `scan:finished` alone would leave usage stale in between.
+  // Hidden, this does nothing for usage: the visible-only poll is what keeps
+  // a hidden popover's next open cheap instead.
   private listenSessionEntryChanged = async (generation: number): Promise<void> => {
     const unlisten = await onSessionEntryChanged((entry) => {
       if (generation !== this.generation) return
       this.patchOrRefetchEntry(entry)
       this.refreshOpenAnalysisIfMatching(entry)
       void this.refreshSessionLimitAllocations()
+      if (this.visible && Date.now() - this.lastUsageRefreshAt >= USAGE_REFRESH_MIN_MS) {
+        this.lastUsageRefreshAt = Date.now()
+        void this.refreshUsage()
+      }
     })
     if (generation !== this.generation) {
       unlisten()
@@ -671,15 +717,11 @@ export class PopoverSession {
     this.stopScanListening = unlisten
   }
 
-  // The shell's own signal that the popover just reached the screen —
-  // separate from the scan events above on purpose. `note_shown` also kicks
-  // a disk scan, but that kick is silently skipped while discovery is
-  // paused or onboarding is unfinished, and even a scan that does run can
-  // take a while to finish. Neither has any bearing on a provider's own
-  // stated limits, so usage gets its own refresh here rather than waiting on
-  // — or being silenced by — the scan pipeline. The open session's analysis
-  // is in the same position: its transcript can grow while the popover is
-  // hidden, and nothing else asks for it again until the reader navigates.
+  // The shell's own signal that the popover just reached the screen — no
+  // longer paired with a scan kick (R1: opening the popover does not ask for
+  // one). The open session's analysis can grow while the popover is hidden,
+  // and nothing else asks for it again until the reader navigates, so it
+  // still gets its own refresh here.
   //
   // Entries are also refetched here, even though the scan scheduler now
   // ticks unconditionally and `listenScanEvent` above is the primary path:
@@ -688,6 +730,8 @@ export class PopoverSession {
   private listenPopoverShown = async (generation: number): Promise<void> => {
     const unlisten = await onPopoverShown(() => {
       if (generation !== this.generation) return
+      this.visible = true
+      this.startUsagePolling()
       if (this.initialContentReady) this.reportContentReady(true)
       void this.restoreFloatingHud(generation)
       void this.refreshEntries(this.windowDays()).catch(() => {})
@@ -700,6 +744,21 @@ export class PopoverSession {
     }
     this.stopPopoverShownListening = unlisten
     void this.restoreFloatingHud(generation)
+  }
+
+  // R6: the close-side counterpart. Usage freshness while visible does not
+  // ride on a scan, so it needs its own signal for when to stop polling too.
+  private listenPopoverHidden = async (generation: number): Promise<void> => {
+    const unlisten = await onPopoverHidden(() => {
+      if (generation !== this.generation) return
+      this.visible = false
+      this.stopUsagePolling()
+    })
+    if (generation !== this.generation) {
+      unlisten()
+      return
+    }
+    this.stopPopoverHiddenListening = unlisten
   }
 
   private reportContentReady(retryAfterPendingFailure = false): void {
@@ -910,6 +969,26 @@ export class PopoverSession {
     if (this.nowTickTimer === null) return
     clearInterval(this.nowTickTimer)
     this.nowTickTimer = null
+  }
+
+  /**
+   * R6: usage freshness while the popover is visible, independent of a scan.
+   * Each tick stamps `lastUsageRefreshAt` the same way the scan- and
+   * entry-changed-triggered refreshes do, so they all share one floor rather
+   * than a poll immediately re-triggering one of the others.
+   */
+  private startUsagePolling(): void {
+    if (this.usagePollTimer !== null) return
+    this.usagePollTimer = setInterval(() => {
+      this.lastUsageRefreshAt = Date.now()
+      void this.refreshUsage()
+    }, USAGE_VISIBLE_POLL_MS)
+  }
+
+  private stopUsagePolling(): void {
+    if (this.usagePollTimer === null) return
+    clearInterval(this.usagePollTimer)
+    this.usagePollTimer = null
   }
 
   private loadAnalysisFor = (subject: SessionSubject): Promise<void> => {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -638,9 +638,14 @@ export class PopoverSession {
   // progress, so the intermediate phases have nothing to say. A full refetch
   // of entries and repositories only runs when the pass says the list needs
   // one, or the reconcile interval has elapsed — `sessions:entry-changed`
-  // already keeps individual rows current in between. Usage follows the
-  // same shape on its own floor (F1): `listChanged` forces an immediate
-  // refresh, and every other pass waits for `USAGE_REFRESH_MIN_MS`.
+  // already keeps individual rows current in between. Usage follows its own
+  // floor (R5): `listChanged` forces an immediate refresh, and otherwise a
+  // pass only counts when it re-described at least one session
+  // (`reDescribed > 0`) — an idle pass, the common case now that the watcher
+  // does the real freshness work, refreshes nothing. `sessions:entry-changed`
+  // shares this same floor while the popover is visible (R6), which is what
+  // replaces the usage refresh a row patch never used to trigger — see
+  // `listenSessionEntryChanged`.
   private listenScanEvent = async (generation: number): Promise<void> => {
     const unlisten = await onScanEvent((status, phase) => {
       if (generation !== this.generation) return
@@ -651,7 +656,10 @@ export class PopoverSession {
         void this.refreshEntries(this.windowDays()).catch(() => {})
         void this.refreshRepositoryList()
       }
-      if (status.listChanged || now - this.lastUsageRefreshAt >= USAGE_REFRESH_MIN_MS) {
+      if (
+        status.listChanged ||
+        (status.reDescribed > 0 && now - this.lastUsageRefreshAt >= USAGE_REFRESH_MIN_MS)
+      ) {
         this.lastUsageRefreshAt = now
         void this.refreshUsage()
       }

--- a/apps/desktop/src/views/popover/ScanStatusBar.test.tsx
+++ b/apps/desktop/src/views/popover/ScanStatusBar.test.tsx
@@ -23,6 +23,7 @@ function status(overrides: Partial<ScanStatus> = {}): ScanStatus {
     error: null,
     agents: [],
     listChanged: false,
+    reDescribed: 0,
     ...overrides,
   }
 }

--- a/apps/desktop/src/views/settings/GeneralPane.test.ts
+++ b/apps/desktop/src/views/settings/GeneralPane.test.ts
@@ -14,6 +14,7 @@ function status(overrides: Partial<ScanStatus> = {}): ScanStatus {
     error: null,
     agents: [],
     listChanged: false,
+    reDescribed: 0,
     ...overrides,
   }
 }

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -288,7 +288,7 @@ Goal: layer 1 is continuous and cheap, and every consumer reads one signal.
   `get_session_analysis_fingerprint` command, `poll_fingerprint_with_subagents`,
   and their tests are deleted along with the poll.
 
-### Phase 5: scoped passes (5a and 5c merged 2026-09-03; 5b in review)
+### Phase 5: scoped passes (5a and 5c merged 2026-09-03; 5b in review; 5d planned)
 
 Goal: a watcher event costs work proportional to what changed, not a
 whole-machine pass. Found on 2026-09-03 after phase 4 had run for a day:
@@ -403,6 +403,40 @@ scheduler task, so passes never overlap and the store sees one writer.
   immediate parent's mtime, so an old project directory would hide every
   session added to it since.
 
+#### Phase 5d: the tick and the popover stop being the freshness path
+
+Found on 2026-09-03 from a live log of the 5b build: watcher bursts were
+cheap (a targeted refresh took about 90 ms), but the 60 s tick and every
+popover open still ran a full pass. Three popover opens in 13 s ran three
+full passes of 1.8 to 2.1 s each, contending with the popover's own render
+and usage recompute. Both were insurance from before the watcher existed.
+What the tick uniquely covers now is WSL sessions (never watched) and a rare
+FSEvents drop under load; a degraded watcher already falls back to the 15 s
+tick, and the watcher re-registers new agent roots itself.
+
+- R1. Opening the popover does not request a scan. `note_shown` still emits
+  `popover:shown`; the `PopoverShown` trigger is removed as dead code.
+- R2. `TICK` is 5 minutes. `FALLBACK_TICK` stays 15 s for a degraded watcher.
+- R3. A full pass writes only the rows the describe step changed (new, or
+  cursor moved), plus any reused row whose evidence is `failed` with
+  `source-missing`, so a returned source still re-queues. An idle tick is
+  stat calls only. Per-agent scan bookkeeping still counts every record.
+- R4. A full pass refreshes repositories only when `list_changed`, or when
+  the trigger is one that can change the repository set: launch, settings
+  transition, insights pane, repository toggle, scan root added, folder
+  access granted, index cleared, manual rescan. The tick and the watcher
+  triggers do not.
+- R5. `ScanStatus` carries `re_described`. The popover's `scan:finished`
+  handler refreshes usage only when `list_changed`, or when the pass
+  re-described at least one session and `USAGE_REFRESH_MIN_MS` has elapsed.
+  A pass that changed nothing triggers no usage refresh.
+- R6. Usage freshness while the popover is visible no longer rides on the
+  scan. The shell emits `popover:hidden` from `note_hidden`. The popover
+  refreshes usage on a 60 s interval while visible (started on shown,
+  stopped on hidden, matching `POPOVER_LIVE_USAGE_MAX_AGE`), and on a
+  `sessions:entry-changed` event under the same 30 s floor, so an active
+  session's totals stay current without a scan pass.
+
 ## Sequencing notes
 
 - Phase 1 stands alone and is reverted by two small edits if it misbehaves.
@@ -411,6 +445,8 @@ scheduler task, so passes never overlap and the store sees one writer.
 - Default cadences are set in phase 4 and reviewed after a week of use.
 - Phase 5a stands alone. 5b stacks on 5a (it consumes the burst paths 5a
   passes through). 5c's two items are independent of each other and of 5b.
+- 5d stacks on 5b: it changes the same scheduler and the popover's scan
+  handler.
 - 5b keeps the tick as a fixed deadline that only a full pass resets, so
   scoped wakes every few seconds cannot starve reconciliation. A burst at
   the watcher's path bound forces a full pass, since paths were dropped.
@@ -427,7 +463,8 @@ scheduler task, so passes never overlap and the store sees one writer.
 - Provider-database agents (OpenCode, Antigravity) persist no row cursor. A
   change still costs a full re-stream of the session's rows.
 - The phase 4 cadences were reviewed after a day, not a week; the result is
-  phase 5. The 60 s tick, 15 s fallback, 1.5 s / 5 s burst coalescing, and
-  60 s list reconcile stay; the per-session and per-agent floors are new.
+  phase 5. The 15 s fallback, 1.5 s / 5 s burst coalescing, and 60 s list
+  reconcile stay; the per-session and per-agent floors are new, and 5d moved
+  the tick to 5 minutes once the watcher carried freshness.
 - While discovery is paused the scan does not run, so the HUD's live signal
   now follows the pause. Decide whether that is the wanted behaviour.


### PR DESCRIPTION
## Summary

Phase 5d of `docs/plans/continuous-session-ingest.md`, following #366 (phase 5b). After 5b, watcher bursts were cheap but the 60 s tick and every popover open still ran a full pass. Both were insurance from before the watcher existed.

- **R1** Opening the popover no longer requests a scan. `ScanTrigger::PopoverShown` is removed as dead code.
- **R2** `TICK` is 5 minutes. `FALLBACK_TICK` stays 15 s for a degraded watcher.
- **R3** A full pass upserts only the rows the describe step changed, plus any reused row whose evidence last failed with `source-missing` so a returned file still re-queues. An idle tick is stat calls only. Per-agent scan bookkeeping still counts every record.
- **R4** Repositories refresh only when `list_changed` or the trigger can change the repository set (launch, settings, insights pane, toggle, scan root, folder access, index cleared, manual rescan). Tick and watcher triggers never refresh them. The match is exhaustive so a new variant forces the decision.
- **R5** `ScanStatus` carries `re_described` / `reDescribed`. The popover's `scan:finished` handler refreshes usage only on `listChanged`, or when the pass re-described something and the 30 s floor has elapsed.
- **R6** Usage freshness while visible no longer rides on the scan. The shell emits `popover:hidden` from `note_hidden`. The popover polls usage every 60 s while visible (started on shown, stopped on hidden, matching `POPOVER_LIVE_USAGE_MAX_AGE`), and refreshes under the 30 s floor on `sessions:entry-changed`.

One known edge: the popover session starts with `visible = true` because the first `popover:shown` can fire before the listener is registered. A prewarmed, never-shown popover would poll usage every 60 s until its first hide. That matches the pre-5d cost (the tick drove the same refresh once a minute) and stops on the first hide.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p antiburn --no-fail-fast`: 823 passed, 0 failed
- [x] `pnpm lint`, `pnpm run type-check`, `pnpm test`: 91 files, 1062 tests passed; `prettier --check` clean
- [ ] Live log: opening the popover produces no `scan_pass_requested`; ticks are 5 minutes apart; an idle tick logs `re_described=0` and no `computed local usage totals` follows it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1ir9iHoiRvkdSQnY8wsy2
