### PR TITLE
fix: bound scan history reads

### DIFF
--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -814,25 +814,23 @@ async fn pass(
         PassScope::Agents(agents) => discover_scoped_agents(app, agents, now, since_secs).await,
     };
 
-    let previous_records = store.session_records()?;
-    let scoped_previous_records;
-    let previous_records_for_pass = match scope {
-        PassScope::Full => &previous_records,
-        PassScope::Agents(agents) => {
-            scoped_previous_records = previous_records
-                .iter()
-                .filter(|(key, _)| agents.iter().any(|agent| agent.slug() == key.agent))
-                .map(|(key, record)| (key.clone(), record.clone()))
-                .collect();
-            &scoped_previous_records
-        }
-    };
+    let activity_keys = logs
+        .iter()
+        .map(|log| {
+            SessionActivityKey::new(
+                log.environment.key(),
+                log.agent_type.slug(),
+                log.source_label(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let previous_records = store.session_records_for_activity_keys(&activity_keys)?;
     let Described {
         records,
         rejected,
         changed,
         list_changed,
-    } = describe_with_states(logs, &home, &ignored, previous_records_for_pass).await;
+    } = describe_with_states(logs, &home, &ignored, &previous_records).await;
     let evidence_agents: Vec<&str> = match scope {
         PassScope::Full => agents::evidence_cohort(),
         PassScope::Agents(agents) => agents.iter().map(|agent| agent.slug()).collect(),
@@ -844,7 +842,11 @@ async fn pass(
     // may also be unchanged, but its evidence last failed on a missing
     // source, and only a write re-runs `upsert_sessions`'s own
     // `source_returned` check to re-queue it.
-    let returned = store.sessions_with_missing_source()?;
+    let record_keys = records
+        .iter()
+        .map(|record| record.key.clone())
+        .collect::<Vec<_>>();
+    let returned = store.sessions_with_missing_source_for(&record_keys)?;
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
@@ -861,7 +863,7 @@ async fn pass(
     // or moved one's deadline later; either way its sleep needs recomputing.
     idle::wake(app);
 
-    announce_changed_rows(&store, &changed, previous_records_for_pass, now, announce);
+    announce_changed_rows(&store, &changed, &previous_records, now, announce);
 
     // A transcript the gate rejected may have been indexed by an earlier
     // version of the app that did not gate; the row is removed rather than

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -21,7 +21,7 @@ use tokio::time::Instant;
 use crate::agents;
 use crate::dto::{ActivityEntry, ScanStatus};
 use crate::storage_health::checked;
-use crate::store::{SessionActivityKey, SessionRecord, Store};
+use crate::store::{SessionActivityKey, SessionKey, SessionRecord, Store};
 
 use super::{PassScope, ScanController, ScanTrigger};
 
@@ -38,6 +38,9 @@ pub const DB_AGENT_REDISCOVER_MIN_INTERVAL: Duration = Duration::from_secs(30);
 
 /// An indexed-title refresh runs at most this often for each agent.
 pub const TITLE_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Stored sessions loaded at once during an indexed-title refresh.
+const TITLE_REFRESH_PAGE_SIZE: usize = 256;
 
 /// T7: how long the scheduler waits before retrying admitted work that found
 /// a command's pass already holding the running flag.
@@ -453,57 +456,77 @@ async fn refresh_indexed_titles_locked(
     agents: &BTreeSet<AgentKind>,
 ) -> anyhow::Result<ScopedSummary> {
     let store = app.state::<Store>();
-    let previous_map: HashMap<SessionActivityKey, SessionRecord> = store
-        .session_records()?
-        .into_iter()
-        .filter(|(_, record)| {
-            record.key.environment_key == "native"
-                && agents.iter().any(|agent| record.key.agent == agent.slug())
-        })
-        .collect();
-    let mut records: Vec<SessionRecord> = previous_map.values().cloned().collect();
-    let mut changed = Vec::new();
-
-    for agent in agents {
-        let session_ids: Vec<String> = records
-            .iter()
-            .filter(|record| record.key.agent == agent.slug())
-            .map(|record| record.key.session_id.clone())
-            .collect();
-        let mut titles = Explorers::DISK
-            .indexed_session_titles_for(agent, &session_ids)
-            .await;
-        for record in records
-            .iter_mut()
-            .filter(|record| record.key.agent == agent.slug())
-        {
-            let Some(resolved) = titles.remove(&record.key.session_id) else {
-                continue;
-            };
-            if super::apply_indexed_title(record, agent, resolved) {
-                changed.push(record.key.clone());
-            }
-        }
-    }
-
-    let changed_records = super::records_to_persist(&records, &changed, &[]);
-    if !changed_records.is_empty() {
-        checked(
-            app,
-            "The session index",
-            store.upsert_sessions(&changed_records, &agents::evidence_cohort()),
-        )?;
-    }
     let now = super::unix_now();
     let announce_app = app.clone();
     let announce = move |entry: ActivityEntry| {
         let _ = announce_app.emit(crate::commands::SESSION_ENTRY_CHANGED_EVENT, &entry);
     };
-    super::announce_changed_rows(&store, &changed, &previous_map, now, &announce);
+    let mut session_count = 0;
+    let mut changed_count = 0;
+
+    for agent in agents {
+        // Keep only IDs while the external index resolves once. Full cached
+        // records remain bounded to each page of titles that the index found.
+        let session_ids = store.native_session_ids_for_agent(agent.slug())?;
+        session_count += session_ids.len();
+        let titles = Explorers::DISK
+            .indexed_session_titles_for(agent, &session_ids)
+            .await;
+        drop(session_ids);
+
+        let mut title_entries = titles.into_iter();
+        loop {
+            let mut page_titles = title_entries
+                .by_ref()
+                .take(TITLE_REFRESH_PAGE_SIZE)
+                .collect::<HashMap<_, _>>();
+            if page_titles.is_empty() {
+                break;
+            }
+            let page_keys = page_titles
+                .keys()
+                .map(|session_id| SessionKey::new("native", agent.slug(), session_id))
+                .collect::<Vec<_>>();
+            let mut records = store.session_records_for_session_keys(&page_keys)?;
+            let previous_map = records
+                .iter()
+                .map(|record| {
+                    (
+                        SessionActivityKey::new(
+                            record.key.environment_key.clone(),
+                            record.key.agent.clone(),
+                            record.source_label.clone(),
+                        ),
+                        record.clone(),
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+            let mut changed = Vec::new();
+            for record in &mut records {
+                let Some(resolved) = page_titles.remove(&record.key.session_id) else {
+                    continue;
+                };
+                if super::apply_indexed_title(record, agent, resolved) {
+                    changed.push(record.key.clone());
+                }
+            }
+
+            let changed_records = super::records_to_persist(&records, &changed, &[]);
+            if !changed_records.is_empty() {
+                checked(
+                    app,
+                    "The session index",
+                    store.upsert_sessions(&changed_records, &agents::evidence_cohort()),
+                )?;
+            }
+            super::announce_changed_rows(&store, &changed, &previous_map, now, &announce);
+            changed_count += changed.len();
+        }
+    }
 
     Ok(ScopedSummary {
-        sessions: records.len(),
-        re_described: changed.len(),
+        sessions: session_count,
+        re_described: changed_count,
     })
 }
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -113,6 +113,27 @@ const EVIDENCE_BY_KEY_SQL: &str = "SELECT environment_key, agent, session_id, st
 /// unbounded table on a reader's disk.
 const ANALYTICS_QUEUE_LIMIT: u32 = 500;
 
+/// Maximum activity or session keys bound by one scan-history query.
+///
+/// Three values per key keep each statement below SQLite's legacy 999-value
+/// limit. A scan can issue more batches, but it never loads unrelated rows.
+const SCAN_HISTORY_KEY_BATCH_SIZE: usize = 256;
+
+fn session_records_for_activity_keys_sql(key_count: usize) -> String {
+    let predicates = (0..key_count)
+        .map(|index| {
+            let first = index * 3 + 1;
+            format!(
+                "(s.source_label = ?{} AND s.environment_key = ?{first} AND s.agent = ?{})",
+                first + 2,
+                first + 1
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    format!("{SESSION_SELECT_SQL}\n WHERE {predicates}")
+}
+
 /// File name of the database inside the app data directory.
 ///
 /// Debug builds use their own file so a half-finished migration cannot damage
@@ -882,11 +903,8 @@ impl Store {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
-    /// Return every session's full cached record keyed by environment, agent,
-    /// and source label. A single map keeps the scan's cheap unchanged-source
-    /// gate outside the SQLite lock without allowing native/WSL rows to
-    /// collide, and lets the scan reuse a whole previous record instead of
-    /// re-describing a source that has not changed.
+    /// Return every session's full cached record.
+    #[cfg(test)]
     pub fn session_records(&self) -> Result<HashMap<SessionActivityKey, SessionRecord>> {
         let connection = self.lock();
         let mut statement = connection.prepare(SESSION_SELECT_SQL)?;
@@ -900,6 +918,85 @@ impl Store {
                 record.source_label.clone(),
             );
             records.insert(key, record);
+        }
+        Ok(records)
+    }
+
+    /// Return cached records for the activity sources in one discovery pass.
+    ///
+    /// Each predicate includes the environment and agent. Native and WSL rows
+    /// can therefore share a source label without sharing cached state.
+    pub fn session_records_for_activity_keys(
+        &self,
+        keys: &[SessionActivityKey],
+    ) -> Result<HashMap<SessionActivityKey, SessionRecord>> {
+        let connection = self.lock();
+        let mut records = HashMap::with_capacity(keys.len());
+        for keys in keys.chunks(SCAN_HISTORY_KEY_BATCH_SIZE) {
+            let mut values = Vec::with_capacity(keys.len() * 3);
+            for key in keys {
+                values.push(rusqlite::types::Value::Text(key.environment_key.clone()));
+                values.push(rusqlite::types::Value::Text(key.agent.clone()));
+                values.push(rusqlite::types::Value::Text(key.source_label.clone()));
+            }
+            let mut statement =
+                connection.prepare(&session_records_for_activity_keys_sql(keys.len()))?;
+            let rows = statement.query_map(params_from_iter(values.iter()), session_from_row)?;
+            for row in rows {
+                let record = row?;
+                let key = SessionActivityKey::new(
+                    record.key.environment_key.clone(),
+                    record.key.agent.clone(),
+                    record.source_label.clone(),
+                );
+                records.insert(key, record);
+            }
+        }
+        Ok(records)
+    }
+
+    /// Return native session identities for one agent title index.
+    pub fn native_session_ids_for_agent(&self, agent: &str) -> Result<Vec<String>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(
+            "SELECT session_id
+               FROM session
+              WHERE environment_key = 'native' AND agent = ?1
+              ORDER BY session_id",
+        )?;
+        let rows = statement.query_map(params![agent], |row| row.get::<_, String>(0))?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    /// Return cached records for exact session identities.
+    pub fn session_records_for_session_keys(
+        &self,
+        keys: &[SessionKey],
+    ) -> Result<Vec<SessionRecord>> {
+        let connection = self.lock();
+        let mut records = Vec::with_capacity(keys.len());
+        for keys in keys.chunks(SCAN_HISTORY_KEY_BATCH_SIZE) {
+            let predicates = (0..keys.len())
+                .map(|index| {
+                    let first = index * 3 + 1;
+                    format!(
+                        "(s.environment_key = ?{first} AND s.agent = ?{} AND s.session_id = ?{})",
+                        first + 1,
+                        first + 2
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            let mut values = Vec::with_capacity(keys.len() * 3);
+            for key in keys {
+                values.push(rusqlite::types::Value::Text(key.environment_key.clone()));
+                values.push(rusqlite::types::Value::Text(key.agent.clone()));
+                values.push(rusqlite::types::Value::Text(key.session_id.clone()));
+            }
+            let mut statement =
+                connection.prepare(&format!("{SESSION_SELECT_SQL}\n WHERE {predicates}"))?;
+            let rows = statement.query_map(params_from_iter(values.iter()), session_from_row)?;
+            records.extend(rows.collect::<rusqlite::Result<Vec<_>>>()?);
         }
         Ok(records)
     }
@@ -977,8 +1074,8 @@ impl Store {
             .optional()?)
     }
 
-    /// Keys of every session whose evidence last failed because its source
-    /// was missing.
+    /// Keys in `sessions` whose evidence last failed because its source was
+    /// missing.
     ///
     /// R3: a full pass reuses an unchanged row without rewriting it, which
     /// would otherwise leave a session stuck once its source returns —
@@ -986,24 +1083,48 @@ impl Store {
     /// persists these rows through `upsert_sessions` even when the row
     /// itself is unchanged, so its own `source_returned` check runs and
     /// clears the failure.
-    pub fn sessions_with_missing_source(&self) -> Result<Vec<SessionKey>> {
+    pub fn sessions_with_missing_source_for(
+        &self,
+        sessions: &[SessionKey],
+    ) -> Result<Vec<SessionKey>> {
         let connection = self.lock();
-        let mut statement = connection.prepare(
-            "SELECT environment_key, agent, session_id
-               FROM session_evidence
-              WHERE status = 'failed' AND last_error = ?1",
-        )?;
-        let rows = statement.query_map(
-            params![crate::insights_worker::EVIDENCE_ERROR_SOURCE_MISSING],
-            |row| {
+        let mut missing = Vec::new();
+        for sessions in sessions.chunks(SCAN_HISTORY_KEY_BATCH_SIZE) {
+            let predicates = (0..sessions.len())
+                .map(|index| {
+                    let first = index * 3 + 2;
+                    format!(
+                        "(environment_key = ?{first} AND agent = ?{} AND session_id = ?{})",
+                        first + 1,
+                        first + 2
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            let mut values = Vec::with_capacity(sessions.len() * 3 + 1);
+            values.push(rusqlite::types::Value::Text(
+                crate::insights_worker::EVIDENCE_ERROR_SOURCE_MISSING.to_string(),
+            ));
+            for key in sessions {
+                values.push(rusqlite::types::Value::Text(key.environment_key.clone()));
+                values.push(rusqlite::types::Value::Text(key.agent.clone()));
+                values.push(rusqlite::types::Value::Text(key.session_id.clone()));
+            }
+            let mut statement = connection.prepare(&format!(
+                "SELECT environment_key, agent, session_id
+                   FROM session_evidence
+                  WHERE status = 'failed' AND last_error = ?1 AND ({predicates})"
+            ))?;
+            let rows = statement.query_map(params_from_iter(values.iter()), |row| {
                 Ok(SessionKey::new(
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, String>(2)?,
                 ))
-            },
-        )?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+            })?;
+            missing.extend(rows.collect::<rusqlite::Result<Vec<_>>>()?);
+        }
+        Ok(missing)
     }
 
     /// One session's persisted source version and optional start time.
@@ -3275,11 +3396,8 @@ fn evidence_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EvidenceRow> {
     })
 }
 
-/// Column list and join shared by every reader of the `session` table:
-/// [`Store::session_records`], [`Store::session`], and
-/// [`Store::session_record_by_activity_key`]. One copy means a schema change
-/// updates every reader together, and [`session_from_row`] stays the single
-/// row mapper for all three.
+/// Every full-record session reader uses this column list and join. One copy
+/// keeps schema changes aligned with [`session_from_row`].
 const SESSION_SELECT_SQL: &str =
     "SELECT environment_key, agent, session_id, source_kind, source_label, wsl_distro,
                     title, title_source, cwd, surface, updated_at_epoch,

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -39,6 +39,210 @@ fn session(session_id: &str, updated_at: i64) -> SessionRecord {
     }
 }
 
+fn seed_historical_sessions(store: &Store, count: usize) {
+    let mut connection = store.lock();
+    let transaction = connection.transaction().unwrap();
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO session (
+                     environment_key, agent, session_id, source_kind, source_label,
+                     updated_at_epoch, first_seen_at, last_seen_at
+                 ) VALUES ('native', 'cursor', ?1, 'file', ?2, 1,
+                           '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')",
+            )
+            .unwrap();
+        for index in 0..count {
+            let session_id = format!("historical-{index}");
+            let source_label = format!("/history/{index}.jsonl");
+            insert.execute(params![session_id, source_label]).unwrap();
+        }
+    }
+    transaction.commit().unwrap();
+}
+
+fn bounded_activity_history_result(
+    history_count: usize,
+) -> HashMap<SessionActivityKey, SessionRecord> {
+    let store = store();
+    seed_historical_sessions(&store, history_count);
+
+    let mut native = session("current-native", 2_000);
+    native.activity_cursor = "native-cursor".into();
+    native.activity_source = "event".into();
+    native.source_fingerprint = Some("native-fingerprint".into());
+    let mut wsl = session("current-wsl", 2_100);
+    wsl.key.environment_key = "wsl:ubuntu".into();
+    wsl.wsl_distro = Some("Ubuntu".into());
+    wsl.source_label = native.source_label.clone();
+    wsl.activity_cursor = "wsl-cursor".into();
+    store
+        .upsert_sessions(&[native.clone(), wsl.clone()], &[])
+        .unwrap();
+
+    let keys = [
+        SessionActivityKey::new(
+            native.key.environment_key.clone(),
+            native.key.agent.clone(),
+            native.source_label.clone(),
+        ),
+        SessionActivityKey::new(
+            wsl.key.environment_key.clone(),
+            wsl.key.agent.clone(),
+            wsl.source_label.clone(),
+        ),
+        SessionActivityKey::new("native", "claude-code", "/missing/recent.jsonl"),
+    ];
+    store.session_records_for_activity_keys(&keys).unwrap()
+}
+
+#[test]
+fn bounded_activity_history_does_not_load_the_lifetime_corpus() {
+    let small = bounded_activity_history_result(1_000);
+    let large = bounded_activity_history_result(100_000);
+
+    assert_eq!(small.len(), 2);
+    assert_eq!(large.len(), 2);
+    assert_eq!(small, large);
+
+    let native_key = SessionActivityKey::new(
+        "native",
+        "claude-code",
+        "/home/avery/.claude/projects/demo/current-native.jsonl",
+    );
+    let native = large.get(&native_key).expect("native prior state");
+    assert_eq!(native.activity_cursor, "native-cursor");
+    assert_eq!(native.activity_source, "event");
+    assert_eq!(
+        native.source_fingerprint.as_deref(),
+        Some("native-fingerprint")
+    );
+
+    let wsl_key = SessionActivityKey::new(
+        "wsl:ubuntu",
+        "claude-code",
+        "/home/avery/.claude/projects/demo/current-native.jsonl",
+    );
+    assert_eq!(
+        large
+            .get(&wsl_key)
+            .and_then(|record| record.wsl_distro.as_deref()),
+        Some("Ubuntu")
+    );
+}
+
+#[test]
+fn scan_history_queries_cross_the_key_batch_boundary() {
+    let store = store();
+    let records = (0..=SCAN_HISTORY_KEY_BATCH_SIZE)
+        .map(|index| {
+            let mut record = session(
+                &format!("batch-{index:03}"),
+                2_000 + i64::try_from(index).unwrap(),
+            );
+            record.source_label = format!("/batch/{index:03}.jsonl");
+            record.activity_cursor = format!("cursor-{index:03}");
+            record
+        })
+        .collect::<Vec<_>>();
+    store
+        .upsert_sessions(&records, &crate::agents::evidence_cohort())
+        .unwrap();
+
+    let activity_keys = records
+        .iter()
+        .map(|record| {
+            SessionActivityKey::new(
+                &record.key.environment_key,
+                &record.key.agent,
+                &record.source_label,
+            )
+        })
+        .collect::<Vec<_>>();
+    let by_activity = store
+        .session_records_for_activity_keys(&activity_keys)
+        .unwrap();
+    assert_eq!(by_activity.len(), records.len());
+    assert_eq!(
+        by_activity
+            .get(activity_keys.last().unwrap())
+            .map(|record| record.activity_cursor.as_str()),
+        Some("cursor-256")
+    );
+
+    let session_keys = records
+        .iter()
+        .map(|record| record.key.clone())
+        .collect::<Vec<_>>();
+    let by_session = store
+        .session_records_for_session_keys(&session_keys)
+        .unwrap();
+    assert_eq!(by_session.len(), records.len());
+    assert!(
+        by_session
+            .iter()
+            .any(|record| record.key.session_id == "batch-256")
+    );
+
+    store
+        .lock()
+        .execute(
+            "UPDATE session_evidence
+                SET status = 'failed', last_error = ?1
+              WHERE session_id IN ('batch-000', 'batch-256')",
+            params![crate::insights_worker::EVIDENCE_ERROR_SOURCE_MISSING],
+        )
+        .unwrap();
+    let missing = store
+        .sessions_with_missing_source_for(&session_keys)
+        .unwrap()
+        .into_iter()
+        .map(|key| key.session_id)
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        missing,
+        HashSet::from(["batch-000".to_string(), "batch-256".to_string()])
+    );
+}
+
+#[test]
+fn title_history_cohort_preserves_all_native_agent_rows() {
+    let store = store();
+    let mut old_codex = session("old-codex", 1_000);
+    old_codex.key.agent = "codex".into();
+    let mut recent_codex = session("recent-codex", 2_000);
+    recent_codex.key.agent = "codex".into();
+    recent_codex.title = Some("Indexed title".into());
+    recent_codex.title_source = Some("aiGenerated".into());
+    let mut wsl_codex = recent_codex.clone();
+    wsl_codex.key.environment_key = "wsl:ubuntu".into();
+    wsl_codex.key.session_id = "wsl-codex".into();
+    let recent_claude = session("recent-claude", 2_000);
+    store
+        .upsert_sessions(
+            &[old_codex, recent_codex.clone(), wsl_codex, recent_claude],
+            &[],
+        )
+        .unwrap();
+
+    let session_ids = store.native_session_ids_for_agent("codex").unwrap();
+    let records = store
+        .session_records_for_session_keys(&[
+            SessionKey::new("native", "codex", "old-codex"),
+            SessionKey::new("native", "codex", "recent-codex"),
+        ])
+        .unwrap();
+
+    assert_eq!(session_ids, ["old-codex", "recent-codex"]);
+    assert_eq!(records.len(), 2);
+    let recent = records
+        .iter()
+        .find(|record| record.key.session_id == "recent-codex")
+        .expect("recent native Codex row");
+    assert_eq!(recent.title.as_deref(), Some("Indexed title"));
+    assert_eq!(recent.title_source.as_deref(), Some("aiGenerated"));
+}
+
 fn projection_revisions() -> ProjectionRevisions {
     ProjectionRevisions {
         parser_revision: 1,

--- a/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/activity_tests.rs
@@ -205,6 +205,36 @@ fn migrated_source_lookup_query_plan_uses_the_source_index() {
 }
 
 #[test]
+fn bounded_scan_history_query_plan_uses_the_source_index() {
+    let store = store();
+    let connection = store.lock();
+    let sql = session_records_for_activity_keys_sql(2);
+    let mut statement = connection
+        .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+        .unwrap();
+    let plan = statement
+        .query_map(
+            params![
+                "native",
+                "claude-code",
+                "/one.jsonl",
+                "wsl:ubuntu",
+                "codex",
+                "/two.jsonl",
+            ],
+            |row| row.get::<_, String>(3),
+        )
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+        .join("\n");
+    assert!(
+        plan.contains("session_source_lookup") && !plan.contains("SCAN s"),
+        "query plan did not search the source lookup index: {plan}"
+    );
+}
+
+#[test]
 fn an_agent_scoped_upsert_leaves_another_agents_rows_intact() {
     let store = store();
     let claude = session("claude-session", 1_000);
@@ -252,6 +282,7 @@ fn sessions_with_missing_source_returns_only_that_failure_reason() {
         .upsert_sessions(
             &[
                 session("returned", 1_000),
+                session("unrequested-returned", 1_500),
                 session("other-failure", 2_000),
                 session("healthy", 3_000),
             ],
@@ -263,7 +294,7 @@ fn sessions_with_missing_source_returns_only_that_failure_reason() {
         connection
             .execute(
                 "UPDATE session_evidence SET status = 'failed', last_error = ?1
-                  WHERE session_id = 'returned'",
+                  WHERE session_id IN ('returned', 'unrequested-returned')",
                 params![crate::insights_worker::EVIDENCE_ERROR_SOURCE_MISSING],
             )
             .unwrap();
@@ -276,7 +307,12 @@ fn sessions_with_missing_source_returns_only_that_failure_reason() {
             .unwrap();
     }
 
-    let missing = store.sessions_with_missing_source().unwrap();
+    let candidates = [
+        SessionKey::new("native", "claude-code", "returned"),
+        SessionKey::new("native", "claude-code", "other-failure"),
+        SessionKey::new("native", "claude-code", "healthy"),
+    ];
+    let missing = store.sessions_with_missing_source_for(&candidates).unwrap();
     let ids: Vec<_> = missing.iter().map(|key| key.session_id.as_str()).collect();
     assert_eq!(ids, vec!["returned"]);
 }


### PR DESCRIPTION
## User impact

Periodic full and agent-scoped scans now load cached records only for activity sources discovered in that pass. Missing-source recovery also checks only those discovered sessions. This prevents scan memory from growing with unrelated lifetime history while preserving unchanged detection, source recovery, title updates, and native/WSL isolation.

Indexed-title refreshes still cover every retained native session for the affected agent, including older sessions reachable through detail and lineage views. This path retains the narrow per-agent session-ID cohort and resolved title metadata proportional to that cohort, while full records are loaded in batches of 256. It is not an absolute constant-memory claim.

Stacked on #432, which is stacked on #430.

## Validation

- cargo fmt --check
- CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings
- CARGO_BUILD_JOBS=2 cargo test — 979 passed
- 1,000-versus-100,000 historical-session regression returns the same two requested full prior states
- 257-key database round trip crosses activity-key, session-key, and missing-source query batch boundaries
- EXPLAIN QUERY PLAN confirms the activity-key history query uses session_source_lookup without scanning the session table
- pnpm run slop:all — 100/100
- pnpm run secrets

## Analytics

Measurement is unchanged because this is an internal scan read/allocation optimization with no user-facing behavior change. Existing scan discovery and result events keep the same triggers, properties, duplicate rules, and meanings. Adding product analytics for internal query counts or returned rows would not answer a reader behavior question and would add noise to background scan measurement.

## Privacy and performance

No new data or network access. Full/scoped discovery retains only prior records matching the discovered environment, agent, and source keys, and missing-source recovery returns only matching pass keys. Title refresh retains only one affected native agents identity/title cohort at a time and drains resolved titles through bounded full-record batches.

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (git commit -s).
- [x] I updated tests and documentation where needed.