### PR TITLE
desktop: read the CLI's own saved usage reading before the network

### DIFF
--- a/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
@@ -4,10 +4,15 @@
 //!
 //! # What this parses
 //!
-//! The body `GET https://api.anthropic.com/api/oauth/usage` returns —
-//! [`sources::anthropic_fetch`](super::sources::anthropic_fetch) is this
-//! module's only caller. It takes a bare `&str` regardless, so a fixture in a
-//! test does not need to pretend to be an HTTP response.
+//! The body `GET https://api.anthropic.com/api/oauth/usage` returns.
+//! [`sources::anthropic_fetch`](super::sources::anthropic_fetch) calls
+//! [`parse_usage`] on that response body directly, so a fixture in a test
+//! does not need to pretend to be an HTTP response.
+//! [`sources::claude_config_cache`](super::sources::claude_config_cache)
+//! calls [`parse_usage_value`] instead: the Claude CLI caches the identical
+//! `utilization` object inside a much larger JSON document, already parsed,
+//! so [`parse_usage_value`] takes the [`Value`] straight from that document
+//! rather than re-serialising it back to a string first.
 //!
 //! # What the payload looks like
 //!
@@ -50,6 +55,13 @@ pub struct AnthropicUsage {
 pub fn parse_usage(input: &str) -> Result<AnthropicUsage, ProviderUsageError> {
     let value: Value = serde_json::from_str(input)
         .map_err(|_| ProviderUsageError::Schema(SchemaReason::InvalidJson))?;
+    parse_usage_value(&value)
+}
+
+/// Parse an already-decoded usage payload. Same rules as [`parse_usage`],
+/// which is `serde_json::from_str` followed by this function — see the
+/// module doc for the other caller this split serves.
+pub fn parse_usage_value(value: &Value) -> Result<AnthropicUsage, ProviderUsageError> {
     if !value.is_object() {
         return Err(ProviderUsageError::Schema(SchemaReason::MissingEnvelope));
     }

--- a/apps/desktop/src-tauri/src/provider_usage/live/codex.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/codex.rs
@@ -2,10 +2,11 @@
 //!
 //! This is what `GET https://chatgpt.com/backend-api/wham/usage` returns —
 //! [`sources::codex_fetch`](super::sources::codex_fetch) is this module's
-//! only caller. Unlike the Anthropic parser this application also carries,
-//! there is exactly one carrier here: no cached copy of this payload exists
-//! on disk anywhere, so there is nothing to reuse this parser for besides the
-//! live response.
+//! only caller. The Codex CLI's own rollout files do carry a cached rate
+//! limit reading, but in a different, smaller shape — the account-wide
+//! window only, with none of `additional_rate_limits` — read by
+//! `sources::codex_rollout` instead of this parser. So this parser still has
+//! exactly one caller: the live response.
 //!
 //! # What the payload looks like
 //!

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -52,6 +52,28 @@
 //! every poll: see that module for the retry and last-good-reading contract
 //! every direct-fetch source shares, and for how a caller's own `max_age`
 //! decides how often "every poll" actually reaches the network.
+//!
+//! # The CLI's own cache
+//!
+//! Before any of the above, this source checks [`claude_config_cache`] — the
+//! same reading the Claude CLI itself cached the last time it called the
+//! usage endpoint. Two tiers follow, in order:
+//!
+//! 1. **Cache pre-empts the network.** When the cached reading is no older
+//!    than the caller's own `max_age`, it is returned as-is and no request is
+//!    made at all — the cache is already at least as fresh as what the
+//!    caller would have accepted from a live call.
+//! 2. **Cache seeds a failure.** When the cache is not fresh enough to
+//!    pre-empt the request, the live endpoint is still asked as normal. If
+//!    that call fails and the cache is no older than [`cooldown::MAX_AGE`],
+//!    the cached reading rides along as [`cooldown::FetchFailure::last_known`]
+//!    — a real figure to show instead of nothing, while the error itself
+//!    still reports that the endpoint did not just answer.
+//!
+//! Both tiers stamp the resulting snapshot with this source's own
+//! [`SOURCE_ID`] and a label naming the cache, not the network — one
+//! registered source, two ways of answering, the same pattern
+//! [`super::codex_app_server`] uses for Codex's fallback.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -65,7 +87,8 @@ use crate::provider_usage::live::model::{
 };
 use crate::provider_usage::live::{LiveUsageSource, SourceOutcome};
 
-use super::cooldown::Cooldown;
+use super::claude_config_cache::{self, CachedUsage};
+use super::cooldown::{self, Cooldown, FetchFailure};
 use super::http;
 
 /// The credentials file is a small, purpose-built OAuth token store, not a
@@ -277,7 +300,9 @@ mod macos_keychain {
     }
 }
 
-/// Asks `GET /api/oauth/usage` with the CLI's own access token.
+/// Asks `GET /api/oauth/usage` with the CLI's own access token, after first
+/// checking the CLI's own cached reading — see the module doc's "The CLI's
+/// own cache" section.
 pub struct ClaudeDirectFetch {
     credentials_path: Option<PathBuf>,
     /// Whether to consult the macOS Keychain before falling back to the
@@ -288,6 +313,11 @@ pub struct ClaudeDirectFetch {
     /// to hold. Unused, and absent from the struct, on every other platform.
     #[cfg(target_os = "macos")]
     try_keychain: bool,
+    /// Where the Claude CLI's own cached usage reading lives. `None` means
+    /// no cache is consulted — the ordinary state for a test that has no
+    /// reason to exercise it, not a special mode.
+    config_cache_path: Option<PathBuf>,
+    transport: Box<dyn AnthropicTransport>,
     cooldown: Cooldown,
 }
 
@@ -297,18 +327,47 @@ impl ClaudeDirectFetch {
             credentials_path: default_credentials_path(),
             #[cfg(target_os = "macos")]
             try_keychain: true,
+            config_cache_path: claude_config_cache::default_config_path(),
+            transport: Box::new(LiveAnthropicTransport),
             cooldown: Cooldown::new(),
         }
     }
 
     /// A source rooted at an explicit path, with the Keychain carrier
     /// disabled — see the `try_keychain` field doc for why tests need that.
+    /// Reads no config cache; see `at_with_config_cache` for a test that
+    /// needs one.
     #[cfg(test)]
     pub fn at(path: PathBuf) -> ClaudeDirectFetch {
         ClaudeDirectFetch {
             credentials_path: Some(path),
             #[cfg(target_os = "macos")]
             try_keychain: false,
+            config_cache_path: None,
+            transport: Box::new(LiveAnthropicTransport),
+            cooldown: Cooldown::new(),
+        }
+    }
+
+    /// A source rooted at an explicit credentials path, also reading the
+    /// CLI's own cache from an explicit path — for a test that exercises the
+    /// cache through the full source rather than through `fetch_with_cache`
+    /// directly.
+    ///
+    /// The transport is explicit so the test never reaches the network
+    /// when its timing assumption fails.
+    #[cfg(test)]
+    fn at_with_config_cache(
+        credentials_path: PathBuf,
+        config_cache_path: PathBuf,
+        transport: Box<dyn AnthropicTransport>,
+    ) -> ClaudeDirectFetch {
+        ClaudeDirectFetch {
+            credentials_path: Some(credentials_path),
+            #[cfg(target_os = "macos")]
+            try_keychain: false,
+            config_cache_path: Some(config_cache_path),
+            transport,
             cooldown: Cooldown::new(),
         }
     }
@@ -367,19 +426,155 @@ impl LiveUsageSource for ClaudeDirectFetch {
 
     fn fetch(&self, max_age: std::time::Duration) -> SourceOutcome {
         let now = OffsetDateTime::now_utc();
-        // The credential read sits inside the cooldown gate on purpose: on
-        // macOS it spawns a `security` subprocess, and a poll that the
-        // cooldown is going to skip anyway should not pay for one — nor
-        // re-raise a Keychain access prompt the reader has already seen.
-        self.cooldown
-            .poll(now, max_age, || match self.read_credentials()? {
-                Some(credentials) => Ok(Some(fetch_live(&credentials, now)?)),
-                None => Ok(None),
-            })
+        // The credential read, and the config-cache read, both sit inside
+        // the cooldown gate on purpose: on macOS the former spawns a
+        // `security` subprocess, and a poll that the cooldown is going to
+        // skip anyway should not pay for either — nor re-raise a Keychain
+        // access prompt the reader has already seen.
+        self.cooldown.poll(now, max_age, || {
+            let Some(credentials) = self.read_credentials()? else {
+                return Ok(None);
+            };
+            let cached = self
+                .config_cache_path
+                .as_deref()
+                .and_then(claude_config_cache::read_cached_usage);
+            fetch_with_cache(self.transport.as_ref(), &credentials, cached, max_age, now)
+        })
+    }
+}
+
+/// The network calls the live path needs, as a trait so a test can supply
+/// them without a socket — the same seam `codex_fetch`'s `CodexTransport`
+/// gives that source.
+trait AnthropicTransport: Send + Sync {
+    fn usage(&self, access_token: &str) -> Result<String, ProviderUsageError>;
+    /// The account id from the profile endpoint. `None` on any failure: this
+    /// is a best-effort enrichment, never a reason to fail the snapshot.
+    fn profile(&self, access_token: &str) -> Option<String>;
+}
+
+struct LiveAnthropicTransport;
+
+impl AnthropicTransport for LiveAnthropicTransport {
+    fn usage(&self, access_token: &str) -> Result<String, ProviderUsageError> {
+        let response = http::client()
+            .get(USAGE_ENDPOINT)
+            .bearer_auth(access_token)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header("anthropic-beta", "oauth-2025-04-20")
+            .send()
+            .map_err(|_| ProviderUsageError::Unavailable)?;
+        if let Some(error) = http::status_error(response.status()) {
+            return Err(error);
+        }
+        http::read_capped_body(response)
+    }
+
+    fn profile(&self, access_token: &str) -> Option<String> {
+        let response = http::client()
+            .get(PROFILE_ENDPOINT)
+            .bearer_auth(access_token)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header("anthropic-beta", "oauth-2025-04-20")
+            .send()
+            .ok()?;
+        if http::status_error(response.status()).is_some() {
+            return None;
+        }
+        let body = http::read_capped_body(response).ok()?;
+        profile_subject(&body)
+    }
+}
+
+/// The two-tier decision the module doc's "The CLI's own cache" section
+/// describes. A free function over [`AnthropicTransport`] rather than a
+/// method, so a test calls it with a fake transport and nothing else this
+/// source owns — mirrors `codex_fetch::fetch_direct`.
+fn fetch_with_cache(
+    transport: &dyn AnthropicTransport,
+    credentials: &ClaudeCredentials,
+    cached: Option<CachedUsage>,
+    max_age: std::time::Duration,
+    now: OffsetDateTime,
+) -> Result<Option<ProviderUsageSnapshot>, FetchFailure> {
+    if let Some(cached) = cached.clone()
+        && cache_covers(now, cached.observed_at, max_age)
+    {
+        log_cache_reading_used(&cached, now, "fresh");
+        return Ok(Some(snapshot_from_cache(cached, credentials)));
+    }
+
+    match fetch_live(transport, credentials, now) {
+        Ok(snapshot) => Ok(Some(snapshot)),
+        Err(error) => {
+            let last_known = cached
+                .filter(|cached| now - cached.observed_at <= cooldown::MAX_AGE)
+                .map(|cached| {
+                    log_cache_reading_used(&cached, now, "seed");
+                    Box::new(snapshot_from_cache(cached, credentials))
+                });
+            Err(FetchFailure { error, last_known })
+        }
+    }
+}
+
+/// Whether `observed_at` is no older than `max_age`, converting the
+/// caller's `std::time::Duration` into `time`'s own type for the
+/// comparison. A `max_age` too large to convert cannot be satisfied, so the
+/// cache does not pre-empt the network in that case either.
+fn cache_covers(
+    now: OffsetDateTime,
+    observed_at: OffsetDateTime,
+    max_age: std::time::Duration,
+) -> bool {
+    time::Duration::try_from(max_age)
+        .map(|max_age| now - observed_at <= max_age)
+        .unwrap_or(false)
+}
+
+/// The `live_cache_reading_used` tracing event, at the two points the
+/// cached reading is used — see the module doc's "The CLI's own cache"
+/// section. `debug`, not `warn`: reading a cache is the ordinary path, not a
+/// problem.
+fn log_cache_reading_used(cached: &CachedUsage, now: OffsetDateTime, reason: &'static str) {
+    ::tracing::debug!(
+        event = "live_cache_reading_used",
+        provider = crate::provider_usage::providers::ANTHROPIC,
+        age_secs = (now - cached.observed_at).whole_seconds(),
+        reason
+    );
+}
+
+/// Build a snapshot from the CLI's own cached reading. Used both when the
+/// cache pre-empts the network and when it seeds a failure — see the module
+/// doc's "The CLI's own cache" section.
+fn snapshot_from_cache(
+    cached: CachedUsage,
+    credentials: &ClaudeCredentials,
+) -> ProviderUsageSnapshot {
+    ProviderUsageSnapshot {
+        provider: crate::provider_usage::providers::ANTHROPIC,
+        account: Some(cached.account),
+        plan: credentials.subscription_type.clone(),
+        plan_tier: credentials.rate_limit_tier.clone(),
+        observed_at: cached.observed_at,
+        source: UsageSource {
+            id: SOURCE_ID,
+            label: "Read from the Claude CLI's own cache".into(),
+            confidence: Confidence::High,
+            freshness: Freshness::Fresh,
+        },
+        windows: cached.usage.windows,
+        supplemental: cached.usage.supplemental,
+        reset_credits: None,
     }
 }
 
 fn fetch_live(
+    transport: &dyn AnthropicTransport,
     credentials: &ClaudeCredentials,
     now: OffsetDateTime,
 ) -> Result<ProviderUsageSnapshot, ProviderUsageError> {
@@ -389,21 +584,9 @@ fn fetch_live(
         return Err(ProviderUsageError::Authentication);
     }
 
-    let response = http::client()
-        .get(USAGE_ENDPOINT)
-        .bearer_auth(&credentials.access_token)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header("anthropic-beta", "oauth-2025-04-20")
-        .send()
-        .map_err(|_| ProviderUsageError::Unavailable)?;
-
-    if let Some(error) = http::status_error(response.status()) {
-        return Err(error);
-    }
-    let body = http::read_capped_body(response)?;
+    let body = transport.usage(&credentials.access_token)?;
     let usage = anthropic::parse_usage(&body)?;
-    let account = fetch_profile_subject(&credentials.access_token);
+    let account = transport.profile(&credentials.access_token);
 
     Ok(ProviderUsageSnapshot {
         provider: crate::provider_usage::providers::ANTHROPIC,
@@ -423,22 +606,6 @@ fn fetch_live(
         supplemental: usage.supplemental,
         reset_credits: None,
     })
-}
-
-fn fetch_profile_subject(access_token: &str) -> Option<String> {
-    let response = http::client()
-        .get(PROFILE_ENDPOINT)
-        .bearer_auth(access_token)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header("anthropic-beta", "oauth-2025-04-20")
-        .send()
-        .ok()?;
-    if http::status_error(response.status()).is_some() {
-        return None;
-    }
-    let body = http::read_capped_body(response).ok()?;
-    profile_subject(&body)
 }
 
 fn profile_subject(body: &str) -> Option<String> {
@@ -462,6 +629,197 @@ mod tests {
     /// whether a reading is found, not how the cooldown's freshness budget
     /// behaves — `cooldown.rs`'s own suite owns that.
     const TEST_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(600);
+
+    /// A popover-shaped `max_age` — well under a minute, matching
+    /// `cooldown.rs`'s own `SHORT_MAX_AGE` — for the `fetch_with_cache`
+    /// tests below, which care whether the cache is fresh enough to
+    /// pre-empt the network, not the cooldown's own gating.
+    const SHORT_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(50);
+
+    fn now() -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(NOW).unwrap()
+    }
+
+    fn valid_credentials() -> ClaudeCredentials {
+        ClaudeCredentials {
+            access_token: "synthetic-token".into(),
+            expires_at_ms: (NOW + 3_600) * 1_000,
+            subscription_type: Some("max".into()),
+            rate_limit_tier: Some("default_claude_max_5x".into()),
+        }
+    }
+
+    fn cached_usage(observed_at: OffsetDateTime) -> CachedUsage {
+        CachedUsage {
+            observed_at,
+            account: "cached-account-uuid".into(),
+            usage: anthropic::AnthropicUsage::default(),
+        }
+    }
+
+    /// A transport that panics if called — for a test asserting the cache
+    /// pre-empted the network entirely.
+    struct UnreachableTransport;
+
+    impl AnthropicTransport for UnreachableTransport {
+        fn usage(&self, _access_token: &str) -> Result<String, ProviderUsageError> {
+            unreachable!("the cache should have pre-empted the network")
+        }
+        fn profile(&self, _access_token: &str) -> Option<String> {
+            unreachable!("the cache should have pre-empted the network")
+        }
+    }
+
+    const LIVE_USAGE_BODY: &str = r#"{"five_hour": {"utilization": 40}}"#;
+
+    /// A transport whose `usage` call returns a fixed result, for tests that
+    /// only care whether the live call was reached and what it answered.
+    struct FakeTransport {
+        usage_result: Result<String, ProviderUsageError>,
+    }
+
+    impl AnthropicTransport for FakeTransport {
+        fn usage(&self, _access_token: &str) -> Result<String, ProviderUsageError> {
+            self.usage_result.clone()
+        }
+        fn profile(&self, _access_token: &str) -> Option<String> {
+            None
+        }
+    }
+
+    #[test]
+    fn a_fresh_cache_pre_empts_the_network() {
+        let cached = cached_usage(now() - time::Duration::seconds(10));
+        let outcome = fetch_with_cache(
+            &UnreachableTransport,
+            &valid_credentials(),
+            Some(cached.clone()),
+            SHORT_MAX_AGE,
+            now(),
+        )
+        .expect("no live call, so no failure")
+        .expect("a snapshot from the cache");
+
+        assert_eq!(outcome.source.label, "Read from the Claude CLI's own cache");
+        assert_eq!(outcome.observed_at, cached.observed_at);
+    }
+
+    #[test]
+    fn a_cache_older_than_max_age_falls_through_to_a_live_call_that_succeeds() {
+        let cached = cached_usage(now() - time::Duration::seconds(100));
+        let transport = FakeTransport {
+            usage_result: Ok(LIVE_USAGE_BODY.to_string()),
+        };
+        let outcome = fetch_with_cache(
+            &transport,
+            &valid_credentials(),
+            Some(cached),
+            SHORT_MAX_AGE,
+            now(),
+        )
+        .expect("the live call succeeded")
+        .expect("a live snapshot");
+
+        assert_eq!(outcome.source.label, "Asked Claude directly");
+        assert_eq!(outcome.observed_at, now());
+    }
+
+    #[test]
+    fn a_cache_older_than_max_age_but_within_the_hour_seeds_a_failed_live_call() {
+        let cached = cached_usage(now() - time::Duration::minutes(30));
+        let transport = FakeTransport {
+            usage_result: Err(ProviderUsageError::RateLimited),
+        };
+        let failure = fetch_with_cache(
+            &transport,
+            &valid_credentials(),
+            Some(cached.clone()),
+            SHORT_MAX_AGE,
+            now(),
+        )
+        .expect_err("the live call failed");
+
+        assert_eq!(failure.error, ProviderUsageError::RateLimited);
+        let last_known = failure.last_known.expect("the cache seeds the failure");
+        assert_eq!(last_known.observed_at, cached.observed_at);
+    }
+
+    #[test]
+    fn a_cache_older_than_the_hour_budget_does_not_seed_a_failed_live_call() {
+        let cached = cached_usage(now() - time::Duration::minutes(90));
+        let transport = FakeTransport {
+            usage_result: Err(ProviderUsageError::Unavailable),
+        };
+        let failure = fetch_with_cache(
+            &transport,
+            &valid_credentials(),
+            Some(cached),
+            SHORT_MAX_AGE,
+            now(),
+        )
+        .expect_err("the live call failed");
+
+        assert!(failure.last_known.is_none());
+    }
+
+    #[test]
+    fn no_cache_never_seeds_a_failed_live_call() {
+        let transport = FakeTransport {
+            usage_result: Err(ProviderUsageError::Unavailable),
+        };
+        let failure =
+            fetch_with_cache(&transport, &valid_credentials(), None, SHORT_MAX_AGE, now())
+                .expect_err("the live call failed");
+
+        assert!(failure.last_known.is_none());
+    }
+
+    #[test]
+    fn fetch_prefers_a_fresh_cache_over_a_live_call() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let credentials_path = dir.path().join(".credentials.json");
+        let real_now = OffsetDateTime::now_utc();
+        fs::write(
+            &credentials_path,
+            credentials_file((real_now.unix_timestamp() + 3_600) * 1_000, "max"),
+        )
+        .expect("write");
+
+        let config_cache_path = dir.path().join(".claude.json");
+        let fetched_at_ms = (real_now.unix_timestamp() - 10) * 1_000;
+        fs::write(
+            &config_cache_path,
+            format!(
+                r#"{{
+                  "oauthAccount": {{"accountUuid": "cached-account-uuid"}},
+                  "cachedUsageUtilization": {{
+                    "fetchedAtMs": {fetched_at_ms},
+                    "accountUuid": "cached-account-uuid",
+                    "utilization": {{"five_hour": {{"utilization": 25}}}}
+                  }}
+                }}"#
+            ),
+        )
+        .expect("write");
+
+        let outcome = ClaudeDirectFetch::at_with_config_cache(
+            credentials_path,
+            config_cache_path,
+            Box::new(UnreachableTransport),
+        )
+        .fetch(TEST_MAX_AGE);
+
+        assert_eq!(outcome.error, None);
+        assert_eq!(outcome.snapshots.len(), 1);
+        assert_eq!(
+            outcome.snapshots[0].source.label,
+            "Read from the Claude CLI's own cache"
+        );
+        assert_eq!(
+            outcome.snapshots[0].account.as_deref(),
+            Some("cached-account-uuid")
+        );
+    }
 
     #[test]
     fn profile_identity_uses_only_the_account_uuid() {
@@ -532,7 +890,7 @@ mod tests {
             rate_limit_tier: None,
         };
         assert_eq!(
-            fetch_live(&credentials, now),
+            fetch_live(&UnreachableTransport, &credentials, now),
             Err(ProviderUsageError::Authentication)
         );
     }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -373,7 +373,7 @@ impl LiveUsageSource for ClaudeDirectFetch {
         // re-raise a Keychain access prompt the reader has already seen.
         self.cooldown
             .poll(now, max_age, || match self.read_credentials()? {
-                Some(credentials) => fetch_live(&credentials, now).map(Some),
+                Some(credentials) => Ok(Some(fetch_live(&credentials, now)?)),
                 None => Ok(None),
             })
     }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/antigravity_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/antigravity_fetch.rs
