### PR TITLE
feat(desktop): remember the Skills & MCPs expanded choice

### DIFF
--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -2402,6 +2402,10 @@ fn read_settings(connection: &Connection) -> Result<AppSettings> {
             .get("overviewLimitsExpanded")
             .map(|value| value == "true")
             .unwrap_or(defaults.overview_limits_expanded),
+        skills_mcp_expanded: stored
+            .get("skillsMcpExpanded")
+            .map(|value| value == "true")
+            .unwrap_or(defaults.skills_mcp_expanded),
         session_badge_metric: stored
             .get("sessionBadgeMetric")
             .and_then(|value| SessionBadgeMetric::parse(value))
@@ -2499,6 +2503,10 @@ fn write_settings(connection: &Connection, settings: &AppSettings) -> Result<()>
     put.execute(params![
         "overviewLimitsExpanded",
         bool_text(settings.overview_limits_expanded)
+    ])?;
+    put.execute(params![
+        "skillsMcpExpanded",
+        bool_text(settings.skills_mcp_expanded)
     ])?;
     put.execute(params![
         "sessionBadgeMetric",

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -783,6 +783,13 @@ pub struct AppSettings {
     /// display preference — it never gates a fetch — so it defaults open and
     /// stays wherever the reader last left it.
     pub overview_limits_expanded: bool,
+    /// Whether a session's Skills & MCPs table shows every row, rather than
+    /// only the first group behind a "Show more" button. One answer for the
+    /// whole app: it applies to every session, it survives a restart, and it
+    /// carries across an upgrade. Purely a display preference — it never
+    /// changes what antiburn reads or analyzes — so it defaults closed and
+    /// stays wherever the reader last left it.
+    pub skills_mcp_expanded: bool,
     /// The metric shown in each activity-session badge.
     pub session_badge_metric: SessionBadgeMetric,
 }
@@ -834,6 +841,10 @@ impl Default for AppSettings {
             // Open by default: a reader who has live limits at all should see
             // them without an extra click the first time they notice this.
             overview_limits_expanded: true,
+            // Closed by default, unlike the limits section above. The table is
+            // a long tail behind a summary. Opening it for every session
+            // pushes the rest of the analysis off the screen.
+            skills_mcp_expanded: false,
             session_badge_metric: SessionBadgeMetric::default(),
         }
     }

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -490,6 +490,9 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     // Open by default, same reasoning: a reader who has limits to see should
     // see them without an extra click the first time they notice the section.
     assert!(defaults.overview_limits_expanded);
+    // Closed by default, unlike the limits section: the skills table is a long
+    // tail behind a summary, and opening it every time buries the rest.
+    assert!(!defaults.skills_mcp_expanded);
     assert_eq!(
         defaults.session_data_retention_days,
         RETAIN_SESSION_DATA_FOREVER
@@ -530,6 +533,7 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
             disabled_agents: DisabledAgents::parse("windsurf,kiro"),
             analytics_enabled: false,
             overview_limits_expanded: false,
+            skills_mcp_expanded: true,
             session_badge_metric: SessionBadgeMetric::WeeklyPercent,
         })
         .unwrap();
@@ -552,6 +556,9 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     // The disabled-agent set survives normalized to sorted slugs.
     assert_eq!(saved.disabled_agents.as_str(), "kiro,windsurf");
     assert!(!saved.overview_limits_expanded);
+    // The two display preferences keep separate answers: this reader closed
+    // the limits section and opened the skills table.
+    assert!(saved.skills_mcp_expanded);
     assert!(saved.onboarding_completed);
     assert!(saved.discovery_paused);
     // Each notification preference is stored on its own key, so a reader who

--- a/apps/desktop/src/components/session/analysis/SkillsMcpChart.test.tsx
+++ b/apps/desktop/src/components/session/analysis/SkillsMcpChart.test.tsx
@@ -1,13 +1,24 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
+import { DEFAULT_SETTINGS, type AppSettings } from "../../../lib/ipc"
 import type { InitialContextBreakdown } from "../../../lib/types/session"
 import { SKILLS_MCP_COLLAPSED_ROWS, SkillsMcpChart } from "./SkillsMcpChart"
 import { skillsMcpExpandedStore } from "./useSkillsMcpExpanded"
 
+// The expanded flag is a stored preference now. These cases are about what the
+// chart draws, so the settings channel is stubbed to a store that always
+// agrees with the default.
+vi.mock("../../../lib/ipc", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getSettings: () => Promise.resolve({ ...DEFAULT_SETTINGS }),
+  setSettings: (settings: AppSettings) => Promise.resolve(settings),
+  onSettingsChanged: () => Promise.resolve(() => {}),
+}))
+
 afterEach(() => {
   cleanup()
-  skillsMcpExpandedStore.set(false)
+  skillsMcpExpandedStore.set(DEFAULT_SETTINGS.skillsMcpExpanded)
 })
 
 function breakdown(sources: InitialContextBreakdown["sources"]): InitialContextBreakdown {

--- a/apps/desktop/src/components/session/analysis/useSkillsMcpExpanded.test.ts
+++ b/apps/desktop/src/components/session/analysis/useSkillsMcpExpanded.test.ts
@@ -1,33 +1,138 @@
-import { act, cleanup, renderHook } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { DEFAULT_SETTINGS, SETTINGS_CHANGED_EVENT, type AppSettings } from "../../../lib/ipc"
 import { skillsMcpExpandedStore, useSkillsMcpExpanded } from "./useSkillsMcpExpanded"
+
+/**
+ * A stand-in for the shell's settings store: it keeps what was written and
+ * hands it back, so a test can close the chart and reopen it the way a reader
+ * does across a launch.
+ */
+let saved: AppSettings
+/** Event handlers the fake `listen` was given, one per live subscriber. */
+const listeners = new Map<string, (event: { payload: unknown }) => void>()
+
+const invoke = vi.hoisted(() => vi.fn())
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }))
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (name: string, handler: (event: { payload: unknown }) => void) => {
+    listeners.set(name, handler)
+    return () => listeners.delete(name)
+  }),
+}))
+
+/** Push a settings broadcast at whatever subscribed to it. */
+function broadcast(settings: AppSettings): void {
+  act(() => listeners.get(SETTINGS_CHANGED_EVENT)?.({ payload: settings }))
+}
+
+beforeEach(() => {
+  saved = { ...DEFAULT_SETTINGS }
+  listeners.clear()
+  invoke.mockImplementation((command: string, args?: { settings?: AppSettings }) => {
+    if (command === "get_settings") return Promise.resolve({ ...saved })
+    if (command === "set_settings") {
+      saved = { ...(args?.settings as AppSettings) }
+      return Promise.resolve({ ...saved })
+    }
+    return Promise.reject(new Error(`unexpected command ${command}`))
+  })
+})
 
 afterEach(() => {
   cleanup()
-  skillsMcpExpandedStore.set(false)
+  skillsMcpExpandedStore.set(DEFAULT_SETTINGS.skillsMcpExpanded)
+  vi.clearAllMocks()
 })
 
 describe("useSkillsMcpExpanded", () => {
-  it("starts collapsed", () => {
+  it("starts collapsed for a reader who has never chosen", async () => {
     const { result } = renderHook(() => useSkillsMcpExpanded())
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_settings"))
+
     expect(result.current[0]).toBe(false)
   })
 
-  it("keeps the flag set after the setting component unmounts", () => {
+  it("opens the table for a reader whose stored answer is expanded", async () => {
+    saved = { ...DEFAULT_SETTINGS, skillsMcpExpanded: true }
+
+    const { result } = renderHook(() => useSkillsMcpExpanded())
+
+    await waitFor(() => expect(result.current[0]).toBe(true))
+  })
+
+  it("writes the reader's choice through to the store", async () => {
+    const { result } = renderHook(() => useSkillsMcpExpanded())
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_settings"))
+
+    act(() => {
+      result.current[1](true)
+    })
+
+    // Optimistic: the button does not wait for the write to land.
+    expect(result.current[0]).toBe(true)
+    await waitFor(() => expect(saved.skillsMcpExpanded).toBe(true))
+  })
+
+  it("puts the previous answer back when the write fails", async () => {
+    const { result } = renderHook(() => useSkillsMcpExpanded())
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_settings"))
+    invoke.mockImplementation(() => Promise.reject(new Error("store is unavailable")))
+
+    act(() => {
+      result.current[1](true)
+    })
+
+    expect(result.current[0]).toBe(true)
+    await waitFor(() => expect(result.current[0]).toBe(false))
+  })
+
+  it("leaves every other preference alone when it writes", async () => {
+    saved = { ...DEFAULT_SETTINGS, theme: "dark", activityWindowDays: 14 }
+    const { result } = renderHook(() => useSkillsMcpExpanded())
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_settings"))
+
+    act(() => {
+      result.current[1](true)
+    })
+    await waitFor(() => expect(saved.skillsMcpExpanded).toBe(true))
+
+    expect(saved.theme).toBe("dark")
+    expect(saved.activityWindowDays).toBe(14)
+  })
+
+  it("comes back expanded after every reader of it has gone away", async () => {
     const first = renderHook(() => useSkillsMcpExpanded())
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_settings"))
     act(() => {
       first.result.current[1](true)
     })
+    await waitFor(() => expect(saved.skillsMcpExpanded).toBe(true))
     first.unmount()
 
+    // The store tore itself down with the last listener, so this remount takes
+    // the same cold path a fresh app launch does.
+    skillsMcpExpandedStore.set(DEFAULT_SETTINGS.skillsMcpExpanded)
     const second = renderHook(() => useSkillsMcpExpanded())
-    expect(second.result.current[0]).toBe(true)
+
+    await waitFor(() => expect(second.result.current[0]).toBe(true))
   })
 
-  it("shares the flag between components mounted at the same time", () => {
+  it("follows a change made in another window", async () => {
+    const { result } = renderHook(() => useSkillsMcpExpanded())
+    await waitFor(() => expect(listeners.has(SETTINGS_CHANGED_EVENT)).toBe(true))
+
+    broadcast({ ...DEFAULT_SETTINGS, skillsMcpExpanded: true })
+
+    expect(result.current[0]).toBe(true)
+  })
+
+  it("shares the flag between components mounted at the same time", async () => {
     const a = renderHook(() => useSkillsMcpExpanded())
     const b = renderHook(() => useSkillsMcpExpanded())
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_settings"))
 
     act(() => {
       a.result.current[1](true)

--- a/apps/desktop/src/components/session/analysis/useSkillsMcpExpanded.ts
+++ b/apps/desktop/src/components/session/analysis/useSkillsMcpExpanded.ts
@@ -1,21 +1,72 @@
 import { useSyncExternalStore } from "react"
 
 import { createExternalStore } from "../../../lib/externalStore"
+import { DEFAULT_SETTINGS, getSettings, onSettingsChanged, setSettings } from "../../../lib/ipc"
+
+// Only the newest optimistic write or shell event can replace the visible
+// value. An older write that lands late has nothing left to say.
+let revision = 0
 
 /**
  * Whether the Skills & MCPs chart shows every row or only the first group.
  *
- * This is a module-level store, not component state. The reader's choice
- * stays for the life of the app process. It does not reset when the reader
- * closes one session and opens another. It resets only when the app
- * restarts.
+ * The reader's answer is one stored preference, not component state and not a
+ * process-lifetime flag: it applies to every session, it survives a quit, and
+ * it carries across an upgrade, because it lives in the same `setting` table
+ * as every other preference. Two controls write it — the chart's own button
+ * and the Appearance pane's switch — and nothing else changes it.
+ *
+ * The store reads the stored answer once and then follows the shell's
+ * `settings:changed` broadcast, so the chart and the settings window agree
+ * without either one knowing about the other.
  */
-export const skillsMcpExpandedStore = createExternalStore<boolean>({ initial: false })
+export const skillsMcpExpandedStore = createExternalStore<boolean>({
+  initial: DEFAULT_SETTINGS.skillsMcpExpanded,
+  load: async () => (await getSettings()).skillsMcpExpanded,
+  subscribe: (set) =>
+    onSettingsChanged((settings) => {
+      revision += 1
+      set(settings.skillsMcpExpanded)
+    }),
+})
+
+/**
+ * Write the reader's choice through to the store.
+ *
+ * Reads the rest of the preferences first so this write carries them
+ * unchanged. A write that fails puts the previous value back, so the button
+ * never keeps claiming a choice the store did not take.
+ */
+async function storeExpanded(
+  expanded: boolean,
+  previous: boolean,
+  written: number,
+): Promise<void> {
+  try {
+    const current = await getSettings()
+    const saved = await setSettings({ ...current, skillsMcpExpanded: expanded })
+    if (written !== revision) return
+    skillsMcpExpandedStore.set(saved.skillsMcpExpanded)
+  } catch {
+    if (written !== revision) return
+    skillsMcpExpandedStore.set(previous)
+  }
+}
+
+function setExpanded(expanded: boolean): void {
+  // Optimistic, the same way the settings panes write: the button must not lag
+  // behind the pointer, and the stored answer replaces this one a moment later.
+  const previous = skillsMcpExpandedStore.getSnapshot()
+  if (previous === expanded) return
+  const written = ++revision
+  skillsMcpExpandedStore.set(expanded)
+  void storeExpanded(expanded, previous, written)
+}
 
 export function useSkillsMcpExpanded(): [boolean, (expanded: boolean) => void] {
   const expanded = useSyncExternalStore(
     skillsMcpExpandedStore.subscribe,
     skillsMcpExpandedStore.getSnapshot,
   )
-  return [expanded, skillsMcpExpandedStore.set]
+  return [expanded, setExpanded]
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -143,6 +143,13 @@ export interface AppSettings {
    * where the reader last left it.
    */
   overviewLimitsExpanded: boolean
+  /**
+   * Whether a session's Skills & MCPs table shows every row, rather than only
+   * the first group behind a "Show more" button. One answer for the whole
+   * app, across every session and every launch. It defaults closed and stays
+   * where the reader last left it.
+   */
+  skillsMcpExpanded: boolean
   /** The metric shown in each activity-session badge. */
   sessionBadgeMetric: "cost" | "weeklyPercent" | "fiveHourPercent"
 }
@@ -478,6 +485,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   disabledAgents: [],
   analyticsEnabled: true,
   overviewLimitsExpanded: true,
+  skillsMcpExpanded: false,
   sessionBadgeMetric: "cost",
 }
 

--- a/apps/desktop/src/views/settings/AppearancePane.tsx
+++ b/apps/desktop/src/views/settings/AppearancePane.tsx
@@ -3,6 +3,7 @@ import { Pane } from "../../components/ui/Pane"
 import { Row } from "../../components/ui/Row"
 import { SectionGroup } from "../../components/ui/SectionGroup"
 import { SegmentedControl } from "../../components/ui/SegmentedControl"
+import { ToggleRow } from "../../components/ui/ToggleRow"
 import type { ThemePreference } from "../../lib/ipc"
 import type { AppSettingsController } from "./useAppSettings"
 
@@ -13,11 +14,15 @@ const THEMES: ReadonlyArray<{ value: ThemePreference; label: string }> = [
 ]
 
 /**
- * Appearance: the one theme choice.
+ * Appearance: the theme choice, and what a session's analysis opens with.
  *
  * "System" is the absence of an override, not a third palette — the token layer
  * already follows the OS when no `data-theme` is set, so choosing it removes
  * the attribute rather than writing a value.
+ *
+ * The Skills & MCPs switch writes the same preference the chart's own button
+ * writes. It is here as well because that button sits at the foot of a long
+ * table, and a reader who wants to always see everything looks in settings.
  */
 export function AppearancePane({ settings, update }: AppSettingsController) {
   return (
@@ -35,6 +40,17 @@ export function AppearancePane({ settings, update }: AppSettingsController) {
                 onChange={(theme) => void update({ theme })}
               />
             }
+          />
+        </Card>
+      </SectionGroup>
+
+      <SectionGroup title="Session analysis">
+        <Card>
+          <ToggleRow
+            label="Show every skill and MCP"
+            description="A session's Skills & MCPs table lists the largest few and hides the rest behind a button. Turn this on to see the whole table every time. That button writes this setting too, so it stays wherever you last left it."
+            checked={settings.skillsMcpExpanded}
+            onChange={(skillsMcpExpanded) => void update({ skillsMcpExpanded })}
           />
         </Card>
       </SectionGroup>


### PR DESCRIPTION
## What

The Skills & MCPs table in a session's analysis collapses to the first 8 rows behind a **Show N more** button. That choice lived in a module-level store, so quitting antiburn threw it away — the old doc comment said so outright: *"It resets only when the app restarts."*

It is now a stored preference. One answer for the whole app: every session sees it, it survives a quit, and it carries across an upgrade and a reinstall, because the `setting` table lives under the app's own data directory (`~/Library/Application Support/<bundle id>` on macOS, which a drag-to-Trash uninstall does not touch).

The same preference also gets a switch in **Settings → Appearance → Session analysis**. The chart's own button sits at the foot of a long table, and a reader who wants to always see everything looks in settings. Both controls write the same row, so they never disagree.

<!-- SCREENSHOT: Settings → Appearance, showing the new "Show every skill and MCP" row -->

## How

Modelled on `overviewLimitsExpanded`, the display preference this one most resembles:

- `skills_mcp_expanded` on Rust `AppSettings`, read and written as the `skillsMcpExpanded` key. No migration — `setting` is key/value, and an absent row falls back to the default.
- `skillsMcpExpanded` on the TypeScript `AppSettings` and `DEFAULT_SETTINGS`.
- `skillsMcpExpandedStore` now loads from `getSettings()` and follows the shell's `settings:changed` broadcast, so the chart and the settings window stay in step without either knowing about the other.
- Writes are optimistic with a revision guard and rollback, matching what `useAppSettings` does — the button never lags the pointer, and a failed write puts the previous answer back.

Default stays **closed**. The table is a long tail behind a summary; opening it for every session would push the rest of the analysis off screen. This change is about honouring a choice, not changing the starting point.

## Not in scope

`subagentsExpandedStore` is the same shape and still in-memory only, but its doc comment says that is deliberate ("The choice does not need to survive a restart"). Left alone.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 823 passed
- `pnpm type-check`, `pnpm lint`, `pnpm format`, `pnpm knip`, `pnpm test` — 1067 passed
- `pnpm run slop:all` — 0 errors, 0 warnings

New cases cover: a stored `true` opening the table on load, the write reaching the store, other preferences surviving the write untouched, rollback on a failed write, a cold remount coming back expanded, and a change made in another window arriving over the broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)