### PR TITLE
Release antiburn-local 0.6.0

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -17,6 +17,55 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-07
+
+### Added
+
+- Aggregate Insights reports now expose finding, clean, unavailable, and
+  not-applicable counts, plus bounded per-check and combined token-burn
+  estimates. `SessionTokenBurnEvidence`, `TokenBurnTurnAccumulator`, and the
+  related source and turn evidence types let an embedding supply the local
+  inputs without transcript content.
+- Context-source evidence can include built-in tool definitions, their token
+  cost, invocation state, and deferred state. The unused built-in-tools check
+  now produces findings for supported Claude sessions.
+- `ContextWindowSource` records whether a context limit was reported, tagged,
+  catalogued, or inferred. Pricing breakdown queries expose token use by the
+  effective model and speed tier.
+- `AgentExplorer::indexed_title_watch_files` and
+  `Explorers::indexed_title_watch_files_for` expose vendor title stores to
+  filesystem watchers.
+
+### Changed
+
+- **Breaking:** `SessionInput` includes `fork_parent_session_id`, and session
+  summaries and metrics include `context_window_source`. Report and evidence
+  structures include the new aggregate, tool-definition, and pricing fields.
+- Claude resume-as-fork sessions can link to their parent and exclude inherited
+  records from the child's analysis. Replayed records with an earlier UUID are
+  also excluded from work, usage, and evidence.
+- Codex `token_usage` records contribute usage without double counting the
+  matching event record. Agent tool calls count as sub-agent launches, and
+  zero-usage synthetic turns no longer receive attributed work.
+- Token-burn estimates use local session evidence for context overdepth,
+  repeated context, model policy, speed, and unused context sources. The
+  combined result avoids adding checks that can describe the same work.
+- Model pricing distinguishes speed tiers, including GPT-6 Astra Fast.
+
+### Fixed
+
+- Claude context remains available for unknown model identifiers through an
+  inferred 200k tier that expands to the observed peak. Tagged one-million-token
+  models and Opus 5 use their correct context limits.
+- Claude housekeeping and in-file resume records no longer make evidence
+  incomplete or inflate usage. Thread links use `parentUuid` rather than an
+  unrelated UUID field.
+- Copilot CLI discovery accepts only `events.jsonl`, so unrelated JSONL files
+  are not treated as sessions.
+- A Claude skill keeps a known `SourceOrigin` after the session invokes it.
+  Origin evidence that cannot be classified no longer suppresses the
+  filesystem probe, and user skills still resolve when a worktree is removed.
+
 ## [0.5.0] - 2026-09-03
 
 ### Added
@@ -33,9 +82,6 @@ version and refuses the release if there is none.
 - `WatchRoot`, `AgentExplorer::watch_roots`, and `Explorers::watch_roots_for`
   expose the directories each agent's discovery reads, for a filesystem
   watcher.
-- `AgentExplorer::indexed_title_watch_files` and
-  `Explorers::indexed_title_watch_files_for` expose vendor title stores to
-  filesystem watchers.
 
 ### Changed
 
@@ -54,19 +100,6 @@ version and refuses the release if there is none.
   `agent-transcripts` and `chats` walks are now bounded by depth to the
   documented layout, rather than mtime-gated, so a rediscovery no longer
   reads a project's other subdirectories.
-
-### Fixed
-
-- A Claude skill keeps a known `SourceOrigin` after the session invokes it.
-  The `invoked_skills` path is a scheme string, such as
-  `userSettings:<name>`, so only the `bundled:` form resolved before and
-  the rest reported `Unknown`.
-- Origin evidence that cannot be classified no longer suppresses the
-  filesystem probe for that skill name.
-- The user-directory probe runs when the session's working directory no
-  longer exists, so a user skill still resolves for a deleted worktree. The
-  project probe and the bare-name `Bundled` inference still need that
-  directory.
 
 ### Removed
 

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "antiburn-local"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MIT"


### PR DESCRIPTION
The application tree contains engine changes after `antiburn-local-v0.5.0`, so the 0.4.0 app release cannot pass the source-parity gate until those changes have an engine tag. This bumps the standalone engine to 0.6.0, refreshes both lockfiles, and records the public contract and behavior changes since 0.5.0.

The 0.6.0 minor version reflects pre-1.0 public contract changes: `SessionInput`, session summary and metrics structures, evidence structures, and report APIs gained fields or types. The app lockfile changes only the in-tree `antiburn-local` package version.

The indexed-title watcher and Claude skill-origin entries had been appended to the 0.5.0 changelog section after the 0.5.0 tag. This moves them to 0.6.0, the first engine release whose source contains those changes, so the published history matches the tagged source.

Validation:

- `node scripts/verify-release-version.mjs engine antiburn-local-v0.6.0`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `pnpm run slop:all` — 100/100, no findings
- `pnpm run secrets`

This release metadata adds no network access, data collection, or runtime work.
