### PR TITLE
fix(analysis): count Agent tool calls as subagent launches

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -28,7 +28,7 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 20,
+            parser_revision: 21,
             analyzer_revision: 17,
             metrics_schema_revision: 6,
             evidence_schema_revision: 12,

--- a/apps/desktop/src/lib/types/session.ts
+++ b/apps/desktop/src/lib/types/session.ts
@@ -43,7 +43,7 @@ export interface SessionBucket {
   isCacheRoutingMiss: boolean
   /** Wall-clock seconds since the prior parent turn, when this bucket contains a timed turn. */
   secsSincePriorTurn: number | null
-  /** Count of `Task` tool calls in this bucket: how many sub-agents launched at this point. */
+  /** Count of `Task` or `Agent` tool calls in this bucket: how many sub-agents launched at this point. */
   subagentLaunches: number
   /** Count of user prompts in this bucket. */
   userPrompts: number

--- a/crates/antiburn-local/src/analysis/engine.rs
+++ b/crates/antiburn-local/src/analysis/engine.rs
@@ -71,9 +71,9 @@ pub struct Bucket {
     /// priority when multiple turns land in this bucket.
     #[serde(default)]
     pub secs_since_prior_turn: Option<u64>,
-    /// Count of `Task` tool calls in this bucket: how many sub-agents the
-    /// parent session launched at this point. Parent turns only — a
-    /// sub-agent does not itself launch sub-agents in this count.
+    /// Count of `Task` or `Agent` tool calls in this bucket: how many
+    /// sub-agents the parent session launched at this point. Parent turns
+    /// only — a sub-agent does not itself launch sub-agents in this count.
     pub subagent_launches: u32,
     /// Count of user prompts in this bucket. A gap that ends at a prompt is
     /// the user away, not a tool that runs.

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -977,7 +977,7 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 20,
+                "parserRevision": 21,
                 "analyzerRevision": 17,
                 "evidenceSchemaRevision": 12,
                 "sourceKind": "file",

--- a/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
@@ -32,7 +32,9 @@ use crate::analysis::initial_context::{
     InitialContextBreakdown, InitialContextSourceCount, InitialContextTokenSource, SourceOrigin,
 };
 use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary};
-use crate::analysis::model::{EventSource, ModelRun, NormalizedEvent, Role, Usage};
+use crate::analysis::model::{
+    EventSource, ModelRun, NormalizedEvent, Role, Usage, is_subagent_launch_tool,
+};
 use crate::pricing::ModelTokens;
 
 const CONTEXT_WINDOW_TIERS: [u64; 2] = [200_000, 1_000_000];
@@ -526,7 +528,7 @@ impl SessionMetricsAccumulator {
         slot.subagent_launches = event
             .tools
             .iter()
-            .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+            .filter(|tool| is_subagent_launch_tool(&tool.name))
             .count()
             .try_into()
             .unwrap_or(u32::MAX);
@@ -779,7 +781,7 @@ impl SessionMetricsAccumulator {
             let candidate = self.late_candidates[index].clone();
             let tool_name = self.last_tool_interner.intern(&tool.name);
             if candidate.source == EventSource::Parent {
-                if tool.name.eq_ignore_ascii_case("task") {
+                if is_subagent_launch_tool(&tool.name) {
                     self.late_candidates[index].late_subagent_launches = self.late_candidates
                         [index]
                         .late_subagent_launches

--- a/crates/antiburn-local/src/analysis/metrics_sink/reference.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/reference.rs
@@ -8,6 +8,7 @@ use crate::analysis::engine::{
 use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary};
 use crate::analysis::model::{
     CompactionTrigger, EventSource, ModelRun, NormalizedEvent, Role, ToolCall, Usage,
+    is_subagent_launch_tool,
 };
 use crate::analysis::pricing::{lookup_pricing, strip_window_tag};
 use crate::pricing::ModelTokens;
@@ -796,7 +797,7 @@ pub(crate) fn finalize_metrics(
             let launches = turn
                 .tools
                 .iter()
-                .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+                .filter(|tool| is_subagent_launch_tool(&tool.name))
                 .count() as u32;
             bucket.subagent_launches = bucket.subagent_launches.saturating_add(launches);
             if turn.role == Role::User {

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -123,7 +123,10 @@ pub use vendors::{adapter_for, has_dedicated_adapter};
 // `artifact-autoreact-ledger` are now recognized as eventless
 // (`analysis::records::is_recognized_eventless`), so a stored Claude session
 // must re-ingest to clear the two names from `unrecognized_types`.
-pub const PARSER_REVISION: i64 = 20;
+// +1 for Claude Code's `Task` → `Agent` tool rename: `is_subagent_launch_tool`
+// (`analysis::model`) now also matches `Agent`, so every Claude session
+// must reparse to count `Agent` launches in `subagent_launches`.
+pub const PARSER_REVISION: i64 = 21;
 // +1 for turn row chart signals: `has_thinking`, `last_tool`, and
 // `subagent_launches` are now ingest-derived row columns
 // (`rows::turn_row_from_event`), so every session must reparse to

--- a/crates/antiburn-local/src/analysis/model.rs
+++ b/crates/antiburn-local/src/analysis/model.rs
@@ -174,6 +174,13 @@ pub fn is_test_command(cmd: &str) -> bool {
     false
 }
 
+/// True for a tool name that launches a subagent: `Task` (Claude Code's
+/// original name) or `Agent` (its rename). The match is case-insensitive so
+/// a vendor's own casing still counts.
+pub(crate) fn is_subagent_launch_tool(name: &str) -> bool {
+    name.eq_ignore_ascii_case("task") || name.eq_ignore_ascii_case("agent")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolCall {
     pub name: String,

--- a/crates/antiburn-local/src/analysis/records.rs
+++ b/crates/antiburn-local/src/analysis/records.rs
@@ -21,7 +21,7 @@ use crate::analysis::interface::{
     ContentKind, ContentPart, ContextSourceKind, EvidenceObservation, RelationProvenance,
 };
 use crate::analysis::model::{
-    CompactionTrigger, EventSource, NormalizedEvent, Role, ToolCall, Usage,
+    CompactionTrigger, EventSource, NormalizedEvent, Role, ToolCall, Usage, is_subagent_launch_tool,
 };
 
 /// The record layout a caller expects. Each variant names the key locations that
@@ -158,7 +158,7 @@ pub(crate) fn evidence_observations(value: &Value) -> Vec<EvidenceObservation> {
                 && item
                     .get("name")
                     .and_then(Value::as_str)
-                    .is_some_and(|name| name.eq_ignore_ascii_case("task"))
+                    .is_some_and(is_subagent_launch_tool)
             {
                 observations.push(EvidenceObservation::SubagentSpawn {
                     ts_ms,
@@ -1460,5 +1460,57 @@ mod tests {
         let test = tool_call_from_input("Bash", Some(&json!({"command": "cargo test"})));
         assert_eq!(test.category, ToolCategory::Test);
         assert_eq!(test.detail, None);
+    }
+
+    fn claude_assistant_record_with_tool(tool_name: &str) -> Value {
+        json!({
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-6",
+                "content": [
+                    {"type": "tool_use", "name": tool_name, "input": {}}
+                ]
+            }
+        })
+    }
+
+    #[test]
+    fn evidence_observations_emits_subagent_spawn_for_an_agent_tool_use() {
+        let record = claude_assistant_record_with_tool("Agent");
+        let observations = evidence_observations(&record);
+        assert!(observations.iter().any(|observation| matches!(
+            observation,
+            EvidenceObservation::SubagentSpawn {
+                provenance: RelationProvenance::TaskToolUse,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn evidence_observations_emits_subagent_spawn_for_a_lowercase_agent_tool_use() {
+        let record = claude_assistant_record_with_tool("agent");
+        let observations = evidence_observations(&record);
+        assert!(observations.iter().any(|observation| matches!(
+            observation,
+            EvidenceObservation::SubagentSpawn {
+                provenance: RelationProvenance::TaskToolUse,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn evidence_observations_does_not_emit_subagent_spawn_for_an_unrelated_tool_use() {
+        let record = claude_assistant_record_with_tool("Read");
+        let observations = evidence_observations(&record);
+        assert!(
+            !observations.iter().any(|observation| matches!(
+                observation,
+                EvidenceObservation::SubagentSpawn { .. }
+            ))
+        );
     }
 }

--- a/crates/antiburn-local/src/analysis/replay.rs
+++ b/crates/antiburn-local/src/analysis/replay.rs
@@ -10,16 +10,18 @@
 use crate::analysis::engine::SessionMetrics;
 use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary};
 use crate::analysis::metrics_sink::{SessionMetricsAccumulator, merge_metrics};
-use crate::analysis::model::{EventSource, NormalizedEvent, Role, ToolCall, Usage};
+use crate::analysis::model::{
+    EventSource, NormalizedEvent, Role, ToolCall, Usage, is_subagent_launch_tool,
+};
 use crate::analysis::rows::{TurnRow, TurnScope};
 
 /// Builds the smallest `Vec<ToolCall>` that reproduces the two reads
 /// `SessionMetricsAccumulator::observe_parent_fields` makes over a row's
 /// tools: `tools.last().name` (the row's own [`TurnRow::last_tool`]) and the
-/// count of tool names equal to `"task"`, case-insensitive (the row's own
-/// [`TurnRow::subagent_launches`]).
+/// count of tool names that are a `Task` or `Agent` call, case-insensitive
+/// (the row's own [`TurnRow::subagent_launches`]).
 ///
-/// A turn's [`TurnRow::last_tool`] that itself reads as `"task"` already
+/// A turn's [`TurnRow::last_tool`] that itself reads as a launch already
 /// counts toward [`TurnRow::subagent_launches`] — `turn_row_from_event`
 /// derives both from the same `event.tools`, and the last tool is one of
 /// the tools. So this function reserves that last slot for the row's own
@@ -31,7 +33,7 @@ fn synthesize_tools(row: &TurnRow) -> Vec<ToolCall> {
     let last_is_task = row
         .last_tool
         .as_deref()
-        .is_some_and(|name| name.eq_ignore_ascii_case("task"));
+        .is_some_and(is_subagent_launch_tool);
     let generic_launches = if last_is_task {
         row.subagent_launches.saturating_sub(1)
     } else {
@@ -332,7 +334,7 @@ mod tests {
         assert_eq!(
             tools
                 .iter()
-                .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+                .filter(|tool| is_subagent_launch_tool(&tool.name))
                 .count(),
             0
         );
@@ -350,7 +352,7 @@ mod tests {
         assert_eq!(
             tools
                 .iter()
-                .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+                .filter(|tool| is_subagent_launch_tool(&tool.name))
                 .count(),
             3
         );
@@ -373,7 +375,28 @@ mod tests {
         assert_eq!(
             tools
                 .iter()
-                .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+                .filter(|tool| is_subagent_launch_tool(&tool.name))
+                .count(),
+            1
+        );
+    }
+
+    /// Mirrors `synthesize_tools_does_not_double_count_when_the_last_tool_is_itself_a_task_launch`
+    /// for Claude Code's renamed `Agent` tool: the last tool call is an
+    /// `Agent` launch, so it already counts toward `subagent_launches`.
+    #[test]
+    fn synthesize_tools_does_not_double_count_when_the_last_tool_is_itself_an_agent_launch() {
+        let mut row = base_row();
+        row.last_tool = Some("Agent".to_owned());
+        row.subagent_launches = 1;
+
+        let tools = synthesize_tools(&row);
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools.last().map(|tool| tool.name.as_str()), Some("Agent"));
+        assert_eq!(
+            tools
+                .iter()
+                .filter(|tool| is_subagent_launch_tool(&tool.name))
                 .count(),
             1
         );

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -16,7 +16,9 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::analysis::evidence::SessionCoverageRecord;
 use crate::analysis::evidence_query::{FenceScope, TurnFacts, query_turn_facts};
 use crate::analysis::interface::{ContentPart, NormalizedRecord, RecordSink, SessionSummary};
-use crate::analysis::model::{CompactionTrigger, EventSource, NormalizedEvent, Role};
+use crate::analysis::model::{
+    CompactionTrigger, EventSource, NormalizedEvent, Role, is_subagent_launch_tool,
+};
 
 /// DDL for the `turn` and `turn_content` tables.
 ///
@@ -253,9 +255,10 @@ pub struct TurnRow {
     /// The name of `event.tools`'s last entry, when the event carries any
     /// tool call. Mirrors `observe_parent_fields`'s `slot.last_tool`.
     pub last_tool: Option<String>,
-    /// The count of `event.tools` entries whose name is `"task"`,
-    /// case-insensitive. Mirrors `observe_parent_fields`'s
-    /// `slot.subagent_launches`.
+    /// The count of `event.tools` entries whose name is a subagent launch
+    /// (`"task"` or `"agent"`, case-insensitive; see
+    /// [`crate::analysis::model::is_subagent_launch_tool`]). Mirrors
+    /// `observe_parent_fields`'s `slot.subagent_launches`.
     pub subagent_launches: u32,
     /// This turn's captured message content, when the source adapter emitted
     /// a `TurnContent` record for it. Attached by [`TurnRowSink`] after
@@ -332,7 +335,7 @@ pub fn turn_row_from_event(event: &NormalizedEvent, source_key: &str, turn_index
         subagent_launches: event
             .tools
             .iter()
-            .filter(|tool| tool.name.eq_ignore_ascii_case("task"))
+            .filter(|tool| is_subagent_launch_tool(&tool.name))
             .count()
             .try_into()
             .unwrap_or(u32::MAX),
@@ -1475,6 +1478,21 @@ mod tests {
         assert!(row.has_thinking);
         assert_eq!(row.last_tool.as_deref(), Some("Task"));
         assert_eq!(row.subagent_launches, 1);
+    }
+
+    #[test]
+    fn turn_row_from_event_counts_agent_tool_calls_as_subagent_launches() {
+        let mut event = NormalizedEvent::new(Role::Assistant);
+        event.tools = vec![
+            ToolCall::new("Task"),
+            ToolCall::new("Agent"),
+            ToolCall::new("agent"),
+            ToolCall::new("Read"),
+        ];
+
+        let row = turn_row_from_event(&event, "parent-1", 0);
+        assert_eq!(row.last_tool.as_deref(), Some("Read"));
+        assert_eq!(row.subagent_launches, 3);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -125,6 +125,19 @@ fn a_zero_usage_synthetic_record_does_not_block_the_models_group() {
     assert_eq!(models.unattributed_turns, 0);
 }
 
+/// Claude Code renamed its subagent launch tool from `Task` to `Agent`. An
+/// `Agent` tool call must still evidence a subagent spawn.
+#[test]
+fn claude_agent_tool_use_counts_as_a_subagent_spawn() {
+    let evidence = claude_evidence(
+        r#"{"type":"assistant","uuid":"33333333-3333-4333-8333-000000000002","parentUuid":null,"timestamp":1,"message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":1},"content":[{"type":"tool_use","name":"Agent","input":{"description":"not retained","prompt":"not retained"}}]}}"#,
+    );
+    let EvidenceValue::Complete(subagents) = evidence.subagents else {
+        panic!("subagents must be complete");
+    };
+    assert_eq!(subagents.spawn_count, 1);
+}
+
 #[derive(Default)]
 struct CountingSink {
     records: usize,
@@ -2577,6 +2590,22 @@ fn subagent_launch_marker_counts_only_parent_task_calls() {
 
     let total_launches: u32 = m.buckets.iter().map(|b| b.subagent_launches).sum();
     assert_eq!(total_launches, 1, "only the parent's own Task call counts");
+}
+
+/// Mirrors `subagent_launch_marker_counts_only_parent_task_calls` for
+/// Claude Code's renamed `Agent` tool.
+#[test]
+fn subagent_launch_marker_counts_parent_agent_calls_too() {
+    let parent_fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Agent","input":{"prompt":"go look"}},{"type":"tool_use","name":"Edit","input":{"file_path":"a.rs"}}]}}"#;
+    let subagent_fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Agent","input":{"prompt":"nested"}}]}}"#;
+
+    let parent = normalize_source(&jsonl_input("claude", parent_fixture)).unwrap();
+    let subagent = normalize_source(&jsonl_input("claude", subagent_fixture)).unwrap();
+    let merged = merge_subagent_events(parent, vec![subagent]);
+    let m = analyze_session(&merged);
+
+    let total_launches: u32 = m.buckets.iter().map(|b| b.subagent_launches).sum();
+    assert_eq!(total_launches, 1, "only the parent's own Agent call counts");
 }
 
 #[test]

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -153,7 +153,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -153,7 +153,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -168,7 +168,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -150,7 +150,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -122,7 +122,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -132,7 +132,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -158,7 +158,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -138,7 +138,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -167,7 +167,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -149,7 +149,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 20,
+      "parserRevision": 21,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },


### PR DESCRIPTION
## User impact

Claude Code renamed its subagent launch tool from `Task` to `Agent`. antiburn
only recognized `task` (case-insensitive), so every session using the
renamed tool reported `subagents.spawnCount = 0` with empty `children` and
`examples` — in one customer export, 87 `Agent` launches went uncounted. The
Overpowered subagents check still fired only because it also gates on
delegated turns, but the spawn-count evidence, the Context chart's launch
markers, and the subagent roster all read zero. This fix restores accurate
counts for any session that used `Agent`.

## What changed

- Added a shared predicate, `is_subagent_launch_tool` (`analysis::model`),
  matching `Task` or `Agent` case-insensitively.
- Replaced every site that decided subagent-ness from a raw tool name with
  it: the Claude evidence-observation pass (`records.rs`), the turn-row
  `subagent_launches` column (`rows.rs`), and the row-replay tool synthesis
  (`replay.rs`), all named in the original bug report.
- Also replaced two sites not named in the bug report but exercising the
  same decision from the same tool names: the live `SessionMetricsAccumulator`
  (`metrics_sink/mod.rs`, both `observe_parent_fields` and its late-tool
  resolution path) and its test-only reference model
  (`metrics_sink/reference.rs`). These compute the bucket-level
  `subagent_launches` the Context chart reads and are exercised by the
  turn-row replay parity test; leaving them on the old `"task"`-only check
  would have reintroduced the same bug through the live/replay path and
  silently diverged from the row-derived count.
- Updated the `subagentLaunches` doc comments in `engine.rs` and the desktop
  `session.ts` type to mention `Agent`.
- Bumped `PARSER_REVISION` (20 → 21, after #383 took 20) so every stored Claude session reparses
  to pick up `Agent` launches.

## Tests

- New unit tests: `records.rs` (an `Agent`/`agent`/unrelated `tool_use`
  each produce the right `SubagentSpawn` observation or not), `rows.rs`
  (`turn_row_from_event` counts `Task`, `Agent`, and `agent` together),
  `replay.rs` (`synthesize_tools` treats a `last_tool` of `Agent` as the
  launch itself, mirroring the existing `Task` edge case), and
  `analysis/tests.rs` (an end-to-end Claude JSONL fixture with an `Agent`
  tool call evidences `subagents.spawn_count == 1`, plus a bucket-level
  `Agent` counterpart to the existing `Task` launch-marker test).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and
  `cargo test --no-fail-fast` from `crates/antiburn-local`: 17 suites, 1400
  tests passed, 0 failed.
- `pnpm --filter @antiburn/desktop lint`, `type-check`, and `test`: clean,
  1086 tests passed.
- `pnpm exec prettier --check` on the changed file, `pnpm run slop` (score
  100), and `pnpm run secrets`: clean.

## Privacy / performance effects

None. No new data is read, stored, or transmitted; the change is a name
comparison on tool names the pipeline already holds.

## Known limits

The `PARSER_REVISION` bump means every stored Claude session reparses on
next analysis to populate the corrected `subagent_launches` count — a
one-time cost, same pattern as prior revision bumps. The Codex and Pi golden
fixtures changed only in their `parserRevision` field (20 → 21) and `analyzerRevision` (16 → 17 from the rebase onto #382); no other
value in those goldens moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYy8knDMctPvE6qud67Vri