@@ -181,13 +181,13 @@ impl LiveUsageSource for AntigravityDirectFetch {
     fn fetch(&self, max_age: std::time::Duration) -> SourceOutcome {
         let now = OffsetDateTime::now_utc();
         self.cooldown.poll(now, max_age, || {
-            fetch_with_refresh_fallback(
+            Ok(fetch_with_refresh_fallback(
                 self.transport.as_ref(),
                 self.local.as_ref(),
                 self.credentials(now).as_ref(),
                 &self.refreshed,
                 now,
-            )
+            )?)
         })
     }
 }

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/claude_config_cache.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/claude_config_cache.rs
@@ -1,0 +1,244 @@
+//! Reads the Claude CLI's own cached usage reading off disk.
+//!
+//! The Claude CLI (Claude Code) caches the last reading it fetched from the
+//! very endpoint [`super::anthropic_fetch`] calls, in its global config file.
+//! That endpoint returns HTTP 429 intermittently, and the CLI and antiburn
+//! draw from one per-account bucket. Reading the CLI's cached copy avoids a
+//! request when the cache is fresh enough, and gives a real reading to show
+//! when the endpoint says 429. See [`super::anthropic_fetch`]'s "The CLI's
+//! own cache" section for how the two-tier fetch uses this.
+//!
+//! # Where the cache lives
+//!
+//! `$CLAUDE_CONFIG_DIR/.claude.json` when that variable is set and
+//! non-empty, otherwise `~/.claude.json`. This sits next to `~/.claude/`, not
+//! inside it — a different file from the credentials
+//! [`super::anthropic_fetch`] reads.
+//!
+//! # What this reads out of it
+//!
+//! The file is a large JSON object with many keys this module has no use
+//! for. Only two matter: `oauthAccount.accountUuid`, the signed-in account,
+//! and `cachedUsageUtilization`, the cached reading itself —
+//! `fetchedAtMs`, its own `accountUuid`, and a `utilization` object that is
+//! byte-for-byte the body the usage endpoint returns, so
+//! [`anthropic::parse_usage_value`] already understands it. Nothing else in
+//! the file is read, and no other key of `cachedUsageUtilization` or
+//! `oauthAccount` is read either — in particular never `emailAddress`.
+//!
+//! # Every failure reads as "no cache", never as an error
+//!
+//! A missing file, an unreadable one, one that is not JSON, one missing
+//! `cachedUsageUtilization`, a missing or invalid `fetchedAtMs`, a missing
+//! `accountUuid` on either side, a `cachedUsageUtilization.accountUuid` that
+//! does not match `oauthAccount.accountUuid`, or a `utilization` object
+//! [`anthropic::parse_usage_value`] rejects — every one of these yields
+//! [`None`], nothing logged. The cache is an optimisation on top of the
+//! endpoint, which stays the source of truth; a reader who has never opened
+//! the CLI, or whose cache is stale or mid-write, is not an error case.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use crate::provider_usage::live::anthropic::{self, AnthropicUsage};
+
+/// `.claude.json` is a general CLI state file, not a purpose-built store —
+/// it grows with use, so the read is capped defensively rather than trusted.
+/// It is ordinarily under 1 MB.
+const MAX_CONFIG_BYTES: u64 = 16 * 1024 * 1024;
+
+/// The CLI's own cached usage reading, and the account it belongs to.
+#[derive(Debug, Clone)]
+pub struct CachedUsage {
+    /// The moment the CLI received this reading — `cachedUsageUtilization`'s
+    /// own `fetchedAtMs`, not when this module read the file.
+    pub observed_at: OffsetDateTime,
+    /// `cachedUsageUtilization.accountUuid`, already confirmed to match
+    /// `oauthAccount.accountUuid`.
+    pub account: String,
+    pub usage: AnthropicUsage,
+}
+
+/// The config file, at the one documented place it lives.
+pub fn default_config_path() -> Option<PathBuf> {
+    let dir = antiburn_local::paths::non_empty_env_path("CLAUDE_CONFIG_DIR")
+        .or_else(antiburn_local::paths::home_dir)?;
+    Some(dir.join(".claude.json"))
+}
+
+/// Read and parse the CLI's cached usage reading from `path`. See the module
+/// doc for why every failure yields [`None`] rather than an error.
+pub fn read_cached_usage(path: &Path) -> Option<CachedUsage> {
+    let metadata = fs::metadata(path).ok()?;
+    if metadata.len() > MAX_CONFIG_BYTES {
+        return None;
+    }
+    let contents = fs::read_to_string(path).ok()?;
+    parse_cached_usage(&contents)
+}
+
+/// Parse `.claude.json`'s contents. A free function separate from
+/// [`read_cached_usage`] so a test can hand it a string directly.
+fn parse_cached_usage(contents: &str) -> Option<CachedUsage> {
+    let document: Value = serde_json::from_str(contents).ok()?;
+    let oauth_account_uuid = document.pointer("/oauthAccount/accountUuid")?.as_str()?;
+    let cached = document.get("cachedUsageUtilization")?;
+    let account_uuid = cached.get("accountUuid")?.as_str()?;
+    if account_uuid != oauth_account_uuid {
+        return None;
+    }
+    let fetched_at_ms = cached.get("fetchedAtMs")?.as_i64()?;
+    let observed_at = OffsetDateTime::from_unix_timestamp(fetched_at_ms / 1_000).ok()?;
+    let usage = anthropic::parse_usage_value(cached.get("utilization")?).ok()?;
+
+    Some(CachedUsage {
+        observed_at,
+        account: account_uuid.to_owned(),
+        usage,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A well-formed `.claude.json`, shaped like the real file: the two keys
+    /// this module reads, plus unrelated top-level and nested keys it must
+    /// ignore.
+    fn well_formed_document(account_uuid: &str, cached_account_uuid: &str) -> String {
+        format!(
+            r#"{{
+              "numStartups": 42,
+              "oauthAccount": {{
+                "accountUuid": "{account_uuid}",
+                "emailAddress": "reader@example.test",
+                "organizationUuid": "org-0000"
+              }},
+              "cachedUsageUtilization": {{
+                "fetchedAtMs": 1788419487009,
+                "accountUuid": "{cached_account_uuid}",
+                "utilization": {{
+                  "seven_day_opus": null,
+                  "seven_day_sonnet": null,
+                  "extra_usage": {{
+                    "is_enabled": false,
+                    "monthly_limit": null,
+                    "used_credits": null,
+                    "utilization": null,
+                    "currency": null
+                  }},
+                  "limits": [
+                    {{"kind": "session", "percent": 54,
+                      "resets_at": "2026-09-03T10:29:59.945982+00:00",
+                      "scope": null, "is_active": true}},
+                    {{"kind": "weekly_all", "percent": 12,
+                      "resets_at": "2026-09-07T00:59:59+00:00",
+                      "scope": null, "is_active": true}},
+                    {{"kind": "weekly_scoped", "percent": 10,
+                      "resets_at": "2026-09-07T00:59:59+00:00",
+                      "scope": {{"model": {{"display_name": "Fable"}}}},
+                      "is_active": true}}
+                  ],
+                  "spend": {{"totalCents": 500}}
+                }}
+              }}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn a_well_formed_file_yields_the_cached_reading() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".claude.json");
+        fs::write(
+            &path,
+            well_formed_document(
+                "8a4d1c2e-0000-4000-8000-000000000001",
+                "8a4d1c2e-0000-4000-8000-000000000001",
+            ),
+        )
+        .expect("write");
+
+        let cached = read_cached_usage(&path).expect("parses");
+        assert_eq!(
+            cached.observed_at,
+            OffsetDateTime::from_unix_timestamp(1_788_419_487).unwrap()
+        );
+        assert_eq!(cached.account, "8a4d1c2e-0000-4000-8000-000000000001");
+        let ids: Vec<&str> = cached
+            .usage
+            .windows
+            .iter()
+            .map(|window| window.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["five-hour", "seven-day", "weekly-fable"]);
+        assert!(!cached.usage.supplemental.expect("supplemental").enabled);
+    }
+
+    #[test]
+    fn a_mismatched_account_uuid_yields_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".claude.json");
+        fs::write(
+            &path,
+            well_formed_document(
+                "8a4d1c2e-0000-4000-8000-000000000001",
+                "different-account-uuid",
+            ),
+        )
+        .expect("write");
+
+        assert!(read_cached_usage(&path).is_none());
+    }
+
+    #[test]
+    fn a_missing_cached_usage_utilization_key_yields_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".claude.json");
+        fs::write(
+            &path,
+            r#"{"oauthAccount": {"accountUuid": "8a4d1c2e-0000-4000-8000-000000000001"}}"#,
+        )
+        .expect("write");
+
+        assert!(read_cached_usage(&path).is_none());
+    }
+
+    #[test]
+    fn a_missing_file_yields_none() {
+        assert!(read_cached_usage(Path::new("/nonexistent/.claude.json")).is_none());
+    }
+
+    #[test]
+    fn a_file_over_the_cap_is_not_read() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".claude.json");
+        let padding = "x".repeat((MAX_CONFIG_BYTES + 1) as usize);
+        fs::write(&path, format!(r#"{{"pad": "{padding}"}}"#)).expect("write");
+
+        assert!(read_cached_usage(&path).is_none());
+    }
+
+    #[test]
+    fn a_utilization_object_parse_usage_rejects_yields_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".claude.json");
+        fs::write(
+            &path,
+            r#"{
+              "oauthAccount": {"accountUuid": "account-uuid"},
+              "cachedUsageUtilization": {
+                "fetchedAtMs": 1788419487009,
+                "accountUuid": "account-uuid",
+                "utilization": {}
+              }
+            }"#,
+        )
+        .expect("write");
+
+        assert!(read_cached_usage(&path).is_none());
+    }
+}

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -46,6 +46,21 @@
 //! two paths can disagree about which error is more informative — see
 //! [`preferred_error`] — but only one of them ever contributes a snapshot.
 //!
+//! # Seeding from the session log
+//!
+//! When the retried direct attempt and the app-server fallback both fail,
+//! this source makes one more offer: the newest rate-limit reading in the
+//! reader's own Codex CLI session log, read by
+//! [`super::codex_rollout::latest_reading`]. It travels as
+//! [`FetchFailure::last_known`](super::cooldown::FetchFailure::last_known),
+//! not as a success — [`super::cooldown::Cooldown::poll`] only lets it
+//! replace an on-screen reading once that reading is stale enough to need
+//! one. This reading is a seed, never a full source, because a CLI rollout
+//! event states only the account-wide window. It carries none of the
+//! model-scoped `additional_rate_limits` the live endpoint reports, and
+//! swapping a snapshot between those two shapes on every poll would make
+//! rows come and go on screen for no reason a reader could see.
+//!
 //! # Testability
 //!
 //! [`CodexTransport`] is the seam: [`fetch_direct`] is a free function over
@@ -67,7 +82,7 @@ use crate::provider_usage::live::model::{
 use crate::provider_usage::live::{LiveUsageSource, SourceOutcome};
 
 use super::codex_app_server;
-use super::cooldown::Cooldown;
+use super::cooldown::{Cooldown, FetchFailure};
 use super::http;
 
 /// `auth.json` is a small, purpose-built token store — cap the read
@@ -92,11 +107,24 @@ const ACCOUNT_CLAIM: &str = "https://api.openai.com/auth/chatgpt_account_id";
 /// response itself does not state one.
 const PLAN_CLAIM: &str = "https://api.openai.com/auth/chatgpt_plan_type";
 
+/// The Codex CLI's own root directory: `$CODEX_HOME` when it is set and
+/// non-empty, otherwise `~/.codex`. Both `auth.json` and the session rollout
+/// files live under it.
+fn codex_home_dir() -> Option<PathBuf> {
+    antiburn_local::paths::non_empty_env_path("CODEX_HOME")
+        .or_else(|| antiburn_local::paths::home_dir().map(|home| home.join(".codex")))
+}
+
 /// The credential file, at the one documented place it lives.
 pub fn default_auth_path() -> Option<PathBuf> {
-    let dir = antiburn_local::paths::non_empty_env_path("CODEX_HOME")
-        .or_else(|| antiburn_local::paths::home_dir().map(|home| home.join(".codex")))?;
-    Some(dir.join("auth.json"))
+    Some(codex_home_dir()?.join("auth.json"))
+}
+
+/// The session log root the CLI appends `token_count` events under, at the
+/// one documented place it lives. See `codex_rollout` for what this source
+/// reads out of it.
+fn default_sessions_root() -> Option<PathBuf> {
+    Some(codex_home_dir()?.join("sessions"))
 }
 
 /// What this source needs out of the CLI's own `auth.json`.
@@ -233,6 +261,10 @@ impl CodexTransport for LiveCodexTransport {
 /// then falling back to the app-server RPC if neither attempt lands.
 pub struct CodexDirectFetch {
     auth_path: Option<PathBuf>,
+    /// The Codex CLI's session log root, for the seed read described in
+    /// "Seeding from the session log" above. `None` skips that seed
+    /// entirely — the state every test constructor below starts from.
+    sessions_root: Option<PathBuf>,
     transport: Box<dyn CodexTransport>,
     cached_refresh: Mutex<Option<RefreshedToken>>,
     cooldown: Cooldown,
@@ -242,6 +274,7 @@ impl CodexDirectFetch {
     pub fn new() -> CodexDirectFetch {
         CodexDirectFetch {
             auth_path: default_auth_path(),
+            sessions_root: default_sessions_root(),
             transport: Box::new(LiveCodexTransport),
             cached_refresh: Mutex::new(None),
             cooldown: Cooldown::new(),
@@ -253,6 +286,7 @@ impl CodexDirectFetch {
     pub fn at(path: PathBuf) -> CodexDirectFetch {
         CodexDirectFetch {
             auth_path: Some(path),
+            sessions_root: None,
             transport: Box::new(LiveCodexTransport),
             cached_refresh: Mutex::new(None),
             cooldown: Cooldown::new(),
@@ -263,10 +297,35 @@ impl CodexDirectFetch {
     fn with_transport(path: PathBuf, transport: Box<dyn CodexTransport>) -> CodexDirectFetch {
         CodexDirectFetch {
             auth_path: Some(path),
+            sessions_root: None,
             transport,
             cached_refresh: Mutex::new(None),
             cooldown: Cooldown::new(),
         }
+    }
+
+    /// The same source, reading its seed from `sessions_root` instead of
+    /// skipping the rollout tier — for tests that exercise it.
+    #[cfg(test)]
+    fn with_sessions_root(mut self, sessions_root: PathBuf) -> CodexDirectFetch {
+        self.sessions_root = Some(sessions_root);
+        self
+    }
+
+    /// The newest rollout reading, when this source has a session log root
+    /// to look under and a recent enough event is there. See
+    /// `codex_rollout::latest_reading`.
+    fn rollout_reading(&self, now: OffsetDateTime) -> Option<super::codex_rollout::RolloutReading> {
+        let sessions_root = self.sessions_root.as_ref()?;
+        let reading = super::codex_rollout::latest_reading(sessions_root, now)?;
+        // `debug`, not `warn`: the seed is the ordinary answer to a failure.
+        ::tracing::debug!(
+            event = "live_cache_reading_used",
+            provider = crate::provider_usage::providers::OPENAI,
+            age_secs = (now - reading.observed_at).whole_seconds(),
+            reason = "seed"
+        );
+        Some(reading)
     }
 }
 
@@ -304,9 +363,12 @@ impl LiveUsageSource for CodexDirectFetch {
                 Ok(snapshot) => Ok(Some(snapshot)),
                 Err(direct_error) => match codex_app_server::fetch(now) {
                     Ok(snapshot) => Ok(snapshot),
-                    Err(fallback_error) => {
-                        Err(preferred_error(direct_error, fallback_error).into())
-                    }
+                    Err(fallback_error) => Err(FetchFailure {
+                        error: preferred_error(direct_error, fallback_error),
+                        last_known: self
+                            .rollout_reading(now)
+                            .map(|reading| Box::new(rollout_snapshot(reading, &auth))),
+                    }),
                 },
             }
         })
@@ -328,6 +390,33 @@ fn preferred_error(direct: ProviderUsageError, fallback: ProviderUsageError) -> 
         direct
     } else {
         fallback
+    }
+}
+
+/// Turn a rollout reading into the snapshot [`FetchFailure::last_known`]
+/// carries — see "Seeding from the session log" in the module doc.
+fn rollout_snapshot(
+    reading: super::codex_rollout::RolloutReading,
+    auth: &CodexAuth,
+) -> ProviderUsageSnapshot {
+    ProviderUsageSnapshot {
+        provider: crate::provider_usage::providers::OPENAI,
+        account: auth.account_id.clone(),
+        // The rollout event's own plan label wins; the JWT claim is only a
+        // fallback for an event that omits it.
+        plan: reading.plan.or_else(|| auth.plan_claim.clone()),
+        // Codex does not report a finer-grained tier below the plan itself.
+        plan_tier: None,
+        observed_at: reading.observed_at,
+        source: UsageSource {
+            id: super::CODEX_SOURCE_ID,
+            label: "Read from the Codex CLI's own session log".into(),
+            confidence: Confidence::High,
+            freshness: Freshness::Fresh,
+        },
+        windows: reading.windows,
+        supplemental: None,
+        reset_credits: None,
     }
 }
 
@@ -407,6 +496,7 @@ fn build_snapshot(
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use time::format_description::well_known::Rfc3339;
 
     const NOW: i64 = 1_800_000_000;
 
@@ -521,6 +611,81 @@ mod tests {
         let cache = Mutex::new(None);
         let result = fetch_direct(&AlwaysFails, &cache, &auth("refresh-a"), now());
         assert_eq!(result, Err(ProviderUsageError::Unavailable));
+    }
+
+    /// Writes a rollout file under `sessions_root` carrying one qualifying
+    /// `token_count` event, dated `now`, at 20% of a seven-day window.
+    ///
+    /// `codex_app_server::fetch` also fails in this suite — there is no
+    /// `codex` binary on the test machine's `PATH` — so a fetch through
+    /// [`CodexDirectFetch`] with an always-failing transport reaches the
+    /// rollout seed the same way a real failed pair of attempts would.
+    fn write_sample_rollout(sessions_root: &Path, now: OffsetDateTime) {
+        let day_dir = sessions_root
+            .join(format!("{:04}", now.year()))
+            .join(format!("{:02}", u8::from(now.month())))
+            .join(format!("{:02}", now.day()));
+        fs::create_dir_all(&day_dir).expect("mkdir");
+        let line = serde_json::json!({
+            "timestamp": now.format(&Rfc3339).expect("format"),
+            "ordinal": 1,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {},
+                "rate_limits": {
+                    "limit_id": "codex",
+                    "primary": {"used_percent": 20.0, "window_minutes": 10_080, "resets_at": null},
+                    "secondary": null,
+                    "plan_type": "pro",
+                },
+            },
+        })
+        .to_string();
+        fs::write(day_dir.join("rollout-a.jsonl"), line).expect("write rollout");
+    }
+
+    #[test]
+    fn a_failure_with_a_sessions_root_carries_the_rollout_reading_as_last_known() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let auth_path = dir.path().join("auth.json");
+        fs::write(
+            &auth_path,
+            r#"{"tokens": {"access_token": "a", "refresh_token": "r", "account_id": "acct-1"}}"#,
+        )
+        .expect("write");
+        let sessions_root = dir.path().join("sessions");
+        write_sample_rollout(&sessions_root, now());
+
+        let source = CodexDirectFetch::with_transport(auth_path, Box::new(AlwaysFails))
+            .with_sessions_root(sessions_root);
+        let outcome = source.fetch(TEST_MAX_AGE);
+
+        assert!(outcome.error.is_some());
+        assert_eq!(outcome.snapshots.len(), 1);
+        assert_eq!(outcome.snapshots[0].windows[0].id, "seven-day");
+        assert_eq!(outcome.snapshots[0].windows[0].used_percent, Some(20.0));
+        assert_eq!(
+            outcome.snapshots[0].source.label,
+            "Read from the Codex CLI's own session log"
+        );
+    }
+
+    #[test]
+    fn a_failure_with_no_sessions_root_carries_no_last_known() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let auth_path = dir.path().join("auth.json");
+        fs::write(
+            &auth_path,
+            r#"{"tokens": {"access_token": "a", "refresh_token": "r", "account_id": "acct-1"}}"#,
+        )
+        .expect("write");
+
+        let source = CodexDirectFetch::with_transport(auth_path, Box::new(AlwaysFails));
+        let outcome = source.fetch(TEST_MAX_AGE);
+
+        assert!(outcome.error.is_some());
+        assert!(outcome.snapshots.is_empty());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_fetch.rs
@@ -304,7 +304,9 @@ impl LiveUsageSource for CodexDirectFetch {
                 Ok(snapshot) => Ok(Some(snapshot)),
                 Err(direct_error) => match codex_app_server::fetch(now) {
                     Ok(snapshot) => Ok(snapshot),
-                    Err(fallback_error) => Err(preferred_error(direct_error, fallback_error)),
+                    Err(fallback_error) => {
+                        Err(preferred_error(direct_error, fallback_error).into())
+                    }
                 },
             }
         })

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_rollout.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/codex_rollout.rs
@@ -1,0 +1,629 @@
+//! Read the newest rate-limit reading out of the Codex CLI's own rollout
+//! files.
+//!
+//! Every turn the Codex CLI runs, it appends a `token_count` event to the
+//! session's rollout file, and that event carries the account's rate limits
+//! as the server reported them on that turn. [`latest_reading`] finds the
+//! newest such event and turns it into a [`RolloutReading`], for
+//! [`super::codex_fetch`] to offer as a seed when the endpoint and the
+//! app-server fallback both fail.
+//!
+//! # Where the rollouts live
+//!
+//! `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<timestamp>-<uuid>.jsonl`, or
+//! `~/.codex/sessions/...` when `CODEX_HOME` is unset. One file is one
+//! session: one JSON object per line, each with a `timestamp`, an `ordinal`,
+//! a `type`, and a `payload`.
+//!
+//! # A bounded read, not a discovery walk
+//!
+//! This module does not use the discovery crate's walkers. It looks at the
+//! newest day directory (and the day before it, for a session that started
+//! before midnight), picks the file in it with the newest modification time,
+//! and reads only that file's last 64 KiB. A rollout file can grow to
+//! several megabytes over a long session; this module only ever wants the
+//! last line that matters.
+//!
+//! # Why this is a seed, not a source in its own right
+//!
+//! A rollout event carries only the account-wide window, not the
+//! model-scoped `additional_rate_limits` the live endpoint also returns.
+//! Swapping between the two shapes on every poll would make rows come and go
+//! on screen, so [`super::codex_fetch`] only ever reaches for a rollout
+//! reading when both its own attempts have failed. See that module's doc
+//! under "Seeding from the session log".
+
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use super::cooldown::MAX_AGE;
+use crate::provider_usage::live::codex::is_sliding_reset_projection;
+use crate::provider_usage::live::model::{UsageScope, UsageWindow, UsageWindowKind, WindowRole};
+
+/// The tail of a rollout file this module reads, in bytes. Wide enough to
+/// hold many turns' worth of `token_count` events, small enough that even a
+/// multi-megabyte session log costs one bounded read.
+const TAIL_BYTES: u64 = 64 * 1024;
+
+/// The newest rate-limit reading a Codex rollout file holds.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RolloutReading {
+    /// When the CLI observed these figures — the reading's own timestamp,
+    /// not when this module read the file.
+    pub observed_at: OffsetDateTime,
+    /// The plan label, when the event stated one.
+    pub plan: Option<String>,
+    /// The account-wide windows the event reported.
+    pub windows: Vec<UsageWindow>,
+}
+
+/// The newest rate-limit reading a Codex rollout file on this machine holds,
+/// when one is recent enough to describe the present.
+///
+/// `sessions_root` is `$CODEX_HOME/sessions` or `~/.codex/sessions`.
+/// `now` is compared against both the chosen file's modification time and
+/// the reading's own timestamp; either one older than `MAX_AGE` (one hour)
+/// makes the result `None`.
+pub fn latest_reading(sessions_root: &Path, now: OffsetDateTime) -> Option<RolloutReading> {
+    let file = newest_rollout_file(sessions_root)?;
+    let modified_at = mtime(&file)?;
+    if now - modified_at > MAX_AGE {
+        return None;
+    }
+    let tail = read_tail(&file)?;
+    let line = find_reading_line(&tail)?;
+    let timestamp = line.get("timestamp").and_then(Value::as_str)?;
+    let observed_at = OffsetDateTime::parse(timestamp, &Rfc3339).ok()?;
+    if now - observed_at > MAX_AGE {
+        return None;
+    }
+    let rate_limits = line.get("payload")?.get("rate_limits")?;
+    let windows = parse_windows(rate_limits, observed_at)?;
+    if windows.is_empty() {
+        return None;
+    }
+    let plan = rate_limits
+        .get("plan_type")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    Some(RolloutReading {
+        observed_at,
+        plan,
+        windows,
+    })
+}
+
+/// A directory's immediate subdirectory names. Missing or unreadable reads
+/// as empty, the same as an account with no rollouts yet.
+fn subdir_names(dir: &Path) -> Vec<String> {
+    fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_dir()))
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect()
+}
+
+/// The day directory name one calendar day before `day`, only when the
+/// decrement stays inside the same month — a plain digit subtraction, not a
+/// calendar computation, matching the bound this module documents.
+fn previous_day_name(day: &str) -> Option<String> {
+    let number: u32 = day.parse().ok()?;
+    number
+        .checked_sub(1)
+        .filter(|n| *n > 0)
+        .map(|n| format!("{n:02}"))
+}
+
+/// The day directories to look in: the newest one under `sessions_root`, and
+/// the day before it when that directory also exists in the same month.
+fn candidate_day_dirs(sessions_root: &Path) -> Vec<PathBuf> {
+    let Some(year) = subdir_names(sessions_root).into_iter().max() else {
+        return Vec::new();
+    };
+    let year_dir = sessions_root.join(year);
+    let Some(month) = subdir_names(&year_dir).into_iter().max() else {
+        return Vec::new();
+    };
+    let month_dir = year_dir.join(month);
+    let days = subdir_names(&month_dir);
+    let Some(newest_day) = days.iter().max() else {
+        return Vec::new();
+    };
+    let mut dirs = vec![month_dir.join(newest_day)];
+    if let Some(previous) = previous_day_name(newest_day)
+        && days.iter().any(|day| day == &previous)
+    {
+        dirs.push(month_dir.join(previous));
+    }
+    dirs
+}
+
+/// The `rollout-*.jsonl` file with the newest modification time, across the
+/// candidate day directories.
+fn newest_rollout_file(sessions_root: &Path) -> Option<PathBuf> {
+    candidate_day_dirs(sessions_root)
+        .iter()
+        .flat_map(|dir| fs::read_dir(dir).into_iter().flatten())
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| is_rollout_file_name(&entry.file_name()))
+        .filter_map(|entry| {
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((entry.path(), modified))
+        })
+        .max_by_key(|(_, modified)| *modified)
+        .map(|(path, _)| path)
+}
+
+fn is_rollout_file_name(name: &std::ffi::OsStr) -> bool {
+    name.to_str()
+        .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+}
+
+fn mtime(path: &Path) -> Option<OffsetDateTime> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    let since_epoch = modified.duration_since(SystemTime::UNIX_EPOCH).ok()?;
+    OffsetDateTime::from_unix_timestamp(since_epoch.as_secs() as i64).ok()
+}
+
+/// The last [`TAIL_BYTES`] of `path`, with a leading partial line dropped
+/// when the read did not start at the file's own beginning.
+fn read_tail(path: &Path) -> Option<Vec<u8>> {
+    let mut file = fs::File::open(path).ok()?;
+    let length = file.metadata().ok()?.len();
+    let start = length.saturating_sub(TAIL_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer).ok()?;
+    if start > 0 {
+        match buffer.iter().position(|byte| *byte == b'\n') {
+            Some(newline) => buffer.drain(..=newline),
+            // No newline in the whole tail: the entire read is one partial
+            // line, so there is nothing usable in it.
+            None => buffer.drain(..),
+        };
+    }
+    Some(buffer)
+}
+
+/// The newest line in `tail` that is an `event_msg` carrying a `token_count`
+/// event with a non-null `rate_limits` whose `limit_id` is `"codex"`, null,
+/// or absent — the account-wide bucket. A line that is not JSON, or does
+/// not match, is skipped rather than treated as an error.
+fn find_reading_line(tail: &[u8]) -> Option<Value> {
+    let text = std::str::from_utf8(tail).ok()?;
+    for line in text.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        if value.get("type").and_then(Value::as_str) != Some("event_msg") {
+            continue;
+        }
+        let payload = value.get("payload");
+        if payload
+            .and_then(|payload| payload.get("type"))
+            .and_then(Value::as_str)
+            != Some("token_count")
+        {
+            continue;
+        }
+        let Some(rate_limits) = payload
+            .and_then(|payload| payload.get("rate_limits"))
+            .filter(|value| !value.is_null())
+        else {
+            continue;
+        };
+        let limit_id = rate_limits.get("limit_id").and_then(Value::as_str);
+        if !matches!(limit_id, None | Some("codex")) {
+            continue;
+        }
+        return Some(value);
+    }
+    None
+}
+
+/// `primary` then `secondary` from a `rate_limits` object, each turned into
+/// an account-wide [`UsageWindow`]. Any window missing its duration or
+/// percentage, or carrying a percentage outside `0..=100`, fails the whole
+/// reading — the same fail-closed rule every other parser here uses.
+fn parse_windows(rate_limits: &Value, observed_at: OffsetDateTime) -> Option<Vec<UsageWindow>> {
+    let mut windows = Vec::new();
+    for key in ["primary", "secondary"] {
+        if let Some(window) = rate_limits.get(key).filter(|value| !value.is_null()) {
+            windows.push(parse_window(window, observed_at)?);
+        }
+    }
+    Some(windows)
+}
+
+fn parse_window(value: &Value, observed_at: OffsetDateTime) -> Option<UsageWindow> {
+    let used_percent = value.get("used_percent").and_then(Value::as_f64)?;
+    if !(0.0..=100.0).contains(&used_percent) {
+        return None;
+    }
+    let minutes = value
+        .get("window_minutes")
+        .and_then(Value::as_f64)
+        .filter(|minutes| minutes.is_finite() && *minutes > 0.0)
+        .map(|minutes| minutes.round() as i64)?;
+
+    let (id, role, kind) = match minutes {
+        10_080 => (
+            "seven-day".to_string(),
+            WindowRole::PrimaryLong,
+            UsageWindowKind::Weekly,
+        ),
+        300 => (
+            "five-hour".to_string(),
+            WindowRole::PrimaryShort,
+            UsageWindowKind::Rolling,
+        ),
+        _ => (
+            format!("rolling-{minutes}m"),
+            WindowRole::PrimaryShort,
+            UsageWindowKind::Rolling,
+        ),
+    };
+
+    let resets_at = value
+        .get("resets_at")
+        .and_then(Value::as_i64)
+        .and_then(|seconds| OffsetDateTime::from_unix_timestamp(seconds).ok())
+        .filter(|reset| {
+            !is_sliding_reset_projection(*reset, observed_at, minutes * 60, used_percent)
+        });
+
+    Some(UsageWindow {
+        id,
+        role,
+        kind,
+        scope: UsageScope::Account,
+        used_percent: Some(used_percent),
+        starts_at: None,
+        resets_at,
+        authoritative: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn rfc3339(at: OffsetDateTime) -> String {
+        at.format(&Rfc3339).expect("format")
+    }
+
+    /// One `event_msg`/`token_count` line, with the given `rate_limits`
+    /// value (pass [`Value::Null`] for a `token_count` event with none).
+    fn token_count_line(timestamp: OffsetDateTime, rate_limits: Value) -> String {
+        json!({
+            "timestamp": rfc3339(timestamp),
+            "ordinal": 1,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {},
+                "rate_limits": rate_limits,
+            },
+        })
+        .to_string()
+    }
+
+    fn window(used_percent: f64, window_minutes: i64, resets_at: Option<i64>) -> Value {
+        json!({
+            "used_percent": used_percent,
+            "window_minutes": window_minutes,
+            "resets_at": resets_at,
+        })
+    }
+
+    fn rate_limits(limit_id: Option<&str>, primary: Option<Value>, plan: Option<&str>) -> Value {
+        json!({
+            "limit_id": limit_id,
+            "primary": primary,
+            "secondary": Value::Null,
+            "plan_type": plan,
+        })
+    }
+
+    /// Writes `sessions_root/<year>/<month>/<day>/<name>` with `contents`,
+    /// creating every parent directory.
+    fn write_rollout(
+        sessions_root: &Path,
+        year: &str,
+        month: &str,
+        day: &str,
+        name: &str,
+        contents: &str,
+    ) -> PathBuf {
+        let dir = sessions_root.join(year).join(month).join(day);
+        fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join(name);
+        fs::write(&path, contents).expect("write");
+        path
+    }
+
+    /// `now`'s own year, month, and day, zero-padded — the directory names a
+    /// rollout for `now` is filed under.
+    fn safe_date(now: OffsetDateTime) -> (String, String, String) {
+        (
+            format!("{:04}", now.year()),
+            format!("{:02}", u8::from(now.month())),
+            format!("{:02}", now.day()),
+        )
+    }
+
+    #[test]
+    fn the_newest_qualifying_event_is_read_from_the_newest_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let observed_at = now;
+        let line = token_count_line(
+            observed_at,
+            rate_limits(
+                Some("codex"),
+                Some(window(20.0, 10_080, Some(1_788_758_562))),
+                Some("pro"),
+            ),
+        );
+        write_rollout(sessions_root, &year, &month, &day, "rollout-a.jsonl", &line);
+
+        let reading = latest_reading(sessions_root, now).expect("a reading");
+        assert_eq!(reading.plan.as_deref(), Some("pro"));
+        assert_eq!(reading.observed_at, observed_at);
+        assert_eq!(reading.windows.len(), 1);
+        assert_eq!(reading.windows[0].id, "seven-day");
+        assert_eq!(reading.windows[0].used_percent, Some(20.0));
+        assert_eq!(
+            reading.windows[0].resets_at,
+            OffsetDateTime::from_unix_timestamp(1_788_758_562).ok()
+        );
+    }
+
+    #[test]
+    fn an_event_with_null_rate_limits_after_a_good_one_is_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let good = token_count_line(
+            now - time::Duration::seconds(10),
+            rate_limits(Some("codex"), Some(window(20.0, 10_080, None)), Some("pro")),
+        );
+        let null_reading = token_count_line(now, Value::Null);
+        let contents = format!("{good}\n{null_reading}\n");
+        write_rollout(
+            sessions_root,
+            &year,
+            &month,
+            &day,
+            "rollout-a.jsonl",
+            &contents,
+        );
+
+        let reading = latest_reading(sessions_root, now).expect("the good reading");
+        assert_eq!(reading.windows[0].used_percent, Some(20.0));
+    }
+
+    #[test]
+    fn an_event_with_a_different_limit_id_is_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let good = token_count_line(
+            now - time::Duration::seconds(10),
+            rate_limits(Some("codex"), Some(window(20.0, 10_080, None)), Some("pro")),
+        );
+        let other = token_count_line(
+            now,
+            rate_limits(Some("other"), Some(window(99.0, 10_080, None)), Some("pro")),
+        );
+        let contents = format!("{good}\n{other}\n");
+        write_rollout(
+            sessions_root,
+            &year,
+            &month,
+            &day,
+            "rollout-a.jsonl",
+            &contents,
+        );
+
+        let reading = latest_reading(sessions_root, now).expect("the good reading");
+        assert_eq!(reading.windows[0].used_percent, Some(20.0));
+    }
+
+    #[test]
+    fn an_out_of_range_percentage_makes_the_reading_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let line = token_count_line(
+            now,
+            rate_limits(
+                Some("codex"),
+                Some(window(140.0, 10_080, None)),
+                Some("pro"),
+            ),
+        );
+        write_rollout(sessions_root, &year, &month, &day, "rollout-a.jsonl", &line);
+
+        assert_eq!(latest_reading(sessions_root, now), None);
+    }
+
+    #[test]
+    fn an_event_older_than_one_hour_makes_the_reading_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let stale = now - time::Duration::hours(2);
+        let line = token_count_line(
+            stale,
+            rate_limits(Some("codex"), Some(window(20.0, 10_080, None)), Some("pro")),
+        );
+        write_rollout(sessions_root, &year, &month, &day, "rollout-a.jsonl", &line);
+
+        assert_eq!(latest_reading(sessions_root, now), None);
+    }
+
+    #[test]
+    fn a_file_whose_token_count_events_never_carry_rate_limits_is_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let line = token_count_line(now, Value::Null);
+        write_rollout(sessions_root, &year, &month, &day, "rollout-a.jsonl", &line);
+
+        assert_eq!(latest_reading(sessions_root, now), None);
+    }
+
+    #[test]
+    fn a_good_event_near_the_end_of_a_long_file_is_still_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let filler = filler_lines(200_000);
+        let good = token_count_line(
+            now,
+            rate_limits(Some("codex"), Some(window(33.0, 10_080, None)), Some("pro")),
+        );
+        let contents = format!("{filler}{good}\n");
+        write_rollout(
+            sessions_root,
+            &year,
+            &month,
+            &day,
+            "rollout-a.jsonl",
+            &contents,
+        );
+
+        let reading = latest_reading(sessions_root, now).expect("a reading within the tail");
+        assert_eq!(reading.windows[0].used_percent, Some(33.0));
+    }
+
+    #[test]
+    fn a_good_event_outside_the_tail_window_is_not_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let good = token_count_line(
+            now,
+            rate_limits(Some("codex"), Some(window(33.0, 10_080, None)), Some("pro")),
+        );
+        let filler = filler_lines(199_000);
+        let contents = format!("{good}\n{filler}");
+        write_rollout(
+            sessions_root,
+            &year,
+            &month,
+            &day,
+            "rollout-a.jsonl",
+            &contents,
+        );
+
+        assert_eq!(latest_reading(sessions_root, now), None);
+    }
+
+    #[test]
+    fn a_five_hour_primary_window_is_identified_by_its_own_minutes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let line = token_count_line(
+            now,
+            rate_limits(Some("codex"), Some(window(10.0, 300, None)), None),
+        );
+        write_rollout(sessions_root, &year, &month, &day, "rollout-a.jsonl", &line);
+
+        let reading = latest_reading(sessions_root, now).expect("a reading");
+        assert_eq!(reading.windows[0].id, "five-hour");
+        assert_eq!(reading.windows[0].role, WindowRole::PrimaryShort);
+        assert_eq!(reading.windows[0].kind, UsageWindowKind::Rolling);
+    }
+
+    #[test]
+    fn an_uncommon_window_length_gets_a_minutes_derived_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let line = token_count_line(
+            now,
+            rate_limits(Some("codex"), Some(window(10.0, 60, None)), None),
+        );
+        write_rollout(sessions_root, &year, &month, &day, "rollout-a.jsonl", &line);
+
+        let reading = latest_reading(sessions_root, now).expect("a reading");
+        assert_eq!(reading.windows[0].id, "rolling-60m");
+    }
+
+    #[test]
+    fn a_zero_usage_reset_landing_on_the_projected_boundary_is_dropped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_root = dir.path();
+        let now = OffsetDateTime::now_utc();
+        let (year, month, day) = safe_date(now);
+        let projected = (now + time::Duration::seconds(300 * 60)).unix_timestamp();
+        let line = token_count_line(
+            now,
+            rate_limits(Some("codex"), Some(window(0.0, 300, Some(projected))), None),
+        );
+        write_rollout(sessions_root, &year, &month, &day, "rollout-a.jsonl", &line);
+
+        let reading = latest_reading(sessions_root, now).expect("a reading");
+        assert_eq!(reading.windows[0].used_percent, Some(0.0));
+        assert_eq!(reading.windows[0].resets_at, None);
+    }
+
+    /// Many small, valid, non-matching lines — enough to push a real event
+    /// past this module's tail-read bound in the tests that document it.
+    fn filler_lines(total_bytes: usize) -> String {
+        let line = json!({
+            "timestamp": "2026-01-01T00:00:00Z",
+            "ordinal": 0,
+            "type": "session_meta",
+            "payload": {"pad": "x".repeat(80)},
+        })
+        .to_string();
+        let per_line = line.len() + 1;
+        let count = total_bytes.div_ceil(per_line);
+        let mut result = String::with_capacity(count * per_line);
+        for _ in 0..count {
+            result.push_str(&line);
+            result.push('\n');
+        }
+        result
+    }
+
+    #[test]
+    fn an_empty_sessions_root_yields_no_reading() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(latest_reading(dir.path(), OffsetDateTime::now_utc()), None);
+    }
+
+    #[test]
+    fn previous_day_name_only_decrements_within_the_month() {
+        assert_eq!(previous_day_name("05"), Some("04".to_string()));
+        assert_eq!(previous_day_name("01"), None);
+    }
+}

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -21,6 +21,12 @@
 //! the last good snapshot, restamped for how old it now is, and the last
 //! attempt's error if that attempt failed. Never a blank while a good
 //! reading exists, and never one pretending to be fresher than it is.
