### PR TITLE
Keep the five-hour session metric visible

### DIFF
--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -230,6 +230,54 @@ describe("SessionList — rows", () => {
     expect(screen.queryByRole("radio", { name: "% 5h" })).toBeNull()
   })
 
+  it("offers five-hour mode when the usage panel shows an empty five-hour window", () => {
+    list({
+      onBadgeMetricChange: vi.fn(),
+      liveUsage: {
+        generatedAt: NOW.toISOString(),
+        errors: [],
+        meters: [],
+        providers: [
+          {
+            provider: "anthropic",
+            accountKey: null,
+            displayName: "Claude",
+            support: "live",
+            freshness: "fresh",
+            sourceLabel: "test",
+            observedAt: NOW.toISOString(),
+            windows: [
+              {
+                id: "five-hour",
+                role: "primaryShort",
+                kind: "rolling",
+                scopeModel: null,
+                usedPercent: 0,
+                startsAt: null,
+                resetsAt: null,
+                hasNonzeroUsageInCurrentPeriod: false,
+                forecast: {
+                  unavailableReason: "sparseHistory",
+                  confidence: null,
+                  consumptionRate: null,
+                  paceRatio: null,
+                  paceTrend: null,
+                  runwayAt: null,
+                  usedToday: null,
+                },
+              },
+            ],
+            extraUsage: null,
+            resetCredits: null,
+            plan: null,
+          },
+        ],
+      },
+    })
+
+    expect(screen.getByRole("radio", { name: "% 5h" })).toBeInTheDocument()
+  })
+
   it("shows a five-hour allocation when the provider exposes that window", () => {
     const props: SessionListProps = {
       entries: [entry()],

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -9,6 +9,7 @@ import { useCallback, useRef, useState, type ReactNode } from "react"
 import { cn } from "../../lib/cn"
 import type { SessionHygienePayload } from "../../lib/insightsIpc"
 import { agentDisplayName, type AgentSurface } from "../../lib/presentation/agents"
+import { liveDisplayableProviders, liveWindows } from "../../lib/presentation/liveUsage"
 import { localSessionKey } from "../../lib/presentation/localIdentity"
 import {
   INITIAL_SESSION_HYGIENE,
@@ -131,31 +132,12 @@ function isFiveHourWindow(provider: string, id: string): boolean {
   return false
 }
 
-function hasCurrentFiveHourWindow(
-  live: LiveUsageSummaryPayload | undefined,
-  now: number,
-): boolean {
-  return (
-    live?.providers.some((provider) => {
-      const observedAt = Date.parse(provider.observedAt)
-      return (
-        provider.freshness === "fresh" &&
-        provider.windows.some((window) => {
-          const resetsAt = Date.parse(window.resetsAt ?? "")
-          return (
-            isFiveHourWindow(provider.provider, window.id) &&
-            window.usedPercent != null &&
-            Number.isFinite(window.usedPercent) &&
-            window.usedPercent >= 0 &&
-            window.usedPercent <= 100 &&
-            Number.isFinite(observedAt) &&
-            observedAt < resetsAt &&
-            now < resetsAt
-          )
-        })
+function hasDisplayedFiveHourWindow(live: LiveUsageSummaryPayload | undefined): boolean {
+  return live
+    ? liveDisplayableProviders(live).some((provider) =>
+        liveWindows(provider).some((window) => isFiveHourWindow(provider.provider, window.id)),
       )
-    }) ?? false
-  )
+    : false
 }
 
 function sessionLimitBadge(
@@ -454,7 +436,7 @@ export function SessionList({
   const currentTime = now?.getTime() ?? Date.now()
   const fiveHourAvailable =
     badgeMetric === "fiveHourPercent" ||
-    hasCurrentFiveHourWindow(liveUsage, currentTime) ||
+    hasDisplayedFiveHourWindow(liveUsage) ||
     (sessionLimitAllocations?.allocations.some(
       (allocation) =>
         allocation.metric === "fiveHour" && allocationIsCurrent(allocation, currentTime),


### PR DESCRIPTION
## Summary

- derive five-hour metric availability from the same displayable live windows as the usage panel
- keep `% 5h` visible when Claude reports an empty five-hour window
- add a regression test for a 0% window without reset metadata

## Validation

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test`
- `pnpm --filter @antiburn/desktop build`

## Impact

No privacy or performance impact. This changes only the visibility rule for the existing session badge metric control.