### PR TITLE
fix(analysis): ignore zero-usage synthetic turns in attribution

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -29,7 +29,7 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
             parser_revision: 19,
-            analyzer_revision: 16,
+            analyzer_revision: 17,
             metrics_schema_revision: 6,
             evidence_schema_revision: 12,
         }

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -978,7 +978,7 @@ mod tests {
             "coverage": coverage,
             "provenance": {
                 "parserRevision": 19,
-                "analyzerRevision": 16,
+                "analyzerRevision": 17,
                 "evidenceSchemaRevision": 12,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",

--- a/crates/antiburn-local/src/analysis/evidence_query.rs
+++ b/crates/antiburn-local/src/analysis/evidence_query.rs
@@ -229,6 +229,12 @@ fn note_collection_cap(diagnostics: &mut ParseDiagnostics, field: &'static str) 
 /* --------------------------------------------------------------------
  * Core aggregate: eligibility, context depth, time range, cache sums,
  * unattributed turns, delegated turns, and the two identity flags.
+ *
+ * An assistant row with no model counts toward `unattributed_turns` (and,
+ * when delegated, `delegated_model_missing`) only if it carries at least
+ * one billable token. A zero-usage no-model row, such as a harness
+ * `<synthetic>` record, has no tokens to attribute to a model, so it does
+ * not count.
  * ----------------------------------------------------------------- */
 
 struct Core {
@@ -258,9 +264,9 @@ const CORE_SQL: &str = "SELECT
     COALESCE(SUM(cache_read_tokens), 0),
     COALESCE(SUM(cache_write_tokens), 0),
     COALESCE(SUM(input_tokens), 0),
-    COALESCE(SUM(role = 'assistant' AND model IS NULL), 0),
+    COALESCE(SUM(role = 'assistant' AND model IS NULL AND (input_tokens + output_tokens + cache_read_tokens + cache_write_tokens) > 0), 0),
     COALESCE(SUM(scope = 'delegated'), 0),
-    COALESCE(SUM(scope = 'delegated' AND role = 'assistant' AND model IS NULL), 0),
+    COALESCE(SUM(scope = 'delegated' AND role = 'assistant' AND model IS NULL AND (input_tokens + output_tokens + cache_read_tokens + cache_write_tokens) > 0), 0),
     COALESCE(SUM(uuid IS NULL), 0)
   FROM turn
  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND (claim_fence = ?4 OR (claim_fence = ?5 AND source_key IN (SELECT value FROM json_each(?6))))";
@@ -1639,6 +1645,67 @@ mod tests {
         assert_eq!(facts.effort_signal.present_turns, 1);
         assert_eq!(facts.speed_signal.eligible_turns, 1);
         assert_eq!(facts.speed_signal.present_turns, 1);
+    }
+
+    #[test]
+    fn a_zero_usage_no_model_row_does_not_count_as_unattributed() {
+        // A harness `<synthetic>` record parses to a no-model assistant row
+        // with all-zero usage. It has no tokens to attribute to a model, so
+        // it must not count toward `unattributed_turns`.
+        let conn = test_connection();
+        let modelled = base_row("s1", 0);
+        let mut synthetic = base_row("s1", 1);
+        synthetic.model = None;
+        synthetic.input_tokens = 0;
+        synthetic.output_tokens = 0;
+        synthetic.cache_read_tokens = 0;
+        synthetic.cache_write_tokens = 0;
+        insert(&conn, &[modelled, synthetic]);
+        let facts = query_turn_facts(&conn, &KEY, &FenceScope::single(1)).expect("query facts");
+        assert_eq!(facts.unattributed_turns, 0);
+    }
+
+    #[test]
+    fn a_no_model_row_with_tokens_still_counts_as_unattributed() {
+        // A no-model row that carries tokens has usage that cannot be
+        // attributed to a model, so it stays unattributed.
+        let conn = test_connection();
+        let modelled = base_row("s1", 0);
+        let mut unattributed = base_row("s1", 1);
+        unattributed.model = None;
+        unattributed.input_tokens = 1;
+        insert(&conn, &[modelled, unattributed]);
+        let facts = query_turn_facts(&conn, &KEY, &FenceScope::single(1)).expect("query facts");
+        assert_eq!(facts.unattributed_turns, 1);
+    }
+
+    #[test]
+    fn a_zero_usage_no_model_delegated_row_does_not_flag_delegated_model_missing() {
+        let conn = test_connection();
+        let mut synthetic = base_row("s1", 0);
+        synthetic.scope = TurnScope::Delegated;
+        synthetic.child_id = Some("s1".to_owned());
+        synthetic.model = None;
+        synthetic.input_tokens = 0;
+        synthetic.output_tokens = 0;
+        synthetic.cache_read_tokens = 0;
+        synthetic.cache_write_tokens = 0;
+        insert(&conn, &[synthetic]);
+        let facts = query_turn_facts(&conn, &KEY, &FenceScope::single(1)).expect("query facts");
+        assert!(!facts.delegated_model_missing);
+    }
+
+    #[test]
+    fn a_no_model_delegated_row_with_tokens_still_flags_delegated_model_missing() {
+        let conn = test_connection();
+        let mut unattributed = base_row("s1", 0);
+        unattributed.scope = TurnScope::Delegated;
+        unattributed.child_id = Some("s1".to_owned());
+        unattributed.model = None;
+        unattributed.input_tokens = 1;
+        insert(&conn, &[unattributed]);
+        let facts = query_turn_facts(&conn, &KEY, &FenceScope::single(1)).expect("query facts");
+        assert!(facts.delegated_model_missing);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -151,7 +151,12 @@ pub const PARSER_REVISION: i64 = 19;
 // from line order alone, for a source with no per-record id
 // (`evidence_sink::SessionEvidenceAccumulator::evidence`), so a Codex
 // session already assessed as `CapabilityMissing` may now assess clean.
-pub const ANALYZER_REVISION: i64 = 16;
+// +1 for the zero-usage synthetic turn fix: a no-model assistant row with
+// no billable tokens, such as a Claude Code `<synthetic>` record, no
+// longer counts toward `unattributed_turns` or `delegated_model_missing`
+// (`evidence_query::CORE_SQL`), so a session with such a record may now
+// assess `models` and `subagents` clean.
+pub const ANALYZER_REVISION: i64 = 17;
 // +1 for seam R2: the worker path now derives `inclusive_model_breakdown`
 // and `model_runs` from published turn rows instead of the accumulator
 // (`query_model_breakdown`, `query_model_runs`), so every session in the

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -108,6 +108,23 @@ fn an_unknown_model_leaves_by_model_unattributed_not_invented() {
     assert!(models.by_model.is_empty());
 }
 
+#[test]
+fn a_zero_usage_synthetic_record_does_not_block_the_models_group() {
+    // Claude Code writes a harness-injected `<synthetic>` assistant record
+    // with all-zero usage for text such as "No response requested." It has
+    // no tokens to attribute to a model, so it must not mark the `models`
+    // group `Partial`.
+    let evidence = claude_evidence(concat!(
+        r#"{"type":"assistant","timestamp":1,"message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[]}}"#,
+        "\n",
+        r#"{"type":"assistant","timestamp":2,"message":{"role":"assistant","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[]}}"#,
+    ));
+    let EvidenceValue::Complete(models) = evidence.models else {
+        panic!("zero-usage synthetic record must not block the models group");
+    };
+    assert_eq!(models.unattributed_turns, 0);
+}
+
 #[derive(Default)]
 struct CountingSink {
     records: usize,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -147,7 +147,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -142,7 +142,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -147,7 +147,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -162,7 +162,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -144,7 +144,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -142,7 +142,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -116,7 +116,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -126,7 +126,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -152,7 +152,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -132,7 +132,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -161,7 +161,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -143,7 +143,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 16,
+      "analyzerRevision": 17,
       "evidenceSchemaRevision": 12,
       "harnessVersion": {
         "state": "unsupported"


### PR DESCRIPTION
## User impact

Model overthinking, Obsolete model, Fast mode overuse, and Cache rehydration checks no longer show "Not assessed" on any session that saw an API error or a "No response requested." record. In a customer export this affected 15 of 42 sessions.

## What changed

Claude Code writes harness-injected `<synthetic>` assistant records (text like "No response requested." or "API Error: ...") with all-zero usage. The parser already dropped the `<synthetic>` model sentinel to `NULL`, but the eligibility query counted every no-model assistant row as unattributed regardless of usage. A `Partial { AttributionIncomplete }` `models` (and, for a delegated row, `subagents`) group blocks every clean badge that group feeds, so a session that ever saw one of these harness records lost its clean model/subagent badges even though the record carried no billable tokens to attribute.

A row with no model and no billable tokens (`input_tokens + output_tokens + cache_read_tokens + cache_write_tokens == 0`) has nothing to attribute to a model, so it no longer counts toward `unattributed_turns` or `delegated_model_missing` in `evidence_query.rs`'s `CORE_SQL`. A no-model row that does carry tokens still counts as unattributed, unchanged.

`ANALYZER_REVISION` is bumped from 16 to 17: this changes the analyze-time query over already-stored turn rows, not what gets parsed or persisted at ingest, so stored coverage records do not need to be reparsed — sessions only requeue for reanalysis.

## Tests run

From `crates/antiburn-local`:
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --no-fail-fast` — 17 suites, 1198 tests passed, 0 failed, 2 pre-existing ignores
- `UPDATE_GOLDENS=1 cargo test --test codex_characterization --test pi_characterization` to regenerate the 16 golden fixtures whose only expected change was `analyzerRevision`

New tests:
- `evidence_query.rs`: `a_zero_usage_no_model_row_does_not_count_as_unattributed`, `a_no_model_row_with_tokens_still_counts_as_unattributed`, `a_zero_usage_no_model_delegated_row_does_not_flag_delegated_model_missing`, `a_no_model_delegated_row_with_tokens_still_flags_delegated_model_missing`
- `tests.rs`: `a_zero_usage_synthetic_record_does_not_block_the_models_group`, an end-to-end test through the Claude adapter with a `<synthetic>`, zero-usage record beside a normal modelled record, asserting `models` is `Complete`

From the worktree root:
- `pnpm run slop` — 0 issues
- `pnpm run secrets` — clean

## Privacy / performance effects

None. This only changes how already-collected, already-local usage fields are aggregated at analysis time; no new data is read, stored, or transmitted, and the query shape is unchanged (an added boolean condition in two existing `SUM` expressions).

## Known limits

- Every stored session requeues for reanalysis on the `ANALYZER_REVISION` bump (expected, standard for this kind of query-level fix).
- The 16 changed golden fixtures under `codex_characterization`/`pi_characterization` differ only in `analyzerRevision`; no fixture's observed behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYy8knDMctPvE6qud67Vri