### PR TITLE
feat(desktop): ten-minute grace period for a failed live usage reading

### DIFF
--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -35,6 +35,15 @@
 //! It is the ordinary state of a machine where the CLI has never signed in.
 //! The source simply has nothing to report.
 //!
+//! A Keychain read that cannot say whether the item exists is different from
+//! one that finds it absent. `security find-generic-password` exits 44 for
+//! "item not found"; a timeout, a spawn failure, or any other exit code
+//! means this carrier could not diagnose the item at all. That case is
+//! reported as [`ProviderUsageError::Unavailable`] instead of falling back
+//! to the credentials file, so a transient Keychain failure cannot read as
+//! "signed out" and erase a cached reading — see [`Cooldown`]'s doc for what
+//! a real failure does to the last good snapshot.
+//!
 //! # Retrying and going quiet
 //!
 //! Every other failure — a rejected credential, a rate limit, an
@@ -154,22 +163,41 @@ mod macos_keychain {
 
     const SERVICE_NAME: &str = "Claude Code-credentials";
 
-    /// The raw JSON `security` printed to stdout, or `None` for every way
-    /// this can fail to produce one — the item does not exist, `security`
-    /// is not on this machine, a nonzero exit, an empty answer, a timeout.
-    /// All of it reads as "nothing to report from this carrier", exactly
-    /// like a missing file: this carrier says nothing about whether the
-    /// account itself has usage to report.
-    pub fn read() -> Option<String> {
-        let mut child = antiburn_local::platform::process::headless_std_command("security")
+    /// The exit code `security find-generic-password` returns when the named
+    /// item does not exist in the keychain — `errSecItemNotFound`.
+    const ITEM_NOT_FOUND_EXIT_CODE: i32 = 44;
+
+    /// What one Keychain read found.
+    #[derive(Debug, PartialEq, Eq)]
+    pub enum KeychainRead {
+        /// The item does not exist. The ordinary state of a machine where the
+        /// CLI has never signed in through the Keychain.
+        Absent,
+        /// The read failed for a reason other than "item not found": a
+        /// timeout, a spawn failure, or an exit this carrier does not
+        /// recognize. This carrier cannot say whether a credential exists.
+        Unreadable,
+        /// The raw JSON `security` printed to stdout.
+        Found(String),
+    }
+
+    /// Reads one Keychain item. See [`KeychainRead`] for what each outcome
+    /// means.
+    pub fn read() -> KeychainRead {
+        let mut child = match antiburn_local::platform::process::headless_std_command("security")
             .args(["find-generic-password", "-s", SERVICE_NAME, "-w"])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
-            .ok()?;
+        {
+            Ok(child) => child,
+            Err(_) => return KeychainRead::Unreadable,
+        };
 
-        let mut stdout = child.stdout.take()?;
+        let Some(mut stdout) = child.stdout.take() else {
+            return KeychainRead::Unreadable;
+        };
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
             let mut buffer = Vec::with_capacity(4096);
@@ -197,14 +225,55 @@ mod macos_keychain {
                 // the pipe closes and simply have nowhere left to send.
                 let _ = child.kill();
                 let _ = child.wait();
-                return None;
+                return KeychainRead::Unreadable;
             }
         };
-        let status = child.wait().ok()?;
-        if !status.success() || bytes.is_empty() || bytes.len() > MAX_BYTES {
-            return None;
+        let Ok(status) = child.wait() else {
+            return KeychainRead::Unreadable;
+        };
+        if !status.success() {
+            return classify_failed_exit(status.code());
         }
-        String::from_utf8(bytes).ok()
+        if bytes.is_empty() || bytes.len() > MAX_BYTES {
+            return KeychainRead::Unreadable;
+        }
+        match String::from_utf8(bytes) {
+            Ok(text) => KeychainRead::Found(text),
+            Err(_) => KeychainRead::Unreadable,
+        }
+    }
+
+    /// Whether a nonzero exit from `security find-generic-password` means
+    /// "item not found" or something this carrier could not diagnose.
+    ///
+    /// A pure function so the one distinction this fix depends on — exit
+    /// code 44 versus everything else — has a test that does not need to
+    /// spawn `security` itself.
+    fn classify_failed_exit(exit_code: Option<i32>) -> KeychainRead {
+        if exit_code == Some(ITEM_NOT_FOUND_EXIT_CODE) {
+            KeychainRead::Absent
+        } else {
+            KeychainRead::Unreadable
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn item_not_found_reads_as_absent() {
+            assert_eq!(
+                classify_failed_exit(Some(ITEM_NOT_FOUND_EXIT_CODE)),
+                KeychainRead::Absent
+            );
+        }
+
+        #[test]
+        fn any_other_exit_reads_as_unreadable() {
+            assert_eq!(classify_failed_exit(Some(1)), KeychainRead::Unreadable);
+            assert_eq!(classify_failed_exit(None), KeychainRead::Unreadable);
+        }
     }
 }
 
@@ -246,16 +315,32 @@ impl ClaudeDirectFetch {
 
     /// The credential from whichever carrier answers first: the Keychain,
     /// where this source is built to try it, then the credentials file.
-    fn read_credentials(&self) -> Option<ClaudeCredentials> {
+    ///
+    /// `Err` means the Keychain carrier could not say whether a credential
+    /// exists — a timeout, a spawn failure, or an exit this carrier does not
+    /// recognize — and the credentials-file fallback is skipped: falling
+    /// back would read a transient failure as "signed out". It is always
+    /// `ProviderUsageError::Unavailable`, reported as a real failure so
+    /// `Cooldown` keeps the last good snapshot instead of clearing it.
+    fn read_credentials(&self) -> Result<Option<ClaudeCredentials>, ProviderUsageError> {
         #[cfg(target_os = "macos")]
-        if self.try_keychain
-            && let Some(credentials) = macos_keychain::read()
-                .as_deref()
-                .and_then(parse_credentials_json)
-        {
-            return Some(credentials);
+        if self.try_keychain {
+            match macos_keychain::read() {
+                macos_keychain::KeychainRead::Found(text) => {
+                    if let Some(credentials) = parse_credentials_json(&text) {
+                        return Ok(Some(credentials));
+                    }
+                }
+                macos_keychain::KeychainRead::Unreadable => {
+                    return Err(ProviderUsageError::Unavailable);
+                }
+                macos_keychain::KeychainRead::Absent => {}
+            }
         }
-        read_credentials_file(self.credentials_path.as_deref()?)
+        Ok(self
+            .credentials_path
+            .as_deref()
+            .and_then(read_credentials_file))
     }
 }
 
@@ -286,12 +371,11 @@ impl LiveUsageSource for ClaudeDirectFetch {
         // macOS it spawns a `security` subprocess, and a poll that the
         // cooldown is going to skip anyway should not pay for one — nor
         // re-raise a Keychain access prompt the reader has already seen.
-        self.cooldown.poll(now, max_age, || {
-            let Some(credentials) = self.read_credentials() else {
-                return Ok(None);
-            };
-            fetch_live(&credentials, now).map(Some)
-        })
+        self.cooldown
+            .poll(now, max_age, || match self.read_credentials()? {
+                Some(credentials) => fetch_live(&credentials, now).map(Some),
+                None => Ok(None),
+            })
     }
 }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -98,6 +98,12 @@ pub fn collect(
         }
         let outcome = source.fetch(max_age);
         if let Some(error) = outcome.error {
+            ::tracing::warn!(
+                event = "live_source_failed",
+                source = source.id(),
+                provider = source.provider(),
+                category = error.category()
+            );
             collected.errors.push(SourceFailure {
                 source: source.id(),
                 provider: source.provider(),

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
@@ -449,3 +449,60 @@ describe("UsageLimitsBar — degraded state", () => {
     )
   })
 })
+
+describe("UsageLimitsBar — grace period", () => {
+  const GRACE_NOTE = "Claude rate limited the last check. Showing the reading from 4 min ago."
+
+  it("keeps a graced reading on the ring, muted, with the grace note attached", () => {
+    bar({
+      live: liveSummary({
+        providers: [liveProvider({ observedAt: "2027-01-15T11:56:00Z" })],
+        errors: [sourceError()],
+      }),
+    })
+    const seat = screen.getByRole("button", { name: `Claude at 42 percent. ${GRACE_NOTE}` })
+    expect(seat).toHaveAttribute("title", `Claude — 42% — ${GRACE_NOTE}`)
+    const figureWrapper = within(seat).getByText("42%").closest('span[aria-hidden="true"]')
+    expect(figureWrapper).toHaveClass("text-label-tertiary")
+  })
+
+  it("drops a reading past its grace period and shows the unavailable seat instead", () => {
+    bar({
+      live: liveSummary({
+        providers: [liveProvider({ observedAt: "2027-01-15T11:49:00Z" })],
+        errors: [sourceError()],
+      }),
+    })
+    expect(
+      screen.queryByRole("button", { name: /Claude at 42 percent/ }),
+    ).not.toBeInTheDocument()
+    const seat = screen.getByTestId("usage-limits-unavailable")
+    expect(seat).toHaveAccessibleName("Claude, usage unavailable (rate limited)")
+  })
+
+  it("adds a muted grace line under the provider name in the expanded meters", () => {
+    bar({
+      live: liveSummary({
+        providers: [liveProvider({ observedAt: "2027-01-15T11:56:00Z" })],
+        errors: [sourceError()],
+      }),
+      expanded: true,
+    })
+    const group = screen.getByRole("group", { name: "Claude" })
+    const note = within(group).getByText(GRACE_NOTE)
+    expect(note).toHaveClass("text-label-tertiary")
+    expect(note).not.toHaveClass("text-system-orange")
+  })
+
+  it("reads exactly the grace boundary as still shown", () => {
+    // Exactly 10 minutes old — LIVE_USAGE_GRACE_MS itself.
+    bar({
+      live: liveSummary({
+        providers: [liveProvider({ observedAt: "2027-01-15T11:50:00Z" })],
+        errors: [sourceError()],
+      }),
+    })
+    expect(screen.getByRole("button", { name: /Claude at 42 percent/ })).toBeInTheDocument()
+    expect(screen.queryByTestId("usage-limits-unavailable")).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
@@ -10,10 +10,16 @@ import type {
   LiveUsageWindowPayload,
 } from "../../lib/ipc"
 import { EMPTY_LIVE_USAGE } from "../../lib/ipc"
-import type { UnavailableLiveProvider } from "../../lib/presentation/liveUsage"
+import type {
+  LiveProviderStatus,
+  UnavailableLiveProvider,
+} from "../../lib/presentation/liveUsage"
 import {
+  liveDisplayableProviders,
   liveErrorNote,
+  liveGraceNote,
   livePlanLabel,
+  liveProviderStatus,
   liveResetLabel,
   liveUnavailableProviders,
   liveUnavailableReason,
@@ -86,7 +92,7 @@ export function UsageLimitsBar({
   onHoverProvider,
   activeProvider,
 }: UsageLimitsBarProps) {
-  const limited = orderedLiveAccounts(live.providers).filter(
+  const limited = orderedLiveAccounts(liveDisplayableProviders(live)).filter(
     ({ reading }) => liveWindows(reading).length > 0,
   )
   const unavailable = liveUnavailableProviders(live)
@@ -124,6 +130,7 @@ export function UsageLimitsBar({
                 key={key}
                 provider={reading}
                 displayName={accountDisplayName(reading, key, accountNumbers, providerCounts)}
+                status={liveProviderStatus(live, reading)}
                 onOpen={onViewAll}
                 onHover={onHoverProvider}
                 activation={
@@ -168,6 +175,7 @@ export function UsageLimitsBar({
               key={key}
               provider={reading}
               displayName={accountDisplayName(reading, key, accountNumbers, providerCounts)}
+              status={liveProviderStatus(live, reading)}
               now={at}
               action={undefined}
               activation={
@@ -259,6 +267,7 @@ function LimitsDisclosure({
 function ProviderGroup({
   provider,
   displayName,
+  status,
   now,
   action,
   onHover,
@@ -266,6 +275,7 @@ function ProviderGroup({
 }: {
   provider: LiveProviderUsagePayload
   displayName: string
+  status: LiveProviderStatus
   now: number
   /** The disclosure, on the topmost group only. */
   action?: ReactNode
@@ -273,6 +283,10 @@ function ProviderGroup({
   activation: Exclude<AnchoredTriggerActivation, "idle"> | null
 }) {
   const plan = livePlanLabel(provider)
+  const graceNote =
+    status.kind === "grace"
+      ? liveGraceNote(status.category, provider.provider, status.ageMs)
+      : null
   return (
     <div
       role="group"
@@ -295,6 +309,8 @@ function ProviderGroup({
         </h3>
         {action}
       </div>
+      {/* Not orange: a grace-period reading is still fine, not a failure. */}
+      {graceNote && <p className="pb-1.5 type-footnote text-label-tertiary">{graceNote}</p>}
       <div className="space-y-2.5">
         {liveWindows(provider).map((window) => (
           <WindowMeterRow key={window.id} window={window} now={now} resetOnHover />
@@ -312,18 +328,31 @@ function ProviderGroup({
 function ProviderRadial({
   provider,
   displayName,
+  status,
   onOpen,
   onHover,
   activation,
 }: {
   provider: LiveProviderUsagePayload
   displayName: string
+  status: LiveProviderStatus
   onOpen?: (() => void) | undefined
   onHover?: ((provider: string | null, anchor: AnchorRegion | null) => void) | undefined
   activation: Exclude<AnchoredTriggerActivation, "idle"> | null
 }) {
   const percent = maxLiveUsedPercent(provider)
   const figure = percent != null ? `${Math.round(percent)}%` : "no stated figure"
+  const graceNote =
+    status.kind === "grace"
+      ? liveGraceNote(status.category, provider.provider, status.ageMs)
+      : null
+  const title = graceNote
+    ? `${displayName} — ${figure} — ${graceNote}`
+    : `${displayName} — ${figure}`
+  const baseLabel = `${displayName}${
+    percent != null ? ` at ${Math.round(percent)} percent` : ", no stated figure"
+  }`
+  const ariaLabel = graceNote ? `${baseLabel}. ${graceNote}` : baseLabel
   return (
     <button
       type="button"
@@ -333,11 +362,9 @@ function ProviderRadial({
       }
       onMouseLeave={() => onHover?.(null, null)}
       data-state={activation ?? "idle"}
-      title={`${displayName} — ${figure}`}
+      title={title}
       className="flex shrink-0 items-center gap-1.5 rounded-full p-1 transition-colors duration-[var(--duration-fast)] hover:bg-brand-tint/[0.08] data-[state=hovered]:bg-brand-tint/[0.08] data-[state=selected]:bg-surface-selected"
-      aria-label={`${displayName}${
-        percent != null ? ` at ${Math.round(percent)} percent` : ", no stated figure"
-      }`}
+      aria-label={ariaLabel}
     >
       <UsageRing
         percent={percent}
@@ -346,7 +373,13 @@ function ProviderRadial({
         size={RING_SIZE}
         className="block text-label-secondary"
       />
-      <span aria-hidden="true" className="type-footnote leading-none text-label">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "type-footnote leading-none",
+          graceNote ? "text-label-tertiary" : "text-label",
+        )}
+      >
         <SegmentFigure>{percent != null ? `${Math.round(percent)}%` : "—"}</SegmentFigure>
       </span>
     </button>

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -9,10 +9,14 @@ import type {
 } from "../ipc"
 import {
   liveAuthNote,
+  liveDisplayableProviders,
   liveErrorNote,
   liveExtraUsageLabel,
   liveForProvider,
   liveFreshnessToneClass,
+  liveGraceNote,
+  LIVE_USAGE_GRACE_MS,
+  liveProviderStatus,
   liveResetLabel,
   liveSourceNote,
   liveStalenessNote,
@@ -718,6 +722,87 @@ describe("the failure surface", () => {
     )
     expect(liveErrorNote("unavailable", "google")).toBe(
       "Google usage is unavailable. Check your connection, then retry.",
+    )
+  })
+})
+
+describe("the grace period", () => {
+  const GENERATED_AT = "2027-01-15T12:00:00Z"
+
+  it("stands in for a live reading within the grace window", () => {
+    // 4 minutes old.
+    const reading = provider({ observedAt: "2027-01-15T11:56:00Z" })
+    const status = liveProviderStatus(
+      { errors: [sourceError()], generatedAt: GENERATED_AT },
+      reading,
+    )
+    expect(status).toEqual({ kind: "grace", category: "rateLimited", ageMs: 4 * 60_000 })
+  })
+
+  it("drops the reading once it is older than the grace window", () => {
+    // 11 minutes old.
+    const reading = provider({ observedAt: "2027-01-15T11:49:00Z" })
+    const status = liveProviderStatus(
+      { errors: [sourceError()], generatedAt: GENERATED_AT },
+      reading,
+    )
+    expect(status).toEqual({ kind: "failed", category: "rateLimited" })
+  })
+
+  it("reads exactly the grace boundary as still grace", () => {
+    // Exactly 10 minutes old — LIVE_USAGE_GRACE_MS itself.
+    const reading = provider({ observedAt: "2027-01-15T11:50:00Z" })
+    const status = liveProviderStatus(
+      { errors: [sourceError()], generatedAt: GENERATED_AT },
+      reading,
+    )
+    expect(status.kind).toBe("grace")
+    expect(status.kind === "grace" && status.ageMs).toBe(LIVE_USAGE_GRACE_MS)
+  })
+
+  it("is live when the provider has no error", () => {
+    const reading = provider()
+    expect(liveProviderStatus({ errors: [], generatedAt: GENERATED_AT }, reading)).toEqual({
+      kind: "live",
+    })
+  })
+
+  it("keeps a graced reading visible and out of the unavailable list", () => {
+    const reading = provider({ observedAt: "2027-01-15T11:56:00Z" })
+    const graced = summary({
+      providers: [reading],
+      errors: [sourceError()],
+      generatedAt: GENERATED_AT,
+    })
+    expect(liveDisplayableProviders(graced)).toEqual([reading])
+    expect(liveUnavailableProviders(graced)).toEqual([])
+  })
+
+  it("drops a failed reading from the displayable list and lists it as unavailable", () => {
+    const reading = provider({ observedAt: "2027-01-15T11:49:00Z" })
+    const failed = summary({
+      providers: [reading],
+      errors: [sourceError()],
+      generatedAt: GENERATED_AT,
+    })
+    expect(liveDisplayableProviders(failed)).toEqual([])
+    expect(liveUnavailableProviders(failed)).toEqual([
+      { provider: "anthropic", displayName: "Claude", category: "rateLimited" },
+    ])
+  })
+
+  it("phrases the grace note per category, and the age in words", () => {
+    expect(liveGraceNote("rateLimited", "anthropic", 4 * 60_000)).toBe(
+      "Claude rate limited the last check. Showing the reading from 4 min ago.",
+    )
+    expect(liveGraceNote("authentication", "google", 30_000)).toBe(
+      "Google rejected the sign-in on the last check. Showing the reading from under 1 min ago.",
+    )
+    expect(liveGraceNote("schema", "openai", 9 * 60_000)).toBe(
+      "Codex sent an unreadable reply. Showing the reading from 9 min ago.",
+    )
+    expect(liveGraceNote("unavailable", undefined, 60_000)).toBe(
+      "Your provider did not answer the last check. Showing the reading from 1 min ago.",
     )
   })
 })

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -480,7 +480,7 @@ function graceVerb(category: string): string {
     case "schema":
       return "sent an unreadable reply"
     default:
-      return "did not answer the last check"
+      return "didn't answer the last check"
   }
 }
 
@@ -496,7 +496,7 @@ export function liveGraceNote(
   ageMs: number,
 ): string {
   const name = liveProviderDisplayName(provider) ?? "Your provider"
-  return `${name} ${graceVerb(category)}. Showing the reading from ${formatGraceAge(ageMs)} ago.`
+  return `${name} ${graceVerb(category)}; reading from ${formatGraceAge(ageMs)} ago.`
 }
 
 /**

--- a/apps/desktop/src/lib/presentation/liveUsage.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.ts
@@ -23,6 +23,7 @@ import type {
   LiveProviderUsagePayload,
   LiveUsageFreshness,
   LiveUsagePlanPayload,
+  LiveUsageSourceErrorPayload,
   LiveUsageSummaryPayload,
   LiveUsageWindowPayload,
 } from "../ipc"
@@ -41,6 +42,9 @@ import { relativeTime } from "./relativeTime"
 const ANTHROPIC = "anthropic"
 const GOOGLE = "google"
 const OPENAI = "openai"
+
+/** How long a failed source's last good reading still stands in for a live one. */
+export const LIVE_USAGE_GRACE_MS = 10 * 60_000
 
 /** Provider window ids whose product names carry the clearest label. */
 const WINDOW_LABEL_BY_ID: Readonly<Record<string, string>> = {
@@ -415,6 +419,86 @@ export function liveForProvider(
   return summary.providers.find((entry) => entry.provider === provider) ?? null
 }
 
+/** Whether a provider's reading is live, standing in during its grace period, or too old to show. */
+export type LiveProviderStatus =
+  | { kind: "live" }
+  | { kind: "grace"; category: string; ageMs: number }
+  | { kind: "failed"; category: string }
+
+/**
+ * A provider's live status: live, within grace after a failed check, or
+ * failed past the grace.
+ *
+ * Age is measured from `summary.generatedAt`, the snapshot's own moment,
+ * never from `Date.now()` — a render must not read the clock. When either
+ * timestamp cannot be parsed, the age cannot be proven past the grace, so
+ * the reading stays in grace rather than being hidden on a guess.
+ */
+export function liveProviderStatus(
+  summary: { errors: readonly LiveUsageSourceErrorPayload[]; generatedAt: string },
+  provider: LiveProviderUsagePayload,
+): LiveProviderStatus {
+  const error = summary.errors.find((entry) => entry.provider === provider.provider)
+  if (!error) return { kind: "live" }
+  const ageMs = Date.parse(summary.generatedAt) - Date.parse(provider.observedAt)
+  if (Number.isNaN(ageMs) || ageMs <= LIVE_USAGE_GRACE_MS) {
+    return { kind: "grace", category: error.category, ageMs: Number.isNaN(ageMs) ? 0 : ageMs }
+  }
+  return { kind: "failed", category: error.category }
+}
+
+/**
+ * The live providers worth showing on screen: every reading whose status is
+ * not `failed`.
+ *
+ * Every surface that lists live providers reads this instead of
+ * `summary.providers` directly, so a provider past its grace period drops
+ * out of all of them at once and appears only through
+ * `liveUnavailableProviders`.
+ */
+export function liveDisplayableProviders(
+  summary: LiveUsageSummaryPayload,
+): LiveProviderUsagePayload[] {
+  return summary.providers.filter(
+    (provider) => liveProviderStatus(summary, provider).kind !== "failed",
+  )
+}
+
+/** `"4 min"` at a minute and above, `"under 1 min"` below. */
+function formatGraceAge(ageMs: number): string {
+  const minutes = Math.floor(ageMs / 60_000)
+  return minutes < 1 ? "under 1 min" : `${minutes} min`
+}
+
+/** The first sentence of a grace note, per failure category. */
+function graceVerb(category: string): string {
+  switch (category) {
+    case "rateLimited":
+      return "rate limited the last check"
+    case "authentication":
+      return "rejected the sign-in on the last check"
+    case "schema":
+      return "sent an unreadable reply"
+    default:
+      return "did not answer the last check"
+  }
+}
+
+/**
+ * The one sentence a grace-period reading needs: still shown, and why.
+ *
+ * Reuses `liveErrorNote`'s provider naming, so the two notes name a provider
+ * the same way.
+ */
+export function liveGraceNote(
+  category: string,
+  provider: string | undefined,
+  ageMs: number,
+): string {
+  const name = liveProviderDisplayName(provider) ?? "Your provider"
+  return `${name} ${graceVerb(category)}. Showing the reading from ${formatGraceAge(ageMs)} ago.`
+}
+
 /**
  * The banner one failed source deserves, or null.
  *
@@ -433,17 +517,19 @@ export function liveAuthNote(summary: LiveUsageSummaryPayload): string | null {
  * exactly the ones the limits surfaces would otherwise drop without a word.
  *
  * A failed source with a cached last-good reading still appears in
- * `providers`, carrying its stale figures; the staleness treatment covers
- * that case and no entry appears here. This list is for the cold-start
- * failure — first fetch rejected, nothing cached — where the error is the
- * only trace of the provider. An error without a provider id (a snapshot
- * cached before the field existed) cannot name a section and is skipped.
+ * `providers`, carrying its stale figures; while that reading is within its
+ * grace period, the staleness treatment covers it and no entry appears
+ * here. This list covers two cases instead: the cold-start failure — first
+ * fetch rejected, nothing cached — and a reading that has aged past its
+ * grace period, which is treated the same way. An error without a provider
+ * id (a snapshot cached before the field existed) cannot name a section and
+ * is skipped.
  */
 export function liveUnavailableProviders(
   summary: LiveUsageSummaryPayload,
 ): UnavailableLiveProvider[] {
   const showing = new Set(
-    summary.providers
+    liveDisplayableProviders(summary)
       .filter((provider) => liveWindows(provider).length > 0)
       .map((provider) => provider.provider),
   )
@@ -475,16 +561,20 @@ export function liveUnavailableReason(category: string): string {
   }
 }
 
+/** The provider's product name, or null when the id is not one this app names. */
+function liveProviderDisplayName(provider?: string): string | null {
+  return provider === GOOGLE
+    ? "Google"
+    : provider === ANTHROPIC
+      ? "Claude"
+      : provider === OPENAI
+        ? "Codex"
+        : null
+}
+
 /** One action for a failed source, with the provider name when it is known. */
 export function liveErrorNote(category: string, provider?: string): string {
-  const providerName =
-    provider === GOOGLE
-      ? "Google"
-      : provider === ANTHROPIC
-        ? "Claude"
-        : provider === OPENAI
-          ? "Codex"
-          : null
+  const providerName = liveProviderDisplayName(provider)
   switch (category) {
     case "authentication":
       return providerName

--- a/apps/desktop/src/lib/usageBars.ts
+++ b/apps/desktop/src/lib/usageBars.ts
@@ -1,5 +1,9 @@
 import type { LiveUsageSummaryPayload } from "./ipc"
-import { liveWindowLabel, liveWindows } from "./presentation/liveUsage"
+import {
+  liveDisplayableProviders,
+  liveWindowLabel,
+  liveWindows,
+} from "./presentation/liveUsage"
 
 export type UsageBarItem = {
   key: string
@@ -45,7 +49,7 @@ export function noMeterSelected(response: LiveUsageSummaryPayload | null): boole
 
 /** Convert a live usage snapshot into the HUD bar order. */
 export function deriveUsageBars(response: LiveUsageSummaryPayload | null): UsageBarItem[] {
-  const withBars = (response?.providers ?? [])
+  const withBars = (response ? liveDisplayableProviders(response) : [])
     .map((provider) => ({
       provider,
       windows: liveWindows(provider).filter((window) => window.usedPercent != null),

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -1113,6 +1113,95 @@ describe("UsageView — plan limits layered over local estimates", () => {
   })
 })
 
+describe("UsageView — the grace period", () => {
+  function withGracedReading(observedAt: string) {
+    return live({
+      providers: [{ ...liveProvider(), observedAt }],
+      errors: [
+        {
+          source: "claude-usage-fetch",
+          provider: "anthropic",
+          displayName: "Claude",
+          category: "rateLimited",
+        },
+      ],
+    })
+  }
+
+  it("shows the reading and a grace note instead of the orange failure note", () => {
+    // 4 minutes before `live()`'s generatedAt of 12:00:00Z.
+    render(
+      <UsageView
+        summary={summary()}
+        live={withGracedReading("2027-01-15T11:56:00Z")}
+        now={NOW}
+        onBack={vi.fn()}
+      />,
+    )
+
+    const card = screen.getByText("Anthropic").closest("li")!
+    expect(
+      within(card).getByRole("region", { name: "Anthropic plan limits" }),
+    ).toBeInTheDocument()
+    expect(
+      within(card).getByText(
+        "Claude rate limited the last check. Showing the reading from 4 min ago.",
+      ),
+    ).toBeInTheDocument()
+    expect(within(card).queryByRole("status")).not.toBeInTheDocument()
+  })
+
+  it("hides a reading past its grace period and keeps the orange failure note", () => {
+    // 11 minutes before `live()`'s generatedAt of 12:00:00Z.
+    render(
+      <UsageView
+        summary={summary()}
+        live={withGracedReading("2027-01-15T11:49:00Z")}
+        now={NOW}
+        onBack={vi.fn()}
+      />,
+    )
+
+    const card = screen.getByText("Anthropic").closest("li")!
+    expect(
+      within(card).queryByRole("region", { name: "Anthropic plan limits" }),
+    ).not.toBeInTheDocument()
+    expect(within(card).getByRole("status")).toHaveTextContent(
+      "Claude rate limited usage checks. Wait, then retry.",
+    )
+  })
+
+  it("reads exactly the grace boundary as still shown", () => {
+    // Exactly 10 minutes before `live()`'s generatedAt — LIVE_USAGE_GRACE_MS
+    // itself.
+    render(
+      <UsageView
+        summary={summary()}
+        live={withGracedReading("2027-01-15T11:50:00Z")}
+        now={NOW}
+        onBack={vi.fn()}
+      />,
+    )
+
+    const card = screen.getByText("Anthropic").closest("li")!
+    expect(
+      within(card).getByRole("region", { name: "Anthropic plan limits" }),
+    ).toBeInTheDocument()
+    expect(within(card).queryByRole("status")).not.toBeInTheDocument()
+  })
+
+  it("changes nothing about a live reading with no error", () => {
+    render(<UsageView summary={summary()} live={live()} now={NOW} onBack={vi.fn()} />)
+
+    const card = screen.getByText("Anthropic").closest("li")!
+    expect(
+      within(card).getByRole("region", { name: "Anthropic plan limits" }),
+    ).toBeInTheDocument()
+    expect(within(card).queryByRole("status")).not.toBeInTheDocument()
+    expect(within(card).queryByText(/rate limited/)).not.toBeInTheDocument()
+  })
+})
+
 describe("UsageView — what history says about a limit", () => {
   const withForecast = (overrides: Partial<LiveUsageForecastPayload>) =>
     live({

--- a/apps/desktop/src/views/popover/UsageView.tsx
+++ b/apps/desktop/src/views/popover/UsageView.tsx
@@ -25,7 +25,9 @@ import { isMacOS } from "../../lib/platform"
 import {
   liveAuthNote,
   liveErrorNote,
+  liveGraceNote,
   livePlanLabel,
+  liveProviderStatus,
   liveWindows,
   orderedLiveAccounts,
 } from "../../lib/presentation/liveUsage"
@@ -331,8 +333,20 @@ export function UsageView({
           </p>
         ) : (
           <>
-            <UsageSection title="Recently used" cards={recent} now={at} showTitle={!embedded} />
-            <UsageSection title="All detected" cards={rest} now={at} showTitle={!embedded} />
+            <UsageSection
+              title="Recently used"
+              cards={recent}
+              now={at}
+              generatedAt={live.generatedAt}
+              showTitle={!embedded}
+            />
+            <UsageSection
+              title="All detected"
+              cards={rest}
+              now={at}
+              generatedAt={live.generatedAt}
+              showTitle={!embedded}
+            />
           </>
         )}
       </ScrollPane>
@@ -369,11 +383,14 @@ function UsageSection({
   title,
   cards,
   now,
+  generatedAt,
   showTitle,
 }: {
   title: string
   cards: readonly UsageCardEntry[]
   now: number
+  /** The snapshot's own moment, for measuring a grace-period reading's age. */
+  generatedAt: string
   showTitle: boolean
 }) {
   if (cards.length === 0) return null
@@ -386,7 +403,7 @@ function UsageSection({
       )}
       <ul className="space-y-2">
         {cards.map(({ key, ...card }) => (
-          <ProviderCard key={key} {...card} now={now} />
+          <ProviderCard key={key} {...card} now={now} generatedAt={generatedAt} />
         ))}
       </ul>
     </section>
@@ -398,13 +415,22 @@ function ProviderCard({
   live,
   errors,
   now,
+  generatedAt,
 }: {
   local: readonly ProviderUsagePayload[]
   live: readonly LiveProviderUsagePayload[]
   errors: readonly LiveUsageSourceErrorPayload[]
   now: number
+  /** The snapshot's own moment, for measuring a grace-period reading's age. */
+  generatedAt: string
 }) {
-  const accounts = orderedLiveAccounts(live)
+  // A reading whose status is `failed` is dropped here, the same as the
+  // cold-start case where no reading arrived at all: its matching local
+  // usage, if any, falls through to `unmatchedLocal` below, and its error
+  // keeps the orange note rather than the grace note.
+  const accounts = orderedLiveAccounts(live).filter(
+    ({ reading }) => liveProviderStatus({ errors, generatedAt }, reading).kind !== "failed",
+  )
   const shownLocal = simplifiedLocalUsage(
     local,
     accounts.map(({ reading }) => reading),
@@ -525,6 +551,11 @@ function ProviderCard({
                   : "Unassigned account"
                 : undefined
             const primaryWindow = liveWindows(reading)[0]
+            const status = liveProviderStatus({ errors, generatedAt }, reading)
+            const graceNote =
+              status.kind === "grace"
+                ? liveGraceNote(status.category, reading.provider, status.ageMs)
+                : null
             return (
               <div key={key} className="space-y-1.5">
                 <LiveUsageDetail
@@ -534,6 +565,7 @@ function ProviderCard({
                   showRunway={!matchingLocal}
                   {...(accountLabel ? { accountLabel } : {})}
                 />
+                {graceNote && <p className="type-caption text-label-tertiary">{graceNote}</p>}
                 {matchingLocal && (
                   <LocalUsageDetail
                     provider={matchingLocal}
@@ -545,15 +577,28 @@ function ProviderCard({
             )
           })}
 
-          {errors.map((error, index) => (
-            <p
-              key={`${error.source}:${index}`}
-              role="status"
-              className="rounded-control bg-system-orange/10 px-2 py-1.5 type-caption text-system-orange"
-            >
-              {liveErrorNote(error.category, error.provider)}
-            </p>
-          ))}
+          {/* A provider in grace already carries its explanation as the note
+              above, directly under its reading — not as a second, orange one
+              here. A failed or reading-less provider's error keeps this
+              note, which is the only trace of the failure it has. */}
+          {errors
+            .filter(
+              (error) =>
+                !accounts.some(
+                  ({ reading }) =>
+                    reading.provider === error.provider &&
+                    liveProviderStatus({ errors, generatedAt }, reading).kind === "grace",
+                ),
+            )
+            .map((error, index) => (
+              <p
+                key={`${error.source}:${index}`}
+                role="status"
+                className="rounded-control bg-system-orange/10 px-2 py-1.5 type-caption text-system-orange"
+              >
+                {liveErrorNote(error.category, error.provider)}
+              </p>
+            ))}
 
           {unmatchedLocal.map((entry) => {
             const key = entry.accountKey

--- a/apps/desktop/src/views/settings/UsagePane.test.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.test.tsx
@@ -246,6 +246,78 @@ describe("UsagePane", () => {
   })
 })
 
+describe("UsagePane — the grace period", () => {
+  const GENERATED_AT = "2027-01-15T12:00:00Z"
+
+  function withGracedReading(observedAt: string) {
+    return summary({
+      generatedAt: GENERATED_AT,
+      providers: [
+        {
+          provider: "anthropic",
+          accountKey: null,
+          displayName: "Anthropic",
+          support: "live",
+          freshness: "fresh",
+          sourceLabel: "Asked Claude directly",
+          observedAt,
+          windows: [],
+          extraUsage: null,
+          resetCredits: null,
+          plan: null,
+        },
+      ],
+      errors: [
+        {
+          source: "claude-usage-fetch",
+          provider: "anthropic",
+          displayName: "Claude",
+          category: "rateLimited",
+        },
+      ],
+    })
+  }
+
+  beforeEach(() => {
+    getLiveUsage.mockReset()
+    refreshLiveUsage.mockReset()
+    refreshLiveUsage.mockResolvedValue(summary())
+  })
+
+  it("replaces the failure note with a grace note while the reading is within its window", async () => {
+    // 4 minutes before `GENERATED_AT`.
+    getLiveUsage.mockResolvedValue(withGracedReading("2027-01-15T11:56:00Z"))
+    pane()
+    await waitFor(() => expect(screen.getByText("Anthropic")).toBeInTheDocument())
+    expect(
+      screen.getByText(
+        "Asked Claude directly. 0 limits reported. Claude rate limited the last check. Showing the reading from 4 min ago.",
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Wait, then retry/)).not.toBeInTheDocument()
+  })
+
+  it("drops the reading and falls back to the plain failure note once past the grace", async () => {
+    // 11 minutes before `GENERATED_AT`.
+    getLiveUsage.mockResolvedValue(withGracedReading("2027-01-15T11:49:00Z"))
+    pane()
+    await waitFor(() => expect(screen.getByText("Anthropic")).toBeInTheDocument())
+    expect(
+      screen.getByText(/rate limited usage checks\. Wait, then retry\./),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Asked Claude directly/)).not.toBeInTheDocument()
+  })
+
+  it("reads exactly the grace boundary as still shown", async () => {
+    // Exactly 10 minutes before `GENERATED_AT` — LIVE_USAGE_GRACE_MS itself.
+    getLiveUsage.mockResolvedValue(withGracedReading("2027-01-15T11:50:00Z"))
+    pane()
+    await waitFor(() => expect(screen.getByText("Anthropic")).toBeInTheDocument())
+    expect(screen.getByText(/Asked Claude directly/)).toBeInTheDocument()
+    expect(screen.queryByText(/Wait, then retry/)).not.toBeInTheDocument()
+  })
+})
+
 describe("UsagePane — floating HUD", () => {
   beforeEach(() => {
     getLiveUsage.mockReset()

--- a/apps/desktop/src/views/settings/UsagePane.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.tsx
@@ -17,7 +17,13 @@ import {
 } from "../../lib/ipc"
 import { HudVisibilitySession } from "../../lib/overlayWindow"
 import { isMacOS } from "../../lib/platform"
-import { liveErrorNote, liveSourceNote } from "../../lib/presentation/liveUsage"
+import {
+  liveDisplayableProviders,
+  liveErrorNote,
+  liveGraceNote,
+  liveProviderStatus,
+  liveSourceNote,
+} from "../../lib/presentation/liveUsage"
 import type { AppSettingsController } from "./useAppSettings"
 
 /**
@@ -128,7 +134,7 @@ export function UsagePane({ settings, update }: UsagePaneProps) {
       <SectionGroup title="Show Meter">
         <Card>
           {meters.map((meter) => {
-            const reading = live.providers.find(
+            const reading = liveDisplayableProviders(live).find(
               (provider) => provider.provider === meter.provider,
             )
             const failure = live.errors.find((error) => error.provider === meter.provider)
@@ -143,6 +149,7 @@ export function UsagePane({ settings, update }: UsagePaneProps) {
                   reading,
                   failure,
                   name: meter.displayName,
+                  generatedAt: live.generatedAt,
                 })}
                 dimmed={!on}
                 trailing={
@@ -215,12 +222,15 @@ function meterNote({
   reading,
   failure,
   name,
+  generatedAt,
 }: {
   shown: boolean
   on: boolean
   reading: LiveUsageSummaryPayload["providers"][number] | undefined
   failure: LiveUsageSummaryPayload["errors"][number] | undefined
   name: string
+  /** The snapshot's own moment, for measuring a grace-period reading's age. */
+  generatedAt: string
 }): string {
   if (!shown) {
     return `antiburn does not ask ${name} for usage, and ${name} milestone notifications do not fire.`
@@ -237,7 +247,18 @@ function meterNote({
       } reported.`,
     )
   }
-  if (failure) parts.push(liveErrorNote(failure.category))
+  if (failure) {
+    // `reading` here has already dropped a `failed` status — see
+    // `liveDisplayableProviders` above — so only `grace` is left to detect.
+    const status = reading
+      ? liveProviderStatus({ errors: [failure], generatedAt }, reading)
+      : null
+    parts.push(
+      status?.kind === "grace"
+        ? liveGraceNote(status.category, failure.provider, status.ageMs)
+        : liveErrorNote(failure.category),
+    )
+  }
   if (parts.length > 0) return parts.join(" ")
   if (!on) return "Turn the switch above back on to ask for current plan limits."
   return `No readings yet. Sign in with ${name} and this fills in.`

--- a/docs/plans/live-usage-degraded-state.md
+++ b/docs/plans/live-usage-degraded-state.md
@@ -76,3 +76,33 @@ change, which targets only what is on `main`.
 - `UsageLimitsSection.test.tsx`: the section keeps a subsection for a
   provider whose source failed with nothing cached, and still renders nothing
   when there are no providers and no errors.
+
+## Grace period
+
+A provider whose source failed keeps showing its last good reading for a
+grace period. The grace period is `LIVE_USAGE_GRACE_MS`, ten minutes. The app
+measures the reading's age as `generatedAt - observedAt`. It never reads the
+wall clock.
+
+Every surface shows a muted grace note next to the reading. The note names
+the failure and says how old the reading is.
+
+Past the grace period, the app treats the provider as the cold-start
+unavailable case above. The reading no longer shows.
+
+Three helpers in `lib/presentation/liveUsage.ts` carry this rule:
+
+- `liveProviderStatus(summary, provider)`: reports `live`, `grace`, or
+  `failed` for one provider.
+- `liveDisplayableProviders(summary)`: the providers to show. It drops every
+  `failed` provider.
+- `liveGraceNote(category, provider, ageMs)`: the note text.
+
+### Rust: a Keychain read must not look like a sign-out
+
+On macOS, `security find-generic-password` can time out or fail to spawn.
+That case must not clear a good reading the way a real sign-out does.
+`ClaudeDirectFetch` now tells the Keychain's `Absent` (item not found) apart
+from `Unreadable` (a timeout or another failure). Only `Absent` falls back
+to the credentials file. `Unreadable` is a real failure, so `Cooldown` keeps
+the last good snapshot.


### PR DESCRIPTION
## Why

Anthropic's `/api/oauth/usage` endpoint intermittently returns HTTP 429. Today's history shows 13 rate-limit outages while the popover was open; 12 of them cleared within 8 minutes. Each one flipped the Claude seat on the usage limits bar to an error, even though the backend's cooldown still held a reading only a few minutes old. Nothing was logged, so the incident could not be confirmed from the app's logs either.

## What

- **Ten-minute grace period.** A provider whose source failed keeps showing its last good reading while that reading is at most 10 minutes old (`generatedAt - observedAt`, never the wall clock). Past that, the provider becomes the existing cold-start "unavailable" seat and its reading is no longer shown.
- **The grace is visible.** A muted (`text-label-tertiary`, not orange) note on every surface: the limits bar (collapsed figure dims and the title/aria label carry the note; expanded group gets a footnote line), the Usage view (replaces the orange note while in grace), the settings Usage pane, and the HUD bars filter the same way.
- **Log source failures.** `collect` now emits a `live_source_failed` warn event with source, provider, and category.
- **Keychain timeout must not erase the cached reading.** `security find-generic-password` timing out or failing to spawn was indistinguishable from "item not found", so a transient Keychain hiccup mapped to `Ok(None)` and cleared the cooldown's last good snapshot, turning the next 429 into a cold-start blank. The Keychain carrier now reports `Absent` (exit 44) separately from `Unreadable`, and `Unreadable` is a real `Unavailable` error that keeps the snapshot.
- Plan doc `docs/plans/live-usage-degraded-state.md` records the rule.

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` (825 passed)
- `pnpm --filter @antiburn/desktop lint`, `type-check`, `test` (1080 passed), `prettier --check src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DSC2RrF6HjTQ1cWvfWfgn
