### PR TITLE
fix(desktop): keep anchored previews open during Checks refreshes

### DIFF
--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -807,9 +807,15 @@ describe("PopoverView", () => {
     expect(await screen.findByText("1 check failed")).toBeInTheDocument()
   })
 
-  it("refreshes Checks after the evidence worker queue settles", async () => {
+  it("keeps an anchored preview open when Checks refreshes in the background", async () => {
     render(<PopoverView />)
     await screen.findByText("1 check failed")
+    const trigger = await screen.findByRole("button", { name: "Codex at 40 percent" })
+    fireEvent.mouseEnter(trigger)
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("show_popover_peek", expect.anything()),
+    )
+
     const callsBefore = invoke.mock.calls.filter(
       ([command]) => command === "get_checks_report",
     ).length
@@ -827,7 +833,7 @@ describe("PopoverView", () => {
     })
     expect(
       invoke.mock.calls.filter(([command]) => command === "hide_popover_peek"),
-    ).toHaveLength(hidesBefore + 1)
+    ).toHaveLength(hidesBefore)
   })
 
   it("publishes the current report while evidence is still processing", async () => {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -52,7 +52,6 @@ import {
   prefersReducedMotion,
   type PopoverSurface,
 } from "../../lib/popoverHeight"
-import { hidePopoverPeek } from "../../lib/popoverPeekIpc"
 import { localSessionKey } from "../../lib/presentation/localIdentity"
 import { costOutlierThreshold } from "../../lib/presentation/sessionAnalysis"
 import {
@@ -1108,9 +1107,7 @@ export class PopoverSession {
         this.update({ checksUnavailable: true })
         return
       }
-      const replacesVisibleReport = this.snapshot.checksReport != null
       this.update({ checksReport, checksUnavailable: false })
-      if (replacesVisibleReport) void hidePopoverPeek().catch(() => undefined)
     } catch {
       if (generation === this.generation && token === this.checksToken) {
         this.update({ checksUnavailable: true })


### PR DESCRIPTION
Fixes a regression introduced by #379.

## User impact

Background Checks refreshes no longer close an anchored preview while the user remains hovering over its trigger.

The open preview retains its current snapshot until the pointer leaves. The next hover uses the refreshed data. Intentional concealment from pointer leave, scrolling, navigation, and anchor-window hiding remains unchanged.

## Validation

- `pnpm --filter @antiburn/desktop exec prettier --check src/views/PopoverView.test.tsx src/views/popover/PopoverSession.ts`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test` — 93 files and 1,123 tests passed
- Built and launched the macOS debug application
- Added regression coverage for a background Checks refresh while a provider preview remains hovered

## Privacy and performance

None.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests; documentation changes are not needed for this behavioral fix.