### PR TITLE
Add the metric-picker hotfix to antiburn 0.4.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ CI changes, and documentation that no user acts on stay out — see
 
 ### Fixed
 
+- The session-list metric picker for cost, weekly usage, and five-hour usage
+  displays as a segmented control again instead of loose header text.
 - Claude resume-as-fork sessions no longer count inherited or replayed records
   as new work. Parent links, sub-agent attribution, compaction, cache, and token
   totals remain consistent across resumed transcripts.


### PR DESCRIPTION
The unpublished antiburn 0.4.0 draft predates the session-list metric-picker hotfix merged in #416. This adds that visible fix to the existing 0.4.0 release notes so the rebuilt draft describes the exact source readers will receive.

All application manifests remain at 0.4.0. After this change merges, the existing unpublished tag and draft can be replaced from the new `main` commit; no published release or asset is modified.

Validation:

- `node scripts/verify-release-version.mjs app antiburn-v0.4.0`
- `node scripts/verify-app-engine-release.mjs`
- locked Cargo metadata resolution for the desktop shell
- `pnpm run slop:all` — 100/100, no findings
- `pnpm run secrets`

The styling fix itself passed review and main CI in #416. This notes-only change adds no network access, data collection, or runtime work.
