### PR TITLE
Desktop: score only assessed session checks

### DIFF
--- a/apps/desktop/src/components/session/SessionStatusBar.test.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.test.tsx
@@ -105,11 +105,11 @@ describe("SessionStatusBar", () => {
     expect(verdict.parentElement?.className).not.toContain("bg-")
   })
 
-  it("keeps the denominator on every check, so it never contradicts the tail", () => {
+  it("excludes not-assessed checks from the denominator and failure share", () => {
     render(<SessionStatusBar checks={WITH_NOT_ASSESSED} />)
-    const verdict = screen.getByLabelText("4 of 6 burn checks pass; 1 not assessed")
-    expect(verdict.textContent).toBe("4/6 burn checks · 1 not assessed")
-    expect(verdict.style.color).toContain("--color-system-red-text) 17%")
+    const verdict = screen.getByLabelText("4 of 5 burn checks pass; 1 not assessed")
+    expect(verdict.textContent).toBe("4/5 burn checks")
+    expect(verdict.style.color).toContain("--color-system-red-text) 20%")
     expect(verdict.style.color).toContain("--color-system-orange")
   })
 
@@ -156,7 +156,7 @@ describe("SessionStatusBar", () => {
     expect(verdict.style.color).toContain("--color-system-orange")
   })
 
-  it("never shows a denominator smaller than the not-assessed tail", () => {
+  it("uses the assessed count when the not-assessed count is larger", () => {
     const oneAssessed: SessionHygieneCheck[] = [
       CHECKS[0]!,
       { ...WITH_NOT_ASSESSED[2]! },
@@ -169,8 +169,8 @@ describe("SessionStatusBar", () => {
       },
     ]
     render(<SessionStatusBar checks={oneAssessed} />)
-    const verdict = screen.getByLabelText("0 of 3 burn checks pass; 2 not assessed")
-    expect(verdict.textContent).toBe("0/3 burn checks · 2 not assessed")
+    const verdict = screen.getByLabelText("0 of 1 burn check pass; 2 not assessed")
+    expect(verdict.textContent).toBe("0/1 burn check")
   })
 
   it("replaces a zero-over-zero fraction with a plain not-assessed verdict", () => {
@@ -186,23 +186,18 @@ describe("SessionStatusBar", () => {
     expect(verdict.style.color).toBe("var(--color-label-tertiary)")
   })
 
-  it("splits a not-assessed check into a bare name and its reason", async () => {
+  it("shows a not-assessed check as a bare name without its reason", async () => {
     render(<SessionStatusBar checks={WITH_NOT_ASSESSED} />)
-    fireEvent.focus(screen.getByLabelText("4 of 6 burn checks pass; 1 not assessed"))
+    fireEvent.focus(screen.getByLabelText("4 of 5 burn checks pass; 1 not assessed"))
 
-    // The name carries no verdict, so it does not repeat the reason below it.
     const name = await screen.findByText("Overpowered subagents detected")
     expect(name.textContent).not.toContain("not assessed")
-    const reason = await screen.findByText("couldn't read the whole session log")
-    // The reason shares the name's column and never runs under the mark.
-    expect(reason.className).toContain("col-start-1")
-    expect(reason.className).not.toContain("col-span-full")
-    expect(reason.className).toContain("text-label-tertiary")
+    expect(screen.queryByText("couldn't read the whole session log")).toBeNull()
   })
 
   it("marks every check status with a named icon, not a text glyph", async () => {
     render(<SessionStatusBar checks={WITH_NOT_ASSESSED} />)
-    fireEvent.focus(screen.getByLabelText("4 of 6 burn checks pass; 1 not assessed"))
+    fireEvent.focus(screen.getByLabelText("4 of 5 burn checks pass; 1 not assessed"))
 
     for (const label of ["Finding", "Pass", "Not assessed"]) {
       const marks = await screen.findAllByLabelText(label)

--- a/apps/desktop/src/components/session/SessionStatusBar.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.tsx
@@ -137,9 +137,7 @@ export function SessionStatusBar({
   const showStateText = stateLabel !== null && assessedCount === 0
   const checkNoun = assessedCount === 1 ? "burn check" : "burn checks"
   const countText =
-    assessedCount === 0
-      ? "Not assessed"
-      : `${passed.length}/${assessedCount} ${checkNoun}`
+    assessedCount === 0 ? "Not assessed" : `${passed.length}/${assessedCount} ${checkNoun}`
   // A transient state next to an assessed verdict still names itself, as a
   // prefix on the aria label and the tooltip text.
   const verdictPrefix = stateLabel && !showStateText ? `${stateLabel} — ` : ""

--- a/apps/desktop/src/components/session/SessionStatusBar.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.tsx
@@ -3,7 +3,6 @@ import { Fragment } from "react"
 
 import type { SessionHygieneEvidenceState } from "../../lib/insightsIpc"
 import {
-  notAssessedReasonLabel,
   sessionHygieneStateIsTransient,
   sessionHygieneStateLabel,
   type SessionHygieneCheck,
@@ -92,8 +91,6 @@ function renderTooltip(
             const mark = STATUS_MARK[check.status]
             return (
               <Fragment key={check.id}>
-                {/* A not-assessed check names itself only. The reason line below
-                    carries the verdict, so the two do not repeat each other. */}
                 <span className={INK_CLASS[check.ink]}>
                   {check.status === "notAssessed" ? check.name : check.title}
                 </span>
@@ -104,13 +101,6 @@ function renderTooltip(
                   aria-label={mark.label}
                   className={`justify-self-center ${INK_CLASS[check.ink]}`}
                 />
-                {/* The reason stays in the name column. A full-width line would
-                    run under the mark column and break the right edge. */}
-                {check.status === "notAssessed" && check.notAssessedReason && (
-                  <span className="col-start-1 type-caption text-label-tertiary">
-                    {notAssessedReasonLabel(check.notAssessedReason)}
-                  </span>
-                )}
               </Fragment>
             )
           })}
@@ -134,11 +124,8 @@ export function SessionStatusBar({
   const passed = checks.filter((check) => check.status === "clean")
   const notAssessed = checks.filter((check) => check.status === "notAssessed")
   const assessedCount = passed.length + failed.length
-  // The denominator is every check the session has, not only the assessed
-  // ones. A denominator that moves with the assessed count contradicts the
-  // not-assessed tail beside it.
-  const failedShare = checks.length === 0 ? 0 : failed.length / checks.length
-  const allPassed = passed.length === checks.length && checks.length > 0
+  const failedShare = assessedCount === 0 ? 0 : failed.length / assessedCount
+  const allPassed = assessedCount > 0 && passed.length === assessedCount
   const stateLabel = sessionHygieneStateLabel(evidenceState)
   // A transient state ends on its own, so its label carries an ellipsis.
   const stateText = stateLabel
@@ -148,12 +135,11 @@ export function SessionStatusBar({
   // state label — a stale or refreshing session still has a last result. Only
   // the never-assessed case keeps the plain state text in the count's place.
   const showStateText = stateLabel !== null && assessedCount === 0
-  const checkNoun = checks.length === 1 ? "burn check" : "burn checks"
-  const notAssessedText = notAssessed.length > 0 ? ` · ${notAssessed.length} not assessed` : ""
+  const checkNoun = assessedCount === 1 ? "burn check" : "burn checks"
   const countText =
     assessedCount === 0
       ? "Not assessed"
-      : `${passed.length}/${checks.length} ${checkNoun}${notAssessedText}`
+      : `${passed.length}/${assessedCount} ${checkNoun}`
   // A transient state next to an assessed verdict still names itself, as a
   // prefix on the aria label and the tooltip text.
   const verdictPrefix = stateLabel && !showStateText ? `${stateLabel} — ` : ""
@@ -164,7 +150,7 @@ export function SessionStatusBar({
           ? "All checks pass"
           : assessedCount === 0
             ? "No checks assessed"
-            : `${passed.length} of ${checks.length} ${checkNoun} pass${
+            : `${passed.length} of ${assessedCount} ${checkNoun} pass${
                 notAssessed.length > 0 ? `; ${notAssessed.length} not assessed` : ""
               }`
       }`


### PR DESCRIPTION
## User impact

The session status bar now calculates its pass count and severity color from assessed checks only. Not-assessed checks remain available in the accessible verdict and tooltip, but their detailed reason no longer adds a second tooltip row.

Known limits: none.

## Validation

- pnpm --filter @antiburn/desktop test -- SessionStatusBar.test.tsx (91 files, 1,062 tests)
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop build
- pnpm run slop:all (100/100)
- pnpm run secrets

## Privacy and performance

None. This changes presentation only and adds no data access, network access, retained data, or background work.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (git commit -s).
- [x] I updated tests and documentation where needed.