### PR TITLE
feat: link Claude resume-as-fork sessions to their parent

### DIFF
--- a/apps/desktop/src-tauri/src/fork_lineage.rs
+++ b/apps/desktop/src-tauri/src/fork_lineage.rs
@@ -1,0 +1,154 @@
+//! Links a Claude Code "resume as fork" session to the session that owns
+//! its first turns.
+//!
+//! Claude's resume-as-fork writes no marker. It copies a parent transcript's
+//! leading records — `uuid` included — into a new file under a new session
+//! id. Nothing in a fork's own file says where it came from.
+//!
+//! This link is made at publish time, not at describe time. Describe skips
+//! re-describing a record whose transcript did not change, and a session's
+//! turn rows exist only once a pass publishes them — so a fork pair that is
+//! finished, or one first indexed alongside its parent at install, could
+//! stop changing before a describe-time lookup ever ran against rows that
+//! exist. Publish is the one moment guaranteed to run this lookup for every
+//! session, however many times its transcript changes afterward.
+//!
+//! The link runs in both directions from whichever side just published:
+//! outward, to claim an earlier session as this one's parent, and inward, to
+//! name this session as parent for a later session that already looks like
+//! its child. Only one side is guaranteed to publish after the other side
+//! is already linkable, so checking one direction only would miss the pair
+//! whose parent finishes after its fork.
+//!
+//! Phase 2 will requeue a session the first time a relation is recorded for
+//! it, so double-counted effort across a linked pair gets corrected. This
+//! phase only records the relation.
+
+use std::cmp::Ordering;
+
+use antiburn_local::model::AgentKind;
+use anyhow::Result;
+
+use crate::store::{OwningSession, SessionKey, Store};
+
+/// Orders two candidates that both own the same first turn uuid, so the
+/// true original session sorts before every fork of it.
+///
+/// The earliest-indexed session sorts first: a fork gets its own session id
+/// only when the user resumes an earlier one, so the original is always
+/// indexed no later than any of its forks. A tie breaks on published turn
+/// row count, fewer rows first: a parent the user has left keeps its row
+/// count fixed, while a fork the user keeps using grows past it. A session
+/// id breaks any remaining tie only to keep the order deterministic — a
+/// wrong pick there only changes which side of an otherwise identical pair
+/// shows as the parent.
+fn rank(a: &OwningSession, b: &OwningSession) -> Ordering {
+    a.first_seen_at
+        .cmp(&b.first_seen_at)
+        .then_with(|| a.published_turn_rows.cmp(&b.published_turn_rows))
+        .then_with(|| a.session_id.cmp(&b.session_id))
+}
+
+/// Link `key`, a session that just published, to the fork parent its
+/// leading turn rows point to, and to any fork of it that already
+/// published first.
+///
+/// Does nothing for a non-Claude key, a session with no published turn
+/// row yet, or a session whose first uuid nobody else owns.
+pub fn link_claude_fork(store: &Store, key: &SessionKey) -> Result<()> {
+    if key.agent != AgentKind::Claude.slug() {
+        return Ok(());
+    }
+    let Some(uuid) = store.first_turn_uuid(key)? else {
+        return Ok(());
+    };
+    let candidates = store.sessions_owning_turn_uuids(key, &[uuid])?;
+    if candidates.is_empty() {
+        return Ok(());
+    }
+    let Some(self_stats) = store.owning_session_stats(key)? else {
+        return Ok(());
+    };
+
+    claim_earlier_parent(store, key, &self_stats, &candidates)?;
+    claim_later_children(store, key, &self_stats, &candidates)?;
+    Ok(())
+}
+
+/// (a) If `key` has no fork parent yet, record the best candidate that
+/// ranks strictly before it as that parent — skipping a candidate that
+/// already names `key` as its own parent, which would otherwise close a
+/// two-session loop.
+fn claim_earlier_parent(
+    store: &Store,
+    key: &SessionKey,
+    self_stats: &OwningSession,
+    candidates: &[OwningSession],
+) -> Result<()> {
+    if store.fork_parent(key)?.is_some() {
+        return Ok(());
+    }
+    let mut earlier: Vec<&OwningSession> = candidates
+        .iter()
+        .filter(|candidate| rank(candidate, self_stats) == Ordering::Less)
+        .collect();
+    earlier.sort_by(|a, b| rank(a, b));
+    for candidate in earlier {
+        let candidate_key = candidate_key(key, candidate);
+        if store.fork_parent(&candidate_key)?.as_deref() == Some(key.session_id.as_str()) {
+            continue;
+        }
+        if store.record_fork_parent(key, &candidate.session_id)? {
+            tracing::info!(
+                event = "fork_lineage_linked",
+                session_id = %key.session_id,
+                parent_session_id = %candidate.session_id,
+            );
+        }
+        return Ok(());
+    }
+    Ok(())
+}
+
+/// (b) For every candidate that ranks strictly after `key` and has no fork
+/// parent yet, record `key` as its parent. This is what makes the link
+/// appear when a parent publishes after its fork: the fork already ran
+/// this lookup and found nothing, so only the parent's own publish can
+/// complete the pair.
+fn claim_later_children(
+    store: &Store,
+    key: &SessionKey,
+    self_stats: &OwningSession,
+    candidates: &[OwningSession],
+) -> Result<()> {
+    for candidate in candidates
+        .iter()
+        .filter(|candidate| rank(candidate, self_stats) == Ordering::Greater)
+    {
+        let candidate_key = candidate_key(key, candidate);
+        if store.fork_parent(&candidate_key)?.is_some() {
+            continue;
+        }
+        if store.record_fork_parent(&candidate_key, &key.session_id)? {
+            tracing::info!(
+                event = "fork_lineage_linked",
+                session_id = %candidate.session_id,
+                parent_session_id = %key.session_id,
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `candidate`'s own key, in `key`'s environment and agent — the scope
+/// [`Store::sessions_owning_turn_uuids`] already searched within.
+fn candidate_key(key: &SessionKey, candidate: &OwningSession) -> SessionKey {
+    SessionKey::new(
+        key.environment_key.clone(),
+        key.agent.clone(),
+        candidate.session_id.clone(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/desktop/src-tauri/src/fork_lineage/tests.rs
+++ b/apps/desktop/src-tauri/src/fork_lineage/tests.rs
@@ -1,0 +1,294 @@
+use std::path::Path;
+
+use antiburn_local::analysis::{TurnRow, TurnRowStore, TurnScope};
+
+use super::*;
+use crate::store::{
+    AnalysisRecord, EvidenceCompletion, FencedTurnRowStore, PublishedEvidence, SessionRecord,
+};
+
+fn store() -> Store {
+    Store::open_in_memory(Path::new("/tmp/antiburn-fork-lineage-test")).unwrap()
+}
+
+fn session_record(session_id: &str, fingerprint: &str) -> SessionRecord {
+    SessionRecord {
+        key: SessionKey::new("native", AgentKind::Claude.slug(), session_id),
+        source_kind: "file".into(),
+        source_label: format!("/tmp/{session_id}.jsonl"),
+        wsl_distro: None,
+        title: None,
+        title_source: None,
+        cwd: None,
+        surface: "cli".into(),
+        updated_at_epoch: Some(1_000),
+        activity_cursor: String::new(),
+        activity_source: "event".into(),
+        subagent_count: 0,
+        fork_parent_session_id: None,
+        source_fingerprint: Some(fingerprint.into()),
+    }
+}
+
+fn turn_row(turn_index: u64, uuid: Option<&str>) -> TurnRow {
+    TurnRow {
+        source_key: "s1".into(),
+        thread_id: "s1".into(),
+        turn_index,
+        scope: TurnScope::Main,
+        child_id: None,
+        role: "assistant",
+        ts_ms: Some(1_000 + turn_index as i64),
+        model: Some("claude-opus-4-6".into()),
+        effort: None,
+        speed: None,
+        input_tokens: 10,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        output_tokens: 5,
+        is_compaction_boundary: false,
+        message_id: None,
+        uuid: uuid.map(str::to_string),
+        parent_uuid: None,
+        compaction_trigger: None,
+        compaction_pre_tokens: None,
+        compaction_post_tokens: None,
+        has_thinking: false,
+        last_tool: None,
+        subagent_launches: 0,
+        content: Vec::new(),
+    }
+}
+
+/// Publish `row_count` turn rows for `session_id`, the first one carrying
+/// `uuid`, under a fresh claim. Safe to call more than once for the same
+/// session: each call replaces its published row set with a new one of
+/// `row_count` rows, which is how [`Store::publish_projections`] treats an
+/// unnamed source with no resume snapshot.
+fn publish_turns(store: &Store, session_id: &str, uuid: &str, row_count: u64) -> SessionKey {
+    let fingerprint = format!("sv{row_count}:{session_id}");
+    store
+        .upsert_sessions(
+            &[session_record(session_id, &fingerprint)],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    let claim = store
+        .claim_next_evidence(&crate::agents::evidence_cohort(), 1_000, 60)
+        .unwrap()
+        .unwrap();
+    let rows: Vec<TurnRow> = (0..row_count)
+        .map(|index| turn_row(index, if index == 0 { Some(uuid) } else { None }))
+        .collect();
+    FencedTurnRowStore::new(store.clone(), claim.key.clone(), claim.claim_fence)
+        .write_turn_rows(&rows)
+        .unwrap();
+    let record = AnalysisRecord {
+        key: claim.key.clone(),
+        model_breakdown_json: "{}".into(),
+        inclusive_models_json: "[]".into(),
+        initial_context_json: None,
+        source_summaries_json: None,
+        provider_hints_json: None,
+        source_fingerprint: fingerprint,
+        pricing_generation: 1,
+        analyzed_generation: claim.source_generation,
+        parser_revision: 1,
+        analyzer_revision: 1,
+        metrics_schema_revision: 1,
+    };
+    let completion = EvidenceCompletion {
+        claim_fence: claim.claim_fence,
+        status: PublishedEvidence::Ready,
+        evidence_schema_revision: 1,
+        evidence_json: "{}".into(),
+    };
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[], &[])
+            .unwrap()
+    );
+    claim.key
+}
+
+fn publish_first_turn(store: &Store, session_id: &str, uuid: &str) -> SessionKey {
+    publish_turns(store, session_id, uuid, 1)
+}
+
+/* --------------------------------------------------------------------
+ * rank
+ * ----------------------------------------------------------------- */
+
+fn owning(session_id: &str, first_seen_at: &str, published_turn_rows: i64) -> OwningSession {
+    OwningSession {
+        session_id: session_id.into(),
+        first_seen_at: first_seen_at.into(),
+        published_turn_rows,
+    }
+}
+
+#[test]
+fn rank_orders_by_first_seen_at_first() {
+    let earlier = owning("a", "2024-01-01T00:00:00Z", 50);
+    let later = owning("b", "2024-01-02T00:00:00Z", 1);
+    assert_eq!(rank(&earlier, &later), Ordering::Less);
+    assert_eq!(rank(&later, &earlier), Ordering::Greater);
+}
+
+#[test]
+fn rank_breaks_a_first_seen_at_tie_on_row_count() {
+    let shorter = owning("a", "2024-01-01T00:00:00Z", 2);
+    let longer = owning("b", "2024-01-01T00:00:00Z", 9);
+    assert_eq!(rank(&shorter, &longer), Ordering::Less);
+    assert_eq!(rank(&longer, &shorter), Ordering::Greater);
+}
+
+#[test]
+fn rank_breaks_a_full_tie_on_session_id() {
+    let a = owning("a", "2024-01-01T00:00:00Z", 2);
+    let b = owning("b", "2024-01-01T00:00:00Z", 2);
+    assert_eq!(rank(&a, &b), Ordering::Less);
+    assert_eq!(rank(&b, &a), Ordering::Greater);
+}
+
+/* --------------------------------------------------------------------
+ * link_claude_fork
+ * ----------------------------------------------------------------- */
+
+#[test]
+fn a_fork_published_after_its_parent_links_to_the_parent() {
+    let store = store();
+    let parent_key = publish_first_turn(&store, "parent", "u1");
+    store
+        .set_first_seen_at_for_test(&parent_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+    let fork_key = publish_first_turn(&store, "fork", "u1");
+    store
+        .set_first_seen_at_for_test(&fork_key, "2024-01-02T00:00:00Z")
+        .unwrap();
+
+    link_claude_fork(&store, &fork_key).unwrap();
+
+    assert_eq!(
+        store.fork_parent(&fork_key).unwrap().as_deref(),
+        Some("parent")
+    );
+    assert_eq!(store.fork_parent(&parent_key).unwrap(), None);
+}
+
+#[test]
+fn a_parent_published_after_its_fork_still_links_with_no_reverse_relation() {
+    let store = store();
+    let fork_key = publish_first_turn(&store, "fork", "u1");
+    store
+        .set_first_seen_at_for_test(&fork_key, "2024-01-02T00:00:00Z")
+        .unwrap();
+    // The fork ran the lookup first and found no candidate yet.
+    link_claude_fork(&store, &fork_key).unwrap();
+    assert_eq!(store.fork_parent(&fork_key).unwrap(), None);
+
+    let parent_key = publish_first_turn(&store, "parent", "u1");
+    store
+        .set_first_seen_at_for_test(&parent_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+
+    link_claude_fork(&store, &parent_key).unwrap();
+
+    assert_eq!(
+        store.fork_parent(&fork_key).unwrap().as_deref(),
+        Some("parent")
+    );
+    assert_eq!(store.fork_parent(&parent_key).unwrap(), None);
+}
+
+#[test]
+fn equal_first_seen_at_breaks_the_tie_on_published_row_count() {
+    let store = store();
+    let short_key = publish_turns(&store, "short", "u1", 1);
+    let long_key = publish_turns(&store, "long", "u1", 3);
+    store
+        .set_first_seen_at_for_test(&short_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+    store
+        .set_first_seen_at_for_test(&long_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+
+    link_claude_fork(&store, &long_key).unwrap();
+
+    assert_eq!(
+        store.fork_parent(&long_key).unwrap().as_deref(),
+        Some("short")
+    );
+    assert_eq!(store.fork_parent(&short_key).unwrap(), None);
+}
+
+#[test]
+fn a_candidate_that_already_calls_this_session_its_parent_is_never_claimed_back() {
+    let store = store();
+    // x and y share a first uuid, and initially rank x before y, so linking
+    // y first names x as y's parent.
+    let x_key = publish_turns(&store, "x", "u1", 2);
+    let y_key = publish_turns(&store, "y", "u1", 2);
+    store
+        .set_first_seen_at_for_test(&x_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+    store
+        .set_first_seen_at_for_test(&y_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+    link_claude_fork(&store, &y_key).unwrap();
+    assert_eq!(store.fork_parent(&y_key).unwrap().as_deref(), Some("x"));
+
+    // x grows well past y's row count. With equal first_seen_at, rank now
+    // favors y — but y already calls x its parent, so x must not claim y
+    // back as its own parent.
+    let x_key = publish_turns(&store, "x", "u1", 9);
+    store
+        .set_first_seen_at_for_test(&x_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+
+    link_claude_fork(&store, &x_key).unwrap();
+
+    assert_eq!(store.fork_parent(&x_key).unwrap(), None);
+    assert_eq!(store.fork_parent(&y_key).unwrap().as_deref(), Some("x"));
+}
+
+#[test]
+fn a_session_whose_first_uuid_nobody_else_owns_gets_no_relation() {
+    let store = store();
+    let key = publish_first_turn(&store, "solo", "u1");
+
+    link_claude_fork(&store, &key).unwrap();
+
+    assert_eq!(store.fork_parent(&key).unwrap(), None);
+}
+
+#[test]
+fn a_second_call_is_idempotent() {
+    let store = store();
+    let parent_key = publish_first_turn(&store, "parent", "u1");
+    store
+        .set_first_seen_at_for_test(&parent_key, "2024-01-01T00:00:00Z")
+        .unwrap();
+    let fork_key = publish_first_turn(&store, "fork", "u1");
+    store
+        .set_first_seen_at_for_test(&fork_key, "2024-01-02T00:00:00Z")
+        .unwrap();
+
+    link_claude_fork(&store, &fork_key).unwrap();
+    link_claude_fork(&store, &fork_key).unwrap();
+
+    assert_eq!(
+        store.fork_parent(&fork_key).unwrap().as_deref(),
+        Some("parent")
+    );
+}
+
+#[test]
+fn a_non_claude_key_is_ignored() {
+    let store = store();
+    let key = SessionKey::new("native", "codex", "solo");
+    // No session row exists at all for this key — a real call would still
+    // return early on the agent guard before it ever queries the store.
+    link_claude_fork(&store, &key).unwrap();
+    assert_eq!(store.fork_parent(&key).unwrap(), None);
+}

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -14,6 +14,7 @@ use tokio::sync::{Notify, Semaphore};
 use crate::analysis::{self, EvidencePass, PassOutcome, PassSignal, UnreadableReason};
 use crate::commands;
 use crate::dto::ActivityEntry;
+use crate::fork_lineage;
 use crate::store::{
     EvidenceClaim, EvidenceCompletion, EvidenceFailure, FencedTurnRowStore, PublishedEvidence,
     RelationKind, RelationRecord, SessionKey, SessionRecord, Store,
@@ -392,6 +393,9 @@ pub(crate) async fn process_next(
     pass.analysis.analyzed_generation = claim.source_generation;
     let applied = apply_outcome(store, &claim, &pass, clock())?;
     let published = applied && pass.outcome == PassOutcome::Published;
+    if published {
+        fork_lineage::link_claude_fork(store, &claim.key)?;
+    }
     if published && let Some(entry) = completion_entry(store, &claim.key, clock()) {
         announce(entry);
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ mod consent;
 mod diagnostics_export;
 mod disk_monitor;
 mod dto;
+mod fork_lineage;
 mod global_click;
 mod hud;
 mod insights_ipc;

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -1384,6 +1384,10 @@ async fn describe_one_with_activity(
 /// bounded preview read for every other provider database. This runs only
 /// when describe runs, which the size cursor already gates, so it costs
 /// nothing for a session that has not changed.
+///
+/// Claude's own "resume as fork" writes no such marker. The insights worker
+/// links those fork sessions from published turn rows instead, once rows
+/// exist — see `fork_lineage`.
 async fn fork_parent_session_id_for(log: &SessionLog, preview: Option<&str>) -> Option<String> {
     match &log.source {
         SessionSource::ProviderDb {

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -54,9 +54,9 @@ pub use model::{
     AnalysisRecord, AppSettings, DisabledAgents, DiskSpaceDisplay, EvidenceClaim,
     EvidenceCompletion, EvidenceFailure, EvidenceRow, EvidenceStatus, HiddenMeters,
     MAX_ACTIVITY_DAYS, MILESTONE_OPTIONS, MIN_ACTIVITY_DAYS, Milestones, NudgePlacement,
-    ProjectionRevisions, PublishedEvidence, RETAIN_SESSION_DATA_FOREVER, RelationKind,
-    RelationRecord, RepositoryRecord, SessionActivityKey, SessionBadgeMetric, SessionKey,
-    SessionRecord, SessionUsageRecord, SessionUsageTurnRecord, SourcePublishMode,
+    OwningSession, ProjectionRevisions, PublishedEvidence, RETAIN_SESSION_DATA_FOREVER,
+    RelationKind, RelationRecord, RepositoryRecord, SessionActivityKey, SessionBadgeMetric,
+    SessionKey, SessionRecord, SessionUsageRecord, SessionUsageTurnRecord, SourcePublishMode,
     SourcePublishOutcome, SourceVersionState, ThemePreference, UsageEvidenceRecord,
 };
 
@@ -187,6 +187,54 @@ const SESSIONS_ACTIVE_SINCE_SQL: &str = "SELECT environment_key, agent, session_
        FROM session
       WHERE COALESCE(updated_at_epoch, 0) >= ?1
       ORDER BY COALESCE(updated_at_epoch, 0) ASC";
+
+/// Ceiling on how many uuids [`Store::sessions_owning_turn_uuids`] matches
+/// in one call, applied to the `IN (...)` list it builds.
+const FORK_LINEAGE_UUID_CAP: usize = 8;
+
+/// [`Store::sessions_owning_turn_uuids`]'s query, built for `uuid_count`
+/// bound uuids since the `IN (...)` list varies in length. Pulled out for
+/// the same reason as [`RECENT_SESSIONS_SQL`]: a schema test can pin it to
+/// the `turn_uuid` index.
+///
+/// `INDEXED BY turn_uuid` is deliberate, not just a test convenience: a
+/// uuid is far more selective than `environment_key`/`agent`, but SQLite's
+/// planner cannot know that without `ANALYZE` statistics, and could
+/// otherwise pick `turn_session_thread` instead. Forcing `turn_uuid` keeps
+/// this lookup cheap regardless of how a reader's own database is shaped.
+fn sessions_owning_turn_uuids_sql(uuid_count: usize) -> String {
+    let placeholders = vec!["?"; uuid_count].join(", ");
+    format!(
+        "WITH matched AS (
+             SELECT DISTINCT t.session_id
+               FROM turn t INDEXED BY turn_uuid
+               JOIN session_evidence e
+                 ON e.environment_key = t.environment_key
+                AND e.agent = t.agent
+                AND e.session_id = t.session_id
+                AND e.published_fence = t.claim_fence
+              WHERE t.environment_key = ?
+                AND t.agent = ?
+                AND t.session_id <> ?
+                AND t.uuid IN ({placeholders})
+         )
+         SELECT s.session_id, s.first_seen_at,
+                (SELECT COUNT(*)
+                   FROM turn pt
+                   JOIN session_evidence pe
+                     ON pe.environment_key = pt.environment_key
+                    AND pe.agent = pt.agent
+                    AND pe.session_id = pt.session_id
+                    AND pe.published_fence = pt.claim_fence
+                  WHERE pt.environment_key = s.environment_key
+                    AND pt.agent = s.agent
+                    AND pt.session_id = s.session_id) AS published_turn_rows
+           FROM session s
+           JOIN matched m ON m.session_id = s.session_id
+          WHERE s.environment_key = ?
+            AND s.agent = ?"
+    )
+}
 
 impl Store {
     /// Open (creating if absent) and migrate the database under `data_dir`.
@@ -2152,6 +2200,47 @@ impl Store {
             params![key.environment_key, key.agent, key.session_id],
             |row| row.get::<_, String>(0),
         )?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    /// Sessions that already hold a published turn row for one of `uuids`,
+    /// within `key`'s own environment and agent, excluding `key` itself.
+    ///
+    /// Serves the Claude fork-lineage lookup: a "resume as fork" session
+    /// copies its parent's leading turn records byte for byte, keeping
+    /// their `uuid`. A session this finds owning one of them is a
+    /// fork-parent candidate.
+    ///
+    /// `uuids` is capped at [`FORK_LINEAGE_UUID_CAP`] entries — the
+    /// caller's own extraction stays far under this, and the cap only
+    /// guards the `IN (...)` list against an oversized call.
+    pub fn sessions_owning_turn_uuids(
+        &self,
+        key: &SessionKey,
+        uuids: &[String],
+    ) -> Result<Vec<OwningSession>> {
+        let uuids = &uuids[..uuids.len().min(FORK_LINEAGE_UUID_CAP)];
+        if uuids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let connection = self.lock();
+        let sql = sessions_owning_turn_uuids_sql(uuids.len());
+        let mut statement = connection.prepare(&sql)?;
+        let mut values: Vec<rusqlite::types::Value> = vec![
+            rusqlite::types::Value::Text(key.environment_key.clone()),
+            rusqlite::types::Value::Text(key.agent.clone()),
+            rusqlite::types::Value::Text(key.session_id.clone()),
+        ];
+        values.extend(uuids.iter().cloned().map(rusqlite::types::Value::Text));
+        values.push(rusqlite::types::Value::Text(key.environment_key.clone()));
+        values.push(rusqlite::types::Value::Text(key.agent.clone()));
+        let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+            Ok(OwningSession {
+                session_id: row.get(0)?,
+                first_seen_at: row.get(1)?,
+                published_turn_rows: row.get(2)?,
+            })
+        })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -192,6 +192,21 @@ const SESSIONS_ACTIVE_SINCE_SQL: &str = "SELECT environment_key, agent, session_
 /// in one call, applied to the `IN (...)` list it builds.
 const FORK_LINEAGE_UUID_CAP: usize = 8;
 
+/// A scalar subquery counting one session's published turn rows, correlated
+/// to an outer `session s` row. Shared by [`sessions_owning_turn_uuids_sql`]
+/// and [`Store::owning_session_stats`]'s query so the two definitions of
+/// "published turn rows" cannot drift apart.
+const PUBLISHED_TURN_ROW_COUNT_SQL: &str = "(SELECT COUNT(*)
+                   FROM turn pt
+                   JOIN session_evidence pe
+                     ON pe.environment_key = pt.environment_key
+                    AND pe.agent = pt.agent
+                    AND pe.session_id = pt.session_id
+                    AND pe.published_fence = pt.claim_fence
+                  WHERE pt.environment_key = s.environment_key
+                    AND pt.agent = s.agent
+                    AND pt.session_id = s.session_id)";
+
 /// [`Store::sessions_owning_turn_uuids`]'s query, built for `uuid_count`
 /// bound uuids since the `IN (...)` list varies in length. Pulled out for
 /// the same reason as [`RECENT_SESSIONS_SQL`]: a schema test can pin it to
@@ -219,16 +234,7 @@ fn sessions_owning_turn_uuids_sql(uuid_count: usize) -> String {
                 AND t.uuid IN ({placeholders})
          )
          SELECT s.session_id, s.first_seen_at,
-                (SELECT COUNT(*)
-                   FROM turn pt
-                   JOIN session_evidence pe
-                     ON pe.environment_key = pt.environment_key
-                    AND pe.agent = pt.agent
-                    AND pe.session_id = pt.session_id
-                    AND pe.published_fence = pt.claim_fence
-                  WHERE pt.environment_key = s.environment_key
-                    AND pt.agent = s.agent
-                    AND pt.session_id = s.session_id) AS published_turn_rows
+                {PUBLISHED_TURN_ROW_COUNT_SQL} AS published_turn_rows
            FROM session s
            JOIN matched m ON m.session_id = s.session_id
           WHERE s.environment_key = ?
@@ -2244,6 +2250,93 @@ impl Store {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
+    /// The uuid of `key`'s own earliest published turn row, scope `main`.
+    ///
+    /// This is the uuid a Claude "resume as fork" session's own leading
+    /// record carries, since a fork copies its parent's early records
+    /// byte for byte. `None` when the session has no published turn row
+    /// with a uuid yet — a describe pass has not published one, or the
+    /// source assigns no uuids at all.
+    pub fn first_turn_uuid(&self, key: &SessionKey) -> Result<Option<String>> {
+        let connection = self.lock();
+        Ok(connection
+            .query_row(
+                "SELECT t.uuid
+                   FROM turn t
+                   JOIN session_evidence e
+                     ON e.environment_key = t.environment_key
+                    AND e.agent = t.agent
+                    AND e.session_id = t.session_id
+                    AND e.published_fence = t.claim_fence
+                  WHERE t.environment_key = ?1
+                    AND t.agent = ?2
+                    AND t.session_id = ?3
+                    AND t.scope = 'main'
+                    AND t.uuid IS NOT NULL
+                  ORDER BY t.turn_index ASC
+                  LIMIT 1",
+                params![key.environment_key, key.agent, key.session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?)
+    }
+
+    /// `key`'s own `first_seen_at` and published turn row count, in the
+    /// same shape [`Self::sessions_owning_turn_uuids`] returns for a
+    /// candidate — so a caller can rank itself against those candidates
+    /// with the same comparison. `None` when `key` has no session row.
+    pub fn owning_session_stats(&self, key: &SessionKey) -> Result<Option<OwningSession>> {
+        let connection = self.lock();
+        Ok(connection
+            .query_row(
+                &format!(
+                    "SELECT s.session_id, s.first_seen_at,
+                            {PUBLISHED_TURN_ROW_COUNT_SQL} AS published_turn_rows
+                       FROM session s
+                      WHERE s.environment_key = ?1 AND s.agent = ?2 AND s.session_id = ?3"
+                ),
+                params![key.environment_key, key.agent, key.session_id],
+                |row| {
+                    Ok(OwningSession {
+                        session_id: row.get(0)?,
+                        first_seen_at: row.get(1)?,
+                        published_turn_rows: row.get(2)?,
+                    })
+                },
+            )
+            .optional()?)
+    }
+
+    /// Record `parent` as `key`'s fork parent. Returns whether this call
+    /// inserted the row.
+    ///
+    /// This does not check whether `key` already has a different parent —
+    /// see [`insert_fork_parent_in`]. A caller that must keep one parent
+    /// per session checks first with [`Self::fork_parent`].
+    pub fn record_fork_parent(&self, key: &SessionKey, parent: &str) -> Result<bool> {
+        let connection = self.lock();
+        insert_fork_parent_in(&connection, key, parent)
+    }
+
+    /// Test scaffolding only. Production code sets `first_seen_at` once, on
+    /// a session's first insert, and never updates it again. A fork-lineage
+    /// ranking test uses this to force two sessions to tie, or to order,
+    /// on `first_seen_at` without depending on wall-clock timing.
+    #[cfg(test)]
+    pub fn set_first_seen_at_for_test(&self, key: &SessionKey, first_seen_at: &str) -> Result<()> {
+        self.lock().execute(
+            "UPDATE session SET first_seen_at = ?1
+              WHERE environment_key = ?2 AND agent = ?3 AND session_id = ?4",
+            params![
+                first_seen_at,
+                key.environment_key,
+                key.agent,
+                key.session_id
+            ],
+        )?;
+        Ok(())
+    }
+
     /* --------------------------------------------------------------------
      * Scan state
      * ----------------------------------------------------------------- */
@@ -2635,6 +2728,26 @@ pub fn iso_from_epoch(epoch: Option<i64>) -> String {
         .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string())
 }
 
+/// Insert a `forkParent` relation naming `parent` as `key`'s fork parent.
+///
+/// The table's primary key covers `related_id`, so this only guards a
+/// repeat call naming the same `parent` — it does not stop a second call
+/// from giving `key` a second, different parent. A caller that must keep
+/// one parent per session checks for an existing one first.
+///
+/// Returns whether this call inserted the row, using `changes()` rather
+/// than the `execute` row count so a caller can log only a real insert.
+fn insert_fork_parent_in(connection: &Connection, key: &SessionKey, parent: &str) -> Result<bool> {
+    connection.execute(
+        "INSERT INTO session_relation
+             (environment_key, agent, session_id, kind, related_id, label)
+         VALUES (?1, ?2, ?3, 'forkParent', ?4, NULL)
+         ON CONFLICT DO NOTHING",
+        params![key.environment_key, key.agent, key.session_id, parent],
+    )?;
+    Ok(connection.changes() > 0)
+}
+
 fn upsert_session_in(
     connection: &Connection,
     record: &SessionRecord,
@@ -2733,18 +2846,7 @@ fn upsert_session_in(
     // Absence is not evidence. Some adapters resolve lineage only when a
     // session opens. A later scan must not erase that relation.
     if let Some(parent) = &record.fork_parent_session_id {
-        connection.execute(
-            "INSERT INTO session_relation
-                 (environment_key, agent, session_id, kind, related_id, label)
-             VALUES (?1, ?2, ?3, 'forkParent', ?4, NULL)
-             ON CONFLICT DO NOTHING",
-            params![
-                record.key.environment_key,
-                record.key.agent,
-                record.key.session_id,
-                parent
-            ],
-        )?;
+        insert_fork_parent_in(connection, &record.key, parent)?;
     }
     let source_generation = connection.query_row(
         "SELECT source_generation FROM session

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -352,6 +352,19 @@ pub struct SessionUsageTurnRecord {
     pub output_tokens: u64,
 }
 
+/// A session [`super::Store::sessions_owning_turn_uuids`] found already
+/// holding a published turn row for one of the queried uuids.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwningSession {
+    pub session_id: String,
+    /// When antiburn first indexed this session, RFC3339. Plain text
+    /// comparison sorts an earlier value first.
+    pub first_seen_at: String,
+    /// How many turn rows this session has published under its current
+    /// fence — a proxy for how long the session ran.
+    pub published_turn_rows: i64,
+}
+
 /// One local relationship between two sessions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RelationRecord {

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -12,7 +12,7 @@
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
     V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,
-    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32,
+    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -597,3 +597,12 @@ CREATE INDEX session_insights_window
 
 /// v32 indexes only assistant rows used by the Insights token-burn reduction.
 const V32: &str = antiburn_local::analysis::TURN_SCHEMA_V5_SQL;
+
+/// v33 indexes turn rows by their vendor `uuid`, serving
+/// [`super::Store::sessions_owning_turn_uuids`]'s Claude fork-lineage
+/// lookup.
+///
+/// `antiburn_local::analysis::TURN_SCHEMA_V6_SQL` owns the index, for the
+/// same reason [`V15`] re-exports `TURN_SCHEMA_SQL` instead of stating its
+/// own DDL.
+const V33: &str = antiburn_local::analysis::TURN_SCHEMA_V6_SQL;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -338,7 +338,7 @@ fn provider_hints_migration_keeps_old_analysis_unknown() {
         .unwrap()
         .expect("legacy analysis survives");
 
-    assert_eq!(store.schema_version().unwrap(), 32);
+    assert_eq!(store.schema_version().unwrap(), 33);
     assert_eq!(analysis.provider_hints_json, None);
 }
 

--- a/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
@@ -11,10 +11,10 @@ use super::*;
 #[test]
 fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pin the count so each new migration requires an explicit test update.
-    assert_eq!(super::schema::MIGRATIONS.len(), 32);
+    assert_eq!(super::schema::MIGRATIONS.len(), 33);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 32);
+    assert_eq!(store.schema_version().unwrap(), 33);
     let index_exists = store
         .lock()
         .query_row(
@@ -110,6 +110,97 @@ fn v32_indexes_existing_assistant_turns() {
     assert_eq!(assistant_rows, 1);
     assert_eq!(all_rows, 2);
     assert!(query_plan.contains("USING INDEX turn_assistant_session"));
+}
+
+/// Publish `uuid` under a fresh claim for `session_id`, so
+/// [`Store::sessions_owning_turn_uuids`] can find it as an owner.
+fn publish_turn_row_with_uuid(store: &Store, session_id: &str, uuid: &str) -> SessionKey {
+    let (record, claim) = claimed_projection(store, session_id, 1_000, 60);
+    let mut row = turn_row(0);
+    row.uuid = Some(uuid.to_string());
+    FencedTurnRowStore::new(store.clone(), record.key.clone(), claim.claim_fence)
+        .write_turn_rows(&[row])
+        .unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[], &[])
+            .unwrap()
+    );
+    record.key
+}
+
+#[test]
+fn sessions_owning_turn_uuids_finds_the_owner_and_excludes_self() {
+    let store = store();
+    let uuid = "11111111-1111-4111-8111-000000000001";
+    publish_turn_row_with_uuid(&store, "uuid-owner-parent", uuid);
+    // The querying session also owns a copy of the same uuid: it must not
+    // come back as its own candidate.
+    let querying_key = publish_turn_row_with_uuid(&store, "uuid-owner-fork", uuid);
+
+    let owners = store
+        .sessions_owning_turn_uuids(&querying_key, &[uuid.to_string()])
+        .unwrap();
+
+    assert_eq!(owners.len(), 1);
+    assert_eq!(owners[0].session_id, "uuid-owner-parent");
+    assert_eq!(owners[0].published_turn_rows, 1);
+}
+
+#[test]
+fn an_unpublished_turn_row_does_not_match_a_uuid_lookup() {
+    let store = store();
+    let uuid = "22222222-2222-4222-8222-000000000001";
+    let (record, claim) = claimed_projection(&store, "uuid-unpublished", 1_000, 60);
+    let mut row = turn_row(0);
+    row.uuid = Some(uuid.to_string());
+    FencedTurnRowStore::new(store.clone(), record.key.clone(), claim.claim_fence)
+        .write_turn_rows(&[row])
+        .unwrap();
+    // No `publish_projections` call: the row sits under `claim_fence`,
+    // never stamped onto `session_evidence.published_fence`.
+
+    let owners = store
+        .sessions_owning_turn_uuids(
+            &SessionKey::new("native", "claude-code", "uuid-lookup-key"),
+            &[uuid.to_string()],
+        )
+        .unwrap();
+
+    assert!(owners.is_empty());
+}
+
+#[test]
+fn sessions_owning_turn_uuids_query_plan_uses_the_turn_uuid_index() {
+    let store = store();
+    let sql = format!(
+        "EXPLAIN QUERY PLAN {}",
+        super::sessions_owning_turn_uuids_sql(1)
+    );
+    let connection = store.lock();
+    let mut statement = connection.prepare(&sql).unwrap();
+    // env, agent, excluded session_id, one uuid, env, agent — six `?`s for a
+    // one-uuid query. The bound values do not matter to a query plan.
+    let plan: Vec<String> = statement
+        .query_map(
+            params![
+                "native",
+                "claude-code",
+                "self",
+                "u1",
+                "native",
+                "claude-code"
+            ],
+            |row| row.get::<_, String>(3),
+        )
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert!(
+        plan.iter().any(|line| line.contains("turn_uuid")),
+        "expected the plan to use turn_uuid, got: {plan:?}"
+    );
 }
 
 #[test]

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -95,9 +95,9 @@ pub use resume::{AdapterResume, AdapterSnapshot, EvidenceSnapshot, StreamSnapsho
 pub use rows::{
     MemoryTurnRowStore, ResumeRevisions, SESSION_COVERAGE_SCHEMA_SQL, SOURCE_RESUME_SCHEMA_SQL,
     StoredResume, TURN_MIGRATIONS, TURN_ROW_BATCH_SIZE, TURN_SCHEMA_SQL, TURN_SCHEMA_V2_SQL,
-    TURN_SCHEMA_V3_SQL, TURN_SCHEMA_V4_SQL, TURN_SCHEMA_V5_SQL, TurnRow, TurnRowError, TurnRowSink,
-    TurnRowStore, TurnScope, TurnSessionKey, count_turn_content_rows, count_turn_rows,
-    delete_source_resume, delete_source_rows_at_fence, delete_stale_source_resume,
+    TURN_SCHEMA_V3_SQL, TURN_SCHEMA_V4_SQL, TURN_SCHEMA_V5_SQL, TURN_SCHEMA_V6_SQL, TurnRow,
+    TurnRowError, TurnRowSink, TurnRowStore, TurnScope, TurnSessionKey, count_turn_content_rows,
+    count_turn_rows, delete_source_resume, delete_source_rows_at_fence, delete_stale_source_resume,
     delete_turn_rows, delete_turn_rows_except_fence, delete_turn_rows_for_fence,
     insert_coverage_record, insert_source_resume, insert_turn_rows, query_coverage_record,
     query_source_resume, restamp_source_rows, turn_row_from_event,

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -118,6 +118,19 @@ CREATE INDEX turn_assistant_session
  WHERE role = 'assistant';
 "#;
 
+/// DDL that indexes turn rows by their vendor `uuid`.
+///
+/// Serves the fork-lineage lookup: a resumed-as-fork session copies its
+/// parent's leading records byte for byte, with the same `uuid` values. The
+/// app's session store matches a fork's leading turn uuids against this
+/// index to find the session that already published them.
+///
+/// The partial predicate excludes rows with no `uuid` from index storage and
+/// write work.
+pub const TURN_SCHEMA_V6_SQL: &str = r#"
+CREATE INDEX turn_uuid ON turn (uuid) WHERE uuid IS NOT NULL;
+"#;
+
 /// DDL for the `session_coverage` table: one row per `(environment_key,
 /// agent, session_id, claim_fence)`, holding the serialized
 /// [`SessionCoverageRecord`] a pass wrote alongside its turn rows under the
@@ -187,8 +200,9 @@ CREATE TABLE source_resume (
 /// every entry in order; the app applies [`TURN_SCHEMA_SQL`],
 /// [`TURN_SCHEMA_V2_SQL`], [`TURN_SCHEMA_V3_SQL`],
 /// [`SESSION_COVERAGE_SCHEMA_SQL`], [`TURN_SCHEMA_V4_SQL`],
-/// [`SOURCE_RESUME_SCHEMA_SQL`], and [`TURN_SCHEMA_V5_SQL`] as its own migrations
-/// instead, since [`TURN_SCHEMA_SQL`] is already applied on user machines.
+/// [`SOURCE_RESUME_SCHEMA_SQL`], [`TURN_SCHEMA_V5_SQL`], and
+/// [`TURN_SCHEMA_V6_SQL`] as its own migrations instead, since
+/// [`TURN_SCHEMA_SQL`] is already applied on user machines.
 pub const TURN_MIGRATIONS: &[&str] = &[
     TURN_SCHEMA_SQL,
     TURN_SCHEMA_V2_SQL,
@@ -197,6 +211,7 @@ pub const TURN_MIGRATIONS: &[&str] = &[
     TURN_SCHEMA_V4_SQL,
     SOURCE_RESUME_SCHEMA_SQL,
     TURN_SCHEMA_V5_SQL,
+    TURN_SCHEMA_V6_SQL,
 ];
 
 /// Number of rows a [`TurnRowSink`] buffers before it writes them, unless the


### PR DESCRIPTION
## Problem

Claude Code's "resume as fork" copies a parent transcript's records — `uuid`, `parentUuid`, `timestamp`, `message.usage` included — into a new file under a new session id, with no marker that says it's a fork. antiburn indexes it as an unrelated session. Locally this shows up in 1 pair out of 83 transcripts; the fork also copies the parent's subagent transcripts, so the pair's subagent rows collide too.

## What this PR does

**Commit 1** — a partial index (`turn_uuid`, migration V33) on `turn.uuid`, and `Store::sessions_owning_turn_uuids`, a query that finds which sessions already hold a published turn row for a given uuid.

**Commit 2** — a publish-time link in the insights worker (`fork_lineage::link_claude_fork`), run right after a session's turn rows publish, in both directions:
- outward: claims an earlier session as this one's parent, if this one has none yet
- inward: names this session as parent for a later session that has none yet

Candidates are ranked by `first_seen_at` (earliest is likely the original), then published turn row count (fewer rows means a parent the user left; more means a fork still growing), then session id (deterministic tie-break only). A cycle guard skips a candidate that already names this session as its own parent, guarding against rank drift as row counts change between calls.

Publish time, not describe time, because describe reuses an unchanged record and turn rows exist only once a pass publishes them — a finished fork, or one first indexed alongside its parent at install, would never again pass through a describe-time lookup.

## What it does not do

No total, cohort, or insight changes. No revision bump. The fork's inherited rows still count as its own work — a stacked follow-up PR will exclude them by emitting `InheritedRecord` and requeuing the fork once a relation is first recorded.

## Testing

- `cargo fmt --all -- --check` — clean in `crates/antiburn-local` and `apps/desktop/src-tauri`
- `cargo clippy --all-targets -- -D warnings` — clean in both crates
- `cargo test --no-fail-fast` in `crates/antiburn-local` — 17 result blocks, all `ok`, 1447 tests passed, 0 failed, 2 ignored
- `cargo test --no-fail-fast` in `apps/desktop/src-tauri` — 907 passed, 0 failed (lib), 0/0 (main, doc-tests)
- `pnpm run slop` — score 100, 0 issues
- `pnpm run secrets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYy8knDMctPvE6qud67Vri