### PR TITLE
fix(desktop): keep activity clock current

### DIFF
--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -236,6 +236,32 @@ describe("PopoverSession surface presentation", () => {
     expect(session.getSnapshot().now).toBeGreaterThan(before)
     unsubscribe()
   })
+
+  it("keeps the activity clock current while visible and refreshes it when shown", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(popoverHiddenHandler).not.toBeNull()
+    expect(popoverShownHandler).not.toBeNull()
+
+    const initial = session.getSnapshot().now
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(session.getSnapshot().now).toBe(initial + 30_000)
+
+    popoverHiddenHandler?.()
+    const hidden = session.getSnapshot().now
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(session.getSnapshot().now).toBe(hidden)
+
+    popoverShownHandler?.()
+    expect(session.getSnapshot().now).toBe(Date.now())
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(session.getSnapshot().now).toBe(Date.now())
+    unsubscribe()
+  })
 })
 
 /**

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -114,11 +114,11 @@ export interface PopoverSnapshot {
    */
   analysisRefreshing: boolean
   /**
-   * A timestamp bumped every `NOW_TICK_MS` while a detail pane is open.
+   * A timestamp bumped every `NOW_TICK_MS` while the popover is visible or a
+   * detail pane is open.
    *
-   * The value itself has no reader: its purpose is to change the snapshot
-   * reference so the header's relative-time text ("last just now") re-renders
-   * on its own clock, not the arrival of new data.
+   * The activity list uses it for day boundaries and future-time checks. The
+   * detail header uses it to update relative-time text without new data.
    */
   now: number
 }
@@ -345,7 +345,7 @@ export class PopoverSession {
     if (top) {
       this.openAnalysis(top)
     } else {
-      this.syncDetailTimers()
+      this.syncNowTicking()
     }
   }
 
@@ -431,10 +431,9 @@ export class PopoverSession {
     // already had its chance to claim the key first.
     window.addEventListener("keydown", this.onWindowKeyDown)
 
-    // A stack carried over from a previous start (the window never really
-    // unmounts, but the listener count can still hit zero and come back)
-    // still needs its relative-time ticker running again.
-    this.syncDetailTimers()
+    // A visible list or a detail stack carried over from a previous start
+    // still needs its clock running again.
+    this.syncNowTicking()
 
     // R6: the session starts visible (see `visible`'s doc comment), so its
     // usage poll starts immediately rather than waiting for a `popover:shown`
@@ -731,6 +730,8 @@ export class PopoverSession {
     const unlisten = await onPopoverShown(() => {
       if (generation !== this.generation) return
       this.visible = true
+      this.update({ now: Date.now() })
+      this.syncNowTicking()
       this.startUsagePolling()
       if (this.initialContentReady) this.reportContentReady(true)
       void this.restoreFloatingHud(generation)
@@ -752,6 +753,7 @@ export class PopoverSession {
     const unlisten = await onPopoverHidden(() => {
       if (generation !== this.generation) return
       this.visible = false
+      this.syncNowTicking()
       this.stopUsagePolling()
     })
     if (generation !== this.generation) {
@@ -945,15 +947,15 @@ export class PopoverSession {
     })
   }
 
-  /** Load a subject's analysis and make sure the relative-time ticker is running — a detail pane is now open. */
+  /** Load a subject's analysis and keep the clock running for the detail pane. */
   private openAnalysis(subject: SessionSubject): void {
     void this.loadAnalysisFor(subject)
-    this.syncDetailTimers()
+    this.syncNowTicking()
   }
 
-  /** Start or stop the relative-time ticker to match whether a detail pane is open. */
-  private syncDetailTimers(): void {
-    if (this.snapshot.stack.length > 0) {
+  /** Run the clock while visible or while a hidden detail pane stays mounted. */
+  private syncNowTicking(): void {
+    if (this.visible || this.snapshot.stack.length > 0) {
       this.startNowTicking()
     } else {
       this.stopNowTicking()


### PR DESCRIPTION
## Summary

- keep the popover clock current while the activity list is visible
- refresh the clock immediately when the popover is shown
- stop the activity clock while hidden, while preserving detail-pane updates
- cover the visible, hidden, and reopened lifecycle with a regression test

## Tests

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test` (1,087 tests)
- `pnpm --filter @antiburn/desktop build`

## User impact

Continued sessions no longer disappear after they become inactive because the resident renderer compares them against a stale startup time.

## Performance and privacy

The 30-second clock tick runs only while the popover is visible or a detail pane remains mounted. It performs no I/O and changes no data collection.