### PR TITLE
Instrument Claude limit reset availability

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -13,7 +13,7 @@ credentials. It also makes two calls to a service of ours, neither of which it
 depends on: the updater plugin, registered in release builds only, asking
 whether a newer version exists; and the anonymised analytics
 channel in [`src-tauri/src/analytics`](src-tauri/src/analytics),
-which reports on the application itself in official release builds. The Ready
+which reports the documented product events in official release builds. The Ready
 screen explains it, and Settings → Privacy provides the opt-out. The analytics
 client is excluded from default source and development builds.
 

--- a/apps/desktop/src-tauri/src/analytics/event.rs
+++ b/apps/desktop/src-tauri/src/analytics/event.rs
@@ -48,6 +48,9 @@ pub enum EventName {
     ErrorOccurred,
     /// An Insights cohort contains unknown record vocabulary.
     UnrecognizedRecordsObserved,
+    /// Claude's limit-reset diagnostic changed during this run.
+    #[cfg(feature = "analytics")]
+    ClaudeLimitResetObserved,
 }
 
 /// Every event this application may send.
@@ -69,6 +72,7 @@ pub const EVERY_EVENT: &[EventName] = &[
     EventName::UsageViewed,
     EventName::ErrorOccurred,
     EventName::UnrecognizedRecordsObserved,
+    EventName::ClaudeLimitResetObserved,
 ];
 
 #[cfg(feature = "analytics")]
@@ -84,6 +88,7 @@ impl EventName {
             EventName::UsageViewed => "antiburn.usage_viewed",
             EventName::ErrorOccurred => "antiburn.error_occurred",
             EventName::UnrecognizedRecordsObserved => "antiburn.unrecognized_records_observed",
+            EventName::ClaudeLimitResetObserved => "antiburn.claude_limit_reset_observed",
         }
     }
 }
@@ -153,6 +158,33 @@ pub struct Properties {
     /// under WSL. Same rules as [`Properties::label`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<&'static str>,
+    /// The short-window usage position returned with a Claude reset probe.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_band: Option<&'static str>,
+    /// Whether the reset member was absent, null, malformed, or an object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_shape: Option<&'static str>,
+    /// Claude's reset eligibility boolean, including absent field states.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eligibility: Option<&'static str>,
+    /// Claude's ineligibility reason from an allowlisted vocabulary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ineligible_reason: Option<&'static str>,
+    /// Claude's experiment-membership boolean, including absent field states.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experiment: Option<&'static str>,
+    /// Claude's experiment arm from an allowlisted vocabulary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reset_arm: Option<&'static str>,
+    /// Claude's reset availability boolean, including absent field states.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reset_availability: Option<&'static str>,
+    /// Claude's weekly reset count reduced to a fixed bucket.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resets_per_week: Option<&'static str>,
+    /// Whether Claude returned a next-availability timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_reset_available: Option<&'static str>,
 }
 
 /// What a caller may attach to an event.
@@ -169,6 +201,34 @@ pub struct Facts {
     pub label: Option<&'static str>,
     /// The secondary dimension, where the event has one.
     pub detail: Option<&'static str>,
+    pub usage_band: Option<&'static str>,
+    pub response_shape: Option<&'static str>,
+    pub eligibility: Option<&'static str>,
+    pub ineligible_reason: Option<&'static str>,
+    pub experiment: Option<&'static str>,
+    pub reset_arm: Option<&'static str>,
+    pub reset_availability: Option<&'static str>,
+    pub resets_per_week: Option<&'static str>,
+    pub next_reset_available: Option<&'static str>,
+}
+
+#[cfg(feature = "analytics")]
+pub fn claude_limit_reset_facts(
+    diagnostic: crate::provider_usage::live::anthropic::LimitResetDiagnostic,
+) -> Facts {
+    Facts {
+        label: Some(diagnostic.request_outcome),
+        usage_band: Some(diagnostic.usage_band),
+        response_shape: Some(diagnostic.response_shape),
+        eligibility: diagnostic.eligibility,
+        ineligible_reason: diagnostic.ineligible_reason,
+        experiment: diagnostic.experiment,
+        reset_arm: diagnostic.arm,
+        reset_availability: diagnostic.availability,
+        resets_per_week: diagnostic.resets_per_week,
+        next_reset_available: diagnostic.next_available,
+        ..Facts::default()
+    }
 }
 
 /// The install context the contract stamps on every track event.
@@ -363,6 +423,15 @@ mod tests {
                 bucket: Some("10-49"),
                 label: Some("claude-code"),
                 detail: Some("native"),
+                usage_band: Some("80_to_under_100"),
+                response_shape: Some("object"),
+                eligibility: Some("eligible"),
+                ineligible_reason: Some("null"),
+                experiment: Some("in_experiment"),
+                reset_arm: Some("reset"),
+                reset_availability: Some("available"),
+                resets_per_week: Some("1"),
+                next_reset_available: Some("present"),
             },
             context: Context {
                 app_version: "antiburn:1.2.3".into(),
@@ -392,7 +461,7 @@ mod tests {
     /// `apps/desktop/src/views/settings/PrivacyPane.tsx` is the bug this
     /// comment exists to prevent.
     #[test]
-    fn the_wire_payload_is_exactly_these_thirteen_fields() {
+    fn the_wire_payload_is_exactly_these_twenty_two_fields() {
         let json = serde_json::to_value(sample()).expect("serializes");
         let object = json.as_object().expect("an object");
         let mut keys: Vec<_> = object.keys().map(String::as_str).collect();
@@ -418,7 +487,24 @@ mod tests {
             .map(String::as_str)
             .collect();
         property_keys.sort_unstable();
-        assert_eq!(property_keys, ["arch", "bucket", "detail", "label"]);
+        assert_eq!(
+            property_keys,
+            [
+                "arch",
+                "bucket",
+                "detail",
+                "eligibility",
+                "experiment",
+                "ineligibleReason",
+                "label",
+                "nextResetAvailable",
+                "resetArm",
+                "resetAvailability",
+                "resetsPerWeek",
+                "responseShape",
+                "usageBand",
+            ]
+        );
 
         let mut context_keys: Vec<_> = object["context"]
             .as_object()
@@ -457,6 +543,15 @@ mod tests {
         event.properties.bucket = None;
         event.properties.label = None;
         event.properties.detail = None;
+        event.properties.usage_band = None;
+        event.properties.response_shape = None;
+        event.properties.eligibility = None;
+        event.properties.ineligible_reason = None;
+        event.properties.experiment = None;
+        event.properties.reset_arm = None;
+        event.properties.reset_availability = None;
+        event.properties.resets_per_week = None;
+        event.properties.next_reset_available = None;
         let json = serde_json::to_string(&event).expect("serializes");
         assert!(!json.contains("bucket"), "{json}");
         assert!(!json.contains("label"), "{json}");
@@ -480,12 +575,13 @@ mod tests {
                 | EventName::SessionOpened
                 | EventName::UsageViewed
                 | EventName::ErrorOccurred
-                | EventName::UnrecognizedRecordsObserved => true,
+                | EventName::UnrecognizedRecordsObserved
+                | EventName::ClaudeLimitResetObserved => true,
             }
         }
         assert_eq!(
             EVERY_EVENT.len(),
-            9,
+            10,
             "a variant was added to the match above but not to EVERY_EVENT"
         );
         assert!(EVERY_EVENT.iter().copied().all(listed));
@@ -540,6 +636,7 @@ mod tests {
             12 => "twelve",
             13 => "thirteen",
             14 => "fourteen",
+            22 => "twenty-two",
             other => panic!("no word for {other} fields; add one and update the documents"),
         };
 

--- a/apps/desktop/src-tauri/src/analytics/mod.rs
+++ b/apps/desktop/src-tauri/src/analytics/mod.rs
@@ -1,4 +1,4 @@
-//! Anonymised events about the application, behind build and opt-out gates.
+//! Anonymised product events behind build and opt-out gates.
 //!
 //! This is the one place antiburn sends anything of its own beyond the update
 //! check. The properties below define its privacy boundary.
@@ -45,7 +45,20 @@ pub fn install(_app: &tauri::AppHandle) {}
 
 #[cfg(not(feature = "analytics"))]
 pub fn record(_app: &tauri::AppHandle, _name: event::EventName, facts: event::Facts) {
-    let _ = (facts.bucket, facts.label, facts.detail);
+    let _ = (
+        facts.bucket,
+        facts.label,
+        facts.detail,
+        facts.usage_band,
+        facts.response_shape,
+        facts.eligibility,
+        facts.ineligible_reason,
+        facts.experiment,
+        facts.reset_arm,
+        facts.reset_availability,
+        facts.resets_per_week,
+        facts.next_reset_available,
+    );
 }
 
 #[cfg(not(feature = "analytics"))]
@@ -149,7 +162,7 @@ mod enabled {
     ///
     /// Read fresh, and default to *not* acting: an unreadable preference is not
     /// permission, the same rule every notifier in this app follows. The
-    fn allowed(app: &tauri::AppHandle) -> bool {
+    pub fn allowed(app: &tauri::AppHandle) -> bool {
         if !available() || environment_disabled() {
             return false;
         }
@@ -164,14 +177,18 @@ mod enabled {
     /// fail an operation the reader actually asked for, would be the tail wagging
     /// the dog; a dropped event is not worth a single line of user-facing text.
     pub fn record(app: &tauri::AppHandle, name: EventName, facts: Facts) {
+        let _ = record_event(app, name, facts);
+    }
+
+    fn record_event(app: &tauri::AppHandle, name: EventName, facts: Facts) -> bool {
         if !allowed(app) {
-            return;
+            return false;
         }
         let Some(store) = app.try_state::<Store>() else {
-            return;
+            return false;
         };
         let Some(install_id) = current_install_id(&store) else {
-            return;
+            return false;
         };
         let payload = Event {
             platform: event::PLATFORM,
@@ -188,6 +205,15 @@ mod enabled {
                 bucket: facts.bucket,
                 label: facts.label,
                 detail: facts.detail,
+                usage_band: facts.usage_band,
+                response_shape: facts.response_shape,
+                eligibility: facts.eligibility,
+                ineligible_reason: facts.ineligible_reason,
+                experiment: facts.experiment,
+                reset_arm: facts.reset_arm,
+                reset_availability: facts.reset_availability,
+                resets_per_week: facts.resets_per_week,
+                next_reset_available: facts.next_reset_available,
             },
             context: event::Context {
                 app_version: format!("antiburn:{}", app.package_info().version),
@@ -195,7 +221,31 @@ mod enabled {
             },
         };
         if let Ok(json) = serde_json::to_string(&payload) {
-            let _ = store.queue_analytics_event(name.as_str(), &json);
+            return store.queue_analytics_event(name.as_str(), &json).is_ok();
+        }
+        false
+    }
+
+    /// Record a changed Claude reset observation after all consent checks pass.
+    pub fn record_claude_limit_reset(
+        app: &tauri::AppHandle,
+        diagnostic: crate::provider_usage::live::anthropic::LimitResetDiagnostic,
+    ) {
+        if !allowed(app) {
+            return;
+        }
+        let mut last = LAST_CLAUDE_LIMIT_RESET
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *last == Some(diagnostic) {
+            return;
+        }
+        if record_event(
+            app,
+            EventName::ClaudeLimitResetObserved,
+            event::claude_limit_reset_facts(diagnostic),
+        ) {
+            *last = Some(diagnostic);
         }
     }
 
@@ -217,6 +267,11 @@ mod enabled {
     static LAST_UNRECOGNIZED: std::sync::Mutex<Option<UnrecognizedOutcome>> =
         std::sync::Mutex::new(None);
 
+    /// The last Claude limit-reset observation queued during this run.
+    static LAST_CLAUDE_LIMIT_RESET: std::sync::Mutex<
+        Option<crate::provider_usage::live::anthropic::LimitResetDiagnostic>,
+    > = std::sync::Mutex::new(None);
+
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum UnrecognizedOutcome {
         None,
@@ -234,7 +289,7 @@ mod enabled {
             Some(Facts {
                 bucket: Some(bucket),
                 label: Some(label),
-                detail: None,
+                ..Facts::default()
             })
         }
     }
@@ -351,6 +406,9 @@ mod enabled {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
         *LAST_UNRECOGNIZED
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        *LAST_CLAUDE_LIMIT_RESET
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     }
@@ -798,11 +856,17 @@ mod enabled {
             };
             assert!(scan_outcome_is_new(Some("1-9")));
             assert!(unrecognized_outcome_is_new(inert));
+            *LAST_CLAUDE_LIMIT_RESET.lock().unwrap() = Some(
+                crate::provider_usage::live::anthropic::empty_limit_reset_diagnostic(
+                    "success", "null",
+                ),
+            );
 
             reset_suppression();
 
             assert!(scan_outcome_is_new(Some("1-9")));
             assert!(unrecognized_outcome_is_new(inert));
+            assert_eq!(*LAST_CLAUDE_LIMIT_RESET.lock().unwrap(), None);
             reset_suppression();
         }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
@@ -45,6 +45,217 @@ pub struct AnthropicUsage {
     pub supplemental: Option<SupplementalUsage>,
 }
 
+/// The closed, privacy-safe summary of Claude's limit-reset experiment data.
+///
+/// Every value is a fixed category. The provider response and its timestamps
+/// never leave the machine.
+#[cfg(feature = "analytics")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LimitResetDiagnostic {
+    pub request_outcome: &'static str,
+    pub usage_band: &'static str,
+    pub response_shape: &'static str,
+    pub eligibility: Option<&'static str>,
+    pub ineligible_reason: Option<&'static str>,
+    pub experiment: Option<&'static str>,
+    pub arm: Option<&'static str>,
+    pub availability: Option<&'static str>,
+    pub resets_per_week: Option<&'static str>,
+    pub next_available: Option<&'static str>,
+}
+
+/// Reduce the `juniper_tide` response member to a closed diagnostic.
+#[cfg(feature = "analytics")]
+pub fn parse_limit_reset_diagnostic(input: &str) -> LimitResetDiagnostic {
+    let Ok(value) = serde_json::from_str::<Value>(input) else {
+        return empty_limit_reset_diagnostic("success", "invalid_json");
+    };
+    let Some(envelope) = value.as_object() else {
+        return empty_limit_reset_diagnostic("success", "malformed_envelope");
+    };
+    let usage_band = usage_band(&value);
+    let Some(tide) = envelope.get("juniper_tide") else {
+        return empty_limit_reset_diagnostic_with_band("success", usage_band, "missing");
+    };
+    if tide.is_null() {
+        return empty_limit_reset_diagnostic_with_band("success", usage_band, "null");
+    }
+    let Some(tide) = tide.as_object() else {
+        return empty_limit_reset_diagnostic_with_band("success", usage_band, "malformed");
+    };
+
+    LimitResetDiagnostic {
+        request_outcome: "success",
+        usage_band,
+        response_shape: "object",
+        eligibility: Some(bool_state(tide.get("eligible"), "eligible", "ineligible")),
+        ineligible_reason: Some(reason_state(tide.get("ineligible_reason"))),
+        experiment: Some(bool_state(
+            tide.get("in_experiment"),
+            "in_experiment",
+            "not_in_experiment",
+        )),
+        arm: Some(string_state(tide.get("arm"), |value| match value {
+            "reset" => "reset",
+            "control" => "control",
+            _ => "other",
+        })),
+        availability: Some(bool_state(
+            tide.get("available"),
+            "available",
+            "unavailable",
+        )),
+        resets_per_week: Some(number_state(tide.get("resets_per_week"))),
+        next_available: Some(presence_state(tide.get("next_available_at"))),
+    }
+}
+
+#[cfg(feature = "analytics")]
+pub fn empty_limit_reset_diagnostic(
+    request_outcome: &'static str,
+    response_shape: &'static str,
+) -> LimitResetDiagnostic {
+    empty_limit_reset_diagnostic_with_band(request_outcome, "unknown", response_shape)
+}
+
+#[cfg(feature = "analytics")]
+fn empty_limit_reset_diagnostic_with_band(
+    request_outcome: &'static str,
+    usage_band: &'static str,
+    response_shape: &'static str,
+) -> LimitResetDiagnostic {
+    LimitResetDiagnostic {
+        request_outcome,
+        usage_band,
+        response_shape,
+        eligibility: None,
+        ineligible_reason: None,
+        experiment: None,
+        arm: None,
+        availability: None,
+        resets_per_week: None,
+        next_available: None,
+    }
+}
+
+#[cfg(feature = "analytics")]
+fn usage_band(value: &Value) -> &'static str {
+    let Ok(usage) = parse_usage_value(value) else {
+        return "unknown";
+    };
+    let Some(percent) = usage
+        .windows
+        .iter()
+        .find(|window| matches!(window.role, WindowRole::PrimaryShort))
+        .and_then(|window| window.used_percent)
+    else {
+        return "unknown";
+    };
+    if percent >= 100.0 {
+        "at_limit"
+    } else if percent >= 80.0 {
+        "80_to_under_100"
+    } else {
+        "below_80"
+    }
+}
+
+#[cfg(feature = "analytics")]
+fn missing_null_or_malformed(value: Option<&Value>) -> Option<&'static str> {
+    match value {
+        None => Some("missing"),
+        Some(value) if value.is_null() => Some("null"),
+        Some(_) => None,
+    }
+}
+
+#[cfg(feature = "analytics")]
+fn bool_state(
+    value: Option<&Value>,
+    when_true: &'static str,
+    when_false: &'static str,
+) -> &'static str {
+    if let Some(state) = missing_null_or_malformed(value) {
+        return state;
+    }
+    match value.and_then(Value::as_bool) {
+        Some(true) => when_true,
+        Some(false) => when_false,
+        None => "malformed",
+    }
+}
+
+#[cfg(feature = "analytics")]
+fn string_state(
+    value: Option<&Value>,
+    classify: impl FnOnce(&str) -> &'static str,
+) -> &'static str {
+    if let Some(state) = missing_null_or_malformed(value) {
+        return state;
+    }
+    match value
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) => classify(value),
+        None => "malformed",
+    }
+}
+
+#[cfg(feature = "analytics")]
+fn reason_state(value: Option<&Value>) -> &'static str {
+    string_state(value, |reason| match reason {
+        "tier" => "tier",
+        "tenure" => "tenure",
+        "surface" => "surface",
+        "mobile" => "mobile",
+        "cli_version" => "cli_version",
+        "not_at_wall" => "not_at_wall",
+        "weekly_limit" => "weekly_limit",
+        "no_weekly_limit" => "no_weekly_limit",
+        "other_experiment" => "other_experiment",
+        "extra_usage" => "extra_usage",
+        "unavailable" => "unavailable",
+        "unknown" => "unknown",
+        _ => "other",
+    })
+}
+
+#[cfg(feature = "analytics")]
+fn number_state(value: Option<&Value>) -> &'static str {
+    if let Some(state) = missing_null_or_malformed(value) {
+        return state;
+    }
+    match value.and_then(Value::as_u64) {
+        Some(0) => "0",
+        Some(1) => "1",
+        Some(_) => "2_plus",
+        None => "malformed",
+    }
+}
+
+#[cfg(feature = "analytics")]
+fn presence_state(value: Option<&Value>) -> &'static str {
+    if let Some(state) = missing_null_or_malformed(value) {
+        return state;
+    }
+    let Some(value) = value else {
+        return "missing";
+    };
+    if value
+        .as_str()
+        .is_some_and(|raw| OffsetDateTime::parse(raw, &Rfc3339).is_ok())
+        || value.as_f64().is_some_and(|seconds| {
+            seconds.is_finite()
+                && OffsetDateTime::from_unix_timestamp(seconds.trunc() as i64).is_ok()
+        })
+    {
+        "present"
+    } else {
+        "malformed"
+    }
+}
+
 /// Parse an Anthropic usage payload into windows and supplemental metering.
 ///
 /// Fails rather than returning a partial reading: a payload we only half

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -117,6 +117,22 @@ pub trait LiveUsageSource: Send + Sync {
     /// than a network endpoint is free to ignore it: there is no round trip
     /// there for a cooldown to gate.
     fn fetch(&self, max_age: std::time::Duration) -> SourceOutcome;
+
+    /// Collect a provider-specific diagnostic for anonymised analytics.
+    ///
+    /// The default keeps sources out of analytics unless they explicitly
+    /// implement a bounded diagnostic. Callers apply consent before this runs.
+    #[cfg(feature = "analytics")]
+    fn analytics_diagnostic(&self) -> Option<AnalyticsDiagnostic> {
+        None
+    }
+}
+
+/// A provider diagnostic that can become a closed analytics event.
+#[cfg(feature = "analytics")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnalyticsDiagnostic {
+    ClaudeLimitReset(anthropic::LimitResetDiagnostic),
 }
 
 /// One source's answer for one collection pass.

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/anthropic_fetch.rs
@@ -77,6 +77,10 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+#[cfg(feature = "analytics")]
+use std::sync::Mutex;
+#[cfg(feature = "analytics")]
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 use time::OffsetDateTime;
@@ -98,7 +102,18 @@ const MAX_CREDENTIAL_BYTES: u64 = 256 * 1024;
 const MAX_CLAUDE_JSON_BYTES: u64 = 8 * 1024 * 1024;
 
 const USAGE_ENDPOINT: &str = "https://api.anthropic.com/api/oauth/usage";
+#[cfg(feature = "analytics")]
+const LIMIT_RESET_ENDPOINT: &str =
+    "https://api.anthropic.com/api/oauth/usage?at_wall=1&skip_spend=1";
 const PROFILE_ENDPOINT: &str = "https://api.anthropic.com/api/oauth/profile";
+/// A verified Claude Code identity for provider compatibility.
+///
+/// Keep this pinned until a newer identity is verified against the endpoint.
+/// The diagnostic reports `cli_version` if the provider rejects this version.
+const CLAUDE_CODE_COMPATIBILITY_USER_AGENT: &str = "claude-cli/2.1.261 (external, cli)";
+
+#[cfg(feature = "analytics")]
+const LIMIT_RESET_DIAGNOSTIC_COOLDOWN: Duration = Duration::from_secs(5 * 60);
 
 /// The stable id [`SourceOutcome::error`] and the milestone engine key this
 /// source under.
@@ -338,6 +353,78 @@ pub struct ClaudeDirectFetch {
     config_cache_path: Option<PathBuf>,
     transport: Box<dyn AnthropicTransport>,
     cooldown: Cooldown,
+    #[cfg(feature = "analytics")]
+    limit_reset_diagnostic: LimitResetDiagnosticState,
+}
+
+#[cfg(feature = "analytics")]
+#[derive(Default)]
+struct LimitResetDiagnosticState {
+    inner: Mutex<LimitResetDiagnosticInner>,
+}
+
+#[cfg(feature = "analytics")]
+#[derive(Default)]
+struct LimitResetDiagnosticInner {
+    next_attempt: Option<Instant>,
+    blocked_for_run: bool,
+}
+
+#[cfg(feature = "analytics")]
+impl LimitResetDiagnosticState {
+    fn observe(
+        &self,
+        fetch: impl FnOnce() -> LimitResetFetch,
+    ) -> Option<anthropic::LimitResetDiagnostic> {
+        let now = Instant::now();
+        {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if inner.blocked_for_run || inner.next_attempt.is_some_and(|next| next > now) {
+                return None;
+            }
+            inner.next_attempt = Some(now + LIMIT_RESET_DIAGNOSTIC_COOLDOWN);
+        }
+
+        let fetched = fetch();
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(retry_after) = fetched.retry_after {
+            match now.checked_add(retry_after) {
+                Some(retry_at) if inner.next_attempt.is_none_or(|next| retry_at > next) => {
+                    inner.next_attempt = Some(retry_at);
+                }
+                None => inner.blocked_for_run = true,
+                Some(_) => {}
+            }
+        }
+        Some(fetched.diagnostic)
+    }
+
+    fn defer(&self, delay: Duration) {
+        let next = Instant::now().checked_add(delay);
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match next {
+            Some(next) if inner.next_attempt.is_none_or(|current| next > current) => {
+                inner.next_attempt = Some(next);
+            }
+            None => inner.blocked_for_run = true,
+            Some(_) => {}
+        }
+    }
+}
+
+#[cfg(feature = "analytics")]
+struct LimitResetFetch {
+    diagnostic: anthropic::LimitResetDiagnostic,
+    retry_after: Option<Duration>,
 }
 
 impl ClaudeDirectFetch {
@@ -351,6 +438,8 @@ impl ClaudeDirectFetch {
             config_cache_path: claude_config_cache::default_config_path(),
             transport: Box::new(LiveAnthropicTransport),
             cooldown: Cooldown::new(),
+            #[cfg(feature = "analytics")]
+            limit_reset_diagnostic: LimitResetDiagnosticState::default(),
         }
     }
 
@@ -369,6 +458,8 @@ impl ClaudeDirectFetch {
             config_cache_path: None,
             transport: Box::new(LiveAnthropicTransport),
             cooldown: Cooldown::new(),
+            #[cfg(feature = "analytics")]
+            limit_reset_diagnostic: LimitResetDiagnosticState::default(),
         }
     }
 
@@ -394,6 +485,8 @@ impl ClaudeDirectFetch {
             config_cache_path: Some(config_cache_path),
             transport,
             cooldown: Cooldown::new(),
+            #[cfg(feature = "analytics")]
+            limit_reset_diagnostic: LimitResetDiagnosticState::default(),
         }
     }
 
@@ -480,7 +573,7 @@ impl LiveUsageSource for ClaudeDirectFetch {
         // `security` subprocess, and a poll that the cooldown is going to
         // skip anyway should not pay for either — nor re-raise a Keychain
         // access prompt the reader has already seen.
-        self.cooldown.poll(now, max_age, || {
+        let outcome = self.cooldown.poll(now, max_age, || {
             let (carriers, carrier_error, native_carriers) = self.read_carriers();
             let native = native_carriers
                 .into_iter()
@@ -522,7 +615,47 @@ impl LiveUsageSource for ClaudeDirectFetch {
                     }),
                 }),
             }
-        })
+        });
+        #[cfg(feature = "analytics")]
+        if let Some(delay) = self.cooldown.rate_limit_retry_after(max_age) {
+            self.limit_reset_diagnostic.defer(delay);
+        }
+        outcome
+    }
+
+    #[cfg(feature = "analytics")]
+    fn analytics_diagnostic(&self) -> Option<crate::provider_usage::live::AnalyticsDiagnostic> {
+        self.limit_reset_diagnostic
+            .observe(|| {
+                let now = OffsetDateTime::now_utc();
+                let (carriers, carrier_error, _) = self.read_carriers();
+                let live = carriers.iter().find(|credentials| credentials.is_live(now));
+                match live {
+                    Some(credentials) => self.transport.limit_reset(&credentials.access_token),
+                    None if !carriers.is_empty() => LimitResetFetch {
+                        diagnostic: anthropic::empty_limit_reset_diagnostic(
+                            "credential_expired",
+                            "not_requested",
+                        ),
+                        retry_after: None,
+                    },
+                    None if carrier_error.is_some() => LimitResetFetch {
+                        diagnostic: anthropic::empty_limit_reset_diagnostic(
+                            "credential_unavailable",
+                            "not_requested",
+                        ),
+                        retry_after: None,
+                    },
+                    None => LimitResetFetch {
+                        diagnostic: anthropic::empty_limit_reset_diagnostic(
+                            "credential_absent",
+                            "not_requested",
+                        ),
+                        retry_after: None,
+                    },
+                }
+            })
+            .map(crate::provider_usage::live::AnalyticsDiagnostic::ClaudeLimitReset)
     }
 }
 
@@ -531,6 +664,13 @@ impl LiveUsageSource for ClaudeDirectFetch {
 /// gives that source.
 trait AnthropicTransport: Send + Sync {
     fn usage(&self, access_token: &str) -> Result<String, ProviderUsageError>;
+    #[cfg(feature = "analytics")]
+    fn limit_reset(&self, _access_token: &str) -> LimitResetFetch {
+        LimitResetFetch {
+            diagnostic: anthropic::empty_limit_reset_diagnostic("unavailable", "not_received"),
+            retry_after: None,
+        }
+    }
     /// The profile body, or `None` when enrichment fails.
     fn profile(&self, access_token: &str) -> Option<String>;
 }
@@ -539,12 +679,7 @@ struct LiveAnthropicTransport;
 
 impl AnthropicTransport for LiveAnthropicTransport {
     fn usage(&self, access_token: &str) -> Result<String, ProviderUsageError> {
-        let response = http::client()
-            .get(USAGE_ENDPOINT)
-            .bearer_auth(access_token)
-            .header(reqwest::header::ACCEPT, "application/json")
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .header("anthropic-beta", "oauth-2025-04-20")
+        let response = claude_request(USAGE_ENDPOINT, access_token)
             .send()
             .map_err(|_| ProviderUsageError::Unavailable)?;
         if let Some(error) = http::status_error(response.status()) {
@@ -553,20 +688,73 @@ impl AnthropicTransport for LiveAnthropicTransport {
         http::read_capped_body(response)
     }
 
+    #[cfg(feature = "analytics")]
+    fn limit_reset(&self, access_token: &str) -> LimitResetFetch {
+        let response = match claude_request(LIMIT_RESET_ENDPOINT, access_token).send() {
+            Ok(response) => response,
+            Err(_) => {
+                return LimitResetFetch {
+                    diagnostic: anthropic::empty_limit_reset_diagnostic(
+                        "unavailable",
+                        "not_received",
+                    ),
+                    retry_after: None,
+                };
+            }
+        };
+        let retry_after = retry_after(&response);
+        if let Some(error) = http::status_error(response.status()) {
+            return LimitResetFetch {
+                diagnostic: anthropic::empty_limit_reset_diagnostic(
+                    error.category(),
+                    "not_received",
+                ),
+                retry_after,
+            };
+        }
+        let diagnostic = match http::read_capped_body(response) {
+            Ok(body) => anthropic::parse_limit_reset_diagnostic(&body),
+            Err(error) => anthropic::empty_limit_reset_diagnostic(error.category(), "unreadable"),
+        };
+        LimitResetFetch {
+            diagnostic,
+            retry_after: None,
+        }
+    }
+
     fn profile(&self, access_token: &str) -> Option<String> {
-        let response = http::client()
-            .get(PROFILE_ENDPOINT)
-            .bearer_auth(access_token)
-            .header(reqwest::header::ACCEPT, "application/json")
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .header("anthropic-beta", "oauth-2025-04-20")
-            .send()
-            .ok()?;
+        let response = claude_request(PROFILE_ENDPOINT, access_token).send().ok()?;
         if http::status_error(response.status()).is_some() {
             return None;
         }
         http::read_capped_body(response).ok()
     }
+}
+
+#[cfg(feature = "analytics")]
+fn retry_after(response: &reqwest::blocking::Response) -> Option<Duration> {
+    response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .map(Duration::from_secs)
+}
+
+fn claude_request(endpoint: &str, access_token: &str) -> reqwest::blocking::RequestBuilder {
+    http::client()
+        .get(endpoint)
+        .bearer_auth(access_token)
+        .header(
+            reqwest::header::USER_AGENT,
+            CLAUDE_CODE_COMPATIBILITY_USER_AGENT,
+        )
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header("anthropic-beta", "oauth-2025-04-20")
 }
 
 /// The two-tier decision the module doc's "The CLI's own cache" section
@@ -825,6 +1013,8 @@ fn resolve_identity(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "analytics")]
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     const NOW: i64 = 1_800_000_000;
@@ -851,6 +1041,68 @@ mod tests {
             subscription_type: Some("max".into()),
             rate_limit_tier: Some("default_claude_max_5x".into()),
         }
+    }
+
+    #[test]
+    fn claude_requests_use_the_recognised_cli_identity() {
+        let request = claude_request(USAGE_ENDPOINT, "synthetic-token")
+            .build()
+            .expect("request builds");
+        assert_eq!(request.url().as_str(), USAGE_ENDPOINT);
+        assert_eq!(
+            request
+                .headers()
+                .get(reqwest::header::USER_AGENT)
+                .and_then(|value| value.to_str().ok()),
+            Some(CLAUDE_CODE_COMPATIBILITY_USER_AGENT)
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("anthropic-beta")
+                .and_then(|value| value.to_str().ok()),
+            Some("oauth-2025-04-20")
+        );
+    }
+
+    #[cfg(feature = "analytics")]
+    #[test]
+    fn the_limit_reset_request_uses_the_separate_probe_query() {
+        let request = claude_request(LIMIT_RESET_ENDPOINT, "synthetic-token")
+            .build()
+            .expect("request builds");
+        assert_eq!(
+            request.url().as_str(),
+            "https://api.anthropic.com/api/oauth/usage?at_wall=1&skip_spend=1"
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get(reqwest::header::USER_AGENT)
+                .and_then(|value| value.to_str().ok()),
+            Some(CLAUDE_CODE_COMPATIBILITY_USER_AGENT)
+        );
+    }
+
+    #[cfg(feature = "analytics")]
+    #[test]
+    fn the_limit_reset_diagnostic_is_bounded_and_honors_retry_after() {
+        let state = LimitResetDiagnosticState::default();
+        let first = state.observe(|| LimitResetFetch {
+            diagnostic: anthropic::empty_limit_reset_diagnostic("rateLimited", "not_received"),
+            retry_after: Some(Duration::from_secs(20 * 60)),
+        });
+        assert!(first.is_some());
+
+        let second = state.observe(|| panic!("the cooldown must skip this request"));
+        assert_eq!(second, None);
+        let inner = state.inner.lock().unwrap();
+        let delay = inner
+            .next_attempt
+            .expect("retry deadline")
+            .checked_duration_since(Instant::now())
+            .expect("future deadline");
+        assert!(delay > Duration::from_secs(19 * 60));
     }
 
     fn cached_usage(observed_at: OffsetDateTime) -> CachedUsage {
@@ -889,6 +1141,49 @@ mod tests {
         fn profile(&self, _access_token: &str) -> Option<String> {
             None
         }
+    }
+
+    #[cfg(feature = "analytics")]
+    struct RateLimitedTransport {
+        limit_reset_calls: Arc<AtomicUsize>,
+    }
+
+    #[cfg(feature = "analytics")]
+    impl AnthropicTransport for RateLimitedTransport {
+        fn usage(&self, _access_token: &str) -> Result<String, ProviderUsageError> {
+            Err(ProviderUsageError::RateLimited)
+        }
+
+        fn limit_reset(&self, _access_token: &str) -> LimitResetFetch {
+            self.limit_reset_calls.fetch_add(1, Ordering::SeqCst);
+            LimitResetFetch {
+                diagnostic: anthropic::empty_limit_reset_diagnostic("success", "null"),
+                retry_after: None,
+            }
+        }
+
+        fn profile(&self, _access_token: &str) -> Option<String> {
+            None
+        }
+    }
+
+    #[cfg(feature = "analytics")]
+    #[test]
+    fn an_ordinary_rate_limit_suppresses_the_immediate_reset_probe() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".credentials.json");
+        let expires_at_ms = (OffsetDateTime::now_utc().unix_timestamp() + 3_600) * 1_000;
+        fs::write(&path, credentials_file(expires_at_ms, "max")).expect("write");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut source = ClaudeDirectFetch::at(path);
+        source.transport = Box::new(RateLimitedTransport {
+            limit_reset_calls: Arc::clone(&calls),
+        });
+
+        let outcome = source.fetch(SHORT_MAX_AGE);
+        assert_eq!(outcome.error, Some(ProviderUsageError::RateLimited));
+        assert_eq!(source.analytics_diagnostic(), None);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/sources/cooldown.rs
@@ -164,6 +164,24 @@ impl Cooldown {
             (None, None) => SourceOutcome::absent(),
         }
     }
+
+    /// Return the remaining provider retry delay after a rate limit.
+    #[cfg(feature = "analytics")]
+    pub fn rate_limit_retry_after(&self, max_age: Duration) -> Option<Duration> {
+        let inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !matches!(inner.error, Some(ProviderUsageError::RateLimited)) {
+            return None;
+        }
+        let (at, _) = inner.last_attempt?;
+        failure_cooldown(max_age).checked_sub(at.elapsed())
+    }
+}
+
+fn failure_cooldown(max_age: Duration) -> Duration {
+    max_age.clamp(MIN_FAILURE_COOLDOWN, FAILURE_COOLDOWN)
 }
 
 /// A failed attempt, with the best reading the source found without the
@@ -224,7 +242,7 @@ fn off_cooldown(last: Option<(Instant, bool)>, max_age: Duration) -> bool {
                 >= if succeeded {
                     max_age
                 } else {
-                    max_age.clamp(MIN_FAILURE_COOLDOWN, FAILURE_COOLDOWN)
+                    failure_cooldown(max_age)
                 }
         }
     }
@@ -319,6 +337,26 @@ mod tests {
         // Both calls landed on the same in-memory cooldown, so only the first
         // one actually reached the network.
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "analytics")]
+    #[test]
+    fn a_rate_limit_exposes_only_its_remaining_retry_delay() {
+        let cooldown = Cooldown::new();
+        cooldown.poll(at(1_000), SHORT_MAX_AGE, || {
+            Err(ProviderUsageError::RateLimited.into())
+        });
+
+        let remaining = cooldown
+            .rate_limit_retry_after(SHORT_MAX_AGE)
+            .expect("rate limit has a delay");
+        assert!(remaining > Duration::ZERO);
+        assert!(remaining <= failure_cooldown(SHORT_MAX_AGE));
+
+        let mut inner = cooldown.inner.lock().unwrap();
+        inner.error = Some(ProviderUsageError::Unavailable);
+        drop(inner);
+        assert_eq!(cooldown.rate_limit_retry_after(SHORT_MAX_AGE), None);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/tests.rs
@@ -107,6 +107,60 @@ fn the_legacy_flat_shape_produces_the_same_two_primary_ids() {
     assert_eq!(usage.windows.len(), 2);
 }
 
+#[cfg(feature = "analytics")]
+#[test]
+fn the_limit_reset_diagnostic_preserves_independent_server_states() {
+    let diagnostic = anthropic::parse_limit_reset_diagnostic(
+        r#"{
+          "five_hour": {"utilization": 86.5, "resets_at": 1800000000},
+          "juniper_tide": {
+            "eligible": false,
+            "ineligible_reason": "not_at_wall",
+            "in_experiment": true,
+            "arm": "control",
+            "available": true,
+            "resets_per_week": 1,
+            "next_available_at": "2026-09-07T00:00:00Z"
+          }
+        }"#,
+    );
+
+    assert_eq!(diagnostic.request_outcome, "success");
+    assert_eq!(diagnostic.usage_band, "80_to_under_100");
+    assert_eq!(diagnostic.response_shape, "object");
+    assert_eq!(diagnostic.eligibility, Some("ineligible"));
+    assert_eq!(diagnostic.ineligible_reason, Some("not_at_wall"));
+    assert_eq!(diagnostic.experiment, Some("in_experiment"));
+    assert_eq!(diagnostic.arm, Some("control"));
+    assert_eq!(diagnostic.availability, Some("available"));
+    assert_eq!(diagnostic.resets_per_week, Some("1"));
+    assert_eq!(diagnostic.next_available, Some("present"));
+}
+
+#[cfg(feature = "analytics")]
+#[test]
+fn the_limit_reset_diagnostic_distinguishes_null_missing_and_malformed() {
+    let null = anthropic::parse_limit_reset_diagnostic(
+        r#"{"five_hour":{"utilization":100,"resets_at":1800000000},"juniper_tide":null}"#,
+    );
+    assert_eq!(null.usage_band, "at_limit");
+    assert_eq!(null.response_shape, "null");
+    assert_eq!(null.eligibility, None);
+
+    let missing = anthropic::parse_limit_reset_diagnostic(r#"{"juniper_tide":{}}"#);
+    assert_eq!(missing.usage_band, "unknown");
+    assert_eq!(missing.eligibility, Some("missing"));
+    assert_eq!(missing.ineligible_reason, Some("missing"));
+
+    let malformed = anthropic::parse_limit_reset_diagnostic(
+        r#"{"juniper_tide":{"eligible":"yes","ineligible_reason":"new_reason","arm":"new_arm","next_available_at":true}}"#,
+    );
+    assert_eq!(malformed.eligibility, Some("malformed"));
+    assert_eq!(malformed.ineligible_reason, Some("other"));
+    assert_eq!(malformed.arm, Some("other"));
+    assert_eq!(malformed.next_available, Some("malformed"));
+}
+
 #[test]
 fn a_payload_carrying_both_shapes_does_not_report_a_window_twice() {
     let both = r#"{

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -285,7 +285,62 @@ pub(crate) fn refresh_publish_and_evaluate(
     if let Some(settings) = settings.as_ref() {
         evaluate_milestones(app, &live, settings, &snapshots, now);
     }
+    #[cfg(feature = "analytics")]
+    schedule_claude_limit_reset_diagnostic(app);
     summary
+}
+
+/// Run the reset probe after the ordinary usage result is already published.
+///
+/// The worker checks every consent gate again immediately before it reads a
+/// credential. The source applies its own five-minute request cooldown.
+#[cfg(feature = "analytics")]
+fn schedule_claude_limit_reset_diagnostic(app: &AppHandle) {
+    if !crate::analytics::allowed(app) {
+        return;
+    }
+    let app = app.clone();
+    drop(tauri::async_runtime::spawn_blocking(move || {
+        if !crate::analytics::allowed(&app) {
+            return;
+        }
+        let Some(store) = app.try_state::<Store>() else {
+            return;
+        };
+        let Ok(settings) = store.settings() else {
+            return;
+        };
+        if !claude_limit_reset_diagnostic_allowed(true, &settings) {
+            return;
+        }
+        let Some(live) = app.try_state::<LiveUsage>() else {
+            return;
+        };
+        for source in &live.sources {
+            if source.provider() != crate::provider_usage::providers::ANTHROPIC {
+                continue;
+            }
+            let Some(provider_usage::live::AnalyticsDiagnostic::ClaudeLimitReset(diagnostic)) =
+                source.analytics_diagnostic()
+            else {
+                continue;
+            };
+            crate::analytics::record_claude_limit_reset(&app, diagnostic);
+        }
+    }));
+}
+
+#[cfg(feature = "analytics")]
+fn claude_limit_reset_diagnostic_allowed(
+    analytics_allowed: bool,
+    settings: &crate::store::AppSettings,
+) -> bool {
+    analytics_allowed
+        && settings.analytics_enabled
+        && settings.live_usage_active()
+        && !settings
+            .live_usage_hidden_providers
+            .contains(crate::provider_usage::providers::ANTHROPIC)
 }
 
 fn evaluate_milestones(
@@ -424,6 +479,28 @@ mod tests {
 
     fn at(epoch: i64) -> time::OffsetDateTime {
         time::OffsetDateTime::from_unix_timestamp(epoch).unwrap()
+    }
+
+    #[cfg(feature = "analytics")]
+    #[test]
+    fn the_claude_reset_diagnostic_requires_every_product_gate() {
+        let mut settings = crate::store::AppSettings {
+            onboarding_completed: true,
+            ..crate::store::AppSettings::default()
+        };
+        assert!(claude_limit_reset_diagnostic_allowed(true, &settings));
+        assert!(!claude_limit_reset_diagnostic_allowed(false, &settings));
+
+        settings.analytics_enabled = false;
+        assert!(!claude_limit_reset_diagnostic_allowed(true, &settings));
+        settings.analytics_enabled = true;
+        settings.live_usage_enabled = false;
+        assert!(!claude_limit_reset_diagnostic_allowed(true, &settings));
+        settings.live_usage_enabled = true;
+        settings.live_usage_hidden_providers = crate::store::HiddenMeters::selected([
+            crate::provider_usage::providers::ANTHROPIC.to_string(),
+        ]);
+        assert!(!claude_limit_reset_diagnostic_allowed(true, &settings));
     }
 
     #[test]

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -809,7 +809,9 @@ describe("SettingsView", () => {
     // The count sits beside the list it counts. The Rust guard
     // `every_document_that_counts_the_fields_counts_the_same_number` greps
     // this pane for that phrase, so it has to survive edits to this section.
-    expect(screen.getByText(/schema has twenty-two fields, and these are all of them/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/schema has twenty-two fields, and these are all of them/i),
+    ).toBeInTheDocument()
     for (const field of [
       /the word .desktop./i,
       /a random id for the message, so a retry/i,

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -802,14 +802,14 @@ describe("SettingsView", () => {
     // earlier version of this test sampled two of them, which is how five
     // fields went unnamed in the pane while the copy claimed to list them all.
     // `analytics::event::Event` is the other half of this pair, and its
-    // `the_wire_payload_is_exactly_these_thirteen_fields` pins the same number
+    // `the_wire_payload_is_exactly_these_twenty_two_fields` pins the same number
     // from the Rust side.
     const enumeration = screen.getByRole("button", { name: "Exactly what is sent" })
     fireEvent.click(enumeration)
     // The count sits beside the list it counts. The Rust guard
     // `every_document_that_counts_the_fields_counts_the_same_number` greps
     // this pane for that phrase, so it has to survive edits to this section.
-    expect(screen.getByText(/thirteen fields, and these are all of them/i)).toBeInTheDocument()
+    expect(screen.getByText(/schema has twenty-two fields, and these are all of them/i)).toBeInTheDocument()
     for (const field of [
       /the word .desktop./i,
       /a random id for the message, so a retry/i,
@@ -836,7 +836,7 @@ describe("SettingsView", () => {
     // neighbouring paragraph: the body is a sibling of nothing predictable,
     // and the id is the component's actual contract.
     const body = document.getElementById(enumeration.getAttribute("aria-controls") ?? "")
-    expect(body?.querySelectorAll("li")).toHaveLength(13)
+    expect(body?.querySelectorAll("li")).toHaveLength(22)
     // The exclusions live in the same body as the list, so a reader checking
     // one against the other does not have to open a second row to find them.
     expect(

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -144,7 +144,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
           keeps the data it needs locally. Your sessions, prompts, and file paths never leave
           it.{" "}
           {analyticsSupported
-            ? "The one thing antiburn reports about itself is anonymised analytics, which you can turn off below."
+            ? "The one thing antiburn reports to us is anonymised product analytics, which you can turn off below."
             : "This build sends no analytics at all."}{" "}
           Each promise opens into the specifics a reader could reasonably want to check.
         </p>
@@ -178,8 +178,8 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
             startup and hourly while running; it asks GitHub Releases whether a newer version
             exists; where a source is enabled, it can ask a provider for your current plan
             limits using the credentials your own tools already stored; and, in a released build
-            with the switch below on, it sends anonymised analytics about the application
-            itself. Handing a provider back a credential it issued you is not a disclosure — it
+            with the switch below on, it sends the anonymised product analytics listed below.
+            Handing a provider back a credential it issued you is not a disclosure — it
             already has it. Those analytics are the one thing that goes to us; they are listed
             field by field below, and they contain none of your work. This build
             {analyticsSupported
@@ -215,7 +215,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                   ? "Off for this launch because ANTIBURN_ANALYTICS_ENABLED=false. Remove it to use this setting."
                   : loaded && !settings.analyticsEnabled
                     ? "Off. Antiburn deleted its analytics identifier and anything waiting to be sent."
-                    : `Sends app launches, onboarding progress, feature use, and error categories${
+                    : `Sends app launches, onboarding progress, feature use, error categories, and coarse Claude reset status${
                         operator ? ` to ${operator}` : ""
                       }. Never prompts, sessions, source code, filenames, or paths.`
               }
@@ -243,10 +243,8 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                   field is added there, it is named here in the same change or
                   the promise below stops being true.
 
-                  A list rather than one long sentence: a reader auditing this
-                  is counting items against that struct, and thirteen clauses
-                  separated by semicolons cannot be counted. */}
-              <p>Thirteen fields, and these are all of them:</p>
+                  The list lets a reader count every field. */}
+              <p>The schema has twenty-two fields, and these are all of them:</p>
               {/* `pl-7`, not the `pl-4` this started as. Root font-size here
                   is 13px, so `pl-4` is 13px of padding — less than the disc
                   marker's own 17.5px advance, which left the bullets painting
@@ -270,6 +268,15 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                   A second such label when an event has two things to tell apart, such as native
                   versus WSL.
                 </li>
+                <li>A range for Claude&rsquo;s current five-hour usage.</li>
+                <li>Whether Claude returned reset data, null, or a malformed value.</li>
+                <li>Claude&rsquo;s reset eligibility state.</li>
+                <li>An allowlisted reason when Claude says a reset is not eligible.</li>
+                <li>Claude&rsquo;s reset-experiment membership state.</li>
+                <li>Claude&rsquo;s reset experiment arm: reset, control, or other.</li>
+                <li>Claude&rsquo;s reset availability state.</li>
+                <li>Claude&rsquo;s weekly reset count rounded to zero, one, or two-plus.</li>
+                <li>Whether Claude supplied a next-reset date, never the date itself.</li>
                 <li>The app version.</li>
                 <li>Your operating system.</li>
               </ul>

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -179,9 +179,9 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
             exists; where a source is enabled, it can ask a provider for your current plan
             limits using the credentials your own tools already stored; and, in a released build
             with the switch below on, it sends the anonymised product analytics listed below.
-            Handing a provider back a credential it issued you is not a disclosure — it
-            already has it. Those analytics are the one thing that goes to us; they are listed
-            field by field below, and they contain none of your work. This build
+            Handing a provider back a credential it issued you is not a disclosure — it already
+            has it. Those analytics are the one thing that goes to us; they are listed field by
+            field below, and they contain none of your work. This build
             {analyticsSupported
               ? " can send them."
               : " has no analytics endpoint, so it cannot send them at all."}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,7 +1,7 @@
 # Anonymised analytics
 
-antiburn sends anonymised events about **the application itself** — which
-features get used, and what breaks. This document is the complete account of
+antiburn sends anonymised product events — which features get used, what
+breaks, and a coarse diagnostic of Claude's session-limit reset. This document is the complete account of
 that: every field, every event, what is deliberately excluded, what antiburn
 cannot promise, and how to verify all of it yourself without trusting this
 page.
@@ -24,9 +24,11 @@ process-level opt-out.
   development build and **every build made from a clean checkout of this
   repository** — the endpoint is injected at build time and is not in the tree.
 
-## Exactly what every event carries
+## Exactly what the event schema can carry
 
-Thirteen fields, and this is the whole list. The payload is a closed Rust struct
+Twenty-two fields, and this is the whole list. Thirteen are the established
+event envelope and general properties. The nine Claude reset fields are optional
+and appear only on `antiburn.claude_limit_reset_observed`. The payload is a closed Rust struct
 ([`analytics/event.rs`](../apps/desktop/src-tauri/src/analytics/event.rs))
 with no map and no free-form string, so there is nowhere for anything else to
 be put.
@@ -44,6 +46,15 @@ be put.
 | `properties.bucket`  | A count rounded into a range. Never exact.                                                                                                                 | `10-49`                   |
 | `properties.label`   | A key from a closed vocabulary — which setting changed, which agent's session was opened, or which kind of failure. Never the value.                       | `live_usage`              |
 | `properties.detail`  | A second value from a closed vocabulary, where one event has two things worth telling apart.                                                               | `native`                  |
+| `properties.usageBand` | Claude's five-hour usage from the same reset-check response: `below_80`, `80_to_under_100`, `at_limit`, or `unknown`. | `80_to_under_100` |
+| `properties.responseShape` | Whether `juniper_tide` was an `object`, `missing`, `null`, or `malformed`; also `invalid_json`, `malformed_envelope`, `not_received`, `unreadable`, or `not_requested` for request and envelope outcomes. | `object` |
+| `properties.eligibility` | Claude's `eligible` boolean as `eligible` or `ineligible`, or `missing`, `null`, or `malformed`. | `eligible` |
+| `properties.ineligibleReason` | An allowlisted Claude reason: `tier`, `tenure`, `surface`, `mobile`, `cli_version`, `not_at_wall`, `weekly_limit`, `no_weekly_limit`, `other_experiment`, `extra_usage`, `unavailable`, `unknown`, or `other`; also `missing`, `null`, or `malformed`. | `not_at_wall` |
+| `properties.experiment` | Claude's `in_experiment` boolean as `in_experiment` or `not_in_experiment`, or `missing`, `null`, or `malformed`. | `in_experiment` |
+| `properties.resetArm` | Claude's experiment arm as `reset`, `control`, or `other`, or `missing`, `null`, or `malformed`. | `reset` |
+| `properties.resetAvailability` | Claude's `available` boolean as `available` or `unavailable`, or `missing`, `null`, or `malformed`. | `available` |
+| `properties.resetsPerWeek` | Claude's reset count as `0`, `1`, or `2_plus`, or `missing`, `null`, or `malformed`. | `1` |
+| `properties.nextResetAvailable` | Whether `next_available_at` was `present`, `missing`, `null`, or `malformed`. The timestamp itself is never sent. | `present` |
 | `context.appVersion` | The application version.                                                                                                                                   | `antiburn:0.1.0`          |
 | `context.os`         | Operating-system family.                                                                                                                                   | `macos`                   |
 
@@ -64,7 +75,7 @@ exists only in memory: quitting antiburn ends it, and nothing on your machine
 remembers it afterwards. It is the shortest-lived thing in the payload, and it
 cannot connect one run of the application to another.
 
-### Which agents you use
+### Agent and provider categories
 
 `antiburn.session_opened` carries the agent that recorded the session you
 opened — `claude-code`, `codex`, `cursor`, and so on, from the fixed list
@@ -72,9 +83,9 @@ antiburn knows how to read. Nothing else about the session travels with it: not
 its title, not its repository, not its path, and not the name of your WSL
 distribution, which you chose and which would identify your machine.
 
-This is called out separately because it is the one field that says something
-about your tools rather than about the application. If that is more than you
-want to share, the switch turns all of it off.
+The Claude reset event also reveals that this provider is enabled. These are the
+only analytics fields that identify an agent or provider category. If that is
+more than you want to share, the switch turns all analytics off.
 
 ### Why counts are bucketed
 
@@ -110,8 +121,9 @@ Event names are namespaced `antiburn.*`.
 | `antiburn.usage_viewed`        | You open the usage view.                                                                                                                                                                                    | `bucket` — how many providers had anything to show. `label` — `live` if any provider reported its own limit figures, `estimated_only` if there were only antiburn's estimates, `none` if there was nothing. |
 | `antiburn.error_occurred`      | Something failed, and the previous pass had not already reported the same failure.                                                                                                                          | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                           |
 | `antiburn.unrecognized_records_observed` | Settings → Insights returns a cohort containing unknown record vocabulary, and its outcome differs from the last one reported during this run. | `bucket` — sessions containing unknown types. `label` — `inert_only`, `inert_capped`, or `evidence_bearing`. No discriminator, payload, session identifier, or second dimension. |
+| `antiburn.claude_limit_reset_observed` | After an ordinary Claude usage refresh, when analytics and Claude live usage are both enabled and the observation differs from the last one queued during this run. The probe uses a separate five-minute cooldown. | `label` — `success`, `authentication`, `rateLimited`, `unavailable`, `credential_absent`, `credential_expired`, or `credential_unavailable`. The nine reset fields listed above. No response body, credential, account identifier, exact usage percentage, or date. |
 
-Three of those are deliberately not sent once per occurrence. A scan result that
+Four of those are deliberately not sent once per occurrence. A scan result that
 repeats the last one is dropped, so a machine left running does not report the
 same number every minute and a machine stuck failing does not report the same
 failure six hundred times a day. What survives is the first pass of each run,
@@ -119,6 +131,23 @@ every crossing of a bucket boundary, and every move into or out of failure. The
 unrecognized-record event likewise reports only a changed `(label, bucket)`
 outcome. A clean cohort updates that in-memory comparison without sending an
 event, so a later return to unknown vocabulary is visible.
+
+The Claude limit-reset event reports the first observation in a run and then
+only a changed observation. It calls the same provider usage endpoint through a
+separate `at_wall=1&skip_spend=1` GET after the ordinary usage result has already
+been published. It runs only when analytics is configured and enabled, live
+usage is active, and Claude is visible. A 429 from either Claude usage request
+defers the probe; the probe also honors a numeric `Retry-After` value. The app
+does not invoke the reset operation. The diagnostic response can
+therefore affect only this analytics event, never the displayed usage result,
+notifications, or provider cache.
+
+The event's usage band comes from the diagnostic response itself. That keeps an
+80–99% or at-limit observation aligned with the reset fields it describes. The
+event preserves missing, null, and malformed field states, and keeps eligibility,
+experiment membership, arm, and availability separate so contradictory server
+states remain visible. It sends only the presence of `next_available_at`, because
+the exact date adds little diagnostic value and reveals more timing detail.
 
 The `inert_capped` label covers either too many distinct unknown types or one
 type name that exceeds the local string limit. The event never sends those

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy policy
 
-Effective: 28 August 2026
+Effective: 6 September 2026
 
 This policy explains the analytics sent by the antiburn desktop application.
 Antiburn is operated by **Cadence AI (Vic) Pty Ltd** ("we", "us"). Contact us
@@ -22,14 +22,21 @@ Official release builds send limited events about how the application works and
 which features are used. This includes application launch and progress through
 the fixed onboarding steps.
 
-Each event contains thirteen fields:
+The event schema contains twenty-two fields:
 
 - the constant product surface `desktop`;
 - random message, installation, and application-run identifiers;
 - the event name and capture and delivery times;
 - the processor architecture, operating-system family, and app version;
 - an optional count rounded to a range; and
-- optional labels selected from a fixed list in the application.
+- optional labels selected from a fixed list in the application;
+- a range for Claude's current five-hour usage;
+- whether Claude returned reset data, null, or a malformed value;
+- Claude's reset eligibility and experiment-membership states;
+- an allowlisted reason when Claude reports ineligibility;
+- Claude's reset experiment arm and availability state;
+- the weekly reset count rounded to zero, one, or two-plus; and
+- whether Claude supplied a next-reset date, never the date itself.
 
 The installation identifier is random and changes every 30 days. The run
 identifier exists only in memory and changes when the app restarts or after 30
@@ -48,7 +55,8 @@ type, and app runtime. We store them with the raw event.
 ## Why we use analytics
 
 We use these events to understand whether onboarding works, which product
-features are useful, and which operations fail. We do not use them for
+features are useful, which operations fail, and when Claude makes its session
+limit-reset feature available. We do not use them for
 advertising, user profiling, or decisions about a person.
 
 We process this data for our legitimate interest in maintaining and improving

--- a/docs/support.md
+++ b/docs/support.md
@@ -134,15 +134,18 @@ signed bundle and restarts antiburn. The app never depends on either connection.
 - Development builds carry no updater at all.
 - Linux AppImage releases update in the app. Debian packages remain install-only
   and require the next package to be installed manually.
-- **Anonymised analytics** are the one thing antiburn reports about itself.
+- **Anonymised product analytics** are the one thing antiburn reports to us.
   Official release builds start with it on, including during onboarding. The Ready
-  screen explains it, and the switch is in Settings → Privacy. Each event carries thirteen fields and
+  screen explains it, and the switch is in Settings → Privacy. The event schema has twenty-two fields and
   no others: the constant `desktop`; a random per-message id used to discard
   duplicate deliveries; a random installation identifier replaced every 30 days;
-  the event name; the time it happened and the time it was delivered; the
+  a random application-run identifier; the event name; the time it happened and the time it was delivered; the
   processor architecture; a count rounded into a range where the event has one;
   a short label naming which setting changed or which kind of failure occurred,
-  never the value; the app version; and the operating system. The payload has no
+  never the value; a second fixed label where needed; a coarse five-hour usage
+  band; the reset response shape; eligibility, experiment membership, experiment
+  arm, and availability states; an allowlisted ineligibility reason; a reset-count
+  bucket; whether a next-reset date was present; the app version; and the operating system. The payload has no
   field able to carry anything else. Because each event is timestamped and the
   identifier lasts up to 30 days, the events do show roughly when the
   application is used within that window; they do not show what it was used on.


### PR DESCRIPTION
## Problem

Claude Code can expose `/limit-reset` availability through a usage diagnostic, but antiburn currently uses a generic client identity and cannot assess that response surface.

This change sends Anthropic usage requests with the verified, deliberately pinned Claude CLI compatibility identity. When product analytics is enabled and consented, it also makes a separate diagnostic-only request to `/api/oauth/usage?at_wall=1&skip_spend=1` after the ordinary usage result is delivered.

## Behavior

- Records only documented, allowlisted categorical fields; it excludes account identifiers, credentials, raw responses, exact percentages, and timestamps.
- Caps diagnostics to once per five minutes, suppresses concurrent probes, honors numeric diagnostic `Retry-After`, and defers probes during the ordinary usage API's rate-limit cooldown.
- Keeps the diagnostic outside the usage cache and visible quota behavior. It never invokes the reset endpoint.
- Documents the analytics schema, privacy policy change, sampling behavior, and maintenance requirement for the verified User-Agent pin.

## Validation

- `cargo fmt --check`
- default Rust clippy and tests (906 passed)
- analytics-feature Rust clippy and tests (938 passed)
- desktop Prettier, ESLint, TypeScript, Knip, tests (1,143 passed), and production build
- slop and secret scans

