### PR TITLE
fix(desktop): refresh Codex titles from watched stores

### DIFF
--- a/apps/desktop/src-tauri/src/dto.rs
+++ b/apps/desktop/src-tauri/src/dto.rs
@@ -273,10 +273,8 @@ pub struct ScanStatus {
     /// evicted a rejected one. A reader's list refetches on this rather than
     /// on every pass, since an unchanged pass patches rows in place instead.
     pub list_changed: bool,
-    /// R5: how many sessions the last pass re-described — new, or a moved
-    /// cursor — never a row it reused verbatim. Lets a reader tell an idle
-    /// pass from a productive one without inferring it from `list_changed`
-    /// alone.
+    /// R5: how many session rows the last pass added or refreshed.
+    /// This lets a reader detect a productive pass without `list_changed`.
     pub re_described: usize,
 }
 

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -36,11 +36,10 @@
 //!   agent's watch roots (`AgentExplorer::watch_roots`), debounces the events
 //!   it sees, and hands the scheduler's loop one [`watch::WatchBurst`] after
 //!   each quiet period — see the `watch` module doc for the debounce shape.
-//!   The `scoped` module classifies that burst into up to three lanes: a
-//!   known session refreshed directly with no discovery walk, a plain
-//!   agent rediscovered on its own, or a database-backed agent rediscovered
-//!   at a longer floor because every write near its store looks like a new
-//!   session. Each lane has its own minimum re-run interval, and a burst
+//!   The `scoped` module classifies that burst into four lanes: a known
+//!   session refresh, an indexed-title refresh, a plain agent rediscovery,
+//!   or a database-backed agent rediscovery. Each lane has its own minimum
+//!   re-run interval, and a burst
 //!   that arrives inside one is folded into the next admitted run rather
 //!   than dropped — see the `scoped` module doc for the full contract.
 //!   [`TICK`] stays as reconciliation for what the watcher cannot cover (a
@@ -500,12 +499,8 @@ async fn sleep_until_due(due: Option<tokio::time::Instant>) {
     }
 }
 
-/// Run one wake's admitted [`scoped::ScopedWork`]: [`scoped::refresh_sessions`]
-/// for the sessions (T1), [`scoped::rediscover_agents`] for the plain and
-/// database-backed agents together (T3/T5) — both floors lead to the same
-/// rediscovery call, so one combined set avoids running it twice. Returns the
-/// part that found a command's pass already running, for the caller to retry
-/// (T7) without re-admitting it through [`scoped::Floors`].
+/// Run each lane admitted for one scheduler wake.
+/// Return work that found another pass running, so the scheduler can retry it.
 async fn run_admitted_work(app: &AppHandle, work: scoped::ScopedWork) -> scoped::ScopedWork {
     let mut busy = scoped::ScopedWork::default();
 
@@ -521,6 +516,22 @@ async fn run_admitted_work(app: &AppHandle, work: scoped::ScopedWork) -> scoped:
             Ok(None) => busy.sessions = work.sessions,
             Err(error) => {
                 ::tracing::debug!(event = "scan_targeted_failed", error = %error);
+            }
+        }
+    }
+
+    if !work.title_agents.is_empty() {
+        match scoped::refresh_indexed_titles(app, &work.title_agents).await {
+            Ok(Some(summary)) => {
+                ::tracing::debug!(
+                    event = "scan_titles_admitted",
+                    agents = work.title_agents.len(),
+                    changed = summary.re_described,
+                );
+            }
+            Ok(None) => busy.title_agents = work.title_agents,
+            Err(error) => {
+                ::tracing::debug!(event = "scan_titles_failed", error = %error);
             }
         }
     }
@@ -727,8 +738,7 @@ struct PassSummary {
     /// patch: this pass indexed a session the list has never shown, or
     /// evicted a rejected one.
     list_changed: bool,
-    /// [`Described::changed`]'s length: rows this pass re-described, new or
-    /// with a moved cursor, never a row reused verbatim.
+    /// [`Described::changed`]'s length: new or refreshed rows.
     re_described: usize,
 }
 
