### PR TITLE
Fix session usage allocation across percentage plateaus

### DIFF
--- a/apps/desktop/src-tauri/src/provider_usage/allocation.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/allocation.rs
@@ -327,6 +327,7 @@ fn distribute_window(
     let mut output = HashMap::new();
     let mut previous_at = start_ms.saturating_sub(1);
     let mut previous_percent = 0.0;
+    let mut has_observation = false;
     for (at, percent) in points {
         let delta = percent - previous_percent;
         if delta > 0.0 {
@@ -340,8 +341,12 @@ fn distribute_window(
                 &mut output,
             );
         }
-        previous_at = at;
-        previous_percent = percent;
+        // Keep the first sample of a plateau. A later increase applies to all turns since that sample.
+        if !has_observation || delta > 0.0 {
+            previous_at = at;
+            previous_percent = percent;
+        }
+        has_observation = true;
     }
     (output, true)
 }

--- a/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
@@ -570,6 +570,87 @@ fn history_deltas_are_allocated_only_to_turns_in_each_interval() {
 }
 
 #[test]
+fn an_unchanged_percentage_keeps_the_start_of_the_plateau() {
+    let turns = weighted_turns(vec![
+        turn("early", NOW - 50, 1_000_000, &[]),
+        turn("late", NOW - 10, 1_000_000, &[]),
+    ]);
+    let refs: Vec<_> = turns.iter().collect();
+    let samples = vec![
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW - 60).unwrap(),
+            used_percent: Some(24.0),
+            freshness: Freshness::Fresh,
+        },
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW - 30).unwrap(),
+            used_percent: Some(24.0),
+            freshness: Freshness::Fresh,
+        },
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW).unwrap(),
+            used_percent: Some(25.0),
+            freshness: Freshness::Fresh,
+        },
+    ];
+
+    let (shares, uses_history) = distribute_window(
+        &refs,
+        25.0,
+        (NOW - 100) * 1_000,
+        NOW * 1_000,
+        &samples,
+        WeightBasis::Price,
+    );
+
+    assert!(uses_history);
+    assert!((shares[&SessionKey::new("native", "claude-code", "early")] - 0.5).abs() < 1e-9);
+    assert!((shares[&SessionKey::new("native", "claude-code", "late")] - 0.5).abs() < 1e-9);
+}
+
+#[test]
+fn an_initial_zero_starts_the_first_plateau() {
+    let turns = weighted_turns(vec![
+        turn("before-zero", NOW - 70, 1_000_000, &[]),
+        turn("after-zero", NOW - 10, 1_000_000, &[]),
+    ]);
+    let refs: Vec<_> = turns.iter().collect();
+    let samples = vec![
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW - 60).unwrap(),
+            used_percent: Some(0.0),
+            freshness: Freshness::Fresh,
+        },
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW - 30).unwrap(),
+            used_percent: Some(0.0),
+            freshness: Freshness::Fresh,
+        },
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW).unwrap(),
+            used_percent: Some(1.0),
+            freshness: Freshness::Fresh,
+        },
+    ];
+
+    let (shares, uses_history) = distribute_window(
+        &refs,
+        1.0,
+        (NOW - 100) * 1_000,
+        NOW * 1_000,
+        &samples,
+        WeightBasis::Price,
+    );
+
+    assert!(uses_history);
+    assert!(!shares.contains_key(&SessionKey::new("native", "claude-code", "before-zero",)));
+    assert_eq!(
+        shares[&SessionKey::new("native", "claude-code", "after-zero")],
+        1.0,
+    );
+}
+
+#[test]
 fn decreasing_history_falls_back_to_the_current_window_share() {
     let turns = weighted_turns(vec![
         turn("one", NOW - 90, 1_000_000, &[]),


### PR DESCRIPTION
## User impact

Session limit badges now attribute a provider percentage increase across the full unchanged-percentage plateau. Sessions no longer lose their estimated share merely because the provider reports usage in whole-number steps.

The estimate still waits for the provider percentage to increase; this change does not add a provisional estimate for the unfinished trailing plateau.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (887 tests)
- `cargo test provider_usage::allocation --lib` (27 tests)
- `pnpm run slop:all`
- `pnpm run secrets`

## Privacy and performance

No change to data access, network access, retained data, or background work. The allocation pass keeps one extra boolean while traversing its existing bounded history.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests. No documentation change is needed for this calculation fix.