### PR TITLE
Measure visible product use and outcomes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@ Describe the user-visible result and any known limits.
 
 List the checks that you ran.
 
+## Analytics
+
+State the product question and the events that cover discovery, meaningful use,
+and the result. Describe new or changed triggers, allowed properties, duplicate
+or rate limits, and validation. Link the updated public catalog when applicable.
+If measurement is unchanged or unnecessary, explain why.
+
 ## Privacy and performance
 
 State any change to data access, network access, retained data, or background work. Write `None` if there is no change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,40 @@ Write code comments in ASD-STE100 Simplified Technical English:
 - Keep identifiers and API names unchanged.
 - Add a comment only when it states important information the code cannot show.
 
+## Product analytics
+
+For each user-facing feature or behavior change, state the product question and
+how analytics answers it. Cover discovery, meaningful use, and the result where
+each matters. Add missing coverage in the same change, or explain why existing
+events suffice or measurement is not useful. Do not add events just to count
+every click.
+
+Read [docs/analytics.md](docs/analytics.md) before instrumentation work. Follow
+the measurement definitions and event review contract in
+[docs/analytics-measurement.md](docs/analytics-measurement.md).
+
+- Use the shell's analytics module and closed Rust event and interaction types.
+  Keep analytics out of the local engine. Do not add generic tracking maps,
+  arbitrary strings, or third-party analytics SDKs.
+- Record user intent in its event handler and results at the boundary that
+  knows the outcome. Record views after actual visibility. Do not add a React
+  effect or count rendering, prewarming, polling, retries, or automatic restores
+  as deliberate use.
+- Define each event's trigger, allowed properties, owner, and duplicate or rate
+  limit rule. Distinguish attempts from success and background work from use.
+- Preserve opt-out, identifier rotation, inert unconfigured builds, bounded
+  queues, and silent failure. Never send work content, local identifiers,
+  paths, credentials, raw errors, or unreviewed setting values.
+- Update the public event catalog and affected privacy disclosures in the same
+  change. Changes to existing event meanings also require documentation and a
+  version boundary for analysis.
+- Test the trigger and outcome, duplicate suppression, rejected properties, and
+  disabled behavior as relevant. Run the analytics-enabled shell checks listed
+  in `CONTRIBUTING.md`; default Cargo checks omit most analytics code.
+
+Include the analytics coverage and validation in the pull request. Documentation,
+styling, and internal refactors can state that measurement is unchanged.
+
 ## Tests and commits
 
 Run the relevant formatter, linter, type checks, and tests for every change. Use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,9 @@ credentials, or other user data to the project or to an unrelated third party.
 The update check and anonymised application analytics are the only
 project-operated network channels. Neither is required for the app to work.
 Analytics must keep all properties documented in [docs/analytics.md](docs/analytics.md):
-it starts automatically only after onboarding completes, Settings → Privacy
-provides the opt-out, payloads contain no work or credentials, identifiers
+official configured builds can record launch and onboarding progress before
+setup completes, Settings → Privacy provides the opt-out, payloads contain no
+work or credentials, identifiers
 rotate, and builds without a configured endpoint send nothing.
 
 Take extra care with operations that modify files, stop processes, or can cost
@@ -67,6 +68,20 @@ cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 cargo test
 ```
+
+For analytics changes, also run these shell checks with the feature enabled:
+
+```bash
+cd apps/desktop/src-tauri
+cargo clippy --all-targets --features analytics -- -D warnings
+ANTIBURN_ANALYTICS_URL=http://127.0.0.1:8787 \
+ANTIBURN_ANALYTICS_OPERATOR="Local development" \
+cargo test --features analytics
+```
+
+The endpoint and operator are build-time inputs. Use the loopback collector in
+[docs/analytics.md](docs/analytics.md#verifying-this-yourself) for manual delivery
+checks. Never use the production collector for synthetic test events.
 
 Run `pnpm run slop:all` and `pnpm run secrets` before you push. Pull-request CI
 also runs `pnpm run slop` against the changed files. See
@@ -115,6 +130,11 @@ names as repository secrets for CI and as `release` environment secrets for
 signed builds.
 
 ## Pull requests
+
+For user-facing changes, describe the product question, existing or new analytics
+coverage, and the validation. Explain any intentional measurement gap. Follow
+the [event review contract](docs/analytics-measurement.md#event-review-contract)
+and update the [public catalog](docs/analytics.md) when instrumentation changes.
 
 Describe the user impact, tests, privacy or performance effects, and any known
 limits. Do not include credentials or private session content in issues, logs,

--- a/apps/desktop/src-tauri/capabilities/popover-peek.json
+++ b/apps/desktop/src-tauri/capabilities/popover-peek.json
@@ -8,6 +8,7 @@
     "core:event:allow-unlisten",
     "allow-get-popover-peek-data",
     "allow-get-popover-peek-state",
+    "allow-note-interaction",
     "allow-popover-peek-concealed",
     "allow-popover-peek-presented",
     "allow-popover-peek-ready",

--- a/apps/desktop/src-tauri/crates/hud/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/hud/src/lib.rs
@@ -672,6 +672,10 @@ fn cursor_inside(window: &WebviewWindow) -> Option<bool> {
 #[cfg(target_os = "macos")]
 const DETAIL_STATE_EVENT: &str = "hud-detail:state";
 
+/// Event emitted after the detail window reaches the screen.
+#[cfg(target_os = "macos")]
+const DETAIL_SHOWN_EVENT: &str = "hud-detail:shown";
+
 /// Event that asks the detail webview to clear its card before a hide.
 #[cfg(target_os = "macos")]
 const DETAIL_CONCEAL_EVENT: &str = "hud-detail:conceal";
@@ -768,8 +772,17 @@ pub fn apply_detail_size(app: &AppHandle, height: f64) {
         return;
     }
     if DETAIL_SHOULD_SHOW.load(Ordering::Relaxed) {
-        let _ = detail.show();
+        let was_visible = detail.is_visible().unwrap_or(false);
+        let show_succeeded = detail.show().is_ok();
+        if should_emit_detail_shown(was_visible, show_succeeded) {
+            let _ = app.emit_to(OVERLAY_LABEL, DETAIL_SHOWN_EVENT, ());
+        }
     }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn should_emit_detail_shown(was_visible: bool, show_succeeded: bool) -> bool {
+    !was_visible && show_succeeded
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -1114,6 +1127,13 @@ mod tests {
     #[test]
     fn before_the_first_show_the_detail_state_is_null() {
         assert_eq!(detail_state(), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn detail_visibility_reports_only_a_successful_hidden_to_visible_transition() {
+        assert!(should_emit_detail_shown(false, true));
+        assert!(!should_emit_detail_shown(true, true));
+        assert!(!should_emit_detail_shown(false, false));
     }
 
     fn placement(monitor: &str, x: f64, y: f64) -> Placement {

--- a/apps/desktop/src-tauri/permissions/autogenerated/take_hud_analytics_origin.toml
+++ b/apps/desktop/src-tauri/permissions/autogenerated/take_hud_analytics_origin.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-take-hud-analytics-origin"
+description = "Enables the take_hud_analytics_origin command without any pre-configured scope."
+commands.allow = ["take_hud_analytics_origin"]
+
+[[permission]]
+identifier = "deny-take-hud-analytics-origin"
+description = "Denies the take_hud_analytics_origin command without any pre-configured scope."
+commands.deny = ["take_hud_analytics_origin"]

--- a/apps/desktop/src-tauri/permissions/default.toml
+++ b/apps/desktop/src-tauri/permissions/default.toml
@@ -67,6 +67,7 @@ permissions = [
   "allow-set-settings",
   "allow-show-hud-detail",
   "allow-start-update-simulation",
+  "allow-take-hud-analytics-origin",
   "allow-take-settings-pane",
   "allow-window-ready",
   "allow-nudge-action",

--- a/apps/desktop/src-tauri/src/analytics/delivery.rs
+++ b/apps/desktop/src-tauri/src/analytics/delivery.rs
@@ -1,0 +1,333 @@
+//! Scheduling policy for the analytics delivery queue.
+
+use std::time::Duration;
+
+/// The maximum number of network requests in one delivery pass.
+pub(super) const REQUEST_BUDGET: u32 = 50;
+
+/// Queue depth that starts a delivery pass without the settling delay.
+const PRESSURE_DEPTH: u32 = REQUEST_BUDGET;
+
+/// The maximum wait for the first event in a new backlog.
+const SETTLE_DELAY: Duration = Duration::from_secs(60);
+
+/// The pause between delivery passes while a backlog remains.
+const DRAIN_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// The maximum wait after delivery fails or consent cannot be read.
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WaitKind {
+    Settle,
+    DrainCooldown,
+    RetryBackoff,
+    ConsentRecheck,
+}
+
+/// The result of one bounded delivery pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FlushOutcome {
+    Empty,
+    Suspended,
+    Delivered { remaining: u32 },
+    Failed { remaining: u32 },
+}
+
+/// The queue scheduler state for one application run.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct DeliverySchedule {
+    deadline: Option<Duration>,
+    wait_kind: Option<WaitKind>,
+    consecutive_failures: u32,
+}
+
+impl DeliverySchedule {
+    /// Create a schedule from the queue depth found at startup.
+    pub(super) fn new(now: Duration, queue_depth: u32) -> Self {
+        let mut schedule = Self {
+            deadline: None,
+            wait_kind: None,
+            consecutive_failures: 0,
+        };
+        schedule.queued(now, queue_depth);
+        schedule
+    }
+
+    /// Update the schedule after the queue depth changes.
+    pub(super) fn queued(&mut self, now: Duration, queue_depth: u32) {
+        if queue_depth == 0 {
+            self.consecutive_failures = 0;
+            self.park();
+            return;
+        }
+        match self.wait_kind {
+            Some(WaitKind::DrainCooldown | WaitKind::RetryBackoff | WaitKind::ConsentRecheck) => {}
+            Some(WaitKind::Settle) if queue_depth >= PRESSURE_DEPTH => {
+                self.deadline = Some(now);
+            }
+            Some(WaitKind::Settle) => {}
+            None => {
+                self.wait_kind = Some(WaitKind::Settle);
+                self.deadline = Some(if queue_depth >= PRESSURE_DEPTH {
+                    now
+                } else {
+                    now + SETTLE_DELAY
+                });
+            }
+        }
+    }
+
+    /// Return the remaining wait, or `None` when the scheduler is parked.
+    pub(super) fn next_delay(&self, now: Duration) -> Option<Duration> {
+        self.deadline.map(|deadline| deadline.saturating_sub(now))
+    }
+
+    /// Update the schedule after one delivery pass finishes.
+    pub(super) fn flush_completed(&mut self, now: Duration, outcome: FlushOutcome) {
+        match outcome {
+            FlushOutcome::Empty => {
+                self.consecutive_failures = 0;
+                self.park();
+            }
+            FlushOutcome::Suspended => {
+                self.wait_kind = Some(WaitKind::ConsentRecheck);
+                self.deadline = Some(now + MAX_RETRY_DELAY);
+            }
+            FlushOutcome::Delivered { remaining } => {
+                self.consecutive_failures = 0;
+                if remaining == 0 {
+                    self.park();
+                } else {
+                    self.wait_kind = Some(WaitKind::DrainCooldown);
+                    self.deadline = Some(now + DRAIN_COOLDOWN);
+                }
+            }
+            FlushOutcome::Failed { remaining } => {
+                if remaining == 0 {
+                    self.consecutive_failures = 0;
+                    self.park();
+                    return;
+                }
+                self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+                self.wait_kind = Some(WaitKind::RetryBackoff);
+                self.deadline = Some(now + retry_delay(self.consecutive_failures));
+            }
+        }
+    }
+
+    fn park(&mut self) {
+        self.deadline = None;
+        self.wait_kind = None;
+    }
+}
+
+fn retry_delay(consecutive_failures: u32) -> Duration {
+    let exponent = consecutive_failures.saturating_sub(1).min(4);
+    SETTLE_DELAY
+        .checked_mul(1_u32 << exponent)
+        .unwrap_or(MAX_RETRY_DELAY)
+        .min(MAX_RETRY_DELAY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VISIT_EVENTS: u32 = 10;
+
+    struct Workload {
+        schedule: DeliverySchedule,
+        store: crate::store::Store,
+        _directory: tempfile::TempDir,
+        now: Duration,
+        captured: u32,
+        delivered: u32,
+        given_up: u32,
+        failed_attempts: u32,
+        largest_delivery: u32,
+    }
+
+    impl Workload {
+        fn new() -> Self {
+            let directory = tempfile::tempdir().unwrap();
+            Self {
+                schedule: DeliverySchedule::new(Duration::ZERO, 0),
+                store: crate::store::Store::open_in_memory(directory.path()).unwrap(),
+                _directory: directory,
+                now: Duration::ZERO,
+                captured: 0,
+                delivered: 0,
+                given_up: 0,
+                failed_attempts: 0,
+                largest_delivery: 0,
+            }
+        }
+
+        fn queue_visit(&mut self) {
+            for event in 0..VISIT_EVENTS {
+                let payload = format!("{}:{event}", self.captured / VISIT_EVENTS);
+                self.store
+                    .queue_analytics_event("surface_viewed", &payload)
+                    .unwrap();
+                self.captured += 1;
+                let depth = self.queue_depth();
+                self.schedule.queued(self.now, depth);
+            }
+        }
+
+        fn queue_depth(&self) -> u32 {
+            self.store.analytics_event_count().unwrap()
+        }
+
+        fn overflow_drops(&self) -> u32 {
+            self.captured - self.delivered - self.given_up - self.queue_depth()
+        }
+
+        fn advance_to(&mut self, target: Duration, online: bool) {
+            while let Some(delay) = self.schedule.next_delay(self.now) {
+                let deadline = self.now + delay;
+                if deadline > target {
+                    break;
+                }
+                self.now = deadline;
+                if online {
+                    let pending = self.store.pending_analytics_events(REQUEST_BUDGET).unwrap();
+                    let delivered = pending.len() as u32;
+                    self.largest_delivery = self.largest_delivery.max(delivered);
+                    self.delivered += delivered;
+                    let ids = pending.into_iter().map(|(id, _)| id).collect::<Vec<_>>();
+                    self.store.drop_analytics_events(&ids).unwrap();
+                    let remaining = self.queue_depth();
+                    self.schedule.flush_completed(
+                        self.now,
+                        if delivered == 0 {
+                            FlushOutcome::Empty
+                        } else {
+                            FlushOutcome::Delivered { remaining }
+                        },
+                    );
+                } else {
+                    self.failed_attempts += 1;
+                    let pending = self.store.pending_analytics_events(1).unwrap();
+                    let ids = pending.into_iter().map(|(id, _)| id).collect::<Vec<_>>();
+                    self.given_up += self.store.fail_analytics_events(&ids, 5).unwrap() as u32;
+                    let remaining = self.queue_depth();
+                    self.schedule
+                        .flush_completed(self.now, FlushOutcome::Failed { remaining });
+                }
+            }
+            self.now = target;
+        }
+    }
+
+    fn minutes(value: u64) -> Duration {
+        Duration::from_secs(value * 60)
+    }
+
+    #[test]
+    fn the_first_arrival_has_a_fixed_deadline_and_pressure_brings_it_forward() {
+        let mut schedule = DeliverySchedule::new(Duration::ZERO, 0);
+        schedule.queued(minutes(5), 1);
+        assert_eq!(schedule.next_delay(minutes(5)), Some(minutes(1)));
+
+        schedule.queued(minutes(5) + Duration::from_secs(30), 2);
+        assert_eq!(schedule.next_delay(minutes(5)), Some(minutes(1)));
+
+        schedule.queued(minutes(5) + Duration::from_secs(40), PRESSURE_DEPTH);
+        assert_eq!(
+            schedule.next_delay(minutes(5) + Duration::from_secs(40)),
+            Some(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn a_delivery_budget_cannot_be_bypassed_by_new_arrivals() {
+        let mut schedule = DeliverySchedule::new(Duration::ZERO, PRESSURE_DEPTH);
+        assert_eq!(schedule.next_delay(Duration::ZERO), Some(Duration::ZERO));
+
+        schedule.flush_completed(Duration::ZERO, FlushOutcome::Delivered { remaining: 450 });
+        schedule.queued(Duration::from_secs(1), 451);
+
+        assert_eq!(
+            schedule.next_delay(Duration::from_secs(1)),
+            Some(Duration::from_secs(59))
+        );
+    }
+
+    #[test]
+    fn failures_back_off_without_restart_from_arrivals() {
+        let mut schedule = DeliverySchedule::new(Duration::ZERO, PRESSURE_DEPTH);
+        let expected = [1, 2, 4, 8, 15, 15];
+
+        for expected_minutes in expected {
+            schedule.flush_completed(Duration::ZERO, FlushOutcome::Failed { remaining: 500 });
+            schedule.queued(Duration::from_secs(30), 500);
+            assert_eq!(
+                schedule.next_delay(Duration::ZERO),
+                Some(minutes(expected_minutes))
+            );
+        }
+    }
+
+    #[test]
+    fn suspended_delivery_rechecks_without_waking_for_new_rows() {
+        let mut schedule = DeliverySchedule::new(Duration::ZERO, PRESSURE_DEPTH);
+        schedule.flush_completed(Duration::ZERO, FlushOutcome::Suspended);
+        schedule.queued(minutes(5), 100);
+
+        assert_eq!(schedule.next_delay(minutes(5)), Some(minutes(10)));
+    }
+
+    #[test]
+    fn an_empty_or_cleared_queue_parks_the_scheduler() {
+        let mut schedule = DeliverySchedule::new(Duration::ZERO, 1);
+        schedule.queued(Duration::from_secs(10), 0);
+        assert_eq!(schedule.next_delay(Duration::from_secs(10)), None);
+
+        schedule.queued(minutes(1), 1);
+        schedule.flush_completed(minutes(2), FlushOutcome::Empty);
+        assert_eq!(schedule.next_delay(minutes(2)), None);
+    }
+
+    /// This replay models activity, two previews, and four provider states per visit.
+    #[test]
+    fn phase_one_load_recovers_a_normal_offline_backlog_within_thirty_minutes() {
+        let mut workload = Workload::new();
+
+        // Six visits per hour stay well below the steady delivery budget.
+        for visit in 0..12 {
+            let at = minutes(visit * 10);
+            workload.advance_to(at, true);
+            workload.queue_visit();
+        }
+        workload.advance_to(minutes(120), true);
+        assert_eq!(workload.queue_depth(), 0);
+        assert_eq!(workload.overflow_drops(), 0);
+
+        // Nine offline hours fill the bound while retry backoff limits requests.
+        for visit in 12..66 {
+            let at = minutes(visit * 10);
+            workload.advance_to(at, false);
+            workload.queue_visit();
+        }
+        let recovery_started = minutes(660);
+        workload.advance_to(recovery_started, false);
+        assert_eq!(workload.queue_depth(), 500);
+        assert!(workload.failed_attempts < 50);
+        assert!(workload.given_up > 0);
+        let overflow_before_recovery = workload.overflow_drops();
+        assert!(overflow_before_recovery > 0);
+
+        // Normal visits continue while the backlog drains after connectivity returns.
+        for at in [minutes(670), minutes(680)] {
+            workload.advance_to(at, true);
+            workload.queue_visit();
+        }
+        workload.advance_to(minutes(690), true);
+
+        assert_eq!(workload.queue_depth(), 0);
+        assert_eq!(workload.overflow_drops(), overflow_before_recovery);
+        assert_eq!(workload.largest_delivery, REQUEST_BUDGET);
+    }
+}

--- a/apps/desktop/src-tauri/src/analytics/event.rs
+++ b/apps/desktop/src-tauri/src/analytics/event.rs
@@ -24,11 +24,12 @@ use serde::Serialize;
 pub enum EventName {
     /// The application started.
     AppLaunched,
-    /// The first run finished. Carries nothing: which step a reader stopped
-    /// on would be worth knowing, but nothing reports abandonment, and a doc
-    /// comment describing an unbuilt capability is how a catalog starts to
-    /// overstate itself.
+    /// A new or explicitly restarted setup flow finished.
+    #[cfg(feature = "analytics")]
     OnboardingFinished,
+    /// A new or explicitly restarted setup flow became visible.
+    #[cfg(feature = "analytics")]
+    OnboardingStarted,
     /// One fixed onboarding step became visible.
     #[cfg(feature = "analytics")]
     OnboardingStepViewed,
@@ -48,6 +49,18 @@ pub enum EventName {
     /// Claude's limit-reset diagnostic changed during this run.
     #[cfg(feature = "analytics")]
     ClaudeLimitResetObserved,
+    /// A product surface became visible.
+    #[cfg(feature = "analytics")]
+    SurfaceViewed,
+    /// A Settings pane became visible.
+    #[cfg(feature = "analytics")]
+    SettingsPaneViewed,
+    /// A visible surface presented a terminal or timed-out data state.
+    #[cfg(feature = "analytics")]
+    SurfaceStateObserved,
+    /// A provider state appeared on a visible usage surface.
+    #[cfg(feature = "analytics")]
+    LiveUsageStateObserved,
 }
 
 /// Every event this application may send.
@@ -62,6 +75,7 @@ pub enum EventName {
 pub const EVERY_EVENT: &[EventName] = &[
     EventName::AppLaunched,
     EventName::OnboardingFinished,
+    EventName::OnboardingStarted,
     EventName::OnboardingStepViewed,
     EventName::ScanCompleted,
     EventName::SettingToggled,
@@ -69,6 +83,10 @@ pub const EVERY_EVENT: &[EventName] = &[
     EventName::ErrorOccurred,
     EventName::UnrecognizedRecordsObserved,
     EventName::ClaudeLimitResetObserved,
+    EventName::SurfaceViewed,
+    EventName::SettingsPaneViewed,
+    EventName::SurfaceStateObserved,
+    EventName::LiveUsageStateObserved,
 ];
 
 #[cfg(feature = "analytics")]
@@ -77,6 +95,7 @@ impl EventName {
         match self {
             EventName::AppLaunched => "antiburn.app_launched",
             EventName::OnboardingFinished => "antiburn.onboarding_finished",
+            EventName::OnboardingStarted => "antiburn.onboarding_started",
             EventName::OnboardingStepViewed => "antiburn.onboarding_step_viewed",
             EventName::ScanCompleted => "antiburn.scan_completed",
             EventName::SettingToggled => "antiburn.setting_toggled",
@@ -84,6 +103,10 @@ impl EventName {
             EventName::ErrorOccurred => "antiburn.error_occurred",
             EventName::UnrecognizedRecordsObserved => "antiburn.unrecognized_records_observed",
             EventName::ClaudeLimitResetObserved => "antiburn.claude_limit_reset_observed",
+            EventName::SurfaceViewed => "antiburn.surface_viewed",
+            EventName::SettingsPaneViewed => "antiburn.settings_pane_viewed",
+            EventName::SurfaceStateObserved => "antiburn.surface_state_observed",
+            EventName::LiveUsageStateObserved => "antiburn.live_usage_state_observed",
         }
     }
 }
@@ -118,11 +141,12 @@ pub struct Event {
     /// Required by the collector, not optional: a payload without it is
     /// rejected outright, so this is the contract's floor rather than
     /// something antiburn chose to add. It is also the *least* persistent
-    /// thing in the payload — minted in memory, never written to disk, gone
-    /// when the process exits, and replaced after
-    /// [`super::SESSION_TIMEOUT`] of inactivity. It cannot outlive a run, so
-    /// it cannot join one to another; the rotating [`Event::anonymous_id`]
-    /// remains the longest-lived identifier here.
+    /// thing in the payload — its generator state lives in memory, is gone
+    /// when the process exits, and is replaced after
+    /// [`super::SESSION_TIMEOUT`] of inactivity. The generator cannot continue
+    /// into another run. Queued event payloads include the captured value until
+    /// delivery or withdrawal. The rotating [`Event::anonymous_id`] remains the
+    /// longest-lived generator state here.
     pub session_id: String,
     /// Event name, in antiburn's own namespace.
     pub event: String,
@@ -153,6 +177,9 @@ pub struct Properties {
     /// under WSL. Same rules as [`Properties::label`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<&'static str>,
+    /// Whether a surface exposure followed a user action or automatic restore.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<&'static str>,
     /// The short-window usage position returned with a Claude reset probe.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_band: Option<&'static str>,
@@ -196,6 +223,8 @@ pub struct Facts {
     pub label: Option<&'static str>,
     /// The secondary dimension, where the event has one.
     pub detail: Option<&'static str>,
+    /// Whether a surface exposure followed a user action or automatic restore.
+    pub origin: Option<&'static str>,
     pub usage_band: Option<&'static str>,
     pub response_shape: Option<&'static str>,
     pub eligibility: Option<&'static str>,
@@ -248,7 +277,7 @@ pub struct Context {
 /// outside it, and every string that reaches the payload is a `&'static str`
 /// this file wrote. Every doc comment below that says "closed" means this.
 #[derive(Debug, Clone, Copy, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", deny_unknown_fields)]
 pub enum Interaction {
     /// A fixed onboarding step became visible.
     OnboardingStepViewed { step: OnboardingStep },
@@ -259,6 +288,110 @@ pub enum Interaction {
         agent: AgentKind,
         environment: Environment,
     },
+    /// A fixed product surface became visible.
+    SurfaceViewed { surface: Surface, origin: Origin },
+    /// A visible surface presented a data state.
+    SurfaceStateObserved {
+        surface: StateSurface,
+        state: SurfaceState,
+        origin: Origin,
+    },
+    /// A fixed Settings pane became visible.
+    SettingsPaneViewed { pane: SettingsPane },
+    /// A provider state appeared on a visible usage surface.
+    LiveUsageStateObserved {
+        provider: LiveUsageProvider,
+        state: LiveUsageState,
+        origin: Origin,
+    },
+}
+
+/// A product surface whose visibility is measured.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Surface {
+    Activity,
+    SessionDetail,
+    ProviderPreview,
+    ChecksPreview,
+    Hud,
+    HudDetail,
+    Settings,
+}
+
+/// A surface that can present a measured data state.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StateSurface {
+    Activity,
+    SessionDetail,
+    ProviderPreview,
+    ChecksPreview,
+    Hud,
+    HudDetail,
+    Settings,
+    Insights,
+}
+
+/// Why a surface became visible.
+#[derive(Debug, Clone, Copy, Deserialize, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Origin {
+    User,
+    Automatic,
+}
+
+/// A visible surface's coarse presentation state.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceState {
+    Ready,
+    Empty,
+    Error,
+    LoadingTimeout,
+}
+
+/// A pane in the fixed Settings window.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SettingsPane {
+    General,
+    Appearance,
+    Sources,
+    Privacy,
+    Notifications,
+    Usage,
+    Insights,
+    About,
+}
+
+/// A provider with a supported live-usage source.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveUsageProvider {
+    Anthropic,
+    Openai,
+    Google,
+}
+
+/// A provider state that a visible usage surface can present.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveUsageState {
+    Fresh,
+    Stale,
+    Authentication,
+    RateLimited,
+    Unavailable,
+    NoCredentials,
+}
+
+/// Which setup lifecycle is active.
+#[cfg(feature = "analytics")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnboardingFlow {
+    New,
+    Restart,
 }
 
 /// A screen in the fixed first-run flow.
@@ -301,9 +434,132 @@ impl Interaction {
                     ..Facts::default()
                 },
             ),
+            Interaction::SurfaceViewed { surface, origin } => (
+                EventName::SurfaceViewed,
+                Facts {
+                    label: Some(surface.as_str()),
+                    detail: Some(origin.as_str()),
+                    ..Facts::default()
+                },
+            ),
+            Interaction::SurfaceStateObserved {
+                surface,
+                state,
+                origin,
+            } => (
+                EventName::SurfaceStateObserved,
+                Facts {
+                    label: Some(surface.as_str()),
+                    detail: Some(state.as_str()),
+                    origin: Some(origin.as_str()),
+                    ..Facts::default()
+                },
+            ),
+            Interaction::SettingsPaneViewed { pane } => (
+                EventName::SettingsPaneViewed,
+                Facts {
+                    label: Some(pane.as_str()),
+                    ..Facts::default()
+                },
+            ),
+            Interaction::LiveUsageStateObserved {
+                provider, state, ..
+            } => (
+                EventName::LiveUsageStateObserved,
+                Facts {
+                    label: Some(provider.as_str()),
+                    detail: Some(state.as_str()),
+                    ..Facts::default()
+                },
+            ),
         }
     }
 }
+
+#[cfg(feature = "analytics")]
+macro_rules! wire_values {
+    ($type:ty, { $($variant:path => $value:literal),+ $(,)? }) => {
+        impl $type {
+            pub(crate) fn as_str(self) -> &'static str {
+                match self {
+                    $($variant => $value),+
+                }
+            }
+        }
+    };
+}
+
+#[cfg(feature = "analytics")]
+wire_values!(Surface, {
+    Surface::Activity => "activity",
+    Surface::SessionDetail => "session_detail",
+    Surface::ProviderPreview => "provider_preview",
+    Surface::ChecksPreview => "checks_preview",
+    Surface::Hud => "hud",
+    Surface::HudDetail => "hud_detail",
+    Surface::Settings => "settings",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(StateSurface, {
+    StateSurface::Activity => "activity",
+    StateSurface::SessionDetail => "session_detail",
+    StateSurface::ProviderPreview => "provider_preview",
+    StateSurface::ChecksPreview => "checks_preview",
+    StateSurface::Hud => "hud",
+    StateSurface::HudDetail => "hud_detail",
+    StateSurface::Settings => "settings",
+    StateSurface::Insights => "insights",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(Origin, {
+    Origin::User => "user",
+    Origin::Automatic => "automatic",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(SurfaceState, {
+    SurfaceState::Ready => "ready",
+    SurfaceState::Empty => "empty",
+    SurfaceState::Error => "error",
+    SurfaceState::LoadingTimeout => "loading_timeout",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(SettingsPane, {
+    SettingsPane::General => "general",
+    SettingsPane::Appearance => "appearance",
+    SettingsPane::Sources => "sources",
+    SettingsPane::Privacy => "privacy",
+    SettingsPane::Notifications => "notifications",
+    SettingsPane::Usage => "usage",
+    SettingsPane::Insights => "insights",
+    SettingsPane::About => "about",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(LiveUsageProvider, {
+    LiveUsageProvider::Anthropic => "anthropic",
+    LiveUsageProvider::Openai => "openai",
+    LiveUsageProvider::Google => "google",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(LiveUsageState, {
+    LiveUsageState::Fresh => "fresh",
+    LiveUsageState::Stale => "stale",
+    LiveUsageState::Authentication => "authentication",
+    LiveUsageState::RateLimited => "rate_limited",
+    LiveUsageState::Unavailable => "unavailable",
+    LiveUsageState::NoCredentials => "no_credentials",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(OnboardingFlow, {
+    OnboardingFlow::New => "new",
+    OnboardingFlow::Restart => "restart",
+});
 
 #[cfg(feature = "analytics")]
 impl OnboardingStep {
@@ -374,6 +630,7 @@ mod tests {
                 bucket: Some("10-49"),
                 label: Some("claude-code"),
                 detail: Some("native"),
+                origin: Some("user"),
                 usage_band: Some("80_to_under_100"),
                 response_shape: Some("object"),
                 eligibility: Some("eligible"),
@@ -412,7 +669,7 @@ mod tests {
     /// `apps/desktop/src/views/settings/PrivacyPane.tsx` is the bug this
     /// comment exists to prevent.
     #[test]
-    fn the_wire_payload_is_exactly_these_twenty_two_fields() {
+    fn the_wire_payload_is_exactly_these_twenty_three_fields() {
         let json = serde_json::to_value(sample()).expect("serializes");
         let object = json.as_object().expect("an object");
         let mut keys: Vec<_> = object.keys().map(String::as_str).collect();
@@ -449,6 +706,7 @@ mod tests {
                 "ineligibleReason",
                 "label",
                 "nextResetAvailable",
+                "origin",
                 "resetArm",
                 "resetAvailability",
                 "resetsPerWeek",
@@ -481,8 +739,8 @@ mod tests {
     #[test]
     fn no_user_or_organisation_identity_is_ever_carried() {
         let json = serde_json::to_string(&sample()).expect("serializes");
-        // `sessionId` is deliberately absent from this list: it identifies a
-        // run of the process, not a person, and never reaches disk.
+        // `sessionId` is deliberately absent from this list. It identifies a
+        // run of the process rather than a person.
         for forbidden in ["userId", "orgId", "email", "locale"] {
             assert!(!json.contains(forbidden), "{forbidden} in {json}");
         }
@@ -494,6 +752,7 @@ mod tests {
         event.properties.bucket = None;
         event.properties.label = None;
         event.properties.detail = None;
+        event.properties.origin = None;
         event.properties.usage_band = None;
         event.properties.response_shape = None;
         event.properties.eligibility = None;
@@ -507,6 +766,7 @@ mod tests {
         assert!(!json.contains("bucket"), "{json}");
         assert!(!json.contains("label"), "{json}");
         assert!(!json.contains("detail"), "{json}");
+        assert!(!json.contains("\"origin\""), "{json}");
     }
 
     /// The compiler, not a reviewer, keeps [`EVERY_EVENT`] complete.
@@ -526,12 +786,17 @@ mod tests {
                 | EventName::SessionOpened
                 | EventName::ErrorOccurred
                 | EventName::UnrecognizedRecordsObserved
+                | EventName::OnboardingStarted
+                | EventName::SurfaceViewed
+                | EventName::SettingsPaneViewed
+                | EventName::SurfaceStateObserved
+                | EventName::LiveUsageStateObserved
                 | EventName::ClaudeLimitResetObserved => true,
             }
         }
         assert_eq!(
             EVERY_EVENT.len(),
-            9,
+            14,
             "a variant was added to the match above but not to EVERY_EVENT"
         );
         assert!(EVERY_EVENT.iter().copied().all(listed));
@@ -587,6 +852,7 @@ mod tests {
             13 => "thirteen",
             14 => "fourteen",
             22 => "twenty-two",
+            23 => "twenty-three",
             other => panic!("no word for {other} fields; add one and update the documents"),
         };
 
@@ -625,6 +891,28 @@ mod tests {
         assert_eq!(facts.label, Some("claude-code"));
         assert_eq!(facts.detail, Some("wsl"));
         assert_eq!(facts.bucket, None);
+
+        let (name, facts) = Interaction::SurfaceStateObserved {
+            surface: StateSurface::ProviderPreview,
+            state: SurfaceState::LoadingTimeout,
+            origin: Origin::User,
+        }
+        .resolve();
+        assert_eq!(name, EventName::SurfaceStateObserved);
+        assert_eq!(facts.label, Some("provider_preview"));
+        assert_eq!(facts.detail, Some("loading_timeout"));
+        assert_eq!(facts.origin, Some("user"));
+
+        let (name, facts) = Interaction::LiveUsageStateObserved {
+            provider: LiveUsageProvider::Google,
+            state: LiveUsageState::RateLimited,
+            origin: Origin::User,
+        }
+        .resolve();
+        assert_eq!(name, EventName::LiveUsageStateObserved);
+        assert_eq!(facts.label, Some("google"));
+        assert_eq!(facts.detail, Some("rate_limited"));
+        assert_eq!(facts.origin, None);
     }
 
     /// The renderer cannot invent a value. This is the whole reason the IPC
@@ -653,6 +941,21 @@ mod tests {
             "environment": "Ubuntu-24.04",
         });
         assert!(serde_json::from_value::<Interaction>(unknown_environment).is_err());
+
+        let extra_property = serde_json::json!({
+            "kind": "surfaceViewed",
+            "surface": "activity",
+            "origin": "user",
+            "repository": "private-name",
+        });
+        assert!(serde_json::from_value::<Interaction>(extra_property).is_err());
+
+        let unknown_origin = serde_json::json!({
+            "kind": "surfaceViewed",
+            "surface": "activity",
+            "origin": "background_poll",
+        });
+        assert!(serde_json::from_value::<Interaction>(unknown_origin).is_err());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/analytics/mod.rs
+++ b/apps/desktop/src-tauri/src/analytics/mod.rs
@@ -13,8 +13,8 @@
 //! - **The identifier cannot build a longitudinal profile.** It is random and
 //!   rotates on [`IDENTITY_LIFETIME_DAYS`]; opting out destroys it, so opting
 //!   back in is a new identity that cannot be joined to the old one. The
-//!   `sessionId` the contract also requires is weaker still — held in memory,
-//!   never written to disk, and gone when the process exits.
+//!   `sessionId` generator state is weaker still — held in memory and gone
+//!   when the process exits. Queued payloads include that value until delivery.
 //!
 //! What this module cannot enforce is what happens after delivery. Retention
 //! and IP handling belong to whoever operates the endpoint, are stated in the
@@ -23,6 +23,8 @@
 
 #[cfg(feature = "analytics")]
 pub mod config;
+#[cfg(feature = "analytics")]
+mod delivery;
 pub mod event;
 
 #[cfg(not(feature = "analytics"))]
@@ -49,6 +51,7 @@ pub fn record(_app: &tauri::AppHandle, _name: event::EventName, facts: event::Fa
         facts.bucket,
         facts.label,
         facts.detail,
+        facts.origin,
         facts.usage_band,
         facts.response_shape,
         facts.eligibility,
@@ -70,7 +73,47 @@ pub fn record_interaction(_app: &tauri::AppHandle, interaction: event::Interacti
         event::Interaction::SessionOpened { agent, environment } => {
             let _ = (agent, environment);
         }
+        event::Interaction::SurfaceViewed { surface, origin } => {
+            let _ = (surface, origin);
+        }
+        event::Interaction::SurfaceStateObserved {
+            surface,
+            state,
+            origin,
+        } => {
+            let _ = (surface, state, origin);
+        }
+        event::Interaction::SettingsPaneViewed { pane } => {
+            let _ = pane;
+        }
+        event::Interaction::LiveUsageStateObserved {
+            provider,
+            state,
+            origin,
+        } => {
+            let _ = (provider, state, origin);
+        }
     }
+}
+
+#[cfg(not(feature = "analytics"))]
+pub fn prepare_onboarding_restart() {}
+
+#[cfg(not(feature = "analytics"))]
+pub fn record_onboarding_started(_app: &tauri::AppHandle) {}
+
+#[cfg(not(feature = "analytics"))]
+pub fn record_onboarding_finished(_app: &tauri::AppHandle) {}
+
+#[cfg(not(feature = "analytics"))]
+pub fn prepare_hud_exposure(_origin: event::Origin) {}
+
+#[cfg(not(feature = "analytics"))]
+pub fn cancel_hud_exposure() {}
+
+#[cfg(not(feature = "analytics"))]
+pub fn take_hud_exposure_origin(_exposed: bool) -> Option<event::Origin> {
+    None
 }
 
 #[cfg(not(feature = "analytics"))]
@@ -95,39 +138,41 @@ pub fn handle_settings_transition(
 #[cfg(feature = "analytics")]
 mod enabled {
 
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use antiburn_local::insights::UnrecognizedRecords;
     use tauri::Manager as _;
 
-    use super::event::{Event, EventName, Facts, Interaction};
-    use super::{config, event};
+    use super::delivery::{DeliverySchedule, FlushOutcome};
+    use super::event::{
+        Event, EventName, Facts, Interaction, LiveUsageProvider, LiveUsageState, OnboardingFlow,
+        Origin, SettingsPane, Surface,
+    };
+    use super::{config, delivery, event};
     use crate::store::{AppSettings, Store};
 
     /// How long an installation identifier lives before it is replaced.
     pub const IDENTITY_LIFETIME_DAYS: i64 = 30;
 
-    /// How long a run identifier survives without activity before it is replaced.
+    /// How long a run identifier survives without an analytics event.
     ///
     /// The collector's contract specifies this window, and matching it is the
     /// point — a client that invented its own would make its rows incomparable
     /// with every other surface reporting to the same place.
     pub const SESSION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
-    /// How many events one delivery attempt carries.
-    const BATCH_SIZE: u32 = 50;
-
-    /// How often the flusher wakes.
-    const FLUSH_INTERVAL: Duration = Duration::from_secs(15 * 60);
-
-    /// A short settling delay so launch does not compete with the first scan.
-    const FIRST_FLUSH_DELAY: Duration = Duration::from_secs(60);
-
     /// How many failures a queued event survives before it is given up on.
     const MAX_ATTEMPTS: u32 = 5;
 
     /// How long one delivery may take before it is abandoned.
     const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Deliberate events separated by this gap belong to different visits.
+    const DELIBERATE_VISIT_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+    /// Wakes the bounded delivery scheduler after a queue depth change.
+    #[derive(Default)]
+    struct DeliveryWake(tokio::sync::Notify);
 
     /// Whether this build could report at all, regardless of the reader's choice.
     ///
@@ -175,13 +220,16 @@ mod enabled {
     }
 
     fn record_event(app: &tauri::AppHandle, name: EventName, facts: Facts) -> bool {
+        let _capture = CAPTURE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if !allowed(app) {
             return false;
         }
         let Some(store) = app.try_state::<Store>() else {
             return false;
         };
-        let Some(install_id) = current_install_id(&store) else {
+        let Some((install_id, session_id)) = current_identity_pair(&store) else {
             return false;
         };
         let payload = Event {
@@ -191,7 +239,7 @@ mod enabled {
             // twice.
             message_id: random_identifier(),
             anonymous_id: install_id,
-            session_id: current_session_id(),
+            session_id,
             event: name.as_str().to_string(),
             original_timestamp: crate::store::now_rfc3339(),
             properties: event::Properties {
@@ -199,6 +247,7 @@ mod enabled {
                 bucket: facts.bucket,
                 label: facts.label,
                 detail: facts.detail,
+                origin: facts.origin,
                 usage_band: facts.usage_band,
                 response_shape: facts.response_shape,
                 eligibility: facts.eligibility,
@@ -214,8 +263,13 @@ mod enabled {
                 os: event::os_family(),
             },
         };
-        if let Ok(json) = serde_json::to_string(&payload) {
-            return store.queue_analytics_event(name.as_str(), &json).is_ok();
+        if let Ok(json) = serde_json::to_string(&payload)
+            && store.queue_analytics_event(name.as_str(), &json).is_ok()
+        {
+            if let Some(wake) = app.try_state::<DeliveryWake>() {
+                wake.0.notify_one();
+            }
+            return true;
         }
         false
     }
@@ -247,8 +301,112 @@ mod enabled {
     ///
     /// The renderer names a shape, not an event. See [`Interaction`] for why.
     pub fn record_interaction(app: &tauri::AppHandle, interaction: Interaction) {
+        if let Some((provider, state)) = deliberate_live_usage_observation(interaction) {
+            record_live_usage_state(app, provider, state);
+            return;
+        }
+        if matches!(interaction, Interaction::LiveUsageStateObserved { .. }) {
+            return;
+        }
         let (name, facts) = interaction.resolve();
-        record(app, name, facts);
+        if !record_event(app, name, facts) {
+            return;
+        }
+        match interaction {
+            Interaction::SurfaceViewed {
+                surface,
+                origin: Origin::User,
+            } if surface != Surface::Settings => note_deliberate_activity(Instant::now()),
+            Interaction::SettingsPaneViewed {
+                pane: SettingsPane::Insights,
+            } => note_deliberate_activity(Instant::now()),
+            _ => {}
+        }
+    }
+
+    fn deliberate_live_usage_observation(
+        interaction: Interaction,
+    ) -> Option<(LiveUsageProvider, LiveUsageState)> {
+        match interaction {
+            Interaction::LiveUsageStateObserved {
+                provider,
+                state,
+                origin: Origin::User,
+            } => Some((provider, state)),
+            _ => None,
+        }
+    }
+
+    #[derive(Default)]
+    struct DeliberateVisit {
+        last_activity: Option<Instant>,
+        live_usage_states: Vec<(LiveUsageProvider, LiveUsageState)>,
+    }
+
+    static DELIBERATE_VISIT: std::sync::Mutex<DeliberateVisit> =
+        std::sync::Mutex::new(DeliberateVisit {
+            last_activity: None,
+            live_usage_states: Vec::new(),
+        });
+
+    fn advance_deliberate_visit(visit: &mut DeliberateVisit, now: Instant) {
+        if visit
+            .last_activity
+            .is_none_or(|last| now.duration_since(last) >= DELIBERATE_VISIT_TIMEOUT)
+        {
+            visit.live_usage_states.clear();
+        }
+        visit.last_activity = Some(now);
+    }
+
+    fn note_deliberate_activity(now: Instant) {
+        let mut visit = DELIBERATE_VISIT
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        advance_deliberate_visit(&mut visit, now);
+    }
+
+    fn record_live_usage_state(
+        app: &tauri::AppHandle,
+        provider: LiveUsageProvider,
+        state: LiveUsageState,
+    ) {
+        if !allowed(app) {
+            return;
+        }
+        let now = Instant::now();
+        let mut visit = DELIBERATE_VISIT
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !visit_accepts_live_usage_state(&mut visit, provider, state, now) {
+            return;
+        }
+        let (name, facts) = Interaction::LiveUsageStateObserved {
+            provider,
+            state,
+            origin: Origin::User,
+        }
+        .resolve();
+        if record_event(app, name, facts) {
+            visit.live_usage_states.push((provider, state));
+        }
+    }
+
+    fn visit_accepts_live_usage_state(
+        visit: &mut DeliberateVisit,
+        provider: LiveUsageProvider,
+        state: LiveUsageState,
+        now: Instant,
+    ) -> bool {
+        let Some(last_activity) = visit.last_activity else {
+            return false;
+        };
+        if now.duration_since(last_activity) >= DELIBERATE_VISIT_TIMEOUT {
+            visit.live_usage_states.clear();
+            visit.last_activity = None;
+            return false;
+        }
+        !visit.live_usage_states.contains(&(provider, state))
     }
 
     /// The last scan outcome reported in this run.
@@ -265,6 +423,125 @@ mod enabled {
     static LAST_CLAUDE_LIMIT_RESET: std::sync::Mutex<
         Option<crate::provider_usage::live::anthropic::LimitResetDiagnostic>,
     > = std::sync::Mutex::new(None);
+
+    #[derive(Debug, Clone, Copy, Default)]
+    struct OnboardingCapture {
+        flow: Option<OnboardingFlow>,
+        started: bool,
+        finished: bool,
+    }
+
+    static ONBOARDING_CAPTURE: std::sync::Mutex<OnboardingCapture> =
+        std::sync::Mutex::new(OnboardingCapture {
+            flow: None,
+            started: false,
+            finished: false,
+        });
+
+    static HUD_EXPOSURE_ORIGIN: std::sync::Mutex<Option<Origin>> = std::sync::Mutex::new(None);
+
+    /// Begin a distinct restart flow after its pending state persists.
+    pub fn prepare_onboarding_restart() {
+        *ONBOARDING_CAPTURE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = OnboardingCapture {
+            flow: Some(OnboardingFlow::Restart),
+            started: false,
+            finished: false,
+        };
+    }
+
+    fn onboarding_flow(app: &tauri::AppHandle) -> OnboardingFlow {
+        if app
+            .try_state::<Store>()
+            .is_some_and(|store| store.onboarding_flow_is_restart())
+        {
+            OnboardingFlow::Restart
+        } else {
+            OnboardingFlow::New
+        }
+    }
+
+    /// Record the first successful reveal of the active setup flow.
+    pub fn record_onboarding_started(app: &tauri::AppHandle) {
+        let flow = onboarding_flow(app);
+        let mut capture = ONBOARDING_CAPTURE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if capture.flow != Some(flow) {
+            *capture = OnboardingCapture {
+                flow: Some(flow),
+                started: false,
+                finished: false,
+            };
+        }
+        if capture.started {
+            return;
+        }
+        if record_event(
+            app,
+            EventName::OnboardingStarted,
+            Facts {
+                label: Some(flow.as_str()),
+                ..Facts::default()
+            },
+        ) {
+            capture.started = true;
+        }
+    }
+
+    /// Record the committed completion of the active setup flow once.
+    pub fn record_onboarding_finished(app: &tauri::AppHandle) {
+        let flow = onboarding_flow(app);
+        let mut capture = ONBOARDING_CAPTURE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if capture.flow != Some(flow) {
+            *capture = OnboardingCapture {
+                flow: Some(flow),
+                started: false,
+                finished: false,
+            };
+        }
+        if capture.finished {
+            return;
+        }
+        if record_event(
+            app,
+            EventName::OnboardingFinished,
+            Facts {
+                label: Some(flow.as_str()),
+                ..Facts::default()
+            },
+        ) {
+            capture.finished = true;
+        }
+    }
+
+    /// Hold the origin until the HUD confirms an actual reveal.
+    pub fn prepare_hud_exposure(origin: Origin) {
+        *HUD_EXPOSURE_ORIGIN
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(origin);
+    }
+
+    /// Cancel a pending HUD exposure when reveal cannot complete.
+    pub fn cancel_hud_exposure() {
+        *HUD_EXPOSURE_ORIGIN
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+
+    /// Take the origin for one confirmed HUD reveal.
+    pub fn take_hud_exposure_origin(exposed: bool) -> Option<Origin> {
+        if !exposed {
+            return None;
+        }
+        HUD_EXPOSURE_ORIGIN
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum UnrecognizedOutcome {
@@ -408,6 +685,10 @@ mod enabled {
         *LAST_CLAUDE_LIMIT_RESET
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        *DELIBERATE_VISIT
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = DeliberateVisit::default();
+        cancel_hud_exposure();
     }
 
     /// The identifier to stamp on an event, minting or rotating it as needed.
@@ -420,7 +701,17 @@ mod enabled {
         }
         let fresh = random_identifier();
         store.set_analytics_identity(&fresh).ok()?;
+        // A session identifier must not join the old and new installation IDs.
+        reset_session();
         Some(fresh)
+    }
+
+    /// Serialize the two identifiers so rotation cannot produce a mixed pair.
+    fn current_identity_pair(store: &Store) -> Option<(String, String)> {
+        let _guard = IDENTITY_SESSION_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Some((current_install_id(store)?, current_session_id()))
     }
 
     /// Whether a mint stamp is old enough that the identifier should roll over.
@@ -439,12 +730,15 @@ mod enabled {
 
     /// The current run identifier, and when it was last touched.
     ///
-    /// Deliberately in memory and nowhere else. A restart mints a new one even
-    /// inside the window, which is the same behaviour the contract describes for
-    /// a desktop client and is the weaker of the two options — a persisted
-    /// session id would be a second durable identifier, and one is enough.
+    /// The generator state stays in memory. A restart mints a new value even
+    /// inside the window. Queued event payloads keep their captured value.
     static SESSION: std::sync::Mutex<Option<(String, std::time::Instant)>> =
         std::sync::Mutex::new(None);
+
+    static IDENTITY_SESSION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Serializes consent checks, capture, and consent withdrawal.
+    static CAPTURE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// The run identifier to stamp on an event, minting or rolling it as needed.
     fn current_session_id() -> String {
@@ -532,8 +826,13 @@ mod enabled {
         // lives in memory rather than in the store, so it has to be dropped
         // separately or opting out and back in inside the same launch would resume
         // the session that was just withdrawn.
-        let _ = store.clear_analytics();
-        reset_session();
+        {
+            let _capture = CAPTURE_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let _ = store.clear_analytics();
+            reset_session();
+        }
         reset_suppression();
     }
 
@@ -563,12 +862,41 @@ mod enabled {
             return;
         }
         ensure_crypto_provider();
+        app.manage(DeliveryWake::default());
         let handle = app.clone();
         tauri::async_runtime::spawn(async move {
-            tokio::time::sleep(FIRST_FLUSH_DELAY).await;
+            let started = Instant::now();
+            let initial_depth = handle
+                .try_state::<Store>()
+                .and_then(|store| store.analytics_event_count().ok())
+                .unwrap_or(0);
+            let mut schedule = DeliverySchedule::new(Duration::ZERO, initial_depth);
             loop {
-                flush_once(&handle).await;
-                tokio::time::sleep(FLUSH_INTERVAL).await;
+                let now = started.elapsed();
+                let Some(delay) = schedule.next_delay(now) else {
+                    let wake = handle.state::<DeliveryWake>();
+                    wake.0.notified().await;
+                    let depth = handle
+                        .try_state::<Store>()
+                        .and_then(|store| store.analytics_event_count().ok())
+                        .unwrap_or(0);
+                    schedule.queued(started.elapsed(), depth);
+                    continue;
+                };
+                let wake = handle.state::<DeliveryWake>();
+                tokio::select! {
+                    () = tokio::time::sleep(delay) => {
+                        let outcome = flush_once(&handle).await;
+                        schedule.flush_completed(started.elapsed(), outcome);
+                    }
+                    () = wake.0.notified() => {
+                        let depth = handle
+                            .try_state::<Store>()
+                            .and_then(|store| store.analytics_event_count().ok())
+                            .unwrap_or(0);
+                        schedule.queued(started.elapsed(), depth);
+                    }
+                }
             }
         });
     }
@@ -579,30 +907,33 @@ mod enabled {
     /// local queue rather than fired at the call site: an event captured while the
     /// machine was offline is still worth sending later, and a call site that
     /// blocks on the network to report on itself has its priorities inverted.
-    async fn flush_once(app: &tauri::AppHandle) {
+    async fn flush_once(app: &tauri::AppHandle) -> FlushOutcome {
         if !allowed(app) {
-            return;
+            return FlushOutcome::Suspended;
         }
         let Some(base) = config::endpoint() else {
-            return;
+            return FlushOutcome::Suspended;
         };
         let Some(store) = app.try_state::<Store>() else {
-            return;
+            return FlushOutcome::Suspended;
         };
-        let Ok(pending) = store.pending_analytics_events(BATCH_SIZE) else {
-            return;
+        let Ok(pending) = store.pending_analytics_events(delivery::REQUEST_BUDGET) else {
+            return FlushOutcome::Suspended;
         };
         if pending.is_empty() {
-            return;
+            return FlushOutcome::Empty;
         }
         ensure_crypto_provider();
         let Ok(client) = reqwest::Client::builder().timeout(REQUEST_TIMEOUT).build() else {
-            return;
+            return FlushOutcome::Failed {
+                remaining: store.analytics_event_count().unwrap_or(0),
+            };
         };
 
         let track = format!("{}/v1/track", base.trim_end_matches('/'));
         let mut delivered = Vec::new();
         let mut failed = Vec::new();
+        let mut suspended = false;
         for (id, payload) in pending {
             // Re-checked every iteration, not once before the loop. A drain of 50
             // events with a 10-second timeout each can outlive the reader's
@@ -611,6 +942,7 @@ mod enabled {
             // switch moved would make that promise false in exactly the moment it
             // matters most.
             if !allowed(app) {
+                suspended = true;
                 break;
             }
             match stamp_sent_at(&payload) {
@@ -643,6 +975,16 @@ mod enabled {
         }
         if !failed.is_empty() {
             let _ = store.fail_analytics_events(&failed, MAX_ATTEMPTS);
+        }
+        let remaining = store.analytics_event_count().unwrap_or(0);
+        if remaining == 0 {
+            FlushOutcome::Empty
+        } else if suspended {
+            FlushOutcome::Suspended
+        } else if failed.is_empty() {
+            FlushOutcome::Delivered { remaining }
+        } else {
+            FlushOutcome::Failed { remaining }
         }
     }
 
@@ -715,6 +1057,72 @@ mod enabled {
         }
 
         #[test]
+        fn automatic_live_usage_observations_are_not_reportable() {
+            let automatic = Interaction::LiveUsageStateObserved {
+                provider: LiveUsageProvider::Anthropic,
+                state: LiveUsageState::Fresh,
+                origin: Origin::Automatic,
+            };
+            assert_eq!(deliberate_live_usage_observation(automatic), None);
+
+            let user = Interaction::LiveUsageStateObserved {
+                provider: LiveUsageProvider::Anthropic,
+                state: LiveUsageState::Fresh,
+                origin: Origin::User,
+            };
+            assert_eq!(
+                deliberate_live_usage_observation(user),
+                Some((LiveUsageProvider::Anthropic, LiveUsageState::Fresh))
+            );
+        }
+
+        #[test]
+        fn provider_polling_cannot_extend_a_deliberate_visit() {
+            let started = Instant::now();
+            let mut visit = DeliberateVisit::default();
+            advance_deliberate_visit(&mut visit, started);
+            assert!(visit_accepts_live_usage_state(
+                &mut visit,
+                LiveUsageProvider::Openai,
+                LiveUsageState::Fresh,
+                started + Duration::from_secs(1),
+            ));
+            visit
+                .live_usage_states
+                .push((LiveUsageProvider::Openai, LiveUsageState::Fresh));
+
+            for elapsed in [60, 15 * 60, 29 * 60] {
+                assert!(!visit_accepts_live_usage_state(
+                    &mut visit,
+                    LiveUsageProvider::Openai,
+                    LiveUsageState::Fresh,
+                    started + Duration::from_secs(elapsed),
+                ));
+                assert_eq!(visit.last_activity, Some(started));
+            }
+
+            assert!(!visit_accepts_live_usage_state(
+                &mut visit,
+                LiveUsageProvider::Openai,
+                LiveUsageState::Stale,
+                started + DELIBERATE_VISIT_TIMEOUT,
+            ));
+            assert_eq!(visit.last_activity, None);
+            assert!(visit.live_usage_states.is_empty());
+        }
+
+        #[test]
+        fn a_hidden_hud_cannot_consume_its_pending_origin() {
+            let _lock = SUPPRESSION_TEST_LOCK.lock().unwrap();
+            cancel_hud_exposure();
+            prepare_hud_exposure(Origin::Automatic);
+
+            assert_eq!(take_hud_exposure_origin(false), None);
+            assert_eq!(take_hud_exposure_origin(true), Some(Origin::Automatic));
+            assert_eq!(take_hud_exposure_origin(true), None);
+        }
+
+        #[test]
         fn an_environment_opt_out_clears_local_analytics_state() {
             let _lock = SUPPRESSION_TEST_LOCK.lock().unwrap();
             let directory = tempfile::tempdir().unwrap();
@@ -764,9 +1172,10 @@ mod enabled {
         /// The first half is what makes the collector's rows coherent; the second
         /// is what stops opting out and straight back in from continuing the
         /// session that was just withdrawn. It is the only identifier here with
-        /// no on-disk representation, so nothing else can assert this.
+        /// no separate persisted generator state, so nothing else can assert this.
         #[test]
         fn a_run_identifier_is_stable_within_a_run_and_dropped_on_opt_out() {
+            let _lock = SUPPRESSION_TEST_LOCK.lock().unwrap();
             reset_session();
             let first = current_session_id();
             assert_eq!(first, current_session_id(), "stable inside one run");
@@ -775,6 +1184,49 @@ mod enabled {
 
             reset_session();
             assert_ne!(first, current_session_id(), "withdrawn, not resumed");
+            reset_session();
+        }
+
+        #[test]
+        fn installation_rotation_cannot_reuse_or_mix_the_previous_session() {
+            let _lock = SUPPRESSION_TEST_LOCK.lock().unwrap();
+            let directory = tempfile::tempdir().unwrap();
+            let store = std::sync::Arc::new(Store::open_in_memory(directory.path()).unwrap());
+            let old_install = "11111111-1111-4111-8111-111111111111";
+            store
+                .set_analytics_identity_at(old_install, "2000-01-01T00:00:00Z")
+                .unwrap();
+            let old_payload = r#"{"anonymousId":"old","sessionId":"old-run"}"#;
+            store
+                .queue_analytics_event("antiburn.app_launched", old_payload)
+                .unwrap();
+            reset_session();
+            let old_session = current_session_id();
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+            let workers: Vec<_> = (0..2)
+                .map(|_| {
+                    let store = store.clone();
+                    let barrier = barrier.clone();
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        current_identity_pair(&store).unwrap()
+                    })
+                })
+                .collect();
+            barrier.wait();
+            let pairs: Vec<_> = workers
+                .into_iter()
+                .map(|worker| worker.join().unwrap())
+                .collect();
+
+            assert_eq!(pairs[0], pairs[1]);
+            assert_ne!(pairs[0].0, old_install);
+            assert_ne!(pairs[0].1, old_session);
+            assert_eq!(
+                store.pending_analytics_events(10).unwrap()[0].1,
+                old_payload
+            );
             reset_session();
         }
 

--- a/apps/desktop/src-tauri/src/app_commands.rs
+++ b/apps/desktop/src-tauri/src/app_commands.rs
@@ -69,6 +69,7 @@ macro_rules! with_app_commands {
             commands::set_settings => "set_settings",
             commands::show_hud_detail => "show_hud_detail",
             commands::start_update_simulation => "start_update_simulation",
+            commands::take_hud_analytics_origin => "take_hud_analytics_origin",
             commands::take_settings_pane => "take_settings_pane",
             commands::window_ready => "window_ready",
             popover_peek::get_popover_peek_data => "get_popover_peek_data",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -198,9 +198,49 @@ pub fn end_popover_hold(app: tauri::AppHandle) {
 
 /// Open or re-show the always-on-top usage HUD.
 #[tauri::command]
-pub async fn open_overlay_window(app: tauri::AppHandle) -> CommandResult<()> {
+pub async fn open_overlay_window(
+    app: tauri::AppHandle,
+    origin: crate::analytics::event::Origin,
+) -> CommandResult<()> {
     let entries = crate::hud::load_placements(&app.state::<Store>());
-    antiburn_hud::open(&app, &entries).map_err(fail)
+    let needs_exposure = hud_needs_exposure(&app);
+    if needs_exposure {
+        crate::analytics::prepare_hud_exposure(origin);
+    }
+    if let Err(error) = antiburn_hud::open(&app, &entries) {
+        if needs_exposure {
+            crate::analytics::cancel_hud_exposure();
+        }
+        return Err(fail(error));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn hud_needs_exposure(app: &tauri::AppHandle) -> bool {
+    !hud_is_exposed(app)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn hud_needs_exposure(_app: &tauri::AppHandle) -> bool {
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn hud_is_exposed(app: &tauri::AppHandle) -> bool {
+    app.get_webview_window(antiburn_hud::OVERLAY_LABEL)
+        .is_some_and(|window| window.is_visible().unwrap_or(false))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn hud_is_exposed(_app: &tauri::AppHandle) -> bool {
+    false
+}
+
+/// Take the origin after the HUD confirms that it reached the screen.
+#[tauri::command]
+pub fn take_hud_analytics_origin(app: tauri::AppHandle) -> Option<crate::analytics::event::Origin> {
+    crate::analytics::take_hud_exposure_origin(hud_is_exposed(&app))
 }
 
 /// Remember where the HUD is, after a drag moved it.
@@ -215,6 +255,7 @@ pub fn record_hud_position(app: tauri::AppHandle) {
 /// Hide the usage HUD and cancel any pending reveal.
 #[tauri::command]
 pub fn hide_overlay_window(app: tauri::AppHandle) -> CommandResult<()> {
+    crate::analytics::cancel_hud_exposure();
     antiburn_hud::hide(&app).map_err(fail)
 }
 
@@ -368,6 +409,7 @@ pub fn set_settings(app: tauri::AppHandle, settings: AppSettings) -> CommandResu
 pub fn restart_onboarding(app: tauri::AppHandle) -> CommandResult<()> {
     let store = app.state::<Store>();
     let (previous, saved) = store.restart_onboarding().map_err(fail)?;
+    crate::analytics::prepare_onboarding_restart();
     apply_settings_transition(&app, &previous, &saved);
     restart_onboarding_surfaces(
         || crate::popover::hide_for_onboarding(&app),
@@ -411,12 +453,9 @@ pub fn finish_onboarding(
         })
         .map_err(fail)?;
     apply_settings_transition(&app, &previous, &saved);
-    // An explicit restart records a new completion because it is a new setup run.
-    crate::analytics::record(
-        &app,
-        crate::analytics::event::EventName::OnboardingFinished,
-        crate::analytics::event::Facts::default(),
-    );
+    if !previous.onboarding_completed && saved.onboarding_completed {
+        crate::analytics::record_onboarding_finished(&app);
+    }
     Ok(saved)
 }
 

--- a/apps/desktop/src-tauri/src/onboarding.rs
+++ b/apps/desktop/src-tauri/src/onboarding.rs
@@ -241,6 +241,8 @@ pub fn renderer_ready(window: &tauri::WebviewWindow, generation: u64) {
 }
 
 fn show(window: &tauri::WebviewWindow) -> tauri::Result<()> {
+    let was_exposed =
+        window.is_visible().unwrap_or(false) && !window.is_minimized().unwrap_or(false);
     center_on_active_monitor(window, WIDTH, HEIGHT);
     window.show()?;
     window.unminimize()?;
@@ -248,6 +250,9 @@ fn show(window: &tauri::WebviewWindow) -> tauri::Result<()> {
     // macOS application and keeps the flow reachable from the Dock.
     window.set_focus()?;
     ::tracing::info!(event = "window_revealed", window = LABEL);
+    if !was_exposed {
+        crate::analytics::record_onboarding_started(window.app_handle());
+    }
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/settings.rs
+++ b/apps/desktop/src-tauri/src/settings.rs
@@ -26,6 +26,9 @@ pub const LABEL: &str = "settings";
 /// Event the shell emits to move an *already open* settings window to a pane.
 pub const EVENT_PANE: &str = "settings:pane";
 
+/// Event the shell emits after Settings reaches the screen.
+pub const EVENT_SHOWN: &str = "settings:shown";
+
 /// The pane a caller asked the window to open on, until the window takes it.
 ///
 /// Two paths need this and only one of them can use an event. A window being
@@ -219,11 +222,23 @@ pub fn renderer_ready(window: &tauri::WebviewWindow, generation: u64) {
 }
 
 fn show(window: &tauri::WebviewWindow) -> tauri::Result<()> {
+    let was_exposed =
+        window.is_visible().unwrap_or(false) && !window.is_minimized().unwrap_or(false);
     center_on_active_monitor(window, WIDTH, HEIGHT);
     window.show()?;
     window.unminimize()?;
     window.set_focus()?;
     ::tracing::info!(event = "window_revealed", window = LABEL);
+    if !was_exposed {
+        crate::analytics::record_interaction(
+            window.app_handle(),
+            crate::analytics::event::Interaction::SurfaceViewed {
+                surface: crate::analytics::event::Surface::Settings,
+                origin: crate::analytics::event::Origin::User,
+            },
+        );
+        let _ = window.emit(EVENT_SHOWN, ());
+    }
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -465,7 +465,25 @@ impl Store {
 
     /// Make setup pending without changing the reader's data or choices.
     pub fn restart_onboarding(&self) -> Result<(AppSettings, AppSettings)> {
-        self.update_settings(|settings| settings.onboarding_completed = false)
+        let mut connection = self.lock();
+        let tx = connection.transaction()?;
+        let previous = read_settings(&tx)?;
+        let mut saved = previous.clone();
+        saved.onboarding_completed = false;
+        let saved = saved.normalized();
+        write_settings(&tx, &saved)?;
+        tx.execute(
+            "INSERT INTO setting (key, value) VALUES ('internal:onboardingFlow', 'restart')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [],
+        )?;
+        tx.commit()?;
+        Ok((previous, saved))
+    }
+
+    /// Whether the pending setup flow came from the explicit restart action.
+    pub fn onboarding_flow_is_restart(&self) -> bool {
+        self.internal_value("internal:onboardingFlow").as_deref() == Some("restart")
     }
 
     /// Replace every preference, returning what was actually stored (clamped).
@@ -572,6 +590,15 @@ impl Store {
         Ok(())
     }
 
+    /// Return the current delivery backlog depth.
+    pub fn analytics_event_count(&self) -> Result<u32> {
+        Ok(self
+            .lock()
+            .query_row("SELECT COUNT(*) FROM analytics_event", [], |row| {
+                row.get::<_, u32>(0)
+            })?)
+    }
+
     /// The next batch to attempt, oldest first, as `(id, payload)`.
     pub fn pending_analytics_events(&self, limit: u32) -> Result<Vec<(i64, String)>> {
         let connection = self.lock();
@@ -632,13 +659,26 @@ impl Store {
 
     /// Mint or rotate the installation identifier.
     pub fn set_analytics_identity(&self, install_id: &str) -> Result<()> {
+        self.set_analytics_identity_with_time(install_id, &now_rfc3339())
+    }
+
+    fn set_analytics_identity_with_time(&self, install_id: &str, minted_at: &str) -> Result<()> {
         self.lock().execute(
             "INSERT INTO analytics_identity (id, install_id, minted_at) VALUES (1, ?1, ?2)
              ON CONFLICT(id) DO UPDATE SET install_id = excluded.install_id,
                                            minted_at  = excluded.minted_at",
-            params![install_id, now_rfc3339()],
+            params![install_id, minted_at],
         )?;
         Ok(())
+    }
+
+    #[cfg(all(test, feature = "analytics"))]
+    pub(crate) fn set_analytics_identity_at(
+        &self,
+        install_id: &str,
+        minted_at: &str,
+    ) -> Result<()> {
+        self.set_analytics_identity_with_time(install_id, minted_at)
     }
 
     /// Opting out: the queue and the identity go together, in one transaction.

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -386,6 +386,23 @@ fn events_are_given_up_on_after_a_bounded_number_of_attempts() {
 }
 
 #[test]
+fn the_analytics_queue_reports_depth_and_keeps_the_newest_five_hundred() {
+    let store = store();
+    for index in 0..510 {
+        store
+            .queue_analytics_event("surface_viewed", &index.to_string())
+            .unwrap();
+        let depth = store.analytics_event_count().unwrap();
+        assert_eq!(depth, (index + 1).min(500));
+    }
+
+    assert_eq!(store.analytics_event_count().unwrap(), 500);
+    let pending = store.pending_analytics_events(500).unwrap();
+    assert_eq!(pending.first().unwrap().1, "10");
+    assert_eq!(pending.last().unwrap().1, "509");
+}
+
+#[test]
 fn consent_grants_round_trip_and_revoke_individually() {
     let store = store();
     assert!(store.granted_dirs().unwrap().is_empty());
@@ -611,10 +628,26 @@ fn restarting_onboarding_preserves_local_state_and_is_idempotent() {
     assert_eq!(store.session_count().unwrap(), 1);
     assert_eq!(store.scan_roots().unwrap(), vec!["/home/avery/work"]);
     assert_eq!(store.pending_analytics_events(10).unwrap().len(), 1);
+    assert!(store.onboarding_flow_is_restart());
 
     let (previous_again, restarted_again) = store.restart_onboarding().unwrap();
     assert_eq!(previous_again, expected);
     assert_eq!(restarted_again, expected);
+}
+
+#[test]
+fn a_restarted_onboarding_flow_keeps_its_classification_after_relaunch() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = Store::open(directory.path()).unwrap();
+    store
+        .update_settings(|settings| settings.onboarding_completed = true)
+        .unwrap();
+    store.restart_onboarding().unwrap();
+    drop(store);
+
+    let reopened = Store::open(directory.path()).unwrap();
+    assert!(!reopened.settings().unwrap().onboarding_completed);
+    assert!(reopened.onboarding_flow_is_restart());
 }
 
 /// Pin the current session shape so migrations remain deliberate. This is not

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -32,6 +32,7 @@ import type {
 } from "./providerUsageIpc"
 
 export * from "./providerUsageIpc"
+export type { SettingsPane } from "./settingsPanes"
 
 /* -------------------------------------------------------------------------
  * Payload shapes — mirrors of `src-tauri/src/dto.rs`
@@ -740,6 +741,36 @@ export type Interaction =
       step: "welcome" | "agents_detected" | "sources_and_repos" | "ready"
     }
   | { kind: "sessionOpened"; agent: string; environment: "native" | "wsl" }
+  | { kind: "surfaceViewed"; surface: Surface; origin: SurfaceOrigin }
+  | {
+      kind: "surfaceStateObserved"
+      surface: StateSurface
+      state: SurfaceState
+      origin: SurfaceOrigin
+    }
+  | { kind: "settingsPaneViewed"; pane: SettingsPane }
+  | {
+      kind: "liveUsageStateObserved"
+      provider: LiveUsageProvider
+      state: LiveUsageState
+      origin: SurfaceOrigin
+    }
+
+export type Surface =
+  | "activity"
+  | "session_detail"
+  | "provider_preview"
+  | "checks_preview"
+  | "hud"
+  | "hud_detail"
+  | "settings"
+
+export type StateSurface = Surface | "insights"
+export type SurfaceOrigin = "user" | "automatic"
+export type SurfaceState = "ready" | "empty" | "error" | "loading_timeout"
+export type LiveUsageProvider = "anthropic" | "openai" | "google"
+export type LiveUsageState =
+  "fresh" | "stale" | "authentication" | "rate_limited" | "unavailable" | "no_credentials"
 
 /**
  * Report one interaction. Fire-and-forget, and silent on failure.
@@ -1236,6 +1267,15 @@ export async function onSettingsChanged(
 ): Promise<UnlistenFn> {
   if (!hasShell()) return noShellUnlisten
   return listen<AppSettings>(SETTINGS_CHANGED_EVENT, (event) => handler(event.payload))
+}
+
+/** Event emitted after the Settings window reaches the screen. */
+export const SETTINGS_SHOWN_EVENT = "settings:shown"
+
+/** Subscribe to the Settings window reaching the screen. */
+export async function onSettingsShown(handler: () => void): Promise<UnlistenFn> {
+  if (!hasShell()) return noShellUnlisten
+  return listen(SETTINGS_SHOWN_EVENT, () => handler())
 }
 
 /**

--- a/apps/desktop/src/lib/overlayWindow.test.ts
+++ b/apps/desktop/src/lib/overlayWindow.test.ts
@@ -72,6 +72,14 @@ describe("HudVisibilitySession", () => {
     unsubscribe()
   })
 
+  it("marks a HUD opened from the settings control as user initiated", () => {
+    const session = new HudVisibilitySession()
+
+    session.set(true)
+
+    expect(invoke).toHaveBeenCalledWith("open_overlay_window", { origin: "user" })
+  })
+
   it("does not let a stale visibility read overwrite a newer native event", async () => {
     let resolveVisibility!: (visible: boolean) => void
     isVisible.mockImplementationOnce(

--- a/apps/desktop/src/lib/overlayWindow.ts
+++ b/apps/desktop/src/lib/overlayWindow.ts
@@ -3,11 +3,18 @@ import { listen } from "@tauri-apps/api/event"
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow"
 import { getCurrentWindow } from "@tauri-apps/api/window"
 
+import type { SurfaceOrigin } from "./ipc"
+
 const OVERLAY_WINDOW_LABEL = "antiburn-overlay"
 const OVERLAY_VISIBILITY_EVENT = "overlay_visibility_changed"
 
-export function openOverlayWindow(): Promise<void> {
-  return invoke("open_overlay_window")
+export function openOverlayWindow(origin: SurfaceOrigin): Promise<void> {
+  return invoke("open_overlay_window", { origin })
+}
+
+/** Take the reason for the latest successful hidden-to-visible HUD transition. */
+export function takeHudAnalyticsOrigin(): Promise<SurfaceOrigin | null> {
+  return invoke<SurfaceOrigin | null>("take_hud_analytics_origin")
 }
 
 export async function hideOverlayWindow(): Promise<void> {
@@ -82,7 +89,7 @@ export class HudVisibilitySession {
     this.revision += 1
     this.setVisible(visible)
     setFloatingHudEnabled(visible)
-    void (visible ? openOverlayWindow() : hideOverlayWindow()).catch(() => {})
+    void (visible ? openOverlayWindow("user") : hideOverlayWindow()).catch(() => {})
   }
 
   toggle = (): void => this.set(!this.visible)

--- a/apps/desktop/src/lib/surfaceExposure.test.ts
+++ b/apps/desktop/src/lib/surfaceExposure.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type * as Ipc from "./ipc"
+import type { LiveUsageSummaryPayload } from "./providerUsageIpc"
+import { SurfaceExposureTracker, liveUsageObservations } from "./surfaceExposure"
+
+const noteInteraction = vi.hoisted(() => vi.fn())
+
+vi.mock("./ipc", async (importOriginal) => {
+  const actual = await importOriginal<typeof Ipc>()
+  return { ...actual, noteInteraction }
+})
+
+function liveUsage(overrides: Partial<LiveUsageSummaryPayload> = {}): LiveUsageSummaryPayload {
+  return {
+    providers: [],
+    errors: [],
+    meters: [{ provider: "anthropic", displayName: "Claude", shown: true }],
+    generatedAt: "2026-09-08T00:05:00Z",
+    ...overrides,
+  }
+}
+
+function provider(freshness: "fresh" | "stale" = "fresh") {
+  return {
+    provider: "anthropic",
+    accountKey: null,
+    displayName: "Claude",
+    support: "live" as const,
+    freshness,
+    sourceLabel: "Claude",
+    observedAt: "2026-09-08T00:04:00Z",
+    windows: [
+      {
+        id: "five-hour",
+        role: "primaryShort",
+        kind: "rolling",
+        scopeModel: null,
+        usedPercent: 20,
+        startsAt: "2026-09-07T20:00:00Z",
+        resetsAt: "2026-09-08T01:00:00Z",
+        hasNonzeroUsageInCurrentPeriod: true,
+        forecast: {
+          unavailableReason: null,
+          confidence: "high",
+          consumptionRate: 4,
+          paceRatio: 1,
+          paceTrend: 1,
+          runwayAt: null,
+          usedToday: 20,
+        },
+      },
+    ],
+    extraUsage: null,
+    resetCredits: null,
+    plan: null,
+    accountUuid: null,
+    accountEmail: null,
+  }
+}
+
+beforeEach(() => {
+  noteInteraction.mockReset()
+  vi.useRealTimers()
+})
+
+describe("SurfaceExposureTracker", () => {
+  it("records one view and each presented state once per exposure", () => {
+    const tracker = new SurfaceExposureTracker()
+    const generation = tracker.expose({ surface: "activity", origin: "user" })
+
+    tracker.observe("ready", generation)
+    tracker.observe("ready", generation)
+    tracker.expose({ surface: "activity", origin: "user", state: "ready" })
+
+    expect(noteInteraction.mock.calls).toEqual([
+      [{ kind: "surfaceViewed", surface: "activity", origin: "user" }],
+      [
+        {
+          kind: "surfaceStateObserved",
+          surface: "activity",
+          state: "ready",
+          origin: "user",
+        },
+      ],
+    ])
+  })
+
+  it("treats a new local identity as a new visible detail exposure", () => {
+    const tracker = new SurfaceExposureTracker()
+
+    tracker.expose({ surface: "session_detail", origin: "user", identity: "one" })
+    tracker.expose({ surface: "session_detail", origin: "user", identity: "two" })
+
+    expect(noteInteraction).toHaveBeenCalledTimes(2)
+    expect(noteInteraction).toHaveBeenNthCalledWith(2, {
+      kind: "surfaceViewed",
+      surface: "session_detail",
+      origin: "user",
+    })
+  })
+
+  it("cancels hidden timeouts and ignores stale results", () => {
+    vi.useFakeTimers()
+    const tracker = new SurfaceExposureTracker()
+    const hidden = tracker.expose({ surface: "activity", origin: "user" })
+    tracker.conceal("activity", hidden)
+    const current = tracker.expose({ surface: "session_detail", origin: "user" })
+
+    tracker.observe("ready", hidden)
+    vi.advanceTimersByTime(10_000)
+
+    expect(noteInteraction).toHaveBeenCalledTimes(3)
+    expect(noteInteraction).toHaveBeenLastCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "session_detail",
+      state: "loading_timeout",
+      origin: "user",
+    })
+
+    tracker.observe("ready", current)
+    expect(noteInteraction).toHaveBeenLastCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "session_detail",
+      state: "ready",
+      origin: "user",
+    })
+  })
+
+  it("preserves the timeout deadline across a controller remount", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2026-09-08T00:00:00Z")
+    const tracker = new SurfaceExposureTracker()
+    tracker.expose({ surface: "activity", origin: "user" })
+    vi.advanceTimersByTime(6_000)
+    tracker.suspend()
+    vi.advanceTimersByTime(3_000)
+
+    tracker.expose({ surface: "activity", origin: "user" })
+    vi.advanceTimersByTime(1_000)
+
+    expect(noteInteraction).toHaveBeenLastCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "activity",
+      state: "loading_timeout",
+      origin: "user",
+    })
+  })
+
+  it("records Insights state without inventing a surface view", () => {
+    const tracker = new SurfaceExposureTracker()
+
+    tracker.expose({ surface: "insights", origin: "user", state: "empty" })
+
+    expect(noteInteraction).toHaveBeenCalledOnce()
+    expect(noteInteraction).toHaveBeenCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "insights",
+      state: "empty",
+      origin: "user",
+    })
+  })
+
+  it("reports live provider states only for a deliberate exposure", () => {
+    const summary = liveUsage({ providers: [provider()] })
+    const tracker = new SurfaceExposureTracker()
+    const automatic = tracker.expose({ surface: "hud", origin: "automatic", state: "ready" })
+    tracker.observeLiveUsage(summary, undefined, automatic)
+    tracker.conceal("hud", automatic)
+    const user = tracker.expose({ surface: "activity", origin: "user", state: "ready" })
+
+    tracker.observeLiveUsage(summary, undefined, user)
+    tracker.observeLiveUsage(summary, undefined, user)
+
+    expect(noteInteraction.mock.calls.flatMap(([interaction]) => interaction)).toContainEqual({
+      kind: "liveUsageStateObserved",
+      provider: "anthropic",
+      state: "fresh",
+      origin: "user",
+    })
+    expect(
+      noteInteraction.mock.calls.filter(
+        ([interaction]) => interaction.kind === "liveUsageStateObserved",
+      ),
+    ).toHaveLength(1)
+  })
+})
+
+describe("liveUsageObservations", () => {
+  it("reports stale cached data and its visible authentication failure separately", () => {
+    const summary = liveUsage({
+      providers: [provider()],
+      errors: [
+        {
+          source: "claude",
+          provider: "anthropic",
+          displayName: "Claude",
+          category: "authentication",
+        },
+      ],
+    })
+
+    expect(liveUsageObservations(summary)).toEqual([
+      { provider: "anthropic", state: "stale" },
+      { provider: "anthropic", state: "authentication" },
+    ])
+  })
+
+  it("does not infer missing credentials from an empty provider result", () => {
+    expect(liveUsageObservations(liveUsage())).toEqual([])
+  })
+
+  it("ignores disabled and unknown providers", () => {
+    const summary = liveUsage({
+      providers: [provider()],
+      meters: [
+        { provider: "anthropic", displayName: "Claude", shown: false },
+        { provider: "future", displayName: "Future", shown: true },
+      ],
+    })
+
+    expect(liveUsageObservations(summary)).toEqual([])
+  })
+})

--- a/apps/desktop/src/lib/surfaceExposure.ts
+++ b/apps/desktop/src/lib/surfaceExposure.ts
@@ -1,0 +1,212 @@
+import {
+  noteInteraction,
+  type LiveUsageProvider,
+  type LiveUsageState,
+  type StateSurface,
+  type SurfaceOrigin,
+  type SurfaceState,
+} from "./ipc"
+import type { LiveUsageSummaryPayload } from "./providerUsageIpc"
+import {
+  liveDisplayableProviders,
+  liveProviderStatus,
+  liveUnavailableProviders,
+  liveWindows,
+} from "./presentation/liveUsage"
+
+const INITIAL_LOAD_TIMEOUT_MS = 10_000
+
+export type SurfaceExposure = {
+  surface: StateSurface
+  origin: SurfaceOrigin
+  /** Local identity for visible content within one surface. This value never leaves the renderer. */
+  identity?: string | number
+  state?: SurfaceState | null
+}
+
+export type LiveUsageObservation = {
+  provider: LiveUsageProvider
+  state: LiveUsageState
+}
+
+type ActiveExposure = {
+  generation: number
+  surface: StateSurface
+  origin: SurfaceOrigin
+  identity: string | number | undefined
+  states: Set<SurfaceState>
+  liveUsageStates: Set<string>
+}
+
+function supportedProvider(provider: string): provider is LiveUsageProvider {
+  return provider === "anthropic" || provider === "openai" || provider === "google"
+}
+
+function failedState(category: string): LiveUsageState {
+  switch (category) {
+    case "authentication":
+      return "authentication"
+    case "rateLimited":
+      return "rate_limited"
+    default:
+      return "unavailable"
+  }
+}
+
+/** Return the provider states that the supplied usage surface presents. */
+export function liveUsageObservations(
+  summary: LiveUsageSummaryPayload,
+  onlyProvider?: string,
+): LiveUsageObservation[] {
+  const observations: LiveUsageObservation[] = []
+  const seen = new Set<LiveUsageProvider>()
+  for (const meter of summary.meters) {
+    if (!meter.shown || (onlyProvider && meter.provider !== onlyProvider)) continue
+    if (!supportedProvider(meter.provider) || seen.has(meter.provider)) continue
+    seen.add(meter.provider)
+
+    const providers = liveDisplayableProviders(summary).filter(
+      (entry) => entry.provider === meter.provider && liveWindows(entry).length > 0,
+    )
+    for (const provider of providers) {
+      const status = liveProviderStatus(summary, provider)
+      if (status.kind === "live") {
+        observations.push({
+          provider: meter.provider,
+          state: provider.freshness === "stale" ? "stale" : "fresh",
+        })
+      } else if (status.kind === "grace") {
+        observations.push({ provider: meter.provider, state: "stale" })
+        observations.push({ provider: meter.provider, state: failedState(status.category) })
+      } else {
+        observations.push({ provider: meter.provider, state: failedState(status.category) })
+      }
+    }
+
+    const unavailable = liveUnavailableProviders(summary).find(
+      (entry) => entry.provider === meter.provider,
+    )
+    if (unavailable) {
+      observations.push({ provider: meter.provider, state: failedState(unavailable.category) })
+    }
+  }
+  return observations.filter(
+    (observation, index) =>
+      observations.findIndex(
+        (candidate) =>
+          candidate.provider === observation.provider && candidate.state === observation.state,
+      ) === index,
+  )
+}
+
+/** Own visible exposure generations and their bounded analytics state. */
+export class SurfaceExposureTracker {
+  private generation = 0
+  private active: ActiveExposure | null = null
+  private timeout: ReturnType<typeof setTimeout> | null = null
+  private timeoutDeadline: number | null = null
+
+  expose(exposure: SurfaceExposure): number {
+    const current = this.active
+    if (
+      current &&
+      current.surface === exposure.surface &&
+      current.origin === exposure.origin &&
+      current.identity === exposure.identity
+    ) {
+      if (exposure.state) this.observe(exposure.state, current.generation)
+      else this.resumeTimeout(current.generation)
+      return current.generation
+    }
+
+    this.clearTimeout()
+    const generation = ++this.generation
+    this.active = {
+      generation,
+      surface: exposure.surface,
+      origin: exposure.origin,
+      identity: exposure.identity,
+      states: new Set(),
+      liveUsageStates: new Set(),
+    }
+    if (exposure.surface !== "insights") {
+      noteInteraction({
+        kind: "surfaceViewed",
+        surface: exposure.surface,
+        origin: exposure.origin,
+      })
+    }
+    if (exposure.state) {
+      this.observe(exposure.state, generation)
+    } else {
+      this.timeoutDeadline = Date.now() + INITIAL_LOAD_TIMEOUT_MS
+      this.resumeTimeout(generation)
+    }
+    return generation
+  }
+
+  observe(state: SurfaceState, generation = this.active?.generation): void {
+    const active = this.active
+    if (!active || generation !== active.generation || active.states.has(state)) return
+    active.states.add(state)
+    if (state !== "loading_timeout") this.clearTimeout()
+    noteInteraction({
+      kind: "surfaceStateObserved",
+      surface: active.surface,
+      state,
+      origin: active.origin,
+    })
+  }
+
+  observeLiveUsage(
+    summary: LiveUsageSummaryPayload,
+    onlyProvider?: string,
+    generation = this.active?.generation,
+  ): void {
+    const active = this.active
+    if (!active || active.origin !== "user" || generation !== active.generation) return
+    for (const observation of liveUsageObservations(summary, onlyProvider)) {
+      const key = `${observation.provider}:${observation.state}`
+      if (active.liveUsageStates.has(key)) continue
+      active.liveUsageStates.add(key)
+      noteInteraction({ kind: "liveUsageStateObserved", ...observation, origin: active.origin })
+    }
+  }
+
+  conceal(surface?: StateSurface, generation = this.active?.generation): void {
+    const active = this.active
+    if (!active || generation !== active.generation) return
+    if (surface && surface !== active.surface) return
+    this.clearTimeout()
+    this.active = null
+    this.generation += 1
+  }
+
+  /** Pause timer work while a controller has no subscriber. */
+  suspend(): void {
+    this.clearTimer()
+  }
+
+  private clearTimeout(): void {
+    this.clearTimer()
+    this.timeoutDeadline = null
+  }
+
+  private clearTimer(): void {
+    if (this.timeout === null) return
+    clearTimeout(this.timeout)
+    this.timeout = null
+  }
+
+  private resumeTimeout(generation: number): void {
+    if (this.timeout !== null || this.timeoutDeadline === null) return
+    this.timeout = setTimeout(
+      () => {
+        this.timeout = null
+        this.timeoutDeadline = null
+        this.observe("loading_timeout", generation)
+      },
+      Math.max(0, this.timeoutDeadline - Date.now()),
+    )
+  }
+}

--- a/apps/desktop/src/views/OverlayWindow.test.tsx
+++ b/apps/desktop/src/views/OverlayWindow.test.tsx
@@ -37,10 +37,56 @@ vi.mock("../lib/ipc", async () => {
 const invoke = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}))
 vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }))
 
+const takeHudAnalyticsOrigin = vi.hoisted(() => vi.fn())
+vi.mock("../lib/overlayWindow", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, takeHudAnalyticsOrigin }
+})
+
+const analytics = vi.hoisted(() => ({
+  conceal: vi.fn(),
+  expose: vi.fn(),
+  nextGeneration: 0,
+  observe: vi.fn(),
+  observeLiveUsage: vi.fn(),
+  suspend: vi.fn(),
+}))
+vi.mock("../lib/surfaceExposure", () => ({
+  SurfaceExposureTracker: class {
+    expose(options: unknown) {
+      analytics.nextGeneration += 1
+      analytics.expose(options, analytics.nextGeneration)
+      return analytics.nextGeneration
+    }
+    observe(state: unknown, generation: unknown) {
+      analytics.observe(state, generation)
+    }
+    observeLiveUsage(summary: unknown, provider: unknown, generation: unknown) {
+      analytics.observeLiveUsage(summary, provider, generation)
+    }
+    conceal(surface: unknown, generation: unknown) {
+      analytics.conceal(surface, generation)
+    }
+    suspend() {
+      analytics.suspend()
+    }
+  },
+}))
+
 const hover = vi.hoisted(() => ({ emit: null as ((next: boolean) => void) | null }))
+const visibility = vi.hoisted(() => ({ emit: null as ((next: boolean) => void) | null }))
+const detailShown = vi.hoisted(() => ({ emit: null as (() => void) | null }))
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(async (_event: string, handler: (event: { payload: boolean }) => void) => {
-    hover.emit = (next: boolean) => handler({ payload: next })
+  listen: vi.fn(async (event: string, handler: (event: { payload: unknown }) => void) => {
+    if (event === "overlay_hover") {
+      hover.emit = (next: boolean) => handler({ payload: next })
+    }
+    if (event === "overlay_visibility_changed") {
+      visibility.emit = (next: boolean) => handler({ payload: next })
+    }
+    if (event === "hud-detail:shown") {
+      detailShown.emit = () => handler({ payload: undefined })
+    }
     return () => {}
   }),
 }))
@@ -187,8 +233,17 @@ describe("OverlayWindow", () => {
     hideHudDetail.mockClear()
     resizeOverlayWindow.mockClear()
     invoke.mockClear()
+    takeHudAnalyticsOrigin.mockReset()
+    takeHudAnalyticsOrigin.mockResolvedValue("automatic")
+    analytics.nextGeneration = 0
+    analytics.conceal.mockClear()
+    analytics.expose.mockClear()
+    analytics.observe.mockClear()
+    analytics.observeLiveUsage.mockClear()
     livePush.emit = null
     onLiveUsageChanged.mockClear()
+    visibility.emit = null
+    detailShown.emit = null
     outerPosition.mockReset()
     outerPosition.mockResolvedValue({ x: 600, y: 40 })
     stored.clear()
@@ -217,6 +272,82 @@ describe("OverlayWindow", () => {
     expect(screen.queryByText("81%")).not.toBeInTheDocument()
     expect(closeButton()).toHaveClass("opacity-0", "pointer-events-none")
     expect(document.querySelectorAll(".pointer-events-none .rounded-full")).toHaveLength(20)
+  })
+
+  it("records an automatic HUD exposure and its visible data outcome", async () => {
+    render(<OverlayWindow />)
+
+    await waitFor(() =>
+      expect(analytics.expose).toHaveBeenCalledWith(
+        expect.objectContaining({ surface: "hud", origin: "automatic" }),
+        1,
+      ),
+    )
+    await waitFor(() => expect(analytics.observe).toHaveBeenCalledWith("ready", 1))
+    expect(analytics.observeLiveUsage).not.toHaveBeenCalled()
+  })
+
+  it("starts the HUD exposure timeout while its first usage read is pending", async () => {
+    getLiveUsage.mockImplementation(() => new Promise(() => undefined))
+    render(<OverlayWindow />)
+
+    await waitFor(() =>
+      expect(analytics.expose).toHaveBeenCalledWith(
+        expect.objectContaining({ surface: "hud", origin: "automatic" }),
+        1,
+      ),
+    )
+    expect(analytics.expose.mock.calls[0]?.[0]).not.toHaveProperty("state")
+  })
+
+  it("reports an empty HUD when no usage bars can be shown", async () => {
+    getLiveUsage.mockResolvedValue({
+      providers: [],
+      errors: [],
+      meters: [],
+      generatedAt: new Date().toISOString(),
+    })
+    render(<OverlayWindow />)
+
+    await waitFor(() => expect(analytics.observe).toHaveBeenCalledWith("empty", 1))
+  })
+
+  it("reports an error when the first visible HUD read fails", async () => {
+    getLiveUsage.mockRejectedValue(new Error("usage unavailable"))
+    render(<OverlayWindow />)
+
+    await waitFor(() =>
+      expect(analytics.expose).toHaveBeenCalledWith(
+        expect.objectContaining({ surface: "hud", state: "error" }),
+        1,
+      ),
+    )
+  })
+
+  it("records provider states only for a user-opened HUD", async () => {
+    takeHudAnalyticsOrigin.mockResolvedValue("user")
+    getLiveUsage.mockResolvedValue({
+      ...summary(),
+      meters: [{ provider: "anthropic", displayName: "Claude", shown: true }],
+    })
+    render(<OverlayWindow />)
+
+    await waitFor(() => expect(analytics.observeLiveUsage).toHaveBeenCalled())
+
+    expect(analytics.expose).toHaveBeenCalledWith(
+      expect.objectContaining({ surface: "hud", origin: "user" }),
+      1,
+    )
+  })
+
+  it("ends the HUD exposure when the native window hides", async () => {
+    render(<OverlayWindow />)
+    await waitFor(() => expect(visibility.emit).not.toBeNull())
+    await waitFor(() => expect(analytics.expose).toHaveBeenCalled())
+
+    act(() => visibility.emit!(false))
+
+    expect(analytics.conceal).toHaveBeenCalledWith("hud", 1)
   })
 
   it("drops a meter the moment settings turns it off, not on the next poll", async () => {
@@ -291,6 +422,50 @@ describe("OverlayWindow", () => {
           bars: [expect.objectContaining({ label: "5-hour limit", percent: 81 })],
         }),
       )
+      expect(
+        analytics.expose.mock.calls.some(([options]) => options.surface === "hud_detail"),
+      ).toBe(false)
+      act(() => detailShown.emit!())
+      expect(analytics.expose).toHaveBeenCalledWith(
+        expect.objectContaining({ surface: "hud_detail", origin: "user", state: "ready" }),
+        expect.any(Number),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not record detail when a pending reveal is canceled", async () => {
+    vi.useFakeTimers()
+    try {
+      const { container } = render(<OverlayWindow />)
+      await advance(0)
+      fireEvent.mouseEnter(frame(container))
+      await advance(400)
+      fireEvent.mouseLeave(frame(container))
+
+      act(() => detailShown.emit!())
+
+      expect(
+        analytics.expose.mock.calls.some(([options]) => options.surface === "hud_detail"),
+      ).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not record detail when its show request fails", async () => {
+    vi.useFakeTimers()
+    showHudDetail.mockRejectedValueOnce(new Error("detail unavailable"))
+    try {
+      const { container } = render(<OverlayWindow />)
+      await advance(0)
+      fireEvent.mouseEnter(frame(container))
+      await advance(400)
+
+      expect(
+        analytics.expose.mock.calls.some(([options]) => options.surface === "hud_detail"),
+      ).toBe(false)
     } finally {
       vi.useRealTimers()
     }

--- a/apps/desktop/src/views/PopoverPeekView.test.tsx
+++ b/apps/desktop/src/views/PopoverPeekView.test.tsx
@@ -20,6 +20,29 @@ const popoverPeekConcealed = vi.hoisted(() => vi.fn(async () => true))
 const popoverPeekPresented = vi.hoisted(() => vi.fn(async () => true))
 const popoverPeekReady = vi.hoisted(() => vi.fn(async () => true))
 const popoverPeekRetargetReady = vi.hoisted(() => vi.fn(async () => true))
+const analytics = vi.hoisted(() => ({
+  conceal: vi.fn(),
+  expose: vi.fn((_options: unknown) => 1),
+  observeLiveUsage: vi.fn(),
+  suspend: vi.fn(),
+}))
+
+vi.mock("../lib/surfaceExposure", () => ({
+  SurfaceExposureTracker: class {
+    expose(options: unknown) {
+      return analytics.expose(options)
+    }
+    observeLiveUsage(summary: unknown, provider: unknown, generation: unknown) {
+      analytics.observeLiveUsage(summary, provider, generation)
+    }
+    conceal() {
+      analytics.conceal()
+    }
+    suspend() {
+      analytics.suspend()
+    }
+  },
+}))
 
 vi.mock("../lib/popoverPeekIpc", () => ({
   getPopoverPeekState,
@@ -415,6 +438,94 @@ describe("PopoverPeekView", () => {
       propertyName: "opacity",
     })
     expect(screen.getByRole("status")).toHaveTextContent(/preview unavailable/i)
+  })
+
+  it("does not record a candidate when native state says it is hidden", async () => {
+    popoverPeekPresented.mockResolvedValue(false)
+    getPopoverPeekState.mockResolvedValue({
+      generation: 1,
+      target: providerTarget("openai"),
+      rendererReady: true,
+      visible: false,
+      awaitingRetargetCommit: false,
+      awaitingPresentation: true,
+      awaitingConcealment: false,
+    })
+    getPopoverPeekData.mockResolvedValue(PROVIDER_DATA)
+
+    render(<PopoverPeekView />)
+
+    await waitFor(() => expect(popoverPeekPresented).toHaveBeenCalledWith(1, 196))
+    act(flushFrames)
+    fireEvent.transitionEnd(document.querySelector('[data-generation="1"]')!, {
+      propertyName: "opacity",
+    })
+
+    expect(analytics.expose).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: expect.any(String) }),
+    )
+  })
+
+  it("records a candidate when native state confirms it is already visible", async () => {
+    popoverPeekPresented.mockResolvedValue(false)
+    getPopoverPeekState.mockResolvedValue({
+      generation: 1,
+      target: providerTarget("openai"),
+      rendererReady: true,
+      visible: true,
+      awaitingRetargetCommit: false,
+      awaitingPresentation: false,
+      awaitingConcealment: false,
+    })
+    getPopoverPeekData.mockResolvedValue(PROVIDER_DATA)
+
+    render(<PopoverPeekView />)
+
+    await waitFor(() => expect(popoverPeekPresented).toHaveBeenCalledWith(1, 196))
+    act(flushFrames)
+    fireEvent.transitionEnd(document.querySelector('[data-generation="1"]')!, {
+      propertyName: "opacity",
+    })
+
+    expect(analytics.expose).toHaveBeenCalledWith(
+      expect.objectContaining({ surface: "provider_preview", state: "empty" }),
+    )
+  })
+
+  it("does not record a candidate when native state has moved to another generation", async () => {
+    popoverPeekPresented.mockResolvedValue(false)
+    getPopoverPeekState
+      .mockResolvedValueOnce({
+        generation: 1,
+        target: providerTarget("openai"),
+        rendererReady: true,
+        visible: false,
+        awaitingRetargetCommit: false,
+        awaitingPresentation: true,
+        awaitingConcealment: false,
+      })
+      .mockResolvedValue({
+        generation: 2,
+        target: providerTarget("anthropic"),
+        rendererReady: true,
+        visible: true,
+        awaitingRetargetCommit: false,
+        awaitingPresentation: false,
+        awaitingConcealment: false,
+      })
+    getPopoverPeekData.mockResolvedValue(PROVIDER_DATA)
+
+    render(<PopoverPeekView />)
+
+    await waitFor(() => expect(popoverPeekPresented).toHaveBeenCalledWith(1, 196))
+    act(flushFrames)
+    fireEvent.transitionEnd(document.querySelector('[data-generation="1"]')!, {
+      propertyName: "opacity",
+    })
+
+    expect(analytics.expose).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: expect.any(String) }),
+    )
   })
 
   it("clears a crossfade before acknowledging concealment", async () => {

--- a/apps/desktop/src/views/PopoverPeekView.tsx
+++ b/apps/desktop/src/views/PopoverPeekView.tsx
@@ -3,6 +3,7 @@ import { Component, useState, useSyncExternalStore } from "react"
 import { ProviderGlyph } from "../components/providerUsage/ProviderUsagePrimitives"
 import { Skeleton } from "../components/ui/Skeleton"
 import {
+  getPopoverPeekState,
   popoverPeekConcealed,
   popoverPeekPresented,
   popoverPeekRetargetReady,
@@ -214,6 +215,21 @@ function PeekContent({
   const request = snapshot.requested
   if (!request.target) return <Standby generation={request.generation} />
   const presented = presentedContent(snapshot)
+  const confirmVisibleGeneration = async (generation: number, transition: Promise<boolean>) => {
+    const transitioned = await transition
+    if (!transitioned) {
+      const state = await getPopoverPeekState().catch(() => null)
+      if (state?.generation !== generation || !state.target || !state.visible) return false
+    }
+    controller.confirmPresented(generation)
+    return true
+  }
+  const acknowledgePresentation = async (generation: number, height: number) => {
+    return confirmVisibleGeneration(generation, popoverPeekPresented(generation, height))
+  }
+  const commitRetarget = async (generation: number, height: number | null) => {
+    return confirmVisibleGeneration(generation, popoverPeekRetargetReady(generation, height))
+  }
   return (
     <AnchoredContentPresenter
       key={request.initialPresentation ? request.generation : "retained"}
@@ -228,8 +244,8 @@ function PeekContent({
       initialPresentationCommitRequired={
         request.initialPresentation != null && !request.retargetCommitRequired
       }
-      commitRetarget={popoverPeekRetargetReady}
-      acknowledge={popoverPeekPresented}
+      commitRetarget={commitRetarget}
+      acknowledge={acknowledgePresentation}
       onPromote={controller.promote}
       onDiscard={controller.discard}
     />

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -1463,7 +1463,7 @@ describe("PopoverView — floating HUD restore", () => {
     render(<PopoverView />)
 
     await screen.findByText("Wire the tray popover")
-    expect(invoke).not.toHaveBeenCalledWith("open_overlay_window")
+    expect(invoke).not.toHaveBeenCalledWith("open_overlay_window", { origin: "automatic" })
   })
 
   it("reopens the stored HUD when the hidden popover appears", async () => {
@@ -1475,7 +1475,9 @@ describe("PopoverView — floating HUD restore", () => {
     hudPreference.popoverVisible = true
     emit("popover:shown", null)
 
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith("open_overlay_window"))
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("open_overlay_window", { origin: "automatic" }),
+    )
   })
 
   it("restores the stored HUD when the popover opened before its listener attached", async () => {
@@ -1484,7 +1486,9 @@ describe("PopoverView — floating HUD restore", () => {
     hudPreference.popoverVisible = true
     render(<PopoverView />)
 
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith("open_overlay_window"))
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("open_overlay_window", { origin: "automatic" }),
+    )
   })
 
   it("does not show a stored HUD that is already visible", async () => {
@@ -1495,14 +1499,14 @@ describe("PopoverView — floating HUD restore", () => {
     render(<PopoverView />)
 
     await waitFor(() => expect(overlayVisibilityRead).toHaveBeenCalled())
-    expect(invoke).not.toHaveBeenCalledWith("open_overlay_window")
+    expect(invoke).not.toHaveBeenCalledWith("open_overlay_window", { origin: "automatic" })
   })
 
   it("does not restore an off preference", async () => {
     platform.mac = true
     render(<PopoverView />)
     await screen.findByText("Wire the tray popover")
-    expect(invoke).not.toHaveBeenCalledWith("open_overlay_window")
+    expect(invoke).not.toHaveBeenCalledWith("open_overlay_window", { origin: "automatic" })
   })
 
   it("does not restore the HUD outside macOS", async () => {

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -816,7 +816,7 @@ describe("SettingsView", () => {
       /the word .desktop./i,
       /a random id for the message, so a retry/i,
       /a random installation id/i,
-      /a random id for this run of the app/i,
+      /a random id for a window of captured analytics events/i,
       /the event name/i,
       /when it happened/i,
       /when it was delivered/i,
@@ -855,8 +855,12 @@ describe("SettingsView", () => {
     // all three are asserted from it.
     open("The two identifiers")
     expect(screen.getByText(/replaced every 30 days/i)).toBeInTheDocument()
-    expect(screen.getByText(/roughly when antiburn is used/i)).toBeInTheDocument()
-    expect(screen.getByText(/quitting antiburn ends it/i)).toBeInTheDocument()
+    expect(screen.getByText(/roughly when analytics events were captured/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/each event waiting to be sent keeps a copy on disk/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/after 30 minutes without an analytics event/i)).toBeInTheDocument()
+    expect(screen.getByText(/does not measure a visit or time spent/i)).toBeInTheDocument()
     open("How the starting default works")
     expect(
       screen.getByText(/official release builds start with analytics on/i),

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -30,7 +30,7 @@ vi.mock("@tauri-apps/api/event", () => ({
   }),
 }))
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({ close: closeWindow }),
+  getCurrentWindow: () => ({ close: closeWindow, isVisible: async () => true }),
 }))
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: openDialog,
@@ -802,7 +802,7 @@ describe("SettingsView", () => {
     // earlier version of this test sampled two of them, which is how five
     // fields went unnamed in the pane while the copy claimed to list them all.
     // `analytics::event::Event` is the other half of this pair, and its
-    // `the_wire_payload_is_exactly_these_twenty_two_fields` pins the same number
+    // `the_wire_payload_is_exactly_these_twenty_three_fields` pins the same number
     // from the Rust side.
     const enumeration = screen.getByRole("button", { name: "Exactly what is sent" })
     fireEvent.click(enumeration)
@@ -810,7 +810,7 @@ describe("SettingsView", () => {
     // `every_document_that_counts_the_fields_counts_the_same_number` greps
     // this pane for that phrase, so it has to survive edits to this section.
     expect(
-      screen.getByText(/schema has twenty-two fields, and these are all of them/i),
+      screen.getByText(/schema has twenty-three fields, and these are all of them/i),
     ).toBeInTheDocument()
     for (const field of [
       /the word .desktop./i,
@@ -822,8 +822,9 @@ describe("SettingsView", () => {
       /when it was delivered/i,
       /your processor architecture/i,
       /a count rounded to a range/i,
-      /a short label .* which setting you changed/i,
+      /a short label .* which surface, Settings pane, provider/i,
       /a second such label when an event has two things/i,
+      /whether a visible state followed a user or automatic exposure/i,
       /the app version/i,
       /your operating system/i,
     ]) {
@@ -838,7 +839,7 @@ describe("SettingsView", () => {
     // neighbouring paragraph: the body is a sibling of nothing predictable,
     // and the id is the component's actual contract.
     const body = document.getElementById(enumeration.getAttribute("aria-controls") ?? "")
-    expect(body?.querySelectorAll("li")).toHaveLength(22)
+    expect(body?.querySelectorAll("li")).toHaveLength(23)
     // The exclusions live in the same body as the list, so a reader checking
     // one against the other does not have to open a second row to find them.
     expect(
@@ -860,6 +861,7 @@ describe("SettingsView", () => {
       screen.getByText(/each event waiting to be sent keeps a copy on disk/i),
     ).toBeInTheDocument()
     expect(screen.getByText(/after 30 minutes without an analytics event/i)).toBeInTheDocument()
+    expect(screen.getByText(/when the installation id rotates/i)).toBeInTheDocument()
     expect(screen.getByText(/does not measure a visit or time spent/i)).toBeInTheDocument()
     open("How the starting default works")
     expect(

--- a/apps/desktop/src/views/SettingsView.tsx
+++ b/apps/desktop/src/views/SettingsView.tsx
@@ -66,7 +66,7 @@ const PANES: readonly (SidebarNavItem & { id: SettingsPane })[] = [
 
 export function SettingsView() {
   const [session] = useState(() => new SettingsWindowSession())
-  const { info, pane } = useSyncExternalStore(
+  const { info, pane, visible } = useSyncExternalStore(
     session.subscribe,
     session.getSnapshot,
     session.getSnapshot,
@@ -167,7 +167,7 @@ export function SettingsView() {
             {pane === "privacy" && <PrivacyPane {...controller} info={info} />}
             {pane === "notifications" && <NotificationsPane {...controller} />}
             {pane === "usage" && <UsagePane {...controller} />}
-            {pane === "insights" && <InsightsPane />}
+            {pane === "insights" && <InsightsPane analyticsVisible={visible} />}
             {pane === "about" && (
               <AboutPane {...controller} info={info} onOpenPane={session.setPane} />
             )}

--- a/apps/desktop/src/views/overlay/OverlaySession.ts
+++ b/apps/desktop/src/views/overlay/OverlaySession.ts
@@ -18,8 +18,11 @@ import {
   hideOverlayWindow,
   recordHudPosition,
   setFloatingHudEnabled,
+  takeHudAnalyticsOrigin,
 } from "../../lib/overlayWindow"
 import { prefersReducedMotion } from "../../lib/popoverHeight"
+import { liveDisplayableProviders, liveWindows } from "../../lib/presentation/liveUsage"
+import { SurfaceExposureTracker } from "../../lib/surfaceExposure"
 import { deriveUsageBars, noMeterSelected, type UsageBarItem } from "../../lib/usageBars"
 
 const REFRESH_MS = 60_000
@@ -68,9 +71,21 @@ export class OverlaySession {
   private resetClock: number | null = null
   private stopHoverListening: (() => void) | null = null
   private stopUsageListening: (() => void) | null = null
+  private stopVisibilityListening: (() => void) | null = null
+  private stopDetailShownListening: (() => void) | null = null
   private dragOrigin: DragOrigin | null = null
   private pendingMove: MouseEvent | null = null
   private moveFrame = 0
+  private readonly hudExposure = new SurfaceExposureTracker()
+  private readonly detailExposure = new SurfaceExposureTracker()
+  private hudExposureGeneration: number | null = null
+  private hudOrigin: "user" | "automatic" | null = null
+  private hudIdentity: string | null = null
+  private hudVisibilityKnown = false
+  private hudNativeVisible = false
+  private detailRevision = 0
+  private latestUsage: LiveUsageSummaryPayload | null = null
+  private usageFailed = false
 
   getSnapshot = (): OverlaySnapshot => this.snapshot
 
@@ -120,9 +135,12 @@ export class OverlaySession {
     const generation = ++this.generation
     document.body.dataset.transparentWindow = "true"
     this.connectPanel()
+    this.resumeHudExposure()
 
     const applyUsage = (response: LiveUsageSummaryPayload | null) => {
       if (!this.isCurrent(generation)) return
+      this.latestUsage = response
+      this.usageFailed = false
       this.commitLayout({
         bars: deriveUsageBars(response),
         noMeterSelected: noMeterSelected(response),
@@ -131,12 +149,19 @@ export class OverlaySession {
       if (this.detailShown) {
         void showHudDetail(this.detailState("refresh")).catch(() => {})
       }
+      this.observeHudUsage(response)
     }
 
     const refreshUsage = () => {
       void getLiveUsage()
         .then(applyUsage)
-        .catch(() => {})
+        .catch(() => {
+          if (!this.isCurrent(generation)) return
+          this.usageFailed = true
+          if (this.hudExposureGeneration !== null) {
+            this.hudExposure.observe("error", this.hudExposureGeneration)
+          }
+        })
     }
     refreshUsage()
     this.usagePoll = window.setInterval(refreshUsage, REFRESH_MS)
@@ -172,6 +197,32 @@ export class OverlaySession {
         else dispose()
       })
       .catch(() => {})
+
+    void listen<boolean>("overlay_visibility_changed", (event) => {
+      if (!this.isCurrent(generation)) return
+      this.hudVisibilityKnown = true
+      this.hudNativeVisible = event.payload
+      if (event.payload) void this.captureHudExposure(generation)
+      else this.concealHudExposure()
+    })
+      .then((dispose) => {
+        if (this.isCurrent(generation)) {
+          this.stopVisibilityListening = dispose
+          void this.captureHudExposure(generation)
+        } else dispose()
+      })
+      .catch(() => {
+        if (this.isCurrent(generation)) void this.captureHudExposure(generation)
+      })
+
+    void listen("hud-detail:shown", () => {
+      if (this.isCurrent(generation)) this.recordDetailExposure()
+    })
+      .then((dispose) => {
+        if (this.isCurrent(generation)) this.stopDetailShownListening = dispose
+        else dispose()
+      })
+      .catch(() => {})
   }
 
   private stop(): void {
@@ -186,6 +237,12 @@ export class OverlaySession {
     this.stopHoverListening = null
     this.stopUsageListening?.()
     this.stopUsageListening = null
+    this.stopVisibilityListening?.()
+    this.stopVisibilityListening = null
+    this.stopDetailShownListening?.()
+    this.stopDetailShownListening = null
+    this.hudExposure.suspend()
+    this.detailExposure.suspend()
     this.removeDragListeners()
     this.observer?.disconnect()
     this.observer = null
@@ -208,7 +265,11 @@ export class OverlaySession {
       this.showTimer = null
       if (!this.started || !this.snapshot.hovered || this.snapshot.dragging) return
       this.detailShown = true
-      void showHudDetail(this.detailState("show")).catch(() => {})
+      const revision = ++this.detailRevision
+      const state = this.detailState("show")
+      void showHudDetail(state).catch(() => {
+        if (revision === this.detailRevision) this.detailShown = false
+      })
     }, SHOW_DELAY_MS)
   }
 
@@ -220,6 +281,8 @@ export class OverlaySession {
   private hideDetail(): void {
     if (!this.detailShown) return
     this.detailShown = false
+    this.detailRevision += 1
+    this.detailExposure.conceal("hud_detail")
     void hideHudDetail().catch(() => {})
   }
 
@@ -237,6 +300,72 @@ export class OverlaySession {
         expectedFraction: bar.expectedFraction,
       })),
     }
+  }
+
+  private async captureHudExposure(generation: number): Promise<void> {
+    const origin = await takeHudAnalyticsOrigin().catch(() => null)
+    if (!origin || !this.isCurrent(generation)) return
+    this.hudOrigin = origin
+    const state = this.latestUsage
+      ? this.snapshot.bars.length > 0
+        ? "ready"
+        : "empty"
+      : this.usageFailed
+        ? "error"
+        : null
+    const identity = `${generation}:${this.detailRevision}`
+    this.hudIdentity = identity
+    this.hudExposureGeneration = this.hudExposure.expose({
+      surface: "hud",
+      origin,
+      identity,
+      ...(state ? { state } : {}),
+    })
+    if (this.latestUsage) this.observeHudUsage(this.latestUsage)
+    if (this.hudVisibilityKnown && !this.hudNativeVisible) this.concealHudExposure()
+  }
+
+  private observeHudUsage(response: LiveUsageSummaryPayload | null): void {
+    const generation = this.hudExposureGeneration
+    if (generation === null) return
+    this.hudExposure.observe(this.snapshot.bars.length > 0 ? "ready" : "empty", generation)
+    if (response && this.hudOrigin === "user") {
+      for (const provider of liveDisplayableProviders(response)) {
+        if (!liveWindows(provider).some((window) => window.usedPercent !== null)) continue
+        this.hudExposure.observeLiveUsage(response, provider.provider, generation)
+      }
+    }
+  }
+
+  private recordDetailExposure(): void {
+    if (!this.detailShown) return
+    this.detailExposure.expose({
+      surface: "hud_detail",
+      origin: "user",
+      identity: this.detailRevision,
+      state: this.snapshot.bars.length > 0 ? "ready" : "empty",
+    })
+  }
+
+  private concealHudExposure(): void {
+    this.hudExposure.conceal("hud", this.hudExposureGeneration ?? undefined)
+    this.hudExposureGeneration = null
+    this.hudOrigin = null
+    this.hudIdentity = null
+    this.detailRevision += 1
+    this.detailExposure.conceal("hud_detail")
+  }
+
+  private resumeHudExposure(): void {
+    if (!this.hudOrigin || !this.hudIdentity || this.hudExposureGeneration === null) return
+    this.hudExposureGeneration = this.hudExposure.expose({
+      surface: "hud",
+      origin: this.hudOrigin,
+      identity: this.hudIdentity,
+      ...(this.latestUsage
+        ? { state: this.snapshot.bars.length > 0 ? ("ready" as const) : ("empty" as const) }
+        : {}),
+    })
   }
 
   private update(change: Partial<OverlaySnapshot>): void {

--- a/apps/desktop/src/views/popover/PopoverPeekController.test.ts
+++ b/apps/desktop/src/views/popover/PopoverPeekController.test.ts
@@ -1,7 +1,31 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { PopoverPeekData } from "../../lib/popoverPeekIpc"
 import { PopoverPeekController } from "./PopoverPeekController"
+
+const analytics = vi.hoisted(() => ({
+  conceal: vi.fn(),
+  expose: vi.fn((_options: unknown) => 41),
+  observeLiveUsage: vi.fn(),
+  suspend: vi.fn(),
+}))
+
+vi.mock("../../lib/surfaceExposure", () => ({
+  SurfaceExposureTracker: class {
+    expose(options: unknown) {
+      return analytics.expose(options)
+    }
+    observeLiveUsage(summary: unknown, provider: unknown, generation: unknown) {
+      analytics.observeLiveUsage(summary, provider, generation)
+    }
+    conceal() {
+      analytics.conceal()
+    }
+    suspend() {
+      analytics.suspend()
+    }
+  },
+}))
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -34,6 +58,76 @@ function providerData(generatedAt: string): PopoverPeekData {
   }
 }
 
+function checksData(): PopoverPeekData {
+  return {
+    kind: "checks",
+    presentation: {
+      failures: [],
+      wins: [],
+      unavailable: [],
+      refreshUnavailable: false,
+      estimate: { tokenBurnBasisPoints: null },
+    },
+  }
+}
+
+function expiredProviderData(): PopoverPeekData {
+  const generatedAt = new Date("2026-09-08T01:00:00Z").toISOString()
+  return {
+    kind: "provider",
+    summary: { providers: [], generatedAt },
+    live: {
+      providers: [
+        {
+          provider: "anthropic",
+          accountKey: null,
+          displayName: "Claude",
+          support: "live",
+          freshness: "stale",
+          sourceLabel: "cached usage",
+          observedAt: new Date("2026-09-08T00:40:00Z").toISOString(),
+          windows: [
+            {
+              id: "five-hour",
+              role: "primaryShort",
+              kind: "rolling",
+              scopeModel: null,
+              usedPercent: 50,
+              startsAt: null,
+              resetsAt: null,
+              hasNonzeroUsageInCurrentPeriod: true,
+              forecast: {
+                unavailableReason: "stale",
+                confidence: null,
+                consumptionRate: null,
+                paceRatio: null,
+                paceTrend: null,
+                runwayAt: null,
+                usedToday: null,
+              },
+            },
+          ],
+          extraUsage: null,
+          resetCredits: null,
+          plan: null,
+          accountUuid: null,
+          accountEmail: null,
+        },
+      ],
+      errors: [
+        {
+          source: "claude",
+          provider: "anthropic",
+          displayName: "Claude",
+          category: "rateLimited",
+        },
+      ],
+      meters: [{ provider: "anthropic", displayName: "Claude", shown: true }],
+      generatedAt,
+    },
+  }
+}
+
 function controllerWith(data: (generation: number) => Promise<PopoverPeekData>) {
   return new PopoverPeekController({
     data,
@@ -44,6 +138,202 @@ function controllerWith(data: (generation: number) => Promise<PopoverPeekData>) 
 }
 
 describe("PopoverPeekController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("records a preview only after its candidate is promoted", async () => {
+    const loaded = deferred<PopoverPeekData>()
+    const controller = controllerWith(vi.fn(() => loaded.promise))
+
+    controller.accept(request(1, "first"))
+    loaded.resolve(providerData("first"))
+    await loaded.promise
+    await Promise.resolve()
+    expect(analytics.expose).not.toHaveBeenCalled()
+
+    controller.confirmPresented(1)
+    expect(analytics.expose).not.toHaveBeenCalled()
+    controller.promote(1)
+
+    expect(analytics.expose).toHaveBeenCalledWith({
+      surface: "provider_preview",
+      origin: "user",
+      identity: 1,
+      state: "empty",
+    })
+    expect(analytics.observeLiveUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ generatedAt: "first" }),
+      "first",
+      41,
+    )
+  })
+
+  it("does not record a promoted candidate without native visibility confirmation", async () => {
+    const loaded = deferred<PopoverPeekData>()
+    const controller = controllerWith(vi.fn(() => loaded.promise))
+
+    controller.accept(request(1, "first"))
+    loaded.resolve(providerData("first"))
+    await loaded.promise
+    await Promise.resolve()
+    controller.promote(1)
+
+    expect(controller.getSnapshot().presented).toMatchObject({ request: { generation: 1 } })
+    expect(analytics.expose).not.toHaveBeenCalled()
+  })
+
+  it("starts the timeout when a cold loading preview becomes visible", async () => {
+    const ready = vi.fn(async () => true)
+    const controller = new PopoverPeekController({
+      data: vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),
+      listen: vi.fn(async () => () => undefined),
+      ready,
+      state: vi.fn(async () => ({
+        generation: 0,
+        target: null,
+        rendererReady: false,
+        visible: false,
+        awaitingRetargetCommit: false,
+        awaitingPresentation: false,
+        awaitingConcealment: false,
+      })),
+    })
+    Object.defineProperty(window, "__ANTIBURN_WINDOW_GENERATION__", {
+      configurable: true,
+      value: 9,
+    })
+    controller.commitRenderer(document.createElement("div"))
+    const unsubscribe = controller.subscribe(() => undefined)
+    await vi.waitFor(() => expect(ready).toHaveBeenCalledWith(9))
+    await Promise.resolve()
+
+    controller.accept(request(1, "first"))
+
+    expect(analytics.expose).toHaveBeenCalledWith({
+      surface: "provider_preview",
+      origin: "user",
+      identity: 1,
+    })
+    unsubscribe()
+  })
+
+  it("waits for native confirmation before recording seeded content", () => {
+    const controller = controllerWith(
+      vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),
+    )
+    controller.accept({
+      ...request(2, "second"),
+      initialPresentation: providerData("seeded"),
+    })
+
+    expect(analytics.expose).not.toHaveBeenCalled()
+    controller.confirmPresented(2)
+
+    expect(analytics.expose).toHaveBeenCalledWith(
+      expect.objectContaining({ surface: "provider_preview", identity: 2 }),
+    )
+  })
+
+  it("records an empty checks preview after native confirmation", () => {
+    const controller = controllerWith(
+      vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),
+    )
+    controller.accept({
+      generation: 3,
+      target: { kind: "checks" },
+      retargetCommitRequired: true,
+      initialPresentation: checksData(),
+    })
+
+    controller.confirmPresented(3)
+
+    expect(analytics.expose).toHaveBeenCalledWith({
+      surface: "checks_preview",
+      origin: "user",
+      identity: 3,
+      state: "empty",
+    })
+  })
+
+  it("does not treat unavailable-only checks as ready data", () => {
+    const controller = controllerWith(
+      vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),
+    )
+    const data = checksData()
+    if (data.kind === "checks") {
+      data.presentation.unavailable.push({
+        id: "cacheChurn",
+        finding: 0,
+        clean: 0,
+        unavailable: 3,
+        estimatedTokenBurnBasisPoints: null,
+      })
+    }
+    controller.accept({
+      generation: 3,
+      target: { kind: "checks" },
+      retargetCommitRequired: true,
+      initialPresentation: data,
+    })
+
+    controller.confirmPresented(3)
+
+    expect(analytics.expose).toHaveBeenCalledWith(expect.objectContaining({ state: "empty" }))
+  })
+
+  it("reports assessed checks as ready data", () => {
+    const controller = controllerWith(
+      vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),
+    )
+    const data = checksData()
+    if (data.kind === "checks") {
+      data.presentation.wins.push({
+        id: "cacheChurn",
+        finding: 0,
+        clean: 3,
+        unavailable: 0,
+        estimatedTokenBurnBasisPoints: 0,
+      })
+    }
+    controller.accept({
+      generation: 4,
+      target: { kind: "checks" },
+      retargetCommitRequired: true,
+      initialPresentation: data,
+    })
+
+    controller.confirmPresented(4)
+
+    expect(analytics.expose).toHaveBeenCalledWith(expect.objectContaining({ state: "ready" }))
+  })
+
+  it("reports an expired provider cache as an error", () => {
+    const controller = controllerWith(
+      vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),
+    )
+    controller.accept({
+      ...request(4, "anthropic"),
+      initialPresentation: expiredProviderData(),
+    })
+
+    controller.confirmPresented(4)
+
+    expect(analytics.expose).toHaveBeenCalledWith(expect.objectContaining({ state: "error" }))
+  })
+
+  it("ends the preview exposure when the shell conceals it", () => {
+    const controller = controllerWith(
+      vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),
+    )
+    controller.accept(request(1, "first"))
+    analytics.conceal.mockClear()
+
+    controller.accept(request(2, null))
+
+    expect(analytics.conceal).toHaveBeenCalledOnce()
+  })
+
   it("marks a cold request as loading without a presented payload", () => {
     const controller = controllerWith(
       vi.fn(() => new Promise<PopoverPeekData>(() => undefined)),

--- a/apps/desktop/src/views/popover/PopoverPeekController.ts
+++ b/apps/desktop/src/views/popover/PopoverPeekController.ts
@@ -7,6 +7,9 @@ import {
   type PopoverPeekRequest,
   type PopoverPeekTarget,
 } from "../../lib/popoverPeekIpc"
+import { SurfaceExposureTracker } from "../../lib/surfaceExposure"
+import { liveDisplayableProviders, liveWindows } from "../../lib/presentation/liveUsage"
+import { providerWindow, windowHasEvidence } from "../../lib/presentation/providerUsage"
 
 export interface PopoverPeekSnapshot {
   requested: PopoverPeekRequest
@@ -62,6 +65,39 @@ function sameTarget(left: PopoverPeekTarget | null, right: PopoverPeekTarget | n
   return left.provider === right.provider && left.utcOffsetMinutes === right.utcOffsetMinutes
 }
 
+function presentationState(
+  request: PopoverPeekActiveRequest,
+  data: PopoverPeekData | null,
+): "ready" | "empty" | "error" {
+  if (!data) return "error"
+  if (data.kind === "checks") {
+    const report = data.presentation
+    if (
+      report.failures.length > 0 ||
+      report.wins.length > 0 ||
+      report.estimate.tokenBurnBasisPoints !== null
+    ) {
+      return "ready"
+    }
+    return report.refreshUnavailable ? "error" : "empty"
+  }
+  const provider = request.target.kind === "provider" ? request.target.provider : null
+  if (!provider) return "error"
+  const localReady = data.summary.providers
+    .filter((entry) => entry.provider === provider)
+    .some((entry) =>
+      (["today", "week", "monthToDate", "last30Days"] as const).some((window) =>
+        windowHasEvidence(providerWindow(entry, window)),
+      ),
+    )
+  const liveReady = liveDisplayableProviders(data.live)
+    .filter((entry) => entry.provider === provider)
+    .some((entry) => liveWindows(entry).length > 0)
+  if (localReady || liveReady) return "ready"
+  if (data.live.errors.some((entry) => entry.provider === provider)) return "error"
+  return "empty"
+}
+
 /** Owns one renderer's request listener and rejects stale async results. */
 export class PopoverPeekController {
   private snapshot: PopoverPeekSnapshot = {
@@ -79,9 +115,12 @@ export class PopoverPeekController {
   private readyRetryTimer: ReturnType<typeof setTimeout> | null = null
   private rendererGeneration: number | null = null
   private readyGeneration: number | null = null
+  private rendererReady = false
   private readyRevision = 0
   private activeLoad: PopoverPeekActiveRequest | null = null
   private pendingLoad: PopoverPeekActiveRequest | null = null
+  private readonly exposure = new SurfaceExposureTracker()
+  private confirmedGeneration: number | null = null
 
   constructor(bridge: PopoverPeekBridge = DEFAULT_BRIDGE) {
     this.bridge = bridge
@@ -110,8 +149,10 @@ export class PopoverPeekController {
         this.readyRetryTimer = null
         this.readyRevision += 1
         this.readyGeneration = null
+        this.rendererReady = false
         this.stopListening?.()
         this.stopListening = null
+        this.exposure.suspend()
       }
     }
   }
@@ -126,6 +167,8 @@ export class PopoverPeekController {
     }
     if (!request.target) {
       this.pendingLoad = null
+      this.confirmedGeneration = null
+      this.exposure.conceal()
       this.snapshot = {
         requested: request,
         presented: null,
@@ -138,6 +181,9 @@ export class PopoverPeekController {
     }
 
     const activeRequest: PopoverPeekActiveRequest = { ...request, target: request.target }
+    if (request.generation !== this.snapshot.requested.generation) {
+      this.confirmedGeneration = null
+    }
     if (request.initialPresentation) {
       this.pendingLoad = null
       this.snapshot = {
@@ -163,6 +209,9 @@ export class PopoverPeekController {
       failed: null,
     }
     this.publish()
+    if (this.rendererReady && this.snapshot.coldLoading) {
+      this.exposeLoadingRequest(activeRequest)
+    }
     if (this.activeLoad == null) this.startLoad(activeRequest)
     else this.pendingLoad = activeRequest
   }
@@ -178,6 +227,7 @@ export class PopoverPeekController {
         coldLoading: false,
       }
       this.publish()
+      this.exposePresentation(generation)
       return
     }
     const failed = this.snapshot.failed
@@ -189,6 +239,15 @@ export class PopoverPeekController {
       failed: null,
     }
     this.publish()
+    this.exposePresentation(generation)
+  }
+
+  confirmPresented = (generation: number): void => {
+    if (generation !== this.snapshot.requested.generation || !this.snapshot.requested.target) {
+      return
+    }
+    this.confirmedGeneration = generation
+    this.exposePresentation(generation)
   }
 
   discard = (generation: number): void => {
@@ -242,7 +301,14 @@ export class PopoverPeekController {
     const readyRevision = ++this.readyRevision
     this.readyGeneration = generation
     try {
-      await this.bridge.ready(generation)
+      const ready = await this.bridge.ready(generation)
+      if (ready && readyRevision === this.readyRevision) {
+        this.rendererReady = true
+        const requested = this.snapshot.requested
+        if (requested.target && this.snapshot.coldLoading) {
+          this.exposeLoadingRequest({ ...requested, target: requested.target })
+        }
+      }
     } catch {
       if (readyRevision !== this.readyRevision || this.readyGeneration !== generation) return
       this.readyGeneration = null
@@ -316,6 +382,32 @@ export class PopoverPeekController {
       request.generation === this.snapshot.requested.generation &&
       sameTarget(request.target, this.snapshot.requested.target)
     )
+  }
+
+  private exposePresentation(generation: number): void {
+    if (this.confirmedGeneration !== generation) return
+    const presented = this.snapshot.presented
+    if (!presented || presented.request.generation !== generation) return
+    const target = presented.request.target
+    const surface = target.kind === "checks" ? "checks_preview" : "provider_preview"
+    const exposureGeneration = this.exposure.expose({
+      surface,
+      origin: "user",
+      identity: generation,
+      state: presentationState(presented.request, presented.data),
+    })
+    if (target.kind === "provider" && presented.data?.kind === "provider") {
+      this.exposure.observeLiveUsage(presented.data.live, target.provider, exposureGeneration)
+    }
+  }
+
+  private exposeLoadingRequest(request: PopoverPeekActiveRequest): void {
+    const surface = request.target.kind === "checks" ? "checks_preview" : "provider_preview"
+    this.exposure.expose({
+      surface,
+      origin: "user",
+      identity: request.generation,
+    })
   }
 
   private publish(): void {

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type * as Ipc from "../../lib/ipc"
 import type * as InsightsIpc from "../../lib/insightsIpc"
+import type * as OverlayWindow from "../../lib/overlayWindow"
 import {
   EMPTY_PROVIDER_USAGE,
   type ActivityEntryPayload,
@@ -23,6 +24,8 @@ const onChecksReportChanged = vi.hoisted(() => vi.fn())
 const getChecksReport = vi.hoisted(() => vi.fn())
 const onPopoverShown = vi.hoisted(() => vi.fn())
 const onPopoverHidden = vi.hoisted(() => vi.fn())
+const noteInteraction = vi.hoisted(() => vi.fn())
+const isCurrentWindowVisible = vi.hoisted(() => vi.fn())
 
 // The analysis, list, and event-subscription commands are overridden. All
 // other wrappers keep their real no-shell fallback because `hasShell()` is
@@ -41,7 +44,13 @@ vi.mock("../../lib/ipc", async (importOriginal) => {
     onScanEvent,
     onPopoverShown,
     onPopoverHidden,
+    noteInteraction,
   }
+})
+
+vi.mock("../../lib/overlayWindow", async (importOriginal) => {
+  const actual = await importOriginal<typeof OverlayWindow>()
+  return { ...actual, isCurrentWindowVisible }
 })
 
 vi.mock("../../lib/insightsIpc", async (importOriginal) => {
@@ -56,6 +65,25 @@ let entryChangedHandler: EntryChangedHandler | null = null
 let scanEventHandler: ScanEventHandler | null = null
 let popoverShownHandler: (() => void) | null = null
 let popoverHiddenHandler: (() => void) | null = null
+
+function activityEntry(overrides: Partial<ActivityEntryPayload> = {}): ActivityEntryPayload {
+  return {
+    agent: "claude-code",
+    sessionId: "session-1",
+    repo: "repo",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    isActive: false,
+    surface: "cli",
+    wslDistro: null,
+    title: null,
+    hasForkParent: false,
+    forkChildCount: 0,
+    cost: null,
+    models: [],
+    modelRuns: [],
+    ...overrides,
+  }
+}
 
 beforeEach(() => {
   entryChangedHandler = null
@@ -102,6 +130,9 @@ beforeEach(() => {
       popoverHiddenHandler = null
     }
   })
+  noteInteraction.mockReset()
+  isCurrentWindowVisible.mockReset()
+  isCurrentWindowVisible.mockResolvedValue(false)
   getSessionLimitAllocations.mockReset()
   getSessionLimitAllocations.mockResolvedValue({
     generatedAt: "2027-01-15T08:00:00Z",
@@ -131,6 +162,350 @@ describe("PopoverSession surface presentation", () => {
     await vi.waitFor(() => expect(session.getSnapshot().checksUnavailable).toBe(true))
 
     unsubscribe()
+  })
+
+  it("does not count a hidden prewarmed renderer as a surface view", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    await vi.waitFor(() => expect(session.getSnapshot().entries).not.toBeNull())
+
+    expect(noteInteraction).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it("records the cached activity outcome when the popover reaches the screen", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    await vi.waitFor(() => expect(session.getSnapshot().usage).not.toBeNull())
+
+    popoverShownHandler?.()
+    popoverShownHandler?.()
+
+    expect(noteInteraction.mock.calls).toEqual([
+      [{ kind: "surfaceViewed", surface: "activity", origin: "user" }],
+      [
+        {
+          kind: "surfaceStateObserved",
+          surface: "activity",
+          state: "empty",
+          origin: "user",
+        },
+      ],
+    ])
+    unsubscribe()
+  })
+
+  it("records useful activity before the secondary usage read settles", async () => {
+    getProviderUsage.mockReturnValue(new Promise(() => undefined))
+    listRecentSessions.mockResolvedValue([activityEntry()])
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    popoverShownHandler?.()
+
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "surfaceStateObserved",
+        surface: "activity",
+        state: "ready",
+        origin: "user",
+      }),
+    )
+    unsubscribe()
+  })
+
+  it("records a failed activity read as error without also calling it empty", async () => {
+    listRecentSessions.mockRejectedValue(new Error("list failed"))
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(session.getSnapshot().entriesUnavailable).toBe(true))
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    popoverShownHandler?.()
+
+    const states = noteInteraction.mock.calls
+      .map(([interaction]) => interaction)
+      .filter((interaction) => interaction.kind === "surfaceStateObserved")
+    expect(states).toEqual([
+      {
+        kind: "surfaceStateObserved",
+        surface: "activity",
+        state: "error",
+        origin: "user",
+      },
+    ])
+    unsubscribe()
+  })
+
+  it("records a visible refresh failure when no cached activity is useful", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(session.getSnapshot().entries).toEqual([]))
+    await vi.waitFor(() => expect(entryChangedHandler).not.toBeNull())
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    popoverShownHandler?.()
+    listRecentSessions.mockRejectedValue(new Error("refresh failed"))
+
+    entryChangedHandler?.(activityEntry({ sessionId: "not-cached" }))
+
+    await vi.waitFor(() => expect(session.getSnapshot().entriesUnavailable).toBe(true))
+    expect(noteInteraction).toHaveBeenCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "activity",
+      state: "error",
+      origin: "user",
+    })
+    unsubscribe()
+  })
+
+  it("records a retained detail surface on reopen and accepts its settled data", async () => {
+    getSessionAnalysis.mockResolvedValue({
+      summary: null,
+      supportsAnalysis: true,
+      title: null,
+      wslDistro: null,
+      isActive: false,
+      cost: null,
+      topLevelCost: null,
+      subagentsCost: null,
+      inclusiveTokens: null,
+      subagentsTokens: null,
+      efficiency: null,
+      models: ["claude-sonnet"],
+      modelRuns: [],
+      orchestration: null,
+      relations: null,
+      sourcePath: null,
+      startedAtEpoch: null,
+      analysisPending: false,
+      analysisStale: false,
+    })
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    session.openSession(subject)
+    await vi.waitFor(() => expect(session.getSnapshot().analysis).not.toBeNull())
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+
+    popoverShownHandler?.()
+
+    expect(noteInteraction).toHaveBeenNthCalledWith(1, {
+      kind: "surfaceViewed",
+      surface: "session_detail",
+      origin: "user",
+    })
+    expect(noteInteraction).toHaveBeenNthCalledWith(2, {
+      kind: "surfaceStateObserved",
+      surface: "session_detail",
+      state: "ready",
+      origin: "user",
+    })
+    unsubscribe()
+  })
+
+  it("treats a detail payload with only a source path as empty", async () => {
+    getSessionAnalysis.mockResolvedValue({
+      summary: null,
+      supportsAnalysis: true,
+      title: null,
+      wslDistro: null,
+      isActive: false,
+      cost: null,
+      topLevelCost: null,
+      subagentsCost: null,
+      inclusiveTokens: null,
+      subagentsTokens: null,
+      efficiency: null,
+      models: [],
+      modelRuns: [],
+      orchestration: null,
+      relations: { title: null, parent: null, children: [] },
+      sourcePath: "/private/session.jsonl",
+      startedAtEpoch: null,
+      analysisPending: false,
+      analysisStale: false,
+    })
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    session.openSession(subject)
+    await vi.waitFor(() => expect(session.getSnapshot().analysis).not.toBeNull())
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    popoverShownHandler?.()
+
+    expect(noteInteraction).toHaveBeenCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "session_detail",
+      state: "empty",
+      origin: "user",
+    })
+    unsubscribe()
+  })
+
+  it("records committed navigation while the popover is visible", async () => {
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    await vi.waitFor(() => expect(session.getSnapshot().usage).not.toBeNull())
+    popoverShownHandler?.()
+    noteInteraction.mockClear()
+
+    session.openSession(subject)
+
+    expect(noteInteraction).toHaveBeenCalledWith({
+      kind: "surfaceViewed",
+      surface: "session_detail",
+      origin: "user",
+    })
+    unsubscribe()
+  })
+
+  it("uses the native visibility read when the shown event was missed", async () => {
+    isCurrentWindowVisible.mockResolvedValue(true)
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "surfaceViewed",
+        surface: "activity",
+        origin: "user",
+      }),
+    )
+    popoverShownHandler?.()
+
+    expect(
+      noteInteraction.mock.calls.filter(
+        ([interaction]) => interaction.kind === "surfaceViewed",
+      ),
+    ).toHaveLength(1)
+    unsubscribe()
+  })
+
+  it("does not invent another view when the controller remounts in a visible window", async () => {
+    isCurrentWindowVisible.mockResolvedValue(true)
+    const session = new PopoverSession()
+    const unsubscribeFirst = session.subscribe(() => undefined)
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "surfaceViewed",
+        surface: "activity",
+        origin: "user",
+      }),
+    )
+    unsubscribeFirst()
+
+    const unsubscribeSecond = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(isCurrentWindowVisible).toHaveBeenCalledTimes(2))
+
+    expect(
+      noteInteraction.mock.calls.filter(
+        ([interaction]) => interaction.kind === "surfaceViewed",
+      ),
+    ).toHaveLength(1)
+    unsubscribeSecond()
+  })
+
+  it("registers visibility listeners before reading the native state", async () => {
+    let finishShownListener!: () => void
+    onPopoverShown.mockImplementation(
+      () =>
+        new Promise<() => void>((resolve) => {
+          finishShownListener = () => {
+            popoverShownHandler = () => undefined
+            resolve(() => {
+              popoverShownHandler = null
+            })
+          }
+        }),
+    )
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(finishShownListener).toBeTypeOf("function"))
+
+    expect(isCurrentWindowVisible).not.toHaveBeenCalled()
+    finishShownListener()
+    await vi.waitFor(() => expect(isCurrentWindowVisible).toHaveBeenCalledOnce())
+    unsubscribe()
+  })
+
+  it("ignores a stale native visibility read after a hidden event", async () => {
+    let resolveVisible!: (visible: boolean) => void
+    isCurrentWindowVisible.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveVisible = resolve
+      }),
+    )
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(popoverHiddenHandler).not.toBeNull())
+
+    popoverHiddenHandler?.()
+    resolveVisible(true)
+    await Promise.resolve()
+
+    expect(noteInteraction).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it("ignores an activity result from a stopped generation", async () => {
+    let resolveStale!: (entries: ActivityEntryPayload[]) => void
+    listRecentSessions.mockReturnValueOnce(
+      new Promise<ActivityEntryPayload[]>((resolve) => {
+        resolveStale = resolve
+      }),
+    )
+    const session = new PopoverSession()
+    const unsubscribeFirst = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(listRecentSessions).toHaveBeenCalledTimes(1))
+    unsubscribeFirst()
+
+    listRecentSessions.mockResolvedValue([])
+    const unsubscribeSecond = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(session.getSnapshot().entries).toEqual([]))
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    popoverShownHandler?.()
+    resolveStale([activityEntry()])
+    await Promise.resolve()
+
+    expect(session.getSnapshot().entries).toEqual([])
+    expect(noteInteraction).not.toHaveBeenCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "activity",
+      state: "ready",
+      origin: "user",
+    })
+    unsubscribeSecond()
+  })
+
+  it("ignores an activity error from a stopped generation", async () => {
+    let rejectStale!: (error: Error) => void
+    listRecentSessions.mockReturnValueOnce(
+      new Promise<ActivityEntryPayload[]>((_resolve, reject) => {
+        rejectStale = reject
+      }),
+    )
+    const session = new PopoverSession()
+    const unsubscribeFirst = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(listRecentSessions).toHaveBeenCalledTimes(1))
+    unsubscribeFirst()
+
+    listRecentSessions.mockResolvedValue([])
+    const unsubscribeSecond = session.subscribe(() => undefined)
+    await vi.waitFor(() => expect(session.getSnapshot().entries).toEqual([]))
+    await vi.waitFor(() => expect(popoverShownHandler).not.toBeNull())
+    popoverShownHandler?.()
+    rejectStale(new Error("stale failure"))
+    await Promise.resolve()
+
+    expect(session.getSnapshot().entriesUnavailable).toBe(false)
+    expect(noteInteraction).not.toHaveBeenCalledWith({
+      kind: "surfaceStateObserved",
+      surface: "activity",
+      state: "error",
+      origin: "user",
+    })
+    unsubscribeSecond()
   })
 
   it("presents equal-height navigation without waiting for native completion", () => {
@@ -349,24 +724,7 @@ describe("PopoverSession event-driven refresh", () => {
     ...overrides,
   })
 
-  const entryPayload = (
-    overrides: Partial<ActivityEntryPayload> = {},
-  ): ActivityEntryPayload => ({
-    agent: "claude-code",
-    sessionId: "session-1",
-    repo: "repo",
-    timestamp: "2024-01-01T00:00:00.000Z",
-    isActive: false,
-    surface: "cli",
-    wslDistro: null,
-    title: null,
-    hasForkParent: false,
-    forkChildCount: 0,
-    cost: null,
-    models: [],
-    modelRuns: [],
-    ...overrides,
-  })
+  const entryPayload = activityEntry
 
   const scanStatus = (overrides: Partial<ScanStatus> = {}): ScanStatus => ({
     running: false,

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -54,6 +54,7 @@ import {
 } from "../../lib/popoverHeight"
 import { localSessionKey } from "../../lib/presentation/localIdentity"
 import { costOutlierThreshold } from "../../lib/presentation/sessionAnalysis"
+import { liveDisplayableProviders, liveWindows } from "../../lib/presentation/liveUsage"
 import {
   isCurrentWindowVisible,
   isFloatingHudEnabled,
@@ -61,6 +62,7 @@ import {
   openOverlayWindow,
 } from "../../lib/overlayWindow"
 import { isMacOS } from "../../lib/platform"
+import { SurfaceExposureTracker, liveUsageObservations } from "../../lib/surfaceExposure"
 import type { LocalRepositoryItem, LocalRepositoryStatus } from "../../lib/types/repository"
 import type { SessionSubject } from "./SessionPane"
 
@@ -86,6 +88,8 @@ export interface PopoverSnapshot {
   debugBuild: boolean
   settings: AppSettings | null
   entries: SessionListEntry[] | null
+  /** True when the initial activity-list read failed. */
+  entriesUnavailable: boolean
   repositories: LocalRepositoryItem[]
   /** Provider usage, or null while the first snapshot is in flight. */
   usage: ProviderUsageSummaryPayload | null
@@ -231,6 +235,9 @@ export class PopoverSession {
   private listeners = new Set<() => void>()
   private started = false
   private generation = 0
+  private analyticsVisibilityRevision = 0
+  private analyticsVisible = false
+  private readonly exposure = new SurfaceExposureTracker()
   private analysisToken = 0
   private checksToken = 0
   private checksConsumerId: string | null = null
@@ -313,6 +320,7 @@ export class PopoverSession {
     debugBuild: false,
     settings: null,
     entries: null,
+    entriesUnavailable: false,
     repositories: [],
     usage: null,
     liveUsage: EMPTY_LIVE_USAGE,
@@ -430,8 +438,7 @@ export class PopoverSession {
     void this.startChecks(generation)
     void this.listenStorageHealth(generation)
     void this.listenScanEvent(generation)
-    void this.listenPopoverShown(generation)
-    void this.listenPopoverHidden(generation)
+    void this.startPopoverVisibility(generation)
     void this.listenLiveUsage(generation)
 
     // ⌘, opens Settings — the platform's standard preferences shortcut, which
@@ -454,6 +461,9 @@ export class PopoverSession {
   private stop(): void {
     this.started = false
     this.generation += 1
+    this.analyticsVisibilityRevision += 1
+    this.analyticsVisible = false
+    this.exposure.suspend()
     this.stopSettingsListening?.()
     this.stopSettingsListening = null
     this.stopSessionsInvalidatedListening?.()
@@ -484,7 +494,7 @@ export class PopoverSession {
   // First load: read independent shell state together, then list sessions for
   // the stored time window. The cached limits do not wait for either read.
   private loadInitial = async (generation: number): Promise<void> => {
-    const usage = this.loadCachedUsage()
+    const usage = this.loadCachedUsage(generation)
     const [stored, health, info] = await Promise.all([
       getSettings().catch(() => DEFAULT_SETTINGS),
       getStorageHealth().catch(() => HEALTHY_STORAGE),
@@ -505,10 +515,7 @@ export class PopoverSession {
     // depends on, and the activity list is what a reader opened the popover
     // for.
     void this.refreshRepositoryList()
-    await Promise.all([
-      this.refreshEntries(stored.activityWindowDays).catch(() => this.update({ entries: [] })),
-      usage,
-    ])
+    await Promise.all([this.loadInitialEntries(stored.activityWindowDays, generation), usage])
     if (generation !== this.generation) return
     this.initialContentReady = true
     this.reportContentReady()
@@ -764,6 +771,8 @@ export class PopoverSession {
   private listenPopoverShown = async (generation: number): Promise<void> => {
     const unlisten = await onPopoverShown(() => {
       if (generation !== this.generation) return
+      this.analyticsVisibilityRevision += 1
+      this.analyticsVisible = true
       this.visible = true
       this.update({ now: Date.now() })
       this.syncNowTicking()
@@ -787,6 +796,9 @@ export class PopoverSession {
   private listenPopoverHidden = async (generation: number): Promise<void> => {
     const unlisten = await onPopoverHidden(() => {
       if (generation !== this.generation) return
+      this.analyticsVisibilityRevision += 1
+      this.analyticsVisible = false
+      this.exposure.conceal()
       this.visible = false
       this.syncNowTicking()
       this.stopUsagePolling()
@@ -796,6 +808,26 @@ export class PopoverSession {
       return
     }
     this.stopPopoverHiddenListening = unlisten
+  }
+
+  private startPopoverVisibility = async (generation: number): Promise<void> => {
+    await Promise.allSettled([
+      this.listenPopoverShown(generation),
+      this.listenPopoverHidden(generation),
+    ])
+    if (generation === this.generation) await this.bootstrapAnalyticsVisibility(generation)
+  }
+
+  private bootstrapAnalyticsVisibility = async (generation: number): Promise<void> => {
+    const revision = this.analyticsVisibilityRevision
+    const visible = await isCurrentWindowVisible()
+    if (generation !== this.generation || revision !== this.analyticsVisibilityRevision) return
+    if (!visible) {
+      this.exposure.conceal()
+      return
+    }
+    this.analyticsVisible = true
+    this.syncAnalyticsExposure()
   }
 
   private reportContentReady(retryAfterPendingFailure = false): void {
@@ -833,7 +865,7 @@ export class PopoverSession {
     if (generation !== this.generation || !visible) return
     const overlayVisible = await isOverlayWindowVisible()
     if (generation !== this.generation || overlayVisible) return
-    await openOverlayWindow().catch(() => {})
+    await openOverlayWindow("automatic").catch(() => {})
   }
 
   private listenLiveUsage = async (generation: number): Promise<void> => {
@@ -870,25 +902,51 @@ export class PopoverSession {
    * Refreshers
    * -------------------------------------------------------------------- */
 
-  private refreshEntries = async (days: number): Promise<void> => {
-    const payloads = await listRecentSessions(days)
-    this.update({ entries: toActivityEntries(payloads) })
+  private loadInitialEntries = async (days: number, generation: number): Promise<void> => {
+    try {
+      await this.refreshEntries(days, generation)
+    } catch {
+      if (generation === this.generation && this.snapshot.entries === null) {
+        this.update({ entries: [] })
+      }
+    }
   }
 
-  private loadCachedUsage = async (): Promise<void> => {
+  private refreshEntries = async (
+    days: number,
+    generation = this.generation,
+  ): Promise<void> => {
+    try {
+      const payloads = await listRecentSessions(days)
+      if (generation !== this.generation) return
+      this.update({ entries: toActivityEntries(payloads), entriesUnavailable: false })
+    } catch (error) {
+      if (
+        generation === this.generation &&
+        (this.snapshot.entries === null || this.snapshot.entries.length === 0)
+      ) {
+        this.update({ entriesUnavailable: true })
+      }
+      throw error
+    }
+  }
+
+  private loadCachedUsage = async (generation: number): Promise<void> => {
     const liveUsageRevision = this.liveUsageRevision
     void this.refreshSessionLimitAllocations()
     const [usage, liveUsage] = await Promise.all([
       getProviderUsage().catch(() => EMPTY_PROVIDER_USAGE),
       getLiveUsage().catch(() => EMPTY_LIVE_USAGE),
     ])
-    this.update({ usage })
+    if (generation !== this.generation) return
     if (liveUsageRevision === this.liveUsageRevision) {
-      this.update({ liveUsage })
+      this.update({ usage, liveUsage })
+    } else {
+      this.update({ usage })
     }
   }
 
-  private refreshUsage = async (): Promise<void> => {
+  private refreshUsage = async (generation = this.generation): Promise<void> => {
     // Counted rather than flagged directly, and flushed to the snapshot as
     // `count > 0`: the popover-shown signal and a scan-finished event can
     // each start a refresh close together, and the first call to settle must
@@ -900,10 +958,13 @@ export class PopoverSession {
       // provider refresh, and the cached limit remains visible meanwhile.
       await Promise.all([
         getProviderUsage()
-          .then((usage) => this.update({ usage }))
+          .then((usage) => {
+            if (generation === this.generation) this.update({ usage })
+          })
           .catch(() => undefined),
         refreshLiveUsage()
           .then((liveUsage) => {
+            if (generation !== this.generation) return
             this.liveUsageRevision += 1
             this.update({ liveUsage })
           })
@@ -912,7 +973,9 @@ export class PopoverSession {
       await this.refreshSessionLimitAllocations()
     } finally {
       this.usageRefreshCount -= 1
-      this.update({ usageRefreshing: this.usageRefreshCount > 0 })
+      if (generation === this.generation) {
+        this.update({ usageRefreshing: this.usageRefreshCount > 0 })
+      }
     }
   }
 
@@ -1116,6 +1179,64 @@ export class PopoverSession {
 
   private update(change: Partial<PopoverSnapshot>): void {
     this.snapshot = { ...this.snapshot, ...change }
+    this.syncAnalyticsExposure()
     for (const listener of this.listeners) listener()
+  }
+
+  private syncAnalyticsExposure(): void {
+    if (!this.analyticsVisible) return
+    const subject = this.snapshot.presentedSession
+    if (this.snapshot.presentedSurface === "session" && subject) {
+      const generation = this.exposure.expose({
+        surface: "session_detail",
+        origin: "user",
+        identity: sessionKey(subject),
+      })
+      const state = this.sessionSurfaceState(subject)
+      if (state) this.exposure.observe(state, generation)
+      return
+    }
+
+    const generation = this.exposure.expose({ surface: "activity", origin: "user" })
+    const totals = this.snapshot.usage?.totals
+    const hasLocalUsage =
+      totals !== undefined &&
+      [totals.today, totals.week, totals.monthToDate, totals.last30Days].some(
+        (window) => window.sessionCount > 0,
+      )
+    const hasLiveReading = liveDisplayableProviders(this.snapshot.liveUsage).some(
+      (provider) => liveWindows(provider).length > 0,
+    )
+    const hasLiveError = liveUsageObservations(this.snapshot.liveUsage).some(
+      ({ state }) => state !== "fresh" && state !== "stale",
+    )
+    const hasData = (this.snapshot.entries?.length ?? 0) > 0 || hasLocalUsage || hasLiveReading
+    if (hasData) {
+      this.exposure.observe("ready", generation)
+    } else if (this.snapshot.entriesUnavailable || hasLiveError) {
+      this.exposure.observe("error", generation)
+    } else if (this.snapshot.entries !== null && this.snapshot.usage !== null) {
+      this.exposure.observe("empty", generation)
+    }
+    this.exposure.observeLiveUsage(this.snapshot.liveUsage, undefined, generation)
+  }
+
+  private sessionSurfaceState(subject: SessionSubject): "ready" | "empty" | "error" | null {
+    const analysis = this.snapshot.analysis
+    if (!analysis || analysis.key !== sessionKey(subject)) return null
+    if (analysis.error) return "error"
+    const payload = analysis.payload
+    if (!payload) return "empty"
+    if (payload.analysisPending) return null
+    const hasData =
+      (payload.summary?.sessions.length ?? 0) > 0 ||
+      payload.cost !== null ||
+      payload.topLevelCost !== null ||
+      payload.efficiency !== null ||
+      (payload.orchestration?.members.length ?? 0) > 0 ||
+      (payload.relations?.parent ?? null) !== null ||
+      (payload.relations?.children.length ?? 0) > 0 ||
+      payload.models.length > 0
+    return hasData ? "ready" : "empty"
   }
 }

--- a/apps/desktop/src/views/settings/InsightsPane.tsx
+++ b/apps/desktop/src/views/settings/InsightsPane.tsx
@@ -1,5 +1,5 @@
 import { Check, CircleAlert, RefreshCw } from "lucide-react"
-import { useState, useSyncExternalStore } from "react"
+import { useCallback, useState, useSyncExternalStore } from "react"
 
 import { Card } from "../../components/ui/Card"
 import { PaneHeader } from "../../components/ui/Pane"
@@ -78,12 +78,16 @@ const LIMIT_KIND_LABELS: Record<string, string> = {
   rateLimit: "Rate limit",
 }
 
-export function InsightsPane() {
-  const [session] = useState(() => new InsightsSession())
+export function InsightsPane({ analyticsVisible = true }: { analyticsVisible?: boolean }) {
+  const [session] = useState(() => new InsightsSession(analyticsVisible))
   const snapshot = useSyncExternalStore(session.subscribe, session.getSnapshot)
+  const visibilityRef = useCallback(
+    (node: HTMLDivElement | null) => session.setHostVisible(node !== null && analyticsVisible),
+    [analyticsVisible, session],
+  )
 
   return (
-    <>
+    <div ref={visibilityRef}>
       <PaneHeader
         title="Insights"
         trailing={
@@ -112,7 +116,7 @@ export function InsightsPane() {
         <InsightsBody snapshot={snapshot} onRecalculate={() => void session.refresh()} />
         <InsightsFreshnessFooter report={snapshot.report} />
       </div>
-    </>
+    </div>
   )
 }
 

--- a/apps/desktop/src/views/settings/InsightsSession.test.ts
+++ b/apps/desktop/src/views/settings/InsightsSession.test.ts
@@ -10,8 +10,33 @@ import { InsightsSession } from "./InsightsSession"
  */
 
 const invoke = vi.hoisted(() => vi.fn())
+const analytics = vi.hoisted(() => ({
+  conceal: vi.fn(),
+  expose: vi.fn(),
+  nextGeneration: 0,
+  observe: vi.fn(),
+  suspend: vi.fn(),
+}))
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }))
+vi.mock("../../lib/surfaceExposure", () => ({
+  SurfaceExposureTracker: class {
+    expose(options: unknown) {
+      analytics.expose(options)
+      analytics.nextGeneration += 1
+      return analytics.nextGeneration
+    }
+    observe(state: unknown, generation: unknown) {
+      analytics.observe(state, generation)
+    }
+    conceal(surface: unknown, generation: unknown) {
+      analytics.conceal(surface, generation)
+    }
+    suspend() {
+      analytics.suspend()
+    }
+  },
+}))
 
 /** A synthetic empty report: nothing discovered, nothing assessed. */
 function report(overrides: Partial<InsightsReportPayload> = {}): InsightsReportPayload {
@@ -90,6 +115,7 @@ function setWindowVisibility(state: DocumentVisibilityState) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  analytics.nextGeneration = 0
   mockCommands()
 })
 
@@ -100,6 +126,24 @@ afterEach(() => {
 })
 
 describe("InsightsSession", () => {
+  it("does not load or observe data before its host window is visible", async () => {
+    const session = new InsightsSession(false)
+    const unsubscribe = session.subscribe(() => {})
+    await flush()
+
+    expect(callsTo("get_insights_report")).toBe(0)
+    expect(analytics.expose).not.toHaveBeenCalled()
+
+    session.setHostVisible(true)
+    await flush()
+
+    expect(callsTo("get_insights_report")).toBe(1)
+    expect(analytics.expose).toHaveBeenCalledOnce()
+    session.setHostVisible(false)
+    expect(analytics.conceal).toHaveBeenCalledWith("insights", 1)
+    unsubscribe()
+  })
+
   it("loads the report on first subscribe and moves loading → ready", async () => {
     const session = new InsightsSession()
     const initial = session.getSnapshot()
@@ -114,6 +158,44 @@ describe("InsightsSession", () => {
     expect(ready.status).toEqual(STATUS)
     // Snapshots are immutable: each update is a new object.
     expect(ready).not.toBe(initial)
+    expect(analytics.expose).toHaveBeenCalledWith({
+      surface: "insights",
+      origin: "user",
+      identity: 1,
+    })
+    expect(analytics.observe).toHaveBeenCalledWith("empty", 1)
+    unsubscribe()
+  })
+
+  it("reports ready only when the visible report has processed evidence", async () => {
+    mockCommands({
+      get_insights_report: report({
+        coverage: { ...report().coverage, discovered: 3, ready: 2 },
+        assessedSessions: 2,
+      }),
+    })
+    const session = new InsightsSession()
+    const unsubscribe = session.subscribe(() => {})
+
+    await flush()
+
+    expect(analytics.observe).toHaveBeenCalledWith("ready", 1)
+    unsubscribe()
+  })
+
+  it("keeps an unprocessed visible report in loading state for the timeout", async () => {
+    mockCommands({
+      get_insights_report: report({
+        coverage: { ...report().coverage, discovered: 3, pending: 3 },
+      }),
+    })
+    const session = new InsightsSession()
+    const unsubscribe = session.subscribe(() => {})
+
+    await flush()
+
+    expect(session.getSnapshot().phase).toBe("ready")
+    expect(analytics.observe).not.toHaveBeenCalled()
     unsubscribe()
   })
 
@@ -157,6 +239,7 @@ describe("InsightsSession", () => {
     expect(snapshot.phase).toBe("error")
     expect(snapshot.error).toContain("synthetic failure")
     expect(snapshot.report).toBeNull()
+    expect(analytics.observe).toHaveBeenCalledWith("error", 1)
     unsubscribe()
   })
 
@@ -259,6 +342,7 @@ describe("InsightsSession", () => {
     // A system visibility change can pause work before the renderer unmounts.
     setWindowVisibility("hidden")
     expect(invoke).toHaveBeenCalledWith("cancel_insights_report")
+    expect(analytics.conceal).toHaveBeenCalledWith("insights", 1)
 
     const polls = callsTo("get_insights_status")
     await vi.advanceTimersByTimeAsync(30_000)
@@ -279,6 +363,9 @@ describe("InsightsSession", () => {
     await flush()
     expect(callsTo("get_insights_status")).toBe(polls + 1)
     expect(callsTo("get_insights_report")).toBe(reports + 1)
+    expect(analytics.expose).toHaveBeenLastCalledWith(
+      expect.objectContaining({ surface: "insights", origin: "user", identity: 3 }),
+    )
 
     await vi.advanceTimersByTimeAsync(5_000)
     expect(callsTo("get_insights_status")).toBe(polls + 2)

--- a/apps/desktop/src/views/settings/InsightsSession.ts
+++ b/apps/desktop/src/views/settings/InsightsSession.ts
@@ -5,6 +5,7 @@ import {
   type InsightsReportPayload,
   type InsightsStatusPayload,
 } from "../../lib/insightsIpc"
+import { SurfaceExposureTracker } from "../../lib/surfaceExposure"
 
 /** Where the report fetch stands. `ready` with a null report means the
  *  shell is absent (browser mode), which the pane names explicitly. */
@@ -19,6 +20,16 @@ export type InsightsSnapshot = {
 
 /** How often the session re-reads the processing status while mounted. */
 const STATUS_POLL_MS = 5_000
+
+type InsightsObservedState = "ready" | "empty" | "error" | null
+
+function observedState(snapshot: InsightsSnapshot): InsightsObservedState {
+  if (snapshot.phase === "loading") return null
+  if (snapshot.phase === "error" || snapshot.report === null) return "error"
+  if (snapshot.report.coverage.discovered === 0) return "empty"
+  if (snapshot.report.coverage.ready === 0) return null
+  return "ready"
+}
 
 /**
  * The imperative boundary behind the Insights pane.
@@ -39,14 +50,23 @@ const STATUS_POLL_MS = 5_000
 export class InsightsSession {
   private listeners = new Set<() => void>()
   private started = false
+  private hostVisible: boolean
+  private workActive = false
   private generation = 0
   private pollTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly exposure = new SurfaceExposureTracker()
+  private exposureGeneration: number | null = null
+  private exposureIdentity: number | null = null
 
   private snapshot: InsightsSnapshot = {
     phase: "loading",
     report: null,
     status: null,
     error: null,
+  }
+
+  constructor(hostVisible = true) {
+    this.hostVisible = hostVisible
   }
 
   getSnapshot = (): InsightsSnapshot => this.snapshot
@@ -63,36 +83,65 @@ export class InsightsSession {
   /** Recompute the report on demand. */
   refresh = async (): Promise<void> => {
     const generation = this.generation
+    const exposureGeneration = this.exposureGeneration
     this.update({ phase: "loading", error: null })
-    await this.loadReport(generation)
+    await this.loadReport(generation, exposureGeneration)
+  }
+
+  setHostVisible = (visible: boolean): void => {
+    if (visible === this.hostVisible) return
+    this.hostVisible = visible
+    if (!this.started) return
+    if (!visible) this.pauseWork()
+    else if (document.visibilityState !== "hidden") this.startWork()
   }
 
   private start(): void {
     this.started = true
     document.addEventListener("visibilitychange", this.handleVisibility)
-    if (document.visibilityState !== "hidden") this.startWork()
+    if (this.hostVisible && document.visibilityState !== "hidden") this.startWork()
   }
 
   private stop(): void {
     this.started = false
     document.removeEventListener("visibilitychange", this.handleVisibility)
-    this.pauseWork()
+    this.pauseWork(false)
   }
 
   private handleVisibility = (): void => {
     if (!this.started) return
     if (document.visibilityState === "hidden") this.pauseWork()
-    else this.startWork()
+    else if (this.hostVisible) this.startWork()
   }
 
   private startWork(): void {
+    if (this.workActive) return
+    this.workActive = true
     const generation = ++this.generation
+    const state = observedState(this.snapshot)
+    const identity = this.exposureIdentity ?? generation
+    this.exposureIdentity = identity
+    this.exposureGeneration = this.exposure.expose({
+      surface: "insights",
+      origin: "user",
+      identity,
+      ...(state ? { state } : {}),
+    })
     void this.pollStatus(generation)
-    void this.loadReport(generation)
+    void this.loadReport(generation, this.exposureGeneration)
   }
 
-  private pauseWork(): void {
+  private pauseWork(concealExposure = true): void {
+    if (!this.workActive) return
+    this.workActive = false
     this.generation += 1
+    if (concealExposure && this.exposureGeneration !== null) {
+      this.exposure.conceal("insights", this.exposureGeneration)
+      this.exposureGeneration = null
+      this.exposureIdentity = null
+    } else {
+      this.exposure.suspend()
+    }
     if (this.pollTimer !== null) {
       clearTimeout(this.pollTimer)
       this.pollTimer = null
@@ -103,16 +152,24 @@ export class InsightsSession {
     void cancelInsightsReport()
   }
 
-  private loadReport = async (generation: number): Promise<void> => {
+  private loadReport = async (
+    generation: number,
+    exposureGeneration: number | null,
+  ): Promise<void> => {
     try {
       const report = await getInsightsReport()
       if (generation !== this.generation) return
       this.update({ phase: "ready", report, error: null })
+      const state = observedState(this.snapshot)
+      if (state && exposureGeneration !== null) {
+        this.exposure.observe(state, exposureGeneration)
+      }
     } catch (error) {
       if (generation !== this.generation) return
       // An error snapshot, never an empty or clean one: the pane renders
       // this as a failure with a retry, not as "no findings".
       this.update({ phase: "error", error: String(error) })
+      if (exposureGeneration !== null) this.exposure.observe("error", exposureGeneration)
     }
   }
 
@@ -131,7 +188,9 @@ export class InsightsSession {
         previous.pending + previous.processing > 0 &&
         status.pending + status.processing === 0 &&
         !status.calculating
-      if (drained && this.snapshot.phase === "ready") void this.loadReport(generation)
+      if (drained && this.snapshot.phase === "ready") {
+        void this.loadReport(generation, this.exposureGeneration)
+      }
     }
     this.pollTimer = setTimeout(() => {
       void this.pollStatus(generation)

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -254,7 +254,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                 <li>The word &ldquo;desktop&rdquo;.</li>
                 <li>A random id for the message, so a retry is not counted twice.</li>
                 <li>A random installation id.</li>
-                <li>A random id for this run of the app.</li>
+                <li>A random id for a window of captured analytics events.</li>
                 <li>The event name, such as &ldquo;a scan finished&rdquo;.</li>
                 <li>When it happened.</li>
                 <li>When it was delivered.</li>
@@ -291,29 +291,27 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                 on its own.
               </p>
             </Disclosure>
-            {/* Both identifiers in one place, with what the timestamps add.
-                They were three rows, but the honest claim only holds when all
-                three facts are read together: a 30-day id plus a time on every
-                event is a coarse picture of when the app gets used, and saying
-                so is cheaper than being caught not having said it. */}
+            {/* Both identifiers stay in one place with the timestamp effect.
+                A 30-day id plus a time shows when analytics events occur. */}
             <Disclosure label="The two identifiers">
               <p>
                 Both are random. Neither is derived from anything about you or your machine.
               </p>
               <p className="mt-2">
                 The <strong className="font-medium text-label">installation id</strong> is
-                replaced every 30 days, so events cannot be joined into a history longer than
-                that. Since every event also carries a time, they do show roughly when antiburn
-                is used within those 30 days &mdash; never what you were working on. Switching
+                replaced every 30 days, limiting how long that id groups events. Since every
+                event also carries a time, they do show roughly when analytics events were
+                captured within those 30 days &mdash; never what you were working on. Switching
                 analytics off deletes the id and anything still queued, so switching back on
-                starts a new id that cannot be linked to the old one.
+                starts a new id.
               </p>
               <p className="mt-2">
-                The <strong className="font-medium text-label">run id</strong> is required by
-                the receiving server. It exists only in memory: quitting antiburn ends it,
-                nothing on your machine remembers it, and it is replaced after 30 minutes of
-                inactivity. It groups one run&rsquo;s events and cannot connect one run to
-                another.
+                The <strong className="font-medium text-label">analytics-session id</strong> is
+                required by the receiving server. Its generator exists only in memory, but each
+                event waiting to be sent keeps a copy on disk. Newly captured events get a new
+                id after 30 minutes without an analytics event or when antiburn restarts.
+                Background events can keep the id active, and one app run can have more than
+                one, so it does not measure a visit or time spent.
               </p>
             </Disclosure>
             <Disclosure label="How the starting default works">

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -244,7 +244,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                   the promise below stops being true.
 
                   The list lets a reader count every field. */}
-              <p>The schema has twenty-two fields, and these are all of them:</p>
+              <p>The schema has twenty-three fields, and these are all of them:</p>
               {/* `pl-7`, not the `pl-4` this started as. Root font-size here
                   is 13px, so `pl-4` is 13px of padding — less than the disc
                   marker's own 17.5px advance, which left the bullets painting
@@ -261,13 +261,14 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                 <li>Your processor architecture.</li>
                 <li>A count rounded to a range, when the event has one.</li>
                 <li>
-                  A short label &mdash; which setting you changed, which agent recorded a
-                  session, what kind of thing failed. The name only, never the value.
+                  A short label &mdash; which surface, Settings pane, provider, setting, agent
+                  category, or failure category. Never work content or a value you entered.
                 </li>
                 <li>
                   A second such label when an event has two things to tell apart, such as native
                   versus WSL.
                 </li>
+                <li>Whether a visible state followed a user or automatic exposure.</li>
                 <li>A range for Claude&rsquo;s current five-hour usage.</li>
                 <li>Whether Claude returned reset data, null, or a malformed value.</li>
                 <li>Claude&rsquo;s reset eligibility state.</li>
@@ -309,9 +310,9 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                 The <strong className="font-medium text-label">analytics-session id</strong> is
                 required by the receiving server. Its generator exists only in memory, but each
                 event waiting to be sent keeps a copy on disk. Newly captured events get a new
-                id after 30 minutes without an analytics event or when antiburn restarts.
-                Background events can keep the id active, and one app run can have more than
-                one, so it does not measure a visit or time spent.
+                id after 30 minutes without an analytics event, when antiburn restarts, or when
+                the installation id rotates. Background events can keep the id active, and one
+                app run can have more than one, so it does not measure a visit or time spent.
               </p>
             </Disclosure>
             <Disclosure label="How the starting default works">

--- a/apps/desktop/src/views/settings/SettingsWindowSession.test.ts
+++ b/apps/desktop/src/views/settings/SettingsWindowSession.test.ts
@@ -1,17 +1,28 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SettingsWindowSession } from "./SettingsWindowSession"
 
 const appInfo = vi.hoisted(() => vi.fn())
 const onSessionsInvalidated = vi.hoisted(() => vi.fn())
 const onSettingsPaneRequest = vi.hoisted(() => vi.fn())
+const onSettingsShown = vi.hoisted(() => vi.fn())
+const noteInteraction = vi.hoisted(() => vi.fn())
 const takeSettingsPane = vi.hoisted(() => vi.fn())
+const isVisible = vi.hoisted(() => vi.fn())
+const shell = vi.hoisted(() => ({ present: true }))
 
 vi.mock("../../lib/ipc", () => ({
   appInfo,
+  hasShell: () => shell.present,
   onSessionsInvalidated,
   onSettingsPaneRequest,
+  onSettingsShown,
+  noteInteraction,
   takeSettingsPane,
+}))
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ isVisible }),
 }))
 
 describe("SettingsWindowSession", () => {
@@ -21,7 +32,18 @@ describe("SettingsWindowSession", () => {
     onSessionsInvalidated.mockReset()
     onSessionsInvalidated.mockResolvedValue(() => {})
     onSettingsPaneRequest.mockReset()
+    onSettingsPaneRequest.mockResolvedValue(() => {})
+    onSettingsShown.mockReset()
+    onSettingsShown.mockResolvedValue(() => {})
+    noteInteraction.mockReset()
     takeSettingsPane.mockReset()
+    isVisible.mockReset()
+    isVisible.mockResolvedValue(true)
+    shell.present = true
+  })
+
+  afterEach(() => {
+    delete (document as unknown as Record<string, unknown>)["visibilityState"]
   })
 
   it("starts listening before it takes the pending pane", async () => {
@@ -40,6 +62,177 @@ describe("SettingsWindowSession", () => {
     await vi.waitFor(() => expect(session.getSnapshot().pane).toBe("sources"))
 
     expect(order).toEqual(["listen", "take"])
+    expect(noteInteraction).toHaveBeenCalledOnce()
+    expect(noteInteraction).toHaveBeenCalledWith({
+      kind: "settingsPaneViewed",
+      pane: "sources",
+    })
+    unsubscribe()
+  })
+
+  it("does not report transient General before the pending pane resolves", async () => {
+    let resolvePending: (pane: string) => void = () => {}
+    onSettingsPaneRequest.mockResolvedValue(() => {})
+    takeSettingsPane.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePending = resolve
+        }),
+    )
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() => expect(takeSettingsPane).toHaveBeenCalledOnce())
+
+    expect(noteInteraction).not.toHaveBeenCalled()
+    resolvePending("insights")
+
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "settingsPaneViewed",
+        pane: "insights",
+      }),
+    )
+    expect(noteInteraction).not.toHaveBeenCalledWith({
+      kind: "settingsPaneViewed",
+      pane: "general",
+    })
+    unsubscribe()
+  })
+
+  it("defers the selected pane until the native window is visible", async () => {
+    const shown: { current: (() => void) | null } = { current: null }
+    isVisible.mockResolvedValue(false)
+    onSettingsShown.mockImplementation(async (handler: () => void) => {
+      shown.current = handler
+      return () => {}
+    })
+    takeSettingsPane.mockResolvedValue("insights")
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() => expect(session.getSnapshot().pane).toBe("insights"))
+
+    expect(session.getSnapshot().visible).toBe(false)
+    expect(noteInteraction).not.toHaveBeenCalled()
+    shown.current?.()
+
+    expect(session.getSnapshot().visible).toBe(true)
+    expect(noteInteraction).toHaveBeenCalledWith({
+      kind: "settingsPaneViewed",
+      pane: "insights",
+    })
+    unsubscribe()
+  })
+
+  it("reports the current pane again after a hidden window is shown", async () => {
+    const shown: { current: (() => void) | null } = { current: null }
+    onSettingsShown.mockImplementation(async (handler: () => void) => {
+      shown.current = handler
+      return () => {}
+    })
+    takeSettingsPane.mockResolvedValue(null)
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() => expect(noteInteraction).toHaveBeenCalledOnce())
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    })
+    document.dispatchEvent(new Event("visibilitychange"))
+    shown.current?.()
+
+    expect(noteInteraction).toHaveBeenCalledTimes(2)
+    expect(noteInteraction).toHaveBeenLastCalledWith({
+      kind: "settingsPaneViewed",
+      pane: "general",
+    })
+    unsubscribe()
+  })
+
+  it("reports General after the shell confirms there is no pending pane", async () => {
+    onSettingsPaneRequest.mockResolvedValue(() => {})
+    takeSettingsPane.mockResolvedValue(null)
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "settingsPaneViewed",
+        pane: "general",
+      }),
+    )
+    unsubscribe()
+  })
+
+  it("reports each visible pane transition and suppresses duplicate requests", async () => {
+    onSettingsPaneRequest.mockResolvedValue(() => {})
+    takeSettingsPane.mockResolvedValue(null)
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "settingsPaneViewed",
+        pane: "general",
+      }),
+    )
+
+    session.setPane("usage")
+    session.setPane("usage")
+    session.setPane("general")
+
+    expect(noteInteraction.mock.calls).toEqual([
+      [{ kind: "settingsPaneViewed", pane: "general" }],
+      [{ kind: "settingsPaneViewed", pane: "usage" }],
+      [{ kind: "settingsPaneViewed", pane: "general" }],
+    ])
+    unsubscribe()
+  })
+
+  it("does not report a new view when the same session resubscribes", async () => {
+    onSettingsPaneRequest.mockResolvedValue(() => {})
+    takeSettingsPane.mockResolvedValue(null)
+    const session = new SettingsWindowSession()
+    const unsubscribeFirst = session.subscribe(() => {})
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "settingsPaneViewed",
+        pane: "general",
+      }),
+    )
+    unsubscribeFirst()
+
+    const unsubscribeSecond = session.subscribe(() => {})
+    await vi.waitFor(() => expect(takeSettingsPane).toHaveBeenCalledTimes(2))
+
+    expect(noteInteraction).toHaveBeenCalledOnce()
+    unsubscribeSecond()
+  })
+
+  it("keeps browser-mode settings visible without a native window", async () => {
+    shell.present = false
+    takeSettingsPane.mockResolvedValue(null)
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+
+    await vi.waitFor(() => expect(session.getSnapshot().visible).toBe(true))
+    expect(noteInteraction).toHaveBeenCalledWith({
+      kind: "settingsPaneViewed",
+      pane: "general",
+    })
+    expect(isVisible).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it("keeps pane setup running when the native visibility API throws", async () => {
+    isVisible.mockImplementation(() => {
+      throw new Error("missing window metadata")
+    })
+    takeSettingsPane.mockResolvedValue("sources")
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+
+    await vi.waitFor(() => expect(session.getSnapshot().pane).toBe("sources"))
+    expect(noteInteraction).not.toHaveBeenCalled()
     unsubscribe()
   })
 
@@ -84,6 +277,43 @@ describe("SettingsWindowSession", () => {
     resolvePending("sources")
 
     await vi.waitFor(() => expect(session.getSnapshot().pane).toBe("usage"))
+    unsubscribe()
+  })
+
+  it("keeps a user pane selection when the pending fallback resolves later", async () => {
+    let resolvePending: (pane: string) => void = () => {}
+    takeSettingsPane.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePending = resolve
+        }),
+    )
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.waitFor(() => expect(takeSettingsPane).toHaveBeenCalledOnce())
+
+    session.setPane("usage")
+    resolvePending("sources")
+
+    await vi.waitFor(() => expect(session.getSnapshot().pane).toBe("usage"))
+    expect(noteInteraction).toHaveBeenLastCalledWith({
+      kind: "settingsPaneViewed",
+      pane: "usage",
+    })
+    unsubscribe()
+  })
+
+  it("uses visible General when the pending-pane read fails", async () => {
+    takeSettingsPane.mockRejectedValue(new Error("pane unavailable"))
+    const session = new SettingsWindowSession()
+    const unsubscribe = session.subscribe(() => {})
+
+    await vi.waitFor(() =>
+      expect(noteInteraction).toHaveBeenCalledWith({
+        kind: "settingsPaneViewed",
+        pane: "general",
+      }),
+    )
     unsubscribe()
   })
 

--- a/apps/desktop/src/views/settings/SettingsWindowSession.ts
+++ b/apps/desktop/src/views/settings/SettingsWindowSession.ts
@@ -1,7 +1,12 @@
+import { getCurrentWindow } from "@tauri-apps/api/window"
+
 import {
   appInfo,
+  hasShell,
+  noteInteraction,
   onSessionsInvalidated,
   onSettingsPaneRequest,
+  onSettingsShown,
   takeSettingsPane,
   type AppInfo,
 } from "../../lib/ipc"
@@ -10,6 +15,7 @@ import { isSettingsPane, type SettingsPane } from "../../lib/settingsPanes"
 export type SettingsWindowSnapshot = {
   info: AppInfo | null
   pane: SettingsPane
+  visible: boolean
 }
 
 /**
@@ -27,10 +33,14 @@ export class SettingsWindowSession {
   private generation = 0
   private infoRevision = 0
   private paneEventRevision = 0
+  private visibilityRevision = 0
+  private paneResolved = false
+  private exposedPane: SettingsPane | null = null
   private stopInvalidationListening: (() => void) | null = null
   private stopPaneListening: (() => void) | null = null
+  private stopShownListening: (() => void) | null = null
 
-  private snapshot: SettingsWindowSnapshot = { info: null, pane: "general" }
+  private snapshot: SettingsWindowSnapshot = { info: null, pane: "general", visible: false }
 
   getSnapshot = (): SettingsWindowSnapshot => this.snapshot
 
@@ -45,12 +55,16 @@ export class SettingsWindowSession {
 
   /** The sidebar's `onChange`. */
   setPane = (pane: SettingsPane): void => {
-    this.update({ pane })
+    this.paneEventRevision += 1
+    this.paneResolved = true
+    this.selectVisiblePane(pane)
   }
 
   private start = async (): Promise<void> => {
     this.started = true
     const generation = ++this.generation
+    const paneEventRevision = this.paneEventRevision
+    document.addEventListener("visibilitychange", this.handleDocumentVisibility)
 
     this.refreshInfo(generation)
 
@@ -67,11 +81,41 @@ export class SettingsWindowSession {
       })
       .catch(() => {})
 
+    const stopShown = await onSettingsShown(() => {
+      if (generation !== this.generation) return
+      this.visibilityRevision += 1
+      this.markVisible()
+    }).catch(() => null)
+    if (generation !== this.generation) {
+      stopShown?.()
+      return
+    }
+    this.stopShownListening = stopShown
+
+    if (!hasShell()) {
+      this.markVisible()
+    }
+
+    const visibilityRevision = this.visibilityRevision
+    if (hasShell()) {
+      void Promise.resolve()
+        .then(() => getCurrentWindow().isVisible())
+        .then((visible) => {
+          if (generation !== this.generation || visibilityRevision !== this.visibilityRevision)
+            return
+          if (visible) this.markVisible()
+        })
+        .catch(() => {})
+    }
+
     const stop = await onSettingsPaneRequest((requested) => {
       if (generation !== this.generation) return
       this.paneEventRevision += 1
       void takeSettingsPane().catch(() => {})
-      if (isSettingsPane(requested)) this.update({ pane: requested })
+      if (isSettingsPane(requested)) {
+        this.paneResolved = true
+        this.selectVisiblePane(requested)
+      }
     }).catch(() => null)
     if (generation !== this.generation) {
       stop?.()
@@ -79,23 +123,31 @@ export class SettingsWindowSession {
     }
     this.stopPaneListening = stop
 
-    const paneEventRevision = this.paneEventRevision
     void takeSettingsPane()
       .then((requested) => {
         if (generation !== this.generation) return
         if (paneEventRevision !== this.paneEventRevision) return
-        if (isSettingsPane(requested)) this.update({ pane: requested })
+        this.paneResolved = true
+        this.selectVisiblePane(isSettingsPane(requested) ? requested : this.snapshot.pane)
       })
-      .catch(() => {})
+      .catch(() => {
+        if (generation !== this.generation) return
+        if (paneEventRevision !== this.paneEventRevision) return
+        this.paneResolved = true
+        this.selectVisiblePane(this.snapshot.pane)
+      })
   }
 
   private stop(): void {
     this.started = false
     this.generation += 1
+    document.removeEventListener("visibilitychange", this.handleDocumentVisibility)
     this.stopInvalidationListening?.()
     this.stopInvalidationListening = null
     this.stopPaneListening?.()
     this.stopPaneListening = null
+    this.stopShownListening?.()
+    this.stopShownListening = null
   }
 
   private refreshInfo(generation: number): void {
@@ -114,5 +166,26 @@ export class SettingsWindowSession {
   private update(change: Partial<SettingsWindowSnapshot>): void {
     this.snapshot = { ...this.snapshot, ...change }
     for (const listener of this.listeners) listener()
+  }
+
+  private selectVisiblePane(pane: SettingsPane): void {
+    if (pane !== this.snapshot.pane) this.update({ pane })
+    if (!this.started || !this.paneResolved || !this.snapshot.visible) return
+    if (pane === this.exposedPane) return
+    this.exposedPane = pane
+    noteInteraction({ kind: "settingsPaneViewed", pane })
+  }
+
+  private markVisible(): void {
+    if (this.snapshot.visible) return
+    this.exposedPane = null
+    this.update({ visible: true })
+    if (this.paneResolved) this.selectVisiblePane(this.snapshot.pane)
+  }
+
+  private handleDocumentVisibility = (): void => {
+    if (document.visibilityState !== "hidden" || !this.snapshot.visible) return
+    this.visibilityRevision += 1
+    this.update({ visible: false })
   }
 }

--- a/docs/analytics-measurement.md
+++ b/docs/analytics-measurement.md
@@ -2,21 +2,31 @@
 
 Audited on 2026-09-08 at `3ce2b1da`. This is a source audit, not an analysis of
 production event volumes. The collector, warehouse, release secrets, and live
-dashboards were not inspected. Proposed events below do not ship yet;
-[analytics.md](analytics.md) remains the catalog of implemented events.
+dashboards were not inspected. The findings below preserve the state at that
+revision. [analytics.md](analytics.md) is the catalog of implemented events.
 
-The current events establish that some installations run, complete setup, and
-open sessions. They cannot establish how often people deliberately use the app,
-which surfaces provide value, or whether a feature is unused because its data
-never loads. Add coverage around visible product outcomes before adding more
-background diagnostics.
+At the audited revision, events established that some installations ran,
+completed setup, and opened sessions. They could not establish how often people
+deliberately used the app, which surfaces provided value, or whether a feature
+was unused because its data never loaded.
 
-## Current coverage
+## Implementation status
 
-The closed catalog has nine events. Envelope fields provide event IDs, rotating
+Phase 1 is implemented in the current source. The closed catalog now records
+successful surface and Settings-pane visibility, visible surface outcomes,
+deliberately viewed provider states, and classified setup starts and
+completions. `no_credentials` is an accepted provider-state value but remains
+dormant because the current product boundary cannot prove it. The queue now
+wakes at a bounded depth and uses protected drain and retry delays. Phase 2 and
+Phase 3 remain proposals. Collector verification, production reports, and
+cohort review remain operational work.
+
+## Coverage at the audited revision
+
+The closed catalog had nine events. Envelope fields provided event IDs, rotating
 installation IDs, application analytics session IDs, capture and send times,
-app version, OS, and architecture. Properties are fixed labels and coarse
-buckets; the Claude diagnostic has nine additional optional fields.
+app version, OS, and architecture. Properties were fixed labels and coarse
+buckets; the Claude diagnostic had nine additional optional fields.
 
 | Current event                            | Actual trigger and dimensions                                                                                                                                      | What it answers and misses                                                                                                              |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -88,8 +98,8 @@ Documentation discrepancies found at the audit revision:
   includes the ID on disk. Public descriptions of inactivity also need to say
   analytics-event inactivity, not imply user inactivity.
 
-This documentation change corrects those disclosures. It does not describe the
-future engagement semantics below as current behavior.
+The foundation documentation change corrected those disclosures. The Phase 1
+implementation status is separate from these historical findings.
 
 ## Measurement definitions
 
@@ -99,7 +109,7 @@ user-agent, or device information to join rotations.
 
 | Question                                           | Definition after the first implementation phase                                                                                                                                                     | Decision supported                                               |
 | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Are people deliberately returning?                 | Daily/weekly distinct `anonymousId` with a user-initiated core `surface_viewed` event. Exclude setup, Settings-only visits, automatic restores, nudges merely appearing, and all background events. | Whether the core utility earns repeat attention.                 |
+| Are people deliberately returning?                 | Daily/weekly distinct `anonymousId` with a user-initiated core `surface_viewed` event or `settings_pane_viewed` for `insights`. Exclude setup, other Settings-only visits, automatic restores, nudges merely appearing, and all background events. | Whether the core utility earns repeat attention.                 |
 | Does setup lead to visible value?                  | Among distinct IDs completing a new setup flow, fraction that see a core surface with `ready` data within 24 hours of completion. Also report empty, error, and timeout outcomes.                   | Whether to improve setup or the first data experience.           |
 | Which features get used?                           | Distinct IDs viewing each core surface divided by engaged reporting IDs in the same interval and supporting versions/platforms. Separate ready-data reach from view reach.                          | Which surfaces merit investment or improved discovery.           |
 | Do users return after value?                       | Among IDs first reaching ready data after new setup, observed return on day 1 and day 7 using deliberate core views. Include only cohorts whose full observation window has elapsed.                | Whether activation translates into observed repeat use.          |
@@ -124,34 +134,36 @@ when constructing visits. Keep the existing wire `sessionId` unchanged initially
 and document its actual meaning. Do not infer attention duration from gaps.
 Neither tray visibility nor a persistent HUD proves that someone looked at it.
 
-## Proposed event additions
+## Event additions and proposals
 
-All names below use the `antiburn.` prefix. The listed dimensions are proposed
-closed vocabularies, not arbitrary strings or permission to upload payloads.
-Use event-specific Rust types even when serializing into existing `label`,
-`detail`, and `bucket` fields. Update disclosures for new meanings even when the
-wire field count stays unchanged.
+All names below use the `antiburn.` prefix. The Phase 1 dimensions are
+implemented closed vocabularies, not arbitrary strings or permission to upload
+payloads. Use event-specific Rust types even when serializing into existing
+`label`, `detail`, and `bucket` fields. Update disclosures for new meanings even
+when the wire field count stays unchanged.
 
-### Phase 1: visible use and value
+### Phase 1: visible use and value (implemented)
 
-| Proposed event/change                              | Trigger and safe dimensions                                                                                                                                                                                                              | Owner and volume rule                                                                                                                                                                                                                                                          |
+| Event/change                                       | Trigger and safe dimensions                                                                                                                                                                                                              | Owner and volume rule                                                                                                                                                                                                                                                          |
 | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `surface_viewed`                                   | Successful reveal or visible navigation. `label`: `activity`, `session_detail`, `provider_preview`, `checks_preview`, `hud`, `hud_detail`, or `settings`. `detail`: `user` or `automatic`.                                               | Shell visibility transition plus surface controllers. One per actual transition; no event for prewarm, repeated show requests, data refresh, or hidden navigation. Only deliberate transitions qualify as engagement.                                                          |
 | `settings_pane_viewed`                             | Requested pane is selected and visible. `label`: the eight existing Settings pane IDs.                                                                                                                                                   | `SettingsWindowSession`, including first opening and external pane requests. One per visible pane transition, with duplicate requests suppressed.                                                                                                                              |
 | `surface_state_observed`                           | Data state presented on a visible surface. Same surface vocabulary, plus `insights`; `detail`: `ready`, `empty`, `error`, or `loading_timeout`. Ready means a usable payload, not merely a mounted component or successful IPC response. | Surface controllers after both visibility and data readiness. At most once per distinct state per surface exposure; ignore stale asynchronous results. Use a documented 10-second visible initial-load timeout, canceled when hidden; later ready data can still emit `ready`. |
-| `live_usage_state_observed`                        | An enabled provider's state is presented on a visible usage surface. `label`: fixed supported provider category; `detail`: `fresh`, `stale`, `authentication`, `rate_limited`, `unavailable`, or `no_credentials`.                       | Map existing presentation states, without an analytics-only provider request. Deduplicate each provider/state within a deliberate visit. No account, plan name, balance, quota value, or raw response.                                                                         |
-| `onboarding_started`, extend `onboarding_finished` | Start and committed completion of a setup flow. `label`: `new` or `restart`.                                                                                                                                                             | Explicit onboarding lifecycle and finish command. One start/completion per flow. Preserve the four existing step events; do not call closing the window an abandonment event.                                                                                                  |
+| `live_usage_state_observed`                        | A provider state is presented on Activity, a provider preview, or a user-opened HUD. `label`: `anthropic`, `openai`, or `google`; `detail`: `fresh`, `stale`, `authentication`, `rate_limited`, `unavailable`, or `no_credentials`. | Map existing presentation states, without an analytics-only provider request. Deduplicate each provider/state within a deliberate visit. `no_credentials` remains dormant. No account, plan name, balance, quota value, or raw response.                                       |
+| `onboarding_started`, extend `onboarding_finished` | Visible start or resume and committed completion of a setup flow. `label`: `new` or `restart`.                                                                                                                                           | Emit a start on the first visible start or resume in each app process. A quit and later resume emits another start with the persisted classification. Emit completion once per pending-to-complete transition. Preserve the four existing step events.                           |
 
 `surface_state_observed` also needs a closed `properties.origin` value of `user`
-or `automatic`, inherited from its exposure. This proposed optional wire field
-lets reports separate deliberate value from passive display without guessing
-from neighboring timestamps. Update the field-count tests and all affected
-disclosures when adding it. Keep the field absent on unrelated events.
+or `automatic`, inherited from its exposure. This optional wire field lets
+reports separate deliberate value from passive display without guessing from
+neighboring timestamps. It stays absent on unrelated events.
 
 Define the start classification from the explicit restart path and existing
 onboarding state, not from whether the analytics identifier has been seen.
 Analyze setup progress by distinct installation and ordered times; repeated
-flows in one observation window are not independent new installations.
+flows in one observation window are not independent new installations. Earlier
+`onboarding_finished` events have no classification label. Exclude those legacy
+events from new-versus-restart cohorts instead of treating a missing label as
+`new`.
 
 Keep `session_opened` as the existing activity-card intent event. Pair it with
 visible session detail and data state for the activation funnel. Record visible
@@ -200,13 +212,13 @@ or events per poll, transcript record, chart hover, scroll tick, or token update
 Give temporary diagnostics, including the Claude reset probe, an owner and
 review date so experiments do not become permanent noise or provider traffic.
 
-Before expanding volume, simulate normal repeated visits, preview use, and an
-offline backlog against the 50-event drain and 500-row queue. If that workload
-exceeds capacity, implement bounded queue-depth-triggered draining with retry
-backoff and a request budget. Preserve the opt-out recheck before each request
-and silent failure. Do not merely increase queue size or add a blocking exit
-flush. Monitor delivery lag, duplicate message IDs, rejection counts, and event
-mix in the collector separately from product engagement.
+Phase 1 adds bounded queue-depth-triggered draining, protected retry backoff, and
+a request budget. Before expanding volume further, simulate normal repeated
+visits, preview use, and an offline backlog against the 50-event drain and
+500-row queue. Preserve the opt-out recheck before each request and silent
+failure. Do not merely increase queue size or add a blocking exit flush. Monitor
+delivery lag, duplicate message IDs, rejection counts, and event mix in the
+collector separately from product engagement.
 
 ## Event review contract
 
@@ -243,12 +255,13 @@ merely requires an analytics file to change in every feature PR.
 
 ## Delivery sequence and acceptance
 
-1. Establish baseline collector queries for the nine current events, by version.
+1. The source now contains the disclosure corrections, Phase 1 events, and
+   bounded delivery changes. Establish baseline collector queries by app version.
    Verify configured release ingestion, retry deduplication, and delivery delay.
    Do not claim production behavior from source alone.
-2. Ship Phase 1 with a loopback recording of setup → activity → preview → session
-   detail → Settings Insights → return visit. Also exercise empty/error data,
-   hidden prewarm, renderer recreation, automatic HUD restore, and opt-out.
+2. Verify Phase 1 with a loopback recording of setup → activity → preview →
+   session detail → Settings Insights → return visit. Also exercise empty/error
+   data, hidden prewarm, renderer recreation, automatic HUD restore, and opt-out.
    Assert the expected sequence and absence of duplicate use events.
 3. Build engagement, activation, feature reach, observed day-1/day-7 return, and
    visible reliability reports using the definitions above. Show reporting
@@ -257,6 +270,7 @@ merely requires an analytics file to change in every feature PR.
    Phase 2 actions based on observed gaps. Assign each report and diagnostic a
    maintainer; review whether its events still support an actual decision.
 
-This audit changes documentation, current public disclosures, and contributor
-expectations only. Runtime instrumentation, collector configuration, dashboards,
-and disclosures for proposed events remain implementation work described above.
+The historical audit changed documentation, current public disclosures, and
+contributor expectations. Phase 1 now adds runtime instrumentation and bounded
+delivery behavior. Collector configuration, dashboards, and Phase 2 and Phase 3
+implementation remain work described above.

--- a/docs/analytics-measurement.md
+++ b/docs/analytics-measurement.md
@@ -1,0 +1,262 @@
+# Product analytics audit and measurement plan
+
+Audited on 2026-09-08 at `3ce2b1da`. This is a source audit, not an analysis of
+production event volumes. The collector, warehouse, release secrets, and live
+dashboards were not inspected. Proposed events below do not ship yet;
+[analytics.md](analytics.md) remains the catalog of implemented events.
+
+The current events establish that some installations run, complete setup, and
+open sessions. They cannot establish how often people deliberately use the app,
+which surfaces provide value, or whether a feature is unused because its data
+never loads. Add coverage around visible product outcomes before adding more
+background diagnostics.
+
+## Current coverage
+
+The closed catalog has nine events. Envelope fields provide event IDs, rotating
+installation IDs, application analytics session IDs, capture and send times,
+app version, OS, and architecture. Properties are fixed labels and coarse
+buckets; the Claude diagnostic has nine additional optional fields.
+
+| Current event                            | Actual trigger and dimensions                                                                                                                                      | What it answers and misses                                                                                                              |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `antiburn.app_launched`                  | Shell setup; no event-specific properties.                                                                                                                         | Reports launches, including unattended startup. Does not measure visits, continued use, or a new installation.                          |
+| `antiburn.onboarding_step_viewed`        | `OnboardingSession.noteOnboardingStep`; four fixed steps, once per step per flow instance.                                                                         | Shows setup progress. Has no new-versus-restarted flow distinction or failure reason.                                                   |
+| `antiburn.onboarding_finished`           | After the finish command saves settings. Explicit setup restarts can emit another completion.                                                                      | Shows completed setup, not first useful data or unique new installations.                                                               |
+| `antiburn.scan_completed`                | Full discovery pass; first outcome or changed count bucket relative to the previous reported outcome. Scoped passes emit nothing.                                  | Shows coarse discovery health and inventory. Is not an interaction or a scan-attempt counter.                                           |
+| `antiburn.setting_toggled`               | Saved changes to `live_usage`, `notifications`, `launch_at_login`, or `discovery_paused`; key only.                                                                | Shows use of four controls. Does not show direction, current adoption, other settings, or success of OS integration.                    |
+| `antiburn.session_opened`                | Activity-card handler before analysis loads; agent category and native/WSL.                                                                                        | Measures list-to-detail intent. Does not establish that detail loaded, or cover related sessions, subagents, or newer/older navigation. |
+| `antiburn.error_occurred`                | Full scan failure, with `scan_failed`; repeated identical outcomes suppressed.                                                                                     | Shows some discovery failures. Misses scoped failures and other feature failures; cannot supply an operation failure rate.              |
+| `antiburn.unrecognized_records_observed` | Nonempty unknown-record summary returned to Settings Insights; changed category/count bucket within the process. Clean results reset suppression without an event. | Diagnoses reader-selected cohorts. Does not count all Insights visits or population parser failure rates.                               |
+| `antiburn.claude_limit_reset_observed`   | Changed Claude reset diagnostic after normal usage refresh, with a separate five-minute cooldown and additional enablement gates.                                  | Answers a narrow provider experiment question. Does not establish that anyone viewed usage or used a reset.                             |
+
+Evidence: [event schema](../apps/desktop/src-tauri/src/analytics/event.rs),
+[recording and delivery](../apps/desktop/src-tauri/src/analytics/mod.rs),
+[shell commands](../apps/desktop/src-tauri/src/commands.rs),
+[launch](../apps/desktop/src-tauri/src/lib.rs),
+[scan scope](../apps/desktop/src-tauri/src/scan/mod.rs),
+[onboarding](../apps/desktop/src/views/onboarding/OnboardingSession.ts), and
+[activity-card handler](../apps/desktop/src/views/PopoverView.tsx).
+
+## Findings, in priority order
+
+1. **There is no deliberate-use denominator.** Popover reveals, Settings pane
+   views, provider/check previews, and HUD detail views are absent. A person
+   reading the tray meter can get value without any recorded interaction. A
+   person opening the popover daily without a session-card click is also almost
+   invisible. Do not equate background operation with engagement.
+2. **Intent has almost no outcome coverage.** Session-card clicks precede
+   analysis. There is no general distinction between useful data, empty data,
+   loading that stalls, and a failed view. Live provider failures, source access
+   trouble, and analysis failures can make a feature appear simply unwanted.
+3. **The analytics session is an event-activity window.** Every queued event
+   calls `current_session_id`, including background scans and diagnostics.
+   Background changes can keep it alive; silence can split one process run.
+   Neither its count nor its first-to-last timestamp measures engaged visits or
+   time spent. Adding events would change these measures again.
+4. **Feature adoption and intervention results are missing.** HUD enablement,
+   notification actions, source setup, report refresh, session actions, and
+   update actions have no complete measurement. Four setting keys without
+   direction cannot show enablement or abandonment. A saved preference also
+   does not prove that the corresponding feature works.
+5. **More events can expose delivery limits.** The queue keeps the newest 500
+   rows. After a 60-second initial delay, a flush sends up to 50 sequential
+   requests, then waits 15 minutes. Healthy sustained capacity is approximately
+   200 events/hour, less when requests are slow. One failed request stops a
+   drain; five failed attempts discard its row. Short-lived installs can leave
+   events queued until a later launch, and overflow drops earlier funnel steps.
+   Increased volume needs a delivery load test, not just more call sites.
+6. **Documentation and tests do not fully enforce semantics.** The catalog test
+   checks that event names occur in the document; it does not validate trigger
+   behavior, property vocabularies, or whether new features have coverage.
+   `Facts` uses static strings, not event-specific property enums. The renderer
+   IPC is more restrictive, but TypeScript still accepts any string for agent.
+   Default Cargo tests exclude most analytics tests; CI does run the enabled
+   suite on Linux.
+
+Documentation discrepancies found at the audit revision:
+
+- `CONTRIBUTING.md` said analytics waits until onboarding completes, whereas
+  `allowed` has no onboarding gate. This audit corrects the contributor text to
+  match the implementation and public policy.
+- The public scan row says exact count changes and once-a-minute visible scans.
+  The code uses count buckets from full passes; it runs full reconciliation
+  about every five minutes, while watcher-driven scoped passes emit no scan
+  analytics.
+- Public identifier descriptions say `sessionId` is never written to disk. Its
+  live generator state is memory-only, but each serialized queued payload
+  includes the ID on disk. Public descriptions of inactivity also need to say
+  analytics-event inactivity, not imply user inactivity.
+
+This documentation change corrects those disclosures. It does not describe the
+future engagement semantics below as current behavior.
+
+## Measurement definitions
+
+Use reporting installations, not people. Installation IDs rotate after 30 days
+and reset after opt-out/re-enable. Do not add a stable identifier or use IP,
+user-agent, or device information to join rotations.
+
+| Question                                           | Definition after the first implementation phase                                                                                                                                                     | Decision supported                                               |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Are people deliberately returning?                 | Daily/weekly distinct `anonymousId` with a user-initiated core `surface_viewed` event. Exclude setup, Settings-only visits, automatic restores, nudges merely appearing, and all background events. | Whether the core utility earns repeat attention.                 |
+| Does setup lead to visible value?                  | Among distinct IDs completing a new setup flow, fraction that see a core surface with `ready` data within 24 hours of completion. Also report empty, error, and timeout outcomes.                   | Whether to improve setup or the first data experience.           |
+| Which features get used?                           | Distinct IDs viewing each core surface divided by engaged reporting IDs in the same interval and supporting versions/platforms. Separate ready-data reach from view reach.                          | Which surfaces merit investment or improved discovery.           |
+| Do users return after value?                       | Among IDs first reaching ready data after new setup, observed return on day 1 and day 7 using deliberate core views. Include only cohorts whose full observation window has elapsed.                | Whether activation translates into observed repeat use.          |
+| Where does the experience fail?                    | Per surface, fraction of reporting exposed IDs with empty, error, or loading-timeout states. For explicit operations, compare terminal outcomes with attempts separately.                           | Which reliability issues block adoption.                         |
+| Does passive monitoring remain enabled and useful? | Report HUD/meter enablement, successful automatic exposure, data availability, and deliberate detail use separately.                                                                                | Whether passive display features are configured and functioning. |
+
+Use capture time for behavior, deduplicate retries by `messageId`, and allow a
+documented late-arrival window before finalizing cohorts. Segment by app version
+and OS so older builds and unsupported features do not enter new-event
+denominators. Installation rotation and missing delivery bias retention
+downward; a first-seen ID is not necessarily a new install. Opted-out and
+unconfigured builds are unobserved, so analytics cannot establish total users,
+opt-out rates, uninstalls, or precise long-term retention.
+
+For activation and return cohorts, require ready data on a user-initiated
+exposure. Automatic HUD restoration can establish that the display works, but
+does not establish that the user has reached value through deliberate use.
+
+For visit frequency, group only deliberate interaction events by installation
+with a documented 30-minute inactivity gap in analysis. Ignore background events
+when constructing visits. Keep the existing wire `sessionId` unchanged initially
+and document its actual meaning. Do not infer attention duration from gaps.
+Neither tray visibility nor a persistent HUD proves that someone looked at it.
+
+## Proposed event additions
+
+All names below use the `antiburn.` prefix. The listed dimensions are proposed
+closed vocabularies, not arbitrary strings or permission to upload payloads.
+Use event-specific Rust types even when serializing into existing `label`,
+`detail`, and `bucket` fields. Update disclosures for new meanings even when the
+wire field count stays unchanged.
+
+### Phase 1: visible use and value
+
+| Proposed event/change                              | Trigger and safe dimensions                                                                                                                                                                                                              | Owner and volume rule                                                                                                                                                                                                                                                          |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `surface_viewed`                                   | Successful reveal or visible navigation. `label`: `activity`, `session_detail`, `provider_preview`, `checks_preview`, `hud`, `hud_detail`, or `settings`. `detail`: `user` or `automatic`.                                               | Shell visibility transition plus surface controllers. One per actual transition; no event for prewarm, repeated show requests, data refresh, or hidden navigation. Only deliberate transitions qualify as engagement.                                                          |
+| `settings_pane_viewed`                             | Requested pane is selected and visible. `label`: the eight existing Settings pane IDs.                                                                                                                                                   | `SettingsWindowSession`, including first opening and external pane requests. One per visible pane transition, with duplicate requests suppressed.                                                                                                                              |
+| `surface_state_observed`                           | Data state presented on a visible surface. Same surface vocabulary, plus `insights`; `detail`: `ready`, `empty`, `error`, or `loading_timeout`. Ready means a usable payload, not merely a mounted component or successful IPC response. | Surface controllers after both visibility and data readiness. At most once per distinct state per surface exposure; ignore stale asynchronous results. Use a documented 10-second visible initial-load timeout, canceled when hidden; later ready data can still emit `ready`. |
+| `live_usage_state_observed`                        | An enabled provider's state is presented on a visible usage surface. `label`: fixed supported provider category; `detail`: `fresh`, `stale`, `authentication`, `rate_limited`, `unavailable`, or `no_credentials`.                       | Map existing presentation states, without an analytics-only provider request. Deduplicate each provider/state within a deliberate visit. No account, plan name, balance, quota value, or raw response.                                                                         |
+| `onboarding_started`, extend `onboarding_finished` | Start and committed completion of a setup flow. `label`: `new` or `restart`.                                                                                                                                                             | Explicit onboarding lifecycle and finish command. One start/completion per flow. Preserve the four existing step events; do not call closing the window an abandonment event.                                                                                                  |
+
+`surface_state_observed` also needs a closed `properties.origin` value of `user`
+or `automatic`, inherited from its exposure. This proposed optional wire field
+lets reports separate deliberate value from passive display without guessing
+from neighboring timestamps. Update the field-count tests and all affected
+disclosures when adding it. Keep the field absent on unrelated events.
+
+Define the start classification from the explicit restart path and existing
+onboarding state, not from whether the analytics identifier has been seen.
+Analyze setup progress by distinct installation and ordered times; repeated
+flows in one observation window are not independent new installations.
+
+Keep `session_opened` as the existing activity-card intent event. Pair it with
+visible session detail and data state for the activation funnel. Record visible
+detail navigation from related sessions and subagents without transmitting a
+session ID or title. Cached ready data counts when actually shown; a background
+cache refresh does not count as a view.
+
+The existing seams are
+[popover reveal/hide](../apps/desktop/src-tauri/src/popover.rs),
+[popover data and navigation](../apps/desktop/src/views/popover/PopoverSession.ts),
+[preview controller](../apps/desktop/src/views/popover/PopoverPeekController.ts),
+[Settings navigation](../apps/desktop/src/views/settings/SettingsWindowSession.ts),
+[Insights controller](../apps/desktop/src/views/settings/InsightsSession.ts), and
+[HUD controller](../apps/desktop/src/views/overlay/OverlaySession.ts).
+Carry an internal exposure generation through readiness and loading callbacks
+to reject duplicates and stale results. It need not leave the process.
+
+### Phase 2: adoption and actions
+
+| Proposed event                                | Trigger and safe dimensions                                                                                                                                                                                                                                                                                                            | Owner and volume rule                                                                                                                                                                                                                         |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setting_changed`                             | Successfully saved change; allowlist product toggles such as live usage, notifications, discovery, launch at login, and HUD enablement. Fixed `enabled`/`disabled` state.                                                                                                                                                              | The relevant persistence boundary. Emit only an actual transition. Keep existing `setting_toggled` semantics stable while migrating dashboards; do not count both as separate actions.                                                        |
+| `action_requested`, `action_completed`        | A deliberate operation starts, then reaches success, failure, or cancellation. Initial action vocabulary: manual scan, report refresh, source add/remove, source permission request, reveal source, diagnostics export, delete local session data, and clear local index. `detail` on completion: `success`, `failed`, or `cancelled`. | UI handler owns intent; operation boundary owns outcome. One pair per explicit attempt; automatic retries remain one attempt. Do not send action arguments, file paths, exported data, or exact deletion counts.                              |
+| `notification_shown`, `notification_actioned` | Actual display and explicit action; fixed notification kind and action vocabulary.                                                                                                                                                                                                                                                     | Nudge lifecycle after display succeeds, not when delivery is requested. Suppress duplicate display callbacks; separate test/location nudges from product alerts. Never send message text, actor, provider account, or usage milestone values. |
+| `update_action_completed`                     | User-requested check, installation, or restart request reaches its known result; fixed action and outcome.                                                                                                                                                                                                                             | Update controller. Do not treat a restart request as verified installation; confirm running versions through later launch events. Suppress background polling and progress callbacks.                                                         |
+
+The setting values and additional provider categories expand today's disclosure;
+update it before shipping. Do not report analytics opt-out after withdrawal or
+send a settings snapshot. Change events establish adoption among observed
+changers, not prevalence across all installs. Use observed HUD exposure for
+existing adopters; add a narrowly scoped state observation only if a specific
+prevalence question still cannot be answered.
+
+For operation success rates, correlate each attempt locally and emit exactly
+one terminal outcome. Compare aggregate counts only after allowing in-flight
+attempts and late delivery to settle. Process exits can leave unmatched
+attempts; expose that category instead of treating every missing completion as
+failure. Do not introduce persistent operation or work identifiers.
+
+### Phase 3: targeted diagnostics and measurement quality
+
+Add scoped scan, analysis, storage, or provider diagnostics only for a named
+reliability question that visible-state events cannot answer. Use fixed error
+categories and changed-state suppression. Do not add an unconditional heartbeat
+or events per poll, transcript record, chart hover, scroll tick, or token update.
+Give temporary diagnostics, including the Claude reset probe, an owner and
+review date so experiments do not become permanent noise or provider traffic.
+
+Before expanding volume, simulate normal repeated visits, preview use, and an
+offline backlog against the 50-event drain and 500-row queue. If that workload
+exceeds capacity, implement bounded queue-depth-triggered draining with retry
+backoff and a request budget. Preserve the opt-out recheck before each request
+and silent failure. Do not merely increase queue size or add a blocking exit
+flush. Monitor delivery lag, duplicate message IDs, rejection counts, and event
+mix in the collector separately from product engagement.
+
+## Event review contract
+
+Every added or changed event must document:
+
+1. The product question, intended metric, denominator, and decision it supports.
+2. The exact trigger and owning boundary, including whether it records intent,
+   visibility, a completed outcome, or background health.
+3. Every allowed property and value, serialization shape, and exclusion of
+   user/work identifiers and content. Do not pass DTOs directly to analytics.
+4. Duplicate suppression, cancellation, hidden-window behavior, retries,
+   automatic restores, and expected maximum volume for the measured flow.
+5. The public catalog/disclosure changes and the app-version boundary when
+   semantics change. Do not silently reuse an event name for a new meaning.
+6. Validation of the actual product path, not just a call to the tracker.
+
+Feature work must answer this contract with existing coverage, added coverage,
+or a concrete reason measurement is unnecessary. The goal is sufficient
+coverage to make decisions, not a fixed event count per pull request.
+
+Tests should prove that the user action produces the expected event, a failed
+operation cannot emit success, and remounts, prewarm, refreshes, and duplicate
+callbacks do not invent use. Exercise canceled and stale requests where the
+flow has them. Validate exact allowed wire properties and rejected unknown
+values at the Rust boundary. Verify opt-out, environment disablement, absent
+configuration, and queue/retry bounds when those paths change. Keep tests in
+the enabled-feature suite as well as relevant frontend tests.
+
+Strengthen the catalog check in a follow-up: use event-specific property enums
+and a machine-readable schema to validate exact names and values against the
+public catalog. A schema check cannot establish that a view was truly visible;
+behavior tests and PR review still own that requirement. Avoid a CI rule that
+merely requires an analytics file to change in every feature PR.
+
+## Delivery sequence and acceptance
+
+1. Establish baseline collector queries for the nine current events, by version.
+   Verify configured release ingestion, retry deduplication, and delivery delay.
+   Do not claim production behavior from source alone.
+2. Ship Phase 1 with a loopback recording of setup → activity → preview → session
+   detail → Settings Insights → return visit. Also exercise empty/error data,
+   hidden prewarm, renderer recreation, automatic HUD restore, and opt-out.
+   Assert the expected sequence and absence of duplicate use events.
+3. Build engagement, activation, feature reach, observed day-1/day-7 return, and
+   visible reliability reports using the definitions above. Show reporting
+   installation counts and observation limits alongside percentages.
+4. Review at least two complete weeks of supported-version cohorts, then choose
+   Phase 2 actions based on observed gaps. Assign each report and diagnostic a
+   maintainer; review whether its events still support an actual decision.
+
+This audit changes documentation, current public disclosures, and contributor
+expectations only. Runtime instrumentation, collector configuration, dashboards,
+and disclosures for proposed events remain implementation work described above.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -26,7 +26,7 @@ process-level opt-out.
 
 ## Exactly what the event schema can carry
 
-Twenty-two fields, and this is the whole list. Thirteen are the established
+Twenty-three fields, and this is the whole list. Fourteen are the established
 event envelope and general properties. The nine Claude reset fields are optional
 and appear only on `antiburn.claude_limit_reset_observed`. The payload is a closed Rust struct
 ([`analytics/event.rs`](../apps/desktop/src-tauri/src/analytics/event.rs))
@@ -38,14 +38,15 @@ be put.
 | `platform`           | Constant. The surface class the collector partitions on.                                                                                                   | `desktop`                 |
 | `messageId`          | Random per-event id, so a redelivered event is not counted twice.                                                                                          | `9f2c…`                   |
 | `anonymousId`        | The rotating installation identifier.                                                                                                                      | `4b81…`                   |
-| `sessionId`          | Groups a window of captured analytics events. Its generator is held in memory, but the value is written into each event queued on disk. Replaced after 30 minutes without a captured analytics event and whenever antiburn restarts. | `7d10…`                   |
+| `sessionId`          | Groups a window of captured analytics events. Its generator is held in memory, but the value is written into each event queued on disk. Replaced after 30 minutes without a captured analytics event, whenever antiburn restarts, and when the installation identifier rotates. | `7d10…`                   |
 | `event`              | The event name, from the closed catalog below.                                                                                                             | `antiburn.scan_completed` |
 | `originalTimestamp`  | When it happened, UTC.                                                                                                                                     | `2026-08-19T09:14:02Z`    |
 | `sentAt`             | When it was delivered. Added at send, not at capture.                                                                                                      | `2026-08-19T09:15:02Z`    |
 | `properties.arch`    | CPU architecture.                                                                                                                                          | `aarch64`                 |
 | `properties.bucket`  | A count rounded into a range. Never exact.                                                                                                                 | `10-49`                   |
-| `properties.label`   | A key from a closed vocabulary — which setting changed, which agent's session was opened, or which kind of failure. Never the value.                       | `live_usage`              |
-| `properties.detail`  | A second value from a closed vocabulary, where one event has two things worth telling apart.                                                               | `native`                  |
+| `properties.label`   | A key from a closed vocabulary — which surface, Settings pane, provider, setting, agent category, or failure category. Never work content or a user-selected value. | `activity`                |
+| `properties.detail`  | A second value from a closed vocabulary, such as a visible state, `user` or `automatic` origin, or `native` versus `wsl`.                                   | `ready`                   |
+| `properties.origin`  | Whether a state appeared after a `user` or `automatic` exposure. Optional and present only on `antiburn.surface_state_observed`.                             | `user`                    |
 | `properties.usageBand` | Claude's five-hour usage from the same reset-check response: `below_80`, `80_to_under_100`, `at_limit`, or `unknown`. | `80_to_under_100` |
 | `properties.responseShape` | Whether `juniper_tide` was an `object`, `missing`, `null`, or `malformed`; also `invalid_json`, `malformed_envelope`, `not_received`, `unreadable`, or `not_requested` for request and envelope outcomes. | `object` |
 | `properties.eligibility` | Claude's `eligible` boolean as `eligible` or `ineligible`, or `missing`, `null`, or `malformed`. | `eligible` |
@@ -75,8 +76,9 @@ The receiving server's contract requires both, and they are not equally
 durable. `anonymousId` is stored on disk and lasts up to 30 days. The live
 `sessionId` generator exists only in memory. Each serialized event also contains
 its `sessionId`, so a queued event keeps that value on disk until it is sent or
-removed. Restarting antiburn creates a new value for newly captured events;
-events already in the queue keep their original value.
+removed. Restarting antiburn or rotating the installation identifier creates a
+new value for newly captured events. Events already in the queue keep their
+original value.
 
 ### Agent and provider categories
 
@@ -86,9 +88,11 @@ antiburn knows how to read. Nothing else about the session travels with it: not
 its title, not its repository, not its path, and not the name of your WSL
 distribution, which you chose and which would identify your machine.
 
-The Claude reset event also reveals that this provider is enabled. These are the
-only analytics fields that identify an agent or provider category. If that is
-more than you want to share, the switch turns all analytics off.
+`antiburn.live_usage_state_observed` carries one of three provider categories:
+`anthropic`, `openai`, or `google`. The Claude reset event also reveals that
+Claude is enabled. These are the only analytics fields that identify an agent or
+provider category. If that is more than you want to share, the switch turns all
+analytics off.
 
 ### Why counts are bucketed
 
@@ -116,16 +120,21 @@ Event names are namespaced `antiburn.*`.
 | Event                          | When it fires                                                                                                                                                                                               | Carries                                                                                                                                                                                                     |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `antiburn.app_launched`        | The application starts.                                                                                                                                                                                     | —                                                                                                                                                                                                           |
-| `antiburn.onboarding_finished` | A setup flow completes, including an explicitly restarted flow.                                                                                                                                             | —                                                                                                                                                                                                           |
-| `antiburn.onboarding_step_viewed` | A fixed first-run step becomes visible. Each step is recorded at most once per onboarding flow. | `label` — one of `welcome`, `agents_detected`, `sources_and_repos`, `ready`. |
+| `antiburn.onboarding_started`  | A new, restarted, or resumed incomplete setup flow first becomes visible in an app process. A quit and later resume can report another start.                                                                                                                             | `label` — `new` or `restart`, preserved when an incomplete flow resumes.                                                                                                                                    |
+| `antiburn.onboarding_finished` | A pending setup flow commits its settings and completes. Reported once per pending-to-complete transition.                                                                                                                                                                | `label` — `new` or `restart`. Earlier app versions sent no label; a missing label must not be treated as `new`.                                                                                              |
+| `antiburn.onboarding_step_viewed` | A fixed setup step becomes visible. Each step is recorded at most once per onboarding flow. | `label` — one of `welcome`, `agents_detected`, `sources_and_repos`, `ready`. |
 | `antiburn.scan_completed`      | A full discovery pass finishes and its session-count bucket differs from the previous reported outcome. The first full pass in a run is reported. Automatic full reconciliation runs at startup and about every five minutes; file watchers usually cause scoped passes, which emit no scan analytics. | `bucket` — how many sessions                                                                                                                                                                                |
 | `antiburn.setting_toggled`     | A preference changes.                                                                                                                                                                                       | `label` — one of `live_usage`, `notifications`, `launch_at_login`, `discovery_paused`. The key only; never the value.                                                                                       |
 | `antiburn.session_opened`      | You open a session from the activity list.                                                                                                                                                                  | `label` — which agent recorded it, from the fixed list antiburn supports. `detail` — `native` or `wsl`. **Not** the session, its title, its repository, or the name of your WSL distribution.               |
+| `antiburn.surface_viewed`      | A native product surface becomes visible after a successful show or navigation transition. Prewarming, refreshes, remounts, resizes, and repeated show requests emit nothing.                                                                                              | `label` — `activity`, `session_detail`, `provider_preview`, `checks_preview`, `hud`, `hud_detail`, or `settings`. `detail` — `user` or `automatic`.                                                          |
+| `antiburn.settings_pane_viewed` | A Settings pane is selected and visible. Repeating the current pane emits nothing. A direct pane link reports only the resulting pane.                                                                                                                                    | `label` — `general`, `appearance`, `sources`, `privacy`, `notifications`, `usage`, `insights`, or `about`.                                                                                                  |
+| `antiburn.surface_state_observed` | A `ready`, `empty`, `error`, or ten-second visible `loading_timeout` state is presented on a visible surface. Each distinct state is reported at most once per exposure; a later `ready` state can follow a timeout.                                                        | `label` — the `surface_viewed` surface list plus `insights`. `detail` — `ready`, `empty`, `error`, or `loading_timeout`. `origin` — `user` or `automatic`.                                                    |
+| `antiburn.live_usage_state_observed` | A provider state is presented on Activity, in a provider preview, or in a user-opened HUD. Automatic HUD restoration emits nothing.                                                                                                                                     | `label` — `anthropic`, `openai`, or `google`. `detail` — `fresh`, `stale`, `authentication`, `rate_limited`, `unavailable`, or `no_credentials`. The last value is reserved but no current call site emits it. |
 | `antiburn.error_occurred`      | A full discovery pass fails, and the previous full pass had not already reported the same failure.                                                                                                          | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                           |
 | `antiburn.unrecognized_records_observed` | Settings → Insights returns a cohort containing unknown record vocabulary, and its outcome differs from the last one reported during this run. | `bucket` — sessions containing unknown types. `label` — `inert_only`, `inert_capped`, or `evidence_bearing`. No discriminator, payload, session identifier, or second dimension. |
 | `antiburn.claude_limit_reset_observed` | After an ordinary Claude usage refresh, when analytics and Claude live usage are both enabled and the observation differs from the last one queued during this run. The probe uses a separate five-minute cooldown. | `label` — `success`, `authentication`, `rateLimited`, `unavailable`, `credential_absent`, `credential_expired`, or `credential_unavailable`. The nine reset fields listed above. No response body, credential, account identifier, exact usage percentage, or date. |
 
-Four of those are deliberately not sent once per occurrence. A full scan result
+Several events are deliberately not sent once per occurrence. A full scan result
 that repeats the last bucket is dropped, so a machine left running does not
 report the same range after every reconciliation and a machine stuck failing
 does not report the same failure after every full pass. What survives is the
@@ -135,6 +144,22 @@ change this comparison. The unrecognized-record event likewise reports only a
 changed `(label, bucket)` outcome. A clean cohort updates that in-memory
 comparison without sending an event, so a later return to unknown vocabulary is
 visible.
+
+Visible-use events start only after native visibility succeeds. A surface state
+is reported at most once per distinct state in one exposure, and hidden or stale
+asynchronous results emit nothing. The ten-second loading timeout runs only
+while the surface is visible. Settings and its selected pane establish the
+Insights exposure, so `settings_pane_viewed` with `insights` qualifies as
+deliberate core use and `surface_state_observed` records its result. Insights
+emits no separate `surface_viewed` event. Other Settings-only visits remain
+outside the return-use denominator.
+
+Provider states are reported only on Activity and for deliberate provider
+previews and user-opened HUD exposures. The renderer suppresses duplicate
+provider states in an exposure, and the shell suppresses the same provider and
+state within a bounded 30-minute deliberate visit.
+`no_credentials` is part of the closed schema but remains dormant until a
+product boundary can prove that state.
 
 The Claude limit-reset event reports the first observation in a run and then
 only a changed observation. It calls the same provider usage endpoint through a
@@ -207,7 +232,17 @@ ANTIBURN_ANALYTICS_OPERATOR="Local development" \
 pnpm tauri dev --features analytics --config src-tauri/tauri.debug.conf.json
 ```
 
-The first delivery is a minute after launch, then every fifteen minutes.
+An empty queue makes no periodic network request. The first queued event starts
+a one-minute delivery timer; later arrivals do not move it. Reaching 50 queued
+events makes delivery due immediately. A pass sends at most 50 requests. If
+rows remain after a successful pass, the next pass waits a protected minute.
+
+A failed request stops the pass and retries after 1, 2, 4, 8, then at most 15
+minutes. Five failed attempts discard a row. The queue keeps the newest 500
+rows. Consent is checked before every request. If consent, configuration, or the
+store cannot be read while a backlog remains, no request is sent and another
+check is scheduled after 15 minutes. Opt-out clears the queue and delivery
+parks.
 
 **Read the queue on disk.** Nothing is hidden from you; the events wait in the
 app's own database:

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -38,7 +38,7 @@ be put.
 | `platform`           | Constant. The surface class the collector partitions on.                                                                                                   | `desktop`                 |
 | `messageId`          | Random per-event id, so a redelivered event is not counted twice.                                                                                          | `9f2c…`                   |
 | `anonymousId`        | The rotating installation identifier.                                                                                                                      | `4b81…`                   |
-| `sessionId`          | Identifies one run of the application. Held in memory only, never written to disk, replaced after 30 minutes of inactivity and whenever antiburn restarts. | `7d10…`                   |
+| `sessionId`          | Groups a window of captured analytics events. Its generator is held in memory, but the value is written into each event queued on disk. Replaced after 30 minutes without a captured analytics event and whenever antiburn restarts. | `7d10…`                   |
 | `event`              | The event name, from the closed catalog below.                                                                                                             | `antiburn.scan_completed` |
 | `originalTimestamp`  | When it happened, UTC.                                                                                                                                     | `2026-08-19T09:14:02Z`    |
 | `sentAt`             | When it was delivered. Added at send, not at capture.                                                                                                      | `2026-08-19T09:15:02Z`    |
@@ -61,19 +61,22 @@ be put.
 ### What the two timestamps make possible
 
 Each event is timestamped and the installation identifier lasts up to 30 days,
-so these events show roughly **when** antiburn is used within that window. The
-`sessionId` additionally groups the events of a single run together, so a run
-can be seen as one visit rather than as scattered events. Neither can show what
-antiburn was used _on_. This is stated because an enumeration that lists fields
-without saying what they enable is not really an enumeration.
+so these events show roughly **when events were captured** within that window.
+The `sessionId` groups captured events separated by less than 30 minutes of
+analytics-event inactivity. Background events can keep it active, and a quiet
+app process can receive more than one, so it does not define a user visit or
+time spent. None of these fields can show what antiburn was used _on_. This is
+stated because an enumeration that lists fields without saying what they enable
+is not really an enumeration.
 
 ### Why there are two identifiers
 
 The receiving server's contract requires both, and they are not equally
-durable. `anonymousId` is stored on disk and lasts up to 30 days. `sessionId`
-exists only in memory: quitting antiburn ends it, and nothing on your machine
-remembers it afterwards. It is the shortest-lived thing in the payload, and it
-cannot connect one run of the application to another.
+durable. `anonymousId` is stored on disk and lasts up to 30 days. The live
+`sessionId` generator exists only in memory. Each serialized event also contains
+its `sessionId`, so a queued event keeps that value on disk until it is sent or
+removed. Restarting antiburn creates a new value for newly captured events;
+events already in the queue keep their original value.
 
 ### Agent and provider categories
 
@@ -113,23 +116,25 @@ Event names are namespaced `antiburn.*`.
 | Event                          | When it fires                                                                                                                                                                                               | Carries                                                                                                                                                                                                     |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `antiburn.app_launched`        | The application starts.                                                                                                                                                                                     | —                                                                                                                                                                                                           |
-| `antiburn.onboarding_finished` | The first run completes.                                                                                                                                                                                    | —                                                                                                                                                                                                           |
+| `antiburn.onboarding_finished` | A setup flow completes, including an explicitly restarted flow.                                                                                                                                             | —                                                                                                                                                                                                           |
 | `antiburn.onboarding_step_viewed` | A fixed first-run step becomes visible. Each step is recorded at most once per onboarding flow. | `label` — one of `welcome`, `agents_detected`, `sources_and_repos`, `ready`. |
-| `antiburn.scan_completed`      | A discovery pass finishes **and finds a different number of sessions than the last one reported**. antiburn rescans about once a minute while the popover is open; a repeat of the same answer is not sent. | `bucket` — how many sessions                                                                                                                                                                                |
+| `antiburn.scan_completed`      | A full discovery pass finishes and its session-count bucket differs from the previous reported outcome. The first full pass in a run is reported. Automatic full reconciliation runs at startup and about every five minutes; file watchers usually cause scoped passes, which emit no scan analytics. | `bucket` — how many sessions                                                                                                                                                                                |
 | `antiburn.setting_toggled`     | A preference changes.                                                                                                                                                                                       | `label` — one of `live_usage`, `notifications`, `launch_at_login`, `discovery_paused`. The key only; never the value.                                                                                       |
 | `antiburn.session_opened`      | You open a session from the activity list.                                                                                                                                                                  | `label` — which agent recorded it, from the fixed list antiburn supports. `detail` — `native` or `wsl`. **Not** the session, its title, its repository, or the name of your WSL distribution.               |
-| `antiburn.error_occurred`      | Something failed, and the previous pass had not already reported the same failure.                                                                                                                          | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                           |
+| `antiburn.error_occurred`      | A full discovery pass fails, and the previous full pass had not already reported the same failure.                                                                                                          | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                           |
 | `antiburn.unrecognized_records_observed` | Settings → Insights returns a cohort containing unknown record vocabulary, and its outcome differs from the last one reported during this run. | `bucket` — sessions containing unknown types. `label` — `inert_only`, `inert_capped`, or `evidence_bearing`. No discriminator, payload, session identifier, or second dimension. |
 | `antiburn.claude_limit_reset_observed` | After an ordinary Claude usage refresh, when analytics and Claude live usage are both enabled and the observation differs from the last one queued during this run. The probe uses a separate five-minute cooldown. | `label` — `success`, `authentication`, `rateLimited`, `unavailable`, `credential_absent`, `credential_expired`, or `credential_unavailable`. The nine reset fields listed above. No response body, credential, account identifier, exact usage percentage, or date. |
 
-Four of those are deliberately not sent once per occurrence. A scan result that
-repeats the last one is dropped, so a machine left running does not report the
-same number every minute and a machine stuck failing does not report the same
-failure six hundred times a day. What survives is the first pass of each run,
-every crossing of a bucket boundary, and every move into or out of failure. The
-unrecognized-record event likewise reports only a changed `(label, bucket)`
-outcome. A clean cohort updates that in-memory comparison without sending an
-event, so a later return to unknown vocabulary is visible.
+Four of those are deliberately not sent once per occurrence. A full scan result
+that repeats the last bucket is dropped, so a machine left running does not
+report the same range after every reconciliation and a machine stuck failing
+does not report the same failure after every full pass. What survives is the
+first full pass of each run, every crossing of a bucket boundary, and every move
+into or out of failure. Scoped watcher passes emit neither scan event and do not
+change this comparison. The unrecognized-record event likewise reports only a
+changed `(label, bucket)` outcome. A clean cohort updates that in-memory
+comparison without sending an event, so a later return to unknown vocabulary is
+visible.
 
 The Claude limit-reset event reports the first observation in a run and then
 only a changed observation. It calls the same provider usage endpoint through a

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy policy
 
-Effective: 6 September 2026
+Effective: 8 September 2026
 
 This policy explains the analytics sent by the antiburn desktop application.
 Antiburn is operated by **Cadence AI (Vic) Pty Ltd** ("we", "us"). Contact us
@@ -25,7 +25,7 @@ the fixed onboarding steps.
 The event schema contains twenty-two fields:
 
 - the constant product surface `desktop`;
-- random message, installation, and application-run identifiers;
+- random message, installation, and analytics-session identifiers;
 - the event name and capture and delivery times;
 - the processor architecture, operating-system family, and app version;
 - an optional count rounded to a range; and
@@ -38,10 +38,14 @@ The event schema contains twenty-two fields:
 - the weekly reset count rounded to zero, one, or two-plus; and
 - whether Claude supplied a next-reset date, never the date itself.
 
-The installation identifier is random and changes every 30 days. The run
-identifier exists only in memory and changes when the app restarts or after 30
-minutes of inactivity. Neither identifier comes from your hardware, account,
-name, or email address.
+The installation identifier is random and changes every 30 days. The live
+analytics-session identifier is generated in memory and changes when the app
+restarts or after 30 minutes without a captured analytics event. Each queued
+event contains the identifier, so that serialized value remains in the local
+analytics queue on disk until the event is sent or removed. Background events
+can keep an analytics session active, and one app run can contain more than one;
+it does not measure a user visit or time spent. Neither identifier comes from
+your hardware, account, name, or email address.
 
 The complete field list, event catalog, and verification steps are in
 [Anonymised analytics](analytics.md).

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -22,14 +22,15 @@ Official release builds send limited events about how the application works and
 which features are used. This includes application launch and progress through
 the fixed onboarding steps.
 
-The event schema contains twenty-two fields:
+The event schema contains twenty-three fields:
 
 - the constant product surface `desktop`;
 - random message, installation, and analytics-session identifiers;
 - the event name and capture and delivery times;
 - the processor architecture, operating-system family, and app version;
-- an optional count rounded to a range; and
-- optional labels selected from a fixed list in the application;
+- an optional count rounded to a range;
+- optional labels selected from fixed lists in the application;
+- whether a visible state followed a user or automatic exposure;
 - a range for Claude's current five-hour usage;
 - whether Claude returned reset data, null, or a malformed value;
 - Claude's reset eligibility and experiment-membership states;
@@ -40,12 +41,13 @@ The event schema contains twenty-two fields:
 
 The installation identifier is random and changes every 30 days. The live
 analytics-session identifier is generated in memory and changes when the app
-restarts or after 30 minutes without a captured analytics event. Each queued
-event contains the identifier, so that serialized value remains in the local
-analytics queue on disk until the event is sent or removed. Background events
-can keep an analytics session active, and one app run can contain more than one;
-it does not measure a user visit or time spent. Neither identifier comes from
-your hardware, account, name, or email address.
+restarts, when the installation identifier rotates, or after 30 minutes without
+a captured analytics event. Each queued event contains the identifier, so that
+serialized value remains in the local analytics queue on disk until the event
+is sent or removed. Background events can keep an analytics session active, and
+one app run can contain more than one; it does not measure a user visit or time
+spent. Neither identifier comes from your hardware, account, name, or email
+address.
 
 The complete field list, event catalog, and verification steps are in
 [Anonymised analytics](analytics.md).

--- a/docs/support.md
+++ b/docs/support.md
@@ -147,18 +147,21 @@ signed bundle and restarts antiburn. The app never depends on either connection.
   and require the next package to be installed manually.
 - **Anonymised product analytics** are the one thing antiburn reports to us.
   Official release builds start with it on, including during onboarding. The Ready
-  screen explains it, and the switch is in Settings → Privacy. The event schema has twenty-two fields and
+  screen explains it, and the switch is in Settings → Privacy. The event schema has twenty-three fields and
   no others: the constant `desktop`; a random per-message id used to discard
   duplicate deliveries; a random installation identifier replaced every 30 days;
   a random analytics-session identifier; the event name; the time it happened and the time it was delivered; the
   processor architecture; a count rounded into a range where the event has one;
-  a short label naming which setting changed or which kind of failure occurred,
-  never the value; a second fixed label where needed; a coarse five-hour usage
+  a short label naming a surface, Settings pane, provider, setting, agent
+  category, or failure category, never work content or an entered value; a
+  second fixed label where needed; whether a visible state followed a user or
+  automatic exposure; a coarse five-hour usage
   band; the reset response shape; eligibility, experiment membership, experiment
   arm, and availability states; an allowlisted ineligibility reason; a reset-count
   bucket; whether a next-reset date was present; the app version; and the operating system. The payload has no
   field able to carry anything else. The analytics-session identifier changes
-  after 30 minutes without a captured analytics event or when the app restarts.
+  after 30 minutes without a captured analytics event, when the app restarts,
+  or when the installation identifier rotates.
   Its generator is memory-only, but each queued event stores the value on disk
   until that event is sent or removed. Background events can keep it active, so
   it does not measure a user visit or time spent. Because each event is

--- a/docs/support.md
+++ b/docs/support.md
@@ -150,16 +150,21 @@ signed bundle and restarts antiburn. The app never depends on either connection.
   screen explains it, and the switch is in Settings → Privacy. The event schema has twenty-two fields and
   no others: the constant `desktop`; a random per-message id used to discard
   duplicate deliveries; a random installation identifier replaced every 30 days;
-  a random application-run identifier; the event name; the time it happened and the time it was delivered; the
+  a random analytics-session identifier; the event name; the time it happened and the time it was delivered; the
   processor architecture; a count rounded into a range where the event has one;
   a short label naming which setting changed or which kind of failure occurred,
   never the value; a second fixed label where needed; a coarse five-hour usage
   band; the reset response shape; eligibility, experiment membership, experiment
   arm, and availability states; an allowlisted ineligibility reason; a reset-count
   bucket; whether a next-reset date was present; the app version; and the operating system. The payload has no
-  field able to carry anything else. Because each event is timestamped and the
-  identifier lasts up to 30 days, the events do show roughly when the
-  application is used within that window; they do not show what it was used on.
+  field able to carry anything else. The analytics-session identifier changes
+  after 30 minutes without a captured analytics event or when the app restarts.
+  Its generator is memory-only, but each queued event stores the value on disk
+  until that event is sent or removed. Background events can keep it active, so
+  it does not measure a user visit or time spent. Because each event is
+  timestamped and the installation identifier lasts up to 30 days, the events
+  do show roughly when events were captured within that window; they do not show
+  what the app was used on.
   [analytics.md](analytics.md) is the complete account: every field,
   the full event catalog, and how to verify all of it yourself.
   Never sent: sessions, transcripts, prompts, titles, file paths, repository or


### PR DESCRIPTION
## User impact

Configured release builds now measure whether people deliberately reach antiburn's core surfaces and whether those surfaces present useful data, an empty state, a failure, or a visible loading timeout. This covers Activity, session detail, provider and checks previews, the HUD and HUD detail, Settings, and Settings Insights.

Default source and development builds still exclude the analytics client. The app remains fully usable with analytics disabled. `no_credentials` is reserved in the closed provider-state vocabulary but remains dormant because the current product boundary cannot prove that state.

Builds on merged #429, which adds the historical audit and measurement contract.

## Validation

- `cargo fmt --check` in `apps/desktop/src-tauri`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features analytics -- -D warnings`
- default shell suite: 964 tests passed
- analytics-enabled shell suite: 1,007 tests passed
- HUD crate Clippy and test suite: 22 tests passed
- focused surface tracker and popover session suite: 43 tests passed
- focused popover view suite: 60 tests passed
- focused auxiliary surface suites: 168 tests passed
- desktop Prettier check
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- desktop suite: 94 files and 1,197 tests passed
- `pnpm --filter @antiburn/desktop build`
- `pnpm run slop:all` (score 100, no findings across 477 files)
- `pnpm run secrets`
- `git diff --check`

The tests cover successful native visibility, hidden prewarm, duplicate show requests, remounts, stale callbacks, hidden timeout cancellation, ready data after a timeout, Settings deep links and browser fallback, onboarding resume and completion classification, closed property rejection, opt-out, identifier rotation, provider-state suppression, queue bounds, protected draining, and delivery backoff.

No live native loopback-collector walkthrough was run. The automated tests use mocked native producer boundaries, and the production collector and dashboards remain unverified.

## Analytics

The product question is whether reporting installations deliberately reach antiburn's core utility, which surfaces provide visible value, and where data availability prevents meaningful use. The implementation adds five events, bringing the closed catalog to 14:

- `antiburn.surface_viewed` records successful native visibility for `activity`, `session_detail`, `provider_preview`, `checks_preview`, `hud`, `hud_detail`, and `settings`. Its closed `detail` is `user` or `automatic`.
- `antiburn.settings_pane_viewed` records a selected and visible `general`, `appearance`, `sources`, `privacy`, `notifications`, `usage`, `insights`, or `about` pane. An Insights pane view qualifies as deliberate core use; other Settings-only visits do not enter the return-use denominator.
- `antiburn.surface_state_observed` records `ready`, `empty`, `error`, or a ten-second visible `loading_timeout` for the surface vocabulary plus `insights`. It reports each distinct state at most once per exposure, rejects stale results, cancels hidden timeouts, and can report `ready` after a timeout.
- `antiburn.live_usage_state_observed` records `anthropic`, `openai`, or `google` as `fresh`, `stale`, `authentication`, `rate_limited`, or `unavailable` when presented on Activity or a deliberate provider preview or user-opened HUD exposure. The closed schema also accepts dormant `no_credentials`. Automatic provider observations are rejected, and provider/state pairs are suppressed within a bounded deliberate visit.
- `antiburn.onboarding_started` records `new` or `restart` on the first visible start or resume in each app process. `antiburn.onboarding_finished` now carries the same classification on a committed pending-to-complete transition. A quit and later resume can produce another start with the persisted classification.

Existing scan and error events remain bucketed full-pass outcomes rather than user actions. Prewarming, polling, refreshes, resizes, hidden navigation, and automatic HUD restoration do not count as deliberate use.

The wire schema has 23 fields. The new optional `properties.origin` accepts only `user` or `automatic` and appears only on `surface_state_observed`. `surface_viewed` keeps origin in the existing closed `detail` field. Provider-state events do not serialize origin and the shell rejects automatic observations. No event carries a product session ID, title, path, repository, account, plan, quota, response body, credential, or exact count.

Reports must use app version as a semantic boundary. Legacy `onboarding_finished` rows have no `new`/`restart` label and must be excluded from classified setup cohorts. Metrics count rotating reporting installations rather than people; first-seen identifiers are not necessarily new installations. The wire `sessionId` remains an analytics-event activity window, so deliberate visits use a separate 30-minute analysis gap and exclude background events. The production collector and dashboards have not been verified by this source change.

The public catalog and privacy disclosures are updated in [docs/analytics.md](docs/analytics.md), [docs/analytics-measurement.md](docs/analytics-measurement.md), [docs/privacy-policy.md](docs/privacy-policy.md), and Settings → Privacy.

## Privacy and performance

The added data is limited to the closed event and property vocabularies above. Installation identifiers still rotate after 30 days, and the analytics-session identifier now resets with installation rotation so it cannot bridge identifier periods. Its generator remains memory-only; queued payloads retain their serialized identifier until delivery or removal. Opt-out clears the identifier, queue, and suppression state.

Delivery is now demand-driven and bounded. An empty queue makes no periodic network request. The first event schedules delivery after 60 seconds, queue depth 50 makes it due immediately, and each pass sends at most 50 requests. A remaining backlog waits a protected 60 seconds. Failures stop the pass and use protected 1, 2, 4, 8, then 15-minute delays; five failed attempts discard a row. The queue still keeps only the newest 500 rows. Consent is checked before every request.

No work content, local identifiers, paths, credentials, raw errors, or exact usage values are added. There is no new provider request or analytics SDK.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
