### PR TITLE
fix(analysis): keep Claude context available for unknown models and add Opus 5 to the window catalogue

### DIFF
--- a/apps/desktop/src-tauri/src/analysis/tests.rs
+++ b/apps/desktop/src-tauri/src/analysis/tests.rs
@@ -790,7 +790,7 @@ fn an_unreadable_child_is_skipped_and_the_session_still_publishes() {
 #[test]
 fn streaming_inline_metrics_equal_the_shipped_batch() {
     let input = inline_input(claude_record("inline-equality", 1_760_000_000), "inline");
-    let mut expected = analyze_sources_with(vec![input.clone()], true)
+    let expected = analyze_sources_with(vec![input.clone()], true)
         .sessions
         .into_iter()
         .next()
@@ -800,12 +800,6 @@ fn streaming_inline_metrics_equal_the_shipped_batch() {
     else {
         panic!("inline source must publish");
     };
-    // The batch path normalizes through `NormalizedSession`, which has no
-    // field for the Claude adapter's real window source (catalogued or
-    // tagged), so it always reports `Reported`/`Inferred`. The streaming
-    // path keeps the adapter's real source; patch it in here so the rest of
-    // the fields still catch a real regression.
-    expected.context_window_source = session.parent.context_window_source;
     assert_eq!(session.parent, expected);
 }
 

--- a/apps/desktop/src-tauri/src/analysis/tests.rs
+++ b/apps/desktop/src-tauri/src/analysis/tests.rs
@@ -790,7 +790,7 @@ fn an_unreadable_child_is_skipped_and_the_session_still_publishes() {
 #[test]
 fn streaming_inline_metrics_equal_the_shipped_batch() {
     let input = inline_input(claude_record("inline-equality", 1_760_000_000), "inline");
-    let expected = analyze_sources_with(vec![input.clone()], true)
+    let mut expected = analyze_sources_with(vec![input.clone()], true)
         .sessions
         .into_iter()
         .next()
@@ -800,6 +800,12 @@ fn streaming_inline_metrics_equal_the_shipped_batch() {
     else {
         panic!("inline source must publish");
     };
+    // The batch path normalizes through `NormalizedSession`, which has no
+    // field for the Claude adapter's real window source (catalogued or
+    // tagged), so it always reports `Reported`/`Inferred`. The streaming
+    // path keeps the adapter's real source; patch it in here so the rest of
+    // the fields still catch a real regression.
+    expected.context_window_source = session.parent.context_window_source;
     assert_eq!(session.parent, expected);
 }
 

--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -28,9 +28,9 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 27,
+            parser_revision: 28,
             analyzer_revision: 18,
-            metrics_schema_revision: 7,
+            metrics_schema_revision: 8,
             evidence_schema_revision: 14,
         }
     );

--- a/apps/desktop/src/lib/types/session.ts
+++ b/apps/desktop/src/lib/types/session.ts
@@ -187,9 +187,12 @@ export interface SessionMetrics {
   cacheRehydrationCount?: number
   /** Provider cache misses. The transport name stays compatible with stored analysis. */
   cacheRoutingMissCount?: number
-  /** False when the model's context window is unknown. */
+  /** Always true from metrics schema 8. `contextWindowSource` says whether
+   * `contextWindow` is a real figure or an inferred one. */
   contextAvailable?: boolean
   contextWindow: number
+  /** How the context window was found. Mirrors engine `ContextWindowSource`. */
+  contextWindowSource?: "reported" | "tagged" | "catalogued" | "inferred"
   buckets: SessionBucket[]
   initialContext?: InitialContextBreakdown | null
   model?: string | null

--- a/crates/antiburn-local/src/analysis/engine.rs
+++ b/crates/antiburn-local/src/analysis/engine.rs
@@ -300,15 +300,10 @@ impl ActiveSessionsSummary {
 /// occupancy, compaction, and cache-rehydration detection read parent-tagged
 /// events only (a sub-agent has its own context window).
 pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
-    let context_window_source = if session.context_window.is_some() {
-        ContextWindowSource::Reported
-    } else {
-        ContextWindowSource::Inferred
-    };
     let summary = crate::analysis::interface::SessionSummary {
         cache_write_tokens_available: session.cache_write_tokens_available,
         context_window: session.context_window,
-        context_window_source,
+        context_window_source: session.context_window_source,
         model: session.model.clone(),
         provider_hints: Vec::new(),
         started_at_ms: None,

--- a/crates/antiburn-local/src/analysis/engine.rs
+++ b/crates/antiburn-local/src/analysis/engine.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::analysis::efficiency::EfficiencyTotals;
 use crate::analysis::initial_context::InitialContextBreakdown;
+use crate::analysis::interface::ContextWindowSource;
 use crate::analysis::model::{CompactionTrigger, ModelRun, NormalizedSession};
 
 /// Number of progress buckets each session is resampled onto (0% → 100%).
@@ -166,13 +167,18 @@ pub struct SessionMetrics {
     /// Cache rebuilds after meaningful user inactivity.
     #[serde(default)]
     pub cache_rehydration_count: u64,
-    /// Whether the model context window is known well enough to present
-    /// occupancy. Unknown Claude model ids deliberately leave this unavailable.
+    /// Always true from metrics schema 8. Kept for stored analyses and the
+    /// current presentation; `context_window_source` says how the window
+    /// was found.
     pub context_available: bool,
     /// The model's context-window size used to normalize occupancy for this
     /// session (Codex's reported window, else the reference `CONTEXT_WINDOW`).
     /// Aggregation rescales each session's occupancy into the shared reference.
     pub context_window: u64,
+    /// How `context_window` was found: a real figure (reported or tagged),
+    /// a catalogue match, or an inferred fallback.
+    #[serde(default)]
+    pub context_window_source: ContextWindowSource,
     pub buckets: Vec<Bucket>,
     /// Where this session's initial context went. `None` means unavailable.
     /// `analyze_sources` populates this field because it needs the raw payload.
@@ -294,9 +300,15 @@ impl ActiveSessionsSummary {
 /// occupancy, compaction, and cache-rehydration detection read parent-tagged
 /// events only (a sub-agent has its own context window).
 pub fn analyze_session(session: &NormalizedSession) -> SessionMetrics {
+    let context_window_source = if session.context_window.is_some() {
+        ContextWindowSource::Reported
+    } else {
+        ContextWindowSource::Inferred
+    };
     let summary = crate::analysis::interface::SessionSummary {
         cache_write_tokens_available: session.cache_write_tokens_available,
         context_window: session.context_window,
+        context_window_source,
         model: session.model.clone(),
         provider_hints: Vec::new(),
         started_at_ms: None,

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -1011,7 +1011,7 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 27,
+                "parserRevision": 28,
                 "analyzerRevision": 18,
                 "evidenceSchemaRevision": 14,
                 "sourceKind": "file",

--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -327,6 +327,7 @@ impl SessionCollector {
             events: self.events,
             cache_write_tokens_available: summary.cache_write_tokens_available,
             context_window: summary.context_window,
+            context_window_source: summary.context_window_source,
             model: summary.model,
         })
     }
@@ -430,17 +431,13 @@ pub trait VendorAdapter: Sync {
             events,
             cache_write_tokens_available,
             context_window,
+            context_window_source,
             model,
             ..
         } = session;
         for event in events {
             sink.record(NormalizedRecord::MetricsEvent(Box::new(event)));
         }
-        let context_window_source = if context_window.is_some() {
-            ContextWindowSource::Reported
-        } else {
-            ContextWindowSource::Inferred
-        };
         sink.finish(SessionSummary {
             cache_write_tokens_available,
             context_window,

--- a/crates/antiburn-local/src/analysis/interface.rs
+++ b/crates/antiburn-local/src/analysis/interface.rs
@@ -224,6 +224,22 @@ pub(crate) fn bounded_provider_hint_value(value: &str) -> Option<String> {
     Some(value[..end].to_owned())
 }
 
+/// How a session's context-window figure was found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextWindowSource {
+    /// The transcript states the window (Codex `model_context_window`).
+    Reported,
+    /// The model id carries an explicit window tag such as `[1m]`.
+    Tagged,
+    /// The model id matched the built-in Claude window catalogue.
+    Catalogued,
+    /// No source gave a window. The metrics use the 200k tier bumped
+    /// by the observed peak.
+    #[default]
+    Inferred,
+}
+
 /// Session facts that an adapter can state only after the last record.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
@@ -231,6 +247,9 @@ pub struct SessionSummary {
     /// True when this adapter can observe cache-write tokens.
     pub cache_write_tokens_available: bool,
     pub context_window: Option<u64>,
+    /// How `context_window` was found. Defaults to `Inferred` for an adapter
+    /// that never sets it.
+    pub context_window_source: ContextWindowSource,
     pub model: Option<String>,
     /// Unique, bounded raw provider and model observations.
     pub provider_hints: Vec<ProviderHint>,
@@ -417,9 +436,15 @@ pub trait VendorAdapter: Sync {
         for event in events {
             sink.record(NormalizedRecord::MetricsEvent(Box::new(event)));
         }
+        let context_window_source = if context_window.is_some() {
+            ContextWindowSource::Reported
+        } else {
+            ContextWindowSource::Inferred
+        };
         sink.finish(SessionSummary {
             cache_write_tokens_available,
             context_window,
+            context_window_source,
             model,
             provider_hints: Vec::new(),
             started_at_ms: None,

--- a/crates/antiburn-local/src/analysis/merge.rs
+++ b/crates/antiburn-local/src/analysis/merge.rs
@@ -14,9 +14,10 @@ use crate::analysis::model::{EventSource, NormalizedEvent, NormalizedSession};
 /// Merge a parent session with every sub-agent it launched into one session.
 ///
 /// The merged session keeps the parent's identity (`agent`, `session_id`,
-/// `context_window`, `model`): a sub-agent's own context window does not
-/// describe the parent, so it is dropped here. Every event keeps a
-/// [`EventSource`] tag so the engine can tell which stream it came from.
+/// `context_window`, `context_window_source`, `model`): a sub-agent's own
+/// context window does not describe the parent, so it is dropped here.
+/// Every event keeps a [`EventSource`] tag so the engine can tell which
+/// stream it came from.
 ///
 /// Ordering: events sort by an effective timestamp. An event that carries its
 /// own `ts_ms` sorts on it. An event with no timestamp takes the timestamp of
@@ -45,6 +46,7 @@ pub fn merge_subagent_events(
         events: parent_events,
         cache_write_tokens_available,
         context_window,
+        context_window_source,
         model,
     } = parent;
 
@@ -62,6 +64,7 @@ pub fn merge_subagent_events(
         events: combined.into_iter().map(|(_, event)| event).collect(),
         cache_write_tokens_available,
         context_window,
+        context_window_source,
         model,
     }
 }
@@ -97,6 +100,7 @@ mod tests {
             events,
             cache_write_tokens_available: true,
             context_window: None,
+            context_window_source: crate::analysis::interface::ContextWindowSource::Inferred,
             model: None,
         }
     }

--- a/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/mod.rs
@@ -31,7 +31,9 @@ use crate::analysis::engine::{
 use crate::analysis::initial_context::{
     InitialContextBreakdown, InitialContextSourceCount, InitialContextTokenSource, SourceOrigin,
 };
-use crate::analysis::interface::{NormalizedRecord, RecordSink, SessionSummary};
+use crate::analysis::interface::{
+    ContextWindowSource, NormalizedRecord, RecordSink, SessionSummary,
+};
 use crate::analysis::model::{
     EventSource, ModelRun, NormalizedEvent, Role, Usage, is_subagent_launch_tool,
 };
@@ -96,6 +98,7 @@ impl OnlineTallies {
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 struct StoredSummary {
     context_window: Option<u64>,
+    context_window_source: ContextWindowSource,
     model: Option<String>,
     started_at_ms: Option<i64>,
     initial_context: Option<InitialContextBreakdown>,
@@ -868,6 +871,7 @@ impl SessionMetricsAccumulator {
         let observed_tool_names = string_count_map(&self.tool_match_counts);
         self.summary = Some(StoredSummary {
             context_window: summary.context_window,
+            context_window_source: summary.context_window_source,
             model: summary.model.map(|model| tally::truncate_name(&model)),
             started_at_ms: summary.started_at_ms,
             initial_context: summary.initial_context.map(|breakdown| {
@@ -1043,8 +1047,9 @@ impl SessionMetricsAccumulator {
             compaction_count: self.tallies.compaction_count,
             cache_routing_miss_count,
             cache_rehydration_count,
-            context_available: self.identity.agent != "claude" || summary.context_window.is_some(),
+            context_available: true,
             context_window,
+            context_window_source: summary.context_window_source,
             buckets,
             initial_context: summary.initial_context.clone(),
             model: summary.model.clone(),

--- a/crates/antiburn-local/src/analysis/metrics_sink/reference.rs
+++ b/crates/antiburn-local/src/analysis/metrics_sink/reference.rs
@@ -929,7 +929,6 @@ pub(crate) fn finalize_metrics(
         }
     }
 
-    let context_available = identity.agent != "claude" || summary.context_window.is_some();
     let context_window = resolve_context_window(
         summary.context_window.unwrap_or(CONTEXT_WINDOW),
         tallies.peak_context_tokens,
@@ -963,8 +962,9 @@ pub(crate) fn finalize_metrics(
         compaction_count: tallies.compaction_count,
         cache_routing_miss_count: provider_cache_miss_count,
         cache_rehydration_count,
-        context_available,
+        context_available: true,
         context_window,
+        context_window_source: summary.context_window_source,
         buckets,
         initial_context: None,
         model: summary.model.clone(),

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -80,10 +80,10 @@ pub use framing::{
 };
 pub use initial_context::{InitialContextBreakdown, InitialContextSourceCount, SourceOrigin};
 pub use interface::{
-    ContentKind, ContentPart, ContextSourceKind, EvidenceObservation, MAX_CONTENT_PART_BYTES,
-    MAX_PROVIDER_HINTS, NormalizedRecord, ProviderHint, RawSource, RecordCoverage, RecordSink,
-    RelationProvenance, ResumedVisit, SessionCollector, SessionInput, SessionSummary,
-    SourceChangedReason, TurnContent, VendorAdapter, VisitOutcome,
+    ContentKind, ContentPart, ContextSourceKind, ContextWindowSource, EvidenceObservation,
+    MAX_CONTENT_PART_BYTES, MAX_PROVIDER_HINTS, NormalizedRecord, ProviderHint, RawSource,
+    RecordCoverage, RecordSink, RelationProvenance, ResumedVisit, SessionCollector, SessionInput,
+    SessionSummary, SourceChangedReason, TurnContent, VendorAdapter, VisitOutcome,
 };
 pub use merge::merge_subagent_events;
 pub use metrics_sink::{RETAINED_METRICS_BYTES_BOUND, SessionMetricsAccumulator, merge_metrics};
@@ -159,7 +159,12 @@ pub use vendors::{adapter_for, has_dedicated_adapter};
 // instead of double-counting it (`vendors::claude::visit_reader`).
 // Codex `token_usage_record` support requires a parser revision bump.
 // Stored sessions must re-ingest to restore complete coverage and deduplicate paired usage rows.
-pub const PARSER_REVISION: i64 = 27;
+// +1 for the Claude context-window rule: the catalogue now covers `opus-5`
+// and `mythos-5`, splits `opus-4` so 4.0 and 4.1 resolve to 200k while 4.6
+// to 4.9 stay 1M, and an explicit `[1m]`/`[200k]` tag beats the catalogue
+// (`vendors::claude::model_context_window`). The summary now also carries
+// `context_window_source`, so a stored Claude session must reparse.
+pub const PARSER_REVISION: i64 = 28;
 // +1 for turn row chart signals: `has_thinking`, `last_tool`, and
 // `subagent_launches` are now ingest-derived row columns
 // (`rows::turn_row_from_event`), so every session must reparse to
@@ -212,7 +217,10 @@ pub const ANALYZER_REVISION: i64 = 18;
 // +1 for provider-specific rehydration thresholds and exact user inactivity.
 // Stored analyses must rerun for the corrected cache-event classification.
 // This revision adds the separate speed-aware pricing breakdown.
-pub const METRICS_SCHEMA_REVISION: i64 = 7;
+// +1 for `context_window_source`: `context_available` is now always true,
+// and the new field says whether the window is reported, tagged,
+// catalogued, or inferred. Stored analyses must rerun to populate it.
+pub const METRICS_SCHEMA_REVISION: i64 = 8;
 // +1 for `RepeatedContext` (`evidence::CacheEvidence::repeated_context`).
 // +1 more for `RepeatedContext::paid_tokens` (part F).
 // +1 more for `SourceCapabilities::linear_record_order`.
@@ -240,7 +248,8 @@ pub const COVERAGE_SCHEMA_REVISION: i64 = 1;
 /// before it restores a snapshot; this constant and the rule are
 /// documented here so a future revision bump remembers to bump this one
 /// too, when the change touches resumable state.
-pub const RESUME_SNAPSHOT_REVISION: i64 = 4;
+// +1 because `ClaudeStreamState` gained a `context_window_source` field.
+pub const RESUME_SNAPSHOT_REVISION: i64 = 5;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/model.rs
+++ b/crates/antiburn-local/src/analysis/model.rs
@@ -6,6 +6,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::analysis::interface::ContextWindowSource;
+
 /// Token accounting for a single turn, as reported by the agent's API usage.
 ///
 /// Fields default to zero so adapters can populate only what a given vendor
@@ -426,10 +428,16 @@ pub struct NormalizedSession {
     #[serde(default)]
     pub cache_write_tokens_available: bool,
     /// The model's context-window size for this session, when the vendor reports
-    /// it (e.g. Codex `model_context_window`). Claude leaves this as `None` for
-    /// unknown model ids so context occupancy can be presented as unavailable.
+    /// it (e.g. Codex `model_context_window`), matches an id in Claude's
+    /// built-in catalogue, or carries an explicit window tag. `None` when no
+    /// source gave a window; `context_window_source` then reads `Inferred`
+    /// and the engine falls back to a 200k-plus-peak-bump estimate.
     #[serde(default)]
     pub context_window: Option<u64>,
+    /// How `context_window` was found. Mirrors the adapter's own
+    /// `SessionSummary::context_window_source`.
+    #[serde(default)]
+    pub context_window_source: ContextWindowSource,
     /// The model id used for this session (e.g. `claude-opus-4-6`), when an
     /// adapter can extract it. For sessions that mix models, the most expensive
     /// priceable one seen. `None` when unknown — pricing then yields no estimate.

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -8,10 +8,11 @@ use crate::analysis::model::{
 };
 use crate::analysis::rows::{MemoryTurnRowStore, TurnRowSink, TurnRowStore};
 use crate::analysis::{
-    CompositeSink, EvidenceSource, EvidenceValue, NormalizedRecord, PartialReason, RawSource,
-    RecordCoverage, RecordSink, SessionCollector, SessionCoverageRecord, SessionEvidence,
-    SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator, SessionSummary,
-    SourceCapabilities, SourceKind, VisitOutcome, adapter_for, analyze_sources, normalize_source,
+    CompositeSink, ContextWindowSource, EvidenceSource, EvidenceValue, NormalizedRecord,
+    PartialReason, RawSource, RecordCoverage, RecordSink, SessionCollector, SessionCoverageRecord,
+    SessionEvidence, SessionEvidenceAccumulator, SessionInput, SessionMetricsAccumulator,
+    SessionSummary, SourceCapabilities, SourceKind, VisitOutcome, adapter_for, analyze_sources,
+    normalize_source,
 };
 
 /// Runs `jsonl` through the Claude adapter into a [`CompositeSink`], the
@@ -2036,14 +2037,16 @@ fn claude_sonnet_5_has_1m_context() {
 }
 
 #[test]
-fn unknown_claude_context_is_unavailable() {
+fn unknown_claude_context_is_inferred() {
     let fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","model":"claude-unknown-99","usage":{"input_tokens":1000,"output_tokens":50},"content":[{"type":"text","text":"x"}]}}"#;
     let session = normalize_source(&jsonl_input("claude", fixture)).unwrap();
     assert_eq!(session.context_window, None);
     let metrics = analyze_session(&session);
-    assert!(!metrics.context_available);
+    assert!(metrics.context_available);
+    assert_eq!(metrics.context_window, 200_000);
+    assert_eq!(metrics.context_window_source, ContextWindowSource::Inferred);
     let summary = analyze_sources(vec![jsonl_input("claude", fixture)]);
-    assert!(!summary.context_available);
+    assert!(summary.context_available);
 }
 
 /// A session whose model isn't recorded (or isn't in the pricing table) yields no

--- a/crates/antiburn-local/src/analysis/tests.rs
+++ b/crates/antiburn-local/src/analysis/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use crate::analysis::engine::analyze_session;
+use crate::analysis::engine::{SessionMetrics, analyze_session};
 use crate::analysis::merge::merge_subagent_events;
 use crate::analysis::model::{
     CompactionTrigger, EventSource, ModelRun, NormalizedEvent, Role, ToolCategory,
@@ -750,6 +750,7 @@ fn codex_rollout_envelope_is_normalized() {
     assert_eq!(m.peak_context_tokens, 1000);
     // The model's real context window is captured from model_context_window.
     assert_eq!(m.context_window, 258400);
+    assert_eq!(m.context_window_source, ContextWindowSource::Reported);
     assert!(m.buckets.iter().any(|b| b.tokens_in > 0));
     assert!(m.buckets.iter().any(|b| b.tokens_out > 0));
     assert!(m.buckets.iter().any(|b| b.context_tokens > 0));
@@ -2047,6 +2048,72 @@ fn unknown_claude_context_is_inferred() {
     assert_eq!(metrics.context_window_source, ContextWindowSource::Inferred);
     let summary = analyze_sources(vec![jsonl_input("claude", fixture)]);
     assert!(summary.context_available);
+}
+
+/// An unrecognized model gives no catalogue window, so the engine falls back to
+/// the 200k tier. A peak above that tier still bumps the window up (to 1M here),
+/// and the source stays `Inferred` because no tag or catalogue entry set it.
+#[test]
+fn unknown_claude_context_infers_a_bumped_tier_from_peak_usage() {
+    let fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","model":"claude-unknown-99","usage":{"input_tokens":300000,"output_tokens":50},"content":[{"type":"text","text":"x"}]}}"#;
+    let session = normalize_source(&jsonl_input("claude", fixture)).unwrap();
+    assert_eq!(session.context_window, None);
+    let metrics = analyze_session(&session);
+    assert!(metrics.context_available);
+    assert_eq!(metrics.context_window, 1_000_000);
+    assert_eq!(metrics.context_window_source, ContextWindowSource::Inferred);
+}
+
+/// `claude-opus-5` sits in the built-in catalogue's 1M set, so the window comes
+/// from the catalogue rather than a tag or the peak-bump fallback.
+#[test]
+fn claude_opus_5_context_window_is_catalogued() {
+    let fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","model":"claude-opus-5","usage":{"input_tokens":1000,"output_tokens":50},"content":[{"type":"text","text":"x"}]}}"#;
+    let session = normalize_source(&jsonl_input("claude", fixture)).unwrap();
+    assert_eq!(session.context_window, Some(1_000_000));
+    let metrics = analyze_session(&session);
+    assert_eq!(metrics.context_window, 1_000_000);
+    assert_eq!(
+        metrics.context_window_source,
+        ContextWindowSource::Catalogued
+    );
+}
+
+/// An explicit `[1m]` window tag beats the catalogue: `claude-sonnet-4` would
+/// otherwise resolve to 200k, but the tag on the id overrides that.
+#[test]
+fn claude_window_tag_beats_the_catalogue() {
+    let fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","model":"claude-sonnet-4-20250514[1m]","usage":{"input_tokens":1000,"output_tokens":50},"content":[{"type":"text","text":"x"}]}}"#;
+    let session = normalize_source(&jsonl_input("claude", fixture)).unwrap();
+    assert_eq!(session.context_window, Some(1_000_000));
+    let metrics = analyze_session(&session);
+    assert_eq!(metrics.context_window, 1_000_000);
+    assert_eq!(metrics.context_window_source, ContextWindowSource::Tagged);
+}
+
+/// A stored analysis written before metrics schema 8 has no `contextWindowSource`
+/// field. Deserializing it must default the field to `Inferred`, not fail.
+#[test]
+fn session_metrics_without_a_context_window_source_field_defaults_to_inferred() {
+    let fixture = r#"{"type":"assistant","timestamp":"2024-06-01T12:00:00Z","message":{"role":"assistant","model":"claude-opus-5","usage":{"input_tokens":1000,"output_tokens":50},"content":[{"type":"text","text":"x"}]}}"#;
+    let session = normalize_source(&jsonl_input("claude", fixture)).unwrap();
+    let metrics = analyze_session(&session);
+    assert_eq!(
+        metrics.context_window_source,
+        ContextWindowSource::Catalogued
+    );
+
+    let mut value = serde_json::to_value(&metrics).expect("serialize metrics");
+    value
+        .as_object_mut()
+        .expect("metrics serializes to an object")
+        .remove("contextWindowSource");
+    let restored: SessionMetrics =
+        serde_json::from_value(value).expect("deserialize metrics missing the field");
+    assert_eq!(
+        restored.context_window_source,
+        ContextWindowSource::Inferred
+    );
 }
 
 /// A session whose model isn't recorded (or isn't in the pricing table) yields no

--- a/crates/antiburn-local/src/analysis/vendors/claude.rs
+++ b/crates/antiburn-local/src/analysis/vendors/claude.rs
@@ -18,8 +18,9 @@ use serde_json::Value;
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::initial_context::ClaudeContextAccumulator;
 use crate::analysis::interface::{
-    ContextSourceKind, EvidenceObservation, NormalizedRecord, RawSource, RecordSink, ResumedVisit,
-    SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter, VisitOutcome,
+    ContextSourceKind, ContextWindowSource, EvidenceObservation, NormalizedRecord, RawSource,
+    RecordSink, ResumedVisit, SessionCollector, SessionInput, SessionSummary, TurnContent,
+    VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, ToolCall, Usage};
 use crate::analysis::records::{
@@ -728,6 +729,7 @@ impl ClaudeAdapter {
 struct ClaudeStreamState {
     max_usage_by_message_id: HashMap<String, Usage>,
     context_window: Option<u64>,
+    context_window_source: Option<ContextWindowSource>,
     first_model: Option<String>,
     best_priceable: Option<(String, f64)>,
     last_seen_model: Option<String>,
@@ -786,11 +788,11 @@ impl ClaudeStreamState {
             return;
         }
         self.last_seen_model = Some(model.to_string());
-        if let Some(window) = model_context_window(model) {
-            self.context_window = Some(
-                self.context_window
-                    .map_or(window, |current| current.max(window)),
-            );
+        if let Some((window, source)) = model_context_window(model)
+            && self.context_window.is_none_or(|current| window > current)
+        {
+            self.context_window = Some(window);
+            self.context_window_source = Some(source);
         }
         if self.first_model.is_none() {
             self.first_model = Some(model.to_string());
@@ -835,6 +837,9 @@ impl ClaudeStreamState {
         SessionSummary {
             cache_write_tokens_available: true,
             context_window: self.context_window,
+            context_window_source: self
+                .context_window_source
+                .unwrap_or(ContextWindowSource::Inferred),
             model,
             provider_hints: Vec::new(),
             started_at_ms: None,
@@ -885,29 +890,86 @@ fn is_builtin_command(command: &str) -> bool {
         .any(|builtin| command.eq_ignore_ascii_case(builtin))
 }
 
-/// The context window for a recognized Claude model family. Unknown model ids
-/// stay unavailable rather than inheriting a misleading 200k guess.
-fn model_context_window(model: &str) -> Option<u64> {
-    let m = model.to_ascii_lowercase();
-    let is_1m = m.contains("opus-4")
-        || m.contains("fable-5")
-        || m.contains("sonnet-5")
-        || m.contains("sonnet-4-5")
-        || m.contains("sonnet-4-6")
-        || m.contains("sonnet-4-7")
-        || m.contains("sonnet-4-8")
-        || m.contains("sonnet-4-9");
-    if is_1m {
-        Some(1_000_000)
-    } else if m.contains("haiku")
-        || m.contains("claude-3")
-        || m.contains("sonnet-4-0")
-        || m.contains("sonnet-4-202")
-    {
-        Some(200_000)
-    } else {
-        None
+/// The context window and its source for a Claude model id. Resolution order:
+/// an explicit window tag (`[1m]`, `[200k]`) beats the built-in catalogue.
+/// An unrecognized id (no tag, no catalogue match) returns `None`; the
+/// caller then infers the window from the 200k-plus-peak-bump fallback.
+fn model_context_window(model: &str) -> Option<(u64, ContextWindowSource)> {
+    let lower = model.to_ascii_lowercase();
+    if let Some(open) = lower.find('[') {
+        let tag = lower[open + 1..].trim_end_matches(']');
+        match tag {
+            "1m" => return Some((1_000_000, ContextWindowSource::Tagged)),
+            "200k" => return Some((200_000, ContextWindowSource::Tagged)),
+            // An unrecognized tag falls through to the catalogue on the
+            // stripped id, below.
+            _ => {}
+        }
     }
+    let stripped = crate::analysis::pricing::strip_window_tag(&lower);
+    catalogued_context_window(stripped).map(|window| (window, ContextWindowSource::Catalogued))
+}
+
+/// True when `segments` contains `pattern` as a contiguous run. Segment
+/// equality (not substring) keeps `opus-4-1` from matching `opus-4-10`.
+fn has_segment_run(segments: &[&str], pattern: &[&str]) -> bool {
+    !pattern.is_empty()
+        && segments.len() >= pattern.len()
+        && segments
+            .windows(pattern.len())
+            .any(|window| window == pattern)
+}
+
+/// True when `segments` holds `prefix` immediately followed by one 8-digit
+/// segment, such as `["opus", "4", "20250514"]` — the date suffix on an
+/// undated model family like Opus 4.0.
+fn has_prefix_then_date(segments: &[&str], prefix: &[&str]) -> bool {
+    segments.windows(prefix.len() + 1).any(|window| {
+        window[..prefix.len()] == *prefix
+            && window[prefix.len()].len() == 8
+            && window[prefix.len()]
+                .bytes()
+                .all(|byte| byte.is_ascii_digit())
+    })
+}
+
+/// The context window for a recognized Claude model family, matched on the
+/// lower-cased, tag-stripped model id's dash-delimited segments. Unknown
+/// model ids return `None` rather than inheriting a misleading guess.
+fn catalogued_context_window(model: &str) -> Option<u64> {
+    let segments: Vec<&str> = model.split('-').collect();
+    let has = |pattern: &[&str]| has_segment_run(&segments, pattern);
+
+    const ONE_MILLION: &[&[&str]] = &[
+        &["opus", "5"],
+        &["mythos", "5"],
+        &["fable", "5"],
+        &["sonnet", "5"],
+        &["opus", "4", "6"],
+        &["opus", "4", "7"],
+        &["opus", "4", "8"],
+        &["opus", "4", "9"],
+        &["sonnet", "4", "5"],
+        &["sonnet", "4", "6"],
+        &["sonnet", "4", "7"],
+        &["sonnet", "4", "8"],
+        &["sonnet", "4", "9"],
+    ];
+    if ONE_MILLION.iter().any(|pattern| has(pattern)) {
+        return Some(1_000_000);
+    }
+
+    const TWO_HUNDRED_K: &[&[&str]] = &[
+        &["opus", "4", "0"],
+        &["opus", "4", "1"],
+        &["sonnet", "4", "0"],
+    ];
+    let is_200k = TWO_HUNDRED_K.iter().any(|pattern| has(pattern))
+        || has_prefix_then_date(&segments, &["opus", "4"])
+        || has_prefix_then_date(&segments, &["sonnet", "4"])
+        || segments.contains(&"haiku")
+        || has(&["claude", "3"]);
+    is_200k.then_some(200_000)
 }
 
 #[cfg(test)]
@@ -2139,5 +2201,91 @@ mod tests {
 
         let session = collector.into_session().expect("session must build");
         assert!(session.events.is_empty());
+    }
+
+    #[test]
+    fn model_context_window_resolves_every_catalogued_and_tagged_id() {
+        const ONE_MILLION_CATALOGUED: &[&str] = &[
+            "claude-opus-5",
+            "claude-mythos-5-1",
+            "claude-fable-5",
+            "claude-fable-5-1",
+            "claude-sonnet-5",
+            "claude-opus-4-6",
+            "claude-opus-4-7-20260115",
+            "claude-opus-4-8",
+            "claude-sonnet-4-6",
+        ];
+        for id in ONE_MILLION_CATALOGUED {
+            assert_eq!(
+                model_context_window(id),
+                Some((1_000_000, ContextWindowSource::Catalogued)),
+                "id {id}"
+            );
+            let upper = id.to_ascii_uppercase();
+            assert_eq!(
+                model_context_window(&upper),
+                Some((1_000_000, ContextWindowSource::Catalogued)),
+                "upper-case id {upper}"
+            );
+        }
+
+        const TWO_HUNDRED_K_CATALOGUED: &[&str] = &[
+            "claude-opus-4-20250514",
+            "claude-opus-4-1-20250805",
+            "claude-sonnet-4-20250514",
+            "claude-haiku-4-5-20251001",
+            "claude-3-5-haiku-20241022",
+        ];
+        for id in TWO_HUNDRED_K_CATALOGUED {
+            assert_eq!(
+                model_context_window(id),
+                Some((200_000, ContextWindowSource::Catalogued)),
+                "id {id}"
+            );
+            let upper = id.to_ascii_uppercase();
+            assert_eq!(
+                model_context_window(&upper),
+                Some((200_000, ContextWindowSource::Catalogued)),
+                "upper-case id {upper}"
+            );
+        }
+
+        assert_eq!(
+            model_context_window("claude-sonnet-4-20250514[1m]"),
+            Some((1_000_000, ContextWindowSource::Tagged))
+        );
+        assert_eq!(
+            model_context_window("claude-fictional[1m]"),
+            Some((1_000_000, ContextWindowSource::Tagged))
+        );
+        assert_eq!(
+            model_context_window("claude-fictional[200k]"),
+            Some((200_000, ContextWindowSource::Tagged))
+        );
+        assert_eq!(model_context_window("claude-fictional"), None);
+        assert_eq!(model_context_window("claude-fictional[weird]"), None);
+    }
+
+    #[test]
+    fn claude_stream_state_takes_the_larger_window_and_its_source() {
+        let mut state = ClaudeStreamState::default();
+        state.observe_model(Some("claude-haiku-4-5-20251001"));
+        state.observe_model(Some("claude-opus-5"));
+        let summary = state.into_summary();
+        assert_eq!(summary.context_window, Some(1_000_000));
+        assert_eq!(
+            summary.context_window_source,
+            ContextWindowSource::Catalogued
+        );
+    }
+
+    #[test]
+    fn claude_stream_state_infers_an_unrecognized_model() {
+        let mut state = ClaudeStreamState::default();
+        state.observe_model(Some("claude-fictional"));
+        let summary = state.into_summary();
+        assert_eq!(summary.context_window, None);
+        assert_eq!(summary.context_window_source, ContextWindowSource::Inferred);
     }
 }

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -52,9 +52,9 @@ use super::read_source;
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::initial_context::CodexContextAccumulator;
 use crate::analysis::interface::{
-    ContentKind, ContentPart, EvidenceObservation, NormalizedRecord, RawSource, RecordSink,
-    RelationProvenance, ResumedVisit, SessionInput, SessionSummary, TurnContent, VendorAdapter,
-    VisitOutcome,
+    ContentKind, ContentPart, ContextWindowSource, EvidenceObservation, NormalizedRecord,
+    RawSource, RecordSink, RelationProvenance, ResumedVisit, SessionInput, SessionSummary,
+    TurnContent, VendorAdapter, VisitOutcome,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role, ToolCall, Usage};
 use crate::analysis::records::{
@@ -684,9 +684,15 @@ impl CodexStreamState {
                 Vec::new()
             };
         let (initial_context, skill_descriptions) = self.context.finish();
+        let context_window_source = if self.context_window.is_some() {
+            ContextWindowSource::Reported
+        } else {
+            ContextWindowSource::Inferred
+        };
         SessionSummary {
             cache_write_tokens_available: self.cache_write_tokens_available,
             context_window: self.context_window,
+            context_window_source,
             model: self.model,
             provider_hints: Vec::new(),
             started_at_ms: self.started_at_ms,
@@ -2048,7 +2054,7 @@ mod tests {
 
     #[test]
     fn record_to_event_changes_require_an_inertness_review() {
-        const EXPECTED_FINGERPRINT: u64 = 15_392_126_338_475_589_352;
+        const EXPECTED_FINGERPRINT: u64 = 13_546_544_228_035_879_293;
         let source = include_str!("codex.rs").replace("\r\n", "\n");
         let start = source.find("fn observe_model_and_effort").unwrap();
         let end = source.find("\n#[cfg(test)]\nmod tests").unwrap();

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -78,12 +78,18 @@ impl VendorAdapter for CodexAdapter {
         let content = read_source(&input.source)
             .with_context(|| format!("reading codex session {}", input.session_id))?;
         let (events, context_window, model, cache_write_tokens_available) = parse_codex(&content);
+        let context_window_source = if context_window.is_some() {
+            ContextWindowSource::Reported
+        } else {
+            ContextWindowSource::Inferred
+        };
         Ok(NormalizedSession {
             agent: input.agent.clone(),
             session_id: input.session_id.clone(),
             events,
             cache_write_tokens_available,
             context_window,
+            context_window_source,
             model,
         })
     }

--- a/crates/antiburn-local/src/analysis/vendors/cursor.rs
+++ b/crates/antiburn-local/src/analysis/vendors/cursor.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use time::{Date, Month, PrimitiveDateTime, Time, UtcOffset};
 
 use super::read_source;
-use crate::analysis::interface::{SessionInput, VendorAdapter};
+use crate::analysis::interface::{ContextWindowSource, SessionInput, VendorAdapter};
 use crate::analysis::model::{NormalizedEvent, NormalizedSession};
 use crate::analysis::records::{RecordShape, parse_record, parse_ts};
 
@@ -26,6 +26,7 @@ impl VendorAdapter for CursorAdapter {
             events,
             cache_write_tokens_available: true,
             context_window: None,
+            context_window_source: ContextWindowSource::Inferred,
             model,
         })
     }

--- a/crates/antiburn-local/src/analysis/vendors/generic_jsonl.rs
+++ b/crates/antiburn-local/src/analysis/vendors/generic_jsonl.rs
@@ -9,7 +9,7 @@
 use anyhow::Context;
 
 use super::read_source;
-use crate::analysis::interface::{SessionInput, VendorAdapter};
+use crate::analysis::interface::{ContextWindowSource, SessionInput, VendorAdapter};
 use crate::analysis::model::NormalizedSession;
 use crate::analysis::records::parse_jsonl;
 
@@ -33,6 +33,7 @@ impl VendorAdapter for GenericJsonlAdapter {
             // vendor's transcript contract; this fallback knows no vendor.
             cache_write_tokens_available: false,
             context_window: None,
+            context_window_source: ContextWindowSource::Inferred,
             model: None,
         })
     }

--- a/crates/antiburn-local/src/analysis/vendors/opencode.rs
+++ b/crates/antiburn-local/src/analysis/vendors/opencode.rs
@@ -20,9 +20,9 @@ use crate::analysis::framing::{
     BoundedJsonlReader, FramedRecord, MAX_RECORD_BYTES, PartialReason, RecordSkip,
 };
 use crate::analysis::interface::{
-    ContentKind, ContentPart, EvidenceObservation, NormalizedRecord, ProviderHint, RawSource,
-    RecordSink, RelationProvenance, SessionCollector, SessionInput, SessionSummary, TurnContent,
-    VendorAdapter, VisitOutcome, push_provider_hint,
+    ContentKind, ContentPart, ContextWindowSource, EvidenceObservation, NormalizedRecord,
+    ProviderHint, RawSource, RecordSink, RelationProvenance, SessionCollector, SessionInput,
+    SessionSummary, TurnContent, VendorAdapter, VisitOutcome, push_provider_hint,
 };
 use crate::analysis::model::{
     CompactionTrigger, EventSource, NormalizedEvent, NormalizedSession, Role, ToolCall,
@@ -608,6 +608,7 @@ impl OpenCodeStreamState {
         SessionSummary {
             cache_write_tokens_available: true,
             context_window: None,
+            context_window_source: ContextWindowSource::Inferred,
             model: self.model.clone(),
             provider_hints: self.provider_hints.clone(),
             started_at_ms: None,

--- a/crates/antiburn-local/src/analysis/vendors/pi.rs
+++ b/crates/antiburn-local/src/analysis/vendors/pi.rs
@@ -23,9 +23,9 @@ use serde_json::Value;
 
 use crate::analysis::framing::{BoundedJsonlReader, FramedRecord, PartialReason, RecordSkip};
 use crate::analysis::interface::{
-    ContentPart, EvidenceObservation, NormalizedRecord, ProviderHint, RawSource, RecordSink,
-    ResumedVisit, SessionCollector, SessionInput, SessionSummary, TurnContent, VendorAdapter,
-    VisitOutcome, bounded_provider_hint_value, push_provider_hint,
+    ContentPart, ContextWindowSource, EvidenceObservation, NormalizedRecord, ProviderHint,
+    RawSource, RecordSink, ResumedVisit, SessionCollector, SessionInput, SessionSummary,
+    TurnContent, VendorAdapter, VisitOutcome, bounded_provider_hint_value, push_provider_hint,
 };
 use crate::analysis::model::{NormalizedEvent, NormalizedSession, Role};
 use crate::analysis::records::{
@@ -585,6 +585,7 @@ impl PiStreamState {
         SessionSummary {
             cache_write_tokens_available: self.cache_write_tokens_available.unwrap_or(true),
             context_window: None,
+            context_window_source: ContextWindowSource::Inferred,
             model: self.model.or(self.current_model),
             provider_hints: self.provider_hints,
             started_at_ms: self.started_at_ms,

--- a/crates/antiburn-local/tests/claude_characterization.rs
+++ b/crates/antiburn-local/tests/claude_characterization.rs
@@ -1028,10 +1028,17 @@ fn fixture_provenance_records_the_source_kind_and_ordering() {
 fn streaming_metrics_equal_the_shipped_batch_for_every_fixture() {
     for name in fixture_names() {
         let input = input(name);
-        let expected = analyze_sources_with(vec![input.clone()], true)
+        let mut expected = analyze_sources_with(vec![input.clone()], true)
             .sessions
             .remove(0);
-        assert_eq!(stream_claude(&input).metrics(), expected, "fixture {name}");
+        let actual = stream_claude(&input).metrics();
+        // `analyze_sources_with` normalizes through `NormalizedSession`,
+        // which has no field for the Claude adapter's real window source
+        // (catalogued or tagged), so it always reports `Reported`/`Inferred`.
+        // The streaming path keeps the adapter's real source; patch it in
+        // here so the rest of the fields still catch a real regression.
+        expected.context_window_source = actual.context_window_source;
+        assert_eq!(actual, expected, "fixture {name}");
     }
 }
 
@@ -1044,7 +1051,17 @@ fn streaming_metrics_match_every_golden() {
             .expect("metrics must serialize");
         let actual: Value =
             serde_json::from_str(&rendered).expect("rendered metrics must be valid JSON");
-        assert_eq!(actual, expected["sessions"][0], "fixture {name}");
+        let mut expected_session = expected["sessions"][0].clone();
+        // The golden's `sessions[0]` comes from the batch path
+        // (`analyze_sources_with`), which normalizes through
+        // `NormalizedSession` and so always reports `contextWindowSource` as
+        // `reported`/`inferred`. The streaming path keeps the adapter's real
+        // source; patch the golden's copy so the rest of the fields still
+        // catch a real regression.
+        if let Some(source) = actual.get("contextWindowSource") {
+            expected_session["contextWindowSource"] = source.clone();
+        }
+        assert_eq!(actual, expected_session, "fixture {name}");
     }
 }
 
@@ -1097,6 +1114,11 @@ fn merged_streaming_metrics_equal_the_merged_batch() {
     per_thread_efficiency.add(stream_claude(&child_input).metrics().efficiency);
     assert_eq!(actual.efficiency, per_thread_efficiency);
     expected.efficiency = actual.efficiency;
+    // `analyze_session` builds its summary from a `NormalizedSession`, which
+    // has no field for the Claude adapter's real window source. It always
+    // reports `Reported`/`Inferred`, so patch in the streaming accumulator's
+    // real source (`Catalogued` here) the same way as `efficiency`, above.
+    expected.context_window_source = actual.context_window_source;
 
     assert_eq!(actual.initial_context, None);
     assert_eq!(actual, expected);

--- a/crates/antiburn-local/tests/claude_characterization.rs
+++ b/crates/antiburn-local/tests/claude_characterization.rs
@@ -4,13 +4,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use antiburn_local::analysis::{
-    ANALYZER_REVISION, CompositeSink, CoverageReason, EVIDENCE_SCHEMA_REVISION, EvidenceCoverage,
-    EvidenceSource, EvidenceValue, MAX_RECORD_BYTES, MemoryTurnRowStore, NormalizedSession,
-    OrderingObservation, PARSER_REVISION, PartialReason, RawSource, RecordCoverage,
-    SessionCollector, SessionEvidence, SessionEvidenceAccumulator, SessionInput,
-    SessionMetricsAccumulator, SourceCapabilities, SourceKind, TurnFacts, TurnRowSink,
-    TurnRowStore, TurnScope, adapter_for, analyze_session, analyze_sources_with, merge_metrics,
-    merge_subagent_events, normalize_source,
+    ANALYZER_REVISION, CompositeSink, ContextWindowSource, CoverageReason,
+    EVIDENCE_SCHEMA_REVISION, EvidenceCoverage, EvidenceSource, EvidenceValue, MAX_RECORD_BYTES,
+    MemoryTurnRowStore, NormalizedSession, OrderingObservation, PARSER_REVISION, PartialReason,
+    RawSource, RecordCoverage, SessionCollector, SessionEvidence, SessionEvidenceAccumulator,
+    SessionInput, SessionMetricsAccumulator, SourceCapabilities, SourceKind, TurnFacts,
+    TurnRowSink, TurnRowStore, TurnScope, adapter_for, analyze_session, analyze_sources_with,
+    merge_metrics, merge_subagent_events, normalize_source,
 };
 use antiburn_local::insights::{
     CoverageCounts, DetectorId, DetectorStatus, EfficiencyReport, EfficiencyReportAccumulator,
@@ -1028,17 +1028,10 @@ fn fixture_provenance_records_the_source_kind_and_ordering() {
 fn streaming_metrics_equal_the_shipped_batch_for_every_fixture() {
     for name in fixture_names() {
         let input = input(name);
-        let mut expected = analyze_sources_with(vec![input.clone()], true)
+        let expected = analyze_sources_with(vec![input.clone()], true)
             .sessions
             .remove(0);
-        let actual = stream_claude(&input).metrics();
-        // `analyze_sources_with` normalizes through `NormalizedSession`,
-        // which has no field for the Claude adapter's real window source
-        // (catalogued or tagged), so it always reports `Reported`/`Inferred`.
-        // The streaming path keeps the adapter's real source; patch it in
-        // here so the rest of the fields still catch a real regression.
-        expected.context_window_source = actual.context_window_source;
-        assert_eq!(actual, expected, "fixture {name}");
+        assert_eq!(stream_claude(&input).metrics(), expected, "fixture {name}");
     }
 }
 
@@ -1051,17 +1044,26 @@ fn streaming_metrics_match_every_golden() {
             .expect("metrics must serialize");
         let actual: Value =
             serde_json::from_str(&rendered).expect("rendered metrics must be valid JSON");
-        let mut expected_session = expected["sessions"][0].clone();
-        // The golden's `sessions[0]` comes from the batch path
-        // (`analyze_sources_with`), which normalizes through
-        // `NormalizedSession` and so always reports `contextWindowSource` as
-        // `reported`/`inferred`. The streaming path keeps the adapter's real
-        // source; patch the golden's copy so the rest of the fields still
-        // catch a real regression.
-        if let Some(source) = actual.get("contextWindowSource") {
-            expected_session["contextWindowSource"] = source.clone();
-        }
-        assert_eq!(actual, expected_session, "fixture {name}");
+        assert_eq!(actual, expected["sessions"][0], "fixture {name}");
+    }
+}
+
+/// `Reported` names a vendor that states its own context window (Codex's
+/// `model_context_window`). A Claude session's window always comes from a
+/// tag, the built-in catalogue, or the 200k-plus-peak-bump inference, never
+/// a self-reported figure — so `Reported` here would mean the batch path
+/// lost the adapter's real source, the bug this guards against.
+#[test]
+fn no_claude_fixture_reports_a_self_reported_context_window() {
+    for name in fixture_names() {
+        let metrics = analyze_sources_with(vec![input(name)], true)
+            .sessions
+            .remove(0);
+        assert_ne!(
+            metrics.context_window_source,
+            ContextWindowSource::Reported,
+            "fixture {name}"
+        );
     }
 }
 
@@ -1114,11 +1116,6 @@ fn merged_streaming_metrics_equal_the_merged_batch() {
     per_thread_efficiency.add(stream_claude(&child_input).metrics().efficiency);
     assert_eq!(actual.efficiency, per_thread_efficiency);
     expected.efficiency = actual.efficiency;
-    // `analyze_session` builds its summary from a `NormalizedSession`, which
-    // has no field for the Claude adapter's real window source. It always
-    // reports `Reported`/`Inferred`, so patch in the streaming accumulator's
-    // real source (`Catalogued` here) the same way as `efficiency`, above.
-    expected.context_window_source = actual.context_window_source;
 
     assert_eq!(actual.initial_context, None);
     assert_eq!(actual, expected);

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_continues_thread.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_continues_thread.json
@@ -4079,6 +4079,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_continues_thread.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_continues_thread.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4079,7 +4080,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_with_cache_rehydration.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_with_cache_rehydration.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4147,7 +4148,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0076,
         "cacheWriteUsd": 0.17759999999999998,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_with_cache_rehydration.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/compaction_with_cache_rehydration.json
@@ -4147,6 +4147,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0076,
         "cacheWriteUsd": 0.17759999999999998,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_model_missing.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_model_missing.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4034,7 +4035,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_model_missing.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_model_missing.json
@@ -4034,6 +4034,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_models.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_models.json
@@ -4058,6 +4058,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_models.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/delegated_models.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4058,7 +4059,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/disorder_ladder.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/disorder_ladder.json
@@ -5370,6 +5370,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/disorder_ladder.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/disorder_ladder.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -5370,7 +5371,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/fast_mode_overuse_clean.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/fast_mode_overuse_clean.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4025,7 +4026,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/fast_mode_overuse_clean.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/fast_mode_overuse_clean.json
@@ -4025,6 +4025,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/housekeeping_records.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/housekeeping_records.json
@@ -4025,6 +4025,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/housekeeping_records.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/housekeeping_records.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4025,7 +4026,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
@@ -4025,6 +4025,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/incomplete_final_record.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4025,7 +4026,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inferred_cache_rehydration.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inferred_cache_rehydration.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4054,7 +4055,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.00536,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inferred_cache_rehydration.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inferred_cache_rehydration.json
@@ -4054,6 +4054,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.00536,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inline_sidechain_own_thread.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inline_sidechain_own_thread.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4179,7 +4180,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inline_sidechain_own_thread.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/inline_sidechain_own_thread.json
@@ -4179,6 +4179,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/late_skill_metrics.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/late_skill_metrics.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4032,7 +4033,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/late_skill_metrics.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/late_skill_metrics.json
@@ -4032,6 +4032,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
@@ -4025,6 +4025,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/malformed_between_valid.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4025,7 +4026,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/model_overthinking_finding.json
@@ -4004,6 +4004,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/model_overthinking_finding.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4004,7 +4005,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/multi_model_session.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/multi_model_session.json
@@ -4070,6 +4070,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/multi_model_session.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/multi_model_session.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4070,7 +4071,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
@@ -4052,6 +4052,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/parent_with_task_spawn.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4052,7 +4053,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4122,7 +4123,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.00064,
         "cacheWriteUsd": 0.001648,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/records_all_kinds.json
@@ -4122,6 +4122,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.00064,
         "cacheWriteUsd": 0.001648,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/rehydration_gap_none.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/rehydration_gap_none.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4054,7 +4055,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.00536,
         "cacheWriteUsd": 0.064,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/rehydration_gap_none.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/rehydration_gap_none.json
@@ -4054,6 +4054,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.00536,
         "cacheWriteUsd": 0.064,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/resume_replay.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/resume_replay.json
@@ -4178,6 +4178,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/resume_replay.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/resume_replay.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4178,7 +4179,7 @@
       "compactionCount": 1,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/session_overdepth_finding.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4025,7 +4026,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/session_overdepth_finding.json
@@ -4025,6 +4025,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/sidechain_in_parent.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/sidechain_in_parent.json
@@ -4046,6 +4046,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/sidechain_in_parent.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/sidechain_in_parent.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4046,7 +4047,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
@@ -4052,6 +4052,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_child.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4052,7 +4053,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_single_timestamp.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_single_timestamp.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4025,7 +4026,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_single_timestamp.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/subagent_single_timestamp.json
@@ -4025,6 +4025,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_chain.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_chain.json
@@ -4126,6 +4126,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.170024,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_chain.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_chain.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4126,7 +4127,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.170024,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_missing_uuid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_missing_uuid.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4078,7 +4079,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_missing_uuid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/thread_identity_missing_uuid.json
@@ -4078,6 +4078,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
@@ -4074,6 +4074,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/timestamps_repeated_and_out_of_order.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4074,7 +4075,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/two_compactions_second_without_metadata.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/two_compactions_second_without_metadata.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4068,7 +4069,7 @@
       "compactionCount": 2,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.045,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/two_compactions_second_without_metadata.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/two_compactions_second_without_metadata.json
@@ -4068,6 +4068,7 @@
       "compactionCount": 2,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.045,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4046,7 +4047,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/unrecognized_type.json
@@ -4046,6 +4046,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 200000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/within_file_duplicate_uuid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/within_file_duplicate_uuid.json
@@ -4054,6 +4054,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
+      "contextWindowSource": "reported",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/within_file_duplicate_uuid.json
+++ b/crates/antiburn-local/tests/fixtures/claude_characterization/goldens/within_file_duplicate_uuid.json
@@ -3,6 +3,7 @@
     "agent": "claude",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "catalogued",
     "events": [
       {
         "compactionPostTokens": null,
@@ -4054,7 +4055,7 @@
       "compactionCount": 0,
       "contextAvailable": true,
       "contextWindow": 1000000,
-      "contextWindowSource": "reported",
+      "contextWindowSource": "catalogued",
       "cost": {
         "cacheReadUsd": 0.0,
         "cacheWriteUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -4213,6 +4213,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -154,7 +154,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4162,6 +4162,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 601,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -149,7 +149,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4177,6 +4177,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 15,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -4228,6 +4228,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -4213,6 +4213,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -154,7 +154,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4162,6 +4162,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 601,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -169,7 +169,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4185,6 +4185,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 0,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -4236,6 +4236,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -144,7 +144,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4151,6 +4151,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 0,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -4202,6 +4202,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -151,7 +151,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4167,6 +4167,7 @@
     "compactionCount": 1,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 7,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -4226,6 +4226,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -144,7 +144,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4151,6 +4151,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 600000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 0,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -4202,6 +4202,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": 600000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -4228,6 +4228,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -149,7 +149,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4177,6 +4177,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "reported",
     "cost": null,
     "durationSecs": 6,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -123,7 +123,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4130,6 +4130,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "inferred",
     "cost": null,
     "durationSecs": 0,
     "efficiency": {

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -4160,6 +4160,7 @@
     "agent": "codex",
     "cacheWriteTokensAvailable": false,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [],
     "model": null,
     "sessionId": "unrecognized_type"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -4173,6 +4173,7 @@
     "agent": "pi",
     "cacheWriteTokensAvailable": true,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -133,7 +133,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4146,6 +4146,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "inferred",
     "durationSecs": 1,
     "efficiency": {
       "carryUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -4224,6 +4224,7 @@
     "agent": "pi",
     "cacheWriteTokensAvailable": true,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -159,7 +159,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4160,6 +4160,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "inferred",
     "durationSecs": 2,
     "efficiency": {
       "carryUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -144,7 +144,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4144,6 +4144,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "inferred",
     "durationSecs": 0,
     "efficiency": {
       "carryUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -4192,6 +4192,7 @@
     "agent": "pi",
     "cacheWriteTokensAvailable": true,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -139,7 +139,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4139,6 +4139,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 1000000,
+    "contextWindowSource": "inferred",
     "durationSecs": 1,
     "efficiency": {
       "carryUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -4186,6 +4186,7 @@
     "agent": "pi",
     "cacheWriteTokensAvailable": true,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -168,7 +168,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4174,6 +4174,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "inferred",
     "durationSecs": 0,
     "efficiency": {
       "carryUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -4221,6 +4221,7 @@
     "agent": "pi",
     "cacheWriteTokensAvailable": true,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -4183,6 +4183,7 @@
     "agent": "pi",
     "cacheWriteTokensAvailable": true,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [],
     "model": null,
     "sessionId": "unknown_row_type"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -150,7 +150,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4156,6 +4156,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "inferred",
     "durationSecs": 0,
     "efficiency": {
       "carryUsd": 0.0,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -4192,6 +4192,7 @@
     "agent": "pi",
     "cacheWriteTokensAvailable": true,
     "contextWindow": null,
+    "contextWindowSource": "inferred",
     "events": [
       {
         "compactionPostTokens": null,

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -144,7 +144,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 27,
+      "parserRevision": 28,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },
@@ -4145,6 +4145,7 @@
     "compactionCount": 0,
     "contextAvailable": true,
     "contextWindow": 200000,
+    "contextWindowSource": "inferred",
     "durationSecs": 1,
     "efficiency": {
       "carryUsd": 0.0,


### PR DESCRIPTION
Closes #400.

## Problem

`model_context_window` had no entry for `opus-5`, so `claude-opus-5` sessions (the most used model in real stores) resolved no window. That flipped `context_available` to false, the aggregate dropped the peak, and the session detail showed 0 context with no chart area. The number itself was never the problem: the pipeline already falls back to the 200k tier bumped by the observed peak. Only the availability flag was missing.

Also: the `[1m]` model-id tag was stripped for pricing but ignored for the window, and `opus-4` put Opus 4.0 and 4.1 (200k models) in the 1M set.

## Change

- **Unknown Claude ids stay context-available.** The existing 200k-plus-peak-bump fallback is shown, and the metrics record that it was inferred.
- **New `ContextWindowSource` field** (`reported`, `tagged`, `catalogued`, `inferred`) on `SessionSummary`, `NormalizedSession`, and `SessionMetrics` (`contextWindowSource`). Backend and TypeScript types only; no component changes. Showing a dash or caveat for an inferred window is a presentation follow-up.
- **`[1m]` / `[200k]` tag beats the catalogue**, so `claude-sonnet-4-20250514[1m]` resolves to 1M.
- **Catalogue** now matches on dash-delimited segments (no more substring accidents), adds `opus-5` and `mythos-5` to the 1M set, and resolves Opus 4.0 and 4.1 to 200k while 4.6 to 4.9 stay 1M.
- **`context_available` is now always true.** Kept for stored analyses and the current presentation; the doc comments point at the source field.
- **Revisions:** parser 27 to 28 (adapter rule changed, stored Claude sessions reparse), metrics schema 7 to 8 (new field, defaults to `inferred` for stored analyses), resume snapshot 4 to 5 (`ClaudeStreamState` gained a field).

## Goldens

Every Claude golden gains `"contextWindowSource": "catalogued"`; Codex goldens read `reported` (7) or `inferred` (1); Pi reads `inferred`. Revision literals updated. No other golden values changed.

## Tests

- Table test over the resolver: every catalogued id in both tiers, upper-case variants, tagged ids, unknown ids with and without an unrecognised tag.
- `ClaudeStreamState` takes the larger window and its source across a model change.
- Metrics: unknown model with peak above 200k gives 1M inferred; `claude-opus-5` catalogued; tagged id tagged; Codex reported.
- `SessionMetrics` JSON without `contextWindowSource` deserializes to `inferred`.
- Guard: no Claude fixture's batch metrics may read `reported`, which is what a lost source looks like.
- Streaming-versus-batch parity tests pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRFn3r1VKrU8DpGjfHDBst
