### PR TITLE
fix: Copilot CLI discovery sees only events.jsonl, and unreadable says why

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -122,7 +122,7 @@ pub enum PassOutcome {
     SourceChanged,
     SourceMissing,
     Unsupported,
-    Unreadable,
+    Unreadable(UnreadableReason),
 }
 
 pub struct EvidencePass {
@@ -175,6 +175,52 @@ pub struct RowProjections {
     pub model_runs: Vec<ModelRun>,
 }
 
+/// Why a pass could not read its parent source through to a publishable
+/// result. Threaded from [`StreamOutcome::ParentUnreadable`] through
+/// [`ComputedAnalysis::Unavailable`] to [`PassOutcome::Unreadable`], so the
+/// worker can record a specific cause instead of one opaque failure and
+/// decide whether the failure consumed a retry attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnreadableReason {
+    /// The pass was cancelled before or during the read. The source was
+    /// never actually tried, so this must not consume a retry attempt.
+    Cancelled,
+    /// Deleting this source's already-flushed rows, ahead of a full retry
+    /// read, failed.
+    RowsDeleteFailed,
+    /// Opening or fingerprinting the parent file failed for a reason other
+    /// than "not found" (that maps to `ParentMissing` instead).
+    ClaimFailed,
+    /// Writing this pass's rows or coverage record failed.
+    RowsWriteFailed,
+    /// Reading this pass's own rows, coverage record, or model projections
+    /// back — after writing them — failed.
+    RowsReadbackFailed,
+    /// The parent source produced no events this pass could publish.
+    NoEvents,
+    /// The vendor adapter returned an error reading the parent.
+    AdapterFailed,
+    /// No parent input was given to stream at all.
+    NoParent,
+}
+
+impl UnreadableReason {
+    /// The `lastError` suffix persisted after `source-unreadable:` — see
+    /// `insights_worker::EVIDENCE_ERROR_UNREADABLE`.
+    pub fn as_error_suffix(self) -> &'static str {
+        match self {
+            Self::Cancelled => "cancelled",
+            Self::RowsDeleteFailed => "rows-delete-failed",
+            Self::ClaimFailed => "claim-failed",
+            Self::RowsWriteFailed => "rows-write-failed",
+            Self::RowsReadbackFailed => "rows-readback-failed",
+            Self::NoEvents => "no-events",
+            Self::AdapterFailed => "adapter-failed",
+            Self::NoParent => "no-parent",
+        }
+    }
+}
+
 enum StreamOutcome {
     Published {
         session: Box<StreamedSession>,
@@ -183,7 +229,7 @@ enum StreamOutcome {
     SourceChanged,
     ParentMissing,
     ParentUnsupported,
-    ParentUnreadable,
+    ParentUnreadable(UnreadableReason),
 }
 
 enum ComputedAnalysis {
@@ -201,7 +247,7 @@ enum ComputedAnalysis {
     SourceChanged,
     Missing,
     Unsupported,
-    Unavailable,
+    Unavailable(UnreadableReason),
 }
 
 /// One session's analysis, before it is split between the wire payload and
@@ -706,7 +752,9 @@ fn delete_then_full_read(
     accumulator: &mut CompositeSink,
 ) -> Result<FullReadRetry, StreamOutcome> {
     if store.delete_rows_for_source(&input.session_id).is_err() {
-        return Err(StreamOutcome::ParentUnreadable);
+        return Err(StreamOutcome::ParentUnreadable(
+            UnreadableReason::RowsDeleteFailed,
+        ));
     }
     if let Some(snapshot) = bootstrap_snapshot(
         adapter,
@@ -738,7 +786,9 @@ fn delete_then_full_read(
                 // before failing partway through. The plain fallback below
                 // must not join them.
                 if store.delete_rows_for_source(&input.session_id).is_err() {
-                    return Err(StreamOutcome::ParentUnreadable);
+                    return Err(StreamOutcome::ParentUnreadable(
+                        UnreadableReason::RowsDeleteFailed,
+                    ));
                 }
             }
         }
@@ -786,7 +836,7 @@ fn stream_vendor_with_hooks(
     let current_revisions = resume_revisions();
     for (index, input) in inputs.iter().enumerate() {
         if cancelled() {
-            return StreamOutcome::ParentUnreadable;
+            return StreamOutcome::ParentUnreadable(UnreadableReason::Cancelled);
         }
         // Every vendor label now resolves to a real (possibly all-unset)
         // capability profile, so this can never fall through to
@@ -829,7 +879,9 @@ fn stream_vendor_with_hooks(
             RawSource::File(path) => {
                 let claim = match claim_file(path) {
                     Ok(claim) => claim,
-                    Err(_) if cancelled() => return StreamOutcome::ParentUnreadable,
+                    Err(_) if cancelled() => {
+                        return StreamOutcome::ParentUnreadable(UnreadableReason::Cancelled);
+                    }
                     Err(error)
                         if index == 0
                             && error.downcast_ref::<std::io::Error>().is_some_and(|error| {
@@ -838,7 +890,9 @@ fn stream_vendor_with_hooks(
                     {
                         return StreamOutcome::ParentMissing;
                     }
-                    Err(_) if index == 0 => return StreamOutcome::ParentUnreadable,
+                    Err(_) if index == 0 => {
+                        return StreamOutcome::ParentUnreadable(UnreadableReason::ClaimFailed);
+                    }
                     Err(_) => {
                         child_folds.push(ChildFold::Unreadable);
                         continue;
@@ -1014,13 +1068,13 @@ fn stream_vendor_with_hooks(
             Ok(outcome) => {
                 accumulator.observe_source_outcome(outcome);
                 if cancelled() {
-                    return StreamOutcome::ParentUnreadable;
+                    return StreamOutcome::ParentUnreadable(UnreadableReason::Cancelled);
                 }
                 // A turn-row write failure must fail the whole pass rather
                 // than publish metrics and evidence the rows disagree with.
                 // Retried like any other unreadable source.
                 if accumulator.turn_row_write_failed() {
-                    return StreamOutcome::ParentUnreadable;
+                    return StreamOutcome::ParentUnreadable(UnreadableReason::RowsWriteFailed);
                 }
                 if turn_row_store.is_some()
                     && let Some(summary) = accumulator.summary()
@@ -1048,7 +1102,7 @@ fn stream_vendor_with_hooks(
                         });
                 let Some((metrics, residual)) = accumulator.into_parts() else {
                     if index == 0 {
-                        return StreamOutcome::ParentUnreadable;
+                        return StreamOutcome::ParentUnreadable(UnreadableReason::NoEvents);
                     }
                     child_folds.push(ChildFold::Unreadable);
                     continue;
@@ -1067,8 +1121,11 @@ fn stream_vendor_with_hooks(
                     });
                 }
             }
-            Err(_) if cancelled() || index == 0 => {
-                return StreamOutcome::ParentUnreadable;
+            Err(_) if cancelled() => {
+                return StreamOutcome::ParentUnreadable(UnreadableReason::Cancelled);
+            }
+            Err(_) if index == 0 => {
+                return StreamOutcome::ParentUnreadable(UnreadableReason::AdapterFailed);
             }
             Err(_) => {
                 child_folds.push(ChildFold::Unreadable);
@@ -1077,10 +1134,10 @@ fn stream_vendor_with_hooks(
         }
     }
     if cancelled() {
-        return StreamOutcome::ParentUnreadable;
+        return StreamOutcome::ParentUnreadable(UnreadableReason::Cancelled);
     }
     let Some((parent, children)) = metrics_accumulators.split_first() else {
-        return StreamOutcome::ParentUnreadable;
+        return StreamOutcome::ParentUnreadable(UnreadableReason::NoParent);
     };
     let started_at_epoch = metrics_accumulators
         .iter()
@@ -1126,15 +1183,23 @@ fn stream_vendor_with_hooks(
                 Some(residual) => {
                     let record = residual.coverage_record();
                     if store.write_coverage_record(&record).is_err() {
-                        return StreamOutcome::ParentUnreadable;
+                        return StreamOutcome::ParentUnreadable(UnreadableReason::RowsWriteFailed);
                     }
                     let facts = match store.query_turn_facts() {
                         Ok(facts) => facts,
-                        Err(_) => return StreamOutcome::ParentUnreadable,
+                        Err(_) => {
+                            return StreamOutcome::ParentUnreadable(
+                                UnreadableReason::RowsReadbackFailed,
+                            );
+                        }
                     };
                     let record = match store.query_coverage_record() {
                         Ok(Some(record)) => record,
-                        Ok(None) | Err(_) => return StreamOutcome::ParentUnreadable,
+                        Ok(None) | Err(_) => {
+                            return StreamOutcome::ParentUnreadable(
+                                UnreadableReason::RowsReadbackFailed,
+                            );
+                        }
                     };
                     Some(evidence_from_facts(&facts, &record))
                 }
@@ -1142,11 +1207,15 @@ fn stream_vendor_with_hooks(
             };
             let model_breakdown = match store.query_model_breakdown() {
                 Ok(model_breakdown) => model_breakdown,
-                Err(_) => return StreamOutcome::ParentUnreadable,
+                Err(_) => {
+                    return StreamOutcome::ParentUnreadable(UnreadableReason::RowsReadbackFailed);
+                }
             };
             let model_runs = match store.query_model_runs() {
                 Ok(model_runs) => model_runs,
-                Err(_) => return StreamOutcome::ParentUnreadable,
+                Err(_) => {
+                    return StreamOutcome::ParentUnreadable(UnreadableReason::RowsReadbackFailed);
+                }
             };
             (
                 evidence,
@@ -1212,8 +1281,11 @@ pub async fn analyze_for_evidence(
         return unavailable_evidence_pass(PassOutcome::SourceMissing, None, None);
     };
     let Some(raw) = raw_source(&source).await else {
+        // Only a provider-database source reaches here: `raw_source` reads
+        // its content directly, so a `None` means that read failed. Treated
+        // the same as a file claim failure — the source could not be opened.
         return unavailable_evidence_pass(
-            PassOutcome::Unreadable,
+            PassOutcome::Unreadable(UnreadableReason::ClaimFailed),
             source_path(&source),
             Some(fingerprint_of(&source)),
         );
@@ -1311,14 +1383,20 @@ pub async fn analyze_for_evidence(
             StreamOutcome::SourceChanged => ComputedAnalysis::SourceChanged,
             StreamOutcome::ParentMissing => ComputedAnalysis::Missing,
             StreamOutcome::ParentUnsupported => ComputedAnalysis::Unsupported,
-            StreamOutcome::ParentUnreadable => ComputedAnalysis::Unavailable,
+            StreamOutcome::ParentUnreadable(reason) => ComputedAnalysis::Unavailable(reason),
         }
     })
     .await;
 
     debug_assert!(signal.progress() > 0);
     let Ok(computed) = computed else {
-        return unavailable_evidence_pass(PassOutcome::Unreadable, source_path, Some(fingerprint));
+        // The blocking task itself did not return — it panicked or the
+        // runtime dropped it. The adapter never got a chance to finish.
+        return unavailable_evidence_pass(
+            PassOutcome::Unreadable(UnreadableReason::AdapterFailed),
+            source_path,
+            Some(fingerprint),
+        );
     };
     let (
         parent_metrics,
@@ -1379,9 +1457,9 @@ pub async fn analyze_for_evidence(
                 Some(fingerprint),
             );
         }
-        ComputedAnalysis::Unavailable => {
+        ComputedAnalysis::Unavailable(reason) => {
             return unavailable_evidence_pass(
-                PassOutcome::Unreadable,
+                PassOutcome::Unreadable(reason),
                 source_path,
                 Some(fingerprint),
             );
@@ -1781,8 +1859,8 @@ fn evidence_pass_with_hook(
         StreamOutcome::ParentUnsupported => {
             unavailable_evidence_pass(PassOutcome::Unsupported, None, None)
         }
-        StreamOutcome::ParentUnreadable => {
-            unavailable_evidence_pass(PassOutcome::Unreadable, None, None)
+        StreamOutcome::ParentUnreadable(reason) => {
+            unavailable_evidence_pass(PassOutcome::Unreadable(reason), None, None)
         }
     }
 }

--- a/apps/desktop/src-tauri/src/analysis/tests.rs
+++ b/apps/desktop/src-tauri/src/analysis/tests.rs
@@ -1150,7 +1150,10 @@ fn a_deleted_source_is_missing_not_unreadable() {
         .expect("restore read permission");
 
     assert_eq!(missing.outcome, PassOutcome::SourceMissing);
-    assert_eq!(unreadable_pass.outcome, PassOutcome::Unreadable);
+    assert_eq!(
+        unreadable_pass.outcome,
+        PassOutcome::Unreadable(UnreadableReason::ClaimFailed)
+    );
 }
 
 #[test]
@@ -1276,7 +1279,10 @@ fn cancellation_during_a_child_read_publishes_and_persists_nothing() {
         None,
         None,
     ) {
-        StreamOutcome::ParentUnreadable => SessionAnalysis::unavailable(),
+        StreamOutcome::ParentUnreadable(reason) => {
+            assert_eq!(reason, UnreadableReason::Cancelled);
+            SessionAnalysis::unavailable()
+        }
         StreamOutcome::Published { .. } => panic!("cancelled child read must not publish"),
         StreamOutcome::SourceChanged => panic!("cancelled child read is not a source change"),
         StreamOutcome::ParentMissing | StreamOutcome::ParentUnsupported => {
@@ -1303,7 +1309,7 @@ fn a_cancelled_pass_publishes_nothing() {
 
     assert!(matches!(
         stream_vendor(&[file_input(&path, "parent")], &flag),
-        StreamOutcome::ParentUnreadable
+        StreamOutcome::ParentUnreadable(UnreadableReason::Cancelled)
     ));
 }
 

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -11,7 +11,7 @@ use antiburn_local::model::AgentKind;
 use tauri::{Emitter, Manager};
 use tokio::sync::{Notify, Semaphore};
 
-use crate::analysis::{self, EvidencePass, PassOutcome, PassSignal};
+use crate::analysis::{self, EvidencePass, PassOutcome, PassSignal, UnreadableReason};
 use crate::commands;
 use crate::dto::ActivityEntry;
 use crate::store::{
@@ -29,6 +29,14 @@ pub(crate) const EVIDENCE_ERROR_SOURCE_CHANGED: &str = "source-changed";
 pub(crate) const EVIDENCE_ERROR_SOURCE_MISSING: &str = "source-missing";
 pub(crate) const EVIDENCE_ERROR_UNREADABLE: &str = "source-unreadable";
 pub(crate) const EVIDENCE_ERROR_UNSUPPORTED: &str = "source-unsupported";
+/// Joins [`EVIDENCE_ERROR_UNREADABLE`] to an [`UnreadableReason`]'s suffix
+/// (`reason.as_error_suffix()`) in a persisted `lastError`, for example
+/// `source-unreadable:no-events`. No stored or reachable code compares
+/// `lastError` against the bare `EVIDENCE_ERROR_UNREADABLE` string — see
+/// `sessions_with_missing_source` for the one exact-match query, which
+/// targets `EVIDENCE_ERROR_SOURCE_MISSING` instead — so the prefix can carry
+/// this suffix safely.
+const UNREADABLE_REASON_SEPARATOR: &str = ":";
 
 struct Permits {
     cpu: Semaphore,
@@ -246,6 +254,7 @@ pub(crate) fn apply_outcome(
             claim,
             EvidenceFailure::Retry {
                 next_attempt_at_epoch: now + backoff_secs(claim.retry_count),
+                counts_as_attempt: true,
             },
             EVIDENCE_ERROR_SOURCE_CHANGED,
         ),
@@ -263,21 +272,41 @@ pub(crate) fn apply_outcome(
             },
             EVIDENCE_ERROR_UNSUPPORTED,
         ),
-        PassOutcome::Unreadable if claim.retry_count < MAX_EVIDENCE_ATTEMPTS => store
-            .fail_evidence(
-                claim,
-                EvidenceFailure::Retry {
-                    next_attempt_at_epoch: now + backoff_secs(claim.retry_count),
-                },
-                EVIDENCE_ERROR_UNREADABLE,
-            ),
-        PassOutcome::Unreadable => store.fail_evidence(
-            claim,
-            EvidenceFailure::Failed {
-                revisions: analysis::projection_revisions(),
-            },
-            EVIDENCE_ERROR_UNREADABLE,
-        ),
+        PassOutcome::Unreadable(reason) => {
+            let last_error = format!(
+                "{EVIDENCE_ERROR_UNREADABLE}{UNREADABLE_REASON_SEPARATOR}{}",
+                reason.as_error_suffix()
+            );
+            if reason == UnreadableReason::Cancelled {
+                // The source was never actually tried, so this retry must
+                // not consume one of the claim's attempts.
+                store.fail_evidence(
+                    claim,
+                    EvidenceFailure::Retry {
+                        next_attempt_at_epoch: now + backoff_secs(claim.retry_count),
+                        counts_as_attempt: false,
+                    },
+                    &last_error,
+                )
+            } else if claim.retry_count < MAX_EVIDENCE_ATTEMPTS {
+                store.fail_evidence(
+                    claim,
+                    EvidenceFailure::Retry {
+                        next_attempt_at_epoch: now + backoff_secs(claim.retry_count),
+                        counts_as_attempt: true,
+                    },
+                    &last_error,
+                )
+            } else {
+                store.fail_evidence(
+                    claim,
+                    EvidenceFailure::Failed {
+                        revisions: analysis::projection_revisions(),
+                    },
+                    &last_error,
+                )
+            }
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/insights_worker/tests.rs
+++ b/apps/desktop/src-tauri/src/insights_worker/tests.rs
@@ -391,7 +391,13 @@ fn an_unreadable_source_is_terminal_after_the_attempt_cap() {
                 .unwrap()
                 .unwrap()
         };
-        apply_outcome(&store, &claim, &failed_pass(PassOutcome::Unreadable), now).unwrap();
+        apply_outcome(
+            &store,
+            &claim,
+            &failed_pass(PassOutcome::Unreadable(UnreadableReason::AdapterFailed)),
+            now,
+        )
+        .unwrap();
         let row = store.evidence(&claim.key).unwrap().unwrap();
         if attempt == MAX_EVIDENCE_ATTEMPTS {
             assert_eq!(row.status, EvidenceStatus::Failed);
@@ -400,6 +406,46 @@ fn an_unreadable_source_is_terminal_after_the_attempt_cap() {
             now = row.next_attempt_at_epoch.unwrap();
         }
     }
+}
+
+#[test]
+fn a_cancelled_pass_does_not_consume_a_retry() {
+    let store = store();
+    let claim = claim(&store, "cancelled", 100);
+    apply_outcome(
+        &store,
+        &claim,
+        &failed_pass(PassOutcome::Unreadable(UnreadableReason::Cancelled)),
+        100,
+    )
+    .unwrap();
+    let row = store.evidence(&claim.key).unwrap().unwrap();
+    assert_eq!(row.status, EvidenceStatus::Pending);
+    assert_eq!(row.retry_count, 0);
+    assert_eq!(
+        row.last_error.as_deref(),
+        Some("source-unreadable:cancelled")
+    );
+}
+
+#[test]
+fn an_unreadable_last_error_carries_the_reason_suffix() {
+    let store = store();
+    let claim = claim(&store, "no-events", 100);
+    apply_outcome(
+        &store,
+        &claim,
+        &failed_pass(PassOutcome::Unreadable(UnreadableReason::NoEvents)),
+        100,
+    )
+    .unwrap();
+    let row = store.evidence(&claim.key).unwrap().unwrap();
+    assert_eq!(row.status, EvidenceStatus::Pending);
+    assert_eq!(row.retry_count, 1);
+    assert_eq!(
+        row.last_error.as_deref(),
+        Some("source-unreadable:no-events")
+    );
 }
 
 #[test]
@@ -932,7 +978,8 @@ async fn an_unreadable_source_reaches_the_cap_through_the_worker() {
         .unwrap();
     let clock = AtomicI64::new(100);
     let runner = |_: &SessionRecord, _: PassSignal, _: i64| {
-        Box::pin(async { failed_pass(PassOutcome::Unreadable) }) as PassFuture
+        Box::pin(async { failed_pass(PassOutcome::Unreadable(UnreadableReason::AdapterFailed)) })
+            as PassFuture
     };
     let key = SessionKey::new("native", "claude-code", "worker-unreadable");
 
@@ -1148,16 +1195,20 @@ async fn pi_file_flows_through_worker_persistence_and_report() {
 #[test]
 fn errors_carry_no_transcript_content() {
     const SOURCE_CONTENT: &str = "PRIVATE_TRANSCRIPT_MARKER";
+    const EVIDENCE_ERROR_UNREADABLE_ADAPTER_FAILED: &str = "source-unreadable:adapter-failed";
     let mappings = [
         (PassOutcome::SourceChanged, EVIDENCE_ERROR_SOURCE_CHANGED),
         (PassOutcome::SourceMissing, EVIDENCE_ERROR_SOURCE_MISSING),
-        (PassOutcome::Unreadable, EVIDENCE_ERROR_UNREADABLE),
+        (
+            PassOutcome::Unreadable(UnreadableReason::AdapterFailed),
+            EVIDENCE_ERROR_UNREADABLE_ADAPTER_FAILED,
+        ),
         (PassOutcome::Unsupported, EVIDENCE_ERROR_UNSUPPORTED),
     ];
     let allowed = [
         EVIDENCE_ERROR_SOURCE_CHANGED,
         EVIDENCE_ERROR_SOURCE_MISSING,
-        EVIDENCE_ERROR_UNREADABLE,
+        EVIDENCE_ERROR_UNREADABLE_ADAPTER_FAILED,
         EVIDENCE_ERROR_UNSUPPORTED,
     ];
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -1241,9 +1241,10 @@ impl Store {
         let updated = match failure {
             EvidenceFailure::Retry {
                 next_attempt_at_epoch,
+                counts_as_attempt,
             } => connection.execute(
                 "UPDATE session_evidence AS evidence
-                    SET status = 'pending', retry_count = retry_count + 1,
+                    SET status = 'pending', retry_count = retry_count + ?8,
                         last_error = ?6, claimed_at_epoch = NULL,
                         lease_expires_at_epoch = NULL, next_attempt_at_epoch = ?7
                   WHERE evidence.environment_key = ?1
@@ -1264,6 +1265,7 @@ impl Store {
                     claim.source_generation,
                     last_error,
                     next_attempt_at_epoch,
+                    i64::from(counts_as_attempt),
                 ],
             )?,
             EvidenceFailure::Failed { revisions } => connection.execute(

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -237,8 +237,17 @@ pub struct EvidenceClaim {
 /// The two failure outcomes available after a claim.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvidenceFailure {
-    Retry { next_attempt_at_epoch: i64 },
-    Failed { revisions: ProjectionRevisions },
+    Retry {
+        next_attempt_at_epoch: i64,
+        /// Whether this retry consumes one of the claim's attempts. `false`
+        /// for a pass abandoned before it read anything — cancellation, for
+        /// example — so it cannot exhaust the attempt cap for a source that
+        /// was never actually tried.
+        counts_as_attempt: bool,
+    },
+    Failed {
+        revisions: ProjectionRevisions,
+    },
 }
 
 /// The two successful publication states.

--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -587,6 +587,7 @@ fn fail_evidence_leaves_published_fence_intact() {
                 &next_claim,
                 EvidenceFailure::Retry {
                     next_attempt_at_epoch: 300,
+                    counts_as_attempt: true,
                 },
                 "transient",
             )

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -3222,6 +3222,7 @@ fn failing_session_evidence_with_retry_returns_it_to_pending_with_backoff() {
                 &claim,
                 EvidenceFailure::Retry {
                     next_attempt_at_epoch: 300,
+                    counts_as_attempt: true,
                 },
                 "try later",
             )

--- a/crates/antiburn-local/src/discovery/agents/copilot.rs
+++ b/crates/antiburn-local/src/discovery/agents/copilot.rs
@@ -494,9 +494,14 @@ mod tests {
         );
 
         let explorer = CopilotExplorer;
-        let events_lower = events.to_string_lossy().to_lowercase();
-        let autopilot_lower = autopilot_objective.to_string_lossy().to_lowercase();
-        let attachment_lower = attachment.to_string_lossy().to_lowercase();
+        // `owns_path` takes a lowercased, forward-slashed path (see its doc
+        // comment) — `normalize_for_matching` is what every real caller
+        // uses, so a Windows-style backslash path matches too.
+        let events_lower = crate::discovery::normalize_for_matching(&events.to_string_lossy());
+        let autopilot_lower =
+            crate::discovery::normalize_for_matching(&autopilot_objective.to_string_lossy());
+        let attachment_lower =
+            crate::discovery::normalize_for_matching(&attachment.to_string_lossy());
         assert!(explorer.owns_path(&events_lower));
         assert!(!explorer.owns_path(&autopilot_lower));
         assert!(!explorer.owns_path(&attachment_lower));

--- a/crates/antiburn-local/src/discovery/agents/copilot.rs
+++ b/crates/antiburn-local/src/discovery/agents/copilot.rs
@@ -15,21 +15,32 @@
 //!      `XDG_CONFIG_HOME` if set, falling back to `~/.config/copilot/...`)
 //!    - Windows: `%LOCALAPPDATA%\GitHub Copilot CLI\session-state\...`
 //!
-//! Each session is its own subdirectory under `session-state/` containing one
-//! or more `*.json` / `*.jsonl` files. The walker is layout-tolerant: it
-//! recursively collects any directory containing matching files.
+//!    Each session is its own subdirectory under `session-state/`. The CLI
+//!    writes `events.jsonl` there as the transcript. The rest of the
+//!    directory holds unrelated files: `workspace.yaml`, `plan.md`, a
+//!    `checkpoints/` directory of markdown, a `files/` directory of user
+//!    attachments (any type, including `.json`), and, when autopilot is
+//!    used, `autopilot-objective.json`. Only `events.jsonl` is a session; the
+//!    walker looks for that exact file name and ignores every sibling.
 
 use std::path::{Path, PathBuf};
 
 use crate::discovery::scanner::AgentKind;
 use crate::discovery::{
     AgentExplorer, DesktopPlatform, SessionLog, SessionSource, SurfacePaths, WatchRoot,
-    app_config_dir_in, collect_dirs_with_exts, current_desktop_platform, env_path_when_real_home,
-    find_chat_session_dirs, home_dir, recent_files_with_exts,
+    app_config_dir_in, collect_dirs_with_file_named, current_desktop_platform,
+    env_path_when_real_home, find_chat_session_dirs, home_dir, recent_files_named,
+    recent_files_with_exts,
 };
 use async_trait::async_trait;
 
-const CLI_FILE_EXTS: &[&str] = &["json", "jsonl"];
+/// The only file name the CLI's `session-state/<session-id>/` directory
+/// holds that antiburn treats as a session transcript.
+const CLI_TRANSCRIPT_FILE_NAME: &str = "events.jsonl";
+
+/// [`CLI_TRANSCRIPT_FILE_NAME`] as a path suffix, for matching a lowercased
+/// full path in [`CopilotExplorer::owns_path`].
+const CLI_TRANSCRIPT_PATH_SUFFIX: &str = "/events.jsonl";
 
 /// Substrings of the VS Code-family on-disk layout used by Copilot Chat.
 /// Both must appear in the (lowercased, forward-slashed) path to claim it
@@ -59,9 +70,23 @@ pub struct CopilotExplorer;
 #[async_trait]
 impl AgentExplorer for CopilotExplorer {
     async fn discover_recent(&self, now: i64, since_secs: i64) -> Vec<SessionLog> {
-        let dirs = all_log_dirs().await;
-        recent_files_with_exts(&dirs, now, since_secs, CLI_FILE_EXTS)
-            .await
+        let home = match home_dir() {
+            Some(h) => h,
+            None => return Vec::new(),
+        };
+
+        // The two source kinds match on different terms: VS Code chat
+        // sessions are any `*.json` file, but a CLI session directory holds
+        // several `.json` / `.jsonl` files and only `events.jsonl` is the
+        // transcript. Each dir set uses the matcher that fits its layout.
+        let vs_code_dirs = vs_code_chat_session_dirs_in(&home).await;
+        let cli_dirs = cli_session_dirs_in(&home).await;
+
+        let mut files = recent_files_with_exts(&vs_code_dirs, now, since_secs, &["json"]).await;
+        files
+            .extend(recent_files_named(&cli_dirs, now, since_secs, CLI_TRANSCRIPT_FILE_NAME).await);
+
+        files
             .into_iter()
             .map(|file| SessionLog {
                 agent_type: AgentKind::Copilot,
@@ -72,24 +97,29 @@ impl AgentExplorer for CopilotExplorer {
             .collect()
     }
 
-    /// Owns CLI `session-state/` trees (`~/.copilot/`, XDG_CONFIG, or
-    /// `GitHub Copilot CLI/`) plus any VS Code `User/{workspace,global}Storage`
-    /// chat session. The VS Code arm is fork-tolerant — works for forks not
-    /// enumerated in `surface_paths`.
+    /// Owns `events.jsonl` under a CLI `session-state/` tree (`~/.copilot/`,
+    /// XDG_CONFIG, or `GitHub Copilot CLI/`) plus any VS Code
+    /// `User/{workspace,global}Storage` chat session. The VS Code arm is
+    /// fork-tolerant — works for forks not enumerated in `surface_paths`.
+    ///
+    /// A CLI session directory also holds `workspace.yaml`, `plan.md`,
+    /// `checkpoints/`, `files/`, and `autopilot-objective.json`; none of
+    /// those is a session, so only the `events.jsonl` path is claimed.
     ///
     /// Substring → `surface_paths` bucket:
-    /// - `/.copilot/session-state/`              → `cli` (CLI + Copilot Desktop App
-    ///                                                    inherit the same store)
-    /// - `/copilot/session-state/`               → `cli` (`$XDG_CONFIG_HOME/copilot/...`)
-    /// - `/github copilot cli/session-state/`    → `cli` (Windows `%LOCALAPPDATA%`)
-    /// - VS Code `User/` + `workspaceStorage/`   → `ide_desktop` (chatSessions)
-    /// - VS Code `User/` + `globalStorage/`      → `ide_desktop`
+    /// - `/.copilot/session-state/.../events.jsonl`           → `cli` (CLI + Copilot
+    ///                                                                 Desktop App inherit
+    ///                                                                 the same store)
+    /// - `/copilot/session-state/.../events.jsonl`            → `cli` (`$XDG_CONFIG_HOME/copilot/...`)
+    /// - `/github copilot cli/session-state/.../events.jsonl` → `cli` (Windows `%LOCALAPPDATA%`)
+    /// - VS Code `User/` + `workspaceStorage/`                → `ide_desktop` (chatSessions)
+    /// - VS Code `User/` + `globalStorage/`                   → `ide_desktop`
     fn owns_path(&self, path_lower: &str) -> bool {
-        if path_lower.contains("/.copilot/session-state/")
+        let is_cli_root = path_lower.contains("/.copilot/session-state/")
             || path_lower.contains("/copilot/session-state/")
-            || path_lower.contains("/github copilot cli/session-state/")
-        {
-            return true;
+            || path_lower.contains("/github copilot cli/session-state/");
+        if is_cli_root {
+            return path_lower.ends_with(CLI_TRANSCRIPT_PATH_SUFFIX);
         }
         path_lower.contains(VS_CODE_USER_FRAGMENT)
             && (path_lower.contains(VS_CODE_WORKSPACE_STORAGE_FRAGMENT)
@@ -159,7 +189,7 @@ pub(crate) fn sample_cli_home_log_path(home: &Path) -> PathBuf {
     home.join(".copilot")
         .join("session-state")
         .join("abc")
-        .join("transcript.jsonl")
+        .join(CLI_TRANSCRIPT_FILE_NAME)
 }
 
 #[cfg(test)]
@@ -168,7 +198,7 @@ pub(crate) fn sample_cli_xdg_log_path(home: &Path) -> PathBuf {
         .join("copilot")
         .join("session-state")
         .join("abc")
-        .join("state.json")
+        .join(CLI_TRANSCRIPT_FILE_NAME)
 }
 
 #[cfg(test)]
@@ -177,7 +207,7 @@ pub(crate) fn sample_cli_windows_log_path(local_appdata: &Path) -> PathBuf {
         .join("GitHub Copilot CLI")
         .join("session-state")
         .join("abc")
-        .join("state.json")
+        .join(CLI_TRANSCRIPT_FILE_NAME)
 }
 
 async fn log_dirs_in(home: &Path) -> Vec<PathBuf> {
@@ -226,7 +256,7 @@ async fn cli_session_dirs_for_platform(
     let roots = cli_root_candidates_for_platform(home, platform, local_appdata, xdg_config_home);
     let mut results = Vec::new();
     for root in roots {
-        collect_dirs_with_exts(&root, &mut results, CLI_FILE_EXTS).await;
+        collect_dirs_with_file_named(&root, &mut results, CLI_TRANSCRIPT_FILE_NAME).await;
     }
     results
 }
@@ -289,7 +319,7 @@ mod tests {
             .join("session-state")
             .join("synth-session");
         tokio::fs::create_dir_all(&cli_session_dir).await.unwrap();
-        tokio::fs::write(cli_session_dir.join("state.json"), "{}")
+        tokio::fs::write(cli_session_dir.join(CLI_TRANSCRIPT_FILE_NAME), "{}")
             .await
             .unwrap();
 
@@ -312,7 +342,7 @@ mod tests {
             .join("synth-session");
         tokio::fs::create_dir_all(&cli_session_dir).await.unwrap();
         tokio::fs::write(
-            cli_session_dir.join("transcript.jsonl"),
+            cli_session_dir.join(CLI_TRANSCRIPT_FILE_NAME),
             "{\"session_id\":\"x\"}\n",
         )
         .await
@@ -329,7 +359,7 @@ mod tests {
         let xdg = TempDir::new().unwrap();
         let xdg_session_dir = xdg.path().join("copilot").join("session-state").join("s1");
         tokio::fs::create_dir_all(&xdg_session_dir).await.unwrap();
-        tokio::fs::write(xdg_session_dir.join("state.json"), "{}")
+        tokio::fs::write(xdg_session_dir.join(CLI_TRANSCRIPT_FILE_NAME), "{}")
             .await
             .unwrap();
 
@@ -353,7 +383,7 @@ mod tests {
             .join("session-state")
             .join("s1");
         tokio::fs::create_dir_all(&cli_session_dir).await.unwrap();
-        tokio::fs::write(cli_session_dir.join("state.json"), "{}")
+        tokio::fs::write(cli_session_dir.join(CLI_TRANSCRIPT_FILE_NAME), "{}")
             .await
             .unwrap();
 
@@ -391,25 +421,84 @@ mod tests {
             .join("session-state")
             .join("synth-session");
         tokio::fs::create_dir_all(&cli_session_dir).await.unwrap();
-        let transcript = cli_session_dir.join("transcript.jsonl");
+        let transcript = cli_session_dir.join(CLI_TRANSCRIPT_FILE_NAME);
         tokio::fs::write(&transcript, "{\"session_id\":\"x\"}\n")
             .await
             .unwrap();
 
         // discover_recent uses log_dirs() which reads the real HOME, so we
         // exercise the platform helper directly to verify the dir-walking and
-        // extension-matching path without depending on env state.
+        // name-matching path without depending on env state.
         let dirs =
             cli_session_dirs_for_platform(home.path(), DesktopPlatform::Linux, None, None).await;
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
-        let files = recent_files_with_exts(&dirs, now, 3600, CLI_FILE_EXTS).await;
+        let files = recent_files_named(&dirs, now, 3600, CLI_TRANSCRIPT_FILE_NAME).await;
         assert!(
             files.iter().any(|f| f.path == transcript),
-            "expected transcript.jsonl to be discovered, got {:?}",
+            "expected events.jsonl to be discovered, got {:?}",
             files.iter().map(|f| &f.path).collect::<Vec<_>>()
         );
+    }
+
+    /// A real CLI session directory holds `events.jsonl` next to
+    /// `workspace.yaml`, `plan.md`, a `checkpoints/` directory, a `files/`
+    /// directory of attachments (any type, including `.json`), and,
+    /// optionally, `autopilot-objective.json`. Only `events.jsonl` is a
+    /// session; the sibling files and the `files/` attachment must not turn
+    /// into their own discovered sessions.
+    #[tokio::test]
+    async fn test_copilot_cli_session_dir_yields_only_events_jsonl() {
+        let home = TempDir::new().unwrap();
+        let session_dir = home
+            .path()
+            .join(".copilot")
+            .join("session-state")
+            .join("synth-session");
+        let checkpoints_dir = session_dir.join("checkpoints");
+        let files_dir = session_dir.join("files");
+        tokio::fs::create_dir_all(&checkpoints_dir).await.unwrap();
+        tokio::fs::create_dir_all(&files_dir).await.unwrap();
+
+        let events = session_dir.join(CLI_TRANSCRIPT_FILE_NAME);
+        tokio::fs::write(&events, "{\"session_id\":\"x\"}\n")
+            .await
+            .unwrap();
+        tokio::fs::write(session_dir.join("workspace.yaml"), "root: /tmp/demo\n")
+            .await
+            .unwrap();
+        tokio::fs::write(session_dir.join("plan.md"), "# Plan\n")
+            .await
+            .unwrap();
+        let autopilot_objective = session_dir.join("autopilot-objective.json");
+        tokio::fs::write(&autopilot_objective, "{}").await.unwrap();
+        tokio::fs::write(checkpoints_dir.join("one.md"), "# Checkpoint\n")
+            .await
+            .unwrap();
+        let attachment = files_dir.join("attachment.json");
+        tokio::fs::write(&attachment, "{}").await.unwrap();
+
+        let dirs =
+            cli_session_dirs_for_platform(home.path(), DesktopPlatform::Linux, None, None).await;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let files = recent_files_named(&dirs, now, 3600, CLI_TRANSCRIPT_FILE_NAME).await;
+        assert_eq!(
+            files.iter().map(|f| f.path.clone()).collect::<Vec<_>>(),
+            vec![events.clone()],
+            "expected exactly one discovered file, the events.jsonl transcript"
+        );
+
+        let explorer = CopilotExplorer;
+        let events_lower = events.to_string_lossy().to_lowercase();
+        let autopilot_lower = autopilot_objective.to_string_lossy().to_lowercase();
+        let attachment_lower = attachment.to_string_lossy().to_lowercase();
+        assert!(explorer.owns_path(&events_lower));
+        assert!(!explorer.owns_path(&autopilot_lower));
+        assert!(!explorer.owns_path(&attachment_lower));
     }
 }

--- a/crates/antiburn-local/src/discovery/mod.rs
+++ b/crates/antiburn-local/src/discovery/mod.rs
@@ -1265,9 +1265,46 @@ pub async fn recent_files_with_exts(
     since_secs: i64,
     exts: &[&str],
 ) -> Vec<DiscoveredFile> {
+    let exts: Vec<String> = exts.iter().map(|e| e.to_string()).collect();
+    recent_files_matching(dirs, now, since_secs, move |file_name| {
+        Path::new(file_name)
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| exts.iter().any(|allowed| allowed.eq_ignore_ascii_case(ext)))
+    })
+    .await
+}
+
+/// Find files in the given directories whose modification time is within
+/// `since_secs` of `now` and whose file name equals `name` (case-insensitive).
+///
+/// Use this, instead of [`recent_files_with_exts`], when a source directory
+/// mixes the transcript with sibling files that share its extension (for
+/// example `events.jsonl` next to `autopilot-objective.json`).
+pub async fn recent_files_named(
+    dirs: &[PathBuf],
+    now: i64,
+    since_secs: i64,
+    name: &str,
+) -> Vec<DiscoveredFile> {
+    let name = name.to_string();
+    recent_files_matching(dirs, now, since_secs, move |file_name| {
+        file_name.eq_ignore_ascii_case(&name)
+    })
+    .await
+}
+
+/// Shared walk behind [`recent_files_with_exts`] and [`recent_files_named`].
+/// `matches` tests a candidate file's name; the walk itself only differs in
+/// that predicate.
+async fn recent_files_matching(
+    dirs: &[PathBuf],
+    now: i64,
+    since_secs: i64,
+    matches: impl Fn(&str) -> bool + Send + 'static,
+) -> Vec<DiscoveredFile> {
     let cutoff = now - since_secs;
     let dirs = dirs.to_vec();
-    let exts: Vec<String> = exts.iter().map(|e| e.to_string()).collect();
 
     tokio::task::spawn_blocking(move || {
         let mut results = Vec::new();
@@ -1278,11 +1315,10 @@ pub async fn recent_files_with_exts(
             for entry in entries.flatten() {
                 let path = entry.path();
 
-                // Only consider files with matching extensions
-                let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+                let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
                     continue;
                 };
-                if !exts.iter().any(|allowed| allowed.eq_ignore_ascii_case(ext)) {
+                if !matches(file_name) {
                     continue;
                 }
 
@@ -1317,8 +1353,40 @@ pub async fn recent_files_with_exts(
 /// an extension listed in `exts` (case-insensitive). The whole walk runs as
 /// one `spawn_blocking` task (see [`recent_files_with_exts`]).
 pub async fn collect_dirs_with_exts(root: &Path, results: &mut Vec<PathBuf>, exts: &[&str]) {
-    let root = root.to_path_buf();
     let exts: Vec<String> = exts.iter().map(|e| e.to_string()).collect();
+    collect_dirs_matching(root, results, move |file_name| {
+        Path::new(file_name)
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| exts.iter().any(|allowed| allowed.eq_ignore_ascii_case(ext)))
+    })
+    .await
+}
+
+/// Recursively collect directories that contain a file named `name`
+/// (case-insensitive). The whole walk runs as one `spawn_blocking` task (see
+/// [`recent_files_with_exts`]).
+///
+/// Use this, instead of [`collect_dirs_with_exts`], to avoid claiming a
+/// directory that only holds a same-extension sibling of the real transcript
+/// file.
+pub async fn collect_dirs_with_file_named(root: &Path, results: &mut Vec<PathBuf>, name: &str) {
+    let name = name.to_string();
+    collect_dirs_matching(root, results, move |file_name| {
+        file_name.eq_ignore_ascii_case(&name)
+    })
+    .await
+}
+
+/// Shared walk behind [`collect_dirs_with_exts`] and
+/// [`collect_dirs_with_file_named`]. `matches` tests a candidate file's name;
+/// the walk itself only differs in that predicate.
+async fn collect_dirs_matching(
+    root: &Path,
+    results: &mut Vec<PathBuf>,
+    matches: impl Fn(&str) -> bool + Send + 'static,
+) {
+    let root = root.to_path_buf();
 
     let found = tokio::task::spawn_blocking(move || {
         let mut found = Vec::new();
@@ -1338,8 +1406,8 @@ pub async fn collect_dirs_with_exts(root: &Path, results: &mut Vec<PathBuf>, ext
                     stack.push(path);
                 } else if file_type.is_file()
                     && !has_match
-                    && let Some(ext) = path.extension().and_then(|e| e.to_str())
-                    && exts.iter().any(|allowed| allowed.eq_ignore_ascii_case(ext))
+                    && let Some(file_name) = path.file_name().and_then(|n| n.to_str())
+                    && matches(file_name)
                 {
                     has_match = true;
                 }

--- a/crates/antiburn-local/src/discovery/scanner.rs
+++ b/crates/antiburn-local/src/discovery/scanner.rs
@@ -1481,7 +1481,7 @@ mod tests {
     /// test pins the contract against future loosening.
     #[tokio::test]
     async fn test_infer_agent_type_copilot_cli_wins_over_cursor() {
-        let path = Path::new("/Users/foo/.copilot/session-state/cursor/transcript.jsonl");
+        let path = Path::new("/Users/foo/.copilot/session-state/cursor/events.jsonl");
         assert_eq!(Explorers::DISK.infer_agent_type(path), AgentKind::Copilot);
     }
 


### PR DESCRIPTION
## Why

A customer export had one GitHub Copilot session in state `failed`, `lastError: "source-unreadable"`, `retryCount: 6`, zero turns, no evidence.

The Copilot CLI's `~/.copilot/session-state/<session-id>/` directory holds `events.jsonl` (the transcript) next to `workspace.yaml`, `plan.md`, a `checkpoints/` directory of markdown, a `files/` directory of user attachments (any type, including `.json`), and, under autopilot, `autopilot-objective.json`. Discovery matched any `.json`/`.jsonl` file under `session-state/`, so a JSON attachment or the autopilot objective file was discovered as its own "session." The generic JSONL adapter found no events in that file, the pass had nothing to publish, and the desktop shell mapped that to `StreamOutcome::ParentUnreadable`. After `MAX_EVIDENCE_ATTEMPTS` the session was marked `failed`/`source-unreadable` with nothing recording which of the many `ParentUnreadable` branches produced it.

Two independent fixes, one PR:

1. Stop discovering anything but `events.jsonl` as a Copilot CLI session.
2. Give `ParentUnreadable` a reason, persist it in `lastError`, and stop charging a retry attempt to a pass that was cancelled before it ever read its source.

## What changed

**Commit 1 — `fix(discovery): only treat events.jsonl as a Copilot CLI session`**

- Added `recent_files_named`/`collect_dirs_with_file_named` in `crates/antiburn-local/src/discovery/mod.rs`, generic name-matching siblings of the existing `recent_files_with_exts`/`collect_dirs_with_exts`, refactored to share their directory-walk through private `recent_files_matching`/`collect_dirs_matching` predicates so no logic is duplicated.
- `copilot.rs`: CLI session-state discovery now matches only the exact file name `events.jsonl`; the VS Code chat-session variant (`chatSessions/*.json`) is untouched. `owns_path` for the CLI roots now requires the path to end in `/events.jsonl`, so a watcher event for `autopilot-objective.json` or `files/anything.json` is not claimed as a Copilot session.
- Updated the module doc comment to describe the real on-disk layout and rewrote the `owns_path` doc to explain that only `events.jsonl` is a session.
- New test `test_copilot_cli_session_dir_yields_only_events_jsonl`: builds a session dir with `events.jsonl`, `workspace.yaml`, `plan.md`, `autopilot-objective.json`, `checkpoints/one.md`, `files/attachment.json`, and asserts discovery returns exactly `events.jsonl`, and `owns_path` is true for it and false for the other two JSON files.
- **`owns_path` and the file watcher**: `owns_path` backs `Explorers::infer_agent_type` (used for title/session-id inference and WSL discovery), not the live watcher's burst dispatch — `scan/scoped.rs::owning_agent` classifies a changed path by longest-matching **watch root** prefix, deliberately independent of `owns_path` (see its own doc comment). So this change doesn't alter what the watcher reacts to on a burst, but it does matter for `infer_agent_type` correctness wherever that fallback path runs.

**Commit 2 — `fix(desktop): record why a source was unreadable`**

- Added `UnreadableReason` (`analysis.rs`) and threaded it through `StreamOutcome::ParentUnreadable(reason)` → `ComputedAnalysis::Unavailable(reason)` → `PassOutcome::Unreadable(reason)`.
- `insights_worker::apply_outcome` now persists `lastError` as `source-unreadable:<reason>` (for example `source-unreadable:no-events`) — checked that nothing in the shell crate, `apps/desktop/src`, or `docs/` compares `lastError` against the bare `EVIDENCE_ERROR_UNREADABLE` string (the one exact-match query, `sessions_with_missing_source`, targets the unrelated `source-missing` constant), so the prefix stays intact and no matcher needed to change.
- Cancellation no longer consumes a retry: `EvidenceFailure::Retry` gained `counts_as_attempt: bool`; `fail_evidence`'s SQL stays one static string and binds `retry_count = retry_count + ?8` with `i64::from(counts_as_attempt)`. `apply_outcome` passes `counts_as_attempt: false` only for `UnreadableReason::Cancelled`.
- New tests: `a_cancelled_pass_does_not_consume_a_retry`, `an_unreadable_last_error_carries_the_reason_suffix`.
- No `*_REVISION` constant was bumped — this PR only changes discovery and error bookkeeping, not what a pass parses or computes.

### `ParentUnreadable` sites and the reason assigned to each (`analysis.rs`)

| Site | Reason |
| --- | --- |
| `delete_then_full_read`, both `delete_rows_for_source` failures | `RowsDeleteFailed` |
| Top of the per-input loop, `cancelled()` | `Cancelled` |
| `claim_file` errored and `cancelled()` | `Cancelled` |
| `claim_file` errored on the parent (not "not found", not cancelled) | `ClaimFailed` |
| After a successful visit, `cancelled()` | `Cancelled` |
| `accumulator.turn_row_write_failed()` | `RowsWriteFailed` |
| `accumulator.into_parts()` returned `None` for the parent (no events observed — the exact shape of the customer bug) | `NoEvents` |
| Visit returned `Err` and `cancelled()` | `Cancelled` |
| Visit returned `Err` on the parent, not cancelled | `AdapterFailed` |
| Post-loop `cancelled()` | `Cancelled` |
| `metrics_accumulators.split_first()` empty (no inputs at all) | `NoParent` |
| `store.write_coverage_record` failed | `RowsWriteFailed` |
| `query_turn_facts` / `query_coverage_record` / `query_model_breakdown` / `query_model_runs` failed after a successful write | `RowsReadbackFailed` |

Two `PassOutcome::Unreadable` sites are independent of `StreamOutcome` but needed a value once the type changed (judgment calls, reused existing variants rather than growing the enum further):

- `analyze_for_evidence`: `raw_source(&source)` returned `None` (a provider-DB content read failed) → `ClaimFailed`.
- `analyze_for_evidence`: the `spawn_blocking` task itself didn't return (panicked/dropped) → `AdapterFailed`.

`RowsReadbackFailed` is one variant beyond the initially sketched set, added to distinguish "wrote successfully but couldn't read our own write back" from `RowsWriteFailed`.

## Testing

- `crates/antiburn-local`: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` — all suites `test result: ok` (main suite 1179 passed, 2 ignored, 0 failed).
- `apps/desktop/src-tauri`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 868 passed, 0 failed.
- `pnpm run slop` (score 100, 0 issues), `pnpm run secrets` (clean).
- `apps/desktop/src` was not touched, so no frontend lint/type-check/test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYy8knDMctPvE6qud67Vri
