### PR TITLE
fix(analysis): keep context sources complete on a long skill description

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -28,7 +28,7 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 21,
+            parser_revision: 22,
             analyzer_revision: 17,
             metrics_schema_revision: 6,
             evidence_schema_revision: 12,

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -977,7 +977,7 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 21,
+                "parserRevision": 22,
                 "analyzerRevision": 17,
                 "evidenceSchemaRevision": 12,
                 "sourceKind": "file",

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -353,11 +353,10 @@ impl SessionEvidenceAccumulator {
         }
         let capped_description = description_field.and_then(|description_field| {
             description.map(|value| {
-                let capped = cap_string(description_field, value, &mut self.diagnostics);
-                if capped.len() != value.len() {
-                    self.context_sources_cap_exceeded = true;
-                }
-                capped
+                // A description is display-only. Truncation does not lose
+                // evidence about which context source loaded or ran, so it
+                // does not degrade the context_sources group.
+                cap_string(description_field, value, &mut self.diagnostics)
             })
         });
         if let Some(existing) = map.get_mut(&capped_name) {
@@ -1934,10 +1933,13 @@ mod tests {
     }
 
     #[test]
-    fn context_sources_skill_description_overflows_to_partial() {
+    fn context_sources_skill_description_overflow_stays_complete() {
         let evidence = source_string_overflow(ContextSourceKind::Skill, true);
         assert_truncated_string(&evidence, "context_sources.skills.description");
-        let sources = assert_cap_partial(evidence.context_sources);
+        assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
+        let EvidenceValue::Complete(sources) = evidence.context_sources else {
+            panic!("a truncated description must not degrade context_sources");
+        };
         assert_eq!(
             sources
                 .skills

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -126,7 +126,12 @@ pub use vendors::{adapter_for, has_dedicated_adapter};
 // +1 for Claude Code's `Task` → `Agent` tool rename: `is_subagent_launch_tool`
 // (`analysis::model`) now also matches `Agent`, so every Claude session
 // must reparse to count `Agent` launches in `subagent_launches`.
-pub const PARSER_REVISION: i64 = 21;
+// +1 for the skill description cap fix: a truncated skill description no
+// longer sets `context_sources_cap_exceeded`
+// (`evidence_sink::SessionEvidenceAccumulator::observe_context_source`), so
+// a stored session must re-ingest to clear the degraded `context_sources`
+// group.
+pub const PARSER_REVISION: i64 = 22;
 // +1 for turn row chart signals: `has_thinking`, `last_tool`, and
 // `subagent_launches` are now ingest-derived row columns
 // (`rows::turn_row_from_event`), so every session must reparse to

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -153,7 +153,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -153,7 +153,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -168,7 +168,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -150,7 +150,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -122,7 +122,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -132,7 +132,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -158,7 +158,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -138,7 +138,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -167,7 +167,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -149,7 +149,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 21,
+      "parserRevision": 22,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },


### PR DESCRIPTION
## User impact

The Unused skills and Unused MCP servers checks no longer show "Not
assessed" whenever a bundled skill description exceeds 256 chars. Several
bundled Claude Code skills ship descriptions longer than that cap, so
nearly every Claude Code user previously saw both checks go unassessed
(38 of 42 sessions in a customer export).

## What changed

`observe_context_source` (`crates/antiburn-local/src/analysis/evidence_sink.rs`)
still truncates a skill's description with `cap_string` and records the
truncation in `diagnostics.truncated_strings`, but a truncated
description no longer sets `context_sources_cap_exceeded`. A description
is display-only: truncating it loses no evidence about which skills
loaded or were invoked. Name truncation and the `MAX_CONTEXT_SOURCES`
collection cap still set the flag, since a truncated name can collapse
two distinct skills into one key.

Checked every other `cap_string` call site in the sink (`tools.by_name`,
the `unrecognized_types` discriminator, and the two subagent
`parent_model` sites) — all are keys/identifiers, not display-only, so
they are unchanged.

`context_sources_cap_exceeded` is persisted per session in
`SessionCoverageRecord` (serialized in `insert_coverage_record`), so
`PARSER_REVISION` is bumped from 21 to 22 (after #383 and #384 took 20 and 21) to force a stored session to
re-ingest and clear the stale degraded `context_sources` group.

## Tests

- Updated the sibling evidence-sink test for a long skill description
  (`context_sources_skill_description_overflow_stays_complete`): it now
  asserts `diagnostics.truncated_strings` contains
  `context_sources.skills.description`, the stored description length
  equals `EVIDENCE_STRING_CAP`, and `evidence.context_sources` stays
  `Complete` (`evidence.coverage` stays `Complete` too). The name-overflow
  sibling test is unchanged and still asserts `Partial`.
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --no-fail-fast` — all 17 suites `ok`, 1228 tests passed, 0
  failed, 2 ignored
- `pnpm run slop` — 0 errors, 0 warnings
- `pnpm run secrets` — clean

## Privacy / performance effects

None. No new data is read, stored, or transmitted; the change only stops
one boolean flag from being set on a display-only string truncation.

## Known limits

A stored session re-ingests once, on the `PARSER_REVISION` bump, to clear
the previously-degraded `context_sources` flag. Sixteen golden fixture
files changed, each by exactly one line (`parserRevision: 21 -> 22`,
confirmed via `git diff --stat`); no other fixture output changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYy8knDMctPvE6qud67Vri
