### PR TITLE
fix(hud): float above full-screen spaces, and keep unlit LEDs visible

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -133,9 +133,9 @@ colors:
   bg-hud:
     light: "hsl(0 0% 96.4%)"
     dark: "hsl(0 0% 12.5%)"
-  led-off: # unlit LED segment; one grey for both themes, because the HUD paints no surface
-    light: "hsl(0 0% 0% / 0.22)"
-    dark: "hsl(0 0% 0% / 0.22)"
+  led-off: # unlit LED segment; one mid grey for both themes, because the HUD paints no surface and floats over any background
+    light: "hsl(0 0% 50% / 0.45)"
+    dark: "hsl(0 0% 50% / 0.45)"
   # Session-analysis sub-palette only (src/styles/session-analysis-colors.css)
   context-fill-top:
     light: "hsl(217.2 91% 59.8% / 0.6)"

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -133,6 +133,9 @@ colors:
   bg-hud:
     light: "hsl(0 0% 96.4%)"
     dark: "hsl(0 0% 12.5%)"
+  led-off: # unlit LED segment; one grey for both themes, because the HUD paints no surface
+    light: "hsl(0 0% 0% / 0.22)"
+    dark: "hsl(0 0% 0% / 0.22)"
   # Session-analysis sub-palette only (src/styles/session-analysis-colors.css)
   context-fill-top:
     light: "hsl(217.2 91% 59.8% / 0.6)"

--- a/apps/desktop/src-tauri/crates/hud/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/hud/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 #[cfg(target_os = "macos")]
-use objc2_app_kit::NSWindow;
+use objc2_app_kit::{NSScreenSaverWindowLevel, NSWindow, NSWindowCollectionBehavior};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 #[cfg(target_os = "macos")]
@@ -383,6 +383,7 @@ pub fn open(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()> {
     .transparent(true)
     .build()?;
 
+    float_over_all_spaces(&window)?;
     spawn_hover_watcher(window.clone());
     place(&window, entries)?;
 
@@ -491,6 +492,43 @@ pub fn resize(
     Ok(())
 }
 
+/// Put the window above every other window, on every space, and over the
+/// full-screen space of another application.
+///
+/// The level must clear a full-screen space. The status level does not: macOS
+/// composites a full-screen space above it, so the HUD stays hidden behind a
+/// full-screen window. The screen-saver level clears it.
+///
+/// The collection behavior shows one window on all spaces. macOS moves that
+/// window with the reader, so the crate does not make a copy for each space.
+/// `FullScreenAuxiliary` adds the full-screen spaces of other applications.
+/// `Stationary` holds the position during a space switch and in Mission
+/// Control. `IgnoresCycle` keeps the window out of the window cycle.
+#[cfg(target_os = "macos")]
+fn apply_float_over_all_spaces(ns_window: &NSWindow) {
+    ns_window.setLevel(NSScreenSaverWindowLevel);
+    ns_window.setCollectionBehavior(
+        NSWindowCollectionBehavior::CanJoinAllSpaces
+            | NSWindowCollectionBehavior::FullScreenAuxiliary
+            | NSWindowCollectionBehavior::Stationary
+            | NSWindowCollectionBehavior::IgnoresCycle,
+    );
+}
+
+/// Apply {@link apply_float_over_all_spaces} to a Tauri window.
+#[cfg(target_os = "macos")]
+fn float_over_all_spaces(window: &WebviewWindow) -> tauri::Result<()> {
+    let native_window = window.clone();
+    window.run_on_main_thread(move || {
+        let Ok(pointer) = native_window.ns_window() else {
+            return;
+        };
+        // SAFETY: The callback runs on the main thread and the pointer is the live NSWindow.
+        let ns_window = unsafe { &*pointer.cast::<NSWindow>() };
+        apply_float_over_all_spaces(ns_window);
+    })
+}
+
 #[cfg(target_os = "macos")]
 fn show_without_activation(window: &WebviewWindow) -> tauri::Result<()> {
     let native_window = window.clone();
@@ -501,9 +539,12 @@ fn show_without_activation(window: &WebviewWindow) -> tauri::Result<()> {
         }
         if let Ok(pointer) = native_window.ns_window() {
             // SAFETY: The callback runs on the main thread and the pointer is the live NSWindow.
-            unsafe {
-                (&*pointer.cast::<NSWindow>()).orderFrontRegardless();
-            }
+            let ns_window = unsafe { &*pointer.cast::<NSWindow>() };
+            // The window is built hidden and revealed later. Set the level and
+            // the collection behavior again here, because the toolkit can
+            // reset them when it shows a window.
+            apply_float_over_all_spaces(ns_window);
+            ns_window.orderFrontRegardless();
             let _ = app.emit(OVERLAY_VISIBILITY_EVENT, true);
         }
     })
@@ -798,6 +839,7 @@ fn build_detail(app: &AppHandle) -> tauri::Result<tauri::WebviewWindow> {
     .decorations(false)
     .transparent(true)
     .build()?;
+    float_over_all_spaces(&window)?;
     let _ = window.set_ignore_cursor_events(true);
     Ok(window)
 }

--- a/apps/desktop/src/components/ui/LedBar.tsx
+++ b/apps/desktop/src/components/ui/LedBar.tsx
@@ -35,7 +35,7 @@ export function LedBar({
         return (
           <span
             key={index}
-            className={`h-1.5 w-1.5 shrink-0 rounded-full ${hit ? "" : "bg-surface-tertiary"} ${index === blinkIndex ? "led-blink" : ""}`.trimEnd()}
+            className={`h-1.5 w-1.5 shrink-0 rounded-full ${hit ? "" : "bg-led-off"} ${index === blinkIndex ? "led-blink" : ""}`.trimEnd()}
             style={
               hit
                 ? index === blinkIndex

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -7,12 +7,20 @@
   --color-burn: var(--color-burn-val);
   --color-burn-muted: var(--color-burn-muted-val);
   --color-bg-hud: var(--color-bg-hud-val);
+  --color-led-off: var(--color-led-off-val);
 }
 
 :root {
   --color-burn-val: hsl(18 100% 50%);
   --color-burn-muted-val: hsl(18.1 88% 51.4%);
   --color-bg-hud-val: hsl(0 0% 96.4%);
+
+  /*
+   * The unlit LED segment. The same grey in each theme, because the HUD
+   * paints no surface: a segment sits directly on the desktop. The dark
+   * theme used white, which disappeared on a light document.
+   */
+  --color-led-off-val: hsl(0 0% 0% / 0.22);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -20,6 +28,7 @@
     --color-burn-val: hsl(25 100% 50%);
     --color-burn-muted-val: hsl(23 88.8% 54%);
     --color-bg-hud-val: hsl(0 0% 12.5%);
+    --color-led-off-val: hsl(0 0% 0% / 0.22);
   }
 }
 
@@ -27,12 +36,14 @@
   --color-burn-val: hsl(18 100% 50%);
   --color-burn-muted-val: hsl(18.1 88% 51.4%);
   --color-bg-hud-val: hsl(0 0% 96.4%);
+  --color-led-off-val: hsl(0 0% 0% / 0.22);
 }
 
 :root[data-theme="dark"] {
   --color-burn-val: hsl(25 100% 50%);
   --color-burn-muted-val: hsl(23 88.8% 54%);
   --color-bg-hud-val: hsl(0 0% 12.5%);
+  --color-led-off-val: hsl(0 0% 0% / 0.22);
 }
 
 /*
@@ -69,7 +80,7 @@ body[data-transparent-window] #root {
 
   50%,
   100% {
-    background-color: var(--color-surface-tertiary);
+    background-color: var(--color-led-off);
   }
 }
 

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -16,11 +16,12 @@
   --color-bg-hud-val: hsl(0 0% 96.4%);
 
   /*
-   * The unlit LED segment. The same grey in each theme, because the HUD
-   * paints no surface: a segment sits directly on the desktop. The dark
-   * theme used white, which disappeared on a light document.
+   * The unlit LED segment. The same mid grey in each theme, because the HUD
+   * paints no surface: a segment sits directly on the desktop. A near-white
+   * segment disappeared on a light document, and a near-black segment
+   * disappeared on a dark one. Only a mid grey holds on both.
    */
-  --color-led-off-val: hsl(0 0% 0% / 0.22);
+  --color-led-off-val: hsl(0 0% 50% / 0.45);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -28,7 +29,7 @@
     --color-burn-val: hsl(25 100% 50%);
     --color-burn-muted-val: hsl(23 88.8% 54%);
     --color-bg-hud-val: hsl(0 0% 12.5%);
-    --color-led-off-val: hsl(0 0% 0% / 0.22);
+    --color-led-off-val: hsl(0 0% 50% / 0.45);
   }
 }
 
@@ -36,14 +37,14 @@
   --color-burn-val: hsl(18 100% 50%);
   --color-burn-muted-val: hsl(18.1 88% 51.4%);
   --color-bg-hud-val: hsl(0 0% 96.4%);
-  --color-led-off-val: hsl(0 0% 0% / 0.22);
+  --color-led-off-val: hsl(0 0% 50% / 0.45);
 }
 
 :root[data-theme="dark"] {
   --color-burn-val: hsl(25 100% 50%);
   --color-burn-muted-val: hsl(23 88.8% 54%);
   --color-bg-hud-val: hsl(0 0% 12.5%);
-  --color-led-off-val: hsl(0 0% 0% / 0.22);
+  --color-led-off-val: hsl(0 0% 50% / 0.45);
 }
 
 /*

--- a/docs/hud-states.md
+++ b/docs/hud-states.md
@@ -160,6 +160,18 @@ windows joined.
 The native frame reserves no transparent expansion space. Desktop clicks
 outside the visible HUD reach the application underneath it.
 
+## Stacking and spaces
+
+The HUD and its detail window use the macOS screen-saver window level. A lower
+level is not enough: macOS composites a full-screen space above the status
+level, which hides the HUD behind any full-screen window. The shell sets the
+level again each time it reveals the window, because the toolkit can reset it.
+
+Both windows join all spaces, so one window follows the reader between spaces.
+The app draws no copy for each space. The windows also join the full-screen
+spaces of other applications, and they hold their position during a space
+switch and in Mission Control.
+
 ## Data and timing
 
 - Each LED bar has 20 segments.


### PR DESCRIPTION
## What

Two HUD fixes, both verified by hand on a rebuilt app.

**The HUD now floats above full-screen apps.** It used the floating window level, which macOS composites *below* a full-screen space, so any full-screen window hid it. The status level is not enough either, for the same reason. This moves both the HUD and its detail window to the screen-saver level and gives them a collection behavior that joins all spaces, plus the full-screen spaces of other applications.

macOS moves a `CanJoinAllSpaces` window with the reader on its own, so the app draws **one** window rather than a copy for each space. `Stationary` holds the position through a space switch and in Mission Control; `IgnoresCycle` keeps the HUD out of the window cycle.

The level is set again on every reveal. The window is built hidden and shown later, and the toolkit can reset the level when it shows a window — setting it once at build time was not enough, which is what made the first attempt look like it had done nothing.

**Unlit LED segments now hold on any background.** The HUD paints no surface: a segment sits directly on whatever is behind it. The dark theme drew unlit segments in near-white, which vanished against a light document. A near-black value has the mirror problem on a dark one. This adds a HUD-scoped `led-off` token at a mid grey, the same value in both themes, at a higher opacity than the `surface-tertiary` it replaces.

## Screenshot

<!-- Keith: drag in a shot of the HUD sitting over a full-screen window, dark mode, over a light document -->

## Testing

Verified by hand: the HUD floats over full-screen apps, and the unlit segments read correctly in dark mode over both light and dark documents.

Automated, all green: 1086 frontend tests, 21 hud-crate tests, `cargo clippy -D warnings`, lint, type-check, prettier, and `check-design-drift.mjs`.

## Notes for review

The branch was 441 commits behind main on a pre-open-sourcing base, so a plain rebase tried to replay the whole bootstrap commit. It was reset onto `origin/main` and the work cherry-picked across instead. Worth knowing for any other long-lived antiburn worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