@@ -880,9 +890,8 @@ async fn pass(
 
 /// R3: which of this pass's records are actually worth writing.
 ///
-/// A record earns a write by being in `changed` (this pass re-described it —
-/// new, or its cursor moved) or in `returned` (its evidence last failed on a
-/// missing source, so even an unchanged row needs a write to re-queue it).
+/// A record earns a write when it is new, refreshed, or returned.
+/// A returned record previously failed because its source was missing.
 /// Every other record is a row reused verbatim, and rewriting it would only
 /// cost a write for no observable change. Order follows `records`, and a key
 /// named by both `changed` and `returned` still yields one copy.
@@ -933,7 +942,7 @@ async fn discover_scoped_agents(
     logs
 }
 
-/// Emit `SESSION_ENTRY_CHANGED_EVENT` for every re-described row the reader's
+/// Emit `SESSION_ENTRY_CHANGED_EVENT` for every refreshed row the reader's
 /// list has already shown, so a row already on screen patches in place
 /// instead of waiting for the next full refetch. A brand-new session is not
 /// announced this way: it has no row to patch, and [`Described::list_changed`]
@@ -961,8 +970,7 @@ fn announce_changed_rows(
 struct Described {
     records: Vec<SessionRecord>,
     rejected: Vec<SessionKey>,
-    /// Keys of every record this pass re-described — new, or its cursor
-    /// moved — never a row this pass reused verbatim.
+    /// Keys of every new or refreshed record.
     changed: Vec<SessionKey>,
     /// True when a reader's list needs a full refetch rather than a row
     /// patch: this pass indexed a session absent from `previous_records`, or
@@ -1006,8 +1014,11 @@ async fn describe_with_states(
             let indexed_title = recovered_id(&log)
                 .and_then(|session_id| indexed_titles.get(&(log.agent_type, session_id)).cloned());
             set.spawn(async move {
-                if let Some(reused) = reuse_unchanged_record(&log, previous.as_ref()).await {
-                    return (DescribeOutcome::Session(Box::new(reused)), false);
+                if let Some(reused) =
+                    reuse_unchanged_record(&log, previous.as_ref(), indexed_title.as_ref()).await
+                {
+                    let changed = previous.as_ref().is_some_and(|stored| stored != &reused);
+                    return (DescribeOutcome::Session(Box::new(reused)), changed);
                 }
                 let outcome = describe_one_with_activity(log, &home, indexed_title, previous).await;
                 (outcome, true)
@@ -1015,14 +1026,14 @@ async fn describe_with_states(
         }
         while let Some(joined) = set.join_next().await {
             match joined {
-                Ok((DescribeOutcome::Session(record), re_described)) => {
+                Ok((DescribeOutcome::Session(record), changed_record)) => {
                     let cwd = record.cwd.as_deref();
                     // The engine's opt-out gate, applied once here so every
                     // surface that reads the store inherits it.
                     if cwd.is_some_and(|cwd| ignored_paths::set_contains(ignored, cwd)) {
                         continue;
                     }
-                    if re_described {
+                    if changed_record {
                         changed.push(record.key.clone());
                     }
                     records.push(*record);
@@ -1158,13 +1169,12 @@ async fn stat_activity_cursor(log: &SessionLog) -> Option<String> {
     Some(activity_cursor(path, size, &child_sizes))
 }
 
-/// Reuse a previous record verbatim when its source has not changed, so the
-/// pass never opens the transcript. Only a native file source with a stored
-/// record is eligible; provider-database, inline, and WSL sources always
-/// describe.
+/// Reuse a previous record when its source has not changed.
+/// Apply a fresh indexed title without opening the transcript.
 async fn reuse_unchanged_record(
     log: &SessionLog,
     previous: Option<&SessionRecord>,
+    indexed_title: Option<&ResolvedTitle>,
 ) -> Option<SessionRecord> {
     let previous = previous?;
     let cursor = stat_activity_cursor(log).await?;
@@ -1177,7 +1187,14 @@ async fn reuse_unchanged_record(
     // discovered mtime before the pass can reuse it.
     let mtime_matches =
         previous.activity_source == "event" || previous.updated_at_epoch == log.updated_at;
-    mtime_matches.then(|| previous.clone())
+    if !mtime_matches {
+        return None;
+    }
+    let mut reused = previous.clone();
+    if let Some(indexed_title) = indexed_title {
+        apply_indexed_title(&mut reused, &log.agent_type, indexed_title.clone());
+    }
+    Some(reused)
 }
 
 /// Resolve the display timestamp from transcript events while using the
@@ -1433,6 +1450,20 @@ fn select_title_pair(
         .and(fallback_source)
         .map(|source| source.as_str().to_string());
     (title, source)
+}
+
+fn apply_indexed_title(
+    record: &mut SessionRecord,
+    agent: &AgentKind,
+    indexed_title: ResolvedTitle,
+) -> bool {
+    let (title, title_source) = select_title_pair(Some(indexed_title), None, None, agent, None);
+    if record.title == title && record.title_source == title_source {
+        return false;
+    }
+    record.title = title;
+    record.title_source = title_source;
+    true
 }
 
 /// Whether this transcript belongs to a sub-agent rather than a top-level

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -2,13 +2,9 @@
 //! discovery walk. See `docs/plans/continuous-session-ingest.md`, "Phase 5b",
 //! rules T1 to T7, for the contract this module implements.
 //!
-//! [`classify_burst`] sorts a burst's paths into a [`ScopedWork`]: known
-//! sessions to refresh directly (T1), agents to rediscover because a new or
-//! database-backed session appeared under their root (T3, T5), or paths
-//! nothing claims (T6). [`Floors`] then admits the part of that work that has
-//! not run too recently, per session and per agent (T2, T4, T5), and defers
-//! the rest without dropping it (T7). [`refresh_sessions`] and
-//! [`rediscover_agents`] run the two admitted lanes.
+//! [`classify_burst`] routes session, title-store, agent, and database changes.
+//! [`Floors`] limits each lane and keeps deferred work.
+//! The refresh functions run admitted work without overlap.
 
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -29,8 +25,7 @@ use crate::store::{SessionActivityKey, SessionRecord, Store};
 
 use super::{PassScope, ScanController, ScanTrigger};
 
-/// T2: a re-described session is not re-described again before this many
-/// seconds pass.
+/// T2: a refreshed session is not refreshed again before this interval ends.
 pub const TARGETED_MIN_INTERVAL: Duration = Duration::from_secs(10);
 
 /// T4: an agent's rediscovery runs at most this often.
@@ -40,6 +35,9 @@ pub const AGENT_REDISCOVER_MIN_INTERVAL: Duration = Duration::from_secs(20);
 /// than [`AGENT_REDISCOVER_MIN_INTERVAL`] because every write under such an
 /// agent's root looks like a new session to the classifier.
 pub const DB_AGENT_REDISCOVER_MIN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// An indexed-title refresh runs at most this often for each agent.
+pub const TITLE_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(10);
 
 /// T7: how long the scheduler waits before retrying admitted work that found
 /// a command's pass already holding the running flag.
@@ -54,11 +52,11 @@ const DATABASE_SIDECAR_SUFFIXES: [&str; 2] = ["-wal", "-journal"];
 /// How many of a burst's paths the classification log line shows.
 const LOG_PATH_SAMPLE: usize = 8;
 
-/// What one path in a burst means for the scheduler, in the classification
-/// order T1, T5, T3, T6 apply.
+/// What one path in a burst means for the scheduler.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ClassifiedPath {
     Session(SessionActivityKey),
+    IndexedTitles(AgentKind),
     DatabaseAgent(AgentKind),
     Agent(AgentKind),
     Ignored,
@@ -70,18 +68,23 @@ enum ClassifiedPath {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ScopedWork {
     pub sessions: BTreeSet<SessionActivityKey>,
+    pub title_agents: BTreeSet<AgentKind>,
     pub agents: BTreeSet<AgentKind>,
     pub db_agents: BTreeSet<AgentKind>,
 }
 
 impl ScopedWork {
     pub fn is_empty(&self) -> bool {
-        self.sessions.is_empty() && self.agents.is_empty() && self.db_agents.is_empty()
+        self.sessions.is_empty()
+            && self.title_agents.is_empty()
+            && self.agents.is_empty()
+            && self.db_agents.is_empty()
     }
 
     /// Fold another burst's work in, dropping nothing (T7).
     pub fn merge(&mut self, other: ScopedWork) {
         self.sessions.extend(other.sessions);
+        self.title_agents.extend(other.title_agents);
         self.agents.extend(other.agents);
         self.db_agents.extend(other.db_agents);
     }
@@ -104,9 +107,12 @@ pub fn classify_burst(
     let mut work = ScopedWork::default();
     let mut ignored = 0usize;
     for path in paths {
-        match classify_path(path, &roots, lookup) {
+        match classify_path(path, home, &roots, lookup) {
             ClassifiedPath::Session(key) => {
                 work.sessions.insert(key);
+            }
+            ClassifiedPath::IndexedTitles(agent) => {
+                work.title_agents.insert(agent);
             }
             ClassifiedPath::DatabaseAgent(agent) => {
                 work.db_agents.insert(agent);
@@ -121,6 +127,8 @@ pub fn classify_burst(
     // database-triggered rediscovery: both lead to the same
     // `discover_recent` call, and the shorter T3 floor already covers it.
     work.db_agents.retain(|agent| !work.agents.contains(agent));
+    work.title_agents
+        .retain(|agent| !work.agents.contains(agent) && !work.db_agents.contains(agent));
     let sample = paths
         .iter()
         .take(LOG_PATH_SAMPLE)
@@ -130,6 +138,7 @@ pub fn classify_burst(
     ::tracing::debug!(
         event = "scan_burst_classified",
         sessions = work.sessions.len(),
+        title_agents = work.title_agents.len(),
         agents = work.agents.len(),
         db_agents = work.db_agents.len(),
         ignored,
@@ -141,6 +150,7 @@ pub fn classify_burst(
 
 fn classify_path(
     path: &Path,
+    home: &Path,
     roots: &[(AgentKind, WatchRoot)],
     lookup: &dyn Fn(&str) -> Option<SessionActivityKey>,
 ) -> ClassifiedPath {
@@ -162,6 +172,9 @@ fn classify_path(
         }
         current = dir.parent();
     }
+    if let Some(agent) = indexed_title_store_owner(path, home) {
+        return ClassifiedPath::IndexedTitles(agent);
+    }
     if is_database_path(path)
         && let Some(agent) = owning_agent(path, roots)
     {
@@ -171,6 +184,24 @@ fn classify_path(
         Some(agent) => ClassifiedPath::Agent(agent),
         None => ClassifiedPath::Ignored,
     }
+}
+
+fn indexed_title_store_owner(path: &Path, home: &Path) -> Option<AgentKind> {
+    AgentKind::ALL.iter().copied().find(|agent| {
+        Explorers::DISK
+            .indexed_title_watch_files_for(agent, home)
+            .iter()
+            .any(|file| path == file || is_sidecar_of(path, file))
+    })
+}
+
+fn is_sidecar_of(path: &Path, file: &Path) -> bool {
+    is_database_path(file)
+        && DATABASE_SIDECAR_SUFFIXES.iter().any(|suffix| {
+            let mut sidecar = file.as_os_str().to_os_string();
+            sidecar.push(suffix);
+            path.as_os_str() == sidecar
+        })
 }
 
 /// T5: whether `path`'s file name is one of the database extensions, or a
@@ -236,6 +267,7 @@ fn all_agent_roots(home: &Path) -> Vec<(AgentKind, WatchRoot)> {
 #[derive(Debug, Default)]
 pub struct Floors {
     sessions: HashMap<SessionActivityKey, Instant>,
+    titles: HashMap<AgentKind, Instant>,
     agents: HashMap<AgentKind, Instant>,
 }
 
@@ -261,6 +293,15 @@ impl Floors {
                 earliest_due: &mut earliest_due,
             };
             outcome.admit(key, last_run, TARGETED_MIN_INTERVAL, now);
+        }
+        for agent in work.title_agents {
+            let last_run = self.titles.get(&agent).copied();
+            let mut outcome = Admission {
+                run_now: &mut run_now.title_agents,
+                deferred: &mut deferred.title_agents,
+                earliest_due: &mut earliest_due,
+            };
+            outcome.admit(agent, last_run, TITLE_REFRESH_MIN_INTERVAL, now);
         }
         for agent in work.agents {
             let last_run = self.agents.get(&agent).copied();
@@ -291,6 +332,9 @@ impl Floors {
     pub fn stamp(&mut self, work: &ScopedWork, now: Instant) {
         for key in &work.sessions {
             self.sessions.insert(key.clone(), now);
+        }
+        for agent in &work.title_agents {
+            self.titles.insert(*agent, now);
         }
         for agent in work.agents.iter().chain(work.db_agents.iter()) {
             self.agents.insert(*agent, now);
@@ -364,6 +408,95 @@ pub(super) async fn refresh_sessions(
         duration_ms = started_at.elapsed().as_millis() as u64,
     );
     Ok(Some(summary))
+}
+
+/// Refresh durable titles without discovery or transcript reads.
+pub(super) async fn refresh_indexed_titles(
+    app: &AppHandle,
+    agents: &BTreeSet<AgentKind>,
+) -> anyhow::Result<Option<ScopedSummary>> {
+    if agents.is_empty() {
+        return Ok(Some(ScopedSummary {
+            sessions: 0,
+            re_described: 0,
+        }));
+    }
+    let controller = app.state::<ScanController>();
+    if !super::on_demand_start(&controller) {
+        return Ok(None);
+    }
+    let started_at = std::time::Instant::now();
+    let outcome = refresh_indexed_titles_locked(app, agents).await;
+    controller.running.store(false, Ordering::SeqCst);
+    controller.cancel.store(false, Ordering::SeqCst);
+    let summary = outcome?;
+    ::tracing::debug!(
+        event = "scan_titles_finished",
+        agents = agents.len(),
+        sessions = summary.sessions,
+        changed = summary.re_described,
+        duration_ms = started_at.elapsed().as_millis() as u64,
+    );
+    Ok(Some(summary))
+}
+
+async fn refresh_indexed_titles_locked(
+    app: &AppHandle,
+    agents: &BTreeSet<AgentKind>,
+) -> anyhow::Result<ScopedSummary> {
+    let store = app.state::<Store>();
+    let previous_map: HashMap<SessionActivityKey, SessionRecord> = store
+        .session_records()?
+        .into_iter()
+        .filter(|(_, record)| {
+            record.key.environment_key == "native"
+                && agents.iter().any(|agent| record.key.agent == agent.slug())
+        })
+        .collect();
+    let mut records: Vec<SessionRecord> = previous_map.values().cloned().collect();
+    let mut changed = Vec::new();
+
+    for agent in agents {
+        let session_ids: Vec<String> = records
+            .iter()
+            .filter(|record| record.key.agent == agent.slug())
+            .map(|record| record.key.session_id.clone())
+            .collect();
+        let mut titles = Explorers::DISK
+            .indexed_session_titles_for(agent, &session_ids)
+            .await;
+        for record in records
+            .iter_mut()
+            .filter(|record| record.key.agent == agent.slug())
+        {
+            let Some(resolved) = titles.remove(&record.key.session_id) else {
+                continue;
+            };
+            if super::apply_indexed_title(record, agent, resolved) {
+                changed.push(record.key.clone());
+            }
+        }
+    }
+
+    let changed_records = super::records_to_persist(&records, &changed, &[]);
+    if !changed_records.is_empty() {
+        checked(
+            app,
+            "The session index",
+            store.upsert_sessions(&changed_records, &agents::evidence_cohort()),
+        )?;
+    }
+    let now = super::unix_now();
+    let announce_app = app.clone();
+    let announce = move |entry: ActivityEntry| {
+        let _ = announce_app.emit(crate::commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
+    };
+    super::announce_changed_rows(&store, &changed, &previous_map, now, &announce);
+
+    Ok(ScopedSummary {
+        sessions: records.len(),
+        re_described: changed.len(),
+    })
 }
 
 async fn refresh_sessions_locked(
@@ -516,19 +649,47 @@ mod tests {
         let lookup = |_: &str| None;
 
         assert_eq!(
-            classify_path(&db_path, &roots, &lookup),
+            classify_path(&db_path, &home, &roots, &lookup),
             ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
         );
         let wal = home.join(".cursor/state.vscdb-wal");
         assert_eq!(
-            classify_path(&wal, &roots, &lookup),
+            classify_path(&wal, &home, &roots, &lookup),
             ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
         );
         let journal = home.join(".cursor/state.vscdb-journal");
         assert_eq!(
-            classify_path(&journal, &roots, &lookup),
+            classify_path(&journal, &home, &roots, &lookup),
             ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
         );
+    }
+
+    #[test]
+    fn codex_title_store_changes_refresh_titles_only() {
+        let home = PathBuf::from("/home/avery");
+        let lookup = |_: &str| None;
+        let paths = [
+            home.join(".codex/state_5.sqlite"),
+            home.join(".codex/state_5.sqlite-wal"),
+            home.join(".codex/session_index.jsonl"),
+        ];
+
+        let work = classify_burst(&paths, &home, &lookup);
+
+        assert_eq!(work.title_agents, BTreeSet::from([AgentKind::Codex]));
+        assert!(work.sessions.is_empty());
+        assert!(work.agents.is_empty());
+        assert!(work.db_agents.is_empty());
+    }
+
+    #[test]
+    fn unrelated_codex_metadata_does_not_request_work() {
+        let home = PathBuf::from("/home/avery");
+        let lookup = |_: &str| None;
+
+        let work = classify_burst(&[home.join(".codex/config.toml")], &home, &lookup);
+
+        assert!(work.is_empty());
     }
 
     #[test]
@@ -539,7 +700,7 @@ mod tests {
         let lookup = |_: &str| None;
 
         assert_eq!(
-            classify_path(&path, &roots, &lookup),
+            classify_path(&path, &home, &roots, &lookup),
             ClassifiedPath::Agent(AgentKind::Codex)
         );
     }
@@ -551,7 +712,7 @@ mod tests {
         let lookup = |_: &str| None;
 
         assert_eq!(
-            classify_path(&path, &roots, &lookup),
+            classify_path(&path, Path::new("/home/avery"), &roots, &lookup),
             ClassifiedPath::Ignored
         );
     }
@@ -653,6 +814,25 @@ mod tests {
         tokio::time::advance(Duration::from_secs(1)).await;
         let (run_now, _deferred, _due) = floors.admit(work, Instant::now());
         assert_eq!(run_now.agents, BTreeSet::from([AgentKind::Codex]));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn indexed_titles_use_the_ten_second_floor() {
+        let mut floors = Floors::default();
+        let mut work = ScopedWork::default();
+        work.title_agents.insert(AgentKind::Codex);
+
+        let t0 = Instant::now();
+        floors.admit(work.clone(), t0);
+
+        tokio::time::advance(TITLE_REFRESH_MIN_INTERVAL - Duration::from_secs(1)).await;
+        let (run_now, deferred, _) = floors.admit(work.clone(), Instant::now());
+        assert!(run_now.title_agents.is_empty());
+        assert_eq!(deferred.title_agents, BTreeSet::from([AgentKind::Codex]));
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let (run_now, _, _) = floors.admit(work, Instant::now());
+        assert_eq!(run_now.title_agents, BTreeSet::from([AgentKind::Codex]));
     }
 
     #[tokio::test(start_paused = true)]

--- a/apps/desktop/src-tauri/src/scan/tests.rs
+++ b/apps/desktop/src-tauri/src/scan/tests.rs
@@ -544,6 +544,33 @@ async fn a_second_pass_over_an_unchanged_source_performs_no_head_read() {
 }
 
 #[tokio::test]
+async fn an_unchanged_rollout_accepts_a_fresh_indexed_title_without_a_head_read() {
+    let home = tempfile::TempDir::new().unwrap();
+    let path = write_codex_session(home.path(), "indexed-after-discovery");
+    let log = log(AgentKind::Codex, path.clone(), 1_800_000_000);
+    let DescribeOutcome::Session(cached) = describe_one(log.clone(), home.path(), None).await
+    else {
+        panic!("session should be described");
+    };
+    antiburn_local::discovery::track_head_reads(&path);
+
+    let refreshed = reuse_unchanged_record(
+        &log,
+        Some(&cached),
+        Some(&ResolvedTitle::new(
+            "Review scan freshness",
+            TitleSource::AiGenerated,
+        )),
+    )
+    .await
+    .expect("unchanged source should be reused");
+
+    assert_eq!(refreshed.title.as_deref(), Some("Review scan freshness"));
+    assert_eq!(refreshed.title_source.as_deref(), Some("aiGenerated"));
+    assert_eq!(antiburn_local::discovery::take_tracked_head_reads(&path), 0);
+}
+
+#[tokio::test]
 async fn an_mtime_row_is_described_again_when_only_its_mtime_moved() {
     let home = tempfile::TempDir::new().unwrap();
     let path = write_claude_session(home.path(), "mtime-source");
@@ -1335,6 +1362,38 @@ fn record(agent: &str, session_id: &str, updated_at: Option<i64>) -> SessionReco
         fork_parent_session_id: None,
         source_fingerprint: None,
     }
+}
+
+#[test]
+fn a_fresh_indexed_title_updates_a_cached_record() {
+    let mut cached = record("codex", "cached-title", Some(1_000));
+    cached.title = Some("The first message".into());
+    cached.title_source = Some("firstMessage".into());
+
+    let changed = apply_indexed_title(
+        &mut cached,
+        &AgentKind::Codex,
+        ResolvedTitle::new("Review scan freshness", TitleSource::AiGenerated),
+    );
+
+    assert!(changed);
+    assert_eq!(cached.title.as_deref(), Some("Review scan freshness"));
+    assert_eq!(cached.title_source.as_deref(), Some("aiGenerated"));
+}
+
+#[test]
+fn an_equal_indexed_title_keeps_a_cached_record_unchanged() {
+    let mut cached = record("codex", "steady-title", Some(1_000));
+    cached.title = Some("Review scan freshness".into());
+    cached.title_source = Some("aiGenerated".into());
+
+    let changed = apply_indexed_title(
+        &mut cached,
+        &AgentKind::Codex,
+        ResolvedTitle::new("Review scan freshness", TitleSource::AiGenerated),
+    );
+
+    assert!(!changed);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/scan/watch.rs
+++ b/apps/desktop/src-tauri/src/scan/watch.rs
@@ -556,13 +556,21 @@ mod tests {
         let wal = codex.join("state_5.sqlite-wal");
         std::fs::write(&wal, b"synthetic WAL change").unwrap();
 
-        let burst = tokio::time::timeout(Duration::from_secs(10), rx.recv())
-            .await
-            .expect("title changes should reach the watcher")
-            .expect("watcher should stay connected");
         let canonical_index = std::fs::canonicalize(index).unwrap();
         let canonical_wal = std::fs::canonicalize(wal).unwrap();
-        assert!(burst.paths.contains(&canonical_index));
-        assert!(burst.paths.contains(&canonical_wal));
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let mut saw_index = false;
+            let mut saw_wal = false;
+            while !saw_index || !saw_wal {
+                let burst = rx.recv().await.expect("watcher should stay connected");
+                for path in burst.paths {
+                    let path = std::fs::canonicalize(&path).unwrap_or(path);
+                    saw_index |= path == canonical_index;
+                    saw_wal |= path == canonical_wal;
+                }
+            }
+        })
+        .await
+        .expect("title changes should reach the watcher");
     }
 }

--- a/apps/desktop/src-tauri/src/scan/watch.rs
+++ b/apps/desktop/src-tauri/src/scan/watch.rs
@@ -9,10 +9,9 @@
 //!
 //! # Roots
 //!
-//! Each agent's [`AgentExplorer::watch_roots`](antiburn_local::discovery::AgentExplorer::watch_roots)
-//! lists the directories its own discovery reads. Only roots that exist are
-//! watched at start. A periodic re-check adds roots that appear later (a
-//! freshly installed agent), on the same cadence as [`super::TICK`].
+//! Each agent lists its discovery roots and indexed-title files.
+//! The watcher observes title files through their parent directories.
+//! A periodic re-check adds roots that appear later.
 //!
 //! # Debouncing
 //!
@@ -94,13 +93,22 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherStatus {
     })
 }
 
-/// The roots every agent's discovery reads, for a given home. One list, so
-/// the watcher and its periodic re-check share one source of truth.
+/// Return every discovery root and indexed-title parent for a home.
 fn all_watch_roots(home: &Path) -> Vec<WatchRoot> {
-    AgentKind::ALL
+    let mut roots: Vec<WatchRoot> = AgentKind::ALL
         .iter()
         .flat_map(|agent| Explorers::DISK.watch_roots_for(agent, home))
-        .collect()
+        .collect();
+    roots.extend(AgentKind::ALL.iter().flat_map(|agent| {
+        Explorers::DISK
+            .indexed_title_watch_files_for(agent, home)
+            .into_iter()
+            .filter_map(|file| file.parent().map(Path::to_path_buf))
+            .map(WatchRoot::shallow)
+    }));
+    roots.sort_by(|left, right| left.path.cmp(&right.path));
+    roots.dedup_by(|left, right| left.path == right.path);
+    roots
 }
 
 /// Testable core of [`spawn_watcher`]: build the roots, start the OS watcher,
@@ -461,6 +469,18 @@ mod tests {
     }
 
     #[test]
+    fn codex_title_stores_add_one_shallow_parent_root() {
+        let home = Path::new("/home/avery");
+        let codex = home.join(".codex");
+
+        let roots = all_watch_roots(home);
+        let matching: Vec<&WatchRoot> = roots.iter().filter(|root| root.path == codex).collect();
+
+        assert_eq!(matching.len(), 1);
+        assert!(!matching[0].recursive);
+    }
+
+    #[test]
     fn a_root_that_does_not_exist_yet_is_skipped_rather_than_failed() {
         let home = tempfile::TempDir::new().unwrap();
         let (tx, _rx) = unbounded_channel::<Event>();
@@ -512,5 +532,37 @@ mod tests {
             1,
             "creating a transcript under a watched root should request one pass"
         );
+    }
+
+    #[tokio::test]
+    async fn the_watcher_reports_codex_title_store_changes() {
+        let home = tempfile::TempDir::new().unwrap();
+        let codex = home.path().join(".codex");
+        std::fs::create_dir_all(&codex).unwrap();
+
+        let (tx, mut rx) = unbounded_channel();
+        let status = spawn_watcher_over(home.path().to_path_buf(), move |burst| {
+            let _ = tx.send(burst);
+        });
+        assert!(status.active);
+        assert!(status.failed_roots.is_empty());
+
+        let index = codex.join("session_index.jsonl");
+        std::fs::write(
+            &index,
+            b"{\"id\":\"synthetic\",\"thread_name\":\"New title\"}\n",
+        )
+        .unwrap();
+        let wal = codex.join("state_5.sqlite-wal");
+        std::fs::write(&wal, b"synthetic WAL change").unwrap();
+
+        let burst = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("title changes should reach the watcher")
+            .expect("watcher should stay connected");
+        let canonical_index = std::fs::canonicalize(index).unwrap();
+        let canonical_wal = std::fs::canonicalize(wal).unwrap();
+        assert!(burst.paths.contains(&canonical_index));
+        assert!(burst.paths.contains(&canonical_wal));
     }
 }

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -31,6 +31,9 @@ version and refuses the release if there is none.
 - `WatchRoot`, `AgentExplorer::watch_roots`, and `Explorers::watch_roots_for`
   expose the directories each agent's discovery reads, for a filesystem
   watcher.
+- `AgentExplorer::indexed_title_watch_files` and
+  `Explorers::indexed_title_watch_files_for` expose vendor title stores to
+  filesystem watchers.
 
 ### Changed
 

--- a/crates/antiburn-local/src/discovery/agents/codex.rs
+++ b/crates/antiburn-local/src/discovery/agents/codex.rs
@@ -118,6 +118,14 @@ impl AgentExplorer for CodexExplorer {
         indexed_session_titles_in(&home, codex_home.as_deref(), agent_session_ids).await
     }
 
+    fn indexed_title_watch_files(&self, home: &Path) -> Vec<PathBuf> {
+        let codex_home = std::env::var("CODEX_HOME").ok().map(PathBuf::from);
+        state_db_paths(home, codex_home.as_deref())
+            .into_iter()
+            .chain(session_index_paths(home, codex_home.as_deref()))
+            .collect()
+    }
+
     /// Point query: every rollout embeds its thread id as the filename suffix
     /// (`rollout-<ts>-<id>.jsonl`), so a filename scan replaces the default
     /// full-tree discover (which also stats every file). Preserves
@@ -1215,6 +1223,17 @@ mod tests {
             index_title_for_rollout(&rollout, "thread").await.as_deref(),
             Some("Latest")
         );
+    }
+
+    #[test]
+    fn title_watch_files_include_the_state_database_and_jsonl_index() {
+        let home = TempDir::new().unwrap();
+        let codex = home.path().join(".codex");
+
+        let files = CodexExplorer.indexed_title_watch_files(home.path());
+
+        assert!(files.contains(&codex.join("state_5.sqlite")));
+        assert!(files.contains(&codex.join("session_index.jsonl")));
     }
 
     /// The child-thread exclusion that `discover_recent` applies must also

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -300,6 +300,12 @@ pub trait AgentExplorer: Send + Sync {
         titles
     }
 
+    /// Return vendor files whose changes can alter indexed session titles.
+    /// The watcher observes their parent directories and filters exact paths.
+    fn indexed_title_watch_files(&self, _home: &Path) -> Vec<PathBuf> {
+        Vec::new()
+    }
+
     /// Classify a `SessionLog` produced by this explorer to a stable surface
     /// label suitable for `tracing` fields and wire types. Returns
     /// one of `"cli"`, `"ide_desktop"`, or `"unknown"`.
@@ -696,6 +702,11 @@ impl Explorers {
     /// and the batched scan path without taking a scan lock just to ask.
     pub fn title_lookup_kind_for(&self, agent: &AgentKind) -> TitleLookupKind {
         self.get(agent).title_lookup_kind()
+    }
+
+    /// Return the files that can change indexed titles for one agent.
+    pub fn indexed_title_watch_files_for(&self, agent: &AgentKind, home: &Path) -> Vec<PathBuf> {
+        self.get(agent).indexed_title_watch_files(home)
     }
 
     /// Infer the agent from a file path using each agent's `owns_path`.

--- a/docs/plans/continuous-session-ingest.md
+++ b/docs/plans/continuous-session-ingest.md
@@ -111,9 +111,9 @@ Goal: fix the pop-in without the new architecture.
 - Test: a second pass over an unchanged transcript performs no head read
   (the discovery crate's tracked-head-read instrumentation exists for this).
 
-Known limit, accepted: a title change in a vendor index while the transcript
-size is unchanged is not picked up until the transcript grows. Phase 3
-replaces the size gate with a verified offset.
+This phase initially accepted one limit: a vendor index title change did not
+refresh an unchanged transcript. The indexed-title lane in Phase 5b now
+resolves that limit.
 
 ### Phase 2: evidence from rows (done)
 
@@ -369,6 +369,13 @@ scheduler task, so passes never overlap and the store sees one writer.
   are coalesced into one deferred refresh at the floor's end, never dropped,
   so a session that keeps writing is refreshed every 10 s and a session that
   writes once is refreshed once.
+- T2a. Indexed titles. An agent can list vendor files whose changes can alter
+  session titles. The watcher observes their parent directories and accepts
+  only the listed files or their SQLite write sidecars. A change batches title
+  lookups for the agent's known native sessions, updates changed rows through
+  `sessions:entry-changed`, and does not run discovery or read transcripts.
+  Each agent runs this lane at most once per 10 seconds, with events inside the
+  floor coalesced into one deferred refresh.
 - T3. New session. A path under an agent's watch root that matches no stored
   session means that agent has a session the store has never seen. The
   agent-scoped pass runs `discover_recent` for that one agent, describes the


### PR DESCRIPTION
## Summary

- watch Codex `state_5.sqlite`, its write sidecars, and `session_index.jsonl` in addition to rollout directories
- route those events through a 10-second, per-agent title-only lane that batches known native session IDs without discovery or transcript reads
- overlay freshly indexed titles on unchanged cached rollouts during every other scan path too
- document the new discovery API and close the stale-title limitation in the ingest plan

## Why

Codex can write the initial first-message fallback and then replace it with an auto-generated title without changing the rollout. antiburn watched only the rollout tree, and the unchanged-source fast path reused the cached title verbatim. That left the first-message title visible until a later rollout write or reconciliation happened.

## Validation

- `cargo test --no-fail-fast` (`crates/antiburn-local`)
- `cargo clippy --all-targets -- -D warnings` (`crates/antiburn-local`)
- `cargo test --no-fail-fast` (`apps/desktop/src-tauri`)
- `cargo clippy --all-targets -- -D warnings` (`apps/desktop/src-tauri`)
- `cargo fmt --check` for both Rust crates
- Codex title-store notify test repeated five times
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop build`
- `pnpm run slop:all`
- `pnpm run secrets`
- GitHub CI: 31 checks passed across Linux, macOS, and Windows

## Performance and privacy

The added parent watch is shallow and exact-path filtered. Store events are coalesced to one lookup per agent per 10 seconds, and only changed rows are written and announced. The lane reads vendor title metadata only; it does not read transcript content or add network activity.