### PR TITLE
perf(scan): batch indexed watcher lookups

### DIFF
--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -429,12 +429,10 @@ pub fn spawn_scheduler(app: &AppHandle) -> tauri::async_runtime::JoinHandle<()> 
                     );
                     overflowed = true;
                 } else {
-                    let work = scoped::classify_burst(&burst.paths, &home, &|label: &str| {
+                    let work = scoped::classify_burst(&burst.paths, &home, &|source_labels| {
                         store
-                            .session_record_by_source_label(label)
-                            .ok()
-                            .flatten()
-                            .map(|(key, _)| key)
+                            .native_file_session_activity_keys(source_labels)
+                            .unwrap_or_default()
                     });
                     pending_work.merge(work);
                 }

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -55,7 +55,7 @@ const LOG_PATH_SAMPLE: usize = 8;
 /// What one path in a burst means for the scheduler.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ClassifiedPath {
-    Session(SessionActivityKey),
+    Sessions(BTreeSet<SessionActivityKey>),
     IndexedTitles(AgentKind),
     DatabaseAgent(AgentKind),
     Agent(AgentKind),
@@ -72,6 +72,12 @@ pub struct ScopedWork {
     pub agents: BTreeSet<AgentKind>,
     pub db_agents: BTreeSet<AgentKind>,
 }
+
+/// Native file activity keys grouped by their source label.
+pub type ActivityKeysBySourceLabel = HashMap<String, BTreeSet<SessionActivityKey>>;
+
+/// Resolves one batch of candidate source labels.
+pub type SourceLabelLookup<'a> = dyn Fn(&BTreeSet<String>) -> ActivityKeysBySourceLabel + 'a;
 
 impl ScopedWork {
     pub fn is_empty(&self) -> bool {
@@ -91,25 +97,27 @@ impl ScopedWork {
 }
 
 /// Classify every path in a burst against `home` and `lookup`, and fold the
-/// result into one [`ScopedWork`]. Pure over its arguments — no I/O beyond
-/// what `lookup` does — so a test can drive it with a fake lookup and a
-/// synthetic home.
+/// result into one [`ScopedWork`]. The lookup runs once with every distinct
+/// direct and ancestor candidate from the burst.
 ///
-/// `lookup` answers "is this string form a stored native file session's
-/// `source_label`", the store query [`crate::store::Store::session_record_by_source_label`]
-/// backs in production.
+/// The store's indexed native file lookup backs `lookup` in production.
 pub fn classify_burst(
     paths: &[PathBuf],
     home: &Path,
-    lookup: &dyn Fn(&str) -> Option<SessionActivityKey>,
+    lookup: &SourceLabelLookup<'_>,
 ) -> ScopedWork {
     let roots = all_agent_roots(home);
+    let candidates = paths
+        .iter()
+        .flat_map(|path| source_label_candidates(path, &roots))
+        .collect::<BTreeSet<_>>();
+    let matches = lookup(&candidates);
     let mut work = ScopedWork::default();
     let mut ignored = 0usize;
     for path in paths {
-        match classify_path(path, home, &roots, lookup) {
-            ClassifiedPath::Session(key) => {
-                work.sessions.insert(key);
+        match classify_path(path, home, &roots, &matches) {
+            ClassifiedPath::Sessions(keys) => {
+                work.sessions.extend(keys);
             }
             ClassifiedPath::IndexedTitles(agent) => {
                 work.title_agents.insert(agent);
@@ -152,25 +160,12 @@ fn classify_path(
     path: &Path,
     home: &Path,
     roots: &[(AgentKind, WatchRoot)],
-    lookup: &dyn Fn(&str) -> Option<SessionActivityKey>,
+    matches: &HashMap<String, BTreeSet<SessionActivityKey>>,
 ) -> ClassifiedPath {
-    if let Some(key) = lookup(&path.to_string_lossy()) {
-        return ClassifiedPath::Session(key);
-    }
-    // T1's sub-agent form: `<dir>/<sessionId>/subagents/agent-*.jsonl` names
-    // its parent transcript as `<dir>/<sessionId>.jsonl`. Walk ancestors
-    // while they stay under an agent's watch root, stopping at the first
-    // ancestor whose `.jsonl` sibling is a stored session.
-    let mut current = path.parent();
-    while let Some(dir) = current {
-        if !roots.iter().any(|(_, root)| dir.starts_with(&root.path)) {
-            break;
+    for source_label in source_label_candidates(path, roots) {
+        if let Some(keys) = matches.get(&source_label) {
+            return ClassifiedPath::Sessions(keys.clone());
         }
-        let candidate = dir.with_extension("jsonl");
-        if let Some(key) = lookup(&candidate.to_string_lossy()) {
-            return ClassifiedPath::Session(key);
-        }
-        current = dir.parent();
     }
     if let Some(agent) = indexed_title_store_owner(path, home) {
         return ClassifiedPath::IndexedTitles(agent);
@@ -184,6 +179,19 @@ fn classify_path(
         Some(agent) => ClassifiedPath::Agent(agent),
         None => ClassifiedPath::Ignored,
     }
+}
+
+fn source_label_candidates(path: &Path, roots: &[(AgentKind, WatchRoot)]) -> Vec<String> {
+    let mut candidates = vec![path.to_string_lossy().into_owned()];
+    let mut current = path.parent();
+    while let Some(dir) = current {
+        if !roots.iter().any(|(_, root)| dir.starts_with(&root.path)) {
+            break;
+        }
+        candidates.push(dir.with_extension("jsonl").to_string_lossy().into_owned());
+        current = dir.parent();
+    }
+    candidates
 }
 
 fn indexed_title_store_owner(path: &Path, home: &Path) -> Option<AgentKind> {
@@ -511,9 +519,7 @@ async fn refresh_sessions_locked(
     let mut previous_map: HashMap<SessionActivityKey, SessionRecord> = HashMap::new();
     let mut logs = Vec::new();
     for key in keys {
-        let Some((activity_key, record)) =
-            store.session_record_by_source_label(&key.source_label)?
-        else {
+        let Some(record) = store.session_record_by_activity_key(key)? else {
             continue;
         };
         // Only a native file source can be reused this way; a provider-database
@@ -537,7 +543,7 @@ async fn refresh_sessions_locked(
             updated_at: record.updated_at_epoch,
             environment: DiscoveryEnvironment::Native,
         });
-        previous_map.insert(activity_key, record);
+        previous_map.insert(key.clone(), record);
     }
 
     let announce_app = app.clone();
@@ -599,6 +605,18 @@ mod tests {
         SessionActivityKey::new("native", "claude-code", source_label)
     }
 
+    fn lookup_for(
+        key: SessionActivityKey,
+    ) -> impl Fn(&BTreeSet<String>) -> HashMap<String, BTreeSet<SessionActivityKey>> {
+        move |source_labels| {
+            source_labels
+                .contains(&key.source_label)
+                .then(|| (key.source_label.clone(), BTreeSet::from([key.clone()])))
+                .into_iter()
+                .collect()
+        }
+    }
+
     /// Cursor's real watch root for `home`, so a `classify_burst` test (which
     /// resolves roots through the actual [`Explorers::DISK`] registry, not a
     /// fake) exercises a path the classifier would really see — the root's
@@ -617,9 +635,7 @@ mod tests {
         let home = PathBuf::from("/home/avery");
         let session_path = home.join(".claude/projects/demo/abc.jsonl");
         let expected = key(&session_path.to_string_lossy());
-        let lookup_key = expected.clone();
-        let lookup =
-            move |label: &str| (label == lookup_key.source_label).then(|| lookup_key.clone());
+        let lookup = lookup_for(expected.clone());
 
         let work = classify_burst(&[session_path], &home, &lookup);
         assert_eq!(work.sessions, BTreeSet::from([expected]));
@@ -633,12 +649,80 @@ mod tests {
         let parent = home.join(".claude/projects/demo/abc.jsonl");
         let subagent = home.join(".claude/projects/demo/abc/subagents/agent-1.jsonl");
         let expected = key(&parent.to_string_lossy());
-        let lookup_key = expected.clone();
-        let lookup =
-            move |label: &str| (label == lookup_key.source_label).then(|| lookup_key.clone());
+        let lookup = lookup_for(expected.clone());
 
         let work = classify_burst(&[subagent], &home, &lookup);
         assert_eq!(work.sessions, BTreeSet::from([expected]));
+    }
+
+    #[test]
+    fn the_nearest_matching_ancestor_keeps_lookup_precedence() {
+        let home = PathBuf::from("/home/avery");
+        let nearest = home.join(".claude/projects/demo/abc/subagents.jsonl");
+        let parent = home.join(".claude/projects/demo/abc.jsonl");
+        let changed = home.join(".claude/projects/demo/abc/subagents/agent-1/data.jsonl");
+        let nearest_key = key(&nearest.to_string_lossy());
+        let parent_key = key(&parent.to_string_lossy());
+        let lookup = move |source_labels: &BTreeSet<String>| {
+            [nearest_key.clone(), parent_key.clone()]
+                .into_iter()
+                .filter(|key| source_labels.contains(&key.source_label))
+                .map(|key| (key.source_label.clone(), BTreeSet::from([key])))
+                .collect()
+        };
+
+        let work = classify_burst(&[changed], &home, &lookup);
+        assert_eq!(
+            work.sessions,
+            BTreeSet::from([key(&nearest.to_string_lossy())])
+        );
+    }
+
+    #[test]
+    fn a_direct_match_precedes_an_ancestor_match() {
+        let home = PathBuf::from("/home/avery");
+        let direct = home.join(".claude/projects/demo/abc/subagents/agent-1.jsonl");
+        let parent = home.join(".claude/projects/demo/abc.jsonl");
+        let direct_key = key(&direct.to_string_lossy());
+        let parent_key = key(&parent.to_string_lossy());
+        let lookup = move |source_labels: &BTreeSet<String>| {
+            [direct_key.clone(), parent_key.clone()]
+                .into_iter()
+                .filter(|key| source_labels.contains(&key.source_label))
+                .map(|key| (key.source_label.clone(), BTreeSet::from([key])))
+                .collect()
+        };
+
+        let work = classify_burst(std::slice::from_ref(&direct), &home, &lookup);
+        assert_eq!(
+            work.sessions,
+            BTreeSet::from([key(&direct.to_string_lossy())])
+        );
+    }
+
+    #[test]
+    fn duplicate_deep_paths_use_one_deduplicated_batch_lookup() {
+        let home = PathBuf::from("/home/avery");
+        let roots = all_agent_roots(&home);
+        let mut changed = home.join(".claude/projects/demo/session/subagents");
+        for depth in 0..40 {
+            changed.push(format!("level-{depth}"));
+        }
+        changed.push("agent-1.jsonl");
+        let expected = source_label_candidates(&changed, &roots)
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let paths = vec![changed; 16];
+        let calls = std::cell::Cell::new(0);
+        let lookup = |source_labels: &BTreeSet<String>| {
+            calls.set(calls.get() + 1);
+            assert_eq!(source_labels, &expected);
+            HashMap::new()
+        };
+
+        let _ = classify_burst(&paths, &home, &lookup);
+        assert_eq!(calls.get(), 1);
+        assert_eq!(expected.len(), 45);
     }
 
     #[test]
@@ -646,20 +730,20 @@ mod tests {
         let home = PathBuf::from("/home/avery");
         let db_path = home.join(".cursor/state.vscdb");
         let roots = [(AgentKind::Cursor, root("/home/avery/.cursor", true))];
-        let lookup = |_: &str| None;
+        let matches = HashMap::new();
 
         assert_eq!(
-            classify_path(&db_path, &home, &roots, &lookup),
+            classify_path(&db_path, &home, &roots, &matches),
             ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
         );
         let wal = home.join(".cursor/state.vscdb-wal");
         assert_eq!(
-            classify_path(&wal, &home, &roots, &lookup),
+            classify_path(&wal, &home, &roots, &matches),
             ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
         );
         let journal = home.join(".cursor/state.vscdb-journal");
         assert_eq!(
-            classify_path(&journal, &home, &roots, &lookup),
+            classify_path(&journal, &home, &roots, &matches),
             ClassifiedPath::DatabaseAgent(AgentKind::Cursor)
         );
     }
@@ -667,7 +751,7 @@ mod tests {
     #[test]
     fn codex_title_store_changes_refresh_titles_only() {
         let home = PathBuf::from("/home/avery");
-        let lookup = |_: &str| None;
+        let lookup = |_: &BTreeSet<String>| HashMap::new();
         let paths = [
             home.join(".codex/state_5.sqlite"),
             home.join(".codex/state_5.sqlite-wal"),
@@ -685,7 +769,7 @@ mod tests {
     #[test]
     fn unrelated_codex_metadata_does_not_request_work() {
         let home = PathBuf::from("/home/avery");
-        let lookup = |_: &str| None;
+        let lookup = |_: &BTreeSet<String>| HashMap::new();
 
         let work = classify_burst(&[home.join(".codex/config.toml")], &home, &lookup);
 
@@ -697,10 +781,10 @@ mod tests {
         let home = PathBuf::from("/home/avery");
         let path = home.join(".codex/sessions/2026/08/01/rollout.jsonl");
         let roots = [(AgentKind::Codex, root("/home/avery/.codex", true))];
-        let lookup = |_: &str| None;
+        let matches = HashMap::new();
 
         assert_eq!(
-            classify_path(&path, &home, &roots, &lookup),
+            classify_path(&path, &home, &roots, &matches),
             ClassifiedPath::Agent(AgentKind::Codex)
         );
     }
@@ -709,10 +793,10 @@ mod tests {
     fn an_unclaimed_path_is_ignored() {
         let path = PathBuf::from("/home/avery/Downloads/random.txt");
         let roots: [(AgentKind, WatchRoot); 0] = [];
-        let lookup = |_: &str| None;
+        let matches = HashMap::new();
 
         assert_eq!(
-            classify_path(&path, Path::new("/home/avery"), &roots, &lookup),
+            classify_path(&path, Path::new("/home/avery"), &roots, &matches),
             ClassifiedPath::Ignored
         );
     }
@@ -726,9 +810,7 @@ mod tests {
         let unclaimed = PathBuf::from("/home/avery/Downloads/random.txt");
 
         let expected_key = key(&session_path.to_string_lossy());
-        let lookup_key = expected_key.clone();
-        let lookup =
-            move |label: &str| (label == lookup_key.source_label).then(|| lookup_key.clone());
+        let lookup = lookup_for(expected_key.clone());
 
         let work = classify_burst(
             &[session_path, db_path, agent_path, unclaimed],
@@ -746,7 +828,7 @@ mod tests {
         let cursor_root = cursor_watch_root(&home);
         let db_path = cursor_root.join("state.vscdb");
         let plain_path = cursor_root.join("some-other-file.json");
-        let lookup = |_: &str| None;
+        let lookup = |_: &BTreeSet<String>| HashMap::new();
 
         let work = classify_burst(&[db_path, plain_path], &home, &lookup);
         assert_eq!(work.agents, BTreeSet::from([AgentKind::Cursor]));

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -33,7 +33,7 @@ mod publish_tests;
 #[cfg(test)]
 mod tests;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -194,6 +194,21 @@ const SESSIONS_ACTIVE_SINCE_SQL: &str = "SELECT environment_key, agent, session_
 /// Ceiling on how many uuids [`Store::sessions_owning_turn_uuids`] matches
 /// in one call, applied to the `IN (...)` list it builds.
 const FORK_LINEAGE_UUID_CAP: usize = 8;
+
+/// Keep each watcher lookup below SQLite's host-parameter limit.
+const SOURCE_LABEL_LOOKUP_CHUNK_SIZE: usize = 500;
+
+/// Build the indexed query for one chunk of native file source labels.
+fn native_file_session_activity_keys_sql(source_label_count: usize) -> String {
+    let placeholders = vec!["?"; source_label_count].join(", ");
+    format!(
+        "SELECT agent, source_label
+           FROM session
+          WHERE source_label IN ({placeholders})
+            AND environment_key = 'native'
+            AND source_kind = 'file'"
+    )
+}
 
 /// A scalar subquery counting one session's published turn rows, correlated
 /// to an outer `session s` row. Shared by [`sessions_owning_turn_uuids_sql`]
@@ -904,31 +919,62 @@ impl Store {
             .optional()?)
     }
 
-    /// One native file session's cached record, addressed by its
-    /// `source_label` (the transcript path) rather than its session id.
+    /// Return native file activity keys grouped by their requested transcript
+    /// paths. One lock and bounded query chunks cover the whole watcher burst.
     ///
-    /// T1: the watcher names a changed path, not a session id, so the scoped
-    /// scan classifies a burst's paths against `source_label` before it can
-    /// build a targeted refresh.
-    pub fn session_record_by_source_label(
+    /// A path can match more than one agent row. Keep every full activity key
+    /// so the classifier does not merge agents or native and WSL identities.
+    pub fn native_file_session_activity_keys(
         &self,
-        source_label: &str,
-    ) -> Result<Option<(SessionActivityKey, SessionRecord)>> {
+        source_labels: &BTreeSet<String>,
+    ) -> Result<HashMap<String, BTreeSet<SessionActivityKey>>> {
+        if source_labels.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let connection = self.lock();
+        let labels = source_labels.iter().collect::<Vec<_>>();
+        let mut matches: HashMap<String, BTreeSet<SessionActivityKey>> = HashMap::new();
+        for chunk in labels.chunks(SOURCE_LABEL_LOOKUP_CHUNK_SIZE) {
+            let mut statement =
+                connection.prepare(&native_file_session_activity_keys_sql(chunk.len()))?;
+            let rows = statement.query_map(
+                params_from_iter(chunk.iter().map(|label| label.as_str())),
+                |row| {
+                    let agent = row.get::<_, String>(0)?;
+                    let source_label = row.get::<_, String>(1)?;
+                    Ok((
+                        source_label.clone(),
+                        SessionActivityKey::new("native", agent, source_label),
+                    ))
+                },
+            )?;
+            for row in rows {
+                let (source_label, key) = row?;
+                matches.entry(source_label).or_default().insert(key);
+            }
+        }
+        Ok(matches)
+    }
+
+    /// Return one file session by its complete activity identity.
+    pub fn session_record_by_activity_key(
+        &self,
+        key: &SessionActivityKey,
+    ) -> Result<Option<SessionRecord>> {
         let connection = self.lock();
         let mut statement = connection.prepare(&format!(
-            "{SESSION_SELECT_SQL}\n              WHERE source_label = ?1"
+            "{SESSION_SELECT_SQL}
+              WHERE source_label = ?3
+                AND environment_key = ?1
+                AND agent = ?2
+                AND source_kind = 'file'"
         ))?;
-        let record = statement
-            .query_row(params![source_label], session_from_row)
-            .optional()?;
-        Ok(record.map(|record| {
-            let key = SessionActivityKey::new(
-                record.key.environment_key.clone(),
-                record.key.agent.clone(),
-                record.source_label.clone(),
-            );
-            (key, record)
-        }))
+        Ok(statement
+            .query_row(
+                params![key.environment_key, key.agent, key.source_label],
+                session_from_row,
+            )
+            .optional()?)
     }
 
     /// Keys of every session whose evidence last failed because its source
@@ -3231,7 +3277,7 @@ fn evidence_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EvidenceRow> {
 
 /// Column list and join shared by every reader of the `session` table:
 /// [`Store::session_records`], [`Store::session`], and
-/// [`Store::session_record_by_source_label`]. One copy means a schema change
+/// [`Store::session_record_by_activity_key`]. One copy means a schema change
 /// updates every reader together, and [`session_from_row`] stays the single
 /// row mapper for all three.
 const SESSION_SELECT_SQL: &str =

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -12,7 +12,7 @@
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
     V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,
-    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36, V37,
+    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36, V37, V38,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -732,4 +732,12 @@ CREATE TABLE provider_usage_session_allocation (
 CREATE INDEX provider_usage_session_allocation_session_metric
     ON provider_usage_session_allocation
        (environment_key, agent, session_id, metric, period_id);
+"#;
+
+/// v38 indexes the native watcher lookup by transcript path and full activity
+/// identity. The source kind completes the lookup predicate without changing
+/// the session identity contract.
+const V38: &str = r#"
+CREATE INDEX session_source_lookup
+    ON session (source_label, environment_key, agent, source_kind);
 "#;

--- a/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
@@ -79,31 +79,128 @@ fn latest_session_activity_ignores_null_epochs() {
 }
 
 #[test]
-fn session_record_by_source_label_round_trips() {
+fn native_file_session_activity_keys_keep_full_identity() {
     let store = store();
     let record = session("by-label", 4_000);
+    let mut wsl = record.clone();
+    wsl.key.environment_key = "wsl:Ubuntu".into();
+    wsl.key.session_id = "by-label-wsl".into();
+    wsl.wsl_distro = Some("Ubuntu".into());
+    let mut codex = record.clone();
+    codex.key.agent = "codex".into();
+    codex.key.session_id = "by-label-codex".into();
+    let mut inline = record.clone();
+    inline.key.session_id = "by-label-inline".into();
+    inline.source_kind = "inline".into();
     store
         .upsert_sessions(
-            std::slice::from_ref(&record),
+            &[record.clone(), wsl, codex, inline],
             &crate::agents::evidence_cohort(),
         )
         .unwrap();
 
-    let (key, found) = store
-        .session_record_by_source_label(&record.source_label)
+    let labels = BTreeSet::from([record.source_label.clone(), "/nowhere/unknown.jsonl".into()]);
+    let found = store
+        .native_file_session_activity_keys(&labels)
         .unwrap()
-        .expect("a stored session is found by its source label");
-    assert_eq!(key.environment_key, "native");
-    assert_eq!(key.agent, "claude-code");
-    assert_eq!(key.source_label, record.source_label);
-    assert_eq!(found.key.session_id, "by-label");
+        .remove(&record.source_label)
+        .expect("native file sessions are found by source label");
+    assert_eq!(
+        found,
+        BTreeSet::from([
+            SessionActivityKey::new("native", "claude-code", &record.source_label),
+            SessionActivityKey::new("native", "codex", &record.source_label),
+        ])
+    );
 
     assert!(
         store
-            .session_record_by_source_label("/nowhere/unknown.jsonl")
+            .native_file_session_activity_keys(&BTreeSet::from(["/nowhere/unknown.jsonl".into()]))
             .unwrap()
-            .is_none(),
+            .is_empty(),
         "an unknown source label finds nothing"
+    );
+}
+
+#[test]
+fn native_file_session_activity_keys_cross_the_query_chunk_boundary() {
+    let store = store();
+    let mut first = session("chunk-first", 4_000);
+    first.source_label = "/lookup/000.jsonl".into();
+    let mut last = session("chunk-last", 4_001);
+    last.source_label = format!("/lookup/{SOURCE_LABEL_LOOKUP_CHUNK_SIZE:03}.jsonl");
+    store
+        .upsert_sessions(
+            &[first.clone(), last.clone()],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+    let labels = (0..=SOURCE_LABEL_LOOKUP_CHUNK_SIZE)
+        .map(|index| format!("/lookup/{index:03}.jsonl"))
+        .collect::<BTreeSet<_>>();
+
+    let found = store.native_file_session_activity_keys(&labels).unwrap();
+
+    assert_eq!(found.len(), 2);
+    assert!(found.contains_key(&first.source_label));
+    assert!(found.contains_key(&last.source_label));
+}
+
+#[test]
+fn session_record_by_activity_key_keeps_environment_and_agent_identity() {
+    let store = store();
+    let native = session("native-label", 4_000);
+    let mut wsl = native.clone();
+    wsl.key.environment_key = "wsl:Ubuntu".into();
+    wsl.key.session_id = "wsl-label".into();
+    wsl.wsl_distro = Some("Ubuntu".into());
+    let mut codex = native.clone();
+    codex.key.agent = "codex".into();
+    codex.key.session_id = "codex-label".into();
+    store
+        .upsert_sessions(
+            &[native.clone(), wsl, codex],
+            &crate::agents::evidence_cohort(),
+        )
+        .unwrap();
+
+    let key = SessionActivityKey::new("native", "claude-code", &native.source_label);
+    let found = store
+        .session_record_by_activity_key(&key)
+        .unwrap()
+        .expect("the exact native agent row is found");
+    assert_eq!(found.key, native.key);
+}
+
+#[test]
+fn migrated_source_lookup_query_plan_uses_the_source_index() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    for &sql in &super::schema::MIGRATIONS[..37] {
+        connection.execute_batch(sql).unwrap();
+    }
+    connection.pragma_update(None, "user_version", 37).unwrap();
+    let store = Store::from_connection(
+        connection,
+        Path::new("/tmp/antiburn-source-lookup-migration-test").to_path_buf(),
+    )
+    .expect("the real prior schema migrates to the source lookup index");
+
+    let connection = store.lock();
+    let sql = native_file_session_activity_keys_sql(2);
+    let mut statement = connection
+        .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+        .unwrap();
+    let plan = statement
+        .query_map(params!["/one.jsonl", "/two.jsonl"], |row| {
+            row.get::<_, String>(3)
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+        .join("\n");
+    assert!(
+        plan.contains("session_source_lookup") && !plan.contains("SCAN session"),
+        "query plan did not search the source lookup index: {plan}"
     );
 }
 

--- a/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
@@ -11,10 +11,10 @@ use super::*;
 #[test]
 fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pin the count so each new migration requires an explicit test update.
-    assert_eq!(super::schema::MIGRATIONS.len(), 37);
+    assert_eq!(super::schema::MIGRATIONS.len(), 38);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 37);
+    assert_eq!(store.schema_version().unwrap(), 38);
     let index_exists = store
         .lock()
         .query_row(


### PR DESCRIPTION
## Stack

- Parent: #430
- This PR must merge after #430.

## User impact

Watcher-triggered refreshes no longer scan the session table once per changed path and ancestor. Classification keeps direct-path and nearest-ancestor precedence, and targeted refreshes preserve native/WSL and agent identity.

## Validation

- `cargo fmt --check`
- `CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test` (975 passed on the stacked head)
- `pnpm run slop:all` (score 100)
- `pnpm run secrets`
- Regression coverage for the v37-to-v38 migration and `EXPLAIN QUERY PLAN`
- Regression coverage for duplicate/deep paths, the 501-label chunk boundary, lookup precedence, and native/WSL identity

## Privacy and performance

This change adds one local SQLite index and replaces repeated watcher lookups with deduplicated, bounded batches. It adds no network access, retained session content, or new data access. Analytics are unchanged because this is an internal performance improvement with no user-facing feature or event meaning change.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.