### PR TITLE
fix(analysis): verify thread links on parentUuid only

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -28,7 +28,7 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 22,
+            parser_revision: 23,
             analyzer_revision: 17,
             metrics_schema_revision: 6,
             evidence_schema_revision: 12,

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -977,7 +977,7 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 22,
+                "parserRevision": 23,
                 "analyzerRevision": 17,
                 "evidenceSchemaRevision": 12,
                 "sourceKind": "file",

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -2122,11 +2122,13 @@ mod tests {
     }
 
     #[test]
-    fn a_compaction_boundarys_logical_parent_resolves_the_link() {
-        // `records::evidence_observations` reports a compaction boundary's
-        // `ThreadLink.parent_uuid` as `parentUuid` falling back to
-        // `logicalParentUuid`, so this accumulator never sees the boundary's
-        // real (null) `parentUuid` directly — only the resolved fallback.
+    fn a_compaction_boundarys_null_parent_uuid_keeps_the_link_verified() {
+        // `records::evidence_observations` reads a compaction boundary's
+        // `ThreadLink.parent_uuid` from `parentUuid` only, with no fallback
+        // to `logicalParentUuid`. The boundary's real `parentUuid` is
+        // always null, so its `ThreadLink` carries no parent to verify: the
+        // boundary's own `uuid` still registers, and the next turn's link
+        // to it resolves normally.
         let mut accumulator = accumulator(true);
         for record in thread_record(Some("u-1"), None, 0) {
             accumulator.record(record);
@@ -2134,7 +2136,7 @@ mod tests {
         accumulator.record(NormalizedRecord::Observation(Box::new(
             EvidenceObservation::ThreadLink {
                 uuid: Some("boundary".to_owned()),
-                parent_uuid: Some("u-1".to_owned()),
+                parent_uuid: None,
             },
         )));
         for record in thread_record(Some("u-2"), Some("boundary"), 1) {
@@ -2142,7 +2144,7 @@ mod tests {
         }
         let facts = TurnFacts::default();
         let EvidenceValue::Complete(cache) = accumulator.evidence(&facts).cache else {
-            panic!("a resolved logical parent must keep the cache group complete");
+            panic!("a null parentUuid on a boundary record must keep the cache group complete");
         };
         assert_eq!(cache.previous_turn, EvidenceValue::Complete(()));
     }

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -131,7 +131,12 @@ pub use vendors::{adapter_for, has_dedicated_adapter};
 // (`evidence_sink::SessionEvidenceAccumulator::observe_context_source`), so
 // a stored session must re-ingest to clear the degraded `context_sources`
 // group.
-pub const PARSER_REVISION: i64 = 22;
+// +1 for the compaction boundary link fix: `ThreadLink.parent_uuid` now
+// comes from `parentUuid` only, with no fallback to `logicalParentUuid`
+// (`records::evidence_observations`), so a stored session must re-ingest to
+// clear a stale `thread_parent_unresolved` flag and its degraded `cache`
+// group.
+pub const PARSER_REVISION: i64 = 23;
 // +1 for turn row chart signals: `has_thinking`, `last_tool`, and
 // `subagent_launches` are now ingest-derived row columns
 // (`rows::turn_row_from_event`), so every session must reparse to

--- a/crates/antiburn-local/src/analysis/records.rs
+++ b/crates/antiburn-local/src/analysis/records.rs
@@ -124,13 +124,13 @@ pub(crate) fn evidence_observations(value: &Value) -> Vec<EvidenceObservation> {
 
     // Per-record thread identity (Claude's top-level `uuid` / `parentUuid`).
     // Emitted for every record that carries either field, so the evidence
-    // sink can verify parent links even through eventless records. A null
-    // `parentUuid` falls back to `logicalParentUuid`, Claude's link across a
-    // compaction boundary, so a boundary record does not read as an
-    // unlinked root.
+    // sink can verify parent links even through eventless records. Read
+    // `parentUuid` only, with no fallback to `logicalParentUuid`: a
+    // compaction boundary's logical parent can sit in another file or later
+    // in this file, so it is not a link this source can verify, and the
+    // sink checks only `parentUuid`.
     let uuid = thread_identity_field(value, "uuid");
-    let parent_uuid = thread_identity_field(value, "parentUuid")
-        .or_else(|| thread_identity_field(value, "logicalParentUuid"));
+    let parent_uuid = thread_identity_field(value, "parentUuid");
     if uuid.is_some() || parent_uuid.is_some() {
         observations.push(EvidenceObservation::ThreadLink { uuid, parent_uuid });
     }

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -9,12 +9,15 @@ use crate::analysis::model::{
 use crate::analysis::rows::{MemoryTurnRowStore, TurnRowSink, TurnRowStore};
 use crate::analysis::{
     CompositeSink, EvidenceSource, EvidenceValue, NormalizedRecord, PartialReason, RawSource,
-    RecordCoverage, RecordSink, SessionCollector, SessionEvidence, SessionEvidenceAccumulator,
-    SessionInput, SessionMetricsAccumulator, SessionSummary, SourceCapabilities, SourceKind,
-    VisitOutcome, adapter_for, analyze_sources, normalize_source,
+    RecordCoverage, RecordSink, SessionCollector, SessionCoverageRecord, SessionEvidence,
+    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SessionSummary,
+    SourceCapabilities, SourceKind, VisitOutcome, adapter_for, analyze_sources, normalize_source,
 };
 
-fn claude_evidence(jsonl: &str) -> SessionEvidence {
+/// Runs `jsonl` through the Claude adapter into a [`CompositeSink`], the
+/// shared setup [`claude_evidence`] and [`claude_evidence_and_coverage`]
+/// build on.
+fn claude_composite(jsonl: &str) -> CompositeSink {
     let input = jsonl_input("claude", jsonl);
     let store = MemoryTurnRowStore::new("claude", "s");
     let turn_rows = TurnRowSink::new(Arc::clone(&store) as Arc<dyn TurnRowStore>, "s", None);
@@ -32,7 +35,22 @@ fn claude_evidence(jsonl: &str) -> SessionEvidence {
         .visit(&input, &mut composite)
         .expect("Claude source must parse");
     composite.observe_source_outcome(outcome);
-    composite.evidence().expect("evidence must publish")
+    composite
+}
+
+fn claude_evidence(jsonl: &str) -> SessionEvidence {
+    claude_composite(jsonl)
+        .evidence()
+        .expect("evidence must publish")
+}
+
+fn claude_evidence_and_coverage(jsonl: &str) -> (SessionEvidence, SessionCoverageRecord) {
+    let composite = claude_composite(jsonl);
+    let coverage = composite
+        .coverage_record()
+        .expect("coverage record must publish");
+    let evidence = composite.evidence().expect("evidence must publish");
+    (evidence, coverage)
 }
 
 fn jsonl_input(agent: &str, jsonl: &str) -> SessionInput {
@@ -956,6 +974,55 @@ fn claude_marked_compaction_without_metadata_leaves_trigger_and_sizes_none() {
     assert_eq!(boundary.compaction_trigger, None);
     assert_eq!(boundary.compaction_pre_tokens, None);
     assert_eq!(boundary.compaction_post_tokens, None);
+}
+
+/// A `compact_boundary` record's `logicalParentUuid` names a uuid absent
+/// from the whole file (the pre-compaction record lives in an earlier,
+/// different file on a resumed session). The `ThreadLink` for this record
+/// must come from its `parentUuid` (always null) alone, so the absent
+/// `logicalParentUuid` must not degrade the cache group.
+#[test]
+fn a_compaction_boundarys_absent_logical_parent_does_not_degrade_cache() {
+    let (evidence, coverage) = claude_evidence_and_coverage(concat!(
+        r#"{"type":"user","uuid":"11111111-1111-4111-8111-000000000001","parentUuid":null,"timestamp":"2024-06-01T12:00:00Z","message":{"role":"user","content":"start"}}"#,
+        "\n",
+        r#"{"type":"assistant","uuid":"22222222-2222-4222-8222-000000000001","parentUuid":"11111111-1111-4111-8111-000000000001","timestamp":"2024-06-01T12:00:01Z","message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":10,"output_tokens":10},"content":[{"type":"text","text":"ok"}]}}"#,
+        "\n",
+        r#"{"type":"system","subtype":"compact_boundary","level":"info","uuid":"33333333-3333-4333-8333-000000000001","parentUuid":null,"logicalParentUuid":"99999999-9999-4999-8999-000000000009","timestamp":"2024-06-01T12:00:02Z","content":"Compacted conversation","compactMetadata":{"trigger":"auto","preTokens":1}}"#,
+        "\n",
+        r#"{"type":"user","uuid":"44444444-4444-4444-8444-000000000001","parentUuid":"33333333-3333-4333-8333-000000000001","timestamp":"2024-06-01T12:00:03Z","message":{"role":"user","content":"continue"}}"#,
+        "\n",
+        r#"{"type":"assistant","uuid":"55555555-5555-4555-8555-000000000001","parentUuid":"44444444-4444-4444-8444-000000000001","timestamp":"2024-06-01T12:00:04Z","message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":10,"output_tokens":10},"content":[{"type":"text","text":"ok"}]}}"#,
+    ));
+    assert!(!coverage.thread_parent_unresolved);
+    let EvidenceValue::Complete(_) = evidence.cache else {
+        panic!("an absent logical parent on a compaction boundary must keep cache complete");
+    };
+}
+
+/// Same as above, but the `logicalParentUuid` names a record that appears
+/// LATER in the same file (the boundary is written before the record it
+/// logically points to). This must not degrade the cache group either: the
+/// fix reads only `parentUuid`, so it never looks at `logicalParentUuid`.
+#[test]
+fn a_compaction_boundarys_later_logical_parent_does_not_degrade_cache() {
+    let (evidence, coverage) = claude_evidence_and_coverage(concat!(
+        r#"{"type":"user","uuid":"11111111-1111-4111-8111-000000000001","parentUuid":null,"timestamp":"2024-06-01T12:00:00Z","message":{"role":"user","content":"start"}}"#,
+        "\n",
+        r#"{"type":"assistant","uuid":"22222222-2222-4222-8222-000000000001","parentUuid":"11111111-1111-4111-8111-000000000001","timestamp":"2024-06-01T12:00:01Z","message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":10,"output_tokens":10},"content":[{"type":"text","text":"ok"}]}}"#,
+        "\n",
+        r#"{"type":"system","subtype":"compact_boundary","level":"info","uuid":"33333333-3333-4333-8333-000000000001","parentUuid":null,"logicalParentUuid":"55555555-5555-4555-8555-000000000001","timestamp":"2024-06-01T12:00:02Z","content":"Compacted conversation","compactMetadata":{"trigger":"auto","preTokens":1}}"#,
+        "\n",
+        r#"{"type":"user","uuid":"44444444-4444-4444-8444-000000000001","parentUuid":"33333333-3333-4333-8333-000000000001","timestamp":"2024-06-01T12:00:03Z","message":{"role":"user","content":"continue"}}"#,
+        "\n",
+        r#"{"type":"assistant","uuid":"55555555-5555-4555-8555-000000000001","parentUuid":"44444444-4444-4444-8444-000000000001","timestamp":"2024-06-01T12:00:04Z","message":{"role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":10,"output_tokens":10},"content":[{"type":"text","text":"ok"}]}}"#,
+    ));
+    assert!(!coverage.thread_parent_unresolved);
+    let EvidenceValue::Complete(_) = evidence.cache else {
+        panic!(
+            "a later-appearing logical parent on a compaction boundary must keep cache complete"
+        );
+    };
 }
 
 /// Codex's compaction event carries no trigger or size info at all.

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -153,7 +153,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -153,7 +153,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -168,7 +168,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -150,7 +150,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -148,7 +148,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -122,7 +122,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -132,7 +132,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -158,7 +158,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -138,7 +138,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -167,7 +167,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -149,7 +149,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 22,
+      "parserRevision": 23,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },


### PR DESCRIPTION
## Why

Claude Code's `compact_boundary` system record always writes `parentUuid: null` and puts its real link, `logicalParentUuid`, on a record that can be absent (a different file on a resumed session) or appear later in the same file. The evidence sink verifies `ThreadLink.parent_uuid` only against uuids it has already seen in this source; falling back to `logicalParentUuid` handed it an unverifiable parent, which set `thread_parent_unresolved` and degraded the `cache` group (and `previousTurn`/`repeatedContext`) to `Partial`. A scan of 82 real local transcripts found 5 with an unresolved thread link, and in all 5 the only unresolved record was this compaction boundary — a false degradation with no other cause.

## What changed

- `records.rs`: build `ThreadLink.parent_uuid` from `parentUuid` only, with no fallback to `logicalParentUuid`. Rewrote the comment to explain why (the logical parent can be in another file or later in this file, so it isn't a verifiable link). The separate `logical_parent_uuid` handling on events is unchanged — that's a different consumer.
- `evidence_sink.rs`: updated the existing test that asserted the old fallback behavior (`a_compaction_boundarys_logical_parent_resolves_the_link` → `a_compaction_boundarys_null_parent_uuid_keeps_the_link_verified`) to match the new, real shape (`parent_uuid: None`).
- `tests.rs`: added two end-to-end pipeline tests via a new `claude_evidence_and_coverage` helper — a boundary whose `logicalParentUuid` names a uuid absent from the file, and one whose `logicalParentUuid` names a record appearing later in the file. Both assert `cache` stays `Complete` and `thread_parent_unresolved` is `false`.
- Bumped `PARSER_REVISION` 22 → 23 (stored sessions must re-ingest to clear the stale flag), with the `evidence.rs` literal, `codex_characterization`/`pi_characterization` goldens, and the `reconcile_tests.rs` pin all updated to match.

## Testing

- `crates/antiburn-local`: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — 17/17 suites `ok`, 0 failed
- `apps/desktop/src-tauri`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 866 passed, 0 failed
- `pnpm run slop` — 0 issues
- `pnpm run secrets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYy8knDMctPvE6qud67Vri