### PR TITLE
feat(desktop): add a fixture-driven UI sandbox mode

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -58,6 +58,7 @@ Run from the repository root:
 pnpm install
 pnpm --filter @antiburn/desktop dev          # Tauri dev build (tray + popover)
 pnpm --filter @antiburn/desktop dev:web      # frontend only, in a browser
+pnpm --filter @antiburn/desktop dev:sandbox  # popover on fixture data, in a browser
 pnpm --filter @antiburn/desktop dev:bundle   # bundled debug .app / installer
 pnpm --filter @antiburn/desktop lint
 pnpm --filter @antiburn/desktop type-check
@@ -65,6 +66,13 @@ pnpm --filter @antiburn/desktop test
 pnpm --filter @antiburn/desktop build        # frontend bundle only
 pnpm --filter @antiburn/desktop icons        # regenerate app and tray icons
 ```
+
+`dev:sandbox` is a development aid for popover styling. It serves
+`sandbox.html`, which frames the real popover at its window size and feeds it
+fixture data instead of a shell: Vite aliases the Tauri packages to the shims in
+`src/sandbox/`, so no product file changes and no other build sees the shims.
+Open `http://127.0.0.1:1420/sandbox.html?scenario=busy` (or `default`) in a
+browser. The scenarios live in `src/sandbox/scenarios.ts`.
 
 The `dev`, `dev:bundle`, and `tauri` scripts load `apps/desktop/.env` when it
 exists. The shell environment takes precedence. `.env.example` lists the Google

--- a/apps/desktop/knip.json
+++ b/apps/desktop/knip.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["src/settings.tsx", "src/onboarding.tsx", "src/styles.css"],
+  "entry": [
+    "src/settings.tsx",
+    "src/onboarding.tsx",
+    "src/styles.css",
+    "src/sandbox/tauri-*.ts"
+  ],
   "project": ["src/**/*.{ts,tsx,css}"],
   "ignoreDependencies": ["@tauri-apps/cli"]
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "dev": "node scripts/run-tauri.mjs dev --config src-tauri/tauri.debug.conf.json",
     "dev:bundle": "node scripts/run-tauri.mjs build --debug --config src-tauri/tauri.debug.conf.json",
     "dev:web": "vite",
+    "dev:sandbox": "vite --mode sandbox",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",

--- a/apps/desktop/sandbox.html
+++ b/apps/desktop/sandbox.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>antiburn sandbox</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+    <style>
+      /* Development aid only. Frame the popover at its native window size. */
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: start center;
+        padding-top: 24px;
+        background: #d9d9d9;
+      }
+      #root {
+        width: 380px;
+        height: 700px;
+        max-height: 700px;
+        overflow: hidden;
+        border-radius: 12px;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.32);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+    <script>
+      // Append the overlay toolbar when the local receiver answers. Stay silent when it does not.
+      const overlayUrl = "http://127.0.0.1:4680/overlay.js"
+      fetch(overlayUrl, { method: "HEAD" })
+        .then((response) => {
+          if (!response.ok) return
+          const script = document.createElement("script")
+          script.src = overlayUrl
+          document.body.append(script)
+        })
+        .catch(() => {})
+    </script>
+  </body>
+</html>

--- a/apps/desktop/src/sandbox/commands.ts
+++ b/apps/desktop/src/sandbox/commands.ts
@@ -1,0 +1,82 @@
+/**
+ * The `invoke` switch for the UI sandbox.
+ *
+ * Each shell command answers from the active scenario. An unknown command
+ * resolves to `null`, the same default the popover test uses, and logs once
+ * so a missing fixture is easy to spot in the console.
+ */
+
+import type { AppSettings, SessionIdentityPayload } from "../lib/ipc"
+import { sessionAnalysis, sessionHygiene } from "./fixtures"
+import { pickScenario, type Scenario } from "./scenarios"
+import { emit } from "./tauri-event"
+
+let active: Scenario | null = null
+
+function scenario(): Scenario {
+  active ??= pickScenario()
+  return active
+}
+
+const unknownCommands = new Set<string>()
+
+export function runCommand(command: string, args: Record<string, unknown> = {}): unknown {
+  const state = scenario()
+  switch (command) {
+    case "app_info":
+      return state.appInfo
+    case "engine_catalog_version":
+      return state.appInfo.pricingCatalogVersion
+    case "get_settings":
+      return state.settings
+    case "set_settings": {
+      state.settings = args["settings"] as AppSettings
+      emit("settings:changed", state.settings)
+      return state.settings
+    }
+    case "list_recent_sessions":
+      return state.entries
+    case "get_session_analysis": {
+      const sessionId = args["sessionId"] as string
+      const entry = state.entries.find((each) => each.sessionId === sessionId)
+      return state.analyses[sessionId] ?? (entry ? sessionAnalysis(entry) : null)
+    }
+    case "get_subagent_analysis":
+      return state.subagentAnalyses[args["subagentId"] as string] ?? null
+    case "get_session_hygiene": {
+      const sessions = args["sessions"] as SessionIdentityPayload[]
+      return sessions.map((each) => state.hygiene[each.sessionId] ?? sessionHygiene())
+    }
+    case "get_provider_usage":
+      return state.providerUsage
+    case "get_live_usage":
+    case "refresh_live_usage":
+      return state.liveUsage
+    case "get_session_limit_allocations":
+      return state.allocations
+    case "get_checks_report":
+      return state.checksReport
+    case "get_scan_status":
+    case "scan_now":
+    case "cancel_scan":
+      return state.scanStatus
+    case "get_storage_health":
+      return state.storageHealth
+    case "list_scan_roots":
+    case "default_scan_roots":
+    case "list_repositories":
+    case "refresh_repositories":
+    case "set_repository_enabled":
+      return []
+    case "set_popover_height":
+      return true
+    case "show_popover_peek":
+      return { generation: 1, target: args["target"] }
+    default:
+      if (!unknownCommands.has(command)) {
+        unknownCommands.add(command)
+        console.warn(`[sandbox] ${command} has no fixture; resolving null`)
+      }
+      return null
+  }
+}

--- a/apps/desktop/src/sandbox/fixtures.ts
+++ b/apps/desktop/src/sandbox/fixtures.ts
@@ -1,0 +1,526 @@
+/**
+ * Fixture factories for the UI sandbox.
+ *
+ * Each factory returns a full IPC payload, typed against `ipc.ts`. A rename on
+ * the shell side then fails `type-check` here instead of blanking the page.
+ * Timestamps count back from load time, so "3 minutes ago" stays true.
+ */
+
+import type { ChecksReportPayload, SessionHygienePayload } from "../lib/insightsIpc"
+import {
+  DEFAULT_SETTINGS,
+  type ActivityEntryPayload,
+  type AppInfo,
+  type AppSettings,
+  type LiveProviderUsagePayload,
+  type LiveUsageSummaryPayload,
+  type LiveUsageWindowPayload,
+  type ProviderUsagePayload,
+  type ProviderUsageSummaryPayload,
+  type ProviderUsageWindowPayload,
+  type ScanStatus,
+  type SessionAnalysisPayload,
+  type SubagentMemberPayload,
+} from "../lib/ipc"
+import type {
+  ActiveSessionsSummary,
+  BillableTokens,
+  SessionBucket,
+  SessionCostComponents,
+  SessionEfficiency,
+  SessionMetrics,
+} from "../lib/types/session"
+
+/** The wall clock at page load. Every relative timestamp counts back from here. */
+const LOADED_AT = Date.now()
+
+export function minutesAgo(minutes: number): string {
+  return new Date(LOADED_AT - minutes * 60_000).toISOString()
+}
+
+export function minutesFromNow(minutes: number): string {
+  return new Date(LOADED_AT + minutes * 60_000).toISOString()
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/* -------------------------------------------------------------------------
+ * App state
+ * ---------------------------------------------------------------------- */
+
+export function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    onboardingCompleted: true,
+    overviewLimitsExpanded: false,
+    ...overrides,
+  }
+}
+
+export function appInfo(overrides: Partial<AppInfo> = {}): AppInfo {
+  return {
+    appVersion: "0.4.0",
+    debugBuild: true,
+    arch: "aarch64",
+    pricingCatalogVersion: "2026-09-01",
+    schemaVersion: 12,
+    dataDir: "/Users/avery/Library/Application Support/antiburn",
+    indexedSessions: 412,
+    databaseBytes: 48_000_000,
+    updatesSupported: false,
+    analyticsSupported: false,
+    analyticsEnvironmentDisabled: false,
+    analyticsOperator: null,
+    ...overrides,
+  }
+}
+
+export function scanStatus(overrides: Partial<ScanStatus> = {}): ScanStatus {
+  return {
+    running: false,
+    completedAgents: 11,
+    totalAgents: 11,
+    sessions: 4,
+    finishedAt: minutesAgo(2),
+    cancelled: false,
+    error: null,
+    agents: [],
+    listChanged: false,
+    reDescribed: 0,
+    ...overrides,
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * Sessions
+ * ---------------------------------------------------------------------- */
+
+/** Split a total the way a well-cached session does. */
+export function cost(totalUsd: number): SessionCostComponents {
+  return {
+    totalUsd,
+    inputUsd: round(totalUsd * 0.12),
+    outputUsd: round(totalUsd * 0.38),
+    cacheReadUsd: round(totalUsd * 0.42),
+    cacheWriteUsd: round(totalUsd * 0.08),
+  }
+}
+
+export function tokens(totalUsd: number): BillableTokens {
+  return {
+    inputTokens: Math.round(totalUsd * 8_000),
+    outputTokens: Math.round(totalUsd * 5_000),
+    cacheReadTokens: Math.round(totalUsd * 900_000),
+    cacheCreationTokens: Math.round(totalUsd * 70_000),
+  }
+}
+
+function efficiency(totalUsd: number): SessionEfficiency {
+  return {
+    totalUsd,
+    newWorkUsd: round(totalUsd * 0.5),
+    carryUsd: round(totalUsd * 0.42),
+    rewriteUsd: round(totalUsd * 0.08),
+    growthTokens: Math.round(totalUsd * 60_000),
+    outputTokens: Math.round(totalUsd * 5_000),
+    pricedTurns: Math.max(4, Math.round(totalUsd * 30)),
+    unpricedTurns: 0,
+  }
+}
+
+export function activityEntry(
+  overrides: Partial<ActivityEntryPayload> = {},
+): ActivityEntryPayload {
+  return {
+    agent: "claude-code",
+    sessionId: "session-abc-123",
+    repo: "widgets",
+    timestamp: minutesAgo(1),
+    isActive: false,
+    surface: "cli",
+    wslDistro: null,
+    title: "Wire the tray popover",
+    hasForkParent: false,
+    forkChildCount: 0,
+    cost: cost(1.25),
+    models: ["claude-opus-4-6"],
+    modelRuns: [{ model: "claude-opus-4-6" }],
+    ...overrides,
+  }
+}
+
+function bucket(overrides: Partial<SessionBucket> = {}): SessionBucket {
+  return {
+    tokensIn: 1_000,
+    tokensOut: 200,
+    subagentTokens: 0,
+    contextTokens: 40_000,
+    isCompactionBoundary: false,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    rewriteTokens: 0,
+    isCacheRehydration: false,
+    isCacheRoutingMiss: false,
+    secsSincePriorTurn: null,
+    subagentLaunches: 0,
+    userPrompts: 0,
+    lastTool: null,
+    model: null,
+    thinkingMode: null,
+    speed: null,
+    hasThinking: false,
+    compactionTrigger: null,
+    compactionPreTokens: null,
+    compactionPostTokens: null,
+    ...overrides,
+  }
+}
+
+const TOOLS = ["Read", "Edit", "Bash", "Grep", "Write"]
+
+/**
+ * A session timeline. Context grows to `peak`, then one automatic compaction
+ * at bucket `compactionAt` drops it before it grows again. The variation is
+ * arithmetic, not random, so a screenshot stays the same between loads.
+ */
+function timeline(
+  count: number,
+  peak: number,
+  model: string,
+  compactionAt: number | null = null,
+): SessionBucket[] {
+  return Array.from({ length: count }, (_, index) => {
+    const compaction = compactionAt !== null && index === compactionAt
+    let contextTokens: number
+    if (compactionAt === null || index < compactionAt) {
+      const span = compactionAt ?? count
+      contextTokens = Math.round(peak * ((index + 1) / span))
+    } else if (compaction) {
+      contextTokens = Math.round(peak * 0.3)
+    } else {
+      const after = (index - compactionAt) / Math.max(1, count - 1 - compactionAt)
+      contextTokens = Math.round(peak * (0.3 + 0.6 * after))
+    }
+    return bucket({
+      tokensIn: 400 + ((index * 37) % 900),
+      tokensOut: 120 + ((index * 53) % 400),
+      contextTokens,
+      cacheReadTokens: Math.round(contextTokens * 0.85),
+      cacheWriteTokens: 300 + ((index * 29) % 500),
+      isCompactionBoundary: compaction,
+      compactionTrigger: compaction ? "auto" : null,
+      compactionPreTokens: compaction ? peak : null,
+      compactionPostTokens: compaction ? contextTokens : null,
+      userPrompts: index % 4 === 0 ? 1 : 0,
+      lastTool: TOOLS[index % TOOLS.length] ?? null,
+      model,
+      hasThinking: index % 2 === 0,
+      secsSincePriorTurn: 20 + ((index * 17) % 90),
+    })
+  })
+}
+
+export function sessionMetrics(overrides: Partial<SessionMetrics> = {}): SessionMetrics {
+  const model = overrides.model ?? "claude-opus-4-6"
+  return {
+    agent: "claude-code",
+    sessionId: "session-abc-123",
+    durationSecs: 5_400,
+    activeSecs: 3_900,
+    eventCount: 212,
+    tokensIn: 180_000,
+    tokensOut: 24_000,
+    peakContextTokens: 150_000,
+    compactionCount: 1,
+    cacheRehydrationCount: 0,
+    contextAvailable: true,
+    contextWindow: 200_000,
+    contextWindowSource: "reported",
+    model,
+    billableInputTokens: 42_000,
+    billableOutputTokens: 24_000,
+    billableCacheReadTokens: 3_100_000,
+    billableCacheCreationTokens: 260_000,
+    initialContext: {
+      sources: [
+        {
+          source: "skill_instructions",
+          sourceName: "discuss",
+          tokenCount: 3_200,
+          useCount: 2,
+          origin: "user",
+        },
+        {
+          source: "mcp_instructions",
+          sourceName: "figma",
+          tokenCount: 9_800,
+          useCount: 0,
+          origin: "plugin",
+        },
+        { source: "builtin_tool", sourceName: "Bash", tokenCount: 1_100, origin: "bundled" },
+      ],
+    },
+    buckets: timeline(40, 150_000, model, 28),
+    ...overrides,
+  }
+}
+
+export function summary(metrics: SessionMetrics): ActiveSessionsSummary {
+  return {
+    sessionCount: 1,
+    avgDurationSecs: metrics.durationSecs,
+    avgActiveSecs: metrics.activeSecs,
+    tokensInTotal: metrics.tokensIn,
+    tokensOutTotal: metrics.tokensOut,
+    peakContextTokens: metrics.peakContextTokens,
+    compactionCount: metrics.compactionCount ?? 0,
+    cacheRehydrationCount: metrics.cacheRehydrationCount ?? 0,
+    contextAvailable: true,
+    contextWindow: metrics.contextWindow,
+    costTotalUsd: metrics.cost?.totalUsd ?? null,
+    buckets: metrics.buckets,
+    sessions: [metrics],
+  }
+}
+
+export function subagentMember(
+  overrides: Partial<SubagentMemberPayload> = {},
+): SubagentMemberPayload {
+  return {
+    agent: "claude-code",
+    subagentId: "subagent-1",
+    label: "Explore the IPC surface for every popover command",
+    cost: cost(0.8),
+    tokens: tokens(0.8),
+    startedAtEpoch: Math.floor((LOADED_AT - 4_000_000) / 1000),
+    modelRuns: [{ model: "claude-sonnet-5" }],
+    ...overrides,
+  }
+}
+
+/** The analysis for `entry`, with a full timeline behind the chart. */
+export function sessionAnalysis(
+  entry: ActivityEntryPayload,
+  overrides: Partial<SessionAnalysisPayload> = {},
+): SessionAnalysisPayload {
+  const totalUsd = entry.cost?.totalUsd ?? 0
+  const model = entry.models[0] ?? "claude-opus-4-6"
+  const metrics = sessionMetrics({
+    agent: entry.agent,
+    sessionId: entry.sessionId,
+    model,
+    cost: entry.cost,
+    efficiency: efficiency(totalUsd),
+  })
+  return {
+    summary: summary(metrics),
+    supportsAnalysis: true,
+    title: entry.title,
+    wslDistro: entry.wslDistro,
+    isActive: entry.isActive,
+    cost: entry.cost,
+    topLevelCost: entry.cost,
+    subagentsCost: null,
+    inclusiveTokens: tokens(totalUsd),
+    subagentsTokens: null,
+    efficiency: efficiency(totalUsd),
+    models: entry.models,
+    modelRuns: entry.modelRuns,
+    orchestration: null,
+    relations: null,
+    sourcePath: `/Users/avery/.claude/projects/${entry.repo}/${entry.sessionId}.jsonl`,
+    startedAtEpoch: Math.floor((LOADED_AT - metrics.durationSecs * 1000) / 1000),
+    analysisPending: false,
+    analysisStale: false,
+    ...overrides,
+  }
+}
+
+export function sessionHygiene(
+  overrides: Partial<SessionHygienePayload> = {},
+): SessionHygienePayload {
+  return {
+    evidenceState: "ready",
+    badges: [
+      { id: "sessionOverdepth", status: "clean", notAssessedReason: null },
+      { id: "modelOverthinking", status: "clean", notAssessedReason: null },
+      { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
+      { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+      { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+      { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+    ],
+    ...overrides,
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * Usage
+ * ---------------------------------------------------------------------- */
+
+export function usageWindow(
+  estimatedUsd: number,
+  sessionCount: number,
+): ProviderUsageWindowPayload {
+  return {
+    tokensIn: Math.round(estimatedUsd * 9_000),
+    tokensOut: Math.round(estimatedUsd * 1_500),
+    cacheRead: Math.round(estimatedUsd * 120_000),
+    estimatedUsd,
+    costComplete: true,
+    sessionCount,
+  }
+}
+
+export function providerUsage(
+  overrides: Partial<ProviderUsagePayload> = {},
+): ProviderUsagePayload {
+  return {
+    provider: "anthropic",
+    accountKey: null,
+    displayName: "Anthropic",
+    state: "estimated",
+    staleness: "fresh",
+    windows: {
+      today: usageWindow(4.8, 3),
+      week: usageWindow(31.2, 14),
+      monthToDate: usageWindow(96.4, 41),
+      last30Days: usageWindow(128.9, 55),
+    },
+    agents: [],
+    lastActivityAt: minutesAgo(1),
+    ...overrides,
+  }
+}
+
+function sumWindows(windows: ProviderUsageWindowPayload[]): ProviderUsageWindowPayload {
+  return windows.reduce(
+    (total, window) => ({
+      tokensIn: total.tokensIn + window.tokensIn,
+      tokensOut: total.tokensOut + window.tokensOut,
+      cacheRead: total.cacheRead + window.cacheRead,
+      estimatedUsd: round((total.estimatedUsd ?? 0) + (window.estimatedUsd ?? 0)),
+      costComplete: total.costComplete && window.costComplete,
+      sessionCount: total.sessionCount + window.sessionCount,
+    }),
+    usageWindow(0, 0),
+  )
+}
+
+/** The summary for `providers`, with `totals` summed across them. */
+export function providerUsageSummary(
+  providers: ProviderUsagePayload[],
+): ProviderUsageSummaryPayload {
+  return {
+    providers,
+    totals: {
+      today: sumWindows(providers.map((provider) => provider.windows.today)),
+      week: sumWindows(providers.map((provider) => provider.windows.week)),
+      monthToDate: sumWindows(providers.map((provider) => provider.windows.monthToDate)),
+      last30Days: sumWindows(providers.map((provider) => provider.windows.last30Days)),
+    },
+    generatedAt: minutesAgo(0),
+  }
+}
+
+export function liveWindow(
+  overrides: Partial<LiveUsageWindowPayload> = {},
+): LiveUsageWindowPayload {
+  return {
+    id: "five-hour",
+    role: "primaryShort",
+    kind: "fiveHour",
+    scopeModel: null,
+    usedPercent: 40,
+    startsAt: minutesAgo(200),
+    resetsAt: minutesFromNow(100),
+    hasNonzeroUsageInCurrentPeriod: true,
+    forecast: {
+      unavailableReason: null,
+      confidence: "medium",
+      consumptionRate: 0.2,
+      paceRatio: 1.1,
+      paceTrend: 0.05,
+      runwayAt: minutesFromNow(240),
+      usedToday: 62,
+    },
+    ...overrides,
+  }
+}
+
+export function liveProvider(
+  overrides: Partial<LiveProviderUsagePayload> = {},
+): LiveProviderUsagePayload {
+  return {
+    provider: "anthropic",
+    accountKey: null,
+    displayName: "Claude",
+    support: "live",
+    freshness: "fresh",
+    sourceLabel: "Asked Claude directly",
+    observedAt: minutesAgo(2),
+    windows: [
+      liveWindow(),
+      liveWindow({
+        id: "seven-day",
+        role: "primaryLong",
+        kind: "weekly",
+        usedPercent: 63,
+        startsAt: minutesAgo(4 * 24 * 60),
+        resetsAt: minutesFromNow(3 * 24 * 60),
+      }),
+    ],
+    extraUsage: null,
+    resetCredits: null,
+    plan: { name: "Max", tier: "20x" },
+    accountUuid: null,
+    accountEmail: null,
+    ...overrides,
+  }
+}
+
+export function liveUsageSummary(
+  providers: LiveProviderUsagePayload[],
+): LiveUsageSummaryPayload {
+  return {
+    providers,
+    errors: [],
+    meters: providers.map((provider) => ({
+      provider: provider.provider,
+      displayName: provider.displayName,
+      shown: true,
+    })),
+    generatedAt: minutesAgo(0),
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * Checks
+ * ---------------------------------------------------------------------- */
+
+export function checksReport(
+  overrides: Partial<ChecksReportPayload> = {},
+): ChecksReportPayload {
+  return {
+    evidenceSettled: true,
+    estimatedTokenBurnBasisPoints: 1_625,
+    categories: [
+      {
+        id: "cacheChurn",
+        finding: 7,
+        clean: 7,
+        unavailable: 0,
+        estimatedTokenBurnBasisPoints: 1_250,
+      },
+      {
+        id: "sessionsOverDepth",
+        finding: 0,
+        clean: 14,
+        unavailable: 0,
+        estimatedTokenBurnBasisPoints: 0,
+      },
+    ],
+    ...overrides,
+  }
+}

--- a/apps/desktop/src/sandbox/scenarios.ts
+++ b/apps/desktop/src/sandbox/scenarios.ts
@@ -1,0 +1,485 @@
+/**
+ * Named fixture sets for the UI sandbox. `?scenario=<name>` picks one.
+ *
+ * `default` mirrors the popover test: one session, one provider.
+ * `busy` is a full week: a dozen sessions across three agents, one active,
+ * one expensive, and live limits for two providers.
+ */
+
+import type { ChecksReportPayload, SessionHygienePayload } from "../lib/insightsIpc"
+import {
+  HEALTHY_STORAGE,
+  type ActivityEntryPayload,
+  type AppInfo,
+  type AppSettings,
+  type LiveUsageSummaryPayload,
+  type ProviderUsageSummaryPayload,
+  type ScanStatus,
+  type SessionAnalysisPayload,
+  type SessionLimitAllocationSummaryPayload,
+  type StorageHealthPayload,
+} from "../lib/ipc"
+import {
+  activityEntry,
+  appInfo,
+  checksReport,
+  cost,
+  liveProvider,
+  liveUsageSummary,
+  liveWindow,
+  minutesAgo,
+  minutesFromNow,
+  providerUsage,
+  providerUsageSummary,
+  scanStatus,
+  sessionAnalysis,
+  sessionHygiene,
+  sessionMetrics,
+  settings,
+  subagentMember,
+  summary,
+  tokens,
+  usageWindow,
+} from "./fixtures"
+
+export interface Scenario {
+  settings: AppSettings
+  appInfo: AppInfo
+  scanStatus: ScanStatus
+  entries: ActivityEntryPayload[]
+  /** Analyses by session id. A session absent here gets `sessionAnalysis(entry)`. */
+  analyses: Record<string, SessionAnalysisPayload>
+  /** Sub-agent analyses by sub-agent id. */
+  subagentAnalyses: Record<string, SessionAnalysisPayload>
+  /** Hygiene by session id. A session absent here is clean. */
+  hygiene: Record<string, SessionHygienePayload>
+  providerUsage: ProviderUsageSummaryPayload
+  liveUsage: LiveUsageSummaryPayload
+  allocations: SessionLimitAllocationSummaryPayload
+  checksReport: ChecksReportPayload
+  storageHealth: StorageHealthPayload
+}
+
+function defaultScenario(): Scenario {
+  return {
+    settings: settings(),
+    appInfo: appInfo(),
+    scanStatus: scanStatus(),
+    entries: [activityEntry()],
+    analyses: {},
+    subagentAnalyses: {},
+    hygiene: {},
+    providerUsage: providerUsageSummary([providerUsage()]),
+    liveUsage: liveUsageSummary([
+      liveProvider({
+        provider: "openai",
+        displayName: "Codex",
+        sourceLabel: "Asked Codex directly",
+        plan: null,
+        windows: [
+          liveWindow({
+            id: "seven-day",
+            role: "primaryLong",
+            kind: "weekly",
+            usedPercent: 40,
+            startsAt: null,
+            resetsAt: null,
+            hasNonzeroUsageInCurrentPeriod: false,
+            forecast: {
+              unavailableReason: "sparseHistory",
+              confidence: null,
+              consumptionRate: null,
+              paceRatio: null,
+              paceTrend: null,
+              runwayAt: null,
+              usedToday: null,
+            },
+          }),
+        ],
+      }),
+    ]),
+    allocations: { generatedAt: minutesAgo(0), allocations: [] },
+    checksReport: checksReport(),
+    storageHealth: HEALTHY_STORAGE,
+  }
+}
+
+const OPUS = "claude-opus-4-6"
+const SONNET = "claude-sonnet-5"
+const HAIKU = "claude-haiku-4-5"
+const CODEX = "gpt-5-codex"
+
+interface BusyRow {
+  id: string
+  agent: string
+  repo: string
+  title: string
+  minutesAgo: number
+  usd: number
+  models?: string[]
+  overrides?: Partial<ActivityEntryPayload>
+}
+
+const BUSY_ROWS: BusyRow[] = [
+  {
+    id: "s-01",
+    agent: "claude-code",
+    repo: "antiburn",
+    title: "Rebuild the session row as a Settings-style card",
+    minutesAgo: 0,
+    usd: 3.4,
+    overrides: { isActive: true },
+  },
+  {
+    id: "s-02",
+    agent: "claude-code",
+    repo: "antiburn",
+    title: "Plan the UI sandbox: fixture mode and mouse overlay",
+    minutesAgo: 14,
+    usd: 48.1,
+    models: [OPUS, SONNET],
+    overrides: { forkChildCount: 1 },
+  },
+  {
+    id: "s-03",
+    agent: "codex",
+    repo: "ai-barometer",
+    title: "Fix the flaky CI job on the macOS runner",
+    minutesAgo: 41,
+    usd: 2.15,
+    models: [CODEX],
+  },
+  {
+    id: "s-04",
+    agent: "cursor",
+    repo: "cadence-marketing-site",
+    title: "Tidy the onboarding copy",
+    minutesAgo: 65,
+    usd: 0.62,
+    models: [SONNET],
+    overrides: { surface: "ide_desktop" },
+  },
+  {
+    id: "s-05",
+    agent: "claude-code",
+    repo: "antiburn",
+    title: "Investigate the HUD z-index in fullscreen",
+    minutesAgo: 130,
+    usd: 5.9,
+  },
+  {
+    id: "s-06",
+    agent: "codex",
+    repo: "antiburn",
+    title: "Write the release notes for 0.4.0",
+    minutesAgo: 180,
+    usd: 0.88,
+    models: [CODEX],
+  },
+  {
+    id: "s-07",
+    agent: "claude-code",
+    repo: "synthesis",
+    title: "Metabase usage report for the ProcurePro deck",
+    minutesAgo: 300,
+    usd: 12.3,
+    overrides: { hasForkParent: true },
+  },
+  {
+    id: "s-08",
+    agent: "cursor",
+    repo: "antiburn",
+    title: "Fix the shimmer in dark mode",
+    minutesAgo: 480,
+    usd: 1.04,
+    models: [SONNET],
+    overrides: { surface: "ide_desktop" },
+  },
+  {
+    id: "s-09",
+    agent: "claude-code",
+    repo: "ai-barometer",
+    title: "Refresh the DB snapshot runbook",
+    minutesAgo: 26 * 60,
+    usd: 0.41,
+    models: [HAIKU],
+  },
+  {
+    id: "s-10",
+    agent: "codex",
+    repo: "antiburn",
+    title: "Add the DCO check to CI",
+    minutesAgo: 30 * 60,
+    usd: 1.77,
+    models: [CODEX],
+  },
+  {
+    id: "s-11",
+    agent: "claude-code",
+    repo: "docs",
+    title: "Explore the Fable vs Sol design",
+    minutesAgo: 50 * 60,
+    usd: 7.25,
+  },
+  {
+    id: "s-12",
+    agent: "claude-code",
+    repo: "antiburn",
+    title: "Nudge window text crop",
+    minutesAgo: 74 * 60,
+    usd: 2.02,
+  },
+]
+
+function busyEntry(row: BusyRow): ActivityEntryPayload {
+  const models = row.models ?? [OPUS]
+  return activityEntry({
+    agent: row.agent,
+    sessionId: row.id,
+    repo: row.repo,
+    title: row.title,
+    timestamp: minutesAgo(row.minutesAgo),
+    cost: cost(row.usd),
+    models,
+    modelRuns: models.map((model) => ({ model })),
+    ...row.overrides,
+  })
+}
+
+function busyScenario(): Scenario {
+  const entries = BUSY_ROWS.map(busyEntry)
+  const expensive = entries[1]
+  const active = entries[0]
+  if (!expensive || !active) throw new Error("The busy scenario needs its first two rows")
+
+  const members = [
+    subagentMember({ subagentId: "sub-a" }),
+    subagentMember({
+      subagentId: "sub-b",
+      label: "Draft the fixture factories against ipc.ts",
+      cost: cost(1.6),
+      tokens: tokens(1.6),
+      startedAtEpoch: Math.floor((Date.now() - 2_400_000) / 1000),
+    }),
+  ]
+  const subagentsUsd = 0.8 + 1.6
+  const expensiveAnalysis = sessionAnalysis(expensive, {
+    topLevelCost: cost(48.1 - subagentsUsd),
+    subagentsCost: cost(subagentsUsd),
+    subagentsTokens: tokens(subagentsUsd),
+    modelRuns: [{ model: OPUS, thinkingMode: "adaptive" }, { model: SONNET }],
+    orchestration: {
+      orchestrating: true,
+      orchestratorAgent: "claude-code",
+      orchestratorSessionId: expensive.sessionId,
+      subagentCount: members.length,
+      members,
+    },
+    relations: {
+      title: expensive.title,
+      parent: null,
+      children: [
+        {
+          identity: { agent: "claude-code", sessionId: "s-02-fork", wslDistro: null },
+          title: "Plan the UI sandbox (fork)",
+          available: false,
+        },
+      ],
+    },
+  })
+
+  const subagentAnalyses = Object.fromEntries(
+    members.map((member) => {
+      const metrics = sessionMetrics({
+        sessionId: member.subagentId,
+        model: SONNET,
+        durationSecs: 600,
+        activeSecs: 540,
+        eventCount: 40,
+        tokensIn: 30_000,
+        tokensOut: 4_000,
+        peakContextTokens: 60_000,
+        compactionCount: 0,
+        cost: member.cost,
+      })
+      return [
+        member.subagentId,
+        sessionAnalysis(expensive, {
+          summary: summary(metrics),
+          title: member.label,
+          cost: member.cost,
+          topLevelCost: member.cost,
+          inclusiveTokens: member.tokens,
+          models: [SONNET],
+          modelRuns: member.modelRuns,
+        }),
+      ]
+    }),
+  )
+
+  return {
+    settings: settings({ overviewLimitsExpanded: true }),
+    appInfo: appInfo({ indexedSessions: 1_284, databaseBytes: 212_000_000 }),
+    scanStatus: scanStatus({
+      completedAgents: 3,
+      totalAgents: 3,
+      sessions: entries.length,
+      finishedAt: minutesAgo(2),
+      agents: [
+        { agent: "claude-code", lastCompletedAt: minutesAgo(2), sessionsSeen: 7 },
+        { agent: "codex", lastCompletedAt: minutesAgo(2), sessionsSeen: 3 },
+        { agent: "cursor", lastCompletedAt: minutesAgo(2), sessionsSeen: 2 },
+      ],
+    }),
+    entries,
+    analyses: { [expensive.sessionId]: expensiveAnalysis },
+    subagentAnalyses,
+    hygiene: {
+      [expensive.sessionId]: sessionHygiene({
+        badges: [
+          {
+            id: "sessionOverdepth",
+            status: "finding",
+            notAssessedReason: null,
+            findingEvidence: {
+              kind: "sessionOverdepth",
+              maxRequestContextTokens: 186_000,
+              depthCapTokens: 150_000,
+            },
+          },
+          {
+            id: "modelOverthinking",
+            status: "finding",
+            notAssessedReason: null,
+            findingEvidence: {
+              kind: "modelOverthinking",
+              tiers: [{ tier: "opus", mainLoopTurns: 61, delegatedTurns: 4 }],
+            },
+          },
+          { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
+          { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+          { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+          { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+        ],
+      }),
+    },
+    providerUsage: providerUsageSummary([
+      providerUsage({
+        windows: {
+          today: usageWindow(51.5, 3),
+          week: usageWindow(79.4, 8),
+          monthToDate: usageWindow(214.7, 33),
+          last30Days: usageWindow(268.2, 48),
+        },
+      }),
+      providerUsage({
+        provider: "openai",
+        displayName: "OpenAI",
+        windows: {
+          today: usageWindow(2.15, 1),
+          week: usageWindow(4.8, 3),
+          monthToDate: usageWindow(19.6, 12),
+          last30Days: usageWindow(24.1, 15),
+        },
+        lastActivityAt: minutesAgo(41),
+      }),
+    ]),
+    liveUsage: liveUsageSummary([
+      liveProvider(),
+      liveProvider({
+        provider: "openai",
+        displayName: "Codex",
+        sourceLabel: "Asked Codex directly",
+        plan: { name: "Pro", tier: null },
+        windows: [
+          liveWindow({
+            usedPercent: 22,
+            forecast: { ...liveWindow().forecast, paceRatio: 0.7 },
+          }),
+          liveWindow({
+            id: "seven-day",
+            role: "primaryLong",
+            kind: "weekly",
+            usedPercent: 71,
+            startsAt: minutesAgo(5 * 24 * 60),
+            resetsAt: minutesFromNow(2 * 24 * 60),
+          }),
+        ],
+      }),
+    ]),
+    allocations: {
+      generatedAt: minutesAgo(0),
+      allocations: [
+        {
+          agent: active.agent,
+          sessionId: active.sessionId,
+          wslDistro: null,
+          metric: "fiveHour",
+          provider: "anthropic",
+          displayName: "Claude",
+          accountKey: null,
+          windowId: "five-hour",
+          resetsAt: minutesFromNow(100),
+          percent: 9,
+        },
+        {
+          agent: active.agent,
+          sessionId: active.sessionId,
+          wslDistro: null,
+          metric: "weekly",
+          provider: "anthropic",
+          displayName: "Claude",
+          accountKey: null,
+          windowId: "seven-day",
+          resetsAt: minutesFromNow(3 * 24 * 60),
+          percent: 2,
+        },
+        {
+          agent: expensive.agent,
+          sessionId: expensive.sessionId,
+          wslDistro: null,
+          metric: "weekly",
+          provider: "anthropic",
+          displayName: "Claude",
+          accountKey: null,
+          windowId: "seven-day",
+          resetsAt: minutesFromNow(3 * 24 * 60),
+          percent: 31,
+        },
+      ],
+    },
+    checksReport: checksReport({
+      estimatedTokenBurnBasisPoints: 2_310,
+      categories: [
+        {
+          id: "cacheChurn",
+          finding: 4,
+          clean: 8,
+          unavailable: 0,
+          estimatedTokenBurnBasisPoints: 1_400,
+        },
+        {
+          id: "sessionsOverDepth",
+          finding: 1,
+          clean: 11,
+          unavailable: 0,
+          estimatedTokenBurnBasisPoints: 910,
+        },
+      ],
+    }),
+    storageHealth: HEALTHY_STORAGE,
+  }
+}
+
+const SCENARIOS = new Map<string, () => Scenario>([
+  ["default", defaultScenario],
+  ["busy", busyScenario],
+])
+
+/** Build the scenario named by `?scenario=`. An unknown name falls back to `default`. */
+export function pickScenario(search: string = window.location.search): Scenario {
+  const name = new URLSearchParams(search).get("scenario") ?? "default"
+  const build = SCENARIOS.get(name)
+  if (!build) console.warn(`[sandbox] unknown scenario "${name}"; using "default"`)
+  return (build ?? defaultScenario)()
+}

--- a/apps/desktop/src/sandbox/tauri-core.ts
+++ b/apps/desktop/src/sandbox/tauri-core.ts
@@ -1,0 +1,17 @@
+/**
+ * Sandbox replacement for `@tauri-apps/api/core`.
+ *
+ * Vite aliases the package to this module in `--mode sandbox`. Each command
+ * resolves from the fixture scenario in `commands.ts`. `isTauri` reports true
+ * so that `hasShell()` lets every IPC wrapper run.
+ */
+
+import { runCommand } from "./commands"
+
+export function isTauri(): boolean {
+  return true
+}
+
+export async function invoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  return runCommand(command, args) as T
+}

--- a/apps/desktop/src/sandbox/tauri-dialog.ts
+++ b/apps/desktop/src/sandbox/tauri-dialog.ts
@@ -1,0 +1,26 @@
+/**
+ * Sandbox replacement for `@tauri-apps/plugin-dialog`.
+ *
+ * `confirm` uses the browser dialog. The file pickers have no browser
+ * equivalent here, so `save` and `open` report that the reader cancelled.
+ */
+
+interface ConfirmOptions {
+  title?: string
+}
+
+export async function confirm(
+  message: string,
+  options?: string | ConfirmOptions,
+): Promise<boolean> {
+  const title = typeof options === "string" ? options : options?.title
+  return window.confirm(title ? `${title}\n\n${message}` : message)
+}
+
+export async function save(): Promise<string | null> {
+  return null
+}
+
+export async function open(): Promise<string | string[] | null> {
+  return null
+}

--- a/apps/desktop/src/sandbox/tauri-event.ts
+++ b/apps/desktop/src/sandbox/tauri-event.ts
@@ -1,0 +1,50 @@
+/**
+ * Sandbox replacement for `@tauri-apps/api/event`.
+ *
+ * `listen` keeps each handler by event name. The page can push an event with
+ * `window.__sandbox.emit(name, payload)` from the console or from the overlay.
+ */
+
+export type UnlistenFn = () => void
+
+interface SandboxEvent<T> {
+  event: string
+  id: number
+  payload: T
+}
+
+type Handler<T> = (event: SandboxEvent<T>) => void
+
+const handlers = new Map<string, Set<Handler<unknown>>>()
+let nextEventId = 0
+
+export async function listen<T>(event: string, handler: Handler<T>): Promise<UnlistenFn> {
+  const set = handlers.get(event) ?? new Set<Handler<unknown>>()
+  set.add(handler as Handler<unknown>)
+  handlers.set(event, set)
+  return () => {
+    set.delete(handler as Handler<unknown>)
+  }
+}
+
+/** Deliver `payload` to every handler of `event`. Returns the handler count. */
+export function emit(event: string, payload: unknown): number {
+  const set = handlers.get(event)
+  if (!set) return 0
+  nextEventId += 1
+  for (const handler of set) handler({ event, id: nextEventId, payload })
+  return set.size
+}
+
+/** The event names that have at least one handler. */
+function listeners(): string[] {
+  return [...handlers.entries()].filter(([, set]) => set.size > 0).map(([name]) => name)
+}
+
+declare global {
+  interface Window {
+    __sandbox?: { emit: typeof emit; listeners: typeof listeners }
+  }
+}
+
+window.__sandbox = { emit, listeners }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -9,7 +9,28 @@ import { defineConfig } from "vitest/config"
 /** Port the Tauri shell expects for the dev server (see `tauri.conf.json`). */
 const DEV_SERVER_PORT = 1420
 
+/**
+ * `vite --mode sandbox` serves the popover in a plain browser on fixture data.
+ * The Tauri packages resolve to the shims in `src/sandbox/`, so product code
+ * stays untouched and no other mode sees the shims.
+ */
+const SANDBOX_ALIASES = {
+  "@tauri-apps/api/core": fileURLToPath(
+    new URL("./src/sandbox/tauri-core.ts", import.meta.url),
+  ),
+  "@tauri-apps/api/event": fileURLToPath(
+    new URL("./src/sandbox/tauri-event.ts", import.meta.url),
+  ),
+  "@tauri-apps/plugin-dialog": fileURLToPath(
+    new URL("./src/sandbox/tauri-dialog.ts", import.meta.url),
+  ),
+}
+
 export default defineConfig(({ command, mode }) => ({
+  resolve: {
+    alias: mode === "sandbox" ? SANDBOX_ALIASES : {},
+  },
+
   plugins: [
     {
       name: "tauri-webview-module-cache",

--- a/docs/plans/antiburn-ui-sandbox-implementation-handoff.md
+++ b/docs/plans/antiburn-ui-sandbox-implementation-handoff.md
@@ -1,0 +1,106 @@
+# Phase Handoff: UI sandbox — Planning → Implementation
+
+**Worktree**: `/Users/keithlang/Documents/GitHub/antiburn/.claude/worktrees/antiburn-ui-sandbox-759ec8`
+**Branch**: `claude/antiburn-ui-sandbox-759ec8` (same branch — do NOT create a new worktree or branch)
+**PR**: None yet
+**Date**: 2026-09-07 (Australia/Sydney)
+**Run this phase on**: Opus 5, effort High
+
+## You Are Continuing Existing Work
+
+This is a phase handoff, not a new task. The worktree above already has the
+work in it. Start there, on that branch. Do not run `/new`.
+
+## What Phase Just Finished
+
+Planning. Keith reviewed the idea in discuss and decided four things: personal
+tool only (not shipped), popover first, changes reach Claude in batches behind
+a Send button, and adding new UI is an Ask note rather than a drag-in. The
+implementation plan was then written and Keith approved it with "Build it".
+Both docs are committed on this branch. No code exists yet.
+
+## What To Do Next
+
+Build steps 0 and 1 of the plan only. Steps 2 and 3 are a global skill and come
+in a later phase.
+
+1. `git fetch origin && git rebase origin/main`. The branch was cut from a
+   stale local main and is 558 commits behind. The only commit is docs, so the
+   rebase is trivial. Then re-check that the files named in the plan still
+   exist at the same paths (`apps/desktop/src/lib/ipc.ts`,
+   `apps/desktop/src/views/PopoverView.test.tsx`,
+   `apps/desktop/src/views/popover/PopoverSession.test.ts`,
+   `apps/desktop/vite.config.ts`, `apps/desktop/knip.json`).
+2. `pnpm install` from the repo root. The worktree has no `node_modules`.
+3. `vite.config.ts`: when `mode === "sandbox"`, add `resolve.alias` for
+   `@tauri-apps/api/core`, `@tauri-apps/api/event`, `@tauri-apps/plugin-dialog`
+   pointing at `apps/desktop/src/sandbox/tauri-core.ts`, `tauri-event.ts`,
+   `tauri-dialog.ts`. Add script `dev:sandbox` = `vite --mode sandbox`.
+4. `src/sandbox/fixtures.ts`, `scenarios.ts` (`default`, `busy`),
+   `commands.ts` (the `invoke` switch, unknown → `null`). Type fixtures against
+   the payload types exported from `ipc.ts`.
+5. `apps/desktop/sandbox.html`: copy of `index.html` plus inline `<style>`
+   sizing `#root` to 380px wide, 700px max height, and an inline loader that
+   fetches `http://127.0.0.1:4680/overlay.js` and appends it if it answers.
+6. `knip.json`: add `src/sandbox/tauri-*.ts` to `entry`. One README paragraph
+   under Commands. Comments in Simplified Technical English.
+7. Run the validation below. Open `sandbox.html?scenario=busy` in the Browser
+   pane and screenshot it for the PR. Update the Status table in the plan.
+8. Open the PR with a placeholder line for the screenshot and tell Keith which
+   screen to drop in. `git commit -s` on every commit.
+
+## Key Decisions
+
+- **Vite alias, not a runtime flag.** The discussion doc says `?sandbox=1`;
+  the plan replaces it with `--mode sandbox` plus package aliases. Reason: ten
+  product files import `@tauri-apps/*` directly and `hasShell()` gates on
+  `isTauri()`. Aliasing the packages means zero product-code edits and the
+  production build never sees the shims. `?scenario=` stays a query param.
+- **Fixtures typed against `ipc.ts`.** A shell-side rename then fails
+  `type-check` instead of silently blanking the popover.
+- **Inline styles in `sandbox.html`, no new stylesheet.** `AGENTS.md` requires
+  every new stylesheet to be listed in `design.md` and the drift check
+  enforces it. An HTML file with an inline `<style>` sidesteps that honestly.
+- **Overlay loader port 4680 is hard-coded.** Personal tool; acceptable.
+- **Test-fixture sharing is optional.** Making `PopoverView.test.tsx` import
+  from `src/sandbox/fixtures.ts` is nice but skip it if the test needs many
+  overrides.
+
+## Known Issues And Gotchas
+
+- Bash working directory persists between calls in this harness. An earlier
+  `cd apps/desktop` broke a relative path. Use absolute paths.
+- zsh in this harness rejects `--include=*.ts` globs in grep. Use `grep -r`
+  then filter with a second grep.
+- No `useEffect` anywhere (`AGENTS.md`). The shims are plain modules; no React.
+- `hasShell()` must return true in sandbox mode or every IPC call returns
+  early. The shim's `isTauri` returns `true` for that reason.
+- `windowReady` invokes `window_ready`; the fixture switch returns `null`,
+  which is fine.
+- Session detail is a lazy chunk (`SessionPane`). Nothing special needed.
+- React 19 fibers have no `_debugSource`. That matters for the overlay
+  (later phase), not for this one.
+- Every PR needs an image and Keith uploads it. Hand him the screenshot path.
+
+## State Of The Tree
+
+- Commits on this branch: `71d1ffc3 docs: plan the UI sandbox (fixture mode + mouse overlay)`
+- Uncommitted files: none — all committed (this handoff doc is added after).
+
+## Validation
+
+```bash
+pnpm --filter @antiburn/desktop lint && pnpm --filter @antiburn/desktop type-check && pnpm --filter @antiburn/desktop test && pnpm --filter @antiburn/desktop knip && pnpm --filter @antiburn/desktop build
+```
+
+Then `pnpm --filter @antiburn/desktop dev:sandbox`, open
+`http://127.0.0.1:1420/sandbox.html?scenario=busy`, and confirm rows, usage
+bars, and a session detail that opens on click. `pnpm run slop:all` and
+`pnpm run secrets` before pushing.
+
+## Context Docs
+
+- `/Users/keithlang/Documents/GitHub/antiburn/.claude/worktrees/antiburn-ui-sandbox-759ec8/docs/plans/ui-sandbox-implementation.md` — the plan; step 1 is the spec for this phase
+- `/Users/keithlang/Documents/GitHub/antiburn/.claude/worktrees/antiburn-ui-sandbox-759ec8/docs/plans/ui-sandbox.md` — the discussion and the four decisions
+- `/Users/keithlang/Documents/GitHub/antiburn/.claude/worktrees/antiburn-ui-sandbox-759ec8/AGENTS.md` — repo rules: no useEffect, design.md contract, STE comments, DCO sign-off
+- `/Users/keithlang/Documents/GitHub/antiburn/.claude/worktrees/antiburn-ui-sandbox-759ec8/apps/desktop/README.md` — commands

--- a/docs/plans/ui-sandbox-implementation.md
+++ b/docs/plans/ui-sandbox-implementation.md
@@ -9,7 +9,7 @@ Builds what [ui-sandbox.md](ui-sandbox.md) decided: personal tool, popover first
 | Step                                              | State       |
 | ------------------------------------------------- | ----------- |
 | 0. Prep: install deps in this worktree            | done        |
-| 1. Sandbox mode in the repo (fixture IPC, page)   | done, in PR |
+| 1. Sandbox mode in the repo (fixture IPC, page)   | done, [PR #415](https://github.com/antiburn/antiburn/pull/415) |
 | 2. `/sandbox` skill: overlay with Draw + Ask, Send | not started |
 | 3. Arrange mode                                   | not started |
 | 4. Later: multi-view page, real-data snapshot     | parked      |

--- a/docs/plans/ui-sandbox-implementation.md
+++ b/docs/plans/ui-sandbox-implementation.md
@@ -8,8 +8,8 @@ Builds what [ui-sandbox.md](ui-sandbox.md) decided: personal tool, popover first
 
 | Step                                              | State       |
 | ------------------------------------------------- | ----------- |
-| 0. Prep: install deps in this worktree            | not started |
-| 1. Sandbox mode in the repo (fixture IPC, page)   | not started |
+| 0. Prep: install deps in this worktree            | done        |
+| 1. Sandbox mode in the repo (fixture IPC, page)   | done, in PR |
 | 2. `/sandbox` skill: overlay with Draw + Ask, Send | not started |
 | 3. Arrange mode                                   | not started |
 | 4. Later: multi-view page, real-data snapshot     | parked      |

--- a/docs/plans/ui-sandbox-implementation.md
+++ b/docs/plans/ui-sandbox-implementation.md
@@ -1,0 +1,172 @@
+# UI sandbox: implementation plan
+
+_Plan. Branch `claude/antiburn-ui-sandbox-759ec8`. 2026-09-07._
+
+Builds what [ui-sandbox.md](ui-sandbox.md) decided: personal tool, popover first, Send button batches changes to Claude, adding things is an Ask.
+
+## Status
+
+| Step                                              | State       |
+| ------------------------------------------------- | ----------- |
+| 0. Prep: install deps in this worktree            | not started |
+| 1. Sandbox mode in the repo (fixture IPC, page)   | not started |
+| 2. `/sandbox` skill: overlay with Draw + Ask, Send | not started |
+| 3. Arrange mode                                   | not started |
+| 4. Later: multi-view page, real-data snapshot     | parked      |
+
+## What gets built, in one picture
+
+```text
+Browser pane (Chromium, inside Claude desktop)
+  http://127.0.0.1:1420/sandbox.html?scenario=busy
+    ├─ the real popover, React + Tailwind, fed by fixtures
+    └─ overlay.js toolbar: Draw · Ask · Arrange · [Send] [Copy]
+                │ POST /send on Send
+                ▼
+  receiver.mjs (node, port 4680)  ──append──▶  sandbox-sends.jsonl
+                                                     │ tail -f
+                                                     ▼
+                                              Monitor task wakes Claude
+                                              Claude screenshots the pane, edits source, HMR updates the page
+```
+
+Two halves. Step 1 is a small PR in this repo. Steps 2 and 3 live in a global skill at `~/.claude/skills/sandbox/` and never ship.
+
+## Step 0: prep
+
+This worktree has no `node_modules`. Run `pnpm install` from the repo root before anything else.
+
+## Step 1: sandbox mode in the repo
+
+### How the seam works
+
+Product code imports `invoke`, `isTauri` and `listen` straight from `@tauri-apps/api/*` in ten files. Rather than touch any of them, a Vite mode swaps the packages:
+
+- New script `dev:sandbox` = `vite --mode sandbox`.
+- In `vite.config.ts`, when `mode === "sandbox"`, add `resolve.alias` entries:
+  - `@tauri-apps/api/core` → `src/sandbox/tauri-core.ts` (exports `invoke`, `isTauri: () => true`)
+  - `@tauri-apps/api/event` → `src/sandbox/tauri-event.ts` (exports `listen`; keeps handlers in a map; exposes `window.__sandbox.emit(name, payload)`)
+  - `@tauri-apps/plugin-dialog` → `src/sandbox/tauri-dialog.ts` (`confirm` → `window.confirm`, `save`/`open` → `null`)
+
+The production build and the Tauri dev build never see the alias, so nothing ships. This replaces the `?sandbox=1` runtime check from the discussion doc: a runtime check would touch `ipc.ts` and all its call sites, an alias touches nothing.
+
+### Fixtures
+
+- `src/sandbox/fixtures.ts`: lift the fixture set from `PopoverView.test.tsx` (settings, scan status, activity entries, provider usage, live usage, storage health) and the rich session analysis from `PopoverSession.test.ts`. Export factories, typed against the `ipc.ts` payload types. A shell-side rename then fails `type-check`, which is the same protection the tests give today.
+- `src/sandbox/scenarios.ts`: named sets picked by `?scenario=`. Two for v1:
+  - `default`: the test set, one session.
+  - `busy`: a dozen sessions across claude-code, codex and cursor, one active, one flagged high-cost, a scan that finished two minutes ago, both providers with live usage.
+- `src/sandbox/commands.ts`: the `invoke` switch. Same shape as `mockCommands` in the test. Unknown commands resolve to `null`, matching the test's default.
+- Timestamps are computed relative to `Date.now()` at load so "3 minutes ago" stays true.
+
+Optional, if it is cheap on the day: make `PopoverView.test.tsx` import its fixtures from `src/sandbox/fixtures.ts` so there is one copy. Skip if the test needs its own overrides in more than a couple of places.
+
+### The page
+
+- `apps/desktop/sandbox.html`: same as `index.html` plus an inline `<style>` that sizes `#root` to the popover's 380px width and a 700px max height on a neutral page background, and a small inline loader that fetches `http://127.0.0.1:4680/overlay.js` and appends it when the receiver answers. Silent when it does not.
+- Vite serves any root HTML file in dev. The file is not added to `build.rollupOptions.input`, so it is not bundled.
+- Inline styles in an HTML file are not a stylesheet, so `design.md` and the drift check are untouched.
+
+### Housekeeping
+
+- `knip.json`: add `src/sandbox/tauri-*.ts` to `entry`. They are reached only through the alias, and knip would otherwise flag them unused.
+- No `useEffect` anywhere. The shims are plain modules.
+- Comments in Simplified Technical English, as in `AGENTS.md`.
+- One paragraph in `apps/desktop/README.md` under Commands: what `dev:sandbox` is and that it is a development aid.
+
+### Done when
+
+- `pnpm --filter @antiburn/desktop dev:sandbox`, open `sandbox.html?scenario=busy` in the Browser pane, the popover renders with rows, usage bars and a session detail that opens.
+- `lint`, `type-check`, `test`, `knip`, `build` all pass. `build` output is unchanged (no alias in production mode).
+- One PR, target under 500 lines, `git commit -s`. Keith uploads the screenshot.
+
+## Step 2: the `/sandbox` skill, Draw + Ask + Send
+
+Lives at `~/.claude/skills/sandbox/`, next to `/proto`. Three files.
+
+### `overlay.js`
+
+Vanilla JS, one file, no build. Injected by the loader in `sandbox.html`. Adds a floating toolbar and:
+
+- **Select.** Hover highlights the element under the cursor and shows its React component name. Found by reading the `__reactFiber$…` key on the DOM node and walking up to the nearest named function component. The source file comes from the fiber's debug stack in React dev builds. Verify this on the first build; fallback is component name plus the CSS path.
+- **Draw.** A full-page canvas above the popover. Pen, arrow, box, text label, undo. Strokes are kept as SVG paths in page coordinates so they survive a Send.
+- **Ask.** A note box tied to the selected element, or to the page when nothing is selected. "A chart of daily burn here" is an Ask.
+- **Change list.** A panel listing every action so far. Each entry can be removed.
+- **Send.** POSTs the change list to the receiver. Clears the list on success, leaves drawings on screen.
+- **Copy.** Same block as text on the clipboard, for the no-receiver case.
+
+Payload per Send:
+
+```json
+{
+  "sentAt": "2026-09-07T01:12:00Z",
+  "scenario": "busy",
+  "viewport": { "width": 380, "height": 700 },
+  "actions": [
+    { "kind": "ask", "target": "SessionRow[2]", "source": "src/components/session/SessionRow.tsx", "text": "move the cost pill left of the time" },
+    { "kind": "hide", "target": "UsageLimitsBar", "source": "src/components/providerUsage/UsageLimitsBar.tsx" }
+  ],
+  "strokes": [ { "tool": "arrow", "path": "M 40 120 L 200 120", "label": "" } ]
+}
+```
+
+### `receiver.mjs`
+
+Node, no dependencies. `node receiver.mjs --port 4680 --log <file>`.
+
+- `GET /overlay.js` serves the overlay.
+- `POST /send` appends one JSON line to the log. CORS open to localhost.
+- `GET /latest` returns the last line, so a second tab can replay strokes.
+
+### `SKILL.md`
+
+The run book Claude follows:
+
+1. Check `dev:sandbox` is up on 1420. If not, ask Keith to start it, or start it through `preview_start` with a launch config.
+2. Start the receiver in the background with the log in the session scratchpad.
+3. Start a `Monitor` that tails the log. One line per Send, one wake per line.
+4. Open `sandbox.html?scenario=…` in the Browser pane.
+5. On each wake: read the line, screenshot the pane (drawings are still on it), restate the asks in one line each, make the edits, say what changed. HMR shows the result in the pane.
+6. On "done": stop the Monitor and the receiver, summarise the session's asks and which landed.
+
+### Which browser
+
+v1 assumes Keith draws in the Browser pane inside Claude desktop. It is Chromium, he can click in it, and Claude's screenshot then carries the drawings for free. If Safari turns out to be the preference, the `/latest` endpoint plus a `?replay=1` flag on the overlay lets Claude's tab redraw the strokes before it screenshots. Small, so it is a follow-up rather than a v1 item.
+
+### Done when
+
+- Draw an arrow, add an Ask, press Send. Claude wakes once, screenshots, reads the ask, edits the source, the pane updates.
+- Copy produces the same content as text.
+
+## Step 3: Arrange mode
+
+The fragile part, kept separate so steps 1 and 2 are usable without it.
+
+- **Reorder.** Drag an element among its siblings. The DOM move is visual only; the action records `move SessionRow[2] before SessionRow[0]` with component names and sources.
+- **Hide.** Click with the hide tool. Sets `display: none`, records `hide UsageLimitsBar`.
+- **Resize.** Drag an edge. Records the new width or height in pixels.
+- **Undo** per action, and the change list removes the visual effect when an entry is deleted.
+- A React re-render from a fixture event will undo a DOM move. Static fixtures make that rare, and the intent is already recorded.
+
+### Done when
+
+- Reorder two rows, hide the usage bar, Send. Claude's edit produces the same arrangement from source.
+
+## Step 4: parked
+
+- Multi-view page: `sandbox.html?view=settings|overlay|nudge` plus a wrapper that iframes two or three views side by side. Needs shims for `@tauri-apps/api/window` and `webviewWindow`.
+- Real-data snapshot: a command that dumps what the engine sees to a fixture file. Needs a Rust-side command. Not before the fixture mode has proved useful.
+
+## Risks
+
+- **Fiber source lookup.** React 19 removed `_debugSource`. Owner stacks exist in dev builds but their shape is not stable. The component name alone is enough for Claude to find the file with a search, so this only affects convenience.
+- **Fixture drift.** Every new IPC payload field must be added to the fixtures. Typing them against `ipc.ts` turns drift into a `type-check` failure rather than a blank popover.
+- **Lazy chunks.** Session detail is a lazy chunk. The sandbox loads it on click, same as the app, so nothing special is needed.
+
+## Checks before each PR
+
+```bash
+pnpm --filter @antiburn/desktop lint && pnpm --filter @antiburn/desktop type-check && pnpm --filter @antiburn/desktop test && pnpm --filter @antiburn/desktop knip && pnpm --filter @antiburn/desktop build
+```
+
+Plus `pnpm run slop:all` and `pnpm run secrets` before pushing, per `CONTRIBUTING.md`.

--- a/docs/plans/ui-sandbox.md
+++ b/docs/plans/ui-sandbox.md
@@ -1,0 +1,73 @@
+# UI sandbox: play with the real antiburn UI, then tell Claude what you did
+
+Status: discussion, 2026-09-07. Nothing built yet. Implementation plan: [ui-sandbox-implementation.md](ui-sandbox-implementation.md). Decided so far: personal tool only, popover first, adding things is an Ask not a drop-in, changes reach Claude in batches on a Send button.
+
+## The idea in one line
+
+Open the real antiburn UI in a browser, move and hide things with the mouse, draw on it, and have Claude turn that into code changes.
+
+## What already exists
+
+Three of the four pieces are closer than they look.
+
+| Piece | Today | Gap |
+|---|---|---|
+| See the real UI in a browser | `pnpm --filter @antiburn/desktop dev:web` serves the frontend on port 1420. | Every IPC call is gated on `hasShell()` and returns nothing outside Tauri, so the browser shows empty states. |
+| Chat to Claude while looking at it | The Claude desktop app has a Browser pane. Claude can open the URL, screenshot it, read the DOM, and read the console. | Nothing in the page tells Claude what you did with the mouse. |
+| Click-to-comment | `discuss` already does element-level comments on static HTML and pin comments on images. `/proto` uses this. | discuss renders files in a sandboxed iframe. It cannot point at a live dev server. No drawing. |
+| Move and remove elements | Nothing. | Needs an overlay in the page. |
+
+## Proposed shape
+
+Two parts. One lives in the antiburn repo, one is a global skill like `/proto`.
+
+### Part 1: sandbox mode in the repo (`?sandbox=1`)
+
+A Vite-only mode that makes the browser build useful:
+
+1. **Fixture IPC.** When the page loads with `?sandbox=1` and no shell, `ipc.ts` answers from a fixture file instead of returning null. The test files already hold complete `invoke` mocks (PopoverView.test.tsx alone has four). Lift the richest one into `src/sandbox/fixtures.ts` and reuse it in both places.
+2. **Popover first.** The sandbox page is index.html with fixture data, at the popover's true size. Settings, the overlay HUD and the nudge are separate Tauri windows; a later `&view=` flag plus a wrapper page that iframes two or three of them side by side gives the multi-view case, so "put the sub menu into the main view" is something you can see.
+3. **Real data option, later.** The Tauri debug shell already loads from the Vite server, so edits hot-reload in the real app. A fixture snapshot command ("dump what the engine sees now to fixtures.json") would give the sandbox your real sessions without a backend. Not needed for v1.
+
+### Part 2: the overlay (a global `/sandbox` skill)
+
+A small script the skill injects into the page. Vanilla JS, no framework, same rule as `/proto`. It adds a toolbar with three modes:
+
+- **Arrange.** Hover shows the React component name and source file (React dev builds carry this). Drag to reorder siblings, click to hide, drag an edge to resize. Each action is recorded as intent, not as DOM: `move SessionRow[2] before SessionRow[0]`, `hide UsageLimitsBar`.
+- **Draw.** A canvas over the page. Pen, arrow, box, text label. Strokes stay on screen so a screenshot captures them.
+- **Ask.** A text box for the "no, bring the sub menu into the main view" kind of note, attached to whatever is selected. Adding something new ("a chart of daily burn here") is also an Ask; Arrange never inserts placeholders in v1.
+
+### How it reaches Claude
+
+Batched, on a Send button. Nothing leaves the page until you press it, so the CLI is not spammed with every drag:
+
+1. The overlay keeps a running change list in the toolbar: arrange actions, notes, and the drawing strokes.
+2. **Send** POSTs the list to a tiny local receiver the skill starts (a few lines of node). The receiver appends one JSONL line per Send.
+3. A Monitor task tails that file, so each Send wakes Claude once, the same way a discuss comment does now. One Send is one turn.
+4. On wake, Claude screenshots the page through the Browser pane with the drawings still on it, reads the change list for intent, and uses the component source names to know where to edit.
+
+No Vite plugin, no repo change, no new discuss feature. A **Copy** button next to Send gives the same block as text for pasting into chat when the receiver is not running.
+
+## What this is not
+
+- Not a code generator. Dragging a row records "move A before B". Claude edits the source. The DOM move is visual only and a React re-render may undo it, which is fine with static fixtures.
+- Not Claude Design or Figma. Those draw mockups. This is the real UI with the real design tokens.
+- Not a discuss feature, at least not first. discuss would need a "live URL" mode plus drawing. Worth a ticket to codesoda if the overlay works and we want the comment threads.
+
+## Prior art to check before building
+
+Stagewise, react-grab, locatorjs and click-to-component all do the "select an element in a dev build and send it to an agent" part. Unverified which are alive and whether any do drag or draw. Worth one hour of looking before writing an overlay from scratch.
+
+## Rough order
+
+1. Fixture IPC for the popover. Half a day. Useful on its own: it makes `dev:web` show something.
+2. Overlay with Draw and Ask, Copy for Claude. Half a day. Most of the value.
+3. Arrange mode. A day. The fragile part.
+4. Multi-view wrapper page and real-data snapshot. Later.
+
+## Open questions
+
+- ✋ Is this for you alone, or a dev tool that ships with the open-source repo? Changes how careful the fixture mode has to be. **Answered: just Keith for now. Reconsider if it proves out.**
+- Is "one page with every window" right, or do you mostly want to work on the popover? **Answered: popover first, multi-view later.**
+- Copy-paste hand-off first, or is the Monitor feed the thing you actually want? **Answered: live feed, but batched behind a Send button so it does not spam the CLI.**
+- Should Arrange also let you *add* things (drop in a chart placeholder), or is add always an Ask? **Answered: Ask only for v1.**


### PR DESCRIPTION
## User impact

None for users. This adds a developer mode: `pnpm --filter @antiburn/desktop dev:sandbox` serves the popover in a plain browser on synthetic data, so UI work does not need the Tauri shell or a real scan.

- `vite --mode sandbox` aliases `@tauri-apps/api/core`, `@tauri-apps/api/event` and `@tauri-apps/plugin-dialog` to shims in `apps/desktop/src/sandbox/`. No other mode sees the alias, so product code and production builds are unchanged.
- `sandbox.html` mounts the popover at its shell size (380×700) on a grey page.
- Fixtures are typed against the IPC payload types, so a shell rename fails `type-check` instead of drifting.
- Scenarios: `?scenario=default` (one session) and `?scenario=busy` (12 sessions across three agents, sub-agents, hygiene findings, two live limits, checks report).
- `window.__sandbox.emit(name, payload)` pushes a shell event from the console. A command with no fixture resolves `null` and warns once.

Known limits: the popover route only. Settings and onboarding windows are not wired. The diff is larger than the plan's aim (~1.2k lines, ~1k of it fixture and scenario data).

Screenshot of `sandbox.html?scenario=busy`:

_(image goes here)_

## Validation

- `pnpm --filter @antiburn/desktop format`, `lint`, `type-check`, `knip`, `test` (93 files, 1139 tests), `build`
- `pnpm run slop:all` and `pnpm run secrets`: clean
- `grep -ri sandbox apps/desktop/dist` finds nothing, so the production bundle has no sandbox code
- Opened `http://127.0.0.1:1420/sandbox.html?scenario=busy` in a browser: spend header, live limits, checks summary, session list and session detail (context chart, tabs) all render on fixture data

## Privacy and performance

None. The sandbox runs only under `--mode sandbox` on the local dev server. Fixture data is synthetic. `sandbox.html` probes `http://127.0.0.1:4680/overlay.js` (a local tooling hook) and ignores a failed fetch.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
