### PR TITLE
fix(desktop): deliver usage milestones from fresh readings

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -183,7 +183,10 @@ Settings teardown, and the memory rules behind those policies.
   `src-tauri/src/nudges.rs`. Nothing about a notification leaves the machine.
   Usage milestones default to every 10% and compare quota consumed with the
   share of the current limit window that has elapsed. Settings offers every 5%
-  step when a reader wants different milestones.
+  step when a reader wants different milestones. Every successful live reading
+  checks for a crossing, and the hidden background monitor checks at most every
+  five minutes. A notification names the crossed milestone separately from the
+  provider's current percentage when usage moves past it between readings.
 - **Attention.** The popover shows a banner above the activity list when a
   repository cannot be read (which opens Settings at Sources) or when the local
   database rejects a write (which retries with a scan). Both are derived from

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -856,31 +856,11 @@ pub async fn refresh_live_usage(
     // boundary for all of it.
     let utc_offset_minutes = utc_offset_minutes.unwrap_or(0);
     tauri::async_runtime::spawn_blocking(move || {
-        // Read here rather than before the hop: this summary is stamped with
-        // the moment it was produced, and a caller queued behind another
-        // summarization can wait a while for its turn.
-        let now = scan::unix_now();
-        let Some(live) = app.try_state::<crate::usage_alerts::LiveUsage>() else {
-            return LiveUsageSummary {
-                generated_at: crate::store::iso_from_epoch(Some(now)),
-                ..LiveUsageSummary::default()
-            };
-        };
-        let store = app.try_state::<Store>();
-        // Held for the whole pass: two of these can now genuinely overlap,
-        // and the reading history they append to is not written atomically.
-        let _summarizing = live.summarizing();
-        live.set_utc_offset_minutes(utc_offset_minutes, store.as_deref());
-        let summary = provider_usage::live::summarize(
-            &live.sources,
-            store.as_deref(),
-            now,
-            utc_offset_minutes,
+        crate::usage_alerts::refresh_publish_and_evaluate(
+            &app,
             POPOVER_LIVE_USAGE_MAX_AGE,
-        );
-        live.replace_snapshot(summary.clone(), store.as_deref());
-        let _ = app.emit(crate::usage_alerts::EVENT_CHANGED, &summary);
-        summary
+            Some(utc_offset_minutes),
+        )
     })
     .await
     .map_err(fail)

--- a/apps/desktop/src-tauri/src/notifications.rs
+++ b/apps/desktop/src-tauri/src/notifications.rs
@@ -254,8 +254,9 @@ fn deliver(
     };
     let tone = tone_override.unwrap_or(default_tone);
     let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let nudge_id = format!("antiburn-{sequence}");
     let mut nudge = Nudge::new(
-        format!("antiburn-{sequence}"),
+        nudge_id.clone(),
         nudge_kind,
         tone,
         copy.title,
@@ -272,6 +273,7 @@ fn deliver(
     }
     nudge = nudge.action("dismiss", "Dismiss", dismiss_primary);
     crate::nudges::deliver(app, nudge);
+    tracing::info!(event = "nudge_dispatched", id = %nudge_id, ?kind, ?delivery);
 }
 
 /// Tell the reader where the explicit install action is.
@@ -363,11 +365,15 @@ pub fn usage_milestone_message(
             elapsed - used
         )
     };
-    NotificationCopy::new(
-        title,
-        format!("{used}% used in {elapsed}% of the usage window."),
-        description,
-    )
+    let subtitle = if used == crossing.threshold {
+        format!("{used}% used in {elapsed}% of the usage window.")
+    } else {
+        format!(
+            "Crossed {}%; now {used}% used in {elapsed}% of the usage window.",
+            crossing.threshold
+        )
+    };
+    NotificationCopy::new(title, subtitle, description)
 }
 
 fn usage_milestone_tone(content: &crate::provider_usage::live::MilestoneContent) -> NudgeTone {
@@ -571,6 +577,7 @@ pub fn note_sample(app: &AppHandle, kind: Kind) {
                     threshold: 40,
                     used_percent: 42.0,
                     elapsed_percent: 20.0,
+                    observed_at_epoch: 0,
                     resets_at_epoch: 0,
                 },
             };
@@ -763,6 +770,7 @@ mod tests {
                 threshold: 40,
                 used_percent: 40.0,
                 elapsed_percent: 20.0,
+                observed_at_epoch: 0,
                 resets_at_epoch: 0,
             },
         };
@@ -786,6 +794,7 @@ mod tests {
                 threshold: 100,
                 used_percent: 120.0,
                 elapsed_percent: 100.0,
+                observed_at_epoch: 0,
                 resets_at_epoch: 0,
             },
         };
@@ -800,6 +809,28 @@ mod tests {
             copy.title.starts_with("Burn warning"),
             "title was {}",
             copy.title
+        );
+    }
+
+    #[test]
+    fn a_delayed_milestone_names_the_threshold_and_current_usage() {
+        use crate::provider_usage::live::milestones::{MilestoneContent, MilestoneCrossing};
+
+        let content = MilestoneContent {
+            provider: "anthropic".to_string(),
+            crossing: MilestoneCrossing {
+                window_label: "5-hour limit".to_string(),
+                threshold: 30,
+                used_percent: 39.0,
+                elapsed_percent: 16.0,
+                observed_at_epoch: 0,
+                resets_at_epoch: 0,
+            },
+        };
+
+        assert_eq!(
+            usage_milestone_message(&content).subtitle,
+            "Crossed 30%; now 39% used in 16% of the usage window."
         );
     }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/milestones.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/milestones.rs
@@ -80,6 +80,8 @@ pub struct LiveUsageSnapshot {
     pub account: Option<String>,
     /// False when the fetch is stale; stale numbers neither prime nor fire.
     pub fresh: bool,
+    /// When the provider stated this reading, as Unix seconds.
+    pub observed_at_epoch: i64,
     pub windows: Vec<LiveUsageWindow>,
 }
 
@@ -101,6 +103,7 @@ pub struct MilestoneCrossing {
     pub threshold: u8,
     pub used_percent: f64,
     pub elapsed_percent: f64,
+    pub observed_at_epoch: i64,
     pub resets_at_epoch: i64,
 }
 
@@ -204,6 +207,7 @@ pub fn milestone_content(
                         threshold,
                         used_percent: window.used_percent,
                         elapsed_percent: window.elapsed_percent,
+                        observed_at_epoch: snapshot.observed_at_epoch,
                         resets_at_epoch: window.resets_at_epoch,
                     },
                 ));
@@ -267,6 +271,7 @@ mod tests {
             provider: "anthropic".into(),
             account: None,
             fresh: true,
+            observed_at_epoch: 0,
             windows: vec![window(
                 "five_hour",
                 UsageWindowClass::Short,
@@ -337,6 +342,21 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn a_crossing_keeps_the_provider_observation_time() {
+        let mut ledger = MilestoneLedger::default();
+        let prefs = Milestones::selected([20]);
+        let mut first = snapshot(10.0, 10.0, 100);
+        first.observed_at_epoch = 1_000;
+        assert!(milestone_content(&mut ledger, &[first], &prefs, &prefs).is_none());
+
+        let mut crossed = snapshot(25.0, 15.0, 100);
+        crossed.observed_at_epoch = 1_234;
+        let content = milestone_content(&mut ledger, &[crossed], &prefs, &prefs).unwrap();
+
+        assert_eq!(content.crossing.observed_at_epoch, 1_234);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -175,6 +175,7 @@ impl SourceOutcome {
 /// within a provider, windows keep the order the parser found them, which is
 /// the provider's own order — shortest window first in practice, and not
 /// something to second-guess.
+#[cfg(test)]
 pub fn summarize(
     sources: &[Box<dyn LiveUsageSource>],
     store: Option<&crate::store::Store>,

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -7,8 +7,8 @@
 //! opt-in is on: the background monitor, every five minutes, and
 //! [`crate::commands::refresh_live_usage`], every time the popover — while it is
 //! visible — polls for a reading. Those two callers do not want the same
-//! thing. The monitor is not shown to anyone and can happily read a
-//! ten-minute-old figure; the popover is on screen right now, being polled
+//! thing. The monitor is not shown to anyone and can accept a five-minute-old
+//! figure; the popover is on screen right now, being polled
 //! *because* someone is looking at it, and a fixed ten-minute cooldown would
 //! mean up to ten minutes of that polling doing nothing.
 //!

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -848,9 +848,9 @@ impl AppSettings {
     /// half exists so the credential read this feature depends on — and, on
     /// macOS, the Keychain prompt that read can trigger — never happens
     /// before the reader has seen what this app is. Every call site that
-    /// might collect or fetch a live usage source must go through this
-    /// rather than reading `live_usage_enabled` alone; see
-    /// `provider_usage::live::summarize` and `usage_alerts::background_pass`.
+    /// might collect or fetch a live usage source must go through this rather
+    /// than reading `live_usage_enabled` alone. App refreshes use
+    /// `usage_alerts::refresh_publish_and_evaluate`.
     pub fn live_usage_active(&self) -> bool {
         self.live_usage_enabled && self.onboarding_completed
     }

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -41,15 +41,11 @@ const STARTUP_DELAY: Duration = Duration::from_secs(120);
 
 /// How fresh a reading the background pass asks each source's cooldown for.
 ///
-/// This pass is not shown to anyone — it runs on [`TICK`], whether or not the
-/// popover is even open — so there is no reason to pay for a fetch more
-/// often than the pass itself runs, and every reason not to: it is exactly
-/// the traffic the sources' cooldown (`provider_usage::live::sources::cooldown`)
-/// exists to keep to a small, predictable trickle. Ten minutes matches what
-/// every source's cooldown fixed unconditionally before `max_age` existed,
-/// so this pass's background traffic is unchanged by the popover's own,
-/// much shorter, `max_age` — see `crate::commands::POPOVER_LIVE_USAGE_MAX_AGE`.
-const BACKGROUND_MAX_AGE: Duration = Duration::from_secs(600);
+/// Match the monitor tick so each pass can fetch when no newer foreground
+/// reading exists. The shared source cooldown still caps background traffic
+/// at one provider request per tick. See
+/// `crate::commands::POPOVER_LIVE_USAGE_MAX_AGE` for the visible refresh budget.
+const BACKGROUND_MAX_AGE: Duration = TICK;
 
 /// Spawn the monitor loop; the handle joins the shell's scheduler registry.
 pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> {
@@ -227,34 +223,70 @@ fn run_pass(app: &AppHandle, _blocking: blocking::Thread) {
 }
 
 fn background_pass(app: &AppHandle, settings: &crate::store::AppSettings) {
-    // `live_usage_active` protects every credential read and provider request.
     if !settings.live_usage_active() {
         return;
     }
+    let _ = refresh_publish_and_evaluate(app, BACKGROUND_MAX_AGE, None);
+}
+
+/// Collect, publish, and evaluate one live-usage reading.
+///
+/// Every app-level refresh uses this path. This keeps milestone evaluation at
+/// the collection boundary, including when the visible popover finds a crossing
+/// between background ticks.
+pub(crate) fn refresh_publish_and_evaluate(
+    app: &AppHandle,
+    max_age: Duration,
+    utc_offset_minutes: Option<i32>,
+) -> LiveUsageSummary {
     let Some(live) = app.try_state::<LiveUsage>() else {
-        return;
+        let now = crate::scan::unix_now();
+        return LiveUsageSummary {
+            generated_at: crate::store::iso_from_epoch(Some(now)),
+            ..LiveUsageSummary::default()
+        };
     };
     let _summarizing = live.summarizing();
+    // Read after the lock because another collection can hold it through a request.
     let now = crate::scan::unix_now();
-    let hidden = &settings.live_usage_hidden_providers;
-    let collected = provider_usage::live::sources::collect(
-        &live.sources,
-        settings.live_usage_active(),
-        hidden,
-        BACKGROUND_MAX_AGE,
-    );
+    let store = app.try_state::<Store>();
+    if let Some(offset) = utc_offset_minutes {
+        live.set_utc_offset_minutes(offset, store.as_deref());
+    }
+    let settings = store.as_deref().and_then(|store| store.settings().ok());
+    let online = settings
+        .as_ref()
+        .is_some_and(|settings| settings.live_usage_active());
+    let hidden = settings
+        .as_ref()
+        .map(|settings| &settings.live_usage_hidden_providers)
+        .cloned()
+        .unwrap_or_default();
+    let collected = provider_usage::live::sources::collect(&live.sources, online, &hidden, max_age);
     let snapshots: Vec<provider_usage::live::milestones::LiveUsageSnapshot> =
         collected.snapshots.iter().map(milestone_snapshot).collect();
-    let store = app.try_state::<Store>();
     let summary = provider_usage::live::summarize_collected(
         collected,
-        provider_usage::live::roster(&live.sources, hidden),
+        provider_usage::live::roster(&live.sources, &hidden),
         store.as_deref(),
         now,
         live.utc_offset_minutes(),
     );
     live.replace_snapshot(summary.clone(), store.as_deref());
     let _ = app.emit(EVENT_CHANGED, &summary);
+    if let Some(settings) = settings.as_ref() {
+        evaluate_milestones(app, &live, settings, &snapshots, now);
+    }
+    summary
+}
+
+fn evaluate_milestones(
+    app: &AppHandle,
+    live: &LiveUsage,
+    settings: &crate::store::AppSettings,
+    snapshots: &[provider_usage::live::milestones::LiveUsageSnapshot],
+    evaluated_at_epoch: i64,
+) {
     // Gate before evaluation because selection records a crossing as delivered.
     // A disabled notification must remain available if the reader enables it.
     if !crate::notifications::allowed(settings, crate::notifications::Kind::UsageMilestone) {
@@ -266,10 +298,25 @@ fn background_pass(app: &AppHandle, settings: &crate::store::AppSettings) {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     if let Some(content) = provider_usage::live::milestone_content(
         &mut ledger,
-        &snapshots,
+        snapshots,
         &settings.milestones_5h,
         &settings.milestones_weekly,
     ) {
+        let crossing = &content.crossing;
+        let cache_age_seconds = evaluated_at_epoch
+            .saturating_sub(crossing.observed_at_epoch)
+            .max(0);
+        ::tracing::info!(
+            event = "usage_milestone_selected",
+            provider = %content.provider,
+            window = %crossing.window_label,
+            threshold_percent = crossing.threshold,
+            used_percent = crossing.used_percent,
+            elapsed_percent = crossing.elapsed_percent,
+            observed_at_epoch = crossing.observed_at_epoch,
+            evaluated_at_epoch,
+            cache_age_seconds,
+        );
         let _ = crate::notifications::note_usage_milestone(app, &content);
     }
 }
@@ -315,6 +362,7 @@ fn milestone_snapshot(
         provider: snapshot.provider.to_string(),
         account: snapshot.account.clone(),
         fresh: snapshot.source.freshness == Freshness::Fresh,
+        observed_at_epoch: snapshot.observed_at.unix_timestamp(),
         windows: snapshot
             .windows
             .iter()

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
@@ -451,7 +451,7 @@ describe("UsageLimitsBar — degraded state", () => {
 })
 
 describe("UsageLimitsBar — grace period", () => {
-  const GRACE_NOTE = "Claude rate limited the last check. Showing the reading from 4 min ago."
+  const GRACE_NOTE = "Claude rate limited the last check; reading from 4 min ago."
 
   it("keeps a graced reading on the ring, muted, with the grace note attached", () => {
     bar({

--- a/apps/desktop/src/lib/presentation/liveUsage.test.ts
+++ b/apps/desktop/src/lib/presentation/liveUsage.test.ts
@@ -793,16 +793,16 @@ describe("the grace period", () => {
 
   it("phrases the grace note per category, and the age in words", () => {
     expect(liveGraceNote("rateLimited", "anthropic", 4 * 60_000)).toBe(
-      "Claude rate limited the last check. Showing the reading from 4 min ago.",
+      "Claude rate limited the last check; reading from 4 min ago.",
     )
     expect(liveGraceNote("authentication", "google", 30_000)).toBe(
-      "Google rejected the sign-in on the last check. Showing the reading from under 1 min ago.",
+      "Google rejected the sign-in on the last check; reading from under 1 min ago.",
     )
     expect(liveGraceNote("schema", "openai", 9 * 60_000)).toBe(
-      "Codex sent an unreadable reply. Showing the reading from 9 min ago.",
+      "Codex sent an unreadable reply; reading from 9 min ago.",
     )
     expect(liveGraceNote("unavailable", undefined, 60_000)).toBe(
-      "Your provider did not answer the last check. Showing the reading from 1 min ago.",
+      "Your provider didn't answer the last check; reading from 1 min ago.",
     )
   })
 })

--- a/apps/desktop/src/views/popover/UsageView.test.tsx
+++ b/apps/desktop/src/views/popover/UsageView.test.tsx
@@ -1144,9 +1144,7 @@ describe("UsageView — the grace period", () => {
       within(card).getByRole("region", { name: "Anthropic plan limits" }),
     ).toBeInTheDocument()
     expect(
-      within(card).getByText(
-        "Claude rate limited the last check. Showing the reading from 4 min ago.",
-      ),
+      within(card).getByText("Claude rate limited the last check; reading from 4 min ago."),
     ).toBeInTheDocument()
     expect(within(card).queryByRole("status")).not.toBeInTheDocument()
   })

--- a/apps/desktop/src/views/settings/UsagePane.test.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.test.tsx
@@ -84,6 +84,8 @@ describe("UsagePane", () => {
     // at all *and* it lets milestone notifications fire.
     pane()
     const row = screen.getByText("Keep my plan limits current").closest("div")!
+    expect(row).toHaveTextContent(/every five minutes in the background/i)
+    expect(row).toHaveTextContent(/more often while visible/i)
     expect(row).toHaveTextContent(/that.s your own connection, made as you/i)
     expect(row).toHaveTextContent(/no antiburn server is involved/i)
     expect(row).toHaveTextContent(/milestone notifications/i)

--- a/apps/desktop/src/views/settings/UsagePane.test.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.test.tsx
@@ -293,7 +293,7 @@ describe("UsagePane — the grace period", () => {
     await waitFor(() => expect(screen.getByText("Anthropic")).toBeInTheDocument())
     expect(
       screen.getByText(
-        "Asked Claude directly. 0 limits reported. Claude rate limited the last check. Showing the reading from 4 min ago.",
+        "Asked Claude directly. 0 limits reported. Claude rate limited the last check; reading from 4 min ago.",
       ),
     ).toBeInTheDocument()
     expect(screen.queryByText(/Wait, then retry/)).not.toBeInTheDocument()

--- a/apps/desktop/src/views/settings/UsagePane.tsx
+++ b/apps/desktop/src/views/settings/UsagePane.tsx
@@ -30,14 +30,12 @@ import type { AppSettingsController } from "./useAppSettings"
  * Usage: where the plan limits come from, and the one switch that turns it
  * off.
  *
- * The switch below is on by default: antiburn asks each provider directly for
- * your current usage, about every ten minutes, using the credentials your own
- * coding tools already hold, entirely over your own connection. That is
- * ordinary traffic — your own usage, from a provider you already use, with a
- * credential you already hold — so it runs without asking first, the same way
- * every other local reading in this app does. The switch exists for a reader
- * who wants none of it: turn it off and this pane has nothing to show, no
- * request is made, and no credential is read.
+ * The switch below is on by default. antiburn asks each provider directly for
+ * current usage every five minutes in the background, and more often while
+ * visible. It uses the credentials your own coding tools already hold. The
+ * requests use your own connection. This traffic reads your usage from a
+ * provider you already use. The switch lets you stop all requests and
+ * credential reads.
  *
  * The copy names both things the switch controls — it is what makes readings
  * possible at all, *and* it is what lets milestone notifications fire —
@@ -103,7 +101,7 @@ export function UsagePane({ settings, update }: UsagePaneProps) {
         <Card>
           <ToggleRow
             label="Keep my plan limits current"
-            description="Asks each provider directly for your current usage, about every ten minutes, using the credentials your own coding tools already have — that's your own connection, made as you; no antiburn server is involved. When a provider can't be reached directly, antiburn falls back to asking your coding tool's own local process the same question. Turning this off also stops usage milestone notifications, since they need readings that keep moving."
+            description="Asks each provider directly for your current usage every five minutes in the background, and more often while visible, using the credentials your own coding tools already have — that's your own connection, made as you; no antiburn server is involved. When a provider can't be reached directly, antiburn falls back to asking your coding tool's own local process the same question. Turning this off also stops usage milestone notifications, since they need readings that keep moving."
             checked={on}
             onChange={(next) =>
               void Promise.resolve(update({ liveUsageEnabled: next })).then(() => {

--- a/docs/support.md
+++ b/docs/support.md
@@ -158,8 +158,9 @@ signed bundle and restarts antiburn. The app never depends on either connection.
 
 **One setting makes antiburn go online as you.** Settings → Usage has a switch,
 on by default once first-run setup is complete, that lets antiburn ask each
-provider directly for your current plan usage — about every ten minutes — using
-the credential your coding tool already keeps on this machine (for example, the
+provider directly for your current plan usage every five minutes in the
+background, and more often while a usage surface is visible. It uses the
+credential your coding tool already keeps on this machine (for example, the
 Claude CLI's own OAuth credential, or the Codex CLI's own). It runs by default
 because this is your own traffic: your usage, from a provider you already use,
 with a credential you already hold, over your own connection — no antiburn
@@ -178,9 +179,13 @@ sample. Milestones need readings that keep moving, so they fire only while
 Settings → Usage is set to refresh; with that off they stay silent. By default,
 they fire at every 10% of a limit and compare quota used with time elapsed in
 that limit's window. Settings → Notifications offers every 5% step, plus
-select-all and clear-all controls. antiburn constructs each notification on this
-machine, and nothing about it leaves the machine. The test and first-run
-location ignore the master switch because both follow a direct action.
+select-all and clear-all controls. Every successful live reading checks for a
+crossing, and the hidden background monitor checks at most every five minutes.
+When usage jumps between readings, the notification names both the crossed
+milestone and the provider's current percentage. antiburn constructs each
+notification on this machine, and nothing about it leaves the machine. The test
+and first-run location ignore the master switch because both follow a direct
+action.
 
 **Notifications respect Focus and Do Not Disturb.** Immediately before an
 automated notification appears, antiburn asks your operating system whether


### PR DESCRIPTION
## Summary

- evaluate usage milestones from every fresh foreground reading, not only the background scheduler
- allow the background scheduler to fetch each provider once per five-minute tick
- identify both the crossed threshold and current usage when a reading arrives late
- log milestone selection, reading age, and nudge dispatch for future diagnosis
- align existing grace-note tests with the copy already shipped on main

## User impact

A visible Usage surface can now deliver a crossing immediately after its refresh. With no Usage surface open, the maximum scheduled detection delay falls from roughly ten minutes to roughly five minutes. If usage jumps between observations, the notification says which configured milestone was crossed and what the latest reading is.

## Privacy and performance

No new data leaves the machine. Logs contain the provider name, window label, percentages, timestamps, and cache age; they do not contain account identifiers. Background provider traffic can increase from at most one request per ten minutes to at most one request per five minutes. Visible refresh behavior is unchanged.

## Verification

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (827 passed)
- pnpm lint
- pnpm type-check
- pnpm test (1,080 passed)
- pnpm build
- pnpm run slop:all
- pnpm run secrets
