### PR TITLE
feat(hud): linear-use notch, Claude's colour, and a hover surface

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -133,9 +133,15 @@ colors:
   bg-hud:
     light: "hsl(0 0% 96.4%)"
     dark: "hsl(0 0% 12.5%)"
+  bg-hud-hover: # the HUD surface on hover; the desktop stays visible through it
+    light: "hsl(0 0% 96.4% / 0.9)"
+    dark: "hsl(0 0% 12.5% / 0.9)"
   led-off: # unlit LED segment; one mid grey for both themes, because the HUD paints no surface and floats over any background
     light: "hsl(0 0% 50% / 0.45)"
     dark: "hsl(0 0% 50% / 0.45)"
+  led-notch: # the linear-use notch; one grey for both themes, for the same reason as led-off
+    light: "hsl(0 0% 45% / 0.9)"
+    dark: "hsl(0 0% 45% / 0.9)"
   # Session-analysis sub-palette only (src/styles/session-analysis-colors.css)
   context-fill-top:
     light: "hsl(217.2 91% 59.8% / 0.6)"
@@ -314,7 +320,10 @@ Notes for what isn't expressible as a token:
   filled paths, not stroked glyphs, and take `--color-agent-mark` rather than a `text-*` label
   colour — a deliberately firmer ink, because a shape has no letterforms to carry it at 18px. A mark
   whose identity _is_ its colour keeps that colour in both themes, taken from the value its source
-  package records. Marks are never drawn inline; they come from the `renderAgentIcon` slot.
+  package records. Marks are never drawn inline; they come from the `renderAgentIcon` slot. The
+  same rule covers the one other place a vendor colour appears: the HUD draws Anthropic's usage bar
+  in the hex `simple-icons` records for the Claude mark, read from the package rather than written
+  into the palette.
 - **Themes** — three sources, in cascade order. The system light/dark preference is the default. A
   platform whose webview exposes live system label/separator/accent tokens picks those up through
   `@supports`, so text and chrome track the OS exactly. A platform without them takes an explicit

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -139,9 +139,9 @@ colors:
   led-off: # unlit LED segment; one mid grey for both themes, because the HUD paints no surface and floats over any background
     light: "hsl(0 0% 50% / 0.45)"
     dark: "hsl(0 0% 50% / 0.45)"
-  led-notch: # the linear-use notch; one grey for both themes, for the same reason as led-off
-    light: "hsl(0 0% 45% / 0.9)"
-    dark: "hsl(0 0% 45% / 0.9)"
+  led-notch: # the linear-use notch; one dark grey for both themes, for the same reason as led-off
+    light: "hsl(0 0% 20% / 0.95)"
+    dark: "hsl(0 0% 20% / 0.95)"
   # Session-analysis sub-palette only (src/styles/session-analysis-colors.css)
   context-fill-top:
     light: "hsl(217.2 91% 59.8% / 0.6)"

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -139,9 +139,12 @@ colors:
   led-off: # unlit LED segment; one mid grey for both themes, because the HUD paints no surface and floats over any background
     light: "hsl(0 0% 50% / 0.45)"
     dark: "hsl(0 0% 50% / 0.45)"
-  led-notch: # the linear-use notch; one dark grey for both themes, for the same reason as led-off
+  led-notch: # the dark line of the linear-use notch; one value for both themes, for the same reason as led-off
     light: "hsl(0 0% 20% / 0.95)"
     dark: "hsl(0 0% 20% / 0.95)"
+  led-notch-highlight: # the light line beside it; the pair reads on a light document and on a dark one
+    light: "hsl(0 0% 100% / 0.85)"
+    dark: "hsl(0 0% 100% / 0.85)"
   # Session-analysis sub-palette only (src/styles/session-analysis-colors.css)
   context-fill-top:
     light: "hsl(217.2 91% 59.8% / 0.6)"

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -332,7 +332,10 @@ Notes for what isn't expressible as a token:
   package records. Marks are never drawn inline; they come from the `renderAgentIcon` slot. The
   same rule covers the one other place a vendor colour appears: the HUD draws Anthropic's usage bar
   in the hex `simple-icons` records for the Claude mark, read from the package rather than written
-  into the palette.
+  into the palette. The bar raises the saturation of that hex and keeps its hue and lightness. A
+  published brand value is made for a filled mark at 18px, and a row of 6px dots on an uncontrolled
+  desktop needs more chroma to read as the same colour. The lift is a factor applied to the package
+  value, so the source stays the package.
 - **Themes** — three sources, in cascade order. The system light/dark preference is the default. A
   platform whose webview exposes live system label/separator/accent tokens picks those up through
   `@supports`, so text and chrome track the OS exactly. A platform without them takes an explicit

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -136,6 +136,12 @@ colors:
   bg-hud-hover: # the HUD surface on hover; the desktop stays visible through it
     light: "hsl(0 0% 96.4% / 0.9)"
     dark: "hsl(0 0% 12.5% / 0.9)"
+  hud-control-ink: # the close control's glyph; no alpha, so it stays solid on the hover surface
+    light: "hsl(0 0% 32%)"
+    dark: "hsl(0 0% 78%)"
+  hud-control-edge: # the close control's edge; no alpha, for the same reason
+    light: "hsl(0 0% 80%)"
+    dark: "hsl(0 0% 32%)"
   led-off: # unlit LED segment; one mid grey for both themes, because the HUD paints no surface and floats over any background
     light: "hsl(0 0% 50% / 0.45)"
     dark: "hsl(0 0% 50% / 0.45)"

--- a/apps/desktop/src/components/ui/LedBar.tsx
+++ b/apps/desktop/src/components/ui/LedBar.tsx
@@ -1,16 +1,26 @@
 import type { CSSProperties } from "react"
 
-/** Render an LED-style bar with fixed circular segments. */
+/**
+ * Render an LED-style bar with fixed circular segments.
+ *
+ * `expectedFraction` draws the linear-use notch, as `SegmentedMeter` does in
+ * the popover: a tick at how far through the window's period the clock has
+ * travelled. It separates 60% used at 30% elapsed from 60% used at 90%
+ * elapsed. With no fraction there is no notch.
+ */
 export function LedBar({
   split,
   segments = 40,
   className = "",
   blinkLast = false,
+  expectedFraction = null,
 }: {
   split: Array<{ fraction: number; color: string }>
   segments?: number
   className?: string
   blinkLast?: boolean
+  /** Elapsed share of the window's period, 0-1, or null when unknown. */
+  expectedFraction?: number | null
 }) {
   const cutoffs: Array<{ upTo: number; color: string }> = []
   let accumulated = 0
@@ -26,7 +36,7 @@ export function LedBar({
 
   return (
     <div
-      className={`flex w-full items-center justify-between ${className}`.trimEnd()}
+      className={`relative flex w-full items-center justify-between ${className}`.trimEnd()}
       aria-hidden="true"
     >
       {Array.from({ length: segments }, (_, index) => {
@@ -49,6 +59,13 @@ export function LedBar({
           />
         )
       })}
+      {expectedFraction != null && (
+        <span
+          data-testid="led-bar-notch"
+          className="absolute -inset-y-[2px] w-[1.5px] bg-led-notch"
+          style={{ left: `${Math.min(100, Math.max(0, expectedFraction * 100))}%` }}
+        />
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/components/ui/LedBar.tsx
+++ b/apps/desktop/src/components/ui/LedBar.tsx
@@ -62,7 +62,7 @@ export function LedBar({
       {expectedFraction != null && (
         <span
           data-testid="led-bar-notch"
-          className="absolute -inset-y-[2px] w-[1.5px] bg-led-notch"
+          className="led-notch absolute -inset-y-[2px]"
           style={{ left: `${Math.min(100, Math.max(0, expectedFraction * 100))}%` }}
         />
       )}

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -945,6 +945,8 @@ export interface HudDetailBar {
   /** ISO timestamp, or null when the reset time is unknown. */
   resetsAt: string | null
   color: string
+  /** Elapsed share of the window's period, 0-1, or null when unknown. */
+  expectedFraction: number | null
 }
 
 /** The payload the HUD pushes to the hover detail window. */

--- a/apps/desktop/src/lib/usageBars.test.ts
+++ b/apps/desktop/src/lib/usageBars.test.ts
@@ -8,6 +8,27 @@ import type {
 } from "./ipc"
 import { deriveUsageBars, providerBarColor, resetsIn, resetsLabel } from "./usageBars"
 
+/** Read a `#rrggbb` colour as hue, saturation, and lightness, for comparison. */
+function hslOf(hex: string): { hue: number; saturation: number; lightness: number } {
+  const value = Number.parseInt(hex.slice(1), 16)
+  const red = ((value >> 16) & 255) / 255
+  const green = ((value >> 8) & 255) / 255
+  const blue = (value & 255) / 255
+  const high = Math.max(red, green, blue)
+  const low = Math.min(red, green, blue)
+  const chroma = high - low
+  const lightness = (high + low) / 2
+  let hue: number
+  if (high === red) hue = (green - blue) / chroma
+  else if (high === green) hue = (blue - red) / chroma + 2
+  else hue = (red - green) / chroma + 4
+  return {
+    hue: (((hue * 60) % 360) + 360) % 360,
+    saturation: (chroma / (1 - Math.abs(2 * lightness - 1))) * 100,
+    lightness: lightness * 100,
+  }
+}
+
 const NOW = Date.parse("2026-08-18T02:00:00Z")
 
 function usageWindow(overrides: Partial<LiveUsageWindowPayload> = {}): LiveUsageWindowPayload {
@@ -130,8 +151,16 @@ describe("deriveUsageBars", () => {
     )
     // Anthropic keeps Claude's own colour, and it comes from the package the
     // brand marks come from — a hex written here would be the thing the
-    // design contract forbids.
-    expect(bars[0]!.color).toBe(`#${siClaude.hex}`)
+    // design contract forbids. The bar raises the saturation for a row of
+    // small dots, so the test states the relationship to the published hex
+    // rather than a value of its own: same hue, same lightness, more chroma.
+    const published = hslOf(`#${siClaude.hex}`)
+    const drawn = /^hsl\(([\d.]+) ([\d.]+)% ([\d.]+)%\)$/.exec(bars[0]!.color)
+    expect(drawn).not.toBeNull()
+    const [hue, saturation, lightness] = drawn!.slice(1).map(Number) as [number, number, number]
+    expect(hue).toBeCloseTo(published.hue, 1)
+    expect(lightness).toBeCloseTo(published.lightness, 1)
+    expect(saturation).toBeGreaterThan(published.saturation)
     expect(bars[1]!.color).toBe("var(--color-label)")
     expect(providerBarColor("cursor")).toBe("var(--color-system-indigo)")
     expect(providerBarColor("somebody-new")).toBe("var(--color-burn)")

--- a/apps/desktop/src/lib/usageBars.test.ts
+++ b/apps/desktop/src/lib/usageBars.test.ts
@@ -1,3 +1,4 @@
+import { siClaude } from "simple-icons"
 import { describe, expect, it } from "vitest"
 
 import type {
@@ -127,10 +128,35 @@ describe("deriveUsageBars", () => {
         provider({ provider: "openai", displayName: "OpenAI", windows: [usageWindow()] }),
       ]),
     )
-    expect(bars[0]!.color).toBe("var(--color-burn)")
+    // Anthropic keeps Claude's own colour, and it comes from the package the
+    // brand marks come from — a hex written here would be the thing the
+    // design contract forbids.
+    expect(bars[0]!.color).toBe(`#${siClaude.hex}`)
     expect(bars[1]!.color).toBe("var(--color-label)")
     expect(providerBarColor("cursor")).toBe("var(--color-system-indigo)")
     expect(providerBarColor("somebody-new")).toBe("var(--color-burn)")
+  })
+
+  it("measures the notch from the snapshot's own time", () => {
+    // The window resets in two hours and its id states a five-hour period, so
+    // three of its five hours have gone.
+    const bars = deriveUsageBars(summary([provider()]))
+    expect(bars[0]!.expectedFraction).toBeCloseTo(0.6, 5)
+  })
+
+  it("draws no notch when nothing states the window's period", () => {
+    // A notch placed from an assumed period is a claim the provider never
+    // made, so there is no notch at all.
+    const bars = deriveUsageBars(
+      summary([provider({ windows: [usageWindow({ id: "monthly", kind: "monthly" })] })]),
+    )
+    expect(bars[0]!.expectedFraction).toBeNull()
+  })
+
+  it("draws no notch when the snapshot states no usable time", () => {
+    const broken = summary([provider()])
+    broken.generatedAt = "not a date"
+    expect(deriveUsageBars(broken)[0]!.expectedFraction).toBeNull()
   })
 })
 

--- a/apps/desktop/src/lib/usageBars.ts
+++ b/apps/desktop/src/lib/usageBars.ts
@@ -1,6 +1,9 @@
+import { siClaude } from "simple-icons"
+
 import type { LiveUsageSummaryPayload } from "./ipc"
 import {
   liveDisplayableProviders,
+  liveWindowElapsed,
   liveWindowLabel,
   liveWindows,
 } from "./presentation/liveUsage"
@@ -11,11 +14,21 @@ export type UsageBarItem = {
   percent: number
   resetsAt: Date | null
   color: string
+  /** Elapsed share of the window's period, 0-1, or null when unknown. */
+  expectedFraction: number | null
 }
 
+/**
+ * Anthropic keeps its own colour, taken from the hex the `simple-icons`
+ * package records for the Claude mark. The brand-mark rule in `design.md`
+ * applies: a vendor colour comes from the source package, never from a hex
+ * written here. The other providers use antiburn's own palette.
+ */
+const CLAUDE_BRAND = `#${siClaude.hex}`
+
 const PROVIDER_COLORS: Record<string, string> = {
-  anthropic: "var(--color-burn)",
-  claude: "var(--color-burn)",
+  anthropic: CLAUDE_BRAND,
+  claude: CLAUDE_BRAND,
   openai: "var(--color-label)",
   cursor: "var(--color-system-indigo)",
   google: "var(--color-system-blue)",
@@ -57,6 +70,10 @@ export function deriveUsageBars(response: LiveUsageSummaryPayload | null): Usage
     .filter((group) => group.windows.length > 0)
 
   const multiProvider = withBars.length > 1
+  // The notch measures from the snapshot's own time, not the wall clock. A
+  // snapshot that states no usable time gets no notch, because a notch drawn
+  // from an assumed time is a claim the provider did not make.
+  const generatedAt = response ? Date.parse(response.generatedAt) : Number.NaN
 
   return withBars.flatMap((group) =>
     group.windows.map((window) => ({
@@ -67,6 +84,9 @@ export function deriveUsageBars(response: LiveUsageSummaryPayload | null): Usage
       percent: window.usedPercent!,
       resetsAt: resetDate(window.resetsAt),
       color: providerBarColor(group.provider.provider),
+      expectedFraction: Number.isNaN(generatedAt)
+        ? null
+        : liveWindowElapsed(window, generatedAt),
     })),
   )
 }

--- a/apps/desktop/src/lib/usageBars.ts
+++ b/apps/desktop/src/lib/usageBars.ts
@@ -56,7 +56,7 @@ function saturated(hex: string, gain: number): string {
  * not control, and at that size the same value looks washed out. The hue and
  * the lightness do not change, so the bar keeps the colour the vendor chose.
  */
-const CLAUDE_SATURATION_GAIN = 1.25
+const CLAUDE_SATURATION_GAIN = 1.15
 
 const CLAUDE_BRAND = saturated(`#${siClaude.hex}`, CLAUDE_SATURATION_GAIN)
 

--- a/apps/desktop/src/lib/usageBars.ts
+++ b/apps/desktop/src/lib/usageBars.ts
@@ -19,12 +19,46 @@ export type UsageBarItem = {
 }
 
 /**
+ * Return a hex colour as a CSS `hsl()` string with more saturation. The hue
+ * and the lightness do not change. A colour this cannot read comes back
+ * unchanged.
+ */
+function saturated(hex: string, gain: number): string {
+  const digits = /^#([0-9a-f]{6})$/i.exec(hex)
+  if (!digits) return hex
+  const value = Number.parseInt(digits[1]!, 16)
+  const red = ((value >> 16) & 255) / 255
+  const green = ((value >> 8) & 255) / 255
+  const blue = (value & 255) / 255
+  const high = Math.max(red, green, blue)
+  const low = Math.min(red, green, blue)
+  const chroma = high - low
+  if (chroma === 0) return hex
+  const lightness = (high + low) / 2
+  const saturation = chroma / (1 - Math.abs(2 * lightness - 1))
+  let hue: number
+  if (high === red) hue = (green - blue) / chroma
+  else if (high === green) hue = (blue - red) / chroma + 2
+  else hue = (red - green) / chroma + 4
+  hue = (((hue * 60) % 360) + 360) % 360
+  const raised = Math.min(1, saturation * gain)
+  return `hsl(${hue.toFixed(1)} ${(raised * 100).toFixed(1)}% ${(lightness * 100).toFixed(1)}%)`
+}
+
+/**
  * Anthropic keeps its own colour, taken from the hex the `simple-icons`
  * package records for the Claude mark. The brand-mark rule in `design.md`
  * applies: a vendor colour comes from the source package, never from a hex
  * written here. The other providers use antiburn's own palette.
+ *
+ * The bar raises the saturation of that hex. The published value is made for
+ * a filled mark at 18px. A bar is a row of 6px dots on a desktop the app does
+ * not control, and at that size the same value looks washed out. The hue and
+ * the lightness do not change, so the bar keeps the colour the vendor chose.
  */
-const CLAUDE_BRAND = `#${siClaude.hex}`
+const CLAUDE_SATURATION_GAIN = 1.25
+
+const CLAUDE_BRAND = saturated(`#${siClaude.hex}`, CLAUDE_SATURATION_GAIN)
 
 const PROVIDER_COLORS: Record<string, string> = {
   anthropic: CLAUDE_BRAND,

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -7,7 +7,9 @@
   --color-burn: var(--color-burn-val);
   --color-burn-muted: var(--color-burn-muted-val);
   --color-bg-hud: var(--color-bg-hud-val);
+  --color-bg-hud-hover: var(--color-bg-hud-hover-val);
   --color-led-off: var(--color-led-off-val);
+  --color-led-notch: var(--color-led-notch-val);
 }
 
 :root {
@@ -22,6 +24,16 @@
    * disappeared on a dark one. Only a mid grey holds on both.
    */
   --color-led-off-val: hsl(0 0% 50% / 0.45);
+
+  /*
+   * The linear-use notch. A darker grey than the unlit segment, for the same
+   * reason: the notch must hold on a light document and on a dark one. The
+   * label ink cannot do this, because it turns near-white in the dark theme.
+   */
+  --color-led-notch-val: hsl(0 0% 45% / 0.9);
+
+  /* The HUD surface on hover. The reader can see the desktop through it. */
+  --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -29,7 +41,9 @@
     --color-burn-val: hsl(25 100% 50%);
     --color-burn-muted-val: hsl(23 88.8% 54%);
     --color-bg-hud-val: hsl(0 0% 12.5%);
+    --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
     --color-led-off-val: hsl(0 0% 50% / 0.45);
+    --color-led-notch-val: hsl(0 0% 45% / 0.9);
   }
 }
 
@@ -37,14 +51,18 @@
   --color-burn-val: hsl(18 100% 50%);
   --color-burn-muted-val: hsl(18.1 88% 51.4%);
   --color-bg-hud-val: hsl(0 0% 96.4%);
+  --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
+  --color-led-notch-val: hsl(0 0% 45% / 0.9);
 }
 
 :root[data-theme="dark"] {
   --color-burn-val: hsl(25 100% 50%);
   --color-burn-muted-val: hsl(23 88.8% 54%);
   --color-bg-hud-val: hsl(0 0% 12.5%);
+  --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
+  --color-led-notch-val: hsl(0 0% 45% / 0.9);
 }
 
 /*

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -26,11 +26,12 @@
   --color-led-off-val: hsl(0 0% 50% / 0.45);
 
   /*
-   * The linear-use notch. A darker grey than the unlit segment, for the same
-   * reason: the notch must hold on a light document and on a dark one. The
-   * label ink cannot do this, because it turns near-white in the dark theme.
+   * The linear-use notch. Much darker than the unlit segment, because the
+   * notch is 1.5px wide and a mid grey was too weak to find at that size. It
+   * holds one value in each theme, as the unlit segment does: the label ink
+   * turns near-white in the dark theme and disappears on a light document.
    */
-  --color-led-notch-val: hsl(0 0% 45% / 0.9);
+  --color-led-notch-val: hsl(0 0% 20% / 0.95);
 
   /* The HUD surface on hover. The reader can see the desktop through it. */
   --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
@@ -43,7 +44,7 @@
     --color-bg-hud-val: hsl(0 0% 12.5%);
     --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
     --color-led-off-val: hsl(0 0% 50% / 0.45);
-    --color-led-notch-val: hsl(0 0% 45% / 0.9);
+    --color-led-notch-val: hsl(0 0% 20% / 0.95);
   }
 }
 
@@ -53,7 +54,7 @@
   --color-bg-hud-val: hsl(0 0% 96.4%);
   --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
-  --color-led-notch-val: hsl(0 0% 45% / 0.9);
+  --color-led-notch-val: hsl(0 0% 20% / 0.95);
 }
 
 :root[data-theme="dark"] {
@@ -62,7 +63,7 @@
   --color-bg-hud-val: hsl(0 0% 12.5%);
   --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
-  --color-led-notch-val: hsl(0 0% 45% / 0.9);
+  --color-led-notch-val: hsl(0 0% 20% / 0.95);
 }
 
 /*

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -8,6 +8,8 @@
   --color-burn-muted: var(--color-burn-muted-val);
   --color-bg-hud: var(--color-bg-hud-val);
   --color-bg-hud-hover: var(--color-bg-hud-hover-val);
+  --color-hud-control-ink: var(--color-hud-control-ink-val);
+  --color-hud-control-edge: var(--color-hud-control-edge-val);
   --color-led-off: var(--color-led-off-val);
   --color-led-notch: var(--color-led-notch-val);
   --color-led-notch-highlight: var(--color-led-notch-highlight-val);
@@ -38,6 +40,16 @@
 
   /* The HUD surface on hover. The reader can see the desktop through it. */
   --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
+
+  /*
+   * The close control. Its glyph and its edge carry no alpha, because the
+   * label and separator inks are partly transparent: on the hover surface,
+   * which is itself partly transparent, the control read as see-through.
+   * The control paints its own opaque surface, so these values follow the
+   * theme rather than holding one value for both.
+   */
+  --color-hud-control-ink-val: hsl(0 0% 32%);
+  --color-hud-control-edge-val: hsl(0 0% 80%);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -46,6 +58,8 @@
     --color-burn-muted-val: hsl(23 88.8% 54%);
     --color-bg-hud-val: hsl(0 0% 12.5%);
     --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
+    --color-hud-control-ink-val: hsl(0 0% 78%);
+    --color-hud-control-edge-val: hsl(0 0% 32%);
     --color-led-off-val: hsl(0 0% 50% / 0.45);
     --color-led-notch-val: hsl(0 0% 20% / 0.95);
     --color-led-notch-highlight-val: hsl(0 0% 100% / 0.85);
@@ -57,6 +71,8 @@
   --color-burn-muted-val: hsl(18.1 88% 51.4%);
   --color-bg-hud-val: hsl(0 0% 96.4%);
   --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
+  --color-hud-control-ink-val: hsl(0 0% 32%);
+  --color-hud-control-edge-val: hsl(0 0% 80%);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
   --color-led-notch-val: hsl(0 0% 20% / 0.95);
   --color-led-notch-highlight-val: hsl(0 0% 100% / 0.85);
@@ -67,6 +83,8 @@
   --color-burn-muted-val: hsl(23 88.8% 54%);
   --color-bg-hud-val: hsl(0 0% 12.5%);
   --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
+  --color-hud-control-ink-val: hsl(0 0% 78%);
+  --color-hud-control-edge-val: hsl(0 0% 32%);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
   --color-led-notch-val: hsl(0 0% 20% / 0.95);
   --color-led-notch-highlight-val: hsl(0 0% 100% / 0.85);

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -10,6 +10,7 @@
   --color-bg-hud-hover: var(--color-bg-hud-hover-val);
   --color-led-off: var(--color-led-off-val);
   --color-led-notch: var(--color-led-notch-val);
+  --color-led-notch-highlight: var(--color-led-notch-highlight-val);
 }
 
 :root {
@@ -26,12 +27,14 @@
   --color-led-off-val: hsl(0 0% 50% / 0.45);
 
   /*
-   * The linear-use notch. Much darker than the unlit segment, because the
-   * notch is 1.5px wide and a mid grey was too weak to find at that size. It
-   * holds one value in each theme, as the unlit segment does: the label ink
-   * turns near-white in the dark theme and disappears on a light document.
+   * The two lines of the linear-use notch. The HUD paints no surface, so one
+   * grey cannot hold on every background: a dark line disappears on a dark
+   * document and a light line disappears on a light one. The notch draws both
+   * lines, side by side, so one of the two always holds. Each line keeps its
+   * value in both themes, as the unlit segment does.
    */
   --color-led-notch-val: hsl(0 0% 20% / 0.95);
+  --color-led-notch-highlight-val: hsl(0 0% 100% / 0.85);
 
   /* The HUD surface on hover. The reader can see the desktop through it. */
   --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
@@ -45,6 +48,7 @@
     --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
     --color-led-off-val: hsl(0 0% 50% / 0.45);
     --color-led-notch-val: hsl(0 0% 20% / 0.95);
+    --color-led-notch-highlight-val: hsl(0 0% 100% / 0.85);
   }
 }
 
@@ -55,6 +59,7 @@
   --color-bg-hud-hover-val: hsl(0 0% 96.4% / 0.9);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
   --color-led-notch-val: hsl(0 0% 20% / 0.95);
+  --color-led-notch-highlight-val: hsl(0 0% 100% / 0.85);
 }
 
 :root[data-theme="dark"] {
@@ -64,6 +69,7 @@
   --color-bg-hud-hover-val: hsl(0 0% 12.5% / 0.9);
   --color-led-off-val: hsl(0 0% 50% / 0.45);
   --color-led-notch-val: hsl(0 0% 20% / 0.95);
+  --color-led-notch-highlight-val: hsl(0 0% 100% / 0.85);
 }
 
 /*
@@ -86,6 +92,19 @@ body[data-transparent-window] #root {
   font-family: var(--font-bitcount);
   text-transform: uppercase;
   letter-spacing: 0.06em;
+}
+
+/*
+ * The linear-use notch: a dark line and a light line, one pixel each, side by
+ * side. The pair reads on a light document and on a dark one.
+ */
+.led-notch {
+  width: 2px;
+  background: linear-gradient(
+    to right,
+    var(--color-led-notch) 0 1px,
+    var(--color-led-notch-highlight) 1px 2px
+  );
 }
 
 .led-blink {

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -107,6 +107,17 @@ body[data-transparent-window] #root {
   );
 }
 
+/*
+ * The HUD close control. It straddles the panel edge, and on hover the panel
+ * behind it is almost its own colour. The shadow is what separates the two.
+ * The value is the design system's `raised` shadow.
+ */
+.hud-close {
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 0.15),
+    0 0 0 0.5px rgb(0 0 0 / 0.04);
+}
+
 .led-blink {
   animation: led-blink 3s steps(1, end) infinite;
 }

--- a/apps/desktop/src/views/OverlayWindow.test.tsx
+++ b/apps/desktop/src/views/OverlayWindow.test.tsx
@@ -79,6 +79,10 @@ const storage = {
 }
 
 function summary(): LiveUsageSummaryPayload {
+  // One instant for the whole snapshot. Sampling the clock twice lets a
+  // millisecond fall between the reset time and the generated time, which
+  // moves the notch off the round percentage the tests state.
+  const at = Date.now()
   return {
     providers: [
       {
@@ -88,7 +92,7 @@ function summary(): LiveUsageSummaryPayload {
         support: "live",
         freshness: "fresh",
         sourceLabel: "cached usage",
-        observedAt: new Date().toISOString(),
+        observedAt: new Date(at).toISOString(),
         windows: [
           {
             id: "five-hour",
@@ -97,7 +101,7 @@ function summary(): LiveUsageSummaryPayload {
             scopeModel: null,
             usedPercent: 81,
             startsAt: null,
-            resetsAt: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+            resetsAt: new Date(at + 2 * 3_600_000).toISOString(),
             hasNonzeroUsageInCurrentPeriod: true,
             forecast: {
               unavailableReason: "sparseHistory",
@@ -117,7 +121,7 @@ function summary(): LiveUsageSummaryPayload {
     ],
     errors: [],
     meters: [],
-    generatedAt: new Date().toISOString(),
+    generatedAt: new Date(at).toISOString(),
   }
 }
 
@@ -265,7 +269,8 @@ describe("OverlayWindow", () => {
     // period, so three of its five hours have gone.
     render(<OverlayWindow />)
     await waitFor(() => expect(screen.getByTestId("led-bar-notch")).toBeInTheDocument())
-    expect(screen.getByTestId("led-bar-notch")).toHaveStyle({ left: "60%" })
+    const offset = Number.parseFloat(screen.getByTestId("led-bar-notch").style.left)
+    expect(offset).toBeCloseTo(60, 3)
   })
 
   it("shows the close control at once and the detail window after the delay", async () => {

--- a/apps/desktop/src/views/OverlayWindow.test.tsx
+++ b/apps/desktop/src/views/OverlayWindow.test.tsx
@@ -248,6 +248,26 @@ describe("OverlayWindow", () => {
     await waitFor(() => expect(resizeOverlayWindow).toHaveBeenCalledWith(44, false, true))
   })
 
+  it("takes a surface on hover and drops it on leave", async () => {
+    // At rest the bars sit on the desktop with nothing behind them. The
+    // surface arrives with the pointer and groups them into one object.
+    const { container } = render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
+    expect(panel(container).style.backgroundColor).toBe("")
+    fireEvent.mouseEnter(frame(container))
+    expect(panel(container).style.backgroundColor).toBe("var(--color-bg-hud-hover)")
+    fireEvent.mouseLeave(frame(container))
+    expect(panel(container).style.backgroundColor).toBe("")
+  })
+
+  it("marks how far through the window the clock has travelled", async () => {
+    // The fixture window resets in two hours and its id states a five-hour
+    // period, so three of its five hours have gone.
+    render(<OverlayWindow />)
+    await waitFor(() => expect(screen.getByTestId("led-bar-notch")).toBeInTheDocument())
+    expect(screen.getByTestId("led-bar-notch")).toHaveStyle({ left: "60%" })
+  })
+
   it("shows the close control at once and the detail window after the delay", async () => {
     vi.useFakeTimers()
     try {

--- a/apps/desktop/src/views/OverlayWindow.tsx
+++ b/apps/desktop/src/views/OverlayWindow.tsx
@@ -29,7 +29,11 @@ export function OverlayWindow() {
     >
       <div
         ref={panelRef}
-        className="relative mx-2 select-none rounded-xl border border-transparent px-3 pt-2 pb-2"
+        className="relative mx-2 select-none rounded-xl border border-transparent px-3 pt-2 pb-2 transition-colors duration-[var(--duration-fast)] ease-out"
+        // At rest the HUD paints no surface and the bars sit on the desktop.
+        // On hover it takes a surface, which groups the bars into one object
+        // the reader can point at and drag.
+        style={state.hovered ? { backgroundColor: "var(--color-bg-hud-hover)" } : undefined}
         onMouseDown={(event) => session.startDrag(event)}
       >
         <button
@@ -56,6 +60,7 @@ export function OverlayWindow() {
                 segments={HUD_SEGMENTS}
                 split={[{ fraction: bar.percent / 100, color: bar.color }]}
                 blinkLast={state.sessionLive && index === 0}
+                expectedFraction={bar.expectedFraction}
               />
             ))}
           </div>

--- a/apps/desktop/src/views/OverlayWindow.tsx
+++ b/apps/desktop/src/views/OverlayWindow.tsx
@@ -40,7 +40,7 @@ export function OverlayWindow() {
           type="button"
           aria-label="Close overlay"
           onClick={() => session.close()}
-          className={`absolute top-2 right-3 translate-x-1/2 -translate-y-1/2 rounded-full border border-separator p-0.5 text-label-tertiary hover:text-label-secondary transition-opacity duration-[var(--duration-fast)] ease-out ${
+          className={`hud-close absolute top-2 right-3 translate-x-1/2 -translate-y-1/2 rounded-full border border-separator p-0.5 text-label-tertiary hover:text-label-secondary transition-opacity duration-[var(--duration-fast)] ease-out ${
             showClose ? "opacity-100" : "pointer-events-none opacity-0"
           }`}
           style={{ backgroundColor: "var(--color-bg-hud)" }}

--- a/apps/desktop/src/views/OverlayWindow.tsx
+++ b/apps/desktop/src/views/OverlayWindow.tsx
@@ -40,7 +40,7 @@ export function OverlayWindow() {
           type="button"
           aria-label="Close overlay"
           onClick={() => session.close()}
-          className={`hud-close absolute top-2 right-3 translate-x-1/2 -translate-y-1/2 rounded-full border border-separator p-0.5 text-label-tertiary hover:text-label-secondary transition-opacity duration-[var(--duration-fast)] ease-out ${
+          className={`hud-close absolute top-2 right-3 translate-x-1/2 -translate-y-1/2 rounded-full border border-hud-control-edge p-0.5 text-hud-control-ink hover:text-label transition-opacity duration-[var(--duration-fast)] ease-out ${
             showClose ? "opacity-100" : "pointer-events-none opacity-0"
           }`}
           style={{ backgroundColor: "var(--color-bg-hud)" }}

--- a/apps/desktop/src/views/overlay/HudDetailView.test.tsx
+++ b/apps/desktop/src/views/overlay/HudDetailView.test.tsx
@@ -40,7 +40,8 @@ function detailState(overrides: Partial<HudDetailState> = {}): HudDetailState {
         label: "5-hour limit",
         percent: 81,
         resetsAt: new Date(Date.now() + 2 * 3_600_000).toISOString(),
-        color: "var(--color-burn)",
+        color: "#D97757",
+        expectedFraction: 0.6,
       },
     ],
     ...overrides,
@@ -62,6 +63,13 @@ describe("HudDetailView", () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it("carries the linear-use notch through to the card", async () => {
+    render(<HudDetailView />)
+    await waitFor(() => expect(push.emit).not.toBeNull())
+    act(() => push.emit!(detailState()))
+    expect(screen.getByTestId("led-bar-notch")).toHaveStyle({ left: "60%" })
   })
 
   it("marks only its own document body as transparent", () => {
@@ -101,7 +109,8 @@ describe("HudDetailView", () => {
               label: "5-hour limit",
               percent: 82,
               resetsAt: null,
-              color: "var(--color-burn)",
+              color: "#D97757",
+              expectedFraction: null,
             },
           ],
         }),

--- a/apps/desktop/src/views/overlay/HudDetailView.tsx
+++ b/apps/desktop/src/views/overlay/HudDetailView.tsx
@@ -205,6 +205,7 @@ export function HudDetailView() {
                   segments={HUD_SEGMENTS}
                   className="mt-1"
                   split={[{ fraction: bar.percent / 100, color: bar.color }]}
+                  expectedFraction={bar.expectedFraction}
                 />
                 <p className="led-caption type-footnote text-label-secondary mt-0.5">
                   {resetsIn(resetDate(bar.resetsAt), state.now)}

--- a/apps/desktop/src/views/overlay/OverlaySession.ts
+++ b/apps/desktop/src/views/overlay/OverlaySession.ts
@@ -234,6 +234,7 @@ export class OverlaySession {
         percent: bar.percent,
         resetsAt: bar.resetsAt ? bar.resetsAt.toISOString() : null,
         color: bar.color,
+        expectedFraction: bar.expectedFraction,
       })),
     }
   }


### PR DESCRIPTION
Follow-on polish to the floating HUD, after [#387](https://github.com/antiburn/antiburn/pull/387).

## The linear-use notch

The HUD bars now carry the same notch the popover meters already draw: a tick at how far through the window's own period the clock has travelled. It keeps 60% used at 30% elapsed from looking like 60% used at 90% elapsed.

It reuses `liveWindowElapsed`, so it inherits the existing honesty rule — a window whose period nothing states gets no notch rather than one drawn from an assumed month. A snapshot with no parseable `generatedAt` gets none either. The notch is measured from the snapshot's own time, not the wall clock.

The notch is drawn as two adjacent 1px lines, one near-black and one near-white. The HUD paints no surface at rest, so its marks sit directly on whatever the reader has behind the window, and no single grey holds on every background. With the pair, whichever line loses contrast the other carries the tick. Both lines keep their value across themes, for the same reason the unlit segments do.

## Claude's colour

Anthropic's bar was antiburn orange, which read as antiburn's own reading rather than Claude's. It now uses Claude's coral, derived from the hex `simple-icons` records — the same rule the brand marks already follow, so no vendor hex is written into the palette.

The bar raises the saturation of that value by a factor and keeps its hue and lightness. A published brand value is made for a filled mark at 18px; a row of 6px dots on an uncontrolled desktop needs more chroma to read as the same colour. The source stays the package, so the rule holds and the bar tracks the package if the value is ever revised. `design.md`'s vendor-mark note is extended to cover both points.

## A surface on hover

At rest the HUD paints nothing and the bars sit directly on the desktop, which is right for a window that must not cover the reader's work. On hover it now takes a 90%-opaque rounded surface, so the bars become one object to point at and drag. The border box was already reserved as transparent, so there is no layout shift.

The close control needed two fixes to survive that surface. It sits on the panel edge, and the hover surface is nearly its own colour, so it lost its edge — it now carries the design system's `raised` shadow to separate the two. It also read as see-through, because `separator` and `label-tertiary` both carry alpha and the surface under them is itself partly transparent. The control now takes its own alpha-free ink and edge, added to the HUD sub-palette.

## Screenshot

<!-- Keith: drag in a shot of the HUD hovered, dark mode, over a light document — shows the notch, the coral bar, and the hover surface in one frame -->

## Testing

Verified by hand on a rebuilt app, and the colour work checked against a swatch over white, dark, warm paper, and slate desktops.

Automated: 1129 tests pass (93 files), plus lint, type-check, prettier, and `check-design-drift.mjs`. Six tests are new — notch placement in both windows, the two no-notch cases, the vendor colour, and the hover surface arriving and leaving. The colour test states the relationship to the published hex (same hue, same lightness, more saturation) rather than a literal of its own, so it cannot drift into a copy of the implementation.

## One thing worth a look in review

The notch has to hold against three different things: a light desktop, a dark desktop, and the lit segments it crosses. The two-line pair covers the first two. Where it is weakest is the third — crossing a lit segment, the tick is reading against the bar colour rather than the background. If that turns out to be too subtle in use, the fix is a hairline gap in the segment beneath the tick rather than a heavier line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
