### PR TITLE
Clarify missing limits in the Activity List

### DIFF
--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -149,7 +149,7 @@ describe("SessionList — rows", () => {
     )
   })
 
-  it("leaves the badge blank when the selected limit has no allocation", () => {
+  it("names the weekly limit when the selected limit has no allocation", async () => {
     list({
       entries: [
         entry({
@@ -160,9 +160,12 @@ describe("SessionList — rows", () => {
     })
 
     expect(screen.queryByLabelText("Estimated cost $1.00")).toBeNull()
-    expect(
-      screen.queryByLabelText("A weekly provider estimate is not available for this session."),
-    ).toBeNull()
+    const badge = screen.getByLabelText("No weekly limit for this session.")
+    expect(badge).toHaveTextContent("no limit")
+    fireEvent.focus(badge)
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("No weekly limit for this session.")
+    })
   })
 
   it("does not fall back to cost when a controlled five-hour metric is unavailable", () => {
@@ -179,6 +182,7 @@ describe("SessionList — rows", () => {
     expect(screen.getByRole("radio", { name: "$" })).toHaveAttribute("aria-checked", "false")
     expect(screen.getByRole("radio", { name: "% 5h" })).toHaveAttribute("aria-checked", "true")
     expect(screen.queryByLabelText("Estimated cost $1.00")).toBeNull()
+    expect(screen.getByLabelText("No 5h limit for this session.")).toHaveTextContent("no limit")
   })
 
   it("does not offer five-hour mode for another short rolling window", () => {

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -143,16 +143,17 @@ function hasDisplayedFiveHourWindow(live: LiveUsageSummaryPayload | undefined): 
 function sessionLimitBadge(
   metric: Exclude<BadgeMetric, "cost">,
   allocation?: SessionLimitAllocationPayload,
-):
-  | {
-      label: string
-      percent: number
-      provider?: string
-      windowId?: string
-    }
-  | undefined {
+): {
+  label: string
+  percent: number | null
+  provider?: string
+  windowId?: string
+} {
   if (!allocation || !Number.isFinite(allocation.percent)) {
-    return undefined
+    return {
+      label: `No ${metric === "weeklyPercent" ? "weekly" : "5h"} limit for this session.`,
+      percent: null,
+    }
   }
   return {
     label: `Estimated share of your ${allocation.displayName} ${metric === "weeklyPercent" ? "weekly" : "5-hour"} limit.`,
@@ -216,7 +217,7 @@ interface SessionRowProps {
   limitBadge?:
     | {
         label: string
-        percent: number
+        percent: number | null
         provider?: string
         windowId?: string
       }

--- a/apps/desktop/src/components/session/SessionStatusBar.test.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.test.tsx
@@ -121,7 +121,7 @@ describe("SessionStatusBar", () => {
     )
     render(<SessionStatusBar checks={checks} />)
     const verdict = screen.getByLabelText("All assessed checks passed")
-    expect(verdict.textContent).toBe("5/5 assessed burn checks")
+    expect(verdict.textContent).toBe("5/5 burn checks")
     expect(screen.queryByLabelText("All checks passed")).toBeNull()
   })
 
@@ -204,7 +204,7 @@ describe("SessionStatusBar", () => {
       <SessionStatusBar checks={[]} cost={{ totalUsd: 2.4, figureLabel: "Estimated cost" }} />,
     )
 
-    expect(screen.getByLabelText("Estimated cost $2.40")).toHaveClass("ml-auto")
+    expect(screen.getByLabelText("Estimated cost $2.40").parentElement).toHaveClass("ml-auto")
   })
 
   it("keeps a limit share at the right edge when no checks were assessed", () => {
@@ -215,7 +215,7 @@ describe("SessionStatusBar", () => {
       />,
     )
 
-    expect(screen.getByLabelText("Estimated weekly share")).toHaveClass("ml-auto")
+    expect(screen.getByLabelText("Estimated weekly share").parentElement).toHaveClass("ml-auto")
   })
 
   it("omits unavailable checks from the tooltip", async () => {

--- a/apps/desktop/src/components/session/SessionStatusBar.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.tsx
@@ -2,7 +2,6 @@ import { Check, Flame, X, type LucideIcon } from "lucide-react"
 import { Fragment } from "react"
 
 import type { SessionHygieneEvidenceState } from "../../lib/insightsIpc"
-import { cn } from "../../lib/cn"
 import {
   sessionHygieneStateIsTransient,
   sessionHygieneStateLabel,
@@ -16,10 +15,11 @@ export interface SessionStatusBarProps {
   evidenceState?: SessionHygieneEvidenceState
   /** Display values for the cost figure; omit when nothing priced the session. */
   cost?: SessionCostBadgeProps | null | undefined
+  /** A null percent shows the missing limit label. An omitted badge uses the cost. */
   limitBadge?:
     | {
         label: string
-        percent: number
+        percent: number | null
         provider?: string
         windowId?: string
       }
@@ -134,9 +134,7 @@ export function SessionStatusBar({
   // the never-assessed case keeps the plain state text in the count's place.
   const showStateText = stateLabel !== null && assessedCount === 0
   const checkNoun = assessedCount === 1 ? "burn check" : "burn checks"
-  const countText = `${passed.length}/${assessedCount} ${
-    allPassed && hasUnavailableChecks ? "assessed " : ""
-  }${checkNoun}`
+  const countText = `${passed.length}/${assessedCount} ${checkNoun}`
   // A transient state next to an assessed verdict still names itself, as a
   // prefix on the aria label and the tooltip text.
   const verdictPrefix = stateLabel && !showStateText ? `${stateLabel} — ` : ""
@@ -170,41 +168,47 @@ export function SessionStatusBar({
         </Tooltip>
       )}
 
-      {limitBadge ? (
-        <Tooltip label={limitBadge.label} delayMs={150}>
-          <span
-            className={
-              isHighLimitShare
-                ? "ml-auto flex shrink-0 items-center gap-0.5 rounded-full bg-brand-tint px-1.5 py-px font-mono type-footnote font-medium! leading-[13px] tracking-tight! text-white tabular-nums"
-                : "ml-auto font-mono type-footnote tabular-nums text-label-secondary"
-            }
-            data-session-limit-provider={limitBadge.provider}
-            data-session-limit-window={limitBadge.windowId}
-            data-session-limit-percent={limitBadge.percent.toFixed(4)}
-            aria-label={
-              isHighLimitShare
-                ? `${limitBadge.label} This session uses 5% or more of your limit.`
-                : limitBadge.label
-            }
-            tabIndex={0}
-            onMouseEnter={() => onLimitBadgeHover?.(limitBadge)}
-            onMouseLeave={() => onLimitBadgeHover?.(null)}
-            onFocus={() => onLimitBadgeHover?.(limitBadge)}
-            onBlur={() => onLimitBadgeHover?.(null)}
-          >
-            {isHighLimitShare && <Flame size={11} className="shrink-0" aria-hidden="true" />}
-            {formatLimitPercent(limitBadge.percent)}
-          </span>
-        </Tooltip>
-      ) : (
-        cost && (
-          <SessionCostBadge
-            {...cost}
-            appearance={cost.isHighCost ? "pill" : "bare"}
-            className={cn(cost.className, "ml-auto")}
-          />
-        )
-      )}
+      <div className="ml-auto">
+        {limitBadge && limitBadge.percent !== null ? (
+          <Tooltip label={limitBadge.label} delayMs={150}>
+            <span
+              className={
+                isHighLimitShare
+                  ? "flex shrink-0 items-center gap-0.5 rounded-full bg-brand-tint px-1.5 py-px font-mono type-footnote font-medium! leading-[13px] tracking-tight! text-white tabular-nums"
+                  : "font-mono type-footnote tabular-nums text-label-secondary"
+              }
+              data-session-limit-provider={limitBadge.provider}
+              data-session-limit-window={limitBadge.windowId}
+              data-session-limit-percent={limitBadge.percent.toFixed(4)}
+              aria-label={
+                isHighLimitShare
+                  ? `${limitBadge.label} This session uses 5% or more of your limit.`
+                  : limitBadge.label
+              }
+              tabIndex={0}
+              onMouseEnter={() => onLimitBadgeHover?.(limitBadge)}
+              onMouseLeave={() => onLimitBadgeHover?.(null)}
+              onFocus={() => onLimitBadgeHover?.(limitBadge)}
+              onBlur={() => onLimitBadgeHover?.(null)}
+            >
+              {isHighLimitShare && <Flame size={11} className="shrink-0" aria-hidden="true" />}
+              {formatLimitPercent(limitBadge.percent)}
+            </span>
+          </Tooltip>
+        ) : limitBadge ? (
+          <Tooltip label={limitBadge.label} delayMs={150}>
+            <span
+              className="font-mono type-footnote text-label-secondary opacity-50"
+              aria-label={limitBadge.label}
+              tabIndex={0}
+            >
+              no limit
+            </span>
+          </Tooltip>
+        ) : (
+          cost && <SessionCostBadge {...cost} appearance={cost.isHighCost ? "pill" : "bare"} />
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## User impact

Activity rows now show muted “no limit” text when the selected limit has no allocation. The tooltip names the selected period: “No 5h limit for this session.” or “No weekly limit for this session.” The status line also uses the shorter “burn checks” wording and keeps the metric aligned at the right edge.

## Validation

- Desktop formatting, lint, type checks, unused-code check, and production build passed.
- All 1,143 desktop tests passed, including missing-limit text and tooltip coverage.
- Design-contract drift check, `pnpm run slop:all`, and `pnpm run secrets` passed.

## Privacy and performance

None.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