+//!
+//! A failed attempt can still carry a reading. A source that finds a copy
+//! of the provider's own figures on disk — the one the reader's CLI cached
+//! for itself — hands it over as [`FetchFailure::last_known`]. It stands in
+//! for the missing fresh reading when there is nothing better: see
+//! [`seed_takes_over`] for the rule.
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -47,6 +53,17 @@ const MIN_FAILURE_COOLDOWN: Duration = Duration::from_secs(60);
 /// caller who wants fresher successes should not be made to wait as long for
 /// a retry after a failure either.
 pub const FAILURE_COOLDOWN: Duration = Duration::from_secs(300);
+
+/// How old a cached reading must be before a failed attempt's
+/// [`FetchFailure::last_known`] replaces it.
+///
+/// Matches `LIVE_USAGE_GRACE_MS` in `lib/presentation/liveUsage.ts`: the
+/// views keep showing a reading through a failure for ten minutes, then
+/// hide it. Up to that point the reading already on screen is the better
+/// one to keep — it may carry windows the on-disk copy does not, and
+/// swapping readings mid-outage makes rows come and go. Past it, the view
+/// is about to blank, and a newer reading from disk is the better answer.
+const SEED_TAKEOVER_AGE: time::Duration = time::Duration::minutes(10);
 
 /// How old a fetched reading may be and still describe the present.
 ///
@@ -93,6 +110,12 @@ impl Cooldown {
     /// describes this account, so keeping it on screen would be the one
     /// thing worse than reporting nothing.
     ///
+    /// `fetch` fails with a [`FetchFailure`]: a bare [`ProviderUsageError`]
+    /// converts into one with `?` or `.into()`, and a source that also found
+    /// a reading on disk attaches it as `last_known`. The reading is kept
+    /// when [`seed_takes_over`] says so; the error is reported either way,
+    /// so the views can say the figure did not just get fresher.
+    ///
     /// Returns the outcome this source should report this pass: the best
     /// snapshot it can currently vouch for — restamped against `now` — and
     /// the error from the most recent attempt, when that attempt is the one
@@ -103,7 +126,7 @@ impl Cooldown {
         &self,
         now: OffsetDateTime,
         max_age: Duration,
-        fetch: impl FnOnce() -> Result<Option<ProviderUsageSnapshot>, ProviderUsageError>,
+        fetch: impl FnOnce() -> Result<Option<ProviderUsageSnapshot>, FetchFailure>,
     ) -> SourceOutcome {
         let mut inner = self
             .inner
@@ -116,8 +139,13 @@ impl Cooldown {
                     inner.error = None;
                     inner.last_attempt = Some((Instant::now(), true));
                 }
-                Err(error) => {
-                    inner.error = Some(error);
+                Err(failure) => {
+                    if let Some(known) = failure.last_known
+                        && seed_takes_over(inner.snapshot.as_ref(), &known, now)
+                    {
+                        inner.snapshot = Some(*known);
+                    }
+                    inner.error = Some(failure.error);
                     inner.last_attempt = Some((Instant::now(), false));
                 }
             }
@@ -134,6 +162,47 @@ impl Cooldown {
             },
             (None, Some(error)) => SourceOutcome::failed(error),
             (None, None) => SourceOutcome::absent(),
+        }
+    }
+}
+
+/// A failed attempt, with the best reading the source found without the
+/// network.
+///
+/// `last_known` is a copy of the provider's own figures that the reader's
+/// CLI saved on disk for itself. It is optional and it is never a reason to
+/// hide `error`: the figures are real, but they did not just get fresher.
+#[derive(Debug)]
+pub struct FetchFailure {
+    pub error: ProviderUsageError,
+    /// Boxed so that a failure stays small on the `Err` path.
+    pub last_known: Option<Box<ProviderUsageSnapshot>>,
+}
+
+impl From<ProviderUsageError> for FetchFailure {
+    fn from(error: ProviderUsageError) -> FetchFailure {
+        FetchFailure {
+            error,
+            last_known: None,
+        }
+    }
+}
+
+/// Whether a failed attempt's on-disk reading replaces the cached one.
+///
+/// With no cached reading, always: the alternative is a blank. With one,
+/// only when the on-disk reading is newer *and* the cached one is older than
+/// [`SEED_TAKEOVER_AGE`] — see that constant for why the reading already on
+/// screen is kept through a short failure.
+fn seed_takes_over(
+    cached: Option<&ProviderUsageSnapshot>,
+    known: &ProviderUsageSnapshot,
+    now: OffsetDateTime,
+) -> bool {
+    match cached {
+        None => true,
+        Some(cached) => {
+            known.observed_at > cached.observed_at && now - cached.observed_at > SEED_TAKEOVER_AGE
         }
     }
 }
@@ -297,10 +366,88 @@ mod tests {
             inner.last_attempt = Some((Instant::now() - FAILURE_COOLDOWN, false));
         }
         let outcome = cooldown.poll(at(2_000), DEFAULT_MAX_AGE, || {
-            Err(ProviderUsageError::Unavailable)
+            Err(ProviderUsageError::Unavailable.into())
         });
 
         assert_eq!(outcome.error, Some(ProviderUsageError::Unavailable));
+        assert_eq!(outcome.snapshots[0].windows[0].used_percent, Some(40.0));
+    }
+
+    fn open_the_cooldown(cooldown: &Cooldown) {
+        let mut inner = cooldown.inner.lock().unwrap();
+        inner.last_attempt = Some((Instant::now() - FAILURE_COOLDOWN, false));
+    }
+
+    #[test]
+    fn a_failure_carrying_a_reading_seeds_an_empty_cache_and_still_reports_the_error() {
+        let cooldown = Cooldown::new();
+        let outcome = cooldown.poll(at(1_000), DEFAULT_MAX_AGE, || {
+            Err(FetchFailure {
+                error: ProviderUsageError::RateLimited,
+                last_known: Some(Box::new(snapshot(at(700), 55.0))),
+            })
+        });
+
+        assert_eq!(outcome.error, Some(ProviderUsageError::RateLimited));
+        assert_eq!(outcome.snapshots[0].windows[0].used_percent, Some(55.0));
+        assert_eq!(outcome.snapshots[0].observed_at, at(700));
+    }
+
+    #[test]
+    fn a_failure_carrying_a_reading_keeps_a_recent_cached_one() {
+        let cooldown = Cooldown::new();
+        cooldown.poll(at(1_000), DEFAULT_MAX_AGE, || {
+            Ok(Some(snapshot(at(1_000), 40.0)))
+        });
+        open_the_cooldown(&cooldown);
+        // Five minutes on: inside `SEED_TAKEOVER_AGE`, so the reading already
+        // on screen stays even though the on-disk one is newer.
+        let outcome = cooldown.poll(at(1_300), DEFAULT_MAX_AGE, || {
+            Err(FetchFailure {
+                error: ProviderUsageError::RateLimited,
+                last_known: Some(Box::new(snapshot(at(1_200), 55.0))),
+            })
+        });
+
+        assert_eq!(outcome.error, Some(ProviderUsageError::RateLimited));
+        assert_eq!(outcome.snapshots[0].windows[0].used_percent, Some(40.0));
+    }
+
+    #[test]
+    fn a_failure_carrying_a_newer_reading_replaces_a_cached_one_past_the_takeover_age() {
+        let cooldown = Cooldown::new();
+        cooldown.poll(at(1_000), DEFAULT_MAX_AGE, || {
+            Ok(Some(snapshot(at(1_000), 40.0)))
+        });
+        open_the_cooldown(&cooldown);
+        // Eleven minutes on: the view is about to hide the cached reading,
+        // and a newer one from disk is the better answer.
+        let outcome = cooldown.poll(at(1_660), DEFAULT_MAX_AGE, || {
+            Err(FetchFailure {
+                error: ProviderUsageError::RateLimited,
+                last_known: Some(Box::new(snapshot(at(1_500), 55.0))),
+            })
+        });
+
+        assert_eq!(outcome.error, Some(ProviderUsageError::RateLimited));
+        assert_eq!(outcome.snapshots[0].windows[0].used_percent, Some(55.0));
+        assert_eq!(outcome.snapshots[0].observed_at, at(1_500));
+    }
+
+    #[test]
+    fn a_failure_carrying_an_older_reading_never_replaces_the_cached_one() {
+        let cooldown = Cooldown::new();
+        cooldown.poll(at(1_000), DEFAULT_MAX_AGE, || {
+            Ok(Some(snapshot(at(1_000), 40.0)))
+        });
+        open_the_cooldown(&cooldown);
+        let outcome = cooldown.poll(at(2_000), DEFAULT_MAX_AGE, || {
+            Err(FetchFailure {
+                error: ProviderUsageError::Unavailable,
+                last_known: Some(Box::new(snapshot(at(900), 55.0))),
+            })
+        });
+
         assert_eq!(outcome.snapshots[0].windows[0].used_percent, Some(40.0));
     }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -41,6 +41,7 @@ mod antigravity_local;
 mod claude_config_cache;
 mod codex_app_server;
 pub mod codex_fetch;
+mod codex_rollout;
 mod cooldown;
 pub(crate) mod http;
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -6,9 +6,11 @@
 //!
 //! # What is registered
 //!
-//! [`anthropic_fetch`] asks Claude's own usage endpoint with the credential
-//! the Claude CLI already keeps on this machine; [`codex_fetch`] does the
-//! same for Codex, retrying once with a token it refreshes itself before
+//! [`anthropic_fetch`] first reads the Claude CLI's own cached reading of its
+//! usage endpoint — see [`claude_config_cache`] — before asking that endpoint
+//! itself with the credential the CLI already keeps on this machine;
+//! [`codex_fetch`] asks the analogous endpoint for Codex directly, retrying
+//! once with a token it refreshes itself before
 //! falling back to [`codex_app_server`] — the Codex CLI's own process, asked
 //! over its own protocol — when neither attempt lands. [`antigravity_fetch`]
 //! reads Antigravity's provider-owned access token and asks Google Code Assist

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -12,7 +12,9 @@
 //! [`codex_fetch`] asks the analogous endpoint for Codex directly, retrying
 //! once with a token it refreshes itself before
 //! falling back to [`codex_app_server`] — the Codex CLI's own process, asked
-//! over its own protocol — when neither attempt lands. [`antigravity_fetch`]
+//! over its own protocol — when neither attempt lands. When both fail,
+//! [`codex_fetch`] seeds the failure from the newest reading in the reader's
+//! own Codex CLI session log, via [`codex_rollout`]. [`antigravity_fetch`]
 //! reads Antigravity's provider-owned access token and asks Google Code Assist
 //! for the managed project and its four shared quota pools. If that path cannot
 //! answer, [`antigravity_local`] probes bounded PID-owned loopback endpoints for

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/mod.rs
@@ -36,6 +36,7 @@
 pub mod anthropic_fetch;
 pub mod antigravity_fetch;
 mod antigravity_local;
+mod claude_config_cache;
 mod codex_app_server;
 pub mod codex_fetch;
 mod cooldown;

--- a/docs/plans/live-usage-degraded-state.md
+++ b/docs/plans/live-usage-degraded-state.md
@@ -106,3 +106,52 @@ That case must not clear a good reading the way a real sign-out does.
 from `Unreadable` (a timeout or another failure). Only `Absent` falls back
 to the credentials file. `Unreadable` is a real failure, so `Cooldown` keeps
 the last good snapshot.
+
+## The tool's own saved reading
+
+The reader's CLI already holds a copy of the provider's figures on this
+machine. Reading that copy needs no request, so it is not subject to the
+provider's rate limit, and it gives the app a real figure when the endpoint
+says 429.
+
+`Cooldown::poll` accepts a `FetchFailure`. A source attaches the reading it
+found on disk as `last_known`. The rule in `seed_takes_over`:
+
+- No cached reading: the on-disk reading is kept at once.
+- A cached reading younger than `SEED_TAKEOVER_AGE` (ten minutes, the same
+  as `LIVE_USAGE_GRACE_MS`): the cached reading stays. The view still shows
+  it under the grace note, and swapping readings mid-outage would make rows
+  come and go.
+- A cached reading older than that: a newer on-disk reading replaces it.
+
+The error is reported in every case. The grace note still says the figure
+did not just get fresher.
+
+### Claude
+
+Claude Code caches the last body it fetched from the usage endpoint in
+`.claude.json` under `cachedUsageUtilization`, with `fetchedAtMs` and the
+account uuid. `sources::claude_config_cache` reads those two keys and
+`oauthAccount.accountUuid`, nothing else. The reading is ignored unless the
+two uuids match.
+
+`ClaudeDirectFetch` uses it in two tiers. A cached reading no older than
+the caller's `max_age` is returned with no request. Otherwise the endpoint
+is asked. On failure, a cached reading under an hour old rides along as
+`last_known`.
+
+### Codex
+
+Each Codex turn appends a `token_count` event to the session rollout with
+the account's `rate_limits`. `sources::codex_rollout` reads the newest such
+event from the newest rollout file: the last 64 KB of one file, bounded to
+one hour. It is offered only as `last_known`, when the endpoint and the
+app-server fallback both fail. The rollout carries only the account-wide
+window, not the model-scoped limits the endpoint returns, so it never
+pre-empts a working endpoint.
+
+### Deferred
+
+Cursor keeps no usage reading on disk. A Cursor meter would be endpoint
+only. Antigravity needs someone with it installed to check what it saves.
+

--- a/docs/support.md
+++ b/docs/support.md
@@ -163,12 +163,17 @@ the credential your coding tool already keeps on this machine (for example, the
 Claude CLI's own OAuth credential, or the Codex CLI's own). It runs by default
 because this is your own traffic: your usage, from a provider you already use,
 with a credential you already hold, over your own connection — no antiburn
-server sees the request or the response. When a provider's endpoint cannot be
+server sees the request or the response. Where your coding tool has already
+saved the same figures on this machine, antiburn reads that copy first and
+skips the request when the copy is recent enough: Claude Code keeps the last
+reading it fetched in its own config file, and the Codex CLI records the
+account's limits in each session log. When a provider's endpoint cannot be
 reached directly, antiburn falls back to asking your coding tool's own local
-process the same question, over its own protocol, rather than leaving the
-reading blank. Turn the switch off if you want none of this — no background
-traffic at all, whatever the reason — and antiburn stops asking, reads no
-credential, and has no plan limits to show.
+process the same question, over its own protocol, or to the reading the tool
+saved most recently, rather than leaving the reading blank. Turn the switch off
+if you want none of this — no background traffic at all, whatever the reason —
+and antiburn stops asking, reads no credential or saved reading, and has no
+plan limits to show.
 
 **Notifications are local.** antiburn shows them in its own small notification
 window and posts exactly these: an update check that found a newer version, the


### PR DESCRIPTION
## Summary

Claude's usage endpoint returns HTTP 429 intermittently, and Claude Code, antiburn, and any other client on the account all draw from one bucket. #369 kept the last good reading on screen through a ten-minute grace. This PR adds the other half: a reading the reader's own CLI already saved on disk, so there is something real to show at cold start and past the grace, and fewer requests in the first place.

**Cooldown.** `Cooldown::poll`'s fetch closure now fails with a `FetchFailure` that can carry `last_known`, a reading found on disk. It seeds an empty cache at once. It replaces a cached reading only when that reading is older than the ten-minute grace the views apply (`SEED_TAKEOVER_AGE`), so a short outage never swaps readings mid-view. The error is reported either way, so the grace note still says the figure did not just get fresher.

**Claude.** Claude Code caches the last body it fetched from the same endpoint in `~/.claude.json` (`cachedUsageUtilization`, with `fetchedAtMs` and the account uuid). The Claude source now reads it after the credential read. A cached reading within the caller's own `max_age` (50 s for the open popover, 600 s for the background monitor) is returned without a network call. Otherwise the endpoint is asked as before, and on failure the cached reading, if under an hour old, rides along as `last_known`. The cache is ignored unless its account uuid matches `oauthAccount`; nothing else in the file is read.

**Codex.** Every Codex turn appends a `token_count` event carrying the account's rate limits to the session rollout. The Codex source now reads the newest such event from the newest rollout (last 64 KB of one file, one hour bound) and offers it as `last_known` when both the endpoint and the app-server fallback fail. It is seed-only: the rollout carries only the account-wide window, not the model-scoped `additional_rate_limits` the endpoint returns, so it never pre-empts a working endpoint.

Cursor and Antigravity are deliberately out of scope here. Cursor keeps no usage reading on disk, and Antigravity needs someone with it installed.

## Test plan

- [ ] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` in `apps/desktop/src-tauri`
- [ ] CI green
- [ ] Manual: with Claude Code recently run, open the popover and check the debug log for `live_cache_reading_used reason=fresh` on the background pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DSC2RrF6HjTQ1cWvfWfgn
