### PR TITLE
Park hidden HUD work and push session liveness

### DIFF
--- a/apps/desktop/src-tauri/crates/hud/Cargo.lock
+++ b/apps/desktop/src-tauri/crates/hud/Cargo.lock
@@ -3401,7 +3401,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/crates/hud/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/hud/Cargo.toml
@@ -22,6 +22,6 @@ serde_json = "1"
 tauri = { version = "2", features = ["macos-private-api"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { version = "1", features = ["macros", "sync", "time"] }
 objc2-app-kit = { version = "0.3", features = ["NSWindow"] }
 tracing = "0.1"

--- a/apps/desktop/src-tauri/crates/hud/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/hud/Cargo.toml
@@ -22,6 +22,6 @@ serde_json = "1"
 tauri = { version = "2", features = ["macos-private-api"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["sync", "time"] }
 objc2-app-kit = { version = "0.3", features = ["NSWindow"] }
 tracing = "0.1"

--- a/apps/desktop/src-tauri/crates/hud/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/hud/src/lib.rs
@@ -8,6 +8,8 @@
 //! that memory — [`Placement`], [`current_placement`], and [`apply_placement`]
 //! — and the shell supplies the storage.
 
+#[cfg(target_os = "macos")]
+use std::sync::LazyLock;
 use std::sync::Mutex;
 #[cfg(target_os = "macos")]
 use std::sync::MutexGuard;
@@ -47,6 +49,70 @@ const RESIZE_DURATION: Duration = Duration::from_millis(140);
 const RESIZE_STEPS: u32 = 12;
 #[cfg(target_os = "macos")]
 const OVERLAY_VISIBILITY_EVENT: &str = "overlay_visibility_changed";
+#[cfg(target_os = "macos")]
+const OVERLAY_WORK_EVENT: &str = "overlay_work_changed";
+
+#[cfg(target_os = "macos")]
+static OVERLAY_VISIBILITY: LazyLock<tokio::sync::watch::Sender<VisibilityState>> =
+    LazyLock::new(|| tokio::sync::watch::channel(VisibilityState::hidden()).0);
+
+/// Native HUD visibility and hover watcher ownership.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Copy)]
+pub struct VisibilityState {
+    visible: bool,
+    hover_generation: u64,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl VisibilityState {
+    const fn hidden() -> Self {
+        Self {
+            visible: false,
+            hover_generation: 0,
+        }
+    }
+
+    /// Return whether the native HUD is on screen.
+    pub fn is_visible(self) -> bool {
+        self.visible
+    }
+
+    fn start_hover_watcher(&mut self) -> u64 {
+        self.hover_generation = self.hover_generation.wrapping_add(1);
+        self.hover_generation
+    }
+
+    fn destroy_hover_watcher(&mut self, generation: u64) {
+        if self.hover_generation == generation {
+            self.hover_generation = self.hover_generation.wrapping_add(1);
+            self.visible = false;
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn set_overlay_visible(visible: bool) {
+    OVERLAY_VISIBILITY.send_modify(|state| state.visible = visible);
+}
+
+/// Return whether the HUD is requested to run, including its first render.
+#[cfg(target_os = "macos")]
+pub fn work_is_active() -> bool {
+    RESIZE_STATE.wants_visible()
+}
+
+/// Keep HUD work inactive where the HUD is unavailable.
+#[cfg(not(target_os = "macos"))]
+pub fn work_is_active() -> bool {
+    false
+}
+
+/// Subscribe to the HUD's actual native visibility.
+#[cfg(target_os = "macos")]
+pub fn visibility_receiver() -> tokio::sync::watch::Receiver<VisibilityState> {
+    OVERLAY_VISIBILITY.subscribe()
+}
 
 #[cfg(any(target_os = "macos", test))]
 struct ResizeState {
@@ -351,6 +417,7 @@ pub fn open(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()> {
             RESIZE_STATE.request_open();
             RESIZE_STATE.is_measured()
         };
+        let _ = app.emit(OVERLAY_WORK_EVENT, true);
         // Displays can connect or disconnect while the HUD is off, so the
         // reopen resolves the remembered position again before it shows.
         place(&window, entries)?;
@@ -364,6 +431,7 @@ pub fn open(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()> {
         let _guard = resize_apply_guard();
         RESIZE_STATE.reset(OVERLAY_SEED_HEIGHT);
     }
+    set_overlay_visible(false);
     let window = WebviewWindowBuilder::new(
         app,
         OVERLAY_LABEL,
@@ -386,6 +454,7 @@ pub fn open(app: &AppHandle, entries: &[Placement]) -> tauri::Result<()> {
     float_over_all_spaces(&window)?;
     spawn_hover_watcher(window.clone());
     place(&window, entries)?;
+    let _ = app.emit(OVERLAY_WORK_EVENT, true);
 
     // The renderer reveals the window after it reports the first content height.
     Ok(())
@@ -402,9 +471,16 @@ pub fn open(_app: &AppHandle, _entries: &[Placement]) -> tauri::Result<()> {
 pub fn hide(app: &AppHandle) -> tauri::Result<()> {
     let _guard = resize_apply_guard();
     RESIZE_STATE.request_hide();
+    set_overlay_visible(false);
+    let _ = app.emit(OVERLAY_WORK_EVENT, false);
     hide_detail(app);
     if let Some(window) = app.get_webview_window(OVERLAY_LABEL) {
-        window.hide()?;
+        if let Err(error) = window.hide() {
+            RESIZE_STATE.request_open();
+            set_overlay_visible(true);
+            let _ = app.emit(OVERLAY_WORK_EVENT, true);
+            return Err(error);
+        }
     }
     let _ = app.emit(OVERLAY_VISIBILITY_EVENT, false);
     Ok(())
@@ -545,6 +621,7 @@ fn show_without_activation(window: &WebviewWindow) -> tauri::Result<()> {
             // reset them when it shows a window.
             apply_float_over_all_spaces(ns_window);
             ns_window.orderFrontRegardless();
+            set_overlay_visible(true);
             let _ = app.emit(OVERLAY_VISIBILITY_EVENT, true);
         }
     })
@@ -624,19 +701,48 @@ fn apply_height(
 
 #[cfg(target_os = "macos")]
 fn spawn_hover_watcher(window: WebviewWindow) {
+    let mut generation = 0;
+    OVERLAY_VISIBILITY.send_modify(|state| {
+        generation = state.start_hover_watcher();
+    });
+    window.on_window_event(move |event| {
+        if matches!(event, tauri::WindowEvent::Destroyed) {
+            OVERLAY_VISIBILITY.send_modify(|state| state.destroy_hover_watcher(generation));
+        }
+    });
     tauri::async_runtime::spawn(async move {
+        let mut visibility = visibility_receiver();
         let mut inside_last = false;
         loop {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            let state = *visibility.borrow_and_update();
+            if state.hover_generation != generation {
+                break;
+            }
+            if !state.visible {
+                inside_last = false;
+                if visibility.changed().await.is_err() {
+                    break;
+                }
+                continue;
+            }
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
+                changed = visibility.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    continue;
+                }
+            }
+            if visibility.borrow().hover_generation != generation {
+                break;
+            }
             if window
                 .app_handle()
                 .get_webview_window(OVERLAY_LABEL)
                 .is_none()
             {
                 break;
-            }
-            if !window.is_visible().unwrap_or(false) {
-                continue;
             }
             let inside = cursor_inside(&window).unwrap_or(false);
             if inside != inside_last {
@@ -731,10 +837,16 @@ pub fn detail_state() -> serde_json::Value {
 /// through [`apply_detail_size`].
 #[cfg(target_os = "macos")]
 pub fn show_detail(app: &AppHandle, state: serde_json::Value) {
-    if let Ok(mut slot) = DETAIL_STATE.lock() {
-        *slot = Some(state.clone());
+    {
+        let _guard = resize_apply_guard();
+        if !RESIZE_STATE.wants_visible() {
+            return;
+        }
+        if let Ok(mut slot) = DETAIL_STATE.lock() {
+            *slot = Some(state.clone());
+        }
+        DETAIL_SHOULD_SHOW.store(true, Ordering::Relaxed);
     }
-    DETAIL_SHOULD_SHOW.store(true, Ordering::Relaxed);
     if app.get_webview_window(DETAIL_LABEL).is_none() && build_detail(app).is_err() {
         return;
     }
@@ -751,6 +863,7 @@ pub fn show_detail(_app: &AppHandle, _state: serde_json::Value) {}
 /// window appears at its final size, so it never resizes on screen.
 #[cfg(target_os = "macos")]
 pub fn apply_detail_size(app: &AppHandle, height: f64) {
+    let _guard = resize_apply_guard();
     let height = clamp_detail_height(height);
     let Some(detail) = app.get_webview_window(DETAIL_LABEL) else {
         return;
@@ -767,7 +880,7 @@ pub fn apply_detail_size(app: &AppHandle, height: f64) {
     if position_detail_window(&detail, &hud, height).is_none() {
         return;
     }
-    if DETAIL_SHOULD_SHOW.load(Ordering::Relaxed) {
+    if RESIZE_STATE.wants_visible() && DETAIL_SHOULD_SHOW.load(Ordering::Relaxed) {
         let _ = detail.show();
     }
 }
@@ -1022,6 +1135,27 @@ mod tests {
         assert!(!state.wants_visible());
         state.request_open();
         assert!(state.wants_visible());
+    }
+
+    #[test]
+    fn destroying_a_hidden_window_cancels_its_hover_watcher() {
+        let mut state = VisibilityState::hidden();
+        state.visible = true;
+        let generation = state.start_hover_watcher();
+        state.destroy_hover_watcher(generation);
+        assert!(!state.visible);
+        assert_ne!(state.hover_generation, generation);
+    }
+
+    #[test]
+    fn destroying_an_old_window_does_not_cancel_its_replacement() {
+        let mut state = VisibilityState::hidden();
+        let old = state.start_hover_watcher();
+        let current = state.start_hover_watcher();
+        state.visible = true;
+        state.destroy_hover_watcher(old);
+        assert!(state.visible);
+        assert_eq!(state.hover_generation, current);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/hud/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/hud/src/lib.rs
@@ -474,13 +474,13 @@ pub fn hide(app: &AppHandle) -> tauri::Result<()> {
     set_overlay_visible(false);
     let _ = app.emit(OVERLAY_WORK_EVENT, false);
     hide_detail(app);
-    if let Some(window) = app.get_webview_window(OVERLAY_LABEL) {
-        if let Err(error) = window.hide() {
-            RESIZE_STATE.request_open();
-            set_overlay_visible(true);
-            let _ = app.emit(OVERLAY_WORK_EVENT, true);
-            return Err(error);
-        }
+    if let Some(window) = app.get_webview_window(OVERLAY_LABEL)
+        && let Err(error) = window.hide()
+    {
+        RESIZE_STATE.request_open();
+        set_overlay_visible(true);
+        let _ = app.emit(OVERLAY_WORK_EVENT, true);
+        return Err(error);
     }
     let _ = app.emit(OVERLAY_VISIBILITY_EVENT, false);
     Ok(())

--- a/apps/desktop/src-tauri/permissions/autogenerated/is_overlay_work_active.toml
+++ b/apps/desktop/src-tauri/permissions/autogenerated/is_overlay_work_active.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-is-overlay-work-active"
+description = "Enables the is_overlay_work_active command without any pre-configured scope."
+commands.allow = ["is_overlay_work_active"]
+
+[[permission]]
+identifier = "deny-is-overlay-work-active"
+description = "Denies the is_overlay_work_active command without any pre-configured scope."
+commands.deny = ["is_overlay_work_active"]

--- a/apps/desktop/src-tauri/permissions/default.toml
+++ b/apps/desktop/src-tauri/permissions/default.toml
@@ -36,6 +36,7 @@ permissions = [
   "allow-hide-overlay-window",
   "allow-hide-popover",
   "allow-install-update",
+  "allow-is-overlay-work-active",
   "allow-list-recent-sessions",
   "allow-list-repositories",
   "allow-list-scan-roots",

--- a/apps/desktop/src-tauri/src/app_commands.rs
+++ b/apps/desktop/src-tauri/src/app_commands.rs
@@ -38,6 +38,7 @@ macro_rules! with_app_commands {
             commands::hide_overlay_window => "hide_overlay_window",
             commands::hide_popover => "hide_popover",
             commands::install_update => "install_update",
+            commands::is_overlay_work_active => "is_overlay_work_active",
             commands::list_recent_sessions => "list_recent_sessions",
             commands::list_repositories => "list_repositories",
             commands::list_scan_roots => "list_scan_roots",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -218,6 +218,12 @@ pub fn hide_overlay_window(app: tauri::AppHandle) -> CommandResult<()> {
     antiburn_hud::hide(&app).map_err(fail)
 }
 
+/// Return whether the HUD should run while its retained renderer mounts.
+#[tauri::command]
+pub fn is_overlay_work_active() -> bool {
+    antiburn_hud::work_is_active()
+}
+
 /// Match the native HUD frame to the rendered panel.
 #[tauri::command]
 pub fn resize_overlay_window(

--- a/apps/desktop/src-tauri/src/hud.rs
+++ b/apps/desktop/src-tauri/src/hud.rs
@@ -68,17 +68,27 @@ pub fn record_position(app: &AppHandle) {
 /// A poll rather than an event: it is the pattern the hover watcher in the HUD
 /// crate already uses, and it needs no platform notification of its own. The
 /// poll costs nothing while the HUD is closed.
+#[cfg(target_os = "macos")]
 pub fn spawn_display_watcher(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
+        let mut visibility = antiburn_hud::visibility_receiver();
         let mut connected: Vec<String> = Vec::new();
         loop {
-            tokio::time::sleep(DISPLAY_POLL).await;
-            if app
-                .get_webview_window(antiburn_hud::OVERLAY_LABEL)
-                .is_none()
-            {
+            if !visibility.borrow_and_update().is_visible() {
+                if visibility.changed().await.is_err() {
+                    break;
+                }
                 continue;
+            }
+            tokio::select! {
+                () = tokio::time::sleep(DISPLAY_POLL) => {}
+                changed = visibility.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    continue;
+                }
             }
             let now = antiburn_hud::monitor_keys(&app);
             if now == connected {
@@ -92,6 +102,10 @@ pub fn spawn_display_watcher(app: &AppHandle) {
         }
     });
 }
+
+/// Keep the display watcher absent where the HUD is unavailable.
+#[cfg(not(target_os = "macos"))]
+pub fn spawn_display_watcher(_app: &AppHandle) {}
 
 /// Read the stored value. Anything unreadable means "no memory yet": a bad row
 /// must never stop the HUD from appearing.

--- a/apps/desktop/src-tauri/src/hud.rs
+++ b/apps/desktop/src-tauri/src/hud.rs
@@ -5,6 +5,7 @@
 //! owns where the HUD's remembered position is kept, and the watcher that
 //! reacts when a display connects or disconnects.
 
+#[cfg(target_os = "macos")]
 use std::time::Duration;
 
 use antiburn_hud::Placement;
@@ -25,6 +26,7 @@ const PLACEMENTS_VERSION: u32 = 1;
 const MAX_PLACEMENTS: usize = 8;
 
 /// How often the watcher looks for a change in the connected displays.
+#[cfg(target_os = "macos")]
 const DISPLAY_POLL: Duration = Duration::from_secs(2);
 
 /// The stored value: remembered placements, newest display first.

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -932,6 +932,12 @@ export async function getLatestSessionActivity(): Promise<number | null> {
   return invoke<number | null>("get_latest_session_activity")
 }
 
+/** Return whether the retained HUD renderer should run background work. */
+export async function isOverlayWorkActive(): Promise<boolean> {
+  if (!hasShell()) return false
+  return invoke<boolean>("is_overlay_work_active")
+}
+
 /** One usage bar as the hover detail window renders it. */
 export interface HudDetailBar {
   key: string

--- a/apps/desktop/src/lib/overlayWindow.ts
+++ b/apps/desktop/src/lib/overlayWindow.ts
@@ -5,6 +5,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window"
 
 const OVERLAY_WINDOW_LABEL = "antiburn-overlay"
 const OVERLAY_VISIBILITY_EVENT = "overlay_visibility_changed"
+const OVERLAY_WORK_EVENT = "overlay_work_changed"
 
 export function openOverlayWindow(): Promise<void> {
   return invoke("open_overlay_window")
@@ -12,6 +13,13 @@ export function openOverlayWindow(): Promise<void> {
 
 export async function hideOverlayWindow(): Promise<void> {
   await invoke("hide_overlay_window")
+}
+
+/** Subscribe to native HUD work transitions. */
+export async function onOverlayWorkChanged(
+  handler: (active: boolean) => void,
+): Promise<() => void> {
+  return listen<boolean>(OVERLAY_WORK_EVENT, (event) => handler(Boolean(event.payload)))
 }
 
 /**

--- a/apps/desktop/src/views/OverlayWindow.test.tsx
+++ b/apps/desktop/src/views/OverlayWindow.test.tsx
@@ -5,8 +5,11 @@ import type * as Ipc from "../lib/ipc"
 import type { LiveUsageSummaryPayload } from "../lib/ipc"
 import { OverlayWindow } from "./OverlayWindow"
 
+const REFRESH_TEST_MS = 60_000
+
 const getLiveUsage = vi.hoisted(() => vi.fn())
 const getLatestSessionActivity = vi.hoisted(() => vi.fn())
+const isOverlayWorkActive = vi.hoisted(() => vi.fn())
 const showHudDetail = vi.hoisted(() => vi.fn(async () => {}))
 const hideHudDetail = vi.hoisted(() => vi.fn(async () => {}))
 const resizeOverlayWindow = vi.hoisted(() => vi.fn(async () => {}))
@@ -27,6 +30,7 @@ vi.mock("../lib/ipc", async () => {
     ...actual,
     getLiveUsage,
     getLatestSessionActivity,
+    isOverlayWorkActive,
     showHudDetail,
     hideHudDetail,
     resizeOverlayWindow,
@@ -37,13 +41,22 @@ vi.mock("../lib/ipc", async () => {
 const invoke = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}))
 vi.mock("@tauri-apps/api/core", () => ({ invoke, isTauri: () => true }))
 
-const hover = vi.hoisted(() => ({ emit: null as ((next: boolean) => void) | null }))
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(async (_event: string, handler: (event: { payload: boolean }) => void) => {
-    hover.emit = (next: boolean) => handler({ payload: next })
-    return () => {}
-  }),
+const nativeEvents = vi.hoisted(
+  () => new Map<string, Set<(event: { payload: unknown }) => void>>(),
+)
+const listenNative = vi.hoisted(() => vi.fn())
+const hover = vi.hoisted(() => ({
+  emit: (next: boolean) => {
+    for (const handler of nativeEvents.get("overlay_hover") ?? []) {
+      handler({ payload: next })
+    }
+  },
 }))
+vi.mock("@tauri-apps/api/event", () => ({ listen: listenNative }))
+
+function emitNative(event: string, payload: unknown): void {
+  for (const handler of nativeEvents.get(event) ?? []) handler({ payload })
+}
 
 const setPosition = vi.hoisted(() => vi.fn(async () => {}))
 const outerPosition = vi.hoisted(() => vi.fn(async () => ({ x: 600, y: 40 })))
@@ -183,11 +196,25 @@ describe("OverlayWindow", () => {
     getLiveUsage.mockResolvedValue(summary())
     getLatestSessionActivity.mockReset()
     getLatestSessionActivity.mockResolvedValue(null)
+    isOverlayWorkActive.mockReset()
+    isOverlayWorkActive.mockResolvedValue(true)
     showHudDetail.mockClear()
     hideHudDetail.mockClear()
     resizeOverlayWindow.mockClear()
     invoke.mockClear()
     livePush.emit = null
+    nativeEvents.clear()
+    listenNative.mockReset()
+    listenNative.mockImplementation(
+      async (event: string, handler: (event: { payload: unknown }) => void) => {
+        const listeners = nativeEvents.get(event) ?? new Set()
+        listeners.add(handler)
+        nativeEvents.set(event, listeners)
+        return () => {
+          listeners.delete(handler)
+        }
+      },
+    )
     onLiveUsageChanged.mockClear()
     outerPosition.mockReset()
     outerPosition.mockResolvedValue({ x: 600, y: 40 })
@@ -208,6 +235,178 @@ describe("OverlayWindow", () => {
     expect(document.body.dataset.transparentWindow).toBe("true")
     unmount()
     expect(document.body.dataset.transparentWindow).toBeUndefined()
+  })
+
+  it("does no polling or subscription work while native policy keeps it hidden", async () => {
+    isOverlayWorkActive.mockResolvedValue(false)
+    vi.useFakeTimers()
+    try {
+      const { unmount } = render(<OverlayWindow />)
+      await advance(0)
+
+      expect(getLiveUsage).not.toHaveBeenCalled()
+      expect(getLatestSessionActivity).not.toHaveBeenCalled()
+      expect(nativeEvents.get("overlay_hover")?.size ?? 0).toBe(0)
+      await advance(5 * 60_000)
+      expect(getLiveUsage).not.toHaveBeenCalled()
+      unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("parks on hide and starts one fresh work set on every reshow", async () => {
+    isOverlayWorkActive.mockResolvedValue(false)
+    vi.useFakeTimers()
+    try {
+      render(<OverlayWindow />)
+      await advance(0)
+
+      act(() => emitNative("overlay_work_changed", true))
+      await advance(0)
+      expect(getLiveUsage).toHaveBeenCalledTimes(1)
+      expect(getLatestSessionActivity).toHaveBeenCalledTimes(1)
+
+      act(() => emitNative("overlay_work_changed", false))
+      expect(nativeEvents.get("overlay_hover")?.size ?? 0).toBe(0)
+      await advance(2 * REFRESH_TEST_MS)
+      expect(getLiveUsage).toHaveBeenCalledTimes(1)
+
+      act(() => emitNative("overlay_work_changed", true))
+      await advance(0)
+      expect(getLiveUsage).toHaveBeenCalledTimes(2)
+      expect(getLatestSessionActivity).toHaveBeenCalledTimes(2)
+
+      act(() => emitNative("overlay_work_changed", false))
+      act(() => emitNative("overlay_work_changed", true))
+      await advance(0)
+      expect(getLiveUsage).toHaveBeenCalledTimes(3)
+      expect(nativeEvents.get("overlay_hover")?.size).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("reports layout readiness again when a reshow returns identical bars", async () => {
+    vi.useFakeTimers()
+    try {
+      render(<OverlayWindow />)
+      await advance(0)
+      const initialResizeCount = resizeOverlayWindow.mock.calls.length
+      expect(initialResizeCount).toBeGreaterThan(0)
+
+      act(() => emitNative("overlay_work_changed", false))
+      act(() => emitNative("overlay_work_changed", true))
+      await advance(0)
+
+      expect(resizeOverlayWindow.mock.calls.length).toBeGreaterThan(initialResizeCount)
+      expect(getLiveUsage).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("ignores a delayed initial load after native hide", async () => {
+    let resolveUsage!: (usage: LiveUsageSummaryPayload) => void
+    getLiveUsage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUsage = resolve
+        }),
+    )
+    render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalledTimes(1))
+    const resizeCount = resizeOverlayWindow.mock.calls.length
+
+    act(() => emitNative("overlay_work_changed", false))
+    await act(async () => resolveUsage(withSecondBar()))
+
+    expect(resizeOverlayWindow).toHaveBeenCalledTimes(resizeCount)
+    expect(document.querySelectorAll(".pointer-events-none .rounded-full")).toHaveLength(20)
+  })
+
+  it("does not let a stale active-state read restart hidden work", async () => {
+    let resolveActive!: (active: boolean) => void
+    isOverlayWorkActive.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveActive = resolve
+        }),
+    )
+    render(<OverlayWindow />)
+    await waitFor(() => expect(isOverlayWorkActive).toHaveBeenCalledTimes(1))
+
+    act(() => emitNative("overlay_work_changed", false))
+    await act(async () => resolveActive(true))
+
+    expect(getLiveUsage).not.toHaveBeenCalled()
+    expect(getLatestSessionActivity).not.toHaveBeenCalled()
+  })
+
+  it("retries a transient native work-listener failure", async () => {
+    listenNative.mockRejectedValueOnce(new Error("listener unavailable"))
+    render(<OverlayWindow />)
+
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
+    expect(listenNative.mock.calls[0]?.[0]).toBe("overlay_work_changed")
+    expect(listenNative.mock.calls[1]?.[0]).toBe("overlay_work_changed")
+    expect(nativeEvents.get("overlay_work_changed")?.size).toBe(1)
+  })
+
+  it("expires live activity once without polling", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-09-08T00:00:00Z"))
+    getLatestSessionActivity.mockResolvedValue(Date.now() / 1000)
+    try {
+      const { container } = render(<OverlayWindow />)
+      await advance(0)
+      expect(container.querySelector(".led-blink")).not.toBeNull()
+
+      await advance(90_001)
+      expect(container.querySelector(".led-blink")).toBeNull()
+      expect(getLatestSessionActivity).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("keeps a far-future activity expiry inside the browser timer bound", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-09-08T00:00:00Z"))
+    const day = 24 * 60 * 60 * 1000
+    getLatestSessionActivity.mockResolvedValue((Date.now() + 40 * day) / 1000)
+    const timeout = vi.spyOn(window, "setTimeout")
+    try {
+      const { container } = render(<OverlayWindow />)
+      await advance(0)
+      expect(container.querySelector(".led-blink")).not.toBeNull()
+      expect(timeout).toHaveBeenCalledWith(expect.any(Function), 2_147_483_647)
+      expect(getLatestSessionActivity).toHaveBeenCalledTimes(1)
+    } finally {
+      timeout.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("uses pushed session activity and cleans its subscriptions on hide", async () => {
+    const { container, unmount } = render(<OverlayWindow />)
+    await waitFor(() => expect(nativeEvents.get("sessions:entry-changed")?.size).toBe(1))
+
+    act(() =>
+      emitNative("sessions:entry-changed", {
+        timestamp: new Date().toISOString(),
+      }),
+    )
+    expect(container.querySelector(".led-blink")).not.toBeNull()
+
+    act(() => emitNative("overlay_work_changed", false))
+    expect(nativeEvents.get("sessions:entry-changed")?.size ?? 0).toBe(0)
+    expect(nativeEvents.get("scan:finished")?.size ?? 0).toBe(0)
+    expect(nativeEvents.get("sessions:invalidated")?.size ?? 0).toBe(0)
+    expect(nativeEvents.get("overlay_work_changed")?.size).toBe(1)
+
+    unmount()
+    expect(nativeEvents.get("overlay_work_changed")?.size ?? 0).toBe(0)
   })
 
   it("rests with bars only and a hidden close control", async () => {
@@ -241,6 +440,18 @@ describe("OverlayWindow", () => {
     expect(document.querySelectorAll(".pointer-events-none .rounded-full")).toHaveLength(20)
     // The window shrinks with it, rather than keeping the old bars' height.
     await waitFor(() => expect(resizeOverlayWindow).toHaveBeenCalledWith(28, false, true))
+  })
+
+  it("does not publish or resize for an equal pushed usage snapshot", async () => {
+    const payload = summary()
+    getLiveUsage.mockResolvedValue(payload)
+    render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
+    const resizeCount = resizeOverlayWindow.mock.calls.length
+
+    await act(async () => livePush.emit!(payload))
+
+    expect(resizeOverlayWindow).toHaveBeenCalledTimes(resizeCount)
   })
 
   it("reveals at the measured collapsed height", async () => {
@@ -332,10 +543,10 @@ describe("OverlayWindow", () => {
     try {
       render(<OverlayWindow />)
       await advance(0)
-      act(() => hover.emit!(true))
+      act(() => hover.emit(true))
       await advance(400)
       expect(showHudDetail).toHaveBeenCalledTimes(1)
-      act(() => hover.emit!(false))
+      act(() => hover.emit(false))
       expect(hideHudDetail).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
@@ -344,8 +555,8 @@ describe("OverlayWindow", () => {
 
   it("keeps hover active inside the transparent frame margin", async () => {
     const { container } = render(<OverlayWindow />)
-    await waitFor(() => expect(hover.emit).not.toBeNull())
-    act(() => hover.emit!(true))
+    await waitFor(() => expect(nativeEvents.get("overlay_hover")?.size).toBe(1))
+    act(() => hover.emit(true))
     await waitFor(() => expect(closeButton()).toHaveClass("opacity-100"))
     fireEvent.mouseLeave(panel(container), { relatedTarget: frame(container) })
     expect(closeButton()).toHaveClass("opacity-100")
@@ -380,6 +591,7 @@ describe("OverlayWindow", () => {
         }),
     )
     const { container } = render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
     fireEvent.mouseEnter(frame(container))
     fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
     await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(1))
@@ -391,8 +603,38 @@ describe("OverlayWindow", () => {
     fireEvent.mouseUp(window)
   })
 
+  it("ignores an old drag position after hide and reshow", async () => {
+    let resolveOldPosition!: (position: { x: number; y: number }) => void
+    outerPosition
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOldPosition = resolve
+          }),
+      )
+      .mockResolvedValueOnce({ x: 600, y: 40 })
+    const { container } = render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
+
+    fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
+    await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(1))
+    act(() => emitNative("overlay_work_changed", false))
+    act(() => emitNative("overlay_work_changed", true))
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalledTimes(2))
+
+    fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
+    await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(2))
+    await act(async () => resolveOldPosition({ x: 100, y: 10 }))
+    fireEvent.mouseMove(window, { screenX: 710, screenY: 110 })
+
+    await waitFor(() => expect(setPosition).toHaveBeenCalled())
+    expect(setPosition).toHaveBeenLastCalledWith(expect.objectContaining({ x: 610, y: 50 }))
+    fireEvent.mouseUp(window)
+  })
+
   it("remembers where a settled drag left the HUD", async () => {
     const { container } = render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
     fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
     await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(1))
     fireEvent.mouseUp(window)
@@ -412,6 +654,7 @@ describe("OverlayWindow", () => {
   it("survives a rejected position record", async () => {
     invoke.mockRejectedValueOnce(new Error("no window"))
     const { container } = render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
     fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
     await waitFor(() => expect(outerPosition).toHaveBeenCalledTimes(1))
     fireEvent.mouseUp(window)
@@ -425,6 +668,7 @@ describe("OverlayWindow", () => {
     const removeListener = vi.spyOn(window, "removeEventListener")
     outerPosition.mockRejectedValueOnce(new Error("position unavailable"))
     const { container } = render(<OverlayWindow />)
+    await waitFor(() => expect(getLiveUsage).toHaveBeenCalled())
 
     fireEvent.mouseDown(panel(container), { screenX: 700, screenY: 100 })
 

--- a/apps/desktop/src/views/overlay/OverlaySession.ts
+++ b/apps/desktop/src/views/overlay/OverlaySession.ts
@@ -8,14 +8,19 @@ import {
   getLatestSessionActivity,
   getLiveUsage,
   hideHudDetail,
+  isOverlayWorkActive,
   onLiveUsageChanged,
+  onSessionEntryChanged,
+  onSessionsInvalidated,
   resizeOverlayWindow,
+  SCAN_EVENTS,
   showHudDetail,
   type HudDetailState,
   type LiveUsageSummaryPayload,
 } from "../../lib/ipc"
 import {
   hideOverlayWindow,
+  onOverlayWorkChanged,
   recordHudPosition,
   setFloatingHudEnabled,
 } from "../../lib/overlayWindow"
@@ -24,15 +29,13 @@ import { deriveUsageBars, noMeterSelected, type UsageBarItem } from "../../lib/u
 
 const REFRESH_MS = 60_000
 const LIVE_WINDOW_SECS = 90
-const LIVENESS_POLL_MS = 5_000
-const RESET_CLOCK_MS = 30_000
 const SHOW_DELAY_MS = 400
+const MAX_TIMEOUT_MS = 2_147_483_647
 
 export type OverlaySnapshot = {
   bars: UsageBarItem[]
   hovered: boolean
   dragging: boolean
-  now: number
   sessionLive: boolean
   /** True when `bars` is empty because every meter is turned off. */
   noMeterSelected: boolean
@@ -42,7 +45,6 @@ const INITIAL_SNAPSHOT: OverlaySnapshot = {
   bars: [],
   hovered: false,
   dragging: false,
-  now: Date.now(),
   sessionLive: false,
   noMeterSelected: false,
 }
@@ -54,20 +56,46 @@ type DragOrigin = {
   windowY: number
 }
 
+function sameBars(left: UsageBarItem[], right: UsageBarItem[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((bar, index) => {
+      const other = right[index]
+      return (
+        other != null &&
+        bar.key === other.key &&
+        bar.label === other.label &&
+        bar.percent === other.percent &&
+        bar.resetsAt?.getTime() === other.resetsAt?.getTime() &&
+        bar.color === other.color &&
+        bar.expectedFraction === other.expectedFraction
+      )
+    })
+  )
+}
+
 export class OverlaySession {
   private listeners = new Set<() => void>()
   private started = false
   private generation = 0
+  private active = false
+  private activityGeneration = 0
+  private workRevision = 0
   private snapshot: OverlaySnapshot = INITIAL_SNAPSHOT
   private panel: HTMLDivElement | null = null
   private observer: ResizeObserver | null = null
   private showTimer: number | null = null
   private detailShown = false
   private usagePoll: number | null = null
-  private livenessPoll: number | null = null
-  private resetClock: number | null = null
+  private livenessExpiry: number | null = null
+  private latestActivity: number | null = null
+  private livenessRevision = 0
+  private stopWorkListening: (() => void) | null = null
   private stopHoverListening: (() => void) | null = null
   private stopUsageListening: (() => void) | null = null
+  private stopSessionEntryListening: (() => void) | null = null
+  private stopScanListening: (() => void) | null = null
+  private stopInvalidationListening: (() => void) | null = null
   private dragOrigin: DragOrigin | null = null
   private pendingMove: MouseEvent | null = null
   private moveFrame = 0
@@ -88,10 +116,11 @@ export class OverlaySession {
     this.observer?.disconnect()
     this.observer = null
     this.panel = panel
-    if (this.started) this.connectPanel()
+    if (this.active) this.connectPanel(this.activityGeneration)
   }
 
   requestHover = (hovered: boolean): void => {
+    if (!this.active) return
     if (hovered) {
       if (!this.snapshot.hovered) this.update({ hovered: true })
       if (!this.snapshot.dragging) this.armShowTimer()
@@ -104,9 +133,14 @@ export class OverlaySession {
   }
 
   startDrag = (event: ReactMouseEvent): void => {
-    if ((event.target as HTMLElement).closest("button") || this.snapshot.dragging) return
+    if (
+      !this.active ||
+      (event.target as HTMLElement).closest("button") ||
+      this.snapshot.dragging
+    )
+      return
     const { screenX, screenY } = event
-    void this.beginDrag(screenX, screenY)
+    void this.beginDrag(screenX, screenY, this.activityGeneration)
   }
 
   close = (): void => {
@@ -119,16 +153,53 @@ export class OverlaySession {
     this.started = true
     const generation = ++this.generation
     document.body.dataset.transparentWindow = "true"
-    this.connectPanel()
+    void this.startWorkLifecycle(generation)
+  }
+
+  private async startWorkLifecycle(generation: number): Promise<void> {
+    let dispose: (() => void) | null = null
+    for (let attempt = 0; attempt < 2 && dispose == null; attempt += 1) {
+      try {
+        dispose = await onOverlayWorkChanged((active) => {
+          if (!this.isLifecycleCurrent(generation)) return
+          this.workRevision += 1
+          this.setActive(active)
+        })
+      } catch {
+        // The second attempt repairs a transient native listener failure.
+      }
+    }
+    if (!this.isLifecycleCurrent(generation)) {
+      dispose?.()
+      return
+    }
+    this.stopWorkListening = dispose
+    const revision = this.workRevision
+    const active = await isOverlayWorkActive().catch(() => true)
+    if (!this.isLifecycleCurrent(generation) || revision !== this.workRevision) return
+    this.setActive(active)
+  }
+
+  private setActive(active: boolean): void {
+    if (active === this.active) return
+    if (active) this.startActivity()
+    else this.stopActivity()
+  }
+
+  private startActivity(): void {
+    this.active = true
+    const generation = ++this.activityGeneration
+    this.update({ hovered: false, dragging: false, sessionLive: false })
+    this.connectPanel(generation)
 
     const applyUsage = (response: LiveUsageSummaryPayload | null) => {
       if (!this.isCurrent(generation)) return
-      this.commitLayout({
+      const changed = this.commitLayout({
         bars: deriveUsageBars(response),
         noMeterSelected: noMeterSelected(response),
       })
-      void this.syncWindow(true)
-      if (this.detailShown) {
+      if (changed) void this.syncWindow(true, generation)
+      if (changed && this.detailShown) {
         void showHudDetail(this.detailState("refresh")).catch(() => {})
       }
     }
@@ -150,19 +221,8 @@ export class OverlaySession {
       })
       .catch(() => {})
 
-    const refreshLiveness = () => {
-      void getLatestSessionActivity()
-        .then((latest) => {
-          if (!this.isCurrent(generation)) return
-          this.update({
-            sessionLive: latest != null && Date.now() / 1000 - latest <= LIVE_WINDOW_SECS,
-          })
-        })
-        .catch(() => {})
-    }
-    refreshLiveness()
-    this.livenessPoll = window.setInterval(refreshLiveness, LIVENESS_POLL_MS)
-    this.resetClock = window.setInterval(() => this.update({ now: Date.now() }), RESET_CLOCK_MS)
+    this.listenForActivity(generation)
+    this.refreshLatestActivity(generation)
 
     void listen<boolean>("overlay_hover", (event) => {
       if (this.isCurrent(generation)) this.requestHover(Boolean(event.payload))
@@ -177,36 +237,139 @@ export class OverlaySession {
   private stop(): void {
     this.started = false
     this.generation += 1
-    this.clearShowTimer()
-    this.hideDetail()
-    this.clearInterval("usagePoll")
-    this.clearInterval("livenessPoll")
-    this.clearInterval("resetClock")
-    this.stopHoverListening?.()
-    this.stopHoverListening = null
-    this.stopUsageListening?.()
-    this.stopUsageListening = null
-    this.removeDragListeners()
+    this.stopActivity()
+    this.stopWorkListening?.()
+    this.stopWorkListening = null
     this.observer?.disconnect()
     this.observer = null
     delete document.body.dataset.transparentWindow
   }
 
+  private stopActivity(): void {
+    if (!this.active) return
+    this.active = false
+    this.activityGeneration += 1
+    this.livenessRevision += 1
+    this.clearShowTimer()
+    this.hideDetail()
+    this.clearUsagePoll()
+    this.clearLivenessExpiry()
+    this.stopHoverListening?.()
+    this.stopHoverListening = null
+    this.stopUsageListening?.()
+    this.stopUsageListening = null
+    this.stopSessionEntryListening?.()
+    this.stopSessionEntryListening = null
+    this.stopScanListening?.()
+    this.stopScanListening = null
+    this.stopInvalidationListening?.()
+    this.stopInvalidationListening = null
+    this.removeDragListeners()
+    this.observer?.disconnect()
+    this.observer = null
+    this.dragOrigin = null
+    this.pendingMove = null
+    this.latestActivity = null
+    this.update({ hovered: false, dragging: false, sessionLive: false })
+  }
+
   private isCurrent(generation: number): boolean {
+    return this.started && this.active && this.activityGeneration === generation
+  }
+
+  private isLifecycleCurrent(generation: number): boolean {
     return this.started && this.generation === generation
   }
 
-  private clearInterval(field: "usagePoll" | "livenessPoll" | "resetClock"): void {
-    const identifier = this[field]
-    if (identifier != null) window.clearInterval(identifier)
-    this[field] = null
+  private clearUsagePoll(): void {
+    if (this.usagePoll != null) window.clearInterval(this.usagePoll)
+    this.usagePoll = null
+  }
+
+  private clearLivenessExpiry(): void {
+    if (this.livenessExpiry != null) window.clearTimeout(this.livenessExpiry)
+    this.livenessExpiry = null
+  }
+
+  private listenForActivity(generation: number): void {
+    void onSessionEntryChanged((entry) => {
+      if (!this.isCurrent(generation)) return
+      const latest = Date.parse(entry.timestamp) / 1000
+      if (!Number.isFinite(latest)) return
+      this.livenessRevision += 1
+      this.setLatestActivity(
+        this.latestActivity == null ? latest : Math.max(this.latestActivity, latest),
+        generation,
+      )
+    })
+      .then((dispose) => {
+        if (this.isCurrent(generation)) this.stopSessionEntryListening = dispose
+        else dispose()
+      })
+      .catch(() => {})
+
+    void listen(SCAN_EVENTS.finished, () => {
+      if (this.isCurrent(generation)) this.refreshLatestActivity(generation)
+    })
+      .then((dispose) => {
+        if (this.isCurrent(generation)) this.stopScanListening = dispose
+        else dispose()
+      })
+      .catch(() => {})
+
+    void onSessionsInvalidated(() => {
+      if (this.isCurrent(generation)) this.refreshLatestActivity(generation)
+    })
+      .then((dispose) => {
+        if (this.isCurrent(generation)) this.stopInvalidationListening = dispose
+        else dispose()
+      })
+      .catch(() => {})
+  }
+
+  private refreshLatestActivity(generation: number): void {
+    const revision = ++this.livenessRevision
+    void getLatestSessionActivity()
+      .then((latest) => {
+        if (!this.isCurrent(generation) || revision !== this.livenessRevision) return
+        this.setLatestActivity(latest, generation)
+      })
+      .catch(() => {})
+  }
+
+  private setLatestActivity(latest: number | null, generation: number): void {
+    this.latestActivity = latest
+    this.clearLivenessExpiry()
+    if (latest == null) {
+      this.update({ sessionLive: false })
+      return
+    }
+    const expiresAt = latest * 1000 + LIVE_WINDOW_SECS * 1000
+    const remaining = expiresAt - Date.now()
+    if (remaining < 0) {
+      this.update({ sessionLive: false })
+      return
+    }
+    this.update({ sessionLive: true })
+    this.livenessExpiry = window.setTimeout(
+      () => {
+        this.livenessExpiry = null
+        if (!this.isCurrent(generation) || this.latestActivity !== latest) return
+        if (Date.now() <= expiresAt) {
+          this.setLatestActivity(latest, generation)
+        } else {
+          this.update({ sessionLive: false })
+        }
+      },
+      Math.min(remaining + 1, MAX_TIMEOUT_MS),
+    )
   }
 
   private armShowTimer(): void {
     if (this.showTimer != null || this.detailShown) return
     this.showTimer = window.setTimeout(() => {
       this.showTimer = null
-      if (!this.started || !this.snapshot.hovered || this.snapshot.dragging) return
+      if (!this.active || !this.snapshot.hovered || this.snapshot.dragging) return
       this.detailShown = true
       void showHudDetail(this.detailState("show")).catch(() => {})
     }, SHOW_DELAY_MS)
@@ -239,39 +402,54 @@ export class OverlaySession {
     }
   }
 
-  private update(change: Partial<OverlaySnapshot>): void {
-    this.snapshot = { ...this.snapshot, ...change }
+  private update(change: Partial<OverlaySnapshot>): boolean {
+    const next = { ...this.snapshot, ...change }
+    if (
+      sameBars(this.snapshot.bars, next.bars) &&
+      this.snapshot.hovered === next.hovered &&
+      this.snapshot.dragging === next.dragging &&
+      this.snapshot.sessionLive === next.sessionLive &&
+      this.snapshot.noMeterSelected === next.noMeterSelected
+    ) {
+      return false
+    }
+    this.snapshot = next
     for (const listener of this.listeners) listener()
+    return true
   }
 
-  private commitLayout(change: Partial<OverlaySnapshot>): void {
-    flushSync(() => this.update(change))
+  private commitLayout(change: Partial<OverlaySnapshot>): boolean {
+    let changed = false
+    flushSync(() => {
+      changed = this.update(change)
+    })
+    return changed
   }
 
-  private connectPanel(): void {
-    if (!this.panel) return
-    void this.syncWindow(false)
+  private connectPanel(generation: number): void {
+    if (!this.panel || !this.isCurrent(generation)) return
+    void this.syncWindow(false, generation)
     if (typeof ResizeObserver === "undefined") return
-    this.observer = new ResizeObserver(() => void this.syncWindow(true))
+    this.observer = new ResizeObserver(() => void this.syncWindow(true, generation))
     this.observer.observe(this.panel)
   }
 
-  private syncWindow(animate: boolean): Promise<void> {
-    if (!this.panel) return Promise.resolve()
+  private syncWindow(animate: boolean, generation: number): Promise<void> {
+    if (!this.panel || !this.isCurrent(generation)) return Promise.resolve()
     const height = Math.ceil(this.panel.getBoundingClientRect().height)
     return resizeOverlayWindow(height, false, animate && !prefersReducedMotion()).catch(
       () => {},
     )
   }
 
-  private async beginDrag(screenX: number, screenY: number): Promise<void> {
+  private async beginDrag(screenX: number, screenY: number, generation: number): Promise<void> {
     this.clearShowTimer()
     this.hideDetail()
     this.update({ dragging: true })
     this.dragOrigin = null
     this.addDragListeners()
-    await this.syncWindow(false)
-    if (!this.started || !this.snapshot.dragging) return
+    await this.syncWindow(false, generation)
+    if (!this.isCurrent(generation) || !this.snapshot.dragging) return
 
     let monitor
     let position
@@ -280,10 +458,10 @@ export class OverlaySession {
       monitor = result[0]
       position = result[1]
     } catch {
-      this.settleDrag()
+      if (this.isCurrent(generation)) this.settleDrag()
       return
     }
-    if (!this.started || !this.snapshot.dragging) return
+    if (!this.isCurrent(generation) || !this.snapshot.dragging) return
     const scale = monitor?.scaleFactor ?? 1
     this.dragOrigin = {
       pointerX: screenX,

--- a/docs/hud-states.md
+++ b/docs/hud-states.md
@@ -144,7 +144,7 @@ nothing. So the preferred display stays at the head, and reconnecting it takes
 the HUD back.
 
 A 2-second poll compares the connected displays and replaces the HUD when the
-set changes. The poll returns at once while the HUD is closed. The same
+set changes. Native visibility parks the poll while the HUD is closed. The same
 resolution runs when the HUD is built and when it reopens, so a display change
 during an off period is also caught.
 
@@ -178,11 +178,11 @@ switch and in Mission Control.
 - Only the first bar blinks during a live session, and only on the HUD. The
   detail window does not blink.
 - A transcript write stays live for 90 seconds.
-- The renderer polls session liveness every 5 seconds.
-- The shell answers each liveness poll with one indexed store query.
-- The renderer polls usage every 60 seconds.
-- Reset labels update every 30 seconds.
+- The renderer reads liveness once when shown. Session and scan events push
+  later changes, and one timer clears the live state at its expiry.
+- The renderer polls usage every 60 seconds while shown.
 - The native hover watcher polls every 100ms while the window is visible.
+- Hiding the HUD parks the native polls and the retained renderer's timers.
 - The HUD uses the Bitcount Prop Single Variable face for captions, numbers,
   and its wordmark.
 


### PR DESCRIPTION
## User impact

Hiding or disabling the floating HUD now parks its native hover and display watchers and stops the retained renderer's timers, polling, subscriptions, resize observation, detail work, and drag work. Reopening resumes one fresh work set, including when the HUD was hidden before its first measurement. Visible usage bars and the 90-second live-session blink keep their existing behavior.

Session liveness no longer reads the database every five seconds. The HUD reconciles once when shown, accepts pushed session changes, reconciles after completed scans or index invalidation, and uses one bounded expiry timer. Equal state and usage snapshots do not republish or resize.

No live GUI or profiling run was performed.

PR #419 changes the fullscreen reveal path in the same HUD detail-size block. When the branches meet, preserve both behaviors: keep this PR's RESIZE_STATE.wants_visible and DETAIL_SHOULD_SHOW guard, then call #419's show_detail_without_activation helper inside that guard. This PR does not modify #419.

## Validation

Merged `main` at `26e0ec9f`. The conflict resolution preserves native detail-show analytics inside the visibility guard and parks the renderer analytics listeners with HUD work. Added regressions for hide/reopen exposure and a pending exposure response that arrives after hiding. Existing analytics events, properties, and meanings are unchanged.

- pnpm --filter @antiburn/desktop format
- pnpm --filter @antiburn/desktop lint
- pnpm --filter @antiburn/desktop type-check
- pnpm --filter @antiburn/desktop knip
- pnpm --filter @antiburn/desktop test (94 files, 1,210 tests)
- pnpm --filter @antiburn/desktop build
- cargo fmt --check in apps/desktop/src-tauri
- CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings in apps/desktop/src-tauri
- CARGO_BUILD_JOBS=2 cargo test in apps/desktop/src-tauri (981 tests)
- CARGO_BUILD_JOBS=2 cargo clippy --all-targets --features analytics -- -D warnings in apps/desktop/src-tauri
- CARGO_BUILD_JOBS=2 cargo test --features analytics with the documented loopback configuration (1,024 tests)
- CARGO_BUILD_JOBS=2 cargo clippy -p antiburn-hud --all-targets -- -D warnings
- CARGO_BUILD_JOBS=2 cargo test -p antiburn-hud (24 tests)
- pnpm run slop:all (score 100)
- pnpm run secrets

## Privacy and performance

The HUD makes no new network requests and accesses no new data. Hidden HUD work now parks instead of waking or polling. Visible session-liveness database reads fall from every five seconds to one initial reconciliation plus event-triggered reconciliation.

Product question: does the HUD preserve its visible usage and liveness behavior while eliminating invisible background work? The existing UI lifecycle and liveness tests cover discovery, meaningful visible use, expiry, hide, reshow, delayed loads, stale work, and cleanup. Analytics are unchanged because this is a resource-lifecycle correction with no new user intent or visible feature meaning. Polling and parking are background mechanics, so recording them would violate the rule against counting background work as deliberate use.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (git commit -s).
- [x] I updated tests and documentation where needed.

