### PR TITLE
Account for GPT-6 Astra Fast pricing

### DIFF
--- a/apps/desktop/src-tauri/src/analysis.rs
+++ b/apps/desktop/src-tauri/src/analysis.rs
@@ -172,6 +172,7 @@ pub struct StreamedSession {
 /// values — see `analyze_for_evidence`.
 pub struct RowProjections {
     pub model_breakdown: std::collections::BTreeMap<String, ModelTokens>,
+    pub pricing_breakdown: std::collections::BTreeMap<String, ModelTokens>,
     pub model_runs: Vec<ModelRun>,
 }
 
@@ -240,7 +241,7 @@ enum ComputedAnalysis {
         started_at_epoch: Option<i64>,
         parent_fingerprint: Option<String>,
         evidence: Box<Option<SessionEvidence>>,
-        row_projections: Option<RowProjections>,
+        row_projections: Option<Box<RowProjections>>,
         source_summaries: Option<BTreeMap<String, SessionSummary>>,
         source_outcomes: Vec<SourcePublishOutcome>,
     },
@@ -290,6 +291,8 @@ pub struct SessionAnalysis {
     /// every sub-agent. The cache stores this map, so a later pass can
     /// re-price the session without reading any transcript again.
     pub inclusive_model_breakdown: HashMap<String, ModelTokens>,
+    /// This map groups billable tokens by the catalog key for the observed speed tier.
+    pub inclusive_pricing_breakdown: HashMap<String, ModelTokens>,
     pub orchestration: Option<OrchestrationStatus>,
     /// The transcript this analysis was read from, when it is a file.
     pub source_path: Option<String>,
@@ -324,6 +327,7 @@ impl SessionAnalysis {
             models: Vec::new(),
             model_runs: Vec::new(),
             inclusive_model_breakdown: HashMap::new(),
+            inclusive_pricing_breakdown: HashMap::new(),
             orchestration: None,
             source_path: None,
             fingerprint: MISSING_FINGERPRINT.to_string(),
@@ -373,6 +377,8 @@ impl SessionAnalysis {
         Some(AnalysisRecord {
             key: key.clone(),
             model_breakdown_json: serde_json::to_string(&self.inclusive_model_breakdown)
+                .unwrap_or_else(|_| "{}".to_string()),
+            pricing_breakdown_json: serde_json::to_string(&self.inclusive_pricing_breakdown)
                 .unwrap_or_else(|_| "{}".to_string()),
             inclusive_models_json: serde_json::to_string(&self.model_runs)
                 .unwrap_or_else(|_| "[]".to_string()),
@@ -1211,6 +1217,12 @@ fn stream_vendor_with_hooks(
                     return StreamOutcome::ParentUnreadable(UnreadableReason::RowsReadbackFailed);
                 }
             };
+            let pricing_breakdown = match store.query_pricing_breakdown() {
+                Ok(pricing_breakdown) => pricing_breakdown,
+                Err(_) => {
+                    return StreamOutcome::ParentUnreadable(UnreadableReason::RowsReadbackFailed);
+                }
+            };
             let model_runs = match store.query_model_runs() {
                 Ok(model_runs) => model_runs,
                 Err(_) => {
@@ -1221,6 +1233,7 @@ fn stream_vendor_with_hooks(
                 evidence,
                 Some(RowProjections {
                     model_breakdown,
+                    pricing_breakdown,
                     model_runs,
                 }),
             )
@@ -1387,7 +1400,7 @@ pub async fn analyze_for_evidence(
                 started_at_epoch: session.started_at_epoch,
                 parent_fingerprint,
                 evidence: Box::new(session.evidence),
-                row_projections: session.row_projections,
+                row_projections: session.row_projections.map(Box::new),
                 source_summaries: session.source_summaries,
                 source_outcomes: session.source_outcomes,
             },
@@ -1437,7 +1450,7 @@ pub async fn analyze_for_evidence(
             started_at_epoch,
             parent_fingerprint,
             *evidence,
-            row_projections,
+            row_projections.map(|projections| *projections),
             source_summaries,
             source_outcomes,
         ),
@@ -1585,7 +1598,8 @@ fn assemble_session_analysis(input: AssembledMetrics) -> SessionAnalysis {
             // transcript could not be analyzed this pass, so its cost and
             // tokens are `None` rather than a zeroed figure.
             let child_metrics = by_id.get(&subagent_id);
-            let cost = child_metrics.and_then(|(child, _)| price_breakdown(&child.model_breakdown));
+            let cost =
+                child_metrics.and_then(|(child, _)| price_breakdown(&child.pricing_breakdown));
             let tokens =
                 child_metrics.map(|(child, _)| sum_billable_tokens(&child.model_breakdown));
             let model_runs = child_metrics
@@ -1626,24 +1640,43 @@ fn assemble_session_analysis(input: AssembledMetrics) -> SessionAnalysis {
         .collect();
     let has_subagents = !subagent_breakdowns.is_empty();
     let subagents_model_breakdown = merge_model_breakdowns(subagent_breakdowns.iter().copied());
+    let subagent_pricing_breakdowns: Vec<&HashMap<String, ModelTokens>> = by_id
+        .values()
+        .map(|(child, _)| &child.pricing_breakdown)
+        .collect();
+    let subagents_pricing_breakdown =
+        merge_model_breakdowns(subagent_pricing_breakdowns.iter().copied());
     let accumulator_model_breakdown = metrics.model_breakdown.clone();
+    let accumulator_pricing_breakdown = metrics.pricing_breakdown.clone();
     let accumulator_model_runs =
         model_runs_parent_first(&parent_metrics, by_id.values().map(|(child, _)| child));
     // The worker path (`row_projections` is `Some`) reads
     // `inclusive_model_breakdown` and `model_runs` back from published turn
     // rows instead of the accumulator — see `RowProjections`. Every other
     // caller keeps the accumulator's own values.
-    let (inclusive_model_breakdown, model_runs) = match row_projections {
+    let (inclusive_model_breakdown, inclusive_pricing_breakdown, model_runs) = match row_projections
+    {
         Some(RowProjections {
             model_breakdown,
+            pricing_breakdown,
             model_runs,
-        }) => (model_breakdown.into_iter().collect(), model_runs),
-        None => (accumulator_model_breakdown, accumulator_model_runs),
+        }) => (
+            model_breakdown.into_iter().collect(),
+            pricing_breakdown.into_iter().collect(),
+            model_runs,
+        ),
+        None => (
+            accumulator_model_breakdown,
+            accumulator_pricing_breakdown,
+            accumulator_model_runs,
+        ),
     };
 
-    let top_level_cost = price_breakdown(&parent_metrics.model_breakdown);
-    let subagents_cost = price_breakdown(&subagents_model_breakdown);
-    let cost = metrics.cost;
+    let top_level_cost = price_breakdown(&parent_metrics.pricing_breakdown);
+    let subagents_cost = price_breakdown(&subagents_pricing_breakdown);
+    let cost = price_breakdown(&inclusive_pricing_breakdown);
+    metrics.pricing_breakdown = inclusive_pricing_breakdown.clone();
+    metrics.cost = cost;
     let models = sorted_models(&inclusive_model_breakdown);
     let inclusive_tokens = Some(sum_billable_tokens(&inclusive_model_breakdown));
     let subagents_tokens = has_subagents.then(|| sum_billable_tokens(&subagents_model_breakdown));
@@ -1661,6 +1694,7 @@ fn assemble_session_analysis(input: AssembledMetrics) -> SessionAnalysis {
         models,
         model_runs,
         inclusive_model_breakdown,
+        inclusive_pricing_breakdown,
         orchestration,
         source_path,
         fingerprint,
@@ -1913,10 +1947,11 @@ fn standalone_session_analysis(
 ) -> SessionAnalysis {
     metrics.agent = agent_slug;
 
-    let cost = price_breakdown(&metrics.model_breakdown);
+    let cost = price_breakdown(&metrics.pricing_breakdown);
     let models = sorted_models(&metrics.model_breakdown);
     let model_runs = model_runs_for_metrics(&metrics);
     let inclusive_model_breakdown = metrics.model_breakdown.clone();
+    let inclusive_pricing_breakdown = metrics.pricing_breakdown.clone();
     let inclusive_tokens = Some(sum_billable_tokens(&inclusive_model_breakdown));
     let summary = aggregate_metrics(vec![metrics.clone()]);
 
@@ -1932,6 +1967,7 @@ fn standalone_session_analysis(
         models,
         model_runs,
         inclusive_model_breakdown,
+        inclusive_pricing_breakdown,
         orchestration: None,
         source_path,
         fingerprint,
@@ -2120,12 +2156,19 @@ pub fn is_active(updated_at_epoch: Option<i64>, now: i64) -> bool {
 }
 
 /// Re-price a cached model breakdown against the current pricing table.
-pub fn price_cached_breakdown(model_breakdown_json: &str) -> (Option<SessionCost>, Vec<String>) {
-    let Ok(breakdown) = serde_json::from_str::<HashMap<String, ModelTokens>>(model_breakdown_json)
+pub fn price_cached_breakdown(
+    model_breakdown_json: &str,
+    pricing_breakdown_json: &str,
+) -> (Option<SessionCost>, Vec<String>) {
+    let Ok(models) = serde_json::from_str::<HashMap<String, ModelTokens>>(model_breakdown_json)
     else {
         return (None, Vec::new());
     };
-    (price_breakdown(&breakdown), sorted_models(&breakdown))
+    let Ok(pricing) = serde_json::from_str::<HashMap<String, ModelTokens>>(pricing_breakdown_json)
+    else {
+        return (None, sorted_models(&models));
+    };
+    (price_breakdown(&pricing), sorted_models(&models))
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/analysis/tests.rs
+++ b/apps/desktop/src-tauri/src/analysis/tests.rs
@@ -613,6 +613,69 @@ fn an_accepted_child_read_publishes_the_merged_metrics() {
 }
 
 #[test]
+fn mixed_astra_speeds_match_live_rows_cache_and_child_costs() {
+    let inputs = [
+        inline_input(
+            claude_record_with("parent", 1_760_000_000, "gpt-6-astra", None),
+            "parent",
+        ),
+        inline_input(
+            claude_record_with("child", 1_760_000_001, "gpt-6-astra", Some("fast")),
+            "child",
+        ),
+    ];
+    let outcome = stream_vendor_with_hooks(
+        &inputs,
+        &|| false,
+        &|_, _| {},
+        None,
+        Some(turn_row_store("claude", "parent")),
+    );
+    let StreamOutcome::Published { session, .. } = outcome else {
+        panic!("the stable mixed-speed sources must publish");
+    };
+    let expected = 2.0 * 10.0e-6 + 3.0 * 50.0e-6 + 2.0 * 20.0e-6 + 3.0 * 100.0e-6;
+    let live = session
+        .merged
+        .cost
+        .expect("the live mixed-speed metrics price")
+        .total_usd;
+    let row_pricing: HashMap<String, ModelTokens> = session
+        .row_projections
+        .as_ref()
+        .expect("the row projection")
+        .pricing_breakdown
+        .clone()
+        .into_iter()
+        .collect();
+    let rows = price_breakdown(&row_pricing)
+        .expect("the row projection prices")
+        .total_usd;
+    let model_json = serde_json::to_string(&session.merged.model_breakdown).unwrap();
+    let pricing_json = serde_json::to_string(
+        &session
+            .row_projections
+            .as_ref()
+            .expect("the row projection")
+            .pricing_breakdown,
+    )
+    .unwrap();
+    let (cached, displayed) = price_cached_breakdown(&model_json, &pricing_json);
+    let cached = cached.expect("the cached projection prices").total_usd;
+    let child = session.subagents[0]
+        .0
+        .cost
+        .expect("the fast child prices")
+        .total_usd;
+
+    assert!((live - expected).abs() < 1e-12);
+    assert!((rows - expected).abs() < 1e-12);
+    assert!((cached - expected).abs() < 1e-12);
+    assert!((child - (2.0 * 20.0e-6 + 3.0 * 100.0e-6)).abs() < 1e-12);
+    assert_eq!(displayed, ["gpt-6-astra"]);
+}
+
+#[test]
 fn a_changed_parent_source_publishes_neither_projection() {
     let directory = tempfile::TempDir::new().expect("tempdir");
     let path = directory.path().join("parent.jsonl");
@@ -1454,7 +1517,7 @@ fn cached_costs_re_price_from_the_stored_breakdown() {
     )]))
     .unwrap();
 
-    let (cost, models) = price_cached_breakdown(&stored);
+    let (cost, models) = price_cached_breakdown(&stored, &stored);
     assert_eq!(models, vec!["claude-opus-4-6".to_string()]);
     let cost = cost.expect("a known model prices");
     assert!((cost.input_usd - 5.0).abs() < 1e-9);
@@ -1465,12 +1528,46 @@ fn cached_costs_re_price_from_the_stored_breakdown() {
         ModelTokens::default(),
     )]))
     .unwrap();
-    let (cost, models) = price_cached_breakdown(&unknown);
+    let (cost, models) = price_cached_breakdown(&unknown, &unknown);
     assert!(cost.is_none());
     assert_eq!(models, vec!["some-unreleased-model".to_string()]);
 
     // Garbage in the cache degrades to "unknown", never to a panic.
-    assert_eq!(price_cached_breakdown("not json").0, None);
+    assert_eq!(price_cached_breakdown("not json", "not json").0, None);
+}
+
+#[test]
+fn cached_mixed_astra_speeds_keep_the_display_identity() {
+    let models = serde_json::to_string(&HashMap::from([(
+        "gpt-6-astra".to_string(),
+        ModelTokens {
+            output_tokens: 2_000_000,
+            ..ModelTokens::default()
+        },
+    )]))
+    .unwrap();
+    let pricing = serde_json::to_string(&HashMap::from([
+        (
+            "gpt-6-astra".to_string(),
+            ModelTokens {
+                output_tokens: 1_000_000,
+                ..ModelTokens::default()
+            },
+        ),
+        (
+            "gpt-6-astra-fast".to_string(),
+            ModelTokens {
+                output_tokens: 1_000_000,
+                ..ModelTokens::default()
+            },
+        ),
+    ]))
+    .unwrap();
+
+    let (cost, displayed) = price_cached_breakdown(&models, &pricing);
+
+    assert_eq!(displayed, ["gpt-6-astra"]);
+    assert!((cost.expect("both tiers price").total_usd - 150.0).abs() < 1e-9);
 }
 
 fn tokens(input: u64) -> ModelTokens {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -598,7 +598,12 @@ pub(crate) fn activity_entry(
     let analysis = store.analysis(&session.key)?;
     let (cost, models) = analysis
         .as_ref()
-        .map(|record| analysis::price_cached_breakdown(&record.model_breakdown_json))
+        .map(|record| {
+            analysis::price_cached_breakdown(
+                &record.model_breakdown_json,
+                &record.pricing_breakdown_json,
+            )
+        })
         .unwrap_or((None, Vec::new()));
     let model_runs = analysis
         .as_ref()

--- a/apps/desktop/src-tauri/src/fork_lineage/tests.rs
+++ b/apps/desktop/src-tauri/src/fork_lineage/tests.rs
@@ -87,6 +87,7 @@ fn publish_turns(store: &Store, session_id: &str, uuid: &str, row_count: u64) ->
     let record = AnalysisRecord {
         key: claim.key.clone(),
         model_breakdown_json: "{}".into(),
+        pricing_breakdown_json: "{}".into(),
         inclusive_models_json: "[]".into(),
         initial_context_json: None,
         source_summaries_json: None,

--- a/apps/desktop/src-tauri/src/insights_report.rs
+++ b/apps/desktop/src-tauri/src/insights_report.rs
@@ -775,6 +775,7 @@ mod tests {
         let analysis = AnalysisRecord {
             key: session.key,
             model_breakdown_json: "{}".to_owned(),
+            pricing_breakdown_json: "{}".to_owned(),
             inclusive_models_json: "[]".to_owned(),
             initial_context_json: None,
             source_summaries_json: None,
@@ -1291,6 +1292,7 @@ mod tests {
                     &AnalysisRecord {
                         key: pi.key.clone(),
                         model_breakdown_json: "{}".to_owned(),
+                        pricing_breakdown_json: "{}".to_owned(),
                         inclusive_models_json: "[]".to_owned(),
                         initial_context_json: None,
                         source_summaries_json: None,

--- a/apps/desktop/src-tauri/src/provider_usage/allocation.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/allocation.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use antiburn_local::analysis::{ProviderHint, lookup_pricing};
+use antiburn_local::analysis::{ProviderHint, lookup_turn_pricing};
 use antiburn_local::pricing::{
     ModelPricing, ModelTokens, calc::calculate_cache_write_cost, canonical_model_key,
 };
@@ -169,9 +169,11 @@ fn weighted_turns(rows: Vec<SessionUsageRecord>) -> Vec<WeightedTurn> {
             }) else {
                 continue;
             };
+            let pricing_key =
+                antiburn_local::analysis::turn_pricing_key(model, row.speed.as_deref());
             let rates = pricing
-                .entry(model.to_string())
-                .or_insert_with(|| lookup_pricing(model));
+                .entry(pricing_key)
+                .or_insert_with(|| lookup_turn_pricing(model, row.speed.as_deref()));
             let price_weight = rates.as_ref().map(|rates| {
                 tokens.input_tokens as f64 * rates.input_cost_per_token
                     + tokens.output_tokens as f64 * rates.output_cost_per_token

--- a/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
@@ -33,6 +33,7 @@ fn turn(session: &str, at: i64, tokens: u64, accounts: &[&str]) -> SessionUsageR
         turns: vec![SessionUsageTurnRecord {
             ts_ms: Some(at * 1_000),
             model: Some(MODEL.to_string()),
+            speed: None,
             input_tokens: tokens,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
@@ -134,6 +135,29 @@ fn sessions_divide_the_share_by_priced_turn_weight() {
         .collect();
     assert!((shares["one"] - 20.0).abs() < 1e-9);
     assert!((shares["two"] - 60.0).abs() < 1e-9);
+}
+
+#[test]
+fn fast_astra_turns_use_the_fast_price_weight() {
+    let mut standard = turn("standard", NOW - 60, 0, &[]);
+    standard.turns[0].model = Some("gpt-6-astra".to_string());
+    standard.turns[0].output_tokens = 1_000_000;
+    let mut fast = turn("fast", NOW - 30, 0, &[]);
+    fast.turns[0].model = Some("gpt-6-astra".to_string());
+    fast.turns[0].speed = Some("fast".to_string());
+    fast.turns[0].output_tokens = 1_000_000;
+
+    let allocations = weekly(
+        &[standard, fast],
+        &live(None, vec![window(SessionLimitMetric::Weekly, 60.0)]),
+    );
+    let shares: HashMap<_, _> = allocations
+        .into_iter()
+        .map(|entry| (entry.session_id, entry.percent))
+        .collect();
+
+    assert!((shares["standard"] - 20.0).abs() < 1e-9);
+    assert!((shares["fast"] - 40.0).abs() < 1e-9);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/provider_usage/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/mod.rs
@@ -32,9 +32,9 @@ pub mod providers;
 #[cfg(test)]
 mod tests;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use antiburn_local::analysis::price_breakdown;
+use antiburn_local::analysis::{price_breakdown, turn_pricing_key};
 use antiburn_local::pricing::ModelTokens;
 use time::{OffsetDateTime, Time, UtcOffset};
 
@@ -168,13 +168,32 @@ impl Membership {
 /// source of flicker.
 #[derive(Debug, Default)]
 struct Bucket {
+    /// Actual model identities supply displayed token totals.
     models: BTreeMap<String, ModelTokens>,
+    /// Catalog pricing keys preserve the observed speed tier.
+    pricing: BTreeMap<String, ModelTokens>,
+    pricing_incomplete: bool,
     session_count: u32,
 }
 
 impl Bucket {
     fn add_tokens(&mut self, model: &str, tokens: &ModelTokens) {
         let entry = self.models.entry(model.to_string()).or_default();
+        entry.input_tokens = entry.input_tokens.saturating_add(tokens.input_tokens);
+        entry.output_tokens = entry.output_tokens.saturating_add(tokens.output_tokens);
+        entry.cache_read_tokens = entry
+            .cache_read_tokens
+            .saturating_add(tokens.cache_read_tokens);
+        entry.cache_creation_tokens = entry
+            .cache_creation_tokens
+            .saturating_add(tokens.cache_creation_tokens);
+        entry.cache_creation_1h_tokens = entry
+            .cache_creation_1h_tokens
+            .saturating_add(tokens.cache_creation_1h_tokens);
+    }
+
+    fn add_pricing_tokens(&mut self, model: &str, tokens: &ModelTokens) {
+        let entry = self.pricing.entry(model.to_string()).or_default();
         entry.input_tokens = entry.input_tokens.saturating_add(tokens.input_tokens);
         entry.output_tokens = entry.output_tokens.saturating_add(tokens.output_tokens);
         entry.cache_read_tokens = entry
@@ -247,7 +266,8 @@ fn price(models: &BTreeMap<String, ModelTokens>) -> Priced {
 
 /// Turn one bucket into its wire shape.
 fn window_of(bucket: &Bucket) -> ProviderUsageWindow {
-    let priced = price(&bucket.models);
+    let mut priced = price(&bucket.pricing);
+    priced.any_unpriced |= bucket.pricing_incomplete;
     let mut window = ProviderUsageWindow {
         session_count: bucket.session_count,
         estimated_usd: priced.any_priced.then_some(priced.usd),
@@ -277,7 +297,8 @@ fn state_of(accumulator: &Accumulator) -> ProviderUsageState {
             ProviderUsageState::Unknown
         };
     }
-    let priced = price(&accumulator.all.models);
+    let mut priced = price(&accumulator.all.pricing);
+    priced.any_unpriced |= accumulator.all.pricing_incomplete;
     if priced.any_unpriced || !priced.any_priced {
         ProviderUsageState::Observed
     } else {
@@ -293,6 +314,17 @@ fn has_tokens(tokens: &ModelTokens) -> bool {
         || tokens.cache_creation_1h_tokens > 0
 }
 
+fn token_totals<'a>(tokens: impl Iterator<Item = &'a ModelTokens>) -> [u128; 5] {
+    tokens.fold([0; 5], |mut totals, tokens| {
+        totals[0] += u128::from(tokens.input_tokens);
+        totals[1] += u128::from(tokens.output_tokens);
+        totals[2] += u128::from(tokens.cache_read_tokens);
+        totals[3] += u128::from(tokens.cache_creation_tokens);
+        totals[4] += u128::from(tokens.cache_creation_1h_tokens);
+        totals
+    })
+}
+
 /// Whether the newest evidence still describes now.
 fn staleness_of(last_activity: Option<i64>, now: i64) -> ProviderUsageStaleness {
     match last_activity {
@@ -306,8 +338,8 @@ fn staleness_of(last_activity: Option<i64>, now: i64) -> ProviderUsageStaleness 
 ///
 /// Unparseable JSON reads as no evidence rather than as an error: a cache row
 /// written by an older build is a state the surface already renders honestly.
-fn breakdown_of(record: &UsageEvidenceRecord) -> BTreeMap<String, ModelTokens> {
-    let Some(json) = record.model_breakdown_json.as_deref() else {
+fn breakdown_json(json: Option<&str>) -> BTreeMap<String, ModelTokens> {
+    let Some(json) = json else {
         return BTreeMap::new();
     };
     serde_json::from_str::<BTreeMap<String, ModelTokens>>(json)
@@ -315,6 +347,14 @@ fn breakdown_of(record: &UsageEvidenceRecord) -> BTreeMap<String, ModelTokens> {
         .into_iter()
         .filter(|(model, _)| !model.trim().is_empty())
         .collect()
+}
+
+fn breakdown_of(record: &UsageEvidenceRecord) -> BTreeMap<String, ModelTokens> {
+    breakdown_json(record.model_breakdown_json.as_deref())
+}
+
+fn pricing_breakdown_of(record: &UsageEvidenceRecord) -> BTreeMap<String, ModelTokens> {
+    breakdown_json(record.pricing_breakdown_json.as_deref())
 }
 
 fn provider_hints_of(record: &UsageEvidenceRecord) -> Vec<ProviderHint> {
@@ -454,6 +494,7 @@ pub fn summarize(
         }
 
         let breakdown = breakdown_of(record);
+        let pricing_breakdown = pricing_breakdown_of(record);
         let hints = provider_hints_of(record);
         let attributed = if breakdown.is_empty() {
             match providers::route_for_agent(&record.agent) {
@@ -484,8 +525,43 @@ pub fn summarize(
         } else {
             attribute(&record.agent, breakdown, &hints)
         };
+        let mut remaining_pricing = pricing_breakdown;
+        let mut pricing_owners: BTreeMap<String, BTreeSet<&str>> = BTreeMap::new();
+        for (provider, attributed) in &attributed {
+            for model in attributed.models.keys() {
+                pricing_owners
+                    .entry(turn_pricing_key(model, None))
+                    .or_default()
+                    .insert(provider);
+                pricing_owners
+                    .entry(turn_pricing_key(model, Some("fast")))
+                    .or_default()
+                    .insert(provider);
+            }
+        }
 
         for (provider, attributed) in attributed {
+            let mut pricing_models = BTreeMap::new();
+            let mut pricing_incomplete = false;
+            let mut keys = BTreeSet::new();
+            for model in attributed.models.keys() {
+                keys.insert(turn_pricing_key(model, None));
+                keys.insert(turn_pricing_key(model, Some("fast")));
+            }
+            for key in keys {
+                if pricing_owners
+                    .get(&key)
+                    .is_some_and(|owners| owners.len() > 1)
+                {
+                    pricing_incomplete |= remaining_pricing.contains_key(&key);
+                    continue;
+                }
+                if let Some(tokens) = remaining_pricing.remove(&key) {
+                    pricing_models.insert(key, tokens);
+                }
+            }
+            pricing_incomplete |=
+                token_totals(attributed.models.values()) != token_totals(pricing_models.values());
             let account_key = account_for(record, provider);
             let accumulator = accumulators.entry((provider, account_key)).or_default();
             accumulator.explicit_provider_detected |= attributed.explicit;
@@ -512,8 +588,12 @@ pub fn summarize(
             }
             for bucket in buckets {
                 bucket.session_count = bucket.session_count.saturating_add(1);
+                bucket.pricing_incomplete |= pricing_incomplete;
                 for (model, tokens) in &attributed.models {
                     bucket.add_tokens(model, tokens);
+                }
+                for (model, tokens) in &pricing_models {
+                    bucket.add_pricing_tokens(model, tokens);
                 }
             }
 
@@ -533,8 +613,12 @@ pub fn summarize(
             }
             for bucket in agent_buckets {
                 bucket.session_count = bucket.session_count.saturating_add(1);
+                bucket.pricing_incomplete |= pricing_incomplete;
                 for (model, tokens) in &attributed.models {
                     bucket.add_tokens(model, tokens);
+                }
+                for (model, tokens) in &pricing_models {
+                    bucket.add_pricing_tokens(model, tokens);
                 }
             }
         }

--- a/apps/desktop/src-tauri/src/provider_usage/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/tests.rs
@@ -37,6 +37,7 @@ fn row(agent: &str, at: i64, models: &[(&str, ModelTokens)]) -> UsageEvidenceRec
         agent: agent.to_string(),
         updated_at_epoch: at,
         model_breakdown_json: Some(serde_json::to_string(&breakdown).unwrap()),
+        pricing_breakdown_json: Some(serde_json::to_string(&breakdown).unwrap()),
         provider_hints_json: None,
         provider_accounts_json: "[]".into(),
     }
@@ -48,6 +49,7 @@ fn unanalyzed(agent: &str, at: i64) -> UsageEvidenceRecord {
         agent: agent.to_string(),
         updated_at_epoch: at,
         model_breakdown_json: None,
+        pricing_breakdown_json: None,
         provider_hints_json: None,
         provider_accounts_json: "[]".into(),
     }
@@ -304,6 +306,67 @@ fn an_explicit_provider_overrides_model_family_inference() {
 }
 
 #[test]
+fn a_model_specific_hint_owns_its_fast_tier_cost() {
+    let mut record = row_with_hints(
+        "pi",
+        NOW - 60,
+        &[("gpt-6-astra", tokens(0, 1_000_000, 0, 0))],
+        &[("openrouter", Some("gpt-6-astra"))],
+    );
+    record.pricing_breakdown_json = Some(
+        serde_json::to_string(&BTreeMap::from([(
+            "gpt-6-astra-fast".to_string(),
+            tokens(0, 1_000_000, 0, 0),
+        )]))
+        .unwrap(),
+    );
+
+    let summary = summarize(&[record], NOW, 0);
+    let openrouter = find(&summary, providers::OPENROUTER);
+
+    assert_eq!(openrouter.state, ProviderUsageState::Estimated);
+    assert!((openrouter.windows.today.estimated_usd.expect("priced") - 100.0).abs() < 1e-9);
+    assert!(
+        summary
+            .providers
+            .iter()
+            .all(|provider| provider.provider != providers::OPENAI)
+    );
+}
+
+#[test]
+fn colliding_fast_key_provider_hints_leave_cost_unavailable() {
+    let mut record = row_with_hints(
+        "pi",
+        NOW - 60,
+        &[
+            ("gpt-6-astra", tokens(0, 500_000, 0, 0)),
+            ("gpt-6-astra-fast", tokens(0, 500_000, 0, 0)),
+        ],
+        &[
+            ("openrouter", Some("gpt-6-astra")),
+            ("openai", Some("gpt-6-astra-fast")),
+        ],
+    );
+    record.pricing_breakdown_json = Some(
+        serde_json::to_string(&BTreeMap::from([(
+            "gpt-6-astra-fast".to_string(),
+            tokens(0, 1_000_000, 0, 0),
+        )]))
+        .unwrap(),
+    );
+
+    let summary = summarize(&[record], NOW, 0);
+
+    for provider in [providers::OPENROUTER, providers::OPENAI] {
+        let usage = find(&summary, provider);
+        assert_eq!(usage.state, ProviderUsageState::Observed);
+        assert_eq!(usage.windows.today.estimated_usd, None);
+        assert!(!usage.windows.today.cost_complete);
+    }
+}
+
+#[test]
 fn an_unknown_explicit_gateway_does_not_fall_through_to_the_model_family() {
     let rows = [row_with_hints(
         "pi",
@@ -496,6 +559,38 @@ fn aggregate_cost_is_incomplete_when_any_provider_window_is_unpriced() {
 }
 
 #[test]
+fn a_missing_pricing_map_keeps_a_mixed_provider_total_incomplete() {
+    let priced = row(
+        "claude-code",
+        NOW,
+        &[(PRICED_MODEL, tokens(1_000_000, 0, 0, 0))],
+    );
+    let mut missing_tier = row(
+        "claude-code",
+        NOW,
+        &[(PRICED_MODEL, tokens(1_000_000, 0, 0, 0))],
+    );
+    missing_tier.pricing_breakdown_json = Some("{}".to_string());
+
+    let summary = summarize(&[priced, missing_tier], NOW, 0);
+    let anthropic = find(&summary, providers::ANTHROPIC);
+
+    assert_eq!(anthropic.state, ProviderUsageState::Observed);
+    assert_eq!(anthropic.windows.today.tokens_in, 2_000_000);
+    assert!(
+        (anthropic
+            .windows
+            .today
+            .estimated_usd
+            .expect("the priced portion")
+            - 5.0)
+            .abs()
+            < 1e-9
+    );
+    assert!(!anthropic.windows.today.cost_complete);
+}
+
+#[test]
 fn a_session_with_no_analysis_yet_is_unknown_rather_than_zero() {
     let rows = [unanalyzed("claude-code", NOW - 60)];
     let summary = summarize(&rows, NOW, 0);
@@ -513,6 +608,7 @@ fn an_unparseable_cache_row_degrades_to_unknown_rather_than_failing() {
         agent: "claude-code".to_string(),
         updated_at_epoch: NOW - 60,
         model_breakdown_json: Some("not json".to_string()),
+        pricing_breakdown_json: Some("not json".to_string()),
         provider_hints_json: None,
         provider_accounts_json: "[]".into(),
     }];

--- a/apps/desktop/src-tauri/src/runtime_pricing.rs
+++ b/apps/desktop/src-tauri/src/runtime_pricing.rs
@@ -583,6 +583,54 @@ mod tests {
     }
 
     #[test]
+    fn astra_fast_mode_keeps_official_rates_for_all_creator_keys() {
+        let catalog = BTreeMap::from([(
+            "openai".to_string(),
+            ModelsDevProvider {
+                models: BTreeMap::from([(
+                    "gpt-6-astra".to_string(),
+                    ModelsDevModel {
+                        last_updated: Some("2026-09-01".to_string()),
+                        cost: Some(ModelsDevCost {
+                            input: Some(10.0),
+                            output: Some(50.0),
+                            cache_read: Some(1.0),
+                            cache_write: Some(12.5),
+                        }),
+                        experimental: Some(ModelsDevExperimental {
+                            modes: BTreeMap::from([(
+                                "fast".to_string(),
+                                ModelsDevMode {
+                                    cost: Some(ModelsDevCost {
+                                        input: Some(20.0),
+                                        output: Some(100.0),
+                                        cache_read: Some(2.0),
+                                        cache_write: Some(25.0),
+                                    }),
+                                },
+                            )]),
+                        }),
+                    },
+                )]),
+            },
+        )]);
+
+        let snapshot = snapshot_from_catalog(catalog, None).expect("build snapshot");
+
+        for key in [
+            "gpt-6-astra-fast",
+            "openai/gpt-6-astra-fast",
+            "openai.gpt-6-astra-fast",
+        ] {
+            let price = &snapshot.models[key];
+            assert_eq!(price.input_cost_per_token, 20e-6);
+            assert_eq!(price.output_cost_per_token, 100e-6);
+            assert_eq!(price.cache_read_cost_per_token, 2e-6);
+            assert_eq!(price.cache_write_cost_per_token, 25e-6);
+        }
+    }
+
+    #[test]
     fn a_single_reseller_price_stays_provider_qualified() {
         let candidates = vec![(
             "reseller".to_string(),

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -43,7 +43,8 @@ use antiburn_local::analysis::{
     delete_source_rows_at_fence, delete_stale_source_resume, delete_turn_rows,
     delete_turn_rows_except_fence, delete_turn_rows_for_fence, insert_coverage_record,
     insert_source_resume, insert_turn_rows, query_coverage_record, query_model_breakdown,
-    query_model_runs, query_source_resume, query_turn_facts, query_turn_rows, restamp_source_rows,
+    query_model_runs, query_pricing_breakdown, query_source_resume, query_turn_facts,
+    query_turn_rows, restamp_source_rows,
 };
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
@@ -1444,13 +1445,15 @@ impl Store {
         transaction.execute(
             "INSERT INTO session_analysis (
                  environment_key, agent, session_id, model_breakdown_json,
+                 pricing_breakdown_json,
                  inclusive_models_json, initial_context_json, source_summaries_json,
                  provider_hints_json,
                  source_fingerprint, pricing_generation, analyzed_generation,
                  parser_revision, analyzer_revision, metrics_schema_revision)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
              ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
                  model_breakdown_json = excluded.model_breakdown_json,
+                 pricing_breakdown_json = excluded.pricing_breakdown_json,
                  inclusive_models_json = excluded.inclusive_models_json,
                  initial_context_json = excluded.initial_context_json,
                  source_summaries_json = excluded.source_summaries_json,
@@ -1466,6 +1469,7 @@ impl Store {
                 record.key.agent,
                 record.key.session_id,
                 record.model_breakdown_json,
+                record.pricing_breakdown_json,
                 record.inclusive_models_json,
                 record.initial_context_json,
                 record.source_summaries_json,
@@ -1802,13 +1806,15 @@ impl Store {
         transaction.execute(
             "INSERT INTO session_analysis (
                  environment_key, agent, session_id, model_breakdown_json,
+                 pricing_breakdown_json,
                  inclusive_models_json, initial_context_json, source_summaries_json,
                  provider_hints_json,
                  source_fingerprint, pricing_generation, analyzed_generation,
                  parser_revision, analyzer_revision, metrics_schema_revision)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
              ON CONFLICT(environment_key, agent, session_id) DO UPDATE SET
                  model_breakdown_json = excluded.model_breakdown_json,
+                 pricing_breakdown_json = excluded.pricing_breakdown_json,
                  inclusive_models_json = excluded.inclusive_models_json,
                  initial_context_json = excluded.initial_context_json,
                  source_summaries_json = excluded.source_summaries_json,
@@ -1824,6 +1830,7 @@ impl Store {
                 record.key.agent,
                 record.key.session_id,
                 record.model_breakdown_json,
+                record.pricing_breakdown_json,
                 record.inclusive_models_json,
                 record.initial_context_json,
                 record.source_summaries_json,
@@ -1857,6 +1864,7 @@ impl Store {
         let connection = self.lock();
         let mut statement = connection.prepare(
             "SELECT environment_key, agent, session_id, model_breakdown_json,
+                    pricing_breakdown_json,
                     inclusive_models_json, initial_context_json, source_summaries_json,
                     provider_hints_json,
                     source_fingerprint, pricing_generation, analyzed_generation,
@@ -1875,16 +1883,17 @@ impl Store {
                             row.get::<_, String>(2)?,
                         ),
                         model_breakdown_json: row.get(3)?,
-                        inclusive_models_json: row.get(4)?,
-                        initial_context_json: row.get(5)?,
-                        source_summaries_json: row.get(6)?,
-                        provider_hints_json: row.get(7)?,
-                        source_fingerprint: row.get(8)?,
-                        pricing_generation: row.get(9)?,
-                        analyzed_generation: row.get(10)?,
-                        parser_revision: row.get(11)?,
-                        analyzer_revision: row.get(12)?,
-                        metrics_schema_revision: row.get(13)?,
+                        pricing_breakdown_json: row.get(4)?,
+                        inclusive_models_json: row.get(5)?,
+                        initial_context_json: row.get(6)?,
+                        source_summaries_json: row.get(7)?,
+                        provider_hints_json: row.get(8)?,
+                        source_fingerprint: row.get(9)?,
+                        pricing_generation: row.get(10)?,
+                        analyzed_generation: row.get(11)?,
+                        parser_revision: row.get(12)?,
+                        analyzer_revision: row.get(13)?,
+                        metrics_schema_revision: row.get(14)?,
                     })
                 },
             )
@@ -1905,7 +1914,7 @@ impl Store {
         let connection = self.lock();
         let mut statement = connection.prepare(
             "SELECT s.agent, COALESCE(s.updated_at_epoch, 0), a.model_breakdown_json,
-                    a.provider_hints_json,
+                    a.pricing_breakdown_json, a.provider_hints_json,
                     COALESCE((
                         SELECT json_group_array(json_object(
                             'provider', spa.provider,
@@ -1929,8 +1938,9 @@ impl Store {
                 agent: row.get(0)?,
                 updated_at_epoch: row.get(1)?,
                 model_breakdown_json: row.get(2)?,
-                provider_hints_json: row.get(3)?,
-                provider_accounts_json: row.get(4)?,
+                pricing_breakdown_json: row.get(3)?,
+                provider_hints_json: row.get(4)?,
+                provider_accounts_json: row.get(5)?,
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
@@ -1994,7 +2004,7 @@ impl Store {
             .collect();
         let mut statement = connection.prepare(
             "SELECT t.environment_key, t.agent, t.session_id,
-                    t.ts_ms, t.model, t.input_tokens, t.cache_read_tokens,
+                    t.ts_ms, t.model, t.speed, t.input_tokens, t.cache_read_tokens,
                     t.cache_write_tokens, t.output_tokens
                FROM turn t
                JOIN session_evidence e
@@ -2019,10 +2029,11 @@ impl Store {
             sessions[index].turns.push(SessionUsageTurnRecord {
                 ts_ms: row.get(3)?,
                 model: row.get(4)?,
-                input_tokens: row.get(5)?,
-                cache_read_tokens: row.get(6)?,
-                cache_write_tokens: row.get(7)?,
-                output_tokens: row.get(8)?,
+                speed: row.get(5)?,
+                input_tokens: row.get(6)?,
+                cache_read_tokens: row.get(7)?,
+                cache_write_tokens: row.get(8)?,
+                output_tokens: row.get(9)?,
             });
         }
         Ok(sessions)
@@ -3201,6 +3212,22 @@ impl TurnRowStore for FencedTurnRowStore {
         let resumed = self.resumed_sources();
         let scope = self.fact_query_scope(&connection, &resumed)?;
         Ok(query_model_runs(
+            &connection,
+            &turn_session_key(&self.key),
+            &scope,
+        )?)
+    }
+
+    fn query_pricing_breakdown(
+        &self,
+    ) -> Result<
+        std::collections::BTreeMap<String, antiburn_local::pricing::ModelTokens>,
+        TurnRowError,
+    > {
+        let connection = self.store.lock();
+        let resumed = self.resumed_sources();
+        let scope = self.fact_query_scope(&connection, &resumed)?;
+        Ok(query_pricing_breakdown(
             &connection,
             &turn_session_key(&self.key),
             &scope,

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -128,6 +128,8 @@ pub struct AnalysisRecord {
     pub key: SessionKey,
     /// Billable tokens per normalized model key, as camelCase JSON.
     pub model_breakdown_json: String,
+    /// This JSON groups billable tokens by the catalog key for each observed speed tier.
+    pub pricing_breakdown_json: String,
     /// This JSON array puts parent model runs before sub-agent-only runs.
     pub inclusive_models_json: String,
     /// Serialized `InitialContextBreakdown`. `None` until an analysis pass
@@ -325,6 +327,8 @@ pub struct UsageEvidenceRecord {
     /// Billable tokens per normalized model key, or `None` when the session has
     /// not been analyzed. Absence is "we do not know yet", never "zero".
     pub model_breakdown_json: Option<String>,
+    /// This value contains speed-aware billable tokens after a current analysis pass.
+    pub pricing_breakdown_json: Option<String>,
     /// Bounded provider hints, or `None` when analysis has not observed them.
     pub provider_hints_json: Option<String>,
     /// Opaque account observations keyed by canonical provider.
@@ -346,6 +350,7 @@ pub struct SessionUsageRecord {
 pub struct SessionUsageTurnRecord {
     pub ts_ms: Option<i64>,
     pub model: Option<String>,
+    pub speed: Option<String>,
     pub input_tokens: u64,
     pub cache_read_tokens: u64,
     pub cache_write_tokens: u64,

--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -43,6 +43,7 @@ fn projection_record(key: SessionKey, fingerprint: &str, generation: i64) -> Ana
     AnalysisRecord {
         key,
         model_breakdown_json: "{}".into(),
+        pricing_breakdown_json: "{}".into(),
         inclusive_models_json: "[]".into(),
         initial_context_json: None,
         source_summaries_json: None,

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -12,7 +12,7 @@
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
     V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,
-    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33,
+    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -606,3 +606,10 @@ const V32: &str = antiburn_local::analysis::TURN_SCHEMA_V5_SQL;
 /// same reason [`V15`] re-exports `TURN_SCHEMA_SQL` instead of stating its
 /// own DDL.
 const V33: &str = antiburn_local::analysis::TURN_SCHEMA_V6_SQL;
+
+/// v34 stores speed-aware pricing keys apart from model identities.
+const V34: &str = r#"
+ALTER TABLE session_analysis
+ADD COLUMN pricing_breakdown_json TEXT NOT NULL DEFAULT '{}';
+DELETE FROM session_analysis;
+"#;

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -313,38 +313,6 @@ fn session_analysis_holds_the_cache_values_and_the_projection_revisions() {
 }
 
 #[test]
-fn pricing_breakdown_migration_invalidates_old_analysis() {
-    let connection = rusqlite::Connection::open_in_memory().unwrap();
-    for &sql in &super::schema::MIGRATIONS[..23] {
-        connection.execute_batch(sql).unwrap();
-    }
-    connection
-        .execute(
-            "INSERT INTO session_analysis (
-                 environment_key, agent, session_id, model_breakdown_json,
-                 inclusive_models_json, source_fingerprint, pricing_generation,
-                 analyzed_generation, parser_revision, analyzer_revision,
-                 metrics_schema_revision)
-             VALUES ('native', 'pi', 'legacy', '{}', '[]', 'sv1:legacy', 1, 1, 1, 1, 3)",
-            [],
-        )
-        .unwrap();
-    connection.pragma_update(None, "user_version", 23).unwrap();
-
-    let store = Store::from_connection(
-        connection,
-        Path::new("/tmp/antiburn-provider-hints-migration-test").to_path_buf(),
-    )
-    .expect("V24 migrates the prior schema");
-    let analysis = store
-        .analysis(&SessionKey::new("native", "pi", "legacy"))
-        .unwrap();
-
-    assert_eq!(store.schema_version().unwrap(), 34);
-    assert!(analysis.is_none());
-}
-
-#[test]
 fn account_observation_migration_initializes_the_latest_timestamp() {
     let connection = rusqlite::Connection::open_in_memory().unwrap();
     for &sql in &super::schema::MIGRATIONS[..26] {

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -52,6 +52,7 @@ fn projection_record(key: SessionKey, fingerprint: &str, generation: i64) -> Ana
     AnalysisRecord {
         key,
         model_breakdown_json: "{}".into(),
+        pricing_breakdown_json: "{}".into(),
         inclusive_models_json: "[]".into(),
         initial_context_json: None,
         source_summaries_json: None,
@@ -306,12 +307,13 @@ fn session_analysis_holds_the_cache_values_and_the_projection_revisions() {
             "initial_context_json",
             "source_summaries_json",
             "provider_hints_json",
+            "pricing_breakdown_json",
         ]
     );
 }
 
 #[test]
-fn provider_hints_migration_keeps_old_analysis_unknown() {
+fn pricing_breakdown_migration_invalidates_old_analysis() {
     let connection = rusqlite::Connection::open_in_memory().unwrap();
     for &sql in &super::schema::MIGRATIONS[..23] {
         connection.execute_batch(sql).unwrap();
@@ -336,11 +338,10 @@ fn provider_hints_migration_keeps_old_analysis_unknown() {
     .expect("V24 migrates the prior schema");
     let analysis = store
         .analysis(&SessionKey::new("native", "pi", "legacy"))
-        .unwrap()
-        .expect("legacy analysis survives");
+        .unwrap();
 
-    assert_eq!(store.schema_version().unwrap(), 33);
-    assert_eq!(analysis.provider_hints_json, None);
+    assert_eq!(store.schema_version().unwrap(), 34);
+    assert!(analysis.is_none());
 }
 
 #[test]
@@ -841,6 +842,7 @@ fn clearing_local_data_forgets_session_records_and_keeps_the_readers_choices() {
             &AnalysisRecord {
                 key: SessionKey::new("native", "claude-code", "abc"),
                 model_breakdown_json: "{}".into(),
+                pricing_breakdown_json: "{}".into(),
                 inclusive_models_json: "[]".into(),
                 initial_context_json: None,
                 source_summaries_json: None,
@@ -1070,6 +1072,7 @@ fn session_retention_removes_all_derived_session_data() {
             &AnalysisRecord {
                 key: key.clone(),
                 model_breakdown_json: "{}".into(),
+                pricing_breakdown_json: "{}".into(),
                 inclusive_models_json: "[]".into(),
                 initial_context_json: None,
                 source_summaries_json: None,
@@ -1556,6 +1559,7 @@ fn analysis_round_trips_and_is_replaced_rather_than_duplicated() {
     let record = AnalysisRecord {
         key: key.clone(),
         model_breakdown_json: r#"{"claude-opus-4-6":{"inputTokens":10}}"#.into(),
+        pricing_breakdown_json: r#"{"claude-opus-4-6":{"inputTokens":10}}"#.into(),
         inclusive_models_json:
             r#"[{"model":"claude-haiku-4-5"},{"model":"claude-opus-4-6","thinkingMode":"high"}]"#
                 .into(),
@@ -1794,6 +1798,7 @@ fn deleting_a_session_takes_its_derived_records_with_it() {
             &AnalysisRecord {
                 key: key.clone(),
                 model_breakdown_json: "{}".into(),
+                pricing_breakdown_json: "{}".into(),
                 inclusive_models_json: "[]".into(),
                 initial_context_json: None,
                 source_summaries_json: None,
@@ -1939,6 +1944,7 @@ fn usage_evidence_joins_the_analysis_and_keeps_sessions_that_have_none() {
             &AnalysisRecord {
                 key: SessionKey::new("native", "claude-code", "analyzed"),
                 model_breakdown_json: r#"{"claude-opus-4-6":{"input_tokens":10}}"#.into(),
+                pricing_breakdown_json: r#"{"claude-opus-4-6":{"input_tokens":10}}"#.into(),
                 inclusive_models_json: r#"[{"model":"claude-opus-4-6","thinkingMode":"high"}]"#
                     .into(),
                 initial_context_json: None,
@@ -2862,6 +2868,7 @@ fn a_catalog_change_requeues_no_session_evidence() {
             &AnalysisRecord {
                 key: record.key.clone(),
                 model_breakdown_json: "{}".into(),
+                pricing_breakdown_json: "{}".into(),
                 inclusive_models_json: "[]".into(),
                 initial_context_json: None,
                 source_summaries_json: None,

--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -29,8 +29,8 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
             parser_revision: 25,
-            analyzer_revision: 17,
-            metrics_schema_revision: 6,
+            analyzer_revision: 18,
+            metrics_schema_revision: 7,
             evidence_schema_revision: 13,
         }
     );

--- a/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
@@ -11,10 +11,10 @@ use super::*;
 #[test]
 fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pin the count so each new migration requires an explicit test update.
-    assert_eq!(super::schema::MIGRATIONS.len(), 33);
+    assert_eq!(super::schema::MIGRATIONS.len(), 34);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 33);
+    assert_eq!(store.schema_version().unwrap(), 34);
     let index_exists = store
         .lock()
         .query_row(

--- a/apps/desktop/src/lib/types/session.ts
+++ b/apps/desktop/src/lib/types/session.ts
@@ -198,6 +198,8 @@ export interface SessionMetrics {
   billableCacheReadTokens?: number
   billableCacheCreationTokens?: number
   modelBreakdown?: Record<string, ModelTokens>
+  /** This map groups billable tokens by the pricing key for the observed speed tier. */
+  pricingBreakdown?: Record<string, ModelTokens>
   cost?: SessionCostComponents | null
   efficiency?: SessionEfficiency
 }

--- a/crates/antiburn-local/src/analysis/efficiency.rs
+++ b/crates/antiburn-local/src/analysis/efficiency.rs
@@ -23,7 +23,9 @@ use std::mem::size_of;
 use serde::{Deserialize, Serialize};
 
 use crate::analysis::model::{EventSource, NormalizedEvent, Role, Usage};
-use crate::analysis::pricing::{lookup_pricing, strip_window_tag};
+#[cfg(test)]
+use crate::analysis::pricing::lookup_pricing;
+use crate::analysis::pricing::{lookup_turn_pricing, strip_window_tag};
 use crate::pricing::ModelPricing;
 
 /// Open message state covers heavily interleaved parent and sidechain records.
@@ -97,8 +99,10 @@ fn hash_bytes(bytes: &[u8], seed: u64) -> u64 {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 enum ModelStatus {
     Missing,
-    Priced(ModelPricing),
-    Unpriced,
+    Known {
+        standard: Option<ModelPricing>,
+        fast: Option<ModelPricing>,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -109,6 +113,7 @@ struct Turn {
     id: Option<MessageKey>,
     source: EventSource,
     model: ModelStatus,
+    fast: bool,
     usage: Usage,
 }
 
@@ -120,6 +125,7 @@ pub(crate) struct EfficiencyInput<'a> {
     pub(crate) source: EventSource,
     pub(crate) message_id: Option<&'a str>,
     pub(crate) model: Option<&'a str>,
+    pub(crate) speed: Option<&'a str>,
     pub(crate) usage: Usage,
 }
 
@@ -157,7 +163,7 @@ pub(crate) struct EfficiencyReducer {
     evicted: VecDeque<MessageKey>,
     reorder: Vec<Turn>,
     totals: EfficiencyTotals,
-    fallback_overflow: FallbackOverflow,
+    fallback_overflow: [FallbackOverflow; 2],
     rewrite_marks: Vec<RewriteMark>,
     previous_context: Option<u64>,
     previous_parent_context: Option<u64>,
@@ -175,7 +181,7 @@ impl Default for EfficiencyReducer {
             evicted: VecDeque::new(),
             reorder: Vec::new(),
             totals: EfficiencyTotals::default(),
-            fallback_overflow: FallbackOverflow::default(),
+            fallback_overflow: [FallbackOverflow::default(); 2],
             rewrite_marks: Vec::new(),
             previous_context: None,
             previous_parent_context: None,
@@ -204,9 +210,10 @@ impl EfficiencyReducer {
         }) {
             let turn = &mut self.open[index];
             turn.usage = turn.usage.saturating_add(input.usage);
-            if matches!(turn.model, ModelStatus::Missing) {
+            if matches!(turn.model, ModelStatus::Missing) && input.model.is_some() {
                 turn.model = model_status(input.model);
             }
+            turn.fast |= is_fast(input.speed);
             return;
         }
         // A message that returns after its turn was evicted splits its usage
@@ -237,6 +244,7 @@ impl EfficiencyReducer {
             id: message_key,
             source: input.source,
             model: model_status(input.model),
+            fast: is_fast(input.speed),
             usage: input.usage,
         });
         self.creation = self.creation.saturating_add(1);
@@ -295,15 +303,18 @@ impl EfficiencyReducer {
         match turn.model {
             // The session fallback model prices a missing-model turn later,
             // at finish. Until then, only its raw usage can be kept.
-            ModelStatus::Missing => {
-                add_fallback_overflow(&mut self.fallback_overflow, turn.usage, growth)
-            }
-            ModelStatus::Priced(price) => {
-                let amounts = priced_contribution(turn.usage, growth, &price);
-                add_priced(&mut self.totals, amounts, 1);
-            }
-            ModelStatus::Unpriced => {
-                self.totals.unpriced_turns = self.totals.unpriced_turns.saturating_add(1);
+            ModelStatus::Missing => add_fallback_overflow(
+                &mut self.fallback_overflow[usize::from(turn.fast)],
+                turn.usage,
+                growth,
+            ),
+            ModelStatus::Known { standard, fast } => {
+                if let Some(price) = if turn.fast { fast } else { standard } {
+                    let amounts = priced_contribution(turn.usage, growth, &price);
+                    add_priced(&mut self.totals, amounts, 1);
+                } else {
+                    self.totals.unpriced_turns = self.totals.unpriced_turns.saturating_add(1);
+                }
             }
         }
     }
@@ -321,8 +332,10 @@ impl EfficiencyReducer {
 
     pub(crate) fn finish(mut self, fallback_model: Option<&str>) -> EfficiencyTotals {
         self.flush();
-        let fallback = model_status(fallback_model);
-        apply_fallback_overflow(&mut self.totals, self.fallback_overflow, &fallback);
+        for (fast, contribution) in self.fallback_overflow.into_iter().enumerate() {
+            let fallback = model_status(fallback_model);
+            apply_fallback_overflow(&mut self.totals, contribution, &fallback, fast == 1);
+        }
         self.totals
     }
 
@@ -349,15 +362,25 @@ impl EfficiencyReducer {
     }
 }
 
+fn is_fast(speed: Option<&str>) -> bool {
+    speed.is_some_and(|speed| speed.trim().eq_ignore_ascii_case("fast"))
+}
+
 fn model_status(model: Option<&str>) -> ModelStatus {
     let Some(model) = model else {
         return ModelStatus::Missing;
     };
     let model = strip_window_tag(model).trim();
     if model.is_empty() {
-        return ModelStatus::Unpriced;
+        return ModelStatus::Known {
+            standard: None,
+            fast: None,
+        };
     }
-    lookup_pricing(model).map_or(ModelStatus::Unpriced, ModelStatus::Priced)
+    ModelStatus::Known {
+        standard: lookup_turn_pricing(model, None),
+        fast: lookup_turn_pricing(model, Some("fast")),
+    }
 }
 
 fn priced_contribution(usage: Usage, growth: u64, price: &ModelPricing) -> PricedAmounts {
@@ -441,8 +464,17 @@ fn apply_fallback_overflow(
     totals: &mut EfficiencyTotals,
     contribution: FallbackOverflow,
     fallback: &ModelStatus,
+    fast: bool,
 ) {
-    let ModelStatus::Priced(price) = fallback else {
+    let ModelStatus::Known {
+        standard,
+        fast: fast_price,
+    } = fallback
+    else {
+        totals.unpriced_turns = totals.unpriced_turns.saturating_add(contribution.turns);
+        return;
+    };
+    let Some(price) = (if fast { fast_price } else { standard }) else {
         totals.unpriced_turns = totals.unpriced_turns.saturating_add(contribution.turns);
         return;
     };
@@ -485,6 +517,7 @@ pub fn thread_efficiency(
                 source: event.source,
                 message_id: event.message_id.as_deref(),
                 model: event.model.as_deref(),
+                speed: event.speed.as_deref(),
                 usage: event.usage,
             }),
         fallback_model,
@@ -720,6 +753,22 @@ mod tests {
     }
 
     #[test]
+    fn one_fast_fragment_prices_the_whole_message_as_fast() {
+        let mut first = turn(1, 0, 500_000, 0, 0);
+        first.model = Some("gpt-6-astra".to_string());
+        first.message_id = Some("message".to_string());
+        first.speed = Some("fast".to_string());
+        let mut tail = turn(2, 0, 500_000, 0, 0);
+        tail.model = Some("gpt-6-astra".to_string());
+        tail.message_id = Some("message".to_string());
+
+        let totals = thread_efficiency(&[first, tail], None);
+
+        assert_eq!(totals.priced_turns, 1);
+        assert!((totals.total_usd - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
     fn non_assistant_records_advance_the_carried_timestamp() {
         let first = turn(10, 100, 10, 0, 0);
         let mut user = NormalizedEvent::new(Role::User);
@@ -804,6 +853,7 @@ mod tests {
                 source: EventSource::Parent,
                 message_id: Some(&message_id),
                 model: Some(MODEL),
+                speed: None,
                 usage: Usage {
                     input_tokens: 1,
                     output_tokens: 1,
@@ -884,6 +934,7 @@ mod tests {
                 source: event.source,
                 message_id: event.message_id.as_deref(),
                 model: event.model.as_deref(),
+                speed: event.speed.as_deref(),
                 usage: event.usage,
             });
         }

--- a/crates/antiburn-local/src/analysis/engine.rs
+++ b/crates/antiburn-local/src/analysis/engine.rs
@@ -205,6 +205,10 @@ pub struct SessionMetrics {
     /// single-model breakdown after analysis.
     #[serde(default)]
     pub model_breakdown: HashMap<String, ModelTokens>,
+    /// This map retains billable tokens per catalog pricing key. Fast turns use
+    /// their `-fast` key while `model_breakdown` keeps the model identity.
+    #[serde(default)]
+    pub pricing_breakdown: HashMap<String, ModelTokens>,
     /// On-device cost estimate (`~$`), or `None` when `model` is unknown/unpriceable.
     #[serde(default)]
     pub cost: Option<SessionCost>,

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -1007,7 +1007,7 @@ mod tests {
             "coverage": coverage,
             "provenance": {
                 "parserRevision": 25,
-                "analyzerRevision": 17,
+                "analyzerRevision": 18,
                 "evidenceSchemaRevision": 13,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",

--- a/crates/antiburn-local/src/analysis/evidence_query.rs
+++ b/crates/antiburn-local/src/analysis/evidence_query.rs
@@ -634,6 +634,50 @@ pub fn query_model_breakdown(
     Ok(breakdown)
 }
 
+const PRICING_BREAKDOWN_SQL: &str = "SELECT model, speed, input_tokens, output_tokens,
+        cache_read_tokens, cache_write_tokens
+   FROM turn
+  WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND (claim_fence = ?4 OR (claim_fence = ?5 AND source_key IN (SELECT value FROM json_each(?6))))
+    AND role = 'assistant' AND model IS NOT NULL
+    AND (input_tokens != 0 OR output_tokens != 0
+         OR cache_read_tokens != 0 OR cache_write_tokens != 0)";
+
+/// Return billable token totals grouped by the exact catalog pricing tier.
+pub fn query_pricing_breakdown(
+    conn: &Connection,
+    key: &TurnSessionKey<'_>,
+    scope: &FenceScope<'_>,
+) -> rusqlite::Result<BTreeMap<String, crate::pricing::ModelTokens>> {
+    let (claim_fence, published_fence, source_keys_json) = scope_bind_values(scope);
+    let mut statement = conn.prepare(PRICING_BREAKDOWN_SQL)?;
+    let mut rows = statement.query(params![
+        key.environment_key,
+        key.agent,
+        key.session_id,
+        claim_fence,
+        published_fence,
+        source_keys_json
+    ])?;
+    let mut breakdown: BTreeMap<String, crate::pricing::ModelTokens> = BTreeMap::new();
+    while let Some(row) = rows.next()? {
+        let model: String = row.get(0)?;
+        let speed: Option<String> = row.get(1)?;
+        let model = strip_window_tag(&model).trim();
+        if model.is_empty() {
+            continue;
+        }
+        let key = crate::analysis::pricing::turn_pricing_key(model, speed.as_deref());
+        let entry = breakdown.entry(key).or_default();
+        entry.input_tokens = entry.input_tokens.saturating_add(as_u64(row.get(2)?));
+        entry.output_tokens = entry.output_tokens.saturating_add(as_u64(row.get(3)?));
+        entry.cache_read_tokens = entry.cache_read_tokens.saturating_add(as_u64(row.get(4)?));
+        entry.cache_creation_tokens = entry
+            .cache_creation_tokens
+            .saturating_add(as_u64(row.get(5)?));
+    }
+    Ok(breakdown)
+}
+
 const MODEL_RUNS_SQL: &str = "SELECT source_key, model, effort
    FROM turn
   WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND (claim_fence = ?4 OR (claim_fence = ?5 AND source_key IN (SELECT value FROM json_each(?6))))

--- a/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
@@ -138,6 +138,8 @@ pub struct SessionMetricsAccumulator {
     skill_match_counts: Vec<(String, u32)>,
     model_breakdown: Vec<(NameId, ModelTokens)>,
     unattributed_model_tokens: ModelTokens,
+    pricing_breakdown: Vec<((NameId, bool), ModelTokens)>,
+    unattributed_pricing_tokens: [ModelTokens; 2],
     model_runs: Vec<ModelRunMark>,
     last_effective_ts: i64,
     folded_last_ts: Option<i64>,
@@ -185,6 +187,8 @@ impl SessionMetricsAccumulator {
             skill_match_counts: Vec::new(),
             model_breakdown: Vec::new(),
             unattributed_model_tokens: ModelTokens::default(),
+            pricing_breakdown: Vec::new(),
+            unattributed_pricing_tokens: std::array::from_fn(|_| ModelTokens::default()),
             model_runs: Vec::new(),
             last_effective_ts: i64::MIN,
             folded_last_ts: None,
@@ -311,6 +315,11 @@ impl SessionMetricsAccumulator {
                     .saturating_mul(size_of::<(NameId, ModelTokens)>()),
             )
             .saturating_add(
+                self.pricing_breakdown
+                    .capacity()
+                    .saturating_mul(size_of::<((NameId, bool), ModelTokens)>()),
+            )
+            .saturating_add(
                 self.model_runs
                     .capacity()
                     .saturating_mul(size_of::<ModelRunMark>()),
@@ -367,6 +376,7 @@ impl SessionMetricsAccumulator {
             source: event.source,
             message_id: event.message_id.as_deref(),
             model: event.model.as_deref(),
+            speed: event.speed.as_deref(),
             usage: event.usage,
         });
         let mut slot = SlotAggregate::new(ordinal, effective_ts);
@@ -693,8 +703,16 @@ impl SessionMetricsAccumulator {
                 tracing::debug!(event = "metrics_model_runs_capped");
             }
         }
+        let fast = event
+            .speed
+            .as_deref()
+            .is_some_and(|speed| speed.trim().eq_ignore_ascii_case("fast"));
         let Some(model) = model else {
             add_usage(&mut self.unattributed_model_tokens, usage);
+            add_usage(
+                &mut self.unattributed_pricing_tokens[usize::from(fast)],
+                usage,
+            );
             return;
         };
         if let Some((_, tokens)) = self
@@ -709,8 +727,24 @@ impl SessionMetricsAccumulator {
             self.model_breakdown.push((model, tokens));
         } else {
             add_usage(&mut self.unattributed_model_tokens, usage);
+            add_usage(
+                &mut self.unattributed_pricing_tokens[usize::from(fast)],
+                usage,
+            );
             self.models_truncated = self.models_truncated.saturating_add(1);
             tracing::debug!(event = "metrics_model_breakdown_capped");
+            return;
+        }
+        if let Some((_, tokens)) = self
+            .pricing_breakdown
+            .iter_mut()
+            .find(|(current, _)| *current == (model, fast))
+        {
+            add_usage(tokens, usage);
+        } else {
+            let mut tokens = ModelTokens::default();
+            add_usage(&mut tokens, usage);
+            self.pricing_breakdown.push(((model, fast), tokens));
         }
     }
 
@@ -971,7 +1005,8 @@ impl SessionMetricsAccumulator {
             .collect::<Vec<_>>();
 
         let mut model_breakdown = self.model_breakdown_map(summary.model.as_deref());
-        let cost = crate::analysis::pricing::price_breakdown(&model_breakdown);
+        let mut pricing_breakdown = self.pricing_breakdown_map(summary.model.as_deref());
+        let cost = crate::analysis::pricing::price_breakdown(&pricing_breakdown);
         let model_runs = self.model_runs(summary.model.as_deref());
         let tool_calls_by_name = count_map(&self.tool_calls_by_name, &self.interner);
         let mcp_tool_calls = count_map(&self.mcp_tool_calls, &self.mcp_interner);
@@ -991,6 +1026,9 @@ impl SessionMetricsAccumulator {
         };
         if model_breakdown.is_empty() {
             model_breakdown.shrink_to_fit();
+        }
+        if pricing_breakdown.is_empty() {
+            pricing_breakdown.shrink_to_fit();
         }
 
         SessionMetrics {
@@ -1016,6 +1054,7 @@ impl SessionMetricsAccumulator {
             billable_cache_read_tokens: self.tallies.billable_cache_read_tokens,
             billable_cache_creation_tokens: self.tallies.billable_cache_creation_tokens,
             model_breakdown,
+            pricing_breakdown,
             cost,
             efficiency: self.efficiency.clone().finish(summary.model.as_deref()),
             skill_uses,
@@ -1039,6 +1078,31 @@ impl SessionMetricsAccumulator {
                 result.entry(model.to_string()).or_default(),
                 &self.unattributed_model_tokens,
             );
+        }
+        result
+    }
+
+    fn pricing_breakdown_map(&self, fallback: Option<&str>) -> HashMap<String, ModelTokens> {
+        let mut result = HashMap::new();
+        for ((model, fast), tokens) in &self.pricing_breakdown {
+            let model = self.model_interner.get(*model);
+            let key = crate::analysis::pricing::turn_pricing_key(model, fast.then_some("fast"));
+            add_model_tokens(result.entry(key).or_default(), tokens);
+        }
+        if let Some(model) = fallback
+            .map(crate::analysis::pricing::strip_window_tag)
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+        {
+            for (fast, tokens) in self.unattributed_pricing_tokens.iter().enumerate() {
+                if has_model_tokens(tokens) {
+                    let key = crate::analysis::pricing::turn_pricing_key(
+                        model,
+                        (fast == 1).then_some("fast"),
+                    );
+                    add_model_tokens(result.entry(key).or_default(), tokens);
+                }
+            }
         }
         result
     }
@@ -1577,6 +1641,7 @@ pub fn merge_metrics(
         .summary
         .as_ref()
         .and_then(|summary| summary.model.as_deref());
+    let mut pricing_complete = true;
     let mut merged_runs = Vec::new();
     collect_merged_runs(
         &mut merged_runs,
@@ -1696,6 +1761,20 @@ pub fn merge_metrics(
                 );
             }
         }
+        for (model, tokens) in subagent.pricing_breakdown_map(parent_fallback) {
+            if !pricing_complete {
+                continue;
+            }
+            if merged.pricing_breakdown.len() < MAX_MODELS.saturating_mul(2)
+                || merged.pricing_breakdown.contains_key(&model)
+            {
+                add_model_tokens(merged.pricing_breakdown.entry(model).or_default(), &tokens);
+            } else {
+                merged.pricing_breakdown.clear();
+                pricing_complete = false;
+                tracing::debug!(event = "metrics_pricing_breakdown_capped");
+            }
+        }
     }
     if !subagents.is_empty() {
         merged_runs.sort_by_key(|(position, stream_index, ordinal, _)| {
@@ -1714,7 +1793,9 @@ pub fn merge_metrics(
     merged
         .skill_uses
         .sort_by(|left, right| left.progress.total_cmp(&right.progress));
-    merged.cost = crate::analysis::pricing::price_breakdown(&merged.model_breakdown);
+    merged.cost = pricing_complete
+        .then(|| crate::analysis::pricing::price_breakdown(&merged.pricing_breakdown))
+        .flatten();
     merged
 }
 

--- a/crates/antiburn-local/src/analysis/metrics_sink/reference.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/reference.rs
@@ -10,7 +10,7 @@ use crate::analysis::model::{
     CompactionTrigger, EventSource, ModelRun, NormalizedEvent, Role, ToolCall, Usage,
     is_subagent_launch_tool,
 };
-use crate::analysis::pricing::{lookup_pricing, strip_window_tag};
+use crate::analysis::pricing::{lookup_turn_pricing, strip_window_tag, turn_pricing_key};
 use crate::pricing::ModelTokens;
 
 const CONTEXT_WINDOW_TIERS: [u64; 2] = [200_000, 1_000_000];
@@ -482,6 +482,7 @@ struct ReferenceEfficiencyTurn<'a> {
     ts: i64,
     source: EventSource,
     model: Option<&'a str>,
+    speed: Option<&'a str>,
     usage: Usage,
 }
 
@@ -547,6 +548,9 @@ fn reference_efficiency(
             if current.model.is_none() {
                 current.model = event.model.as_deref();
             }
+            if event.speed.is_some() {
+                current.speed = event.speed.as_deref();
+            }
             continue;
         }
         if let Some(id) = event.message_id.as_deref() {
@@ -557,6 +561,7 @@ fn reference_efficiency(
             ts: last_ts,
             source: *source,
             model: event.model.as_deref(),
+            speed: event.speed.as_deref(),
             usage: event.usage,
         });
     }
@@ -564,7 +569,10 @@ fn reference_efficiency(
     merged.sort_by_key(|turn| turn.ts);
 
     let mut totals = EfficiencyTotals::default();
-    let mut fallback = ReferenceFallbackAggregate::default();
+    let mut fallback = [
+        ReferenceFallbackAggregate::default(),
+        ReferenceFallbackAggregate::default(),
+    ];
     let mut rewrites = Vec::new();
     let mut previous_context = None;
     let mut previous_parent_context = None;
@@ -588,6 +596,10 @@ fn reference_efficiency(
         }
 
         let Some(model) = turn.model else {
+            let fast = turn
+                .speed
+                .is_some_and(|speed| speed.trim().eq_ignore_ascii_case("fast"));
+            let fallback = &mut fallback[usize::from(fast)];
             let fresh = usage
                 .input_tokens
                 .saturating_add(usage.cache_creation_tokens);
@@ -616,7 +628,7 @@ fn reference_efficiency(
             totals.unpriced_turns = totals.unpriced_turns.saturating_add(1);
             continue;
         }
-        let Some(price) = lookup_pricing(model) else {
+        let Some(price) = lookup_turn_pricing(model, turn.speed) else {
             totals.unpriced_turns = totals.unpriced_turns.saturating_add(1);
             continue;
         };
@@ -647,28 +659,30 @@ fn reference_efficiency(
 
     // The fallback aggregate prices once, after every priced turn above has
     // already summed. This matches `EfficiencyReducer::finish`'s order.
-    let priced_fallback = fallback_model
-        .map(|name| strip_window_tag(name).trim())
-        .filter(|name| !name.is_empty())
-        .and_then(lookup_pricing);
-    match priced_fallback {
-        None => {
-            totals.unpriced_turns = totals.unpriced_turns.saturating_add(fallback.turns);
-        }
-        Some(price) => {
-            let new_work = fallback.output_tokens as f64 * price.output_cost_per_token
-                + fallback.new_input_tokens * price.input_cost_per_token
-                + fallback.new_cache_tokens * price.cache_write_cost_per_token;
-            let carry = fallback.cache_read_tokens as f64 * price.cache_read_cost_per_token;
-            let rewrite = fallback.rewrite_input_tokens * price.input_cost_per_token
-                + fallback.rewrite_cache_tokens * price.cache_write_cost_per_token;
-            totals.new_work_usd += new_work;
-            totals.carry_usd += carry;
-            totals.rewrite_usd += rewrite;
-            totals.total_usd += new_work + carry + rewrite;
-            totals.growth_tokens = totals.growth_tokens.saturating_add(fallback.growth_tokens);
-            totals.output_tokens = totals.output_tokens.saturating_add(fallback.output_tokens);
-            totals.priced_turns = totals.priced_turns.saturating_add(fallback.turns);
+    for (fast, fallback) in fallback.into_iter().enumerate() {
+        let priced_fallback = fallback_model
+            .map(|name| strip_window_tag(name).trim())
+            .filter(|name| !name.is_empty())
+            .and_then(|model| lookup_turn_pricing(model, (fast == 1).then_some("fast")));
+        match priced_fallback {
+            None => {
+                totals.unpriced_turns = totals.unpriced_turns.saturating_add(fallback.turns);
+            }
+            Some(price) => {
+                let new_work = fallback.output_tokens as f64 * price.output_cost_per_token
+                    + fallback.new_input_tokens * price.input_cost_per_token
+                    + fallback.new_cache_tokens * price.cache_write_cost_per_token;
+                let carry = fallback.cache_read_tokens as f64 * price.cache_read_cost_per_token;
+                let rewrite = fallback.rewrite_input_tokens * price.input_cost_per_token
+                    + fallback.rewrite_cache_tokens * price.cache_write_cost_per_token;
+                totals.new_work_usd += new_work;
+                totals.carry_usd += carry;
+                totals.rewrite_usd += rewrite;
+                totals.total_usd += new_work + carry + rewrite;
+                totals.growth_tokens = totals.growth_tokens.saturating_add(fallback.growth_tokens);
+                totals.output_tokens = totals.output_tokens.saturating_add(fallback.output_tokens);
+                totals.priced_turns = totals.priced_turns.saturating_add(fallback.turns);
+            }
         }
     }
     (totals, rewrites)
@@ -862,6 +876,7 @@ pub(crate) fn finalize_metrics(
     }
 
     let mut model_breakdown: HashMap<String, ModelTokens> = HashMap::new();
+    let mut pricing_breakdown: HashMap<String, ModelTokens> = HashMap::new();
     let mut model_runs = Vec::new();
     let mut seen_model_runs = HashSet::new();
     for (_, turn) in turns {
@@ -887,13 +902,27 @@ pub(crate) fn finalize_metrics(
                 if seen_model_runs.insert(run.clone()) {
                     model_runs.push(run);
                 }
-                let entry = model_breakdown.entry(model).or_default();
+                let entry = model_breakdown.entry(model.clone()).or_default();
                 entry.input_tokens = entry.input_tokens.saturating_add(usage.input_tokens);
                 entry.output_tokens = entry.output_tokens.saturating_add(usage.output_tokens);
                 entry.cache_read_tokens = entry
                     .cache_read_tokens
                     .saturating_add(usage.cache_read_tokens);
                 entry.cache_creation_tokens = entry
+                    .cache_creation_tokens
+                    .saturating_add(usage.cache_creation_tokens);
+                let pricing_key = turn_pricing_key(&model, turn.speed.as_deref());
+                let pricing_entry = pricing_breakdown.entry(pricing_key).or_default();
+                pricing_entry.input_tokens = pricing_entry
+                    .input_tokens
+                    .saturating_add(usage.input_tokens);
+                pricing_entry.output_tokens = pricing_entry
+                    .output_tokens
+                    .saturating_add(usage.output_tokens);
+                pricing_entry.cache_read_tokens = pricing_entry
+                    .cache_read_tokens
+                    .saturating_add(usage.cache_read_tokens);
+                pricing_entry.cache_creation_tokens = pricing_entry
                     .cache_creation_tokens
                     .saturating_add(usage.cache_creation_tokens);
             }
@@ -905,7 +934,7 @@ pub(crate) fn finalize_metrics(
         summary.context_window.unwrap_or(CONTEXT_WINDOW),
         tallies.peak_context_tokens,
     );
-    let cost = crate::analysis::pricing::price_breakdown(&model_breakdown);
+    let cost = crate::analysis::pricing::price_breakdown(&pricing_breakdown);
     let (efficiency, rewrites) = reference_efficiency(turns, summary.model.as_deref());
     for rewrite in rewrites {
         let progress = if active_ms > 0 {
@@ -945,6 +974,7 @@ pub(crate) fn finalize_metrics(
         billable_cache_read_tokens: tallies.billable_cache_read_tokens,
         billable_cache_creation_tokens: tallies.billable_cache_creation_tokens,
         model_breakdown,
+        pricing_breakdown,
         cost,
         efficiency,
         skill_uses,

--- a/crates/antiburn-local/src/analysis/metrics_sink/tests.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/tests.rs
@@ -766,6 +766,53 @@ fn merged_model_overflow_uses_a_normalized_fallback_key() {
 }
 
 #[test]
+fn merged_pricing_overflow_returns_no_partial_cost() {
+    let parent = finished(Vec::new(), SessionSummary::default());
+    let children = (0..=MAX_MODELS)
+        .map(|index| {
+            let mut standard = event(Some(index as i64), Role::Assistant, 1, 1);
+            standard.model = Some(format!("synthetic-model-{index}"));
+            let mut fast = standard.clone();
+            fast.speed = Some("fast".to_string());
+            finished(vec![standard, fast], SessionSummary::default())
+        })
+        .collect::<Vec<_>>();
+
+    let merged = merge_metrics(&parent, &children);
+
+    assert!(merged.pricing_breakdown.is_empty());
+    assert!(merged.cost.is_none());
+}
+
+#[test]
+fn merged_parent_and_fast_child_keep_both_astra_pricing_tiers() {
+    let mut parent_event = event(Some(0), Role::Assistant, 0, 1_000_000);
+    parent_event.model = Some("gpt-6-astra".to_string());
+    let parent = finished(vec![parent_event], SessionSummary::default());
+    let mut child_event = event(Some(1), Role::Assistant, 0, 1_000_000);
+    child_event.model = Some("gpt-6-astra".to_string());
+    child_event.speed = Some("fast".to_string());
+    let child = finished(vec![child_event], SessionSummary::default());
+
+    let merged = merge_metrics(&parent, &[child]);
+
+    assert_eq!(merged.model_breakdown.len(), 1);
+    assert_eq!(
+        merged.model_breakdown["gpt-6-astra"].output_tokens,
+        2_000_000
+    );
+    assert_eq!(
+        merged.pricing_breakdown["gpt-6-astra"].output_tokens,
+        1_000_000
+    );
+    assert_eq!(
+        merged.pricing_breakdown["gpt-6-astra-fast"].output_tokens,
+        1_000_000
+    );
+    assert!((merged.cost.expect("both tiers price").total_usd - 150.0).abs() < 1e-9);
+}
+
+#[test]
 fn merged_skill_uses_follow_shared_chronology() {
     let make_skill = |timestamp, name: &str| {
         let mut current = event(Some(timestamp), Role::Assistant, 1, 1);
@@ -1261,6 +1308,34 @@ fn tagged_models_do_not_share_the_breakdown_interner_budget() {
     let metrics = accumulator.metrics();
     assert_eq!(metrics.model_breakdown.len(), MAX_MODELS);
     assert_eq!(accumulator.models_truncated, 0);
+}
+
+#[test]
+fn mixed_astra_speeds_keep_one_identity_and_two_pricing_tiers() {
+    let mut standard = event(Some(1), Role::Assistant, 0, 1_000_000);
+    standard.model = Some("gpt-6-astra".to_string());
+    standard.speed = Some("standard".to_string());
+    let mut fast = event(Some(2), Role::Assistant, 0, 1_000_000);
+    fast.model = Some("gpt-6-astra".to_string());
+    fast.speed = Some("fast".to_string());
+
+    let metrics = finished(vec![standard, fast], SessionSummary::default()).metrics();
+
+    assert_eq!(metrics.model_breakdown.len(), 1);
+    assert_eq!(
+        metrics.model_breakdown["gpt-6-astra"].output_tokens,
+        2_000_000
+    );
+    assert_eq!(
+        metrics.pricing_breakdown["gpt-6-astra"].output_tokens,
+        1_000_000
+    );
+    assert_eq!(
+        metrics.pricing_breakdown["gpt-6-astra-fast"].output_tokens,
+        1_000_000
+    );
+    assert!((metrics.cost.expect("both tiers price").total_usd - 150.0).abs() < 1e-9);
+    assert!((metrics.efficiency.total_usd - 150.0).abs() < 1e-9);
 }
 
 #[test]

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -68,7 +68,7 @@ pub use evidence::{
 };
 pub use evidence_query::{
     FenceScope, PublishedScope, TurnFacts, query_model_breakdown, query_model_runs,
-    query_turn_facts, query_turn_rows,
+    query_pricing_breakdown, query_turn_facts, query_turn_rows,
 };
 pub use evidence_replay::evidence_from_facts;
 pub use evidence_sink::{
@@ -90,7 +90,10 @@ pub use metrics_sink::{RETAINED_METRICS_BYTES_BOUND, SessionMetricsAccumulator, 
 pub use model::{
     EventSource, ModelRun, NormalizedEvent, NormalizedSession, Role, ToolCall, ToolCategory, Usage,
 };
-pub use pricing::{install_runtime_pricing, lookup_pricing, price_breakdown, pricing_generation};
+pub use pricing::{
+    install_runtime_pricing, lookup_pricing, lookup_turn_pricing, price_breakdown,
+    pricing_generation, strip_window_tag, turn_pricing_key,
+};
 pub use replay::{MissingParentRows, metrics_by_source, metrics_from_rows};
 pub use resume::{AdapterResume, AdapterSnapshot, EvidenceSnapshot, StreamSnapshot};
 pub use rows::{
@@ -187,7 +190,8 @@ pub const PARSER_REVISION: i64 = 25;
 // longer counts toward `unattributed_turns` or `delegated_model_missing`
 // (`evidence_query::CORE_SQL`), so a session with such a record may now
 // assess `models` and `subagents` clean.
-pub const ANALYZER_REVISION: i64 = 17;
+// This revision adds speed-aware Fast tier cost accounting.
+pub const ANALYZER_REVISION: i64 = 18;
 // +1 for seam R2: the worker path now derives `inclusive_model_breakdown`
 // and `model_runs` from published turn rows instead of the accumulator
 // (`query_model_breakdown`, `query_model_runs`), so every session in the
@@ -201,7 +205,8 @@ pub const ANALYZER_REVISION: i64 = 17;
 // inference. Stored analyses must rerun for the corrected event data.
 // +1 for provider-specific rehydration thresholds and exact user inactivity.
 // Stored analyses must rerun for the corrected cache-event classification.
-pub const METRICS_SCHEMA_REVISION: i64 = 6;
+// This revision adds the separate speed-aware pricing breakdown.
+pub const METRICS_SCHEMA_REVISION: i64 = 7;
 // +1 for `RepeatedContext` (`evidence::CacheEvidence::repeated_context`).
 // +1 more for `RepeatedContext::paid_tokens` (part F).
 // +1 more for `SourceCapabilities::linear_record_order`.
@@ -227,7 +232,7 @@ pub const COVERAGE_SCHEMA_REVISION: i64 = 1;
 /// before it restores a snapshot; this constant and the rule are
 /// documented here so a future revision bump remembers to bump this one
 /// too, when the change touches resumable state.
-pub const RESUME_SNAPSHOT_REVISION: i64 = 1;
+pub const RESUME_SNAPSHOT_REVISION: i64 = 2;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/pricing.rs
+++ b/crates/antiburn-local/src/analysis/pricing.rs
@@ -79,6 +79,14 @@ fn initial_pricing() -> HashMap<String, ModelPricing> {
             price(1e-6, 6e-6, 0.1e-6, 1.25e-6),
         ),
         (
+            "gpt-6-astra".to_string(),
+            price(10e-6, 50e-6, 1e-6, 12.5e-6),
+        ),
+        (
+            "gpt-6-astra-fast".to_string(),
+            price(20e-6, 100e-6, 2e-6, 25e-6),
+        ),
+        (
             "gemini-3.8-pro".to_string(),
             price(2e-6, 12e-6, 0.2e-6, 2e-6),
         ),
@@ -135,6 +143,22 @@ pub fn lookup_pricing(model: &str) -> Option<ModelPricing> {
         .read()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     crate::pricing::lookup_pricing(strip_window_tag(model), &table).cloned()
+}
+
+/// Return the catalog key for one model turn and its observed speed.
+pub fn turn_pricing_key(model: &str, speed: Option<&str>) -> String {
+    let model = crate::pricing::normalize_model_key(strip_window_tag(model).trim());
+    if !speed.is_some_and(|speed| speed.trim().eq_ignore_ascii_case("fast"))
+        || crate::pricing::canonical_model_key(model).ends_with("-fast")
+    {
+        return model.to_string();
+    }
+    format!("{model}-fast")
+}
+
+/// Look up the exact catalog tier observed for one model turn.
+pub fn lookup_turn_pricing(model: &str, speed: Option<&str>) -> Option<ModelPricing> {
+    lookup_pricing(&turn_pricing_key(model, speed))
 }
 
 /// Estimate a complete per-model token breakdown.
@@ -199,5 +223,28 @@ mod tests {
             rate.clone(),
         )]));
         assert_eq!(normalized.get("sample-model"), Some(&rate));
+    }
+
+    #[test]
+    fn fast_pricing_keys_preserve_namespaces_and_avoid_double_suffixes() {
+        assert_eq!(
+            turn_pricing_key("openai/gpt-6-astra-20260901[272k]", Some(" FAST ")),
+            "openai/gpt-6-astra-fast"
+        );
+        assert_eq!(
+            turn_pricing_key("openai.gpt-6-astra-fast[272k]", Some("fast")),
+            "openai.gpt-6-astra-fast"
+        );
+        assert_eq!(
+            turn_pricing_key("gpt-6-astra", Some("standard")),
+            "gpt-6-astra"
+        );
+    }
+
+    #[test]
+    fn fast_pricing_does_not_fall_back_to_standard() {
+        assert!(lookup_turn_pricing("gpt-6-astra", Some("fast")).is_some());
+        assert!(lookup_turn_pricing("gpt-5.6", Some("fast")).is_none());
+        assert!(lookup_turn_pricing("gpt-5.6-sol-fast", Some("fast")).is_some());
     }
 }

--- a/crates/antiburn-local/src/analysis/rows.rs
+++ b/crates/antiburn-local/src/analysis/rows.rs
@@ -414,6 +414,13 @@ pub trait TurnRowStore: Send + Sync {
         &self,
     ) -> Result<std::collections::BTreeMap<String, crate::pricing::ModelTokens>, TurnRowError>;
 
+    /// Read the speed-aware pricing breakdown for this session's rows.
+    fn query_pricing_breakdown(
+        &self,
+    ) -> Result<std::collections::BTreeMap<String, crate::pricing::ModelTokens>, TurnRowError> {
+        self.query_model_breakdown()
+    }
+
     /// Reads the distinct model runs for every row this store wrote under
     /// its own session key and fence, parent runs first. See
     /// [`crate::analysis::query_model_runs`].
@@ -1246,6 +1253,18 @@ impl TurnRowStore for MemoryTurnRowStore {
         .map_err(TurnRowError::from)
     }
 
+    fn query_pricing_breakdown(
+        &self,
+    ) -> Result<std::collections::BTreeMap<String, crate::pricing::ModelTokens>, TurnRowError> {
+        let connection = self.connection.lock().expect("lock");
+        crate::analysis::evidence_query::query_pricing_breakdown(
+            &connection,
+            &self.key(),
+            &FenceScope::single(self.claim_fence),
+        )
+        .map_err(TurnRowError::from)
+    }
+
     fn query_model_runs(&self) -> Result<Vec<crate::analysis::model::ModelRun>, TurnRowError> {
         let connection = self.connection.lock().expect("lock");
         crate::analysis::evidence_query::query_model_runs(
@@ -1373,6 +1392,35 @@ mod tests {
 
         assert_eq!(count_turn_rows(&conn, &key, 7).expect("count"), 2);
         assert_eq!(count_turn_rows(&conn, &key, 8).expect("count"), 0);
+    }
+
+    #[test]
+    fn pricing_breakdown_splits_standard_and_fast_rows() {
+        let conn = test_connection();
+        let key = TurnSessionKey {
+            environment_key: "native",
+            agent: "codex",
+            session_id: "s1",
+        };
+        insert_session(&conn, &key);
+        let mut standard = sample_row(0);
+        standard.model = Some("openai/gpt-6-astra-20260901[272k]".to_owned());
+        standard.output_tokens = 10;
+        let mut fast = sample_row(1);
+        fast.model = standard.model.clone();
+        fast.speed = Some("fast".to_owned());
+        fast.output_tokens = 20;
+        insert_turn_rows(&conn, &key, 7, &[standard, fast]).expect("insert rows");
+
+        let breakdown = crate::analysis::evidence_query::query_pricing_breakdown(
+            &conn,
+            &key,
+            &FenceScope::single(7),
+        )
+        .expect("query pricing breakdown");
+
+        assert_eq!(breakdown["openai/gpt-6-astra"].output_tokens, 10);
+        assert_eq!(breakdown["openai/gpt-6-astra-fast"].output_tokens, 20);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -2451,6 +2451,8 @@ mod tests {
             "\n",
             r#"{"timestamp":"2026-08-05T10:00:06Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":300,"cached_input_tokens":100,"output_tokens":40,"total_tokens":340},"total_token_usage":{"input_tokens":300,"cached_input_tokens":100,"output_tokens":40,"total_tokens":340},"model_context_window":100000}}}"#,
             "\n",
+            r#"{"timestamp":"2026-08-05T10:00:07Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":350,"cached_input_tokens":100,"output_tokens":50,"total_tokens":400},"total_token_usage":{"input_tokens":650,"cached_input_tokens":200,"output_tokens":90,"total_tokens":740},"model_context_window":100000}}}"#,
+            "\n",
         );
         let input = SessionInput {
             agent: "codex".to_string(),
@@ -2471,6 +2473,13 @@ mod tests {
             .find(|event| event.model.as_deref() == Some("gpt-child"))
             .expect("the child's owned token_count turn is emitted");
         assert_eq!(owned_event.speed.as_deref(), Some("fast"));
+        assert!(
+            session
+                .events
+                .iter()
+                .filter(|event| event.usage.output_tokens > 0)
+                .all(|event| event.speed.as_deref() == Some("fast"))
+        );
     }
 
     /// Collects every `EvidenceObservation` and `Unusable` reason a visit

--- a/crates/antiburn-local/src/insights/detectors/mod.rs
+++ b/crates/antiburn-local/src/insights/detectors/mod.rs
@@ -179,7 +179,7 @@ pub struct PremiumPolicy {
     /// substrings (Claude: `opus`, `fable`, `mythos`).
     pub substrings: Vec<String>,
     /// A canonical model key is premium when it starts with any of these
-    /// prefixes (OpenAI: `gpt-5.6`, `gpt-5.5`), unless it is in
+    /// prefixes (OpenAI: `gpt-6-astra`, `gpt-5.6`, `gpt-5.5`), unless it is in
     /// `exceptions`.
     pub prefixes: Vec<String>,
     /// Canonical model keys that a substring or prefix match would
@@ -314,7 +314,11 @@ impl Default for ReportCatalogs {
                 premium: PremiumPolicy {
                     reviewed: true,
                     substrings: Vec::new(),
-                    prefixes: vec!["gpt-5.6".to_owned(), "gpt-5.5".to_owned()],
+                    prefixes: vec![
+                        "gpt-6-astra".to_owned(),
+                        "gpt-5.6".to_owned(),
+                        "gpt-5.5".to_owned(),
+                    ],
                     exceptions: [
                         "gpt-5.6-terra",
                         "gpt-5.6-luna",
@@ -348,7 +352,7 @@ impl Default for ReportCatalogs {
         families.insert(ModelFamily::Unknown, FamilyPolicy::default());
 
         Self {
-            revision: 7,
+            revision: 8,
             depth_cap_tokens: 400_000,
             families,
             model_replacements: model_registry::default_registry(),
@@ -613,6 +617,19 @@ mod tests {
     fn openai_premium_policy_flags_gpt_5_5_fast() {
         let policy = &ReportCatalogs::default().families[&ModelFamily::OpenAi].premium;
         assert!(policy.is_premium("gpt-5.5-fast"));
+    }
+
+    #[test]
+    fn openai_premium_policy_flags_gpt_6_astra() {
+        let policy = &ReportCatalogs::default().families[&ModelFamily::OpenAi].premium;
+        assert!(policy.is_premium("gpt-6-astra"));
+        assert!(policy.is_premium("gpt-6-astra-fast"));
+    }
+
+    #[test]
+    fn openai_premium_policy_does_not_guess_other_gpt_6_models() {
+        let policy = &ReportCatalogs::default().families[&ModelFamily::OpenAi].premium;
+        assert!(!policy.is_premium("gpt-6-unknown"));
     }
 
     #[test]

--- a/crates/antiburn-local/src/insights/detectors/overpowered_subagents.rs
+++ b/crates/antiburn-local/src/insights/detectors/overpowered_subagents.rs
@@ -281,6 +281,19 @@ mod tests {
     }
 
     #[test]
+    fn an_astra_parent_and_child_are_a_finding() {
+        let evidence = with_dominant_main_model(
+            evidence_with_models(Some("gpt-6-astra"), &["gpt-6-astra"]),
+            "gpt-6-astra",
+        );
+
+        assert_eq!(
+            evaluate(&evidence, &ReportCatalogs::default()),
+            Observation::Finding
+        );
+    }
+
+    #[test]
     fn an_openai_non_premium_luna_child_reports_no_finding() {
         let evidence = with_dominant_main_model(
             evidence_with_models(Some("gpt-5.6-sol"), &["gpt-5.6-luna"]),

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::analysis::{
     CacheEvidence, CoverageReason, EvidenceCoverage, EvidenceValue, SessionEvidence,
-    SourceAcceptance, lookup_pricing,
+    SourceAcceptance, lookup_turn_pricing, strip_window_tag,
 };
 use crate::pricing::{ModelPricing, canonical_model_key};
 
@@ -776,8 +776,12 @@ fn cost_saving_tokens(
     Some((equivalent.round() as u128).clamp(1, total_tokens))
 }
 
-fn report_pricing(model: &str, canonical_model: &str) -> Option<ModelPricing> {
-    lookup_pricing(model).or_else(|| lookup_pricing(canonical_model))
+fn report_turn_pricing(
+    model: &str,
+    canonical_model: &str,
+    speed: Option<&str>,
+) -> Option<ModelPricing> {
+    lookup_turn_pricing(model, speed).or_else(|| lookup_turn_pricing(canonical_model, speed))
 }
 
 fn priced_or_assumed_saving(
@@ -786,8 +790,12 @@ fn priced_or_assumed_saving(
     replacement: &str,
 ) -> Option<u128> {
     let replacement_canonical = canonical_model_key(replacement);
-    let priced = report_pricing(&turn.model, canonical_model)
-        .zip(report_pricing(replacement, &replacement_canonical))
+    let priced = report_turn_pricing(&turn.model, canonical_model, turn.speed.as_deref())
+        .zip(report_turn_pricing(
+            replacement,
+            &replacement_canonical,
+            turn.speed.as_deref(),
+        ))
         .and_then(|(actual, replacement)| cost_saving_tokens(turn, &actual, &replacement));
     priced.or_else(|| percentage_of_tokens(turn.total_tokens()?, 10))
 }
@@ -826,12 +834,20 @@ fn premium_replacement(
 }
 
 fn fast_mode_saving(turn: &TokenBurnTurnEvidence, canonical_model: &str) -> Option<u128> {
-    let standard_model = canonical_model
+    let observed_model = strip_window_tag(&turn.model).trim();
+    let observed_model = crate::pricing::normalize_model_key(observed_model);
+    let standard_model = observed_model
+        .strip_suffix("-fast")
+        .unwrap_or(observed_model);
+    let standard_canonical = canonical_model
         .strip_suffix("-fast")
         .unwrap_or(canonical_model);
-    let fast_model = format!("{standard_model}-fast");
-    let priced = report_pricing(&fast_model, &fast_model)
-        .zip(report_pricing(standard_model, standard_model))
+    let priced = report_turn_pricing(standard_model, standard_canonical, Some("fast"))
+        .zip(report_turn_pricing(
+            standard_model,
+            standard_canonical,
+            None,
+        ))
         .and_then(|(fast, standard)| cost_saving_tokens(turn, &fast, &standard));
     priced.or_else(|| percentage_of_tokens(turn.total_tokens()?, 10))
 }
@@ -1729,7 +1745,7 @@ mod tests {
         token_burn.observe(token_evidence, [true; 9], [true; 3]);
         let (combined, estimates) = token_burn.finish(&finding_statuses(&all_findings));
 
-        assert_eq!(combined, Some(1_200));
+        assert_eq!(combined, Some(800));
         for detector in all_findings {
             assert!(estimates[detector.index()].is_some_and(|value| value > 0));
         }
@@ -1738,7 +1754,7 @@ mod tests {
             [
                 Some(800),
                 Some(350),
-                Some(1_200),
+                Some(500),
                 Some(100),
                 Some(100),
                 Some(100),
@@ -1800,6 +1816,34 @@ mod tests {
         );
         assert_eq!(turn_evidence([fast], &catalogs).fast_mode, Some(100));
         assert_eq!(turn_evidence([old], &catalogs).old_model, Some(100));
+    }
+
+    #[test]
+    fn astra_parent_usage_is_excluded_but_delegated_usage_has_savings() {
+        let catalogs = ReportCatalogs::default();
+        let evidence = turn_evidence(
+            [
+                token_turn("main", "gpt-6-astra", None, None, 1_000),
+                token_turn("delegated", "gpt-6-astra", None, None, 1_000),
+            ],
+            &catalogs,
+        );
+
+        assert_eq!(evidence.overpowered_subagents, Some(880));
+    }
+
+    #[test]
+    fn namespaced_astra_fast_savings_use_fast_and_standard_rates() {
+        let catalogs = ReportCatalogs::default();
+        let turn = token_turn(
+            "delegated",
+            "openai/gpt-6-astra-20260901[272k]",
+            None,
+            Some("fast"),
+            1_000,
+        );
+
+        assert_eq!(turn_evidence([turn], &catalogs).fast_mode, Some(500));
     }
 
     #[test]

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_continues_thread.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_continues_thread.json
@@ -4127,6 +4127,22 @@
         }
       ],
       "peakContextTokens": 30,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 30,
+          "output_tokens": 6
+        },
+        "claude-sonnet-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 20,
+          "output_tokens": 4
+        }
+      },
       "sessionId": "compaction_continues_thread",
       "tokensIn": 50,
       "tokensOut": 10

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_with_cache_rehydration.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_with_cache_rehydration.json
@@ -4185,6 +4185,15 @@
         }
       ],
       "peakContextTokens": 41500,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 111000,
+          "cache_read_tokens": 95000,
+          "input_tokens": 3300,
+          "output_tokens": 60
+        }
+      },
       "sessionId": "compaction_with_cache_rehydration",
       "tokensIn": 114300,
       "tokensOut": 60

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_model_missing.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_model_missing.json
@@ -4072,6 +4072,15 @@
         }
       ],
       "peakContextTokens": 20,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 32,
+          "output_tokens": 7
+        }
+      },
       "sessionId": "delegated_model_missing",
       "tokensIn": 32,
       "tokensOut": 7

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_models.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_models.json
@@ -4106,6 +4106,22 @@
         }
       ],
       "peakContextTokens": 20,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 32,
+          "output_tokens": 7
+        },
+        "claude-sonnet-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 10,
+          "output_tokens": 2
+        }
+      },
       "sessionId": "delegated_models",
       "tokensIn": 42,
       "tokensOut": 9

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/disorder_ladder.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/disorder_ladder.json
@@ -5408,6 +5408,15 @@
         }
       ],
       "peakContextTokens": 65,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 66,
+          "output_tokens": 2
+        }
+      },
       "sessionId": "disorder_ladder",
       "tokensIn": 66,
       "tokensOut": 2

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/fast_mode_overuse_clean.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/fast_mode_overuse_clean.json
@@ -4073,6 +4073,22 @@
         }
       ],
       "peakContextTokens": 20,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 20,
+          "output_tokens": 5
+        },
+        "claude-sonnet-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 15,
+          "output_tokens": 4
+        }
+      },
       "sessionId": "fast_mode_overuse_clean",
       "tokensIn": 35,
       "tokensOut": 9

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/housekeeping_records.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/housekeeping_records.json
@@ -4063,6 +4063,15 @@
         }
       ],
       "peakContextTokens": 24,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 24,
+          "output_tokens": 12
+        }
+      },
       "sessionId": "housekeeping_records",
       "tokensIn": 24,
       "tokensOut": 12

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
@@ -4063,6 +4063,15 @@
         }
       ],
       "peakContextTokens": 15,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 15,
+          "output_tokens": 8
+        }
+      },
       "sessionId": "incomplete_final_record",
       "tokensIn": 15,
       "tokensOut": 8

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inferred_cache_rehydration.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inferred_cache_rehydration.json
@@ -4092,6 +4092,15 @@
         }
       ],
       "peakContextTokens": 35000,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 67000,
+          "input_tokens": 31500,
+          "output_tokens": 30
+        }
+      },
       "sessionId": "inferred_cache_rehydration",
       "tokensIn": 31500,
       "tokensOut": 30

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inline_sidechain_own_thread.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inline_sidechain_own_thread.json
@@ -4227,6 +4227,22 @@
         }
       ],
       "peakContextTokens": 10,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 20,
+          "output_tokens": 4
+        },
+        "claude-sonnet-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 20,
+          "output_tokens": 4
+        }
+      },
       "sessionId": "inline_sidechain_own_thread",
       "tokensIn": 40,
       "tokensOut": 8

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/late_skill_metrics.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/late_skill_metrics.json
@@ -4070,6 +4070,15 @@
         }
       ],
       "peakContextTokens": 100,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 100,
+          "output_tokens": 10
+        }
+      },
       "sessionId": "late_skill_metrics",
       "tokensIn": 100,
       "tokensOut": 10

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
@@ -4063,6 +4063,15 @@
         }
       ],
       "peakContextTokens": 25,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 25,
+          "output_tokens": 12
+        }
+      },
       "sessionId": "malformed_between_valid",
       "tokensIn": 25,
       "tokensOut": 12

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/model_overthinking_finding.json
@@ -4043,6 +4043,15 @@
         }
       ],
       "peakContextTokens": 40,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 40,
+          "output_tokens": 10
+        }
+      },
       "sessionId": "model_overthinking_finding",
       "tokensIn": 40,
       "tokensOut": 10

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/multi_model_session.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/multi_model_session.json
@@ -4128,6 +4128,29 @@
         }
       ],
       "peakContextTokens": 400,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 100,
+          "output_tokens": 10
+        },
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 700,
+          "output_tokens": 70
+        },
+        "claude-opus-4-7": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 200,
+          "output_tokens": 20
+        }
+      },
       "sessionId": "multi_model_session",
       "tokensIn": 1000,
       "tokensOut": 100

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
@@ -4090,6 +4090,15 @@
         }
       ],
       "peakContextTokens": 50,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 80,
+          "output_tokens": 40
+        }
+      },
       "sessionId": "parent_with_task_spawn",
       "tokensIn": 80,
       "tokensOut": 40

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
@@ -4175,6 +4175,15 @@
         }
       ],
       "peakContextTokens": 5000,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 1030,
+          "cache_read_tokens": 8000,
+          "input_tokens": 1140,
+          "output_tokens": 190
+        }
+      },
       "sessionId": "records_all_kinds",
       "tokensIn": 2170,
       "tokensOut": 190

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/rehydration_gap_none.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/rehydration_gap_none.json
@@ -4092,6 +4092,15 @@
         }
       ],
       "peakContextTokens": 72000,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 40000,
+          "cache_read_tokens": 67000,
+          "input_tokens": 31500,
+          "output_tokens": 30
+        }
+      },
       "sessionId": "rehydration_gap_none",
       "tokensIn": 71500,
       "tokensOut": 30

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/session_overdepth_finding.json
@@ -4063,6 +4063,15 @@
         }
       ],
       "peakContextTokens": 450000,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 450000,
+          "output_tokens": 50
+        }
+      },
       "sessionId": "session_overdepth_finding",
       "tokensIn": 450000,
       "tokensOut": 50

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/sidechain_in_parent.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/sidechain_in_parent.json
@@ -4094,6 +4094,22 @@
         }
       ],
       "peakContextTokens": 100,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 100,
+          "output_tokens": 10
+        },
+        "claude-sonnet-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 200,
+          "output_tokens": 20
+        }
+      },
       "sessionId": "sidechain_in_parent",
       "tokensIn": 300,
       "tokensOut": 30

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
@@ -4090,6 +4090,15 @@
         }
       ],
       "peakContextTokens": 35,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 55,
+          "output_tokens": 27
+        }
+      },
       "sessionId": "subagent_child",
       "tokensIn": 55,
       "tokensOut": 27

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_single_timestamp.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_single_timestamp.json
@@ -4063,6 +4063,15 @@
         }
       ],
       "peakContextTokens": 0,
+      "pricingBreakdown": {
+        "claude-sonnet-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 300,
+          "output_tokens": 30
+        }
+      },
       "sessionId": "subagent_single_timestamp",
       "tokensIn": 300,
       "tokensOut": 30

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_chain.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_chain.json
@@ -4174,6 +4174,22 @@
         }
       ],
       "peakContextTokens": 17040,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 17000,
+          "cache_read_tokens": 0,
+          "input_tokens": 9080,
+          "output_tokens": 14
+        },
+        "claude-sonnet-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 4,
+          "cache_read_tokens": 0,
+          "input_tokens": 22,
+          "output_tokens": 5
+        }
+      },
       "sessionId": "thread_identity_chain",
       "tokensIn": 26106,
       "tokensOut": 19

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_missing_uuid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_missing_uuid.json
@@ -4116,6 +4116,15 @@
         }
       ],
       "peakContextTokens": 24,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 66,
+          "output_tokens": 14
+        }
+      },
       "sessionId": "thread_identity_missing_uuid",
       "tokensIn": 66,
       "tokensOut": 14

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
@@ -4112,6 +4112,15 @@
         }
       ],
       "peakContextTokens": 40,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 90,
+          "output_tokens": 45
+        }
+      },
       "sessionId": "timestamps_repeated_and_out_of_order",
       "tokensIn": 90,
       "tokensOut": 45

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/two_compactions_second_without_metadata.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/two_compactions_second_without_metadata.json
@@ -4106,6 +4106,15 @@
         }
       ],
       "peakContextTokens": 91000,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 90000,
+          "input_tokens": 1100,
+          "output_tokens": 15
+        }
+      },
       "sessionId": "two_compactions_second_without_metadata",
       "tokensIn": 1100,
       "tokensOut": 15

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
@@ -4084,6 +4084,15 @@
         }
       ],
       "peakContextTokens": 18,
+      "pricingBreakdown": {
+        "claude-3-5-haiku": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 18,
+          "output_tokens": 9
+        }
+      },
       "sessionId": "unrecognized_type",
       "tokensIn": 18,
       "tokensOut": 9

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/within_file_duplicate_uuid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/within_file_duplicate_uuid.json
@@ -4117,6 +4117,15 @@
         }
       ],
       "peakContextTokens": 15,
+      "pricingBreakdown": {
+        "claude-opus-4-6": {
+          "cache_creation_1h_tokens": 0,
+          "cache_creation_tokens": 0,
+          "cache_read_tokens": 0,
+          "input_tokens": 20,
+          "output_tokens": 8
+        }
+      },
       "sessionId": "within_file_duplicate_uuid",
       "tokensIn": 20,
       "tokensOut": 8

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -147,7 +147,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4194,6 +4194,15 @@
       }
     ],
     "peakContextTokens": 60000,
+    "pricingBreakdown": {
+      "gpt-test": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 3500,
+        "cache_read_tokens": 58000,
+        "input_tokens": 60500,
+        "output_tokens": 170
+      }
+    },
     "sessionId": "cache_write_tokens",
     "tokensIn": 64000,
     "tokensOut": 170

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -142,7 +142,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4209,6 +4209,15 @@
       }
     ],
     "peakContextTokens": 560,
+    "pricingBreakdown": {
+      "gpt-alpha": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 200,
+        "input_tokens": 860,
+        "output_tokens": 85
+      }
+    },
     "sessionId": "collab_agent_records",
     "tokensIn": 860,
     "tokensOut": 85

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -147,7 +147,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4194,6 +4194,15 @@
       }
     ],
     "peakContextTokens": 60000,
+    "pricingBreakdown": {
+      "gpt-test": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 58000,
+        "input_tokens": 64000,
+        "output_tokens": 170
+      }
+    },
     "sessionId": "context_reread",
     "tokensIn": 64000,
     "tokensOut": 170

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -162,7 +162,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4217,6 +4217,15 @@
       }
     ],
     "peakContextTokens": 200,
+    "pricingBreakdown": {
+      "gpt-test": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 50,
+        "input_tokens": 150,
+        "output_tokens": 30
+      }
+    },
     "sessionId": "malformed_between_valid",
     "tokensIn": 150,
     "tokensOut": 30

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4183,6 +4183,15 @@
       }
     ],
     "peakContextTokens": 500,
+    "pricingBreakdown": {
+      "gpt-test": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+        "input_tokens": 500,
+        "output_tokens": 50
+      }
+    },
     "sessionId": "model_overthinking_finding",
     "tokensIn": 500,
     "tokensOut": 50

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -144,7 +144,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4207,6 +4207,15 @@
       }
     ],
     "peakContextTokens": 1000,
+    "pricingBreakdown": {
+      "gpt-test": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 600,
+        "input_tokens": 400,
+        "output_tokens": 80
+      }
+    },
     "sessionId": "records_all_kinds",
     "tokensIn": 400,
     "tokensOut": 80

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4183,6 +4183,15 @@
       }
     ],
     "peakContextTokens": 450000,
+    "pricingBreakdown": {
+      "gpt-test": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+        "input_tokens": 450000,
+        "output_tokens": 50
+      }
+    },
     "sessionId": "session_overdepth_finding",
     "tokensIn": 450000,
     "tokensOut": 50

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -142,7 +142,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4209,6 +4209,15 @@
       }
     ],
     "peakContextTokens": 560,
+    "pricingBreakdown": {
+      "gpt-alpha": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 200,
+        "input_tokens": 860,
+        "output_tokens": 85
+      }
+    },
     "sessionId": "spawn_agent",
     "tokensIn": 860,
     "tokensOut": 85

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -116,7 +116,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4149,6 +4149,7 @@
     "modelBreakdown": {},
     "modelRuns": [],
     "peakContextTokens": 0,
+    "pricingBreakdown": {},
     "sessionId": "unrecognized_type",
     "tokensIn": 0,
     "tokensOut": 0

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -126,7 +126,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4162,6 +4162,7 @@
     "modelBreakdown": {},
     "modelRuns": [],
     "peakContextTokens": 0,
+    "pricingBreakdown": {},
     "sessionId": "content_blocks",
     "tokensIn": 0,
     "tokensOut": 0

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -152,7 +152,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4198,6 +4198,22 @@
       }
     ],
     "peakContextTokens": 9040,
+    "pricingBreakdown": {
+      "claude-opus-4-6": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 8000,
+        "cache_read_tokens": 0,
+        "input_tokens": 30,
+        "output_tokens": 6
+      },
+      "claude-sonnet-4-6": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 9000,
+        "cache_read_tokens": 0,
+        "input_tokens": 40,
+        "output_tokens": 8
+      }
+    },
     "sessionId": "excess_cache_rehydration_finding",
     "tokensIn": 17070,
     "tokensOut": 14

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4173,6 +4173,15 @@
       }
     ],
     "peakContextTokens": 10,
+    "pricingBreakdown": {
+      "claude-opus-4-6": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+        "input_tokens": 10,
+        "output_tokens": 5
+      }
+    },
     "sessionId": "model_overthinking_finding",
     "tokensIn": 10,
     "tokensOut": 5

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -132,7 +132,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4167,6 +4167,15 @@
       }
     ],
     "peakContextTokens": 450000,
+    "pricingBreakdown": {
+      "model-a": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+        "input_tokens": 450000,
+        "output_tokens": 50
+      }
+    },
     "sessionId": "session_overdepth_finding",
     "tokensIn": 450000,
     "tokensOut": 50

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -161,7 +161,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4202,6 +4202,15 @@
       }
     ],
     "peakContextTokens": 8,
+    "pricingBreakdown": {
+      "model-a": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 4,
+        "cache_read_tokens": 3,
+        "input_tokens": 1,
+        "output_tokens": 2
+      }
+    },
     "sessionId": "unknown_content_block",
     "tokensIn": 5,
     "tokensOut": 2

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -143,7 +143,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4172,6 +4172,7 @@
     "modelBreakdown": {},
     "modelRuns": [],
     "peakContextTokens": 0,
+    "pricingBreakdown": {},
     "sessionId": "unknown_row_type",
     "tokensIn": 0,
     "tokensOut": 0

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 17,
+      "analyzerRevision": 18,
       "evidenceSchemaRevision": 13,
       "harnessVersion": {
         "state": "unsupported"
@@ -4173,6 +4173,15 @@
       }
     ],
     "peakContextTokens": 16,
+    "pricingBreakdown": {
+      "model-a": {
+        "cache_creation_1h_tokens": 0,
+        "cache_creation_tokens": 9,
+        "cache_read_tokens": 16,
+        "input_tokens": 5,
+        "output_tokens": 7
+      }
+    },
     "sessionId": "usage_all_buckets",
     "tokensIn": 14,
     "tokensOut": 7

--- a/crates/antiburn-local/tests/turn_facts_parity.rs
+++ b/crates/antiburn-local/tests/turn_facts_parity.rs
@@ -68,6 +68,15 @@ struct Mismatch {
     detail: String,
 }
 
+type FixtureProjections = (
+    SessionEvidence,
+    TurnFacts,
+    SessionMetrics,
+    BTreeMap<String, ModelTokens>,
+    BTreeMap<String, ModelTokens>,
+    Vec<ModelRun>,
+);
+
 /// Streams `jsonl` through the named vendor's adapter into both an evidence
 /// accumulator and a `MemoryTurnRowStore`, and returns both projections.
 fn run_fixture(
@@ -76,7 +85,7 @@ fn run_fixture(
     jsonl: &str,
     capabilities: SourceCapabilities,
 ) -> (SessionEvidence, TurnFacts) {
-    let (evidence, facts, _, _, _) = run_fixture_with_row_projections(
+    let (evidence, facts, _, _, _, _) = run_fixture_with_row_projections(
         agent,
         fixture,
         &SessionInput {
@@ -102,13 +111,7 @@ fn run_fixture_with_row_projections(
     fixture: &str,
     input: &SessionInput,
     capabilities: SourceCapabilities,
-) -> (
-    SessionEvidence,
-    TurnFacts,
-    SessionMetrics,
-    BTreeMap<String, ModelTokens>,
-    Vec<ModelRun>,
-) {
+) -> FixtureProjections {
     let metrics = SessionMetricsAccumulator::new(input.agent.clone(), input.session_id.clone());
     let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
         agent: input.agent.clone(),
@@ -142,6 +145,9 @@ fn run_fixture_with_row_projections(
     let model_breakdown = store
         .query_model_breakdown()
         .expect("model breakdown query must succeed");
+    let pricing_breakdown = store
+        .query_pricing_breakdown()
+        .expect("pricing breakdown query must succeed");
     let model_runs = store
         .query_model_runs()
         .expect("model runs query must succeed");
@@ -150,6 +156,7 @@ fn run_fixture_with_row_projections(
         facts,
         session_metrics,
         model_breakdown,
+        pricing_breakdown,
         model_runs,
     )
 }
@@ -340,6 +347,7 @@ fn compare_model_projections(
     fixture: &str,
     metrics: &SessionMetrics,
     model_breakdown: &BTreeMap<String, ModelTokens>,
+    pricing_breakdown: &BTreeMap<String, ModelTokens>,
     model_runs: &[ModelRun],
 ) {
     let expected_breakdown: BTreeMap<String, ModelTokens> = metrics
@@ -353,6 +361,18 @@ fn compare_model_projections(
         "model_breakdown",
         model_breakdown.clone(),
         expected_breakdown,
+    );
+    let expected_pricing: BTreeMap<String, ModelTokens> = metrics
+        .pricing_breakdown
+        .iter()
+        .map(|(model, tokens)| (model.clone(), tokens.clone()))
+        .collect();
+    diff(
+        mismatches,
+        fixture,
+        "pricing_breakdown",
+        pricing_breakdown.clone(),
+        expected_pricing,
     );
     diff(
         mismatches,
@@ -575,7 +595,7 @@ fn claude_model_projections_match_the_accumulator_for_every_fixture() {
             source: RawSource::Jsonl(claude_fixture(name).to_owned()),
             fork_parent_session_id: None,
         };
-        let (_, _, metrics, model_breakdown, model_runs) =
+        let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
             run_fixture_with_row_projections("claude", name, &input, SourceCapabilities::claude());
         // `delegated_model_missing` carries an assistant turn with billable
         // tokens and no model. `SessionMetricsAccumulator` folds such a
@@ -607,6 +627,7 @@ fn claude_model_projections_match_the_accumulator_for_every_fixture() {
             name,
             &metrics,
             &model_breakdown,
+            &pricing_breakdown,
             &model_runs,
         );
     }
@@ -688,13 +709,14 @@ fn codex_model_projections_match_the_accumulator_for_every_fixture() {
             source: RawSource::Jsonl(codex_fixture(name).to_owned()),
             fork_parent_session_id: None,
         };
-        let (_, _, metrics, model_breakdown, model_runs) =
+        let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
             run_fixture_with_row_projections("codex", name, &input, SourceCapabilities::codex());
         compare_model_projections(
             &mut mismatches,
             name,
             &metrics,
             &model_breakdown,
+            &pricing_breakdown,
             &model_runs,
         );
     }
@@ -834,13 +856,14 @@ fn pi_model_projections_match_the_accumulator_for_every_fixture() {
             source: RawSource::Jsonl(pi_fixture(name).to_owned()),
             fork_parent_session_id: None,
         };
-        let (_, _, metrics, model_breakdown, model_runs) =
+        let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
             run_fixture_with_row_projections("pi", name, &input, SourceCapabilities::pi());
         compare_model_projections(
             &mut mismatches,
             name,
             &metrics,
             &model_breakdown,
+            &pricing_breakdown,
             &model_runs,
         );
     }
@@ -941,7 +964,7 @@ fn opencode_sqlite_input(path: &Path, session_id: &str) -> SessionInput {
 /// Streams one OpenCode `SessionInput` through the real adapter and the
 /// real evidence and turn-row pipeline, the same path production uses.
 fn run_opencode_fixture(fixture: &str, input: &SessionInput) -> (SessionEvidence, TurnFacts) {
-    let (evidence, facts, _, _, _) = run_fixture_with_row_projections(
+    let (evidence, facts, _, _, _, _) = run_fixture_with_row_projections(
         "opencode",
         fixture,
         input,
@@ -1136,78 +1159,88 @@ fn opencode_model_projections_match_the_accumulator_for_every_fixture() {
     let mut mismatches = Vec::new();
 
     let (_messages_dir, messages_input) = opencode_fixture_messages_with_cache_and_reasoning();
-    let (_, _, metrics, model_breakdown, model_runs) = run_fixture_with_row_projections(
-        "opencode",
-        "messages_with_cache_and_reasoning",
-        &messages_input,
-        SourceCapabilities::opencode(),
-    );
+    let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
+        run_fixture_with_row_projections(
+            "opencode",
+            "messages_with_cache_and_reasoning",
+            &messages_input,
+            SourceCapabilities::opencode(),
+        );
     compare_model_projections(
         &mut mismatches,
         "messages_with_cache_and_reasoning",
         &metrics,
         &model_breakdown,
+        &pricing_breakdown,
         &model_runs,
     );
 
     let (_subagent_dir, subagent_input) =
         opencode_fixture_subagent_delegation_with_model_transition();
-    let (_, _, metrics, model_breakdown, model_runs) = run_fixture_with_row_projections(
-        "opencode",
-        "subagent_delegation_with_model_transition",
-        &subagent_input,
-        SourceCapabilities::opencode(),
-    );
+    let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
+        run_fixture_with_row_projections(
+            "opencode",
+            "subagent_delegation_with_model_transition",
+            &subagent_input,
+            SourceCapabilities::opencode(),
+        );
     compare_model_projections(
         &mut mismatches,
         "subagent_delegation_with_model_transition",
         &metrics,
         &model_breakdown,
+        &pricing_breakdown,
         &model_runs,
     );
 
     let (_malformed_dir, malformed_input) = opencode_fixture_malformed_between_valid();
-    let (_, _, metrics, model_breakdown, model_runs) = run_fixture_with_row_projections(
-        "opencode",
-        "malformed_between_valid",
-        &malformed_input,
-        SourceCapabilities::opencode(),
-    );
+    let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
+        run_fixture_with_row_projections(
+            "opencode",
+            "malformed_between_valid",
+            &malformed_input,
+            SourceCapabilities::opencode(),
+        );
     compare_model_projections(
         &mut mismatches,
         "malformed_between_valid",
         &metrics,
         &model_breakdown,
+        &pricing_breakdown,
         &model_runs,
     );
 
     let (_compaction_dir, compaction_input) = opencode_fixture_compaction_boundary();
-    let (_, _, metrics, model_breakdown, model_runs) = run_fixture_with_row_projections(
-        "opencode",
-        "compaction_boundary",
-        &compaction_input,
-        SourceCapabilities::opencode(),
-    );
+    let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
+        run_fixture_with_row_projections(
+            "opencode",
+            "compaction_boundary",
+            &compaction_input,
+            SourceCapabilities::opencode(),
+        );
     compare_model_projections(
         &mut mismatches,
         "compaction_boundary",
         &metrics,
         &model_breakdown,
+        &pricing_breakdown,
         &model_runs,
     );
 
     let export_input = opencode_fixture_export_jsonl_child_delegation();
-    let (_, _, metrics, model_breakdown, model_runs) = run_fixture_with_row_projections(
-        "opencode",
-        "export_jsonl_child_delegation",
-        &export_input,
-        SourceCapabilities::opencode(),
-    );
+    let (_, _, metrics, model_breakdown, pricing_breakdown, model_runs) =
+        run_fixture_with_row_projections(
+            "opencode",
+            "export_jsonl_child_delegation",
+            &export_input,
+            SourceCapabilities::opencode(),
+        );
     compare_model_projections(
         &mut mismatches,
         "export_jsonl_child_delegation",
         &metrics,
         &model_breakdown,
+        &pricing_breakdown,
         &model_runs,
     );
 


### PR DESCRIPTION
## User impact

GPT-6 Astra now counts as a reviewed premium OpenAI model in overpowered-subagent insights. Fast-mode turns use the observed Fast rate across session totals, efficiency, cached activity rows, subagent rollups, provider allocation, provider summaries, and savings estimates while displayed model identities remain unchanged.

Mixed standard and Fast turns retain a separate, bounded pricing breakdown. Missing Fast rates and ambiguous provider ownership make session totals unavailable instead of falling back to a standard rate. Provider summaries retain a priced floor and mark it explicitly incomplete. The cache schema and projection revisions rebuild legacy analysis that lacks the tier breakdown.

Long-context pricing remains deferred because this change only accounts for the observed Fast billing tier.

## Validation

- `cargo fmt --all -- --check` in both Rust workspaces
- `cargo clippy --all-targets -- -D warnings` in both Rust workspaces
- `cargo test` in both Rust workspaces
- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test`
- `pnpm --filter @antiburn/desktop build`
- `pnpm run slop:all` (score 100, zero findings)
- `pnpm run secrets`

## Privacy and performance

No new data or network access. Session analysis stores one bounded pricing-tier map alongside the existing model-identity map. Fast and standard entries are capped at two tiers for each bounded model identity; overflow makes cost unavailable. Migration V34 removes legacy cached analysis so the normal worker rebuilds it with complete tier data.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
