### PR TITLE
chore(desktop): add pointer-exit grace to anchored previews

### DIFF
--- a/apps/desktop/src-tauri/crates/anchored-window/src/geometry.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/geometry.rs
@@ -12,6 +12,52 @@ pub(crate) struct Point {
     pub y: f64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CursorProximity {
+    Inside,
+    WithinTolerance,
+    Outside,
+}
+
+pub(crate) fn classify_cursor(
+    bounds: Rect,
+    point: Point,
+    logical_tolerance: f64,
+    scale_factor: f64,
+) -> CursorProximity {
+    let inside = point.x >= bounds.x
+        && point.x < bounds.x + bounds.width
+        && point.y >= bounds.y
+        && point.y < bounds.y + bounds.height;
+    if inside {
+        return CursorProximity::Inside;
+    }
+
+    let tolerance = if logical_tolerance.is_finite() && logical_tolerance > 0.0 {
+        logical_tolerance
+    } else {
+        0.0
+    };
+    if tolerance == 0.0 {
+        return CursorProximity::Outside;
+    }
+    let scale = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+    let tolerance = tolerance * scale;
+    let within_tolerance = point.x >= bounds.x - tolerance
+        && point.x <= bounds.x + bounds.width + tolerance
+        && point.y >= bounds.y - tolerance
+        && point.y <= bounds.y + bounds.height + tolerance;
+    if within_tolerance {
+        CursorProximity::WithinTolerance
+    } else {
+        CursorProximity::Outside
+    }
+}
+
 pub(crate) fn place_left_preferred(
     anchor: Rect,
     work_area: Rect,

--- a/apps/desktop/src-tauri/crates/anchored-window/src/geometry/tests/mod.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/geometry/tests/mod.rs
@@ -1,6 +1,6 @@
-mod fixtures;
+use super::{CursorProximity, Point, Rect, classify_cursor, place_left_preferred};
 
-use super::place_left_preferred;
+mod fixtures;
 
 #[test]
 fn placement_covers_fit_clamp_negative_origin_and_scale() {
@@ -18,6 +18,141 @@ fn placement_covers_fit_clamp_negative_origin_and_scale() {
             case.expected,
             "{}",
             case.name,
+        );
+    }
+}
+
+#[test]
+fn cursor_classification_distinguishes_exact_bounds_tolerance_and_outside() {
+    let bounds = Rect {
+        x: 100.0,
+        y: 200.0,
+        width: 300.0,
+        height: 150.0,
+    };
+
+    for point in [
+        Point { x: 100.0, y: 200.0 },
+        Point {
+            x: 399.999,
+            y: 349.999,
+        },
+    ] {
+        assert_eq!(
+            classify_cursor(bounds, point, 12.0, 1.0),
+            CursorProximity::Inside,
+            "{point:?} should be inside the exact bounds",
+        );
+    }
+
+    for point in [
+        Point { x: 88.0, y: 275.0 },
+        Point { x: 412.0, y: 275.0 },
+        Point { x: 250.0, y: 188.0 },
+        Point { x: 250.0, y: 362.0 },
+        Point { x: 88.0, y: 188.0 },
+        Point { x: 412.0, y: 362.0 },
+    ] {
+        assert_eq!(
+            classify_cursor(bounds, point, 12.0, 1.0),
+            CursorProximity::WithinTolerance,
+            "{point:?} should be inside the tolerance bounds",
+        );
+    }
+
+    for point in [
+        Point {
+            x: 87.999,
+            y: 275.0,
+        },
+        Point {
+            x: 412.001,
+            y: 275.0,
+        },
+        Point {
+            x: 250.0,
+            y: 187.999,
+        },
+        Point {
+            x: 250.0,
+            y: 362.001,
+        },
+        Point {
+            x: 87.999,
+            y: 187.999,
+        },
+    ] {
+        assert_eq!(
+            classify_cursor(bounds, point, 12.0, 1.0),
+            CursorProximity::Outside,
+            "{point:?} should be outside the tolerance bounds",
+        );
+    }
+}
+
+#[test]
+fn cursor_classification_scales_logical_tolerance_to_physical_coordinates() {
+    let bounds = Rect {
+        x: 100.0,
+        y: 200.0,
+        width: 300.0,
+        height: 150.0,
+    };
+
+    assert_eq!(
+        classify_cursor(bounds, Point { x: 424.0, y: 275.0 }, 12.0, 2.0),
+        CursorProximity::WithinTolerance,
+    );
+    assert_eq!(
+        classify_cursor(
+            bounds,
+            Point {
+                x: 424.001,
+                y: 275.0
+            },
+            12.0,
+            2.0
+        ),
+        CursorProximity::Outside,
+    );
+}
+
+#[test]
+fn cursor_classification_sanitizes_invalid_tolerance_and_scale() {
+    let bounds = Rect {
+        x: 100.0,
+        y: 200.0,
+        width: 300.0,
+        height: 150.0,
+    };
+    let beyond_right_edge = Point { x: 400.0, y: 275.0 };
+
+    for tolerance in [-12.0, f64::NAN, f64::INFINITY] {
+        assert_eq!(
+            classify_cursor(bounds, beyond_right_edge, tolerance, 1.0),
+            CursorProximity::Outside,
+            "{tolerance:?} should produce zero tolerance",
+        );
+    }
+
+    for scale in [-1.0, 0.0, f64::NAN, f64::INFINITY] {
+        assert_eq!(
+            classify_cursor(bounds, Point { x: 412.0, y: 275.0 }, 12.0, scale),
+            CursorProximity::WithinTolerance,
+            "{scale:?} should use a scale factor of one",
+        );
+        assert_eq!(
+            classify_cursor(
+                bounds,
+                Point {
+                    x: 412.001,
+                    y: 275.0
+                },
+                12.0,
+                scale
+            ),
+            CursorProximity::Outside,
+            "{scale:?} should use a scale factor of one",
         );
     }
 }

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
@@ -19,7 +19,7 @@ pub use manager::AnchoredWindowManager;
 pub use model::{
     AnchorRegion, AnchoredWindowConfig, AnchoredWindowLifecycleEvent, AnchoredWindowRenderRequest,
     AnchoredWindowRequest, AnchoredWindowState, HeightPolicy, InteractionPolicy, PlacementPolicy,
-    RevealPolicy, WindowMaterial,
+    PointerExitPolicy, RevealPolicy, WindowMaterial,
 };
 
 /// The event that carries each target generation to the resident renderer.

--- a/apps/desktop/src-tauri/crates/anchored-window/src/linux.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/linux.rs
@@ -1,10 +1,122 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use gtk::gdk::prelude::DisplayExtManual;
+use gtk::gdk::{CrossingMode, EventMask, NotifyType};
 use gtk::prelude::*;
 use tauri::{Manager, Runtime, WebviewWindow, WebviewWindowBuilder};
+
+use crate::geometry::CursorProximity;
+
+const POINTER_PENDING: u8 = 0;
+const POINTER_INSTALLING: u8 = 1;
+const POINTER_GLOBAL: u8 = 2;
+const POINTER_OUTSIDE: u8 = 3;
+const POINTER_INSIDE: u8 = 4;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CursorSource {
+    Pending,
+    Global,
+    Local(CursorProximity),
+}
+
+pub(crate) struct PointerTracker {
+    state: AtomicU8,
+}
+
+impl PointerTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: AtomicU8::new(POINTER_PENDING),
+        }
+    }
+
+    fn begin_install(&self) -> bool {
+        self.state
+            .compare_exchange(
+                POINTER_PENDING,
+                POINTER_INSTALLING,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    fn set(&self, state: u8) {
+        self.state.store(state, Ordering::Relaxed);
+    }
+
+    pub(crate) fn reset_for_show(&self) {
+        if self.state.load(Ordering::Relaxed) >= POINTER_OUTSIDE {
+            self.set(POINTER_OUTSIDE);
+        }
+    }
+
+    pub(crate) fn reset_for_install(&self) {
+        self.set(POINTER_PENDING);
+    }
+
+    pub(crate) fn source(&self) -> CursorSource {
+        match self.state.load(Ordering::Relaxed) {
+            POINTER_GLOBAL => CursorSource::Global,
+            POINTER_OUTSIDE => CursorSource::Local(CursorProximity::Outside),
+            POINTER_INSIDE => CursorSource::Local(CursorProximity::Inside),
+            _ => CursorSource::Pending,
+        }
+    }
+}
 
 pub(crate) fn configure<'a, R: Runtime, M: Manager<R>>(
     builder: WebviewWindowBuilder<'a, R, M>,
 ) -> WebviewWindowBuilder<'a, R, M> {
     builder
+}
+
+pub(crate) fn install_pointer_tracking(
+    window: &WebviewWindow,
+    tracker: Arc<PointerTracker>,
+) -> tauri::Result<()> {
+    if !tracker.begin_install() {
+        return Ok(());
+    }
+    let window = window.clone();
+    window.clone().run_on_main_thread(move || {
+        let Ok(gtk_window) = window.gtk_window() else {
+            tracker.set(POINTER_PENDING);
+            tracing::warn!("failed to access the anchored GTK window for pointer tracking");
+            return;
+        };
+        if !gtk_window.display().backend().is_wayland() {
+            tracker.set(POINTER_GLOBAL);
+            return;
+        }
+
+        // Wayland does not expose global pointer coordinates. Use exact window crossing events with the configured exit delay.
+        tracker.set(POINTER_OUTSIDE);
+        gtk_window.add_events(EventMask::ENTER_NOTIFY_MASK | EventMask::LEAVE_NOTIFY_MASK);
+        let enter_tracker = Arc::clone(&tracker);
+        gtk_window.connect_enter_notify_event(move |_, event| {
+            if is_window_crossing(event) {
+                enter_tracker.set(POINTER_INSIDE);
+            }
+            gtk::glib::Propagation::Proceed
+        });
+        gtk_window.connect_leave_notify_event(move |_, event| {
+            if is_window_crossing(event) {
+                tracker.set(POINTER_OUTSIDE);
+            }
+            gtk::glib::Propagation::Proceed
+        });
+    })
+}
+
+fn is_window_crossing(event: &gtk::gdk::EventCrossing) -> bool {
+    is_window_crossing_kind(event.mode(), event.detail())
+}
+
+fn is_window_crossing_kind(mode: CrossingMode, detail: NotifyType) -> bool {
+    mode == CrossingMode::Normal && detail != NotifyType::Inferior
 }
 
 pub(crate) fn show_without_activation(window: &WebviewWindow) -> tauri::Result<()> {
@@ -23,4 +135,45 @@ pub(crate) fn show_without_activation(window: &WebviewWindow) -> tauri::Result<(
 
 pub(crate) fn hide(window: &WebviewWindow) -> tauri::Result<()> {
     window.hide()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pointer_tracker_resets_reveal_and_reinstallation_state() {
+        let tracker = PointerTracker::new();
+        assert_eq!(tracker.source(), CursorSource::Pending);
+
+        tracker.set(POINTER_INSIDE);
+        tracker.reset_for_show();
+        assert_eq!(
+            tracker.source(),
+            CursorSource::Local(CursorProximity::Outside)
+        );
+
+        tracker.set(POINTER_GLOBAL);
+        tracker.reset_for_show();
+        assert_eq!(tracker.source(), CursorSource::Global);
+
+        tracker.reset_for_install();
+        assert_eq!(tracker.source(), CursorSource::Pending);
+    }
+
+    #[test]
+    fn pointer_tracker_uses_only_physical_window_crossings() {
+        assert!(is_window_crossing_kind(
+            CrossingMode::Normal,
+            NotifyType::Ancestor
+        ));
+        assert!(!is_window_crossing_kind(
+            CrossingMode::Normal,
+            NotifyType::Inferior
+        ));
+        assert!(!is_window_crossing_kind(
+            CrossingMode::Grab,
+            NotifyType::Ancestor
+        ));
+    }
 }

--- a/apps/desktop/src-tauri/crates/anchored-window/src/macos.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/macos.rs
@@ -4,7 +4,7 @@ use objc2_app_kit::{NSEvent, NSWindow};
 use tauri::window::{Effect, EffectState, EffectsBuilder};
 use tauri::{Manager, Runtime, WebviewWindow, WebviewWindowBuilder};
 
-use crate::geometry::{Rect, place_left_preferred};
+use crate::geometry::{CursorProximity, Point, Rect, classify_cursor, place_left_preferred};
 use crate::{AnchorRegion, WindowMaterial};
 
 pub(crate) struct FrameRequest {
@@ -171,20 +171,26 @@ fn cache_frame(native_frame: &Mutex<Option<Rect>>, x: f64, y: f64, width: f64, h
     });
 }
 
-pub(crate) fn cursor_inside(native_frame: &Mutex<Option<Rect>>) -> bool {
+pub(crate) fn cursor_location(
+    native_frame: &Mutex<Option<Rect>>,
+    edge_tolerance: f64,
+) -> Option<CursorProximity> {
     let Ok(cached) = native_frame.lock() else {
-        tracing::warn!("failed to read the anchored native frame");
-        return false;
+        return None;
     };
     let Some(frame) = *cached else {
-        return false;
+        return Some(CursorProximity::Outside);
     };
     let cursor = NSEvent::mouseLocation();
-    frame_contains(frame, cursor.x, cursor.y)
-}
-
-fn frame_contains(frame: Rect, x: f64, y: f64) -> bool {
-    x >= frame.x && x < frame.x + frame.width && y >= frame.y && y < frame.y + frame.height
+    Some(classify_cursor(
+        frame,
+        Point {
+            x: cursor.x,
+            y: cursor.y,
+        },
+        edge_tolerance,
+        1.0,
+    ))
 }
 
 fn vertical_origin(

--- a/apps/desktop/src-tauri/crates/anchored-window/src/macos/tests.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/macos/tests.rs
@@ -1,27 +1,12 @@
 use crate::model::AnchorRegion;
 
-use super::{FrameRequest, Rect, frame_contains, horizontal_origin, vertical_origin};
+use super::{FrameRequest, Rect, horizontal_origin, vertical_origin};
 
 #[test]
 fn vertical_item_alignment_clamps_to_both_screen_margins() {
     assert_eq!(vertical_origin(800.0, 0.0, 200.0, 0.0, 800.0, 8.0), 592.0);
     assert_eq!(vertical_origin(400.0, 100.0, 200.0, 0.0, 800.0, 8.0), 100.0);
     assert_eq!(vertical_origin(180.0, 100.0, 200.0, 0.0, 800.0, 8.0), 8.0);
-}
-
-#[test]
-fn native_frame_hit_test_uses_half_open_edges() {
-    let frame = Rect {
-        x: 100.0,
-        y: 200.0,
-        width: 80.0,
-        height: 60.0,
-    };
-
-    assert!(frame_contains(frame, 100.0, 200.0));
-    assert!(frame_contains(frame, 179.9, 259.9));
-    assert!(!frame_contains(frame, 180.0, 230.0));
-    assert!(!frame_contains(frame, 140.0, 260.0));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use std::sync::{Arc, Mutex};
 use tauri::{Emitter, Manager, WebviewWindow};
 
+#[cfg(target_os = "macos")]
 use crate::geometry::Rect;
 use crate::lifecycle::{Lifecycle, RequestTransition};
 use crate::model::{
@@ -19,6 +20,8 @@ struct Inner<T, P> {
     frame_update: Mutex<()>,
     #[cfg(target_os = "macos")]
     native_frame: Arc<Mutex<Option<Rect>>>,
+    #[cfg(target_os = "linux")]
+    pointer_tracker: Arc<crate::linux::PointerTracker>,
 }
 
 /// Creates, reuses, places, reveals, and conceals one anchored companion.
@@ -42,6 +45,8 @@ where
                 frame_update: Mutex::new(()),
                 #[cfg(target_os = "macos")]
                 native_frame: Arc::new(Mutex::new(None)),
+                #[cfg(target_os = "linux")]
+                pointer_tracker: Arc::new(crate::linux::PointerTracker::new()),
             }),
         }
     }
@@ -310,6 +315,8 @@ where
                 self.lock_lifecycle().force_hidden();
                 return Ok(false);
             }
+            #[cfg(target_os = "linux")]
+            self.inner.pointer_tracker.reset_for_show();
             platform::show(&window, self.inner.config.interaction)?;
         }
         let should_reveal = presentation_pending && self.lock_lifecycle().presented(generation);
@@ -378,6 +385,8 @@ where
     pub fn handle_companion_destroyed(&self) {
         let _frame_update = self.lock_frame_update();
         self.lock_lifecycle().renderer_destroyed();
+        #[cfg(target_os = "linux")]
+        self.inner.pointer_tracker.reset_for_install();
     }
 
     fn lock_lifecycle(&self) -> std::sync::MutexGuard<'_, Lifecycle<T, P>> {

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/tasks.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/tasks.rs
@@ -1,15 +1,65 @@
 use std::sync::{Arc, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tauri::{Emitter, Manager};
 
 use crate::REQUEST_EVENT;
+use crate::geometry::CursorProximity;
 use crate::lifecycle::Lifecycle;
 use crate::model::AnchoredWindowRenderRequest;
 use crate::platform;
 
 use super::{AnchoredWindowManager, Inner};
+
+const CURSOR_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+pub(super) struct CursorExitTracker {
+    bridge_delay: Duration,
+    outside_delay: Duration,
+    started_at: Option<Instant>,
+    outside_since: Option<Instant>,
+    engaged: bool,
+}
+
+impl CursorExitTracker {
+    pub(super) fn new(bridge_delay: Duration, outside_delay: Duration) -> Self {
+        Self {
+            bridge_delay,
+            outside_delay,
+            started_at: None,
+            outside_since: None,
+            engaged: false,
+        }
+    }
+
+    pub(super) fn update(&mut self, now: Instant, proximity: Option<CursorProximity>) -> bool {
+        let started_at = *self.started_at.get_or_insert(now);
+        if !self.engaged {
+            if proximity == Some(CursorProximity::Inside) {
+                self.engaged = true;
+                return false;
+            }
+            if proximity.is_none() {
+                return false;
+            }
+            return now.checked_duration_since(started_at).unwrap_or_default() >= self.bridge_delay;
+        }
+
+        match proximity {
+            Some(CursorProximity::Inside | CursorProximity::WithinTolerance) | None => {
+                self.outside_since = None;
+                false
+            }
+            Some(CursorProximity::Outside) => {
+                let outside_since = *self.outside_since.get_or_insert(now);
+                now.checked_duration_since(outside_since)
+                    .unwrap_or_default()
+                    >= self.outside_delay
+            }
+        }
+    }
+}
 
 impl<T, P> AnchoredWindowManager<T, P>
 where
@@ -52,8 +102,27 @@ where
         generation: u64,
         task_token: u64,
     ) {
-        tokio::time::sleep(delay).await;
-        if !Self::wait_for_cursor_exit(&manager, |owner| owner.cursor_is_over_companion(&app)).await
+        let Some(pointer_exit) = manager
+            .upgrade()
+            .and_then(|inner| inner.config.pointer_exit)
+        else {
+            tokio::time::sleep(delay).await;
+            if !Self::wait_for_cursor_exit(&manager, |owner| owner.cursor_is_over_companion(&app))
+                .await
+            {
+                return;
+            }
+            let Some(inner) = manager.upgrade() else {
+                return;
+            };
+            Self { inner }.finish_scheduled_conceal(&app, generation, task_token);
+            return;
+        };
+
+        if !Self::wait_for_cursor_policy(&manager, delay, pointer_exit.outside_delay, |owner| {
+            owner.cursor_location(&app, pointer_exit.edge_tolerance)
+        })
+        .await
         {
             return;
         }
@@ -61,6 +130,27 @@ where
             return;
         };
         Self { inner }.finish_scheduled_conceal(&app, generation, task_token);
+    }
+
+    pub(super) async fn wait_for_cursor_policy(
+        manager: &Weak<Inner<T, P>>,
+        bridge_delay: Duration,
+        outside_delay: Duration,
+        mut cursor_location: impl FnMut(&Self) -> Option<CursorProximity>,
+    ) -> bool {
+        let mut tracker = CursorExitTracker::new(bridge_delay, outside_delay);
+        loop {
+            let location = {
+                let Some(inner) = manager.upgrade() else {
+                    return false;
+                };
+                cursor_location(&Self { inner })
+            };
+            if tracker.update(Instant::now(), location) {
+                return true;
+            }
+            tokio::time::sleep(CURSOR_POLL_INTERVAL).await;
+        }
     }
 
     fn finish_scheduled_conceal(&self, app: &tauri::AppHandle, generation: u64, task_token: u64) {

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/tests/fixtures.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/tests/fixtures.rs
@@ -27,6 +27,7 @@ pub(super) fn config() -> AnchoredWindowConfig {
             screen_margin: 8.0,
         },
         conceal_fallback: Duration::from_millis(80),
+        pointer_exit: None,
     }
 }
 

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/tests/tasks.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/tests/tasks.rs
@@ -1,10 +1,141 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use crate::geometry::CursorProximity::{Inside, Outside, WithinTolerance};
 use crate::lifecycle::ScheduledTask;
 
 use super::super::AnchoredWindowManager;
+use super::super::tasks::CursorExitTracker;
 use super::fixtures::manager;
+
+const BRIDGE_DELAY: Duration = Duration::from_millis(300);
+const OUTSIDE_DELAY: Duration = Duration::from_millis(180);
+
+fn tracker() -> CursorExitTracker {
+    CursorExitTracker::new(BRIDGE_DELAY, OUTSIDE_DELAY)
+}
+
+fn elapsed(start: Instant, millis: u64) -> Instant {
+    start + Duration::from_millis(millis)
+}
+
+#[test]
+fn cursor_exit_without_entry_uses_only_the_bridge_delay() {
+    let start = Instant::now();
+    let mut tracker = tracker();
+
+    assert!(!tracker.update(start, Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 299), Some(Outside)));
+    assert!(tracker.update(elapsed(start, 300), Some(Outside)));
+}
+
+#[test]
+fn tolerance_does_not_engage_the_companion_before_exact_entry() {
+    let start = Instant::now();
+    let mut tracker = tracker();
+
+    assert!(!tracker.update(start, Some(WithinTolerance)));
+    assert!(tracker.update(elapsed(start, 300), Some(WithinTolerance)));
+}
+
+#[test]
+fn exact_entry_switches_from_bridge_delay_to_outside_delay() {
+    let start = Instant::now();
+    let mut tracker = tracker();
+
+    assert!(!tracker.update(start, Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 299), Some(Inside)));
+    assert!(!tracker.update(elapsed(start, 300), Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 479), Some(Outside)));
+    assert!(tracker.update(elapsed(start, 480), Some(Outside)));
+}
+
+#[test]
+fn tolerance_keeps_an_engaged_companion_open() {
+    let start = Instant::now();
+    let mut tracker = tracker();
+
+    assert!(!tracker.update(start, Some(Inside)));
+    assert!(!tracker.update(elapsed(start, 1), Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 180), Some(WithinTolerance)));
+    assert!(!tracker.update(elapsed(start, 10_000), Some(WithinTolerance)));
+}
+
+#[test]
+fn reentry_resets_the_continuous_outside_delay() {
+    let start = Instant::now();
+    let mut tracker = tracker();
+
+    assert!(!tracker.update(start, Some(Inside)));
+    assert!(!tracker.update(elapsed(start, 10), Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 189), Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 190), Some(Inside)));
+    assert!(!tracker.update(elapsed(start, 200), Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 379), Some(Outside)));
+    assert!(tracker.update(elapsed(start, 380), Some(Outside)));
+}
+
+#[test]
+fn unavailable_cursor_resets_the_continuous_outside_delay() {
+    let start = Instant::now();
+    let mut tracker = tracker();
+
+    assert!(!tracker.update(start, Some(Inside)));
+    assert!(!tracker.update(elapsed(start, 10), Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 190), None));
+    assert!(!tracker.update(elapsed(start, 200), Some(Outside)));
+    assert!(!tracker.update(elapsed(start, 379), Some(Outside)));
+    assert!(tracker.update(elapsed(start, 380), Some(Outside)));
+}
+
+#[test]
+fn unavailable_cursor_never_triggers_concealment_directly() {
+    let start = Instant::now();
+    let mut tracker = tracker();
+
+    assert!(!tracker.update(start, None));
+    assert!(!tracker.update(elapsed(start, 10_000), None));
+}
+
+#[test]
+fn configured_cursor_task_does_not_retain_its_manager() {
+    let manager = manager();
+    let weak = Arc::downgrade(&manager.inner);
+    let task_weak = weak.clone();
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+    let mut entered_tx = Some(entered_tx);
+    let task = tauri::async_runtime::spawn(async move {
+        let owner_survived = AnchoredWindowManager::wait_for_cursor_policy(
+            &task_weak,
+            BRIDGE_DELAY,
+            OUTSIDE_DELAY,
+            move |_| {
+                if let Some(entered_tx) = entered_tx.take() {
+                    let _ = entered_tx.send(());
+                }
+                Some(Inside)
+            },
+        )
+        .await;
+        let _ = done_tx.send(owner_survived);
+    });
+    manager.lock_lifecycle().task = Some(ScheduledTask {
+        token: 1,
+        handle: task,
+    });
+
+    tauri::async_runtime::block_on(async move {
+        entered_rx.await.expect("the cursor policy loop starts");
+        drop(manager);
+        let owner_survived = tokio::time::timeout(Duration::from_secs(1), done_rx)
+            .await
+            .expect("the cursor policy loop stops after its owner drops")
+            .expect("the cursor policy loop reports its result");
+        assert!(!owner_survived);
+    });
+    assert!(weak.upgrade().is_none());
+}
 
 #[test]
 fn stored_cursor_task_does_not_retain_its_manager() {

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/window.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/window.rs
@@ -1,10 +1,14 @@
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+
 use serde::Serialize;
 use tauri::{Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 #[cfg(not(target_os = "macos"))]
 use tauri::{PhysicalPosition, PhysicalSize};
 
+use crate::geometry::CursorProximity;
 #[cfg(not(target_os = "macos"))]
-use crate::geometry::{Rect, place_left_preferred};
+use crate::geometry::{Point, Rect, classify_cursor, place_left_preferred};
 use crate::model::{HeightPolicy, PlacementPolicy, normalized_height_policy};
 use crate::platform;
 
@@ -17,6 +21,11 @@ where
 {
     pub(super) fn ensure_window(&self, app: &tauri::AppHandle) -> tauri::Result<WebviewWindow> {
         if let Some(window) = app.get_webview_window(&self.inner.config.label) {
+            #[cfg(target_os = "linux")]
+            crate::linux::install_pointer_tracking(
+                &window,
+                Arc::clone(&self.inner.pointer_tracker),
+            )?;
             return Ok(window);
         }
         let (renderer_generation, initial_height) = {
@@ -47,7 +56,10 @@ where
         .focused(false)
         .transparent(platform::is_transparent(self.inner.config.material))
         .focusable(self.inner.config.interaction == crate::model::InteractionPolicy::Interactive);
-        platform::configure(builder, self.inner.config.material).build()
+        let window = platform::configure(builder, self.inner.config.material).build()?;
+        #[cfg(target_os = "linux")]
+        crate::linux::install_pointer_tracking(&window, Arc::clone(&self.inner.pointer_tracker))?;
+        Ok(window)
     }
 
     pub(super) fn apply_size_and_position(
@@ -157,45 +169,56 @@ where
     }
 
     pub(super) fn cursor_is_over_companion(&self, app: &tauri::AppHandle) -> Option<bool> {
+        self.cursor_location(app, 0.0)
+            .map(|proximity| proximity == CursorProximity::Inside)
+    }
+
+    pub(super) fn cursor_location(
+        &self,
+        app: &tauri::AppHandle,
+        edge_tolerance: f64,
+    ) -> Option<CursorProximity> {
         let Some(window) = app.get_webview_window(&self.inner.config.label) else {
-            return Some(false);
+            return Some(CursorProximity::Outside);
         };
         match window.is_visible() {
             Ok(true) => {}
-            Ok(false) => return Some(false),
-            Err(error) => {
-                tracing::warn!(%error, "failed to read anchored-window visibility");
-                return None;
-            }
+            Ok(false) => return Some(CursorProximity::Outside),
+            Err(_) => return None,
         }
 
         #[cfg(target_os = "macos")]
         {
-            Some(crate::macos::cursor_inside(&self.inner.native_frame))
+            crate::macos::cursor_location(&self.inner.native_frame, edge_tolerance)
         }
 
         #[cfg(not(target_os = "macos"))]
         {
-            let cursor = app.cursor_position().map_err(|error| {
-                tracing::warn!(%error, "failed to read the anchored-window cursor position");
-            });
-            let position = window.outer_position().map_err(|error| {
-                tracing::warn!(%error, "failed to read the anchored-window position");
-            });
-            let size = window.outer_size().map_err(|error| {
-                tracing::warn!(%error, "failed to read the anchored-window size");
-            });
-            let (Ok(cursor), Ok(position), Ok(size)) = (cursor, position, size) else {
-                return None;
-            };
-            let left = f64::from(position.x);
-            let top = f64::from(position.y);
-            Some(
-                cursor.x >= left
-                    && cursor.x < left + f64::from(size.width)
-                    && cursor.y >= top
-                    && cursor.y < top + f64::from(size.height),
-            )
+            #[cfg(target_os = "linux")]
+            match self.inner.pointer_tracker.source() {
+                crate::linux::CursorSource::Pending => return None,
+                crate::linux::CursorSource::Local(proximity) => return Some(proximity),
+                crate::linux::CursorSource::Global => {}
+            }
+
+            let cursor = app.cursor_position().ok()?;
+            let position = window.outer_position().ok()?;
+            let size = window.outer_size().ok()?;
+            let scale = window.scale_factor().ok()?;
+            Some(classify_cursor(
+                Rect {
+                    x: f64::from(position.x),
+                    y: f64::from(position.y),
+                    width: f64::from(size.width),
+                    height: f64::from(size.height),
+                },
+                Point {
+                    x: cursor.x,
+                    y: cursor.y,
+                },
+                edge_tolerance,
+                scale,
+            ))
         }
     }
 
@@ -225,6 +248,8 @@ where
             self.lock_lifecycle().force_hidden();
             return Ok(());
         }
+        #[cfg(target_os = "linux")]
+        self.inner.pointer_tracker.reset_for_show();
         if let Err(error) = platform::show(window, self.inner.config.interaction) {
             self.lock_lifecycle().force_hidden();
             return Err(error);

--- a/apps/desktop/src-tauri/crates/anchored-window/src/model.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/model.rs
@@ -74,6 +74,15 @@ pub enum WindowMaterial {
     },
 }
 
+/// Pointer tolerance after the pointer enters a companion window.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PointerExitPolicy {
+    /// The logical distance outside the native frame that still counts as inside.
+    pub edge_tolerance: f64,
+    /// The continuous time outside the tolerance before concealment starts.
+    pub outside_delay: Duration,
+}
+
 /// A target element's logical bounds relative to the anchor window.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -130,6 +139,8 @@ pub struct AnchoredWindowConfig {
     pub placement: PlacementPolicy,
     /// The maximum wait for renderer-confirmed concealment.
     pub conceal_fallback: Duration,
+    /// Optional pointer tolerance after the pointer enters the companion.
+    pub pointer_exit: Option<PointerExitPolicy>,
 }
 
 /// One target request delivered to the companion renderer.

--- a/apps/desktop/src-tauri/src/popover_peek.rs
+++ b/apps/desktop/src-tauri/src/popover_peek.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use antiburn_anchored_window::{
     AnchorRegion, AnchoredWindowConfig, AnchoredWindowManager, AnchoredWindowRequest,
-    AnchoredWindowState, HeightPolicy, InteractionPolicy, PlacementPolicy, RevealPolicy,
-    WindowMaterial,
+    AnchoredWindowState, HeightPolicy, InteractionPolicy, PlacementPolicy, PointerExitPolicy,
+    RevealPolicy, WindowMaterial,
 };
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
@@ -67,6 +67,10 @@ pub fn manager() -> PopoverPeekManager {
             screen_margin: 8.0,
         },
         conceal_fallback: Duration::from_millis(80),
+        pointer_exit: Some(PointerExitPolicy {
+            edge_tolerance: 12.0,
+            outside_delay: Duration::from_millis(180),
+        }),
     })
 }
 


### PR DESCRIPTION
## Summary

- Add an optional pointer-exit policy to anchored windows.
- Keep the existing 300 ms trigger-to-companion bridge.
- After exact companion entry, allow a 12 px edge tolerance and require 180 ms continuously outside before concealment.
- Reset pending concealment when the pointer returns or the anchored target changes.
- Preserve PR #363 initial-hover delay, immediate retargeting, click behavior, and keyboard behavior.

## Platform behavior

- macOS classifies the pointer using logical window coordinates.
- Windows and X11 scale the logical edge tolerance into physical coordinates.
- Wayland uses native window enter/leave events with the 180 ms exit delay because global pointer coordinates are unavailable.
- Cursor-query failures do not advance concealment.

## Testing

- 28 anchored-window tests passed.
- macOS Clippy passed.
- Windows cross-target Clippy passed.
- Native Linux all-target Clippy passed, including Linux-only test compilation.
- Parent Tauri cargo check passed.
- Rust formatting and git diff --check passed.
- Manually verified the anchored preview interaction on macOS.