### PR TITLE
fix: bound peek renderer lifetime

### DIFF
--- a/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
@@ -1,7 +1,8 @@
 //! Reusable native infrastructure for a window placed beside another window.
 //!
-//! The manager owns one renderer, one target, and one cancellable task. The
-//! host application owns the target type, IPC authorization, and data policy.
+//! The manager owns one interaction-bound renderer, one target, and one
+//! cancellable task. The host owns the target type, IPC authorization, and
+//! data policy.
 
 mod geometry;
 mod lifecycle;
@@ -22,7 +23,7 @@ pub use model::{
     PointerExitPolicy, RevealPolicy, WindowMaterial,
 };
 
-/// The event that carries each target generation to the resident renderer.
+/// The event that carries each target generation to the active renderer.
 pub const REQUEST_EVENT: &str = "anchored-window-request";
 
 /// The event that reports companion lifecycle changes to the anchor window.

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle.rs
@@ -196,6 +196,7 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
 
     pub(crate) fn renderer_destroyed(&mut self) {
         self.cancel_task();
+        self.renderer_generation = self.renderer_generation.wrapping_add(1).max(1);
         self.renderer_ready = false;
         self.delivery_pending = self.target.is_some();
         self.placeholder_reveal_pending = false;
@@ -280,6 +281,13 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
 
     pub(crate) fn concealment_is_current(&self, generation: u64) -> bool {
         generation == self.generation && self.awaiting_concealment
+    }
+
+    pub(crate) fn renderer_retirement_is_current(&self, generation: u64) -> bool {
+        generation == self.generation
+            && self.target.is_none()
+            && !self.visible
+            && !self.awaiting_concealment
     }
 
     pub(crate) fn force_hidden(&mut self) {

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/concealment.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/concealment.rs
@@ -47,6 +47,106 @@ fn generation_checks_cover_concealment_and_retargeting() {
 }
 
 #[test]
+fn renderer_retirement_requires_the_current_completed_concealment() {
+    let mut lifecycle = lifecycle();
+    lifecycle.renderer_ready = true;
+    let (first, _) = retargeted(lifecycle.request(
+        "first",
+        region(),
+        RevealPolicy::ImmediatePlaceholder,
+        120.0,
+        None,
+    ));
+    assert!(lifecycle.presented(first.generation));
+
+    let conceal = lifecycle.conceal();
+    assert!(!lifecycle.renderer_retirement_is_current(conceal.generation));
+    assert!(lifecycle.concealed(conceal.generation));
+    assert!(lifecycle.renderer_retirement_is_current(conceal.generation));
+
+    let (second, _) = retargeted(lifecycle.request(
+        "second",
+        region(),
+        RevealPolicy::ImmediatePlaceholder,
+        120.0,
+        None,
+    ));
+    assert!(!lifecycle.renderer_retirement_is_current(conceal.generation));
+    assert!(!lifecycle.renderer_retirement_is_current(second.generation));
+}
+
+#[test]
+fn late_renderer_destruction_preserves_a_new_target_for_rebuild() {
+    let mut lifecycle = lifecycle();
+    lifecycle.renderer_generation = 7;
+    lifecycle.renderer_ready = true;
+    let (first, _) = retargeted(lifecycle.request(
+        "first",
+        region(),
+        RevealPolicy::ImmediatePlaceholder,
+        120.0,
+        None,
+    ));
+    assert!(lifecycle.presented(first.generation));
+    let conceal = lifecycle.conceal();
+    assert!(lifecycle.concealed(conceal.generation));
+
+    let (second, _) = retargeted(lifecycle.request(
+        "second",
+        region(),
+        RevealPolicy::ImmediatePlaceholder,
+        120.0,
+        None,
+    ));
+    assert!(!lifecycle.renderer_retirement_is_current(conceal.generation));
+
+    lifecycle.renderer_destroyed();
+    assert_eq!(lifecycle.state().target, Some("second"));
+    assert!(lifecycle.awaiting_presentation);
+    assert_eq!(
+        lifecycle.renderer_ready(7, RevealPolicy::ImmediatePlaceholder),
+        None
+    );
+    assert_eq!(
+        lifecycle.renderer_ready(8, RevealPolicy::ImmediatePlaceholder),
+        Some(false)
+    );
+    let pending = lifecycle
+        .pending_render_request()
+        .expect("the new target needs the replacement renderer");
+    assert_eq!(pending.generation, second.generation);
+    assert_eq!(pending.target, Some("second"));
+}
+
+#[test]
+fn anchor_teardown_retires_a_renderer_that_is_still_loading() {
+    let mut lifecycle = lifecycle();
+    lifecycle.renderer_generation = 7;
+    let (request, _) = retargeted(lifecycle.request(
+        "target",
+        region(),
+        RevealPolicy::ImmediatePlaceholder,
+        120.0,
+        None,
+    ));
+    assert!(lifecycle.awaiting_presentation);
+
+    let conceal = lifecycle.conceal();
+    lifecycle.force_hidden();
+    assert!(lifecycle.concealed(conceal.generation));
+    assert!(lifecycle.renderer_retirement_is_current(conceal.generation));
+
+    lifecycle.renderer_destroyed();
+    assert_eq!(lifecycle.state().target, None);
+    assert!(!lifecycle.awaiting_presentation);
+    assert_eq!(
+        lifecycle.renderer_ready(7, RevealPolicy::ImmediatePlaceholder),
+        None
+    );
+    assert!(!lifecycle.presented(request.generation));
+}
+
+#[test]
 fn forced_anchor_conceal_makes_the_next_immediate_request_a_cold_reveal() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_ready = true;

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
@@ -51,13 +51,16 @@ where
         }
     }
 
-    /// Build the hidden renderer if it does not exist yet.
-    pub fn prewarm(&self, app: &tauri::AppHandle) -> tauri::Result<()> {
+    /// Rebuild a destroyed renderer only while a target still owns it.
+    pub fn rebuild_if_targeted(&self, app: &tauri::AppHandle) -> tauri::Result<bool> {
         let _frame_update = self.lock_frame_update();
-        self.ensure_window(app).map(|_| ())
+        if self.lock_lifecycle().target.is_none() {
+            return Ok(false);
+        }
+        self.ensure_window(app).map(|_| true)
     }
 
-    /// Retarget the resident renderer and apply its configured reveal policy.
+    /// Retarget the active renderer and apply its configured reveal policy.
     pub fn request(
         &self,
         app: &tauri::AppHandle,
@@ -67,7 +70,7 @@ where
         self.request_with_presentation(app, target, anchor_region, None)
     }
 
-    /// Retarget the resident renderer with optional instigator-owned content.
+    /// Retarget the active renderer with optional instigator-owned content.
     pub fn request_with_presentation(
         &self,
         app: &tauri::AppHandle,
@@ -342,6 +345,9 @@ where
         if concealed && let Err(error) = self.emit_state(app) {
             tracing::warn!(%error, "failed to emit anchored-window concealed state");
         }
+        if concealed {
+            self.schedule_renderer_retirement(app, generation);
+        }
         concealed
     }
 
@@ -387,6 +393,33 @@ where
         self.lock_lifecycle().renderer_destroyed();
         #[cfg(target_os = "linux")]
         self.inner.pointer_tracker.reset_for_install();
+    }
+
+    fn schedule_renderer_retirement(&self, app: &tauri::AppHandle, generation: u64) {
+        let manager = Arc::downgrade(&self.inner);
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::task::yield_now().await;
+            let Some(inner) = manager.upgrade() else {
+                return;
+            };
+            Self { inner }.retire_renderer_if_current(&app, generation);
+        });
+    }
+
+    fn retire_renderer_if_current(&self, app: &tauri::AppHandle, generation: u64) {
+        let _frame_update = self.lock_frame_update();
+        if !self
+            .lock_lifecycle()
+            .renderer_retirement_is_current(generation)
+        {
+            return;
+        }
+        if let Some(window) = app.get_webview_window(&self.inner.config.label)
+            && let Err(error) = window.destroy()
+        {
+            tracing::warn!(%error, "failed to destroy the concealed anchored window");
+        }
     }
 
     fn lock_lifecycle(&self) -> std::sync::MutexGuard<'_, Lifecycle<T, P>> {

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/tasks.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/tasks.rs
@@ -206,7 +206,9 @@ where
         if !renderer_ready {
             platform::hide(&window)?;
             if self.lock_lifecycle().concealed(request.generation) {
-                self.emit_state(app)?;
+                let emit_result = self.emit_state(app);
+                self.schedule_renderer_retirement(app, request.generation);
+                emit_result?;
             }
             return Ok(());
         }
@@ -235,12 +237,14 @@ where
             tracing::warn!(%error, "failed to hide anchored window after fallback");
             return;
         }
-        if self
+        let concealed = self
             .lock_lifecycle()
-            .fallback_concealed(generation, task_token)
-            && let Err(error) = self.emit_state(app)
-        {
-            tracing::warn!(%error, "failed to emit anchored-window fallback state");
+            .fallback_concealed(generation, task_token);
+        if concealed {
+            if let Err(error) = self.emit_state(app) {
+                tracing::warn!(%error, "failed to emit anchored-window fallback state");
+            }
+            self.schedule_renderer_retirement(app, generation);
         }
     }
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -69,7 +69,6 @@ pub fn window_ready(window: tauri::WebviewWindow, generation: u64) {
     match window.label() {
         crate::popover::LABEL => {
             crate::popover::renderer_ready(&window, generation);
-            crate::popover_peek::prewarm(window.app_handle());
         }
         crate::settings::LABEL => crate::settings::renderer_ready(&window, generation),
         crate::onboarding::LABEL => crate::onboarding::renderer_ready(&window, generation),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -231,9 +231,6 @@ pub fn run() {
             app.manage(nudges::AnchorOverride::default());
             app.manage(antiburn_nudge::NotificationGate::default());
 
-            // Build the resident placeholder before any hover can request it.
-            popover_peek::prewarm(app.handle());
-
             tray::create(app.handle())?;
             tray::install_usage_meter(app.handle());
             // After the tray, and on the main thread: the monitor reaches the
@@ -502,11 +499,13 @@ fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
         manager.handle_anchor_event(window, event);
         if window.label() == popover_peek::LABEL && matches!(event, WindowEvent::Destroyed) {
             manager.handle_companion_destroyed();
-            let app = window.app_handle().clone();
-            tauri::async_runtime::spawn(async move {
-                tokio::task::yield_now().await;
-                popover_peek::prewarm(&app);
-            });
+            if manager.state().target.is_some() {
+                let app = window.app_handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::task::yield_now().await;
+                    popover_peek::rebuild_if_targeted(&app);
+                });
+            }
         }
     }
     match event {

--- a/apps/desktop/src-tauri/src/popover_peek.rs
+++ b/apps/desktop/src-tauri/src/popover_peek.rs
@@ -360,11 +360,11 @@ pub fn popover_peek_concealed(
     Ok(manager.concealed(window.app_handle(), generation))
 }
 
-pub fn prewarm(app: &tauri::AppHandle) {
+pub fn rebuild_if_targeted(app: &tauri::AppHandle) {
     if let Some(manager) = app.try_state::<PopoverPeekManager>()
-        && let Err(error) = manager.prewarm(app)
+        && let Err(error) = manager.rebuild_if_targeted(app)
     {
-        ::tracing::warn!(event = "popover_peek_prewarm_failed", companion_label = LABEL, error = %error);
+        ::tracing::warn!(event = "popover_peek_rebuild_failed", companion_label = LABEL, error = %error);
     }
 }
 

--- a/docs/window-renderer-lifecycle.md
+++ b/docs/window-renderer-lifecycle.md
@@ -8,9 +8,9 @@ The main popover renderer also stays resident after its first use, so the
 application's primary surface can reopen immediately. Other renderers remain
 bounded by their interaction or handoff.
 
-This document covers the popover, onboarding, and Settings renderers. The HUD
-and nudge windows have separate ownership rules. See [HUD states](hud-states.md)
-for the HUD and its detail window.
+This document covers the popover, its peek companion, onboarding, and Settings
+renderers. The HUD and nudge windows have separate ownership rules. See
+[HUD states](hud-states.md) for the HUD and its detail window.
 
 ## The shared lifecycle
 
@@ -124,6 +124,26 @@ timer therefore cannot destroy a revealed or replaced renderer. After prewarm
 eviction, the next open starts from `Idle` and creates a fresh renderer from
 native and persisted state.
 
+## Peek companion interaction lifetime
+
+The passive peek companion is created on the first provider or checks hover.
+Starting the application and revealing the main popover do not create its
+renderer. A request made while the renderer loads remains attached to its
+target generation and reveals after the matching readiness and presentation
+reports.
+
+Pointer exit starts the existing bridge and outside delays. The renderer first
+clears the current target and hides, then the shell destroys its native window.
+The concealment generation also owns the delayed destruction, so a new hover or
+retarget makes an older destruction callback stale. If native destruction wins
+a race with a new target, the destroyed-window handler rebuilds only while that
+target is still active. Renderer readiness then redelivers the retained request.
+
+Hiding or destroying the main popover starts the same concealment path. The
+companion therefore exists only for an active peek interaction and its bounded
+pointer-exit transition. A renderer that does not acknowledge concealment is
+hidden and destroyed after the configured 80-millisecond fallback.
+
 ## Settings teardown
 
 Settings is created on demand and destroyed on close. It does not use a grace
@@ -236,6 +256,8 @@ Use these principles when adding or changing desktop windows:
 | Tauri readiness, timing, and trace adapters                      | [`window_lifecycle.rs`](../apps/desktop/src-tauri/src/window_lifecycle.rs)      |
 | Popover facade, first-click reuse, and Tauri window effects      | [`popover.rs`](../apps/desktop/src-tauri/src/popover.rs)                        |
 | Popover prewarm leases, eviction tokens, and deadline ownership  | [`retention.rs`](../apps/desktop/src-tauri/src/popover/retention.rs)            |
+| Peek target policy and shell hooks                               | [`popover_peek.rs`](../apps/desktop/src-tauri/src/popover_peek.rs)              |
+| Peek generations, concealment, and renderer destruction          | [`anchored-window`](../apps/desktop/src-tauri/crates/anchored-window/src/lib.rs) |
 | Popover latency milestones and structured timing                 | [`timing.rs`](../apps/desktop/src-tauri/src/popover/timing.rs)                  |
 | Onboarding completion and delayed teardown                       | [`onboarding.rs`](../apps/desktop/src-tauri/src/onboarding.rs)                  |
 | Settings creation, destruction, and native Insights cancellation | [`settings.rs`](../apps/desktop/src-tauri/src/settings.rs)                      |


### PR DESCRIPTION
## User impact

The popover peek renderer is now created on its first hover instead of during application startup or main-popover readiness. It is destroyed after the peek interaction finishes, including the bounded concealment fallback, so readers who never use previews do not retain that renderer all day.

Generation guards keep in-flight readiness, presentation, retarget, content-height, concealment, and native destruction races attached to the current target. A renderer destroyed after a newer target arrives is rebuilt only while that target remains active.

Known limit: the required live macOS memory and first-hover latency report was not run because Steve 0.5.1 is not installed in the test environment. This PR makes no measured memory-savings or latency claim.

## Validation

- `cargo fmt --all -- --check` in `apps/desktop/src-tauri/crates/anchored-window`
- `cargo clippy --all-targets --locked -- -D warnings` in `apps/desktop/src-tauri/crates/anchored-window`
- `cargo test --locked` in `apps/desktop/src-tauri/crates/anchored-window`: 31 passed
- `cargo fmt --all -- --check` in `apps/desktop/src-tauri`
- `cargo clippy --all-targets --locked -- -D warnings` in `apps/desktop/src-tauri`
- `cargo test --locked` in `apps/desktop/src-tauri`: 962 passed
- `node --test scripts/mem-report.test.mjs`: 16 passed
- `pnpm run slop:all`: score 100
- `pnpm run secrets`

The live macOS report remains blocked only by the missing Steve executable. No package was installed, no application was stopped, and no GUI process was launched.

## Analytics

Product question: does interaction-bound peek rendering reduce idle renderer residency without harming meaningful preview use or its visible result?

Analytics is unchanged. Startup prewarming, renderer creation, and eviction are implementation mechanics and must not count as deliberate use. The reader interaction and displayed preview semantics do not change, so new product events would not answer the resource or first-hover-latency question. The generation lifecycle tests cover correctness; the documented local process-tree memory and latency report is the appropriate measurement boundary when Steve is available.

## Privacy and performance

No data access, network access, or content retention changes. The change removes unconditional renderer creation and bounds the peek renderer to an active hover plus its existing pointer-exit and 80-millisecond fallback transitions.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
