### PR TITLE
Define product analytics measurement contract

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@ Describe the user-visible result and any known limits.
 
 List the checks that you ran.
 
+## Analytics
+
+State the product question and the events that cover discovery, meaningful use,
+and the result. Describe new or changed triggers, allowed properties, duplicate
+or rate limits, and validation. Link the updated public catalog when applicable.
+If measurement is unchanged or unnecessary, explain why.
+
 ## Privacy and performance
 
 State any change to data access, network access, retained data, or background work. Write `None` if there is no change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,18 @@ Write code comments in ASD-STE100 Simplified Technical English:
 - Keep identifiers and API names unchanged.
 - Add a comment only when it states important information the code cannot show.
 
+## Product analytics
+
+Cover features well with analytics so we can improve the product further.
+
+Read [docs/analytics.md](docs/analytics.md) before instrumentation work. Follow
+the measurement definitions and event review contract in
+[docs/analytics-measurement.md](docs/analytics-measurement.md).
+
 ## Tests and commits
 
 Run the relevant formatter, linter, type checks, and tests for every change. Use
 the commands in `CONTRIBUTING.md` and `apps/desktop/README.md`.
 
-Every commit must include a Developer Certificate of Origin sign-off. Use
-`git commit -s`. CI rejects a pull request if any authored commit lacks it.
+Every commit must include a DCO sign-off. Use `git commit -s`. CI rejects a pull
+request if any authored commit lacks it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,9 @@ credentials, or other user data to the project or to an unrelated third party.
 The update check and anonymised application analytics are the only
 project-operated network channels. Neither is required for the app to work.
 Analytics must keep all properties documented in [docs/analytics.md](docs/analytics.md):
-it starts automatically only after onboarding completes, Settings → Privacy
-provides the opt-out, payloads contain no work or credentials, identifiers
+official configured builds can record launch and onboarding progress before
+setup completes, Settings → Privacy provides the opt-out, payloads contain no
+work or credentials, identifiers
 rotate, and builds without a configured endpoint send nothing.
 
 Take extra care with operations that modify files, stop processes, or can cost
@@ -67,6 +68,20 @@ cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 cargo test
 ```
+
+For analytics changes, also run these shell checks with the feature enabled:
+
+```bash
+cd apps/desktop/src-tauri
+cargo clippy --all-targets --features analytics -- -D warnings
+ANTIBURN_ANALYTICS_URL=http://127.0.0.1:8787 \
+ANTIBURN_ANALYTICS_OPERATOR="Local development" \
+cargo test --features analytics
+```
+
+The endpoint and operator are build-time inputs. Use the loopback collector in
+[docs/analytics.md](docs/analytics.md#verifying-this-yourself) for manual delivery
+checks. Never use the production collector for synthetic test events.
 
 Run `pnpm run slop:all` and `pnpm run secrets` before you push. Pull-request CI
 also runs `pnpm run slop` against the changed files. See
@@ -115,6 +130,11 @@ names as repository secrets for CI and as `release` environment secrets for
 signed builds.
 
 ## Pull requests
+
+For user-facing changes, describe the product question, existing or new analytics
+coverage, and the validation. Explain any intentional measurement gap. Follow
+the [event review contract](docs/analytics-measurement.md#event-review-contract)
+and update the [public catalog](docs/analytics.md) when instrumentation changes.
 
 Describe the user impact, tests, privacy or performance effects, and any known
 limits. Do not include credentials or private session content in issues, logs,

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -816,7 +816,7 @@ describe("SettingsView", () => {
       /the word .desktop./i,
       /a random id for the message, so a retry/i,
       /a random installation id/i,
-      /a random id for this run of the app/i,
+      /a random id for a window of captured analytics events/i,
       /the event name/i,
       /when it happened/i,
       /when it was delivered/i,
@@ -855,8 +855,12 @@ describe("SettingsView", () => {
     // all three are asserted from it.
     open("The two identifiers")
     expect(screen.getByText(/replaced every 30 days/i)).toBeInTheDocument()
-    expect(screen.getByText(/roughly when antiburn is used/i)).toBeInTheDocument()
-    expect(screen.getByText(/quitting antiburn ends it/i)).toBeInTheDocument()
+    expect(screen.getByText(/roughly when analytics events were captured/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/each event waiting to be sent keeps a copy on disk/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/after 30 minutes without an analytics event/i)).toBeInTheDocument()
+    expect(screen.getByText(/does not measure a visit or time spent/i)).toBeInTheDocument()
     open("How the starting default works")
     expect(
       screen.getByText(/official release builds start with analytics on/i),

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -254,7 +254,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                 <li>The word &ldquo;desktop&rdquo;.</li>
                 <li>A random id for the message, so a retry is not counted twice.</li>
                 <li>A random installation id.</li>
-                <li>A random id for this run of the app.</li>
+                <li>A random id for a window of captured analytics events.</li>
                 <li>The event name, such as &ldquo;a scan finished&rdquo;.</li>
                 <li>When it happened.</li>
                 <li>When it was delivered.</li>
@@ -291,29 +291,27 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                 on its own.
               </p>
             </Disclosure>
-            {/* Both identifiers in one place, with what the timestamps add.
-                They were three rows, but the honest claim only holds when all
-                three facts are read together: a 30-day id plus a time on every
-                event is a coarse picture of when the app gets used, and saying
-                so is cheaper than being caught not having said it. */}
+            {/* Both identifiers stay in one place with the timestamp effect.
+                A 30-day id plus a time shows when analytics events occur. */}
             <Disclosure label="The two identifiers">
               <p>
                 Both are random. Neither is derived from anything about you or your machine.
               </p>
               <p className="mt-2">
                 The <strong className="font-medium text-label">installation id</strong> is
-                replaced every 30 days, so events cannot be joined into a history longer than
-                that. Since every event also carries a time, they do show roughly when antiburn
-                is used within those 30 days &mdash; never what you were working on. Switching
+                replaced every 30 days, limiting how long that id groups events. Since every
+                event also carries a time, they do show roughly when analytics events were
+                captured within those 30 days &mdash; never what you were working on. Switching
                 analytics off deletes the id and anything still queued, so switching back on
-                starts a new id that cannot be linked to the old one.
+                starts a new id.
               </p>
               <p className="mt-2">
-                The <strong className="font-medium text-label">run id</strong> is required by
-                the receiving server. It exists only in memory: quitting antiburn ends it,
-                nothing on your machine remembers it, and it is replaced after 30 minutes of
-                inactivity. It groups one run&rsquo;s events and cannot connect one run to
-                another.
+                The <strong className="font-medium text-label">analytics-session id</strong> is
+                required by the receiving server. Its generator exists only in memory, but each
+                event waiting to be sent keeps a copy on disk. Newly captured events get a new
+                id after 30 minutes without an analytics event or when antiburn restarts.
+                Background events can keep the id active, and one app run can have more than
+                one, so it does not measure a visit or time spent.
               </p>
             </Disclosure>
             <Disclosure label="How the starting default works">

--- a/docs/analytics-measurement.md
+++ b/docs/analytics-measurement.md
@@ -1,0 +1,262 @@
+# Product analytics audit and measurement plan
+
+Audited on 2026-09-08 at `3ce2b1da`. This is a source audit, not an analysis of
+production event volumes. The collector, warehouse, release secrets, and live
+dashboards were not inspected. Proposed events below do not ship yet;
+[analytics.md](analytics.md) remains the catalog of implemented events.
+
+The current events establish that some installations run, complete setup, and
+open sessions. They cannot establish how often people deliberately use the app,
+which surfaces provide value, or whether a feature is unused because its data
+never loads. Add coverage around visible product outcomes before adding more
+background diagnostics.
+
+## Current coverage
+
+The closed catalog has nine events. Envelope fields provide event IDs, rotating
+installation IDs, application analytics session IDs, capture and send times,
+app version, OS, and architecture. Properties are fixed labels and coarse
+buckets; the Claude diagnostic has nine additional optional fields.
+
+| Current event                            | Actual trigger and dimensions                                                                                                                                      | What it answers and misses                                                                                                              |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `antiburn.app_launched`                  | Shell setup; no event-specific properties.                                                                                                                         | Reports launches, including unattended startup. Does not measure visits, continued use, or a new installation.                          |
+| `antiburn.onboarding_step_viewed`        | `OnboardingSession.noteOnboardingStep`; four fixed steps, once per step per flow instance.                                                                         | Shows setup progress. Has no new-versus-restarted flow distinction or failure reason.                                                   |
+| `antiburn.onboarding_finished`           | After the finish command saves settings. Explicit setup restarts can emit another completion.                                                                      | Shows completed setup, not first useful data or unique new installations.                                                               |
+| `antiburn.scan_completed`                | Full discovery pass; first outcome or changed count bucket relative to the previous reported outcome. Scoped passes emit nothing.                                  | Shows coarse discovery health and inventory. Is not an interaction or a scan-attempt counter.                                           |
+| `antiburn.setting_toggled`               | Saved changes to `live_usage`, `notifications`, `launch_at_login`, or `discovery_paused`; key only.                                                                | Shows use of four controls. Does not show direction, current adoption, other settings, or success of OS integration.                    |
+| `antiburn.session_opened`                | Activity-card handler before analysis loads; agent category and native/WSL.                                                                                        | Measures list-to-detail intent. Does not establish that detail loaded, or cover related sessions, subagents, or newer/older navigation. |
+| `antiburn.error_occurred`                | Full scan failure, with `scan_failed`; repeated identical outcomes suppressed.                                                                                     | Shows some discovery failures. Misses scoped failures and other feature failures; cannot supply an operation failure rate.              |
+| `antiburn.unrecognized_records_observed` | Nonempty unknown-record summary returned to Settings Insights; changed category/count bucket within the process. Clean results reset suppression without an event. | Diagnoses reader-selected cohorts. Does not count all Insights visits or population parser failure rates.                               |
+| `antiburn.claude_limit_reset_observed`   | Changed Claude reset diagnostic after normal usage refresh, with a separate five-minute cooldown and additional enablement gates.                                  | Answers a narrow provider experiment question. Does not establish that anyone viewed usage or used a reset.                             |
+
+Evidence: [event schema](../apps/desktop/src-tauri/src/analytics/event.rs),
+[recording and delivery](../apps/desktop/src-tauri/src/analytics/mod.rs),
+[shell commands](../apps/desktop/src-tauri/src/commands.rs),
+[launch](../apps/desktop/src-tauri/src/lib.rs),
+[scan scope](../apps/desktop/src-tauri/src/scan/mod.rs),
+[onboarding](../apps/desktop/src/views/onboarding/OnboardingSession.ts), and
+[activity-card handler](../apps/desktop/src/views/PopoverView.tsx).
+
+## Findings, in priority order
+
+1. **There is no deliberate-use denominator.** Popover reveals, Settings pane
+   views, provider/check previews, and HUD detail views are absent. A person
+   reading the tray meter can get value without any recorded interaction. A
+   person opening the popover daily without a session-card click is also almost
+   invisible. Do not equate background operation with engagement.
+2. **Intent has almost no outcome coverage.** Session-card clicks precede
+   analysis. There is no general distinction between useful data, empty data,
+   loading that stalls, and a failed view. Live provider failures, source access
+   trouble, and analysis failures can make a feature appear simply unwanted.
+3. **The analytics session is an event-activity window.** Every queued event
+   calls `current_session_id`, including background scans and diagnostics.
+   Background changes can keep it alive; silence can split one process run.
+   Neither its count nor its first-to-last timestamp measures engaged visits or
+   time spent. Adding events would change these measures again.
+4. **Feature adoption and intervention results are missing.** HUD enablement,
+   notification actions, source setup, report refresh, session actions, and
+   update actions have no complete measurement. Four setting keys without
+   direction cannot show enablement or abandonment. A saved preference also
+   does not prove that the corresponding feature works.
+5. **More events can expose delivery limits.** The queue keeps the newest 500
+   rows. After a 60-second initial delay, a flush sends up to 50 sequential
+   requests, then waits 15 minutes. Healthy sustained capacity is approximately
+   200 events/hour, less when requests are slow. One failed request stops a
+   drain; five failed attempts discard its row. Short-lived installs can leave
+   events queued until a later launch, and overflow drops earlier funnel steps.
+   Increased volume needs a delivery load test, not just more call sites.
+6. **Documentation and tests do not fully enforce semantics.** The catalog test
+   checks that event names occur in the document; it does not validate trigger
+   behavior, property vocabularies, or whether new features have coverage.
+   `Facts` uses static strings, not event-specific property enums. The renderer
+   IPC is more restrictive, but TypeScript still accepts any string for agent.
+   Default Cargo tests exclude most analytics tests; CI does run the enabled
+   suite on Linux.
+
+Documentation discrepancies found at the audit revision:
+
+- `CONTRIBUTING.md` said analytics waits until onboarding completes, whereas
+  `allowed` has no onboarding gate. This audit corrects the contributor text to
+  match the implementation and public policy.
+- The public scan row says exact count changes and once-a-minute visible scans.
+  The code uses count buckets from full passes; it runs full reconciliation
+  about every five minutes, while watcher-driven scoped passes emit no scan
+  analytics.
+- Public identifier descriptions say `sessionId` is never written to disk. Its
+  live generator state is memory-only, but each serialized queued payload
+  includes the ID on disk. Public descriptions of inactivity also need to say
+  analytics-event inactivity, not imply user inactivity.
+
+This documentation change corrects those disclosures. It does not describe the
+future engagement semantics below as current behavior.
+
+## Measurement definitions
+
+Use reporting installations, not people. Installation IDs rotate after 30 days
+and reset after opt-out/re-enable. Do not add a stable identifier or use IP,
+user-agent, or device information to join rotations.
+
+| Question                                           | Definition after the first implementation phase                                                                                                                                                     | Decision supported                                               |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Are people deliberately returning?                 | Daily/weekly distinct `anonymousId` with a user-initiated core `surface_viewed` event. Exclude setup, Settings-only visits, automatic restores, nudges merely appearing, and all background events. | Whether the core utility earns repeat attention.                 |
+| Does setup lead to visible value?                  | Among distinct IDs completing a new setup flow, fraction that see a core surface with `ready` data within 24 hours of completion. Also report empty, error, and timeout outcomes.                   | Whether to improve setup or the first data experience.           |
+| Which features get used?                           | Distinct IDs viewing each core surface divided by engaged reporting IDs in the same interval and supporting versions/platforms. Separate ready-data reach from view reach.                          | Which surfaces merit investment or improved discovery.           |
+| Do users return after value?                       | Among IDs first reaching ready data after new setup, observed return on day 1 and day 7 using deliberate core views. Include only cohorts whose full observation window has elapsed.                | Whether activation translates into observed repeat use.          |
+| Where does the experience fail?                    | Per surface, fraction of reporting exposed IDs with empty, error, or loading-timeout states. For explicit operations, compare terminal outcomes with attempts separately.                           | Which reliability issues block adoption.                         |
+| Does passive monitoring remain enabled and useful? | Report HUD/meter enablement, successful automatic exposure, data availability, and deliberate detail use separately.                                                                                | Whether passive display features are configured and functioning. |
+
+Use capture time for behavior, deduplicate retries by `messageId`, and allow a
+documented late-arrival window before finalizing cohorts. Segment by app version
+and OS so older builds and unsupported features do not enter new-event
+denominators. Installation rotation and missing delivery bias retention
+downward; a first-seen ID is not necessarily a new install. Opted-out and
+unconfigured builds are unobserved, so analytics cannot establish total users,
+opt-out rates, uninstalls, or precise long-term retention.
+
+For activation and return cohorts, require ready data on a user-initiated
+exposure. Automatic HUD restoration can establish that the display works, but
+does not establish that the user has reached value through deliberate use.
+
+For visit frequency, group only deliberate interaction events by installation
+with a documented 30-minute inactivity gap in analysis. Ignore background events
+when constructing visits. Keep the existing wire `sessionId` unchanged initially
+and document its actual meaning. Do not infer attention duration from gaps.
+Neither tray visibility nor a persistent HUD proves that someone looked at it.
+
+## Proposed event additions
+
+All names below use the `antiburn.` prefix. The listed dimensions are proposed
+closed vocabularies, not arbitrary strings or permission to upload payloads.
+Use event-specific Rust types even when serializing into existing `label`,
+`detail`, and `bucket` fields. Update disclosures for new meanings even when the
+wire field count stays unchanged.
+
+### Phase 1: visible use and value
+
+| Proposed event/change                              | Trigger and safe dimensions                                                                                                                                                                                                              | Owner and volume rule                                                                                                                                                                                                                                                          |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `surface_viewed`                                   | Successful reveal or visible navigation. `label`: `activity`, `session_detail`, `provider_preview`, `checks_preview`, `hud`, `hud_detail`, or `settings`. `detail`: `user` or `automatic`.                                               | Shell visibility transition plus surface controllers. One per actual transition; no event for prewarm, repeated show requests, data refresh, or hidden navigation. Only deliberate transitions qualify as engagement.                                                          |
+| `settings_pane_viewed`                             | Requested pane is selected and visible. `label`: the eight existing Settings pane IDs.                                                                                                                                                   | `SettingsWindowSession`, including first opening and external pane requests. One per visible pane transition, with duplicate requests suppressed.                                                                                                                              |
+| `surface_state_observed`                           | Data state presented on a visible surface. Same surface vocabulary, plus `insights`; `detail`: `ready`, `empty`, `error`, or `loading_timeout`. Ready means a usable payload, not merely a mounted component or successful IPC response. | Surface controllers after both visibility and data readiness. At most once per distinct state per surface exposure; ignore stale asynchronous results. Use a documented 10-second visible initial-load timeout, canceled when hidden; later ready data can still emit `ready`. |
+| `live_usage_state_observed`                        | An enabled provider's state is presented on a visible usage surface. `label`: fixed supported provider category; `detail`: `fresh`, `stale`, `authentication`, `rate_limited`, `unavailable`, or `no_credentials`.                       | Map existing presentation states, without an analytics-only provider request. Deduplicate each provider/state within a deliberate visit. No account, plan name, balance, quota value, or raw response.                                                                         |
+| `onboarding_started`, extend `onboarding_finished` | Start and committed completion of a setup flow. `label`: `new` or `restart`.                                                                                                                                                             | Explicit onboarding lifecycle and finish command. One start/completion per flow. Preserve the four existing step events; do not call closing the window an abandonment event.                                                                                                  |
+
+`surface_state_observed` also needs a closed `properties.origin` value of `user`
+or `automatic`, inherited from its exposure. This proposed optional wire field
+lets reports separate deliberate value from passive display without guessing
+from neighboring timestamps. Update the field-count tests and all affected
+disclosures when adding it. Keep the field absent on unrelated events.
+
+Define the start classification from the explicit restart path and existing
+onboarding state, not from whether the analytics identifier has been seen.
+Analyze setup progress by distinct installation and ordered times; repeated
+flows in one observation window are not independent new installations.
+
+Keep `session_opened` as the existing activity-card intent event. Pair it with
+visible session detail and data state for the activation funnel. Record visible
+detail navigation from related sessions and subagents without transmitting a
+session ID or title. Cached ready data counts when actually shown; a background
+cache refresh does not count as a view.
+
+The existing seams are
+[popover reveal/hide](../apps/desktop/src-tauri/src/popover.rs),
+[popover data and navigation](../apps/desktop/src/views/popover/PopoverSession.ts),
+[preview controller](../apps/desktop/src/views/popover/PopoverPeekController.ts),
+[Settings navigation](../apps/desktop/src/views/settings/SettingsWindowSession.ts),
+[Insights controller](../apps/desktop/src/views/settings/InsightsSession.ts), and
+[HUD controller](../apps/desktop/src/views/overlay/OverlaySession.ts).
+Carry an internal exposure generation through readiness and loading callbacks
+to reject duplicates and stale results. It need not leave the process.
+
+### Phase 2: adoption and actions
+
+| Proposed event                                | Trigger and safe dimensions                                                                                                                                                                                                                                                                                                            | Owner and volume rule                                                                                                                                                                                                                         |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setting_changed`                             | Successfully saved change; allowlist product toggles such as live usage, notifications, discovery, launch at login, and HUD enablement. Fixed `enabled`/`disabled` state.                                                                                                                                                              | The relevant persistence boundary. Emit only an actual transition. Keep existing `setting_toggled` semantics stable while migrating dashboards; do not count both as separate actions.                                                        |
+| `action_requested`, `action_completed`        | A deliberate operation starts, then reaches success, failure, or cancellation. Initial action vocabulary: manual scan, report refresh, source add/remove, source permission request, reveal source, diagnostics export, delete local session data, and clear local index. `detail` on completion: `success`, `failed`, or `cancelled`. | UI handler owns intent; operation boundary owns outcome. One pair per explicit attempt; automatic retries remain one attempt. Do not send action arguments, file paths, exported data, or exact deletion counts.                              |
+| `notification_shown`, `notification_actioned` | Actual display and explicit action; fixed notification kind and action vocabulary.                                                                                                                                                                                                                                                     | Nudge lifecycle after display succeeds, not when delivery is requested. Suppress duplicate display callbacks; separate test/location nudges from product alerts. Never send message text, actor, provider account, or usage milestone values. |
+| `update_action_completed`                     | User-requested check, installation, or restart request reaches its known result; fixed action and outcome.                                                                                                                                                                                                                             | Update controller. Do not treat a restart request as verified installation; confirm running versions through later launch events. Suppress background polling and progress callbacks.                                                         |
+
+The setting values and additional provider categories expand today's disclosure;
+update it before shipping. Do not report analytics opt-out after withdrawal or
+send a settings snapshot. Change events establish adoption among observed
+changers, not prevalence across all installs. Use observed HUD exposure for
+existing adopters; add a narrowly scoped state observation only if a specific
+prevalence question still cannot be answered.
+
+For operation success rates, correlate each attempt locally and emit exactly
+one terminal outcome. Compare aggregate counts only after allowing in-flight
+attempts and late delivery to settle. Process exits can leave unmatched
+attempts; expose that category instead of treating every missing completion as
+failure. Do not introduce persistent operation or work identifiers.
+
+### Phase 3: targeted diagnostics and measurement quality
+
+Add scoped scan, analysis, storage, or provider diagnostics only for a named
+reliability question that visible-state events cannot answer. Use fixed error
+categories and changed-state suppression. Do not add an unconditional heartbeat
+or events per poll, transcript record, chart hover, scroll tick, or token update.
+Give temporary diagnostics, including the Claude reset probe, an owner and
+review date so experiments do not become permanent noise or provider traffic.
+
+Before expanding volume, simulate normal repeated visits, preview use, and an
+offline backlog against the 50-event drain and 500-row queue. If that workload
+exceeds capacity, implement bounded queue-depth-triggered draining with retry
+backoff and a request budget. Preserve the opt-out recheck before each request
+and silent failure. Do not merely increase queue size or add a blocking exit
+flush. Monitor delivery lag, duplicate message IDs, rejection counts, and event
+mix in the collector separately from product engagement.
+
+## Event review contract
+
+Every added or changed event must document:
+
+1. The product question, intended metric, denominator, and decision it supports.
+2. The exact trigger and owning boundary, including whether it records intent,
+   visibility, a completed outcome, or background health.
+3. Every allowed property and value, serialization shape, and exclusion of
+   user/work identifiers and content. Do not pass DTOs directly to analytics.
+4. Duplicate suppression, cancellation, hidden-window behavior, retries,
+   automatic restores, and expected maximum volume for the measured flow.
+5. The public catalog/disclosure changes and the app-version boundary when
+   semantics change. Do not silently reuse an event name for a new meaning.
+6. Validation of the actual product path, not just a call to the tracker.
+
+Feature work must answer this contract with existing coverage, added coverage,
+or a concrete reason measurement is unnecessary. The goal is sufficient
+coverage to make decisions, not a fixed event count per pull request.
+
+Tests should prove that the user action produces the expected event, a failed
+operation cannot emit success, and remounts, prewarm, refreshes, and duplicate
+callbacks do not invent use. Exercise canceled and stale requests where the
+flow has them. Validate exact allowed wire properties and rejected unknown
+values at the Rust boundary. Verify opt-out, environment disablement, absent
+configuration, and queue/retry bounds when those paths change. Keep tests in
+the enabled-feature suite as well as relevant frontend tests.
+
+Strengthen the catalog check in a follow-up: use event-specific property enums
+and a machine-readable schema to validate exact names and values against the
+public catalog. A schema check cannot establish that a view was truly visible;
+behavior tests and PR review still own that requirement. Avoid a CI rule that
+merely requires an analytics file to change in every feature PR.
+
+## Delivery sequence and acceptance
+
+1. Establish baseline collector queries for the nine current events, by version.
+   Verify configured release ingestion, retry deduplication, and delivery delay.
+   Do not claim production behavior from source alone.
+2. Ship Phase 1 with a loopback recording of setup → activity → preview → session
+   detail → Settings Insights → return visit. Also exercise empty/error data,
+   hidden prewarm, renderer recreation, automatic HUD restore, and opt-out.
+   Assert the expected sequence and absence of duplicate use events.
+3. Build engagement, activation, feature reach, observed day-1/day-7 return, and
+   visible reliability reports using the definitions above. Show reporting
+   installation counts and observation limits alongside percentages.
+4. Review at least two complete weeks of supported-version cohorts, then choose
+   Phase 2 actions based on observed gaps. Assign each report and diagnostic a
+   maintainer; review whether its events still support an actual decision.
+
+This audit changes documentation, current public disclosures, and contributor
+expectations only. Runtime instrumentation, collector configuration, dashboards,
+and disclosures for proposed events remain implementation work described above.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -38,7 +38,7 @@ be put.
 | `platform`           | Constant. The surface class the collector partitions on.                                                                                                   | `desktop`                 |
 | `messageId`          | Random per-event id, so a redelivered event is not counted twice.                                                                                          | `9f2c…`                   |
 | `anonymousId`        | The rotating installation identifier.                                                                                                                      | `4b81…`                   |
-| `sessionId`          | Identifies one run of the application. Held in memory only, never written to disk, replaced after 30 minutes of inactivity and whenever antiburn restarts. | `7d10…`                   |
+| `sessionId`          | Groups a window of captured analytics events. Its generator is held in memory, but the value is written into each event queued on disk. Replaced after 30 minutes without a captured analytics event and whenever antiburn restarts. | `7d10…`                   |
 | `event`              | The event name, from the closed catalog below.                                                                                                             | `antiburn.scan_completed` |
 | `originalTimestamp`  | When it happened, UTC.                                                                                                                                     | `2026-08-19T09:14:02Z`    |
 | `sentAt`             | When it was delivered. Added at send, not at capture.                                                                                                      | `2026-08-19T09:15:02Z`    |
@@ -61,19 +61,22 @@ be put.
 ### What the two timestamps make possible
 
 Each event is timestamped and the installation identifier lasts up to 30 days,
-so these events show roughly **when** antiburn is used within that window. The
-`sessionId` additionally groups the events of a single run together, so a run
-can be seen as one visit rather than as scattered events. Neither can show what
-antiburn was used _on_. This is stated because an enumeration that lists fields
-without saying what they enable is not really an enumeration.
+so these events show roughly **when events were captured** within that window.
+The `sessionId` groups captured events separated by less than 30 minutes of
+analytics-event inactivity. Background events can keep it active, and a quiet
+app process can receive more than one, so it does not define a user visit or
+time spent. None of these fields can show what antiburn was used _on_. This is
+stated because an enumeration that lists fields without saying what they enable
+is not really an enumeration.
 
 ### Why there are two identifiers
 
 The receiving server's contract requires both, and they are not equally
-durable. `anonymousId` is stored on disk and lasts up to 30 days. `sessionId`
-exists only in memory: quitting antiburn ends it, and nothing on your machine
-remembers it afterwards. It is the shortest-lived thing in the payload, and it
-cannot connect one run of the application to another.
+durable. `anonymousId` is stored on disk and lasts up to 30 days. The live
+`sessionId` generator exists only in memory. Each serialized event also contains
+its `sessionId`, so a queued event keeps that value on disk until it is sent or
+removed. Restarting antiburn creates a new value for newly captured events;
+events already in the queue keep their original value.
 
 ### Agent and provider categories
 
@@ -113,23 +116,25 @@ Event names are namespaced `antiburn.*`.
 | Event                          | When it fires                                                                                                                                                                                               | Carries                                                                                                                                                                                                     |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `antiburn.app_launched`        | The application starts.                                                                                                                                                                                     | —                                                                                                                                                                                                           |
-| `antiburn.onboarding_finished` | The first run completes.                                                                                                                                                                                    | —                                                                                                                                                                                                           |
+| `antiburn.onboarding_finished` | A setup flow completes, including an explicitly restarted flow.                                                                                                                                             | —                                                                                                                                                                                                           |
 | `antiburn.onboarding_step_viewed` | A fixed first-run step becomes visible. Each step is recorded at most once per onboarding flow. | `label` — one of `welcome`, `agents_detected`, `sources_and_repos`, `ready`. |
-| `antiburn.scan_completed`      | A discovery pass finishes **and finds a different number of sessions than the last one reported**. antiburn rescans about once a minute while the popover is open; a repeat of the same answer is not sent. | `bucket` — how many sessions                                                                                                                                                                                |
+| `antiburn.scan_completed`      | A full discovery pass finishes and its session-count bucket differs from the previous reported outcome. The first full pass in a run is reported. Automatic full reconciliation runs at startup and about every five minutes; file watchers usually cause scoped passes, which emit no scan analytics. | `bucket` — how many sessions                                                                                                                                                                                |
 | `antiburn.setting_toggled`     | A preference changes.                                                                                                                                                                                       | `label` — one of `live_usage`, `notifications`, `launch_at_login`, `discovery_paused`. The key only; never the value.                                                                                       |
 | `antiburn.session_opened`      | You open a session from the activity list.                                                                                                                                                                  | `label` — which agent recorded it, from the fixed list antiburn supports. `detail` — `native` or `wsl`. **Not** the session, its title, its repository, or the name of your WSL distribution.               |
-| `antiburn.error_occurred`      | Something failed, and the previous pass had not already reported the same failure.                                                                                                                          | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                           |
+| `antiburn.error_occurred`      | A full discovery pass fails, and the previous full pass had not already reported the same failure.                                                                                                          | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                           |
 | `antiburn.unrecognized_records_observed` | Settings → Insights returns a cohort containing unknown record vocabulary, and its outcome differs from the last one reported during this run. | `bucket` — sessions containing unknown types. `label` — `inert_only`, `inert_capped`, or `evidence_bearing`. No discriminator, payload, session identifier, or second dimension. |
 | `antiburn.claude_limit_reset_observed` | After an ordinary Claude usage refresh, when analytics and Claude live usage are both enabled and the observation differs from the last one queued during this run. The probe uses a separate five-minute cooldown. | `label` — `success`, `authentication`, `rateLimited`, `unavailable`, `credential_absent`, `credential_expired`, or `credential_unavailable`. The nine reset fields listed above. No response body, credential, account identifier, exact usage percentage, or date. |
 
-Four of those are deliberately not sent once per occurrence. A scan result that
-repeats the last one is dropped, so a machine left running does not report the
-same number every minute and a machine stuck failing does not report the same
-failure six hundred times a day. What survives is the first pass of each run,
-every crossing of a bucket boundary, and every move into or out of failure. The
-unrecognized-record event likewise reports only a changed `(label, bucket)`
-outcome. A clean cohort updates that in-memory comparison without sending an
-event, so a later return to unknown vocabulary is visible.
+Four of those are deliberately not sent once per occurrence. A full scan result
+that repeats the last bucket is dropped, so a machine left running does not
+report the same range after every reconciliation and a machine stuck failing
+does not report the same failure after every full pass. What survives is the
+first full pass of each run, every crossing of a bucket boundary, and every move
+into or out of failure. Scoped watcher passes emit neither scan event and do not
+change this comparison. The unrecognized-record event likewise reports only a
+changed `(label, bucket)` outcome. A clean cohort updates that in-memory
+comparison without sending an event, so a later return to unknown vocabulary is
+visible.
 
 The Claude limit-reset event reports the first observation in a run and then
 only a changed observation. It calls the same provider usage endpoint through a

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy policy
 
-Effective: 6 September 2026
+Effective: 8 September 2026
 
 This policy explains the analytics sent by the antiburn desktop application.
 Antiburn is operated by **Cadence AI (Vic) Pty Ltd** ("we", "us"). Contact us
@@ -25,7 +25,7 @@ the fixed onboarding steps.
 The event schema contains twenty-two fields:
 
 - the constant product surface `desktop`;
-- random message, installation, and application-run identifiers;
+- random message, installation, and analytics-session identifiers;
 - the event name and capture and delivery times;
 - the processor architecture, operating-system family, and app version;
 - an optional count rounded to a range; and
@@ -38,10 +38,14 @@ The event schema contains twenty-two fields:
 - the weekly reset count rounded to zero, one, or two-plus; and
 - whether Claude supplied a next-reset date, never the date itself.
 
-The installation identifier is random and changes every 30 days. The run
-identifier exists only in memory and changes when the app restarts or after 30
-minutes of inactivity. Neither identifier comes from your hardware, account,
-name, or email address.
+The installation identifier is random and changes every 30 days. The live
+analytics-session identifier is generated in memory and changes when the app
+restarts or after 30 minutes without a captured analytics event. Each queued
+event contains the identifier, so that serialized value remains in the local
+analytics queue on disk until the event is sent or removed. Background events
+can keep an analytics session active, and one app run can contain more than one;
+it does not measure a user visit or time spent. Neither identifier comes from
+your hardware, account, name, or email address.
 
 The complete field list, event catalog, and verification steps are in
 [Anonymised analytics](analytics.md).

--- a/docs/support.md
+++ b/docs/support.md
@@ -150,16 +150,21 @@ signed bundle and restarts antiburn. The app never depends on either connection.
   screen explains it, and the switch is in Settings → Privacy. The event schema has twenty-two fields and
   no others: the constant `desktop`; a random per-message id used to discard
   duplicate deliveries; a random installation identifier replaced every 30 days;
-  a random application-run identifier; the event name; the time it happened and the time it was delivered; the
+  a random analytics-session identifier; the event name; the time it happened and the time it was delivered; the
   processor architecture; a count rounded into a range where the event has one;
   a short label naming which setting changed or which kind of failure occurred,
   never the value; a second fixed label where needed; a coarse five-hour usage
   band; the reset response shape; eligibility, experiment membership, experiment
   arm, and availability states; an allowlisted ineligibility reason; a reset-count
   bucket; whether a next-reset date was present; the app version; and the operating system. The payload has no
-  field able to carry anything else. Because each event is timestamped and the
-  identifier lasts up to 30 days, the events do show roughly when the
-  application is used within that window; they do not show what it was used on.
+  field able to carry anything else. The analytics-session identifier changes
+  after 30 minutes without a captured analytics event or when the app restarts.
+  Its generator is memory-only, but each queued event stores the value on disk
+  until that event is sent or removed. Background events can keep it active, so
+  it does not measure a user visit or time spent. Because each event is
+  timestamped and the installation identifier lasts up to 30 days, the events
+  do show roughly when events were captured within that window; they do not show
+  what the app was used on.
   [analytics.md](analytics.md) is the complete account: every field,
   the full event catalog, and how to verify all of it yourself.
   Never sent: sessions, transcripts, prompts, titles, file paths, repository or


### PR DESCRIPTION
## User impact

Adds a source-audited product analytics measurement plan and event review contract. It also corrects the public description of current scan analytics and analytics-session identifiers in the analytics guide, privacy policy, support guide, and Settings privacy pane.

The proposed events in the plan are not implemented by this change.

## Validation

- `pnpm install --frozen-lockfile`
- Prettier check for the changed TypeScript files
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test` (1,140 tests)
- focused `SettingsView.test.tsx` run (62 tests)
- `pnpm --filter @antiburn/desktop build`
- `cargo fmt --check` in `apps/desktop/src-tauri`
- `cargo clippy --all-targets --features analytics -- -D warnings`
- `cargo test --features analytics` with the documented loopback build configuration (995 tests)
- `pnpm run slop:all` (score 100, no findings)
- `pnpm run secrets`

## Analytics

The product question is whether antiburn can distinguish discovery, deliberate use, visible value, and feature results well enough to guide product decisions. The historical source audit shows that the nine current events cover launches, setup progress, selected actions, and narrow diagnostics, but do not provide a deliberate-use denominator or general outcome coverage.

Runtime measurement is unchanged. This change defines phased coverage and an event review contract for future instrumentation. It also corrects the current public catalog: scan analytics use bucketed full-pass outcomes, explicit setup restarts can produce another completion, and the current session identifier groups analytics-event activity rather than visits.

## Privacy and performance

The disclosures now state that the live analytics-session generator is memory-only while each queued payload stores its value on disk until delivery or removal. They also explain that background events can extend the 30-minute analytics-event window and that it does not measure a visit or time spent.

There is no change to collected data, network access, retention, or background work.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
