### PR TITLE
fix(desktop): give the session list metric picker its segmented styling back

### DIFF
--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -621,7 +621,6 @@ export function SessionList({
               value={selectedMetric}
               onChange={onBadgeMetricChange}
               ariaLabel="Session badge metric"
-              variant="text-tabs"
               className="normal-case"
             />
           )}


### PR DESCRIPTION

<img width="417" height="380" alt="Screenshot 2026-09-07 at 13-40-28" src="https://github.com/user-attachments/assets/b1c4f37f-1e5c-4542-9314-c03163f9fded" />

## User impact

The badge metric picker at the top of the session list (`$`, `% week`, `% 5h`) had lost its pill chrome and read as loose header text. It draws as a segmented control again, matching the other pickers in the popover.

_Screenshot: Keith to add (popover session list header, light mode)._

## Validation

Run from `apps/desktop`.

- `pnpm exec vitest run src/components/session` — 212 passed, 13 files
- `pnpm type-check` — clean
- `pnpm lint` — clean
- `node scripts/check-design-drift.mjs` (repo root) — design contract in sync with the stylesheets

## Privacy and performance

None. One prop removed; no new data access, network access, retained data, or background work.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
