### PR TITLE
Release antiburn 0.3.3 and antiburn-local 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,24 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-09-03
+
+### Added
+
+- Usage now summarizes total tokens and estimated cost for today, the last
+  seven days, and the last 30 days.
+- Activity rows can show each session's estimated share of the current weekly
+  or 5-hour provider limit, with the matching usage detail available from
+  the row.
+
 ### Changed
 
+- The popover now presents usage totals as a compact header with separate cost
+  and token figures, while the provider-limit header stays in place when its
+  meters expand.
+- Session activity, open details, and the HUD now update as transcript files
+  change. Analysis of growing Claude, Codex, and Pi transcripts resumes from
+  prior work instead of rereading the full file.
 - Context charts now distinguish provider cache misses from cache rehydration
   after meaningful user inactivity, using provider-specific timing.
 
@@ -31,6 +47,10 @@ CI changes, and documentation that no user acts on stay out — see
   renderer startup failures on newer graphics stacks.
 - Claude session details now apply the Claude inactivity threshold when they
   rebuild metrics from stored rows, and name provider cache misses consistently.
+- Session hygiene scores now count only assessed checks in their denominator;
+  checks without enough evidence remain identified separately.
+- When a live usage check fails, its last successful reading remains visible
+  for up to ten minutes and shows its age instead of disappearing immediately.
 
 ### Removed
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -163,13 +163,13 @@ Settings teardown, and the memory rules behind those policies.
   is never modified or deleted. Migrations are embedded and versioned by the
   `user_version` pragma.
 - **Scanning.** A single background task refreshes what the app knows: once at
-  launch (after onboarding), whenever the popover is opened, every 60s whether
-  or not it is visible, shortly after a watched transcript directory changes,
-  and on demand. A pass over unchanged sources costs stat calls, not disk
-  reads, which is what makes the unconditional tick affordable. Passes never
-  overlap and are bounded. CPU, memory, and disk I/O are product constraints:
-  background work must be no more frequent or intensive than the visible
-  feature requires. See the policy at the top of `src-tauri/src/scan/mod.rs`.
+  launch (after onboarding), shortly after a watched transcript changes, every
+  five minutes as a reconciliation fallback, and on demand. Watcher refreshes
+  target the affected sessions or agents. A full pass over unchanged sources
+  costs stat calls, not transcript reads. Passes never overlap and are bounded.
+  CPU, memory, and disk I/O are product constraints: background work must be no
+  more frequent or intensive than the visible feature requires. See the policy
+  at the top of `src-tauri/src/scan/mod.rs`.
 - **Notifications.** Six kinds, all posted by the shell and never by the webview
   (which is granted no notification permission): an automatic update, a failed
   scan, low disk space, a crossed usage milestone, the first-run menu-bar

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "antiburn-anchored-window",
  "antiburn-hud",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/anchored-window", "crates/hud", "crates/nudge", "crates/sound
 
 [package]
 name = "antiburn"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -1156,9 +1156,8 @@ pub fn toggle(app: &AppHandle, anchor: Rect) {
 /// Dismisses the popover from the webview — the Escape key, and anything else
 /// the views treat as "put this away".
 ///
-/// Deliberately a shell command rather than `getCurrentWindow().hide()`: the
-/// scan scheduler is gated on the popover being on screen, and a window hidden
-/// behind the shell's back would leave that gate stuck open.
+/// Use a shell command instead of `getCurrentWindow().hide()`. The shell must
+/// emit `popover:hidden` to stop the visible usage poll.
 ///
 /// No-op while pinned. The webview still asks — the decision is the shell's,
 /// so every dismissal answers to the same gate.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -17,6 +17,8 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-03
+
 ### Added
 
 - Snapshot resume: `AdapterResume`, `AdapterSnapshot`, `EvidenceSnapshot`,

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "antiburn-local"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MIT"


### PR DESCRIPTION
## Summary

- publish the complete antiburn 0.3.3 reader-facing release notes
- bump every desktop version source to 0.3.3
- prepare antiburn-local 0.5.0 for its required engine-first release
- correct stale scanning documentation and its matching shell comment

## User impact

The 0.3.3 update includes usage totals and per-session limit attribution, live transcript-driven refreshes, corrected hygiene denominators, cache-event fixes, a ten-minute live-usage grace period, the Linux AppImage Wayland fix, and removal of session-analysis export.

## Verification

- engine formatter, Clippy, and tests
- desktop formatter, ESLint, TypeScript, and 1,085 frontend tests
- shell formatter, Clippy, and 825 tests
- frontend and CI-equivalent release-profile production builds
- release-version, locked-metadata, policy, and secret checks

## Privacy and performance

No privacy boundary changes. The release metadata adds no runtime work; the documented watcher and snapshot changes reduce repeated scans and transcript reads.