### PR TITLE
perf: bound session allowance allocation work

### DIFF
--- a/apps/desktop/src-tauri/src/provider_usage/allocation.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/allocation.rs
@@ -341,6 +341,19 @@ fn distribute_window(
     samples: &[crate::provider_usage::live::metrics::UsageSample],
     basis: WeightBasis,
 ) -> (HashMap<SessionKey, f64>, bool) {
+    let (output, uses_history, _) =
+        distribute_window_with_work(turns, used_percent, start_ms, observed_ms, samples, basis);
+    (output, uses_history)
+}
+
+fn distribute_window_with_work(
+    turns: &[&WeightedTurn],
+    used_percent: f64,
+    start_ms: i64,
+    observed_ms: i64,
+    samples: &[crate::provider_usage::live::metrics::UsageSample],
+    basis: WeightBasis,
+) -> (HashMap<SessionKey, f64>, bool, usize) {
     let mut points: BTreeMap<_, _> = samples
         .iter()
         .filter(|sample| sample.freshness == Freshness::Fresh)
@@ -357,43 +370,53 @@ fn distribute_window(
     if points.len() < 2 || points.windows(2).any(|pair| pair[1].1 < pair[0].1) {
         let mut output = HashMap::new();
         distribute(turns.iter().copied(), used_percent, basis, &mut output);
-        return (output, false);
+        return (output, false, turns.len());
     }
 
+    let mut ordered = turns.to_vec();
+    ordered.sort_by_key(|turn| turn.at_ms);
     let mut output = HashMap::new();
-    let mut previous_at = start_ms.saturating_sub(1);
+    let mut interval_start = 0;
+    let mut interval_end = 0;
     let mut previous_percent = 0.0;
     let mut has_observation = false;
+    let mut turn_visits = 0;
     for (at, percent) in points {
+        while interval_end < ordered.len() && ordered[interval_end].at_ms <= at {
+            interval_end += 1;
+        }
         let delta = percent - previous_percent;
         if delta > 0.0 {
+            turn_visits += interval_end - interval_start;
             distribute(
-                turns
-                    .iter()
-                    .copied()
-                    .filter(|turn| turn.at_ms > previous_at && turn.at_ms <= at),
+                ordered[interval_start..interval_end].iter().copied(),
                 delta,
-                basis,
-                &mut output,
-            );
-        } else {
-            distribute_zero(
-                turns
-                    .iter()
-                    .copied()
-                    .filter(|turn| turn.at_ms > previous_at && turn.at_ms <= at),
                 basis,
                 &mut output,
             );
         }
         // Keep the first sample of a plateau. A later increase applies to all turns since that sample.
         if !has_observation || delta > 0.0 {
-            previous_at = at;
+            if delta <= 0.0 {
+                turn_visits += interval_end - interval_start;
+                distribute_zero(
+                    ordered[interval_start..interval_end].iter().copied(),
+                    basis,
+                    &mut output,
+                );
+            }
+            interval_start = interval_end;
             previous_percent = percent;
         }
         has_observation = true;
     }
-    (output, true)
+    turn_visits += interval_end - interval_start;
+    distribute_zero(
+        ordered[interval_start..interval_end].iter().copied(),
+        basis,
+        &mut output,
+    );
+    (output, true, turn_visits)
 }
 
 /// Estimate current weekly and five-hour shares from published local turns.

--- a/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
@@ -905,6 +905,98 @@ fn an_initial_zero_starts_the_first_plateau() {
 }
 
 #[test]
+fn interval_boundaries_and_duplicate_observations_visit_each_turn_once() {
+    let start_ms = (NOW - 100) * 1_000;
+    let first_end_ms = (NOW - 60) * 1_000;
+    let observed_ms = NOW * 1_000;
+    let turns = [
+        WeightedTurn {
+            at_ms: start_ms,
+            ..weighted_turns(vec![turn("at-start", NOW - 100, 1_000_000, &[])]).remove(0)
+        },
+        WeightedTurn {
+            at_ms: first_end_ms,
+            ..weighted_turns(vec![turn("at-first-end", NOW - 60, 1_000_000, &[])]).remove(0)
+        },
+        WeightedTurn {
+            at_ms: first_end_ms + 1,
+            ..weighted_turns(vec![turn("after-first-end", NOW - 59, 1_000_000, &[])]).remove(0)
+        },
+        WeightedTurn {
+            at_ms: observed_ms,
+            ..weighted_turns(vec![turn("at-observed", NOW, 1_000_000, &[])]).remove(0)
+        },
+    ];
+    let refs: Vec<_> = turns.iter().rev().collect();
+    let samples = vec![
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW - 60).unwrap(),
+            used_percent: Some(7.0),
+            freshness: Freshness::Fresh,
+        },
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW - 60).unwrap(),
+            used_percent: Some(10.0),
+            freshness: Freshness::Fresh,
+        },
+        UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW).unwrap(),
+            used_percent: Some(20.0),
+            freshness: Freshness::Fresh,
+        },
+    ];
+
+    let (shares, uses_history, turn_visits) = distribute_window_with_work(
+        &refs,
+        20.0,
+        start_ms,
+        observed_ms,
+        &samples,
+        WeightBasis::Price,
+    );
+
+    assert!(uses_history);
+    assert_eq!(turn_visits, turns.len());
+    for session in ["at-start", "at-first-end", "after-first-end", "at-observed"] {
+        assert_eq!(
+            shares[&SessionKey::new("native", "claude-code", session)],
+            5.0
+        );
+    }
+}
+
+#[test]
+fn long_plateaus_keep_turn_visits_linear_with_or_without_a_final_increase() {
+    let rows = (0..128)
+        .map(|index| turn(&format!("plateau-{index}"), NOW - 50, 1_000_000, &[]))
+        .collect();
+    let turns = weighted_turns(rows);
+    let refs: Vec<_> = turns.iter().collect();
+    let samples = (0..96)
+        .map(|index| UsageSample {
+            observed_at: OffsetDateTime::from_unix_timestamp(NOW - 100 + index).unwrap(),
+            used_percent: Some(10.0),
+            freshness: Freshness::Fresh,
+        })
+        .collect::<Vec<_>>();
+
+    for used_percent in [10.0, 11.0] {
+        let (shares, uses_history, turn_visits) = distribute_window_with_work(
+            &refs,
+            used_percent,
+            (NOW - 200) * 1_000,
+            NOW * 1_000,
+            &samples,
+            WeightBasis::Price,
+        );
+
+        assert!(uses_history);
+        assert_eq!(turn_visits, turns.len());
+        assert!((shares.values().sum::<f64>() - (used_percent - 10.0)).abs() < 1e-9);
+    }
+}
+
+#[test]
 fn decreasing_history_falls_back_to_the_current_window_share() {
     let turns = weighted_turns(vec![
         turn("one", NOW - 90, 1_000_000, &[]),

--- a/apps/desktop/src-tauri/src/provider_usage/ledger.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/ledger.rs
@@ -14,12 +14,22 @@ const MAX_TURN_GROUPS: usize = 50_000;
 
 /// Materialize a small durable queue batch outside the popover read path.
 pub fn reconcile(store: &Store, now_epoch: i64) {
+    let Some(_in_flight) = store.try_begin_allocation_reconcile() else {
+        return;
+    };
     let Ok(periods) = store.provider_usage_allocation_dirty_periods(PERIOD_BATCH) else {
         ::tracing::warn!(event = "provider_usage_allocation_claim_failed");
         return;
     };
+    if periods.is_empty() {
+        return;
+    }
+    let Ok(reader) = store.open_allocation_reader() else {
+        ::tracing::warn!(event = "provider_usage_allocation_reader_failed");
+        return;
+    };
     for dirty in periods {
-        let result = reconcile_period(store, dirty, now_epoch);
+        let result = reconcile_period(store, reader.as_ref(), dirty, now_epoch);
         if let Err(error) = result {
             ::tracing::warn!(event = "provider_usage_allocation_reconcile_failed", error = %error);
         }
@@ -28,6 +38,7 @@ pub fn reconcile(store: &Store, now_epoch: i64) {
 
 fn reconcile_period(
     store: &Store,
+    reader: Option<&rusqlite::Connection>,
     dirty: crate::store::provider_usage_ledger::DirtyPeriod,
     now_epoch: i64,
 ) -> anyhow::Result<()> {
@@ -79,7 +90,8 @@ fn reconcile_period(
         );
     };
     let end_ms = observed_at_ms.saturating_add(1);
-    let Some(turns) = store.session_usage_turns_grouped_between(
+    let Some(turns) = store.session_usage_turns_grouped_between_with(
+        reader,
         start.saturating_mul(1_000),
         end_ms,
         &interval_ends,

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -35,7 +35,7 @@ mod tests;
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, TryLockError};
 use std::time::Duration;
 
 use antiburn_local::analysis::{
@@ -74,6 +74,60 @@ pub struct EvidenceBacklogCounts {
 /// to read.
 pub const DEFERRED_PERMISSION_DIRS_KEY: &str = "internal:deferredPermissionDirs";
 const PROVIDER_ACCOUNT_SECRET_KEY: &str = "internal:providerAccountHmacSecretV1";
+const ALLOCATION_READ_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn allocation_grouped_turn_sql(interval_count: usize) -> String {
+    let interval_values = (0..interval_count)
+        .map(|_| "(?, ?, ?)")
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "WITH interval(interval_start_ms, interval_end_ms, bucket_end_ms) AS (
+            VALUES {interval_values}
+         ), grouped_turn AS (
+            SELECT t.environment_key, t.agent, t.session_id,
+                   i.bucket_end_ms,
+                   t.model, t.speed,
+                   SUM(t.input_tokens) AS input_tokens,
+                   SUM(t.cache_read_tokens) AS cache_read_tokens,
+                   SUM(t.cache_write_tokens) AS cache_write_tokens,
+                   SUM(t.output_tokens) AS output_tokens
+              FROM interval i
+              JOIN turn t INDEXED BY turn_usage_timestamp
+                ON t.ts_ms >= i.interval_start_ms
+               AND t.ts_ms <= i.interval_end_ms
+              JOIN session_evidence e
+                ON e.environment_key = t.environment_key
+               AND e.agent = t.agent AND e.session_id = t.session_id
+               AND e.published_fence = t.claim_fence
+             WHERE t.ts_ms < ?
+             GROUP BY t.environment_key, t.agent, t.session_id, bucket_end_ms,
+                      t.model, t.speed
+             ORDER BY bucket_end_ms
+             LIMIT ?
+         )
+         SELECT g.environment_key, g.agent, g.session_id, s.wsl_distro,
+                a.provider_hints_json,
+                COALESCE((
+                    SELECT json_group_array(json_object(
+                        'provider', spa.provider,
+                        'accountKey', spa.account_key
+                    ))
+                      FROM session_provider_account spa
+                     WHERE spa.environment_key = s.environment_key
+                       AND spa.agent = s.agent AND spa.session_id = s.session_id
+                ), '[]'),
+                g.bucket_end_ms, g.model, g.speed, g.input_tokens,
+                g.cache_read_tokens, g.cache_write_tokens, g.output_tokens
+           FROM grouped_turn g
+           JOIN session s
+             ON s.environment_key = g.environment_key
+            AND s.agent = g.agent AND s.session_id = g.session_id
+           LEFT JOIN session_analysis a
+             ON a.environment_key = s.environment_key
+            AND a.agent = s.agent AND a.session_id = s.session_id"
+    )
+}
 
 fn encode_secret(secret: &[u8; 32]) -> String {
     const DIGITS: &[u8; 16] = b"0123456789abcdef";
@@ -159,6 +213,8 @@ pub fn open_read_only(data_dir: &Path, busy_timeout: Duration) -> Result<Connect
 #[derive(Clone)]
 pub struct Store {
     connection: Arc<Mutex<Connection>>,
+    allocation_reconcile: Arc<Mutex<()>>,
+    database_path: Option<PathBuf>,
     /// The directory the engine's own state files (scan roots, ignored paths)
     /// live in. The engine never chooses this; the shell does.
     state_dir: PathBuf,
@@ -269,8 +325,14 @@ impl Store {
         connection.pragma_update(None, "journal_mode", "WAL").ok();
         connection.pragma_update(None, "synchronous", "NORMAL")?;
         connection.pragma_update(None, "foreign_keys", true)?;
+        let database_path = connection
+            .path()
+            .filter(|path| !path.is_empty() && *path != ":memory:")
+            .map(PathBuf::from);
         let store = Store {
             connection: Arc::new(Mutex::new(connection)),
+            allocation_reconcile: Arc::new(Mutex::new(())),
+            database_path,
             state_dir,
         };
         store.migrate()?;
@@ -344,6 +406,32 @@ impl Store {
         self.connection
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Start one shared allocation pass, or skip work another clone already owns.
+    pub(crate) fn try_begin_allocation_reconcile(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
+        match self.allocation_reconcile.try_lock() {
+            Ok(guard) => Some(guard),
+            Err(TryLockError::Poisoned(poisoned)) => Some(poisoned.into_inner()),
+            Err(TryLockError::WouldBlock) => None,
+        }
+    }
+
+    /// Open one read-only WAL connection for a bounded allocation pass.
+    pub(crate) fn open_allocation_reader(&self) -> Result<Option<Connection>> {
+        let Some(path) = &self.database_path else {
+            return Ok(None);
+        };
+        let connection = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY
+                | OpenFlags::SQLITE_OPEN_URI
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .with_context(|| format!("failed to open {} for allocation", path.display()))?;
+        connection.busy_timeout(ALLOCATION_READ_BUSY_TIMEOUT)?;
+        connection.pragma_update(None, "query_only", true)?;
+        Ok(Some(connection))
     }
 
     /* --------------------------------------------------------------------
@@ -2082,6 +2170,24 @@ impl Store {
         interval_ends_ms: &[i64],
         max_groups: usize,
     ) -> Result<Option<Vec<SessionUsageRecord>>> {
+        let reader = self.open_allocation_reader()?;
+        self.session_usage_turns_grouped_between_with(
+            reader.as_ref(),
+            start_ms,
+            end_ms,
+            interval_ends_ms,
+            max_groups,
+        )
+    }
+
+    pub(crate) fn session_usage_turns_grouped_between_with(
+        &self,
+        reader: Option<&Connection>,
+        start_ms: i64,
+        end_ms: i64,
+        interval_ends_ms: &[i64],
+        max_groups: usize,
+    ) -> Result<Option<Vec<SessionUsageRecord>>> {
         if end_ms <= start_ms || interval_ends_ms.is_empty() {
             return Ok(Some(Vec::new()));
         }
@@ -2095,104 +2201,77 @@ impl Store {
         if ends.last().copied() != Some(end_ms) {
             ends.push(end_ms);
         }
-        let case_parts = ends
+        let mut interval_start = start_ms;
+        let intervals = ends
             .iter()
-            .map(|_| "WHEN t.ts_ms <= ? THEN ?")
-            .collect::<Vec<_>>()
-            .join(" ");
-        let sql = format!(
-            "WITH grouped_turn AS (
-                SELECT t.environment_key, t.agent, t.session_id,
-                       CASE {case_parts} ELSE ? END AS bucket_end_ms,
-                       t.model, t.speed,
-                       SUM(t.input_tokens) AS input_tokens,
-                       SUM(t.cache_read_tokens) AS cache_read_tokens,
-                       SUM(t.cache_write_tokens) AS cache_write_tokens,
-                       SUM(t.output_tokens) AS output_tokens
-                  FROM turn t
-                  JOIN session_evidence e
-                    ON e.environment_key = t.environment_key
-                   AND e.agent = t.agent AND e.session_id = t.session_id
-                   AND e.published_fence = t.claim_fence
-                 WHERE t.ts_ms >= ? AND t.ts_ms < ?
-                 GROUP BY t.environment_key, t.agent, t.session_id, bucket_end_ms,
-                          t.model, t.speed
-                 ORDER BY bucket_end_ms
-                 LIMIT ?
-             )
-             SELECT g.environment_key, g.agent, g.session_id, s.wsl_distro,
-                    a.provider_hints_json,
-                    COALESCE((
-                        SELECT json_group_array(json_object(
-                            'provider', spa.provider,
-                            'accountKey', spa.account_key
-                        ))
-                          FROM session_provider_account spa
-                         WHERE spa.environment_key = s.environment_key
-                           AND spa.agent = s.agent AND spa.session_id = s.session_id
-                    ), '[]'),
-                    g.bucket_end_ms, g.model, g.speed, g.input_tokens,
-                    g.cache_read_tokens, g.cache_write_tokens, g.output_tokens
-               FROM grouped_turn g
-               JOIN session s
-                 ON s.environment_key = g.environment_key
-                AND s.agent = g.agent AND s.session_id = g.session_id
-               LEFT JOIN session_analysis a
-                 ON a.environment_key = s.environment_key
-                AND a.agent = s.agent AND a.session_id = s.session_id"
-        );
-        let mut values = Vec::with_capacity(ends.len() * 2 + 3);
-        for end in &ends {
-            values.push(rusqlite::types::Value::from(*end));
-            values.push(rusqlite::types::Value::from(*end));
+            .copied()
+            .filter_map(|interval_end| {
+                if interval_end < interval_start {
+                    return None;
+                }
+                let interval = (interval_start, interval_end, interval_end);
+                interval_start = interval_end.saturating_add(1);
+                Some(interval)
+            })
+            .collect::<Vec<_>>();
+        let sql = allocation_grouped_turn_sql(intervals.len());
+        let mut values = Vec::with_capacity(intervals.len() * 3 + 2);
+        for (interval_start, interval_end, bucket_end) in intervals {
+            values.push(rusqlite::types::Value::from(interval_start));
+            values.push(rusqlite::types::Value::from(interval_end));
+            values.push(rusqlite::types::Value::from(bucket_end));
         }
-        values.push(rusqlite::types::Value::from(end_ms));
-        values.push(rusqlite::types::Value::from(start_ms));
         values.push(rusqlite::types::Value::from(end_ms));
         let limit =
             i64::try_from(max_groups.clamp(1, 50_000)).expect("bounded group limit fits i64");
         values.push(rusqlite::types::Value::from(limit + 1));
-        let connection = self.lock();
-        let mut statement = connection.prepare(&sql)?;
-        let mut rows = statement.query(params_from_iter(values))?;
-        let mut sessions = Vec::new();
-        let mut indexes = HashMap::new();
-        let mut group_count = 0usize;
-        while let Some(row) = rows.next()? {
-            group_count += 1;
-            if group_count > max_groups {
-                return Ok(None);
-            }
-            let key = SessionKey::new(
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-            );
-            let index = if let Some(index) = indexes.get(&key) {
-                *index
-            } else {
-                let index = sessions.len();
-                sessions.push(SessionUsageRecord {
-                    key: key.clone(),
-                    wsl_distro: row.get(3)?,
-                    provider_hints_json: row.get(4)?,
-                    provider_accounts_json: row.get(5)?,
-                    turns: Vec::new(),
+        let load = |connection: &Connection| -> Result<Option<Vec<SessionUsageRecord>>> {
+            let mut statement = connection.prepare(&sql)?;
+            let mut rows = statement.query(params_from_iter(values.iter()))?;
+            let mut sessions = Vec::new();
+            let mut indexes = HashMap::new();
+            let mut group_count = 0usize;
+            while let Some(row) = rows.next()? {
+                group_count += 1;
+                if group_count > max_groups {
+                    return Ok(None);
+                }
+                let key = SessionKey::new(
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                );
+                let index = if let Some(index) = indexes.get(&key) {
+                    *index
+                } else {
+                    let index = sessions.len();
+                    sessions.push(SessionUsageRecord {
+                        key: key.clone(),
+                        wsl_distro: row.get(3)?,
+                        provider_hints_json: row.get(4)?,
+                        provider_accounts_json: row.get(5)?,
+                        turns: Vec::new(),
+                    });
+                    indexes.insert(key, index);
+                    index
+                };
+                sessions[index].turns.push(SessionUsageTurnRecord {
+                    ts_ms: row.get(6)?,
+                    model: row.get(7)?,
+                    speed: row.get(8)?,
+                    input_tokens: row.get::<_, i64>(9)?.try_into().unwrap_or(u64::MAX),
+                    cache_read_tokens: row.get::<_, i64>(10)?.try_into().unwrap_or(u64::MAX),
+                    cache_write_tokens: row.get::<_, i64>(11)?.try_into().unwrap_or(u64::MAX),
+                    output_tokens: row.get::<_, i64>(12)?.try_into().unwrap_or(u64::MAX),
                 });
-                indexes.insert(key, index);
-                index
-            };
-            sessions[index].turns.push(SessionUsageTurnRecord {
-                ts_ms: row.get(6)?,
-                model: row.get(7)?,
-                speed: row.get(8)?,
-                input_tokens: row.get::<_, i64>(9)?.try_into().unwrap_or(u64::MAX),
-                cache_read_tokens: row.get::<_, i64>(10)?.try_into().unwrap_or(u64::MAX),
-                cache_write_tokens: row.get::<_, i64>(11)?.try_into().unwrap_or(u64::MAX),
-                output_tokens: row.get::<_, i64>(12)?.try_into().unwrap_or(u64::MAX),
-            });
+            }
+            Ok(Some(sessions))
+        };
+        if let Some(reader) = reader {
+            return load(reader);
         }
-        Ok(Some(sessions))
+        let connection = self.lock();
+        load(&connection)
     }
 
     /// Bind recent sessions after the account-attribution rollout.

--- a/apps/desktop/src-tauri/src/store/provider_usage_ledger.rs
+++ b/apps/desktop/src-tauri/src/store/provider_usage_ledger.rs
@@ -260,93 +260,104 @@ impl super::Store {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
+        let reader = self.open_allocation_reader()?;
+        if let Some(reader) = reader.as_ref() {
+            return cumulative_session_limit_allocations_in(reader, keys);
+        }
         let connection = self.lock();
-        let mut clauses = Vec::with_capacity(keys.len());
-        let mut values = Vec::with_capacity(keys.len() * 3);
-        for key in keys.iter().take(500) {
-            clauses.push("(a.environment_key = ? AND a.agent = ? AND a.session_id = ?)");
-            values.push(rusqlite::types::Value::from(key.environment_key.clone()));
-            values.push(rusqlite::types::Value::from(key.agent.clone()));
-            values.push(rusqlite::types::Value::from(key.session_id.clone()));
-        }
-        let sql = format!(
-            "SELECT a.environment_key, a.agent, a.session_id, s.wsl_distro, a.metric,
-                    p.provider, p.account_key, p.window_id, a.percent, a.partial,
-                    a.period_id, p.starts_at_epoch, p.resets_at_epoch, p.duration_seconds,
-                    p.window_role, p.scope_key
-               FROM provider_usage_session_allocation a
-               JOIN provider_usage_period p ON p.id = a.period_id
-               JOIN session s ON s.environment_key = a.environment_key
-                 AND s.agent = a.agent AND s.session_id = a.session_id
-              WHERE {}",
-            clauses.join(" OR ")
-        );
-        let mut statement = connection.prepare(&sql)?;
-        let rows = statement
-            .query_map(params_from_iter(values), |row| {
-                Ok(PeriodContribution {
-                    allocation: CumulativeSessionAllocation {
-                        key: SessionKey::new(
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, String>(2)?,
-                        ),
-                        wsl_distro: row.get(3)?,
-                        metric: row.get(4)?,
-                        provider: row.get(5)?,
-                        account_key: row.get(6)?,
-                        window_id: row.get(7)?,
-                        percent: row.get(8)?,
-                        partial: row.get::<_, i64>(9)? != 0,
-                        period_count: 1,
-                    },
-                    period_id: row.get(10)?,
-                    starts_at_epoch: row.get(11)?,
-                    resets_at_epoch: row.get(12)?,
-                    duration_seconds: row.get(13)?,
-                    window_role: row.get(14)?,
-                    scope_key: row.get(15)?,
-                })
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-
-        let mut by_account: HashMap<_, Vec<_>> = HashMap::new();
-        for contribution in rows {
-            let allocation = &contribution.allocation;
-            by_account
-                .entry((
-                    allocation.key.clone(),
-                    allocation.metric.clone(),
-                    allocation.provider.clone(),
-                    allocation.account_key.clone(),
-                ))
-                .or_default()
-                .push(contribution);
-        }
-
-        let mut best: HashMap<(SessionKey, String), CumulativeSessionAllocation> = HashMap::new();
-        for (_, contributions) in by_account {
-            let Some(allocation) = cumulative_lane_allocation(contributions) else {
-                continue;
-            };
-            let key = (allocation.key.clone(), allocation.metric.clone());
-            if best
-                .get(&key)
-                .is_none_or(|current| allocation.percent > current.percent)
-            {
-                best.insert(key, allocation);
-            }
-        }
-        let mut allocations: Vec<_> = best.into_values().collect();
-        allocations.sort_by(|left, right| {
-            left.key
-                .agent
-                .cmp(&right.key.agent)
-                .then_with(|| left.key.session_id.cmp(&right.key.session_id))
-                .then_with(|| left.metric.cmp(&right.metric))
-        });
-        Ok(allocations)
+        cumulative_session_limit_allocations_in(&connection, keys)
     }
+}
+
+fn cumulative_session_limit_allocations_in(
+    connection: &rusqlite::Connection,
+    keys: &[SessionKey],
+) -> Result<Vec<CumulativeSessionAllocation>> {
+    let mut clauses = Vec::with_capacity(keys.len());
+    let mut values = Vec::with_capacity(keys.len() * 3);
+    for key in keys.iter().take(500) {
+        clauses.push("(a.environment_key = ? AND a.agent = ? AND a.session_id = ?)");
+        values.push(rusqlite::types::Value::from(key.environment_key.clone()));
+        values.push(rusqlite::types::Value::from(key.agent.clone()));
+        values.push(rusqlite::types::Value::from(key.session_id.clone()));
+    }
+    let sql = format!(
+        "SELECT a.environment_key, a.agent, a.session_id, s.wsl_distro, a.metric,
+                p.provider, p.account_key, p.window_id, a.percent, a.partial,
+                a.period_id, p.starts_at_epoch, p.resets_at_epoch, p.duration_seconds,
+                p.window_role, p.scope_key
+           FROM provider_usage_session_allocation a
+           JOIN provider_usage_period p ON p.id = a.period_id
+           JOIN session s ON s.environment_key = a.environment_key
+             AND s.agent = a.agent AND s.session_id = a.session_id
+          WHERE {}",
+        clauses.join(" OR ")
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement
+        .query_map(params_from_iter(values), |row| {
+            Ok(PeriodContribution {
+                allocation: CumulativeSessionAllocation {
+                    key: SessionKey::new(
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ),
+                    wsl_distro: row.get(3)?,
+                    metric: row.get(4)?,
+                    provider: row.get(5)?,
+                    account_key: row.get(6)?,
+                    window_id: row.get(7)?,
+                    percent: row.get(8)?,
+                    partial: row.get::<_, i64>(9)? != 0,
+                    period_count: 1,
+                },
+                period_id: row.get(10)?,
+                starts_at_epoch: row.get(11)?,
+                resets_at_epoch: row.get(12)?,
+                duration_seconds: row.get(13)?,
+                window_role: row.get(14)?,
+                scope_key: row.get(15)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut by_account: HashMap<_, Vec<_>> = HashMap::new();
+    for contribution in rows {
+        let allocation = &contribution.allocation;
+        by_account
+            .entry((
+                allocation.key.clone(),
+                allocation.metric.clone(),
+                allocation.provider.clone(),
+                allocation.account_key.clone(),
+            ))
+            .or_default()
+            .push(contribution);
+    }
+
+    let mut best: HashMap<(SessionKey, String), CumulativeSessionAllocation> = HashMap::new();
+    for (_, contributions) in by_account {
+        let Some(allocation) = cumulative_lane_allocation(contributions) else {
+            continue;
+        };
+        let key = (allocation.key.clone(), allocation.metric.clone());
+        if best
+            .get(&key)
+            .is_none_or(|current| allocation.percent > current.percent)
+        {
+            best.insert(key, allocation);
+        }
+    }
+    let mut allocations: Vec<_> = best.into_values().collect();
+    allocations.sort_by(|left, right| {
+        left.key
+            .agent
+            .cmp(&right.key.agent)
+            .then_with(|| left.key.session_id.cmp(&right.key.session_id))
+            .then_with(|| left.metric.cmp(&right.metric))
+    });
+    Ok(allocations)
 }
 
 fn cumulative_lane_allocation(

--- a/apps/desktop/src-tauri/src/store/provider_usage_ledger/lifecycle_tests.rs
+++ b/apps/desktop/src-tauri/src/store/provider_usage_ledger/lifecycle_tests.rs
@@ -74,6 +74,20 @@ fn queued(store: &Store, period_id: i64) -> DirtyPeriod {
 }
 
 #[test]
+fn allocation_reconcile_gate_is_shared_by_store_clones() {
+    let store = memory_store();
+    let clone = store.clone();
+    let first = store
+        .try_begin_allocation_reconcile()
+        .expect("claims the first pass");
+    assert!(clone.try_begin_allocation_reconcile().is_none());
+
+    drop(first);
+
+    assert!(clone.try_begin_allocation_reconcile().is_some());
+}
+
+#[test]
 fn retained_adjacent_weekly_and_five_hour_periods_survive_reopen_over_one_hundred_percent() {
     let directory = tempfile::tempdir().expect("creates synthetic state directory");
     let key = session("cumulative").key;
@@ -119,8 +133,16 @@ fn retained_adjacent_weekly_and_five_hour_periods_survive_reopen_over_one_hundre
 }
 
 #[test]
-fn a_single_session_many_turn_estimate_replaces_one_ledger_row() {
+fn disabled_network_setting_still_recomputes_the_local_dirty_ledger() {
     let store = memory_store();
+    store
+        .save_settings(&crate::store::AppSettings {
+            live_usage_enabled: false,
+            onboarding_completed: true,
+            ..crate::store::AppSettings::default()
+        })
+        .expect("disables provider network collection");
+    assert!(!store.settings().unwrap().live_usage_active());
     let record = session("many-turns");
     let key = record.key.clone();
     store
@@ -197,6 +219,13 @@ fn a_single_session_many_turn_estimate_replaces_one_ledger_row() {
         )
         .expect("counts ledger rows");
     assert_eq!(rows, 1);
+    drop(connection);
+    assert!(
+        store
+            .provider_usage_allocation_dirty_periods(32)
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
@@ -304,6 +304,78 @@ fn session_usage_turns_returns_published_rows_at_the_time_boundary() {
 }
 
 #[test]
+fn grouped_usage_turns_use_disjoint_inclusive_observation_boundaries() {
+    let store = store();
+    let (record, claim) = claimed_projection(&store, "grouped-usage-turns", 100, 60);
+    let key = record.key.clone();
+    let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
+    writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
+    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    assert!(
+        store
+            .publish_projections(&record, None, &completion, &[], &[])
+            .unwrap()
+    );
+
+    let rows = store
+        .session_usage_turns_grouped_between(1_000, 1_002, &[1_000, 1_001], 10)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key, key);
+    assert_eq!(rows[0].turns.len(), 2);
+    assert_eq!(rows[0].turns[0].ts_ms, Some(1_000));
+    assert_eq!(rows[0].turns[1].ts_ms, Some(1_001));
+    assert_eq!(rows[0].turns[0].input_tokens, 10);
+    assert_eq!(rows[0].turns[1].input_tokens, 10);
+}
+
+#[test]
+fn grouped_usage_turns_plan_uses_timestamp_range_lookups() {
+    let store = store();
+    let sql = format!("EXPLAIN QUERY PLAN {}", allocation_grouped_turn_sql(2));
+    let connection = store.lock();
+    let mut statement = connection.prepare(&sql).unwrap();
+    let details = statement
+        .query_map(
+            params![1_000, 1_000, 1_000, 1_001, 1_001, 1_001, 1_002, 11],
+            |row| row.get::<_, String>(3),
+        )
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+
+    assert!(
+        details.iter().any(|detail| {
+            detail.contains("turn_usage_timestamp")
+                && detail.contains("ts_ms>?")
+                && detail.contains("ts_ms<?")
+        }),
+        "{details:?}"
+    );
+}
+
+#[test]
+fn grouped_usage_turns_do_not_wait_for_the_writer_mutex() {
+    let directory = tempfile::tempdir().unwrap();
+    let store = Store::open(directory.path()).unwrap();
+    let writer = store.lock();
+    let reader_store = store.clone();
+    let (send, receive) = std::sync::mpsc::channel();
+    let thread = std::thread::spawn(move || {
+        let result = reader_store.session_usage_turns_grouped_between(1_000, 1_002, &[1_001], 10);
+        send.send(result).unwrap();
+    });
+
+    let result = receive.recv_timeout(std::time::Duration::from_secs(1));
+    drop(writer);
+    thread.join().unwrap();
+
+    assert!(result.unwrap().unwrap().unwrap().is_empty());
+}
+
+#[test]
 fn a_lost_publish_race_deletes_only_its_own_fences_turn_rows() {
     let store = store();
     let (record, claim) = claimed_projection(&store, "lost-race-turn-rows", 100, 60);

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -223,8 +223,8 @@ fn run_pass(app: &AppHandle, _blocking: blocking::Thread) {
 }
 
 fn background_pass(app: &AppHandle, settings: &crate::store::AppSettings) {
-    // Reconciliation uses only local durable inputs. It must run even when the
-    // user disabled provider network collection.
+    // Reconciliation uses only local durable inputs.
+    // It must run without provider network collection.
     if let Some(store) = app.try_state::<Store>() {
         crate::provider_usage::ledger::reconcile(store.inner(), crate::scan::unix_now());
     }

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -539,12 +539,10 @@ describe("PopoverView", () => {
     expect(
       invoke.mock.calls.filter(([command]) => command === "list_recent_sessions"),
     ).toHaveLength(listCallsBefore)
-    await waitFor(() =>
-      expect(
-        invoke.mock.calls.filter(([command]) => command === "get_session_limit_allocations")
-          .length,
-      ).toBeGreaterThan(allocationCallsBefore),
-    )
+    await act(async () => Promise.resolve())
+    expect(
+      invoke.mock.calls.filter(([command]) => command === "get_session_limit_allocations"),
+    ).toHaveLength(allocationCallsBefore)
   })
 
   it("keeps a row's high-cost flag after a sessions:entry-changed event replaces it", async () => {

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -380,6 +380,34 @@ describe("PopoverView", () => {
     expect(invoke).toHaveBeenCalledWith("get_session_limit_allocations")
   })
 
+  it("refreshes cached allocations after an offline cohort setting changes", async () => {
+    const settings = {
+      ...SETTINGS,
+      liveUsageEnabled: false,
+      disabledAgents: [],
+    }
+    mockCommands({ get_settings: settings })
+    render(<PopoverView />)
+    await screen.findByText("Wire the tray popover")
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_session_limit_allocations"))
+    const allocationCallsBefore = invoke.mock.calls.filter(
+      ([command]) => command === "get_session_limit_allocations",
+    ).length
+    const currentTime = Date.now()
+    const now = vi.spyOn(Date, "now").mockReturnValue(currentTime + 30_001)
+
+    try {
+      emit("settings:changed", { ...settings, activityWindowDays: 30 })
+      await waitFor(() =>
+        expect(
+          invoke.mock.calls.filter(([command]) => command === "get_session_limit_allocations"),
+        ).toHaveLength(allocationCallsBefore + 1),
+      )
+    } finally {
+      now.mockRestore()
+    }
+  })
+
   it("keeps the last allocation when a refresh fails", async () => {
     const allocationSummary = {
       generatedAt: "2027-01-15T08:00:00Z",

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type * as Ipc from "../../lib/ipc"
 import type * as InsightsIpc from "../../lib/insightsIpc"
 import {
+  DEFAULT_SETTINGS,
   EMPTY_PROVIDER_USAGE,
   type ActivityEntryPayload,
   type ScanStatus,
@@ -15,6 +16,8 @@ const getSessionAnalysis = vi.hoisted(() => vi.fn())
 const getSubagentAnalysis = vi.hoisted(() => vi.fn())
 const getSessionLimitAllocations = vi.hoisted(() => vi.fn())
 const getProviderUsage = vi.hoisted(() => vi.fn())
+const getSettings = vi.hoisted(() => vi.fn())
+const onSettingsChanged = vi.hoisted(() => vi.fn())
 const setPopoverHeight = vi.hoisted(() => vi.fn())
 const listRecentSessions = vi.hoisted(() => vi.fn())
 const onSessionEntryChanged = vi.hoisted(() => vi.fn())
@@ -23,6 +26,7 @@ const onChecksReportChanged = vi.hoisted(() => vi.fn())
 const getChecksReport = vi.hoisted(() => vi.fn())
 const onPopoverShown = vi.hoisted(() => vi.fn())
 const onPopoverHidden = vi.hoisted(() => vi.fn())
+const onLiveUsageChanged = vi.hoisted(() => vi.fn())
 
 // The analysis, list, and event-subscription commands are overridden. All
 // other wrappers keep their real no-shell fallback because `hasShell()` is
@@ -35,12 +39,15 @@ vi.mock("../../lib/ipc", async (importOriginal) => {
     getSubagentAnalysis,
     getSessionLimitAllocations,
     getProviderUsage,
+    getSettings,
+    onSettingsChanged,
     setPopoverHeight,
     listRecentSessions,
     onSessionEntryChanged,
     onScanEvent,
     onPopoverShown,
     onPopoverHidden,
+    onLiveUsageChanged,
   }
 })
 
@@ -56,12 +63,16 @@ let entryChangedHandler: EntryChangedHandler | null = null
 let scanEventHandler: ScanEventHandler | null = null
 let popoverShownHandler: (() => void) | null = null
 let popoverHiddenHandler: (() => void) | null = null
+let liveUsageChangedHandler: ((liveUsage: Ipc.LiveUsageSummaryPayload) => void) | null = null
+let settingsChangedHandler: ((settings: Ipc.AppSettings) => void) | null = null
 
 beforeEach(() => {
   entryChangedHandler = null
   scanEventHandler = null
   popoverShownHandler = null
   popoverHiddenHandler = null
+  liveUsageChangedHandler = null
+  settingsChangedHandler = null
   getSessionAnalysis.mockReset()
   getSessionAnalysis.mockResolvedValue(null)
   getSubagentAnalysis.mockReset()
@@ -102,6 +113,22 @@ beforeEach(() => {
       popoverHiddenHandler = null
     }
   })
+  onLiveUsageChanged.mockReset()
+  onLiveUsageChanged.mockImplementation(
+    async (handler: (liveUsage: Ipc.LiveUsageSummaryPayload) => void) => {
+      liveUsageChangedHandler = handler
+      return () => {
+        liveUsageChangedHandler = null
+      }
+    },
+  )
+  onSettingsChanged.mockReset()
+  onSettingsChanged.mockImplementation(async (handler: (settings: Ipc.AppSettings) => void) => {
+    settingsChangedHandler = handler
+    return () => {
+      settingsChangedHandler = null
+    }
+  })
   getSessionLimitAllocations.mockReset()
   getSessionLimitAllocations.mockResolvedValue({
     generatedAt: "2027-01-15T08:00:00Z",
@@ -109,6 +136,11 @@ beforeEach(() => {
   })
   getProviderUsage.mockReset()
   getProviderUsage.mockResolvedValue(EMPTY_PROVIDER_USAGE)
+  getSettings.mockReset()
+  getSettings.mockResolvedValue({
+    ...DEFAULT_SETTINGS,
+    onboardingCompleted: true,
+  })
 })
 
 describe("PopoverSession surface presentation", () => {
@@ -156,26 +188,75 @@ describe("PopoverSession surface presentation", () => {
     unsubscribe()
   })
 
-  it("coalesces overlapping allocation requests into one trailing refresh", async () => {
-    let resolveFirst!: () => void
+  it("coalesces allocation events behind one refresh floor", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+    expect(liveUsageChangedHandler).not.toBeNull()
+
+    liveUsageChangedHandler?.({ providers: [], errors: [], meters: [], generatedAt: "one" })
+    liveUsageChangedHandler?.({ providers: [], errors: [], meters: [], generatedAt: "two" })
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it("publishes a current allocation response during an event storm", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    let resolveFirst!: (value: Ipc.SessionLimitAllocationSummaryPayload) => void
     getSessionLimitAllocations
       .mockImplementationOnce(
         () =>
-          new Promise((resolve) => {
-            resolveFirst = () =>
-              resolve({ generatedAt: "2027-01-15T08:00:00Z", allocations: [] })
+          new Promise<Ipc.SessionLimitAllocationSummaryPayload>((resolve) => {
+            resolveFirst = resolve
           }),
       )
-      .mockResolvedValue({ generatedAt: "2027-01-15T08:00:01Z", allocations: [] })
+      .mockResolvedValue({ generatedAt: "later", allocations: [] })
     const session = new PopoverSession()
     const unsubscribe = session.subscribe(() => {})
-    await vi.waitFor(() => expect(resolveFirst).toBeTypeOf("function"))
-    await vi.waitFor(() => expect(session.getSnapshot().usage).not.toBeNull())
+    await vi.advanceTimersByTimeAsync(0)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
 
-    resolveFirst()
+    for (let index = 0; index < 20; index += 1) {
+      liveUsageChangedHandler?.({
+        providers: [],
+        errors: [],
+        meters: [],
+        generatedAt: String(index),
+      })
+    }
+    resolveFirst({
+      generatedAt: "current",
+      allocations: [
+        {
+          agent: "claude-code",
+          sessionId: "session-1",
+          wslDistro: null,
+          provider: "anthropic",
+          displayName: "Claude",
+          accountKey: null,
+          metric: "weekly",
+          windowId: "weekly-main",
+          resetsAt: null,
+          percent: 10,
+          coverage: "complete",
+          periodCount: 1,
+        },
+      ],
+    })
+    await vi.advanceTimersByTimeAsync(0)
 
-    await vi.waitFor(() => expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2))
+    expect(session.getSnapshot().sessionLimitAllocations.generatedAt).toBe("current")
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
     unsubscribe()
   })
 
@@ -208,6 +289,147 @@ describe("PopoverSession surface presentation", () => {
     await vi.advanceTimersByTimeAsync(1_001)
 
     expect(session.getSnapshot().sessionLimitAllocations.allocations).toHaveLength(1)
+    unsubscribe()
+  })
+
+  it("keeps cached history but skips recurring allocation reads while hidden or disabled", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    getSettings.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      onboardingCompleted: true,
+      liveUsageEnabled: false,
+    })
+    getSessionLimitAllocations.mockResolvedValue({
+      generatedAt: "2027-01-15T08:00:00Z",
+      allocations: [
+        {
+          agent: "claude-code",
+          sessionId: "session-1",
+          wslDistro: null,
+          provider: "anthropic",
+          displayName: "Claude",
+          accountKey: null,
+          metric: "weekly",
+          windowId: "weekly-main",
+          resetsAt: null,
+          percent: 10,
+          coverage: "complete",
+          periodCount: 2,
+        },
+      ],
+    })
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+    expect(session.getSnapshot().sessionLimitAllocations.allocations).toHaveLength(1)
+
+    popoverHiddenHandler?.()
+    liveUsageChangedHandler?.({ providers: [], errors: [], meters: [], generatedAt: "hidden" })
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+    expect(session.getSnapshot().sessionLimitAllocations.allocations).toHaveLength(1)
+
+    popoverShownHandler?.()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
+
+    liveUsageChangedHandler?.({
+      providers: [],
+      errors: [],
+      meters: [],
+      generatedAt: "disabled",
+    })
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
+    expect(session.getSnapshot().sessionLimitAllocations.allocations).toHaveLength(1)
+    unsubscribe()
+  })
+
+  it("preserves a disabled cached read queued behind a stale hidden response", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    getSettings.mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      onboardingCompleted: true,
+      liveUsageEnabled: false,
+    })
+    let resolveFirst!: (value: Ipc.SessionLimitAllocationSummaryPayload) => void
+    getSessionLimitAllocations
+      .mockImplementationOnce(
+        () =>
+          new Promise<Ipc.SessionLimitAllocationSummaryPayload>((resolve) => {
+            resolveFirst = resolve
+          }),
+      )
+      .mockResolvedValue({ generatedAt: "shown", allocations: [] })
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+
+    popoverHiddenHandler?.()
+    popoverShownHandler?.()
+    resolveFirst({ generatedAt: "hidden", allocations: [] })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
+    expect(session.getSnapshot().sessionLimitAllocations.generatedAt).toBe("shown")
+    unsubscribe()
+  })
+
+  it("refreshes disabled cached history for local entry and cohort changes", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime("2027-01-15T08:00:00Z")
+    const disabled = {
+      ...DEFAULT_SETTINGS,
+      onboardingCompleted: true,
+      liveUsageEnabled: false,
+    }
+    getSettings.mockResolvedValue(disabled)
+    const session = new PopoverSession()
+    const unsubscribe = session.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+
+    entryChangedHandler?.({
+      agent: "claude-code",
+      sessionId: "session-1",
+      repo: "repo",
+      timestamp: "2027-01-15T08:00:00Z",
+      isActive: true,
+      surface: "cli",
+      wslDistro: null,
+      title: null,
+      hasForkParent: false,
+      forkChildCount: 0,
+      cost: null,
+      models: [],
+      modelRuns: [],
+    })
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
+
+    settingsChangedHandler?.({
+      ...disabled,
+      activityWindowDays: disabled.activityWindowDays === 7 ? 30 : 7,
+    })
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(3)
+
+    liveUsageChangedHandler?.({
+      providers: [],
+      errors: [],
+      meters: [],
+      generatedAt: "disabled",
+    })
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(3)
     unsubscribe()
   })
 

--- a/apps/desktop/src/views/popover/PopoverSession.test.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.test.ts
@@ -3,11 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type * as Ipc from "../../lib/ipc"
 import type * as InsightsIpc from "../../lib/insightsIpc"
 import {
-  DEFAULT_SETTINGS,
   EMPTY_PROVIDER_USAGE,
   type ActivityEntryPayload,
   type ScanStatus,
   type SessionAnalysisPayload,
+  type SessionLimitAllocationSummaryPayload,
 } from "../../lib/ipc"
 import { PopoverSession, sessionKey } from "./PopoverSession"
 import type { SessionSubject } from "./SessionPane"
@@ -16,8 +16,6 @@ const getSessionAnalysis = vi.hoisted(() => vi.fn())
 const getSubagentAnalysis = vi.hoisted(() => vi.fn())
 const getSessionLimitAllocations = vi.hoisted(() => vi.fn())
 const getProviderUsage = vi.hoisted(() => vi.fn())
-const getSettings = vi.hoisted(() => vi.fn())
-const onSettingsChanged = vi.hoisted(() => vi.fn())
 const setPopoverHeight = vi.hoisted(() => vi.fn())
 const listRecentSessions = vi.hoisted(() => vi.fn())
 const onSessionEntryChanged = vi.hoisted(() => vi.fn())
@@ -26,7 +24,6 @@ const onChecksReportChanged = vi.hoisted(() => vi.fn())
 const getChecksReport = vi.hoisted(() => vi.fn())
 const onPopoverShown = vi.hoisted(() => vi.fn())
 const onPopoverHidden = vi.hoisted(() => vi.fn())
-const onLiveUsageChanged = vi.hoisted(() => vi.fn())
 
 // The analysis, list, and event-subscription commands are overridden. All
 // other wrappers keep their real no-shell fallback because `hasShell()` is
@@ -39,15 +36,12 @@ vi.mock("../../lib/ipc", async (importOriginal) => {
     getSubagentAnalysis,
     getSessionLimitAllocations,
     getProviderUsage,
-    getSettings,
-    onSettingsChanged,
     setPopoverHeight,
     listRecentSessions,
     onSessionEntryChanged,
     onScanEvent,
     onPopoverShown,
     onPopoverHidden,
-    onLiveUsageChanged,
   }
 })
 
@@ -63,16 +57,30 @@ let entryChangedHandler: EntryChangedHandler | null = null
 let scanEventHandler: ScanEventHandler | null = null
 let popoverShownHandler: (() => void) | null = null
 let popoverHiddenHandler: (() => void) | null = null
-let liveUsageChangedHandler: ((liveUsage: Ipc.LiveUsageSummaryPayload) => void) | null = null
-let settingsChangedHandler: ((settings: Ipc.AppSettings) => void) | null = null
+
+function changedEntry(): ActivityEntryPayload {
+  return {
+    agent: "claude-code",
+    sessionId: "session-1",
+    repo: "repo",
+    timestamp: "2027-01-15T08:00:00Z",
+    isActive: true,
+    surface: "cli",
+    wslDistro: null,
+    title: null,
+    hasForkParent: false,
+    forkChildCount: 0,
+    cost: null,
+    models: [],
+    modelRuns: [],
+  }
+}
 
 beforeEach(() => {
   entryChangedHandler = null
   scanEventHandler = null
   popoverShownHandler = null
   popoverHiddenHandler = null
-  liveUsageChangedHandler = null
-  settingsChangedHandler = null
   getSessionAnalysis.mockReset()
   getSessionAnalysis.mockResolvedValue(null)
   getSubagentAnalysis.mockReset()
@@ -113,22 +121,6 @@ beforeEach(() => {
       popoverHiddenHandler = null
     }
   })
-  onLiveUsageChanged.mockReset()
-  onLiveUsageChanged.mockImplementation(
-    async (handler: (liveUsage: Ipc.LiveUsageSummaryPayload) => void) => {
-      liveUsageChangedHandler = handler
-      return () => {
-        liveUsageChangedHandler = null
-      }
-    },
-  )
-  onSettingsChanged.mockReset()
-  onSettingsChanged.mockImplementation(async (handler: (settings: Ipc.AppSettings) => void) => {
-    settingsChangedHandler = handler
-    return () => {
-      settingsChangedHandler = null
-    }
-  })
   getSessionLimitAllocations.mockReset()
   getSessionLimitAllocations.mockResolvedValue({
     generatedAt: "2027-01-15T08:00:00Z",
@@ -136,11 +128,6 @@ beforeEach(() => {
   })
   getProviderUsage.mockReset()
   getProviderUsage.mockResolvedValue(EMPTY_PROVIDER_USAGE)
-  getSettings.mockReset()
-  getSettings.mockResolvedValue({
-    ...DEFAULT_SETTINGS,
-    onboardingCompleted: true,
-  })
 })
 
 describe("PopoverSession surface presentation", () => {
@@ -195,10 +182,9 @@ describe("PopoverSession surface presentation", () => {
     const unsubscribe = session.subscribe(() => {})
     await vi.advanceTimersByTimeAsync(0)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
-    expect(liveUsageChangedHandler).not.toBeNull()
 
-    liveUsageChangedHandler?.({ providers: [], errors: [], meters: [], generatedAt: "one" })
-    liveUsageChangedHandler?.({ providers: [], errors: [], meters: [], generatedAt: "two" })
+    entryChangedHandler?.(changedEntry())
+    entryChangedHandler?.(changedEntry())
     await vi.advanceTimersByTimeAsync(29_999)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
 
@@ -210,11 +196,11 @@ describe("PopoverSession surface presentation", () => {
   it("publishes a current allocation response during an event storm", async () => {
     vi.useFakeTimers()
     vi.setSystemTime("2027-01-15T08:00:00Z")
-    let resolveFirst!: (value: Ipc.SessionLimitAllocationSummaryPayload) => void
+    let resolveFirst!: (value: SessionLimitAllocationSummaryPayload) => void
     getSessionLimitAllocations
       .mockImplementationOnce(
         () =>
-          new Promise<Ipc.SessionLimitAllocationSummaryPayload>((resolve) => {
+          new Promise<SessionLimitAllocationSummaryPayload>((resolve) => {
             resolveFirst = resolve
           }),
       )
@@ -224,13 +210,8 @@ describe("PopoverSession surface presentation", () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
 
-    for (let index = 0; index < 20; index += 1) {
-      liveUsageChangedHandler?.({
-        providers: [],
-        errors: [],
-        meters: [],
-        generatedAt: String(index),
-      })
+    for (let event = 0; event < 20; event += 1) {
+      entryChangedHandler?.(changedEntry())
     }
     resolveFirst({
       generatedAt: "current",
@@ -292,14 +273,9 @@ describe("PopoverSession surface presentation", () => {
     unsubscribe()
   })
 
-  it("keeps cached history but skips recurring allocation reads while hidden or disabled", async () => {
+  it("keeps cached history but skips recurring allocation reads while hidden", async () => {
     vi.useFakeTimers()
     vi.setSystemTime("2027-01-15T08:00:00Z")
-    getSettings.mockResolvedValue({
-      ...DEFAULT_SETTINGS,
-      onboardingCompleted: true,
-      liveUsageEnabled: false,
-    })
     getSessionLimitAllocations.mockResolvedValue({
       generatedAt: "2027-01-15T08:00:00Z",
       allocations: [
@@ -326,22 +302,13 @@ describe("PopoverSession surface presentation", () => {
     expect(session.getSnapshot().sessionLimitAllocations.allocations).toHaveLength(1)
 
     popoverHiddenHandler?.()
-    liveUsageChangedHandler?.({ providers: [], errors: [], meters: [], generatedAt: "hidden" })
+    entryChangedHandler?.(changedEntry())
     await vi.advanceTimersByTimeAsync(60_000)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
     expect(session.getSnapshot().sessionLimitAllocations.allocations).toHaveLength(1)
 
     popoverShownHandler?.()
     await vi.advanceTimersByTimeAsync(0)
-    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
-
-    liveUsageChangedHandler?.({
-      providers: [],
-      errors: [],
-      meters: [],
-      generatedAt: "disabled",
-    })
-    await vi.advanceTimersByTimeAsync(60_000)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
     expect(session.getSnapshot().sessionLimitAllocations.allocations).toHaveLength(1)
     unsubscribe()
@@ -350,16 +317,11 @@ describe("PopoverSession surface presentation", () => {
   it("preserves a disabled cached read queued behind a stale hidden response", async () => {
     vi.useFakeTimers()
     vi.setSystemTime("2027-01-15T08:00:00Z")
-    getSettings.mockResolvedValue({
-      ...DEFAULT_SETTINGS,
-      onboardingCompleted: true,
-      liveUsageEnabled: false,
-    })
-    let resolveFirst!: (value: Ipc.SessionLimitAllocationSummaryPayload) => void
+    let resolveFirst!: (value: SessionLimitAllocationSummaryPayload) => void
     getSessionLimitAllocations
       .mockImplementationOnce(
         () =>
-          new Promise<Ipc.SessionLimitAllocationSummaryPayload>((resolve) => {
+          new Promise<SessionLimitAllocationSummaryPayload>((resolve) => {
             resolveFirst = resolve
           }),
       )
@@ -379,57 +341,19 @@ describe("PopoverSession surface presentation", () => {
     unsubscribe()
   })
 
-  it("refreshes disabled cached history for local entry and cohort changes", async () => {
+  it("refreshes inactive cached history for local entry changes", async () => {
     vi.useFakeTimers()
     vi.setSystemTime("2027-01-15T08:00:00Z")
-    const disabled = {
-      ...DEFAULT_SETTINGS,
-      onboardingCompleted: true,
-      liveUsageEnabled: false,
-    }
-    getSettings.mockResolvedValue(disabled)
     const session = new PopoverSession()
     const unsubscribe = session.subscribe(() => {})
     await vi.advanceTimersByTimeAsync(0)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
 
-    entryChangedHandler?.({
-      agent: "claude-code",
-      sessionId: "session-1",
-      repo: "repo",
-      timestamp: "2027-01-15T08:00:00Z",
-      isActive: true,
-      surface: "cli",
-      wslDistro: null,
-      title: null,
-      hasForkParent: false,
-      forkChildCount: 0,
-      cost: null,
-      models: [],
-      modelRuns: [],
-    })
+    entryChangedHandler?.(changedEntry())
     await vi.advanceTimersByTimeAsync(29_999)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(1)
     await vi.advanceTimersByTimeAsync(1)
     expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
-
-    settingsChangedHandler?.({
-      ...disabled,
-      activityWindowDays: disabled.activityWindowDays === 7 ? 30 : 7,
-    })
-    await vi.advanceTimersByTimeAsync(29_999)
-    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(2)
-    await vi.advanceTimersByTimeAsync(1)
-    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(3)
-
-    liveUsageChangedHandler?.({
-      providers: [],
-      errors: [],
-      meters: [],
-      generatedAt: "disabled",
-    })
-    await vi.advanceTimersByTimeAsync(60_000)
-    expect(getSessionLimitAllocations).toHaveBeenCalledTimes(3)
     unsubscribe()
   })
 

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -201,6 +201,13 @@ const USAGE_REFRESH_MIN_MS = 30_000
  */
 const USAGE_VISIBLE_POLL_MS = 60_000
 
+/** Minimum spacing between cached session-allocation reads. */
+const SESSION_LIMIT_ALLOCATION_REFRESH_MIN_MS = 30_000
+
+function liveUsageActive(settings: AppSettings | null): boolean {
+  return Boolean(settings?.liveUsageEnabled && settings.onboardingCompleted)
+}
+
 /**
  * Order list rows the way the backend does: newest activity first, and a
  * revived session's own id breaking a tie. `listenSessionEntryChanged`
@@ -257,8 +264,11 @@ export class PopoverSession {
    */
   private pendingAnalysisRefresh = false
   private liveUsageRevision = 0
-  private sessionLimitAllocationRequested = 0
   private sessionLimitAllocationRefresh: Promise<void> | null = null
+  private sessionLimitAllocationRefreshPending = false
+  private sessionLimitAllocationRefreshTimer: ReturnType<typeof setTimeout> | null = null
+  private lastSessionLimitAllocationRefreshAt = 0
+  private sessionLimitAllocationResultRevision = 0
   private initialContentReady = false
   private contentReadyReportedGeneration: number | null = null
   private contentReadyReportInFlightGeneration: number | null = null
@@ -474,6 +484,7 @@ export class PopoverSession {
     this.stopLiveUsageListening = null
     this.stopNowTicking()
     this.stopUsagePolling()
+    this.cancelSessionLimitAllocationRefresh()
     this.checksRefreshQueued = false
     const checksConsumerId = this.checksConsumerId
     this.checksConsumerId = null
@@ -525,13 +536,21 @@ export class PopoverSession {
       if (generation !== this.generation) return
       const previousDays = this.windowDays()
       const previousDisabled = (this.snapshot.settings?.disabledAgents ?? []).join(",")
+      const wasLiveUsageActive = liveUsageActive(this.snapshot.settings)
       applyTheme(settings.theme)
       this.update({ settings })
+      if (!liveUsageActive(settings)) {
+        this.cancelSessionLimitAllocationRefresh()
+      } else if (!wasLiveUsageActive && this.visible) {
+        this.requestSessionLimitAllocationRefresh(true)
+      }
       if (
         settings.activityWindowDays !== previousDays ||
         settings.disabledAgents.join(",") !== previousDisabled
       ) {
+        this.sessionLimitAllocationResultRevision += 1
         void this.refreshEntries(settings.activityWindowDays).catch(() => {})
+        this.requestSessionLimitAllocationRefresh(false, true)
       }
     })
     if (generation !== this.generation) {
@@ -550,6 +569,7 @@ export class PopoverSession {
       void this.refreshUsage()
       void this.refreshRepositoryList()
       void this.refreshChecks()
+      this.requestSessionLimitAllocationRefresh(false, true)
     })
     if (generation !== this.generation) {
       unlisten()
@@ -576,7 +596,7 @@ export class PopoverSession {
       if (generation !== this.generation) return
       this.patchOrRefetchEntry(entry)
       this.refreshOpenAnalysisIfMatching(entry)
-      void this.refreshSessionLimitAllocations()
+      this.requestSessionLimitAllocationRefresh(false, true)
       if (this.visible && Date.now() - this.lastUsageRefreshAt >= USAGE_REFRESH_MIN_MS) {
         this.lastUsageRefreshAt = Date.now()
         void this.refreshUsage()
@@ -768,6 +788,7 @@ export class PopoverSession {
       this.update({ now: Date.now() })
       this.syncNowTicking()
       this.startUsagePolling()
+      this.requestSessionLimitAllocationRefresh(true, true)
       if (this.initialContentReady) this.reportContentReady(true)
       void this.restoreFloatingHud(generation)
       void this.refreshEntries(this.windowDays()).catch(() => {})
@@ -788,8 +809,10 @@ export class PopoverSession {
     const unlisten = await onPopoverHidden(() => {
       if (generation !== this.generation) return
       this.visible = false
+      this.sessionLimitAllocationResultRevision += 1
       this.syncNowTicking()
       this.stopUsagePolling()
+      this.cancelSessionLimitAllocationRefresh()
     })
     if (generation !== this.generation) {
       unlisten()
@@ -841,7 +864,7 @@ export class PopoverSession {
       if (generation !== this.generation) return
       this.liveUsageRevision += 1
       this.update({ liveUsage })
-      void this.refreshSessionLimitAllocations()
+      this.requestSessionLimitAllocationRefresh()
     })
     if (generation !== this.generation) {
       unlisten()
@@ -877,7 +900,6 @@ export class PopoverSession {
 
   private loadCachedUsage = async (): Promise<void> => {
     const liveUsageRevision = this.liveUsageRevision
-    void this.refreshSessionLimitAllocations()
     const [usage, liveUsage] = await Promise.all([
       getProviderUsage().catch(() => EMPTY_PROVIDER_USAGE),
       getLiveUsage().catch(() => EMPTY_LIVE_USAGE),
@@ -886,6 +908,7 @@ export class PopoverSession {
     if (liveUsageRevision === this.liveUsageRevision) {
       this.update({ liveUsage })
     }
+    this.requestSessionLimitAllocationRefresh(true, true)
   }
 
   private refreshUsage = async (): Promise<void> => {
@@ -909,36 +932,83 @@ export class PopoverSession {
           })
           .catch(() => undefined),
       ])
-      await this.refreshSessionLimitAllocations()
     } finally {
       this.usageRefreshCount -= 1
       this.update({ usageRefreshing: this.usageRefreshCount > 0 })
     }
   }
 
-  private refreshSessionLimitAllocations = (): Promise<void> => {
-    this.sessionLimitAllocationRequested += 1
-    if (!this.sessionLimitAllocationRefresh) {
-      this.sessionLimitAllocationRefresh = this.runSessionLimitAllocationRefreshes().finally(
-        () => {
-          this.sessionLimitAllocationRefresh = null
-        },
-      )
+  private requestSessionLimitAllocationRefresh(
+    immediate = false,
+    includeDisabledCache = false,
+  ): void {
+    if (
+      !this.started ||
+      !this.visible ||
+      (!includeDisabledCache && !liveUsageActive(this.snapshot.settings))
+    )
+      return
+    this.sessionLimitAllocationRefreshPending = true
+    if (immediate) this.lastSessionLimitAllocationRefreshAt = 0
+    if (immediate && this.sessionLimitAllocationRefreshTimer !== null) {
+      clearTimeout(this.sessionLimitAllocationRefreshTimer)
+      this.sessionLimitAllocationRefreshTimer = null
     }
-    return this.sessionLimitAllocationRefresh
+    if (this.sessionLimitAllocationRefresh || this.sessionLimitAllocationRefreshTimer !== null)
+      return
+    this.scheduleSessionLimitAllocationRefresh(immediate)
   }
 
-  private runSessionLimitAllocationRefreshes = async (): Promise<void> => {
-    let completed = 0
-    while (completed < this.sessionLimitAllocationRequested) {
-      const target = this.sessionLimitAllocationRequested
-      const generation = this.generation
-      const sessionLimitAllocations = await getSessionLimitAllocations().catch(() => null)
-      if (sessionLimitAllocations && generation === this.generation) {
-        this.update({ sessionLimitAllocations })
-      }
-      completed = target
+  private scheduleSessionLimitAllocationRefresh(immediate = false): void {
+    const delay = immediate
+      ? 0
+      : Math.max(
+          0,
+          this.lastSessionLimitAllocationRefreshAt +
+            SESSION_LIMIT_ALLOCATION_REFRESH_MIN_MS -
+            Date.now(),
+        )
+    if (delay > 0) {
+      this.sessionLimitAllocationRefreshTimer = setTimeout(() => {
+        this.sessionLimitAllocationRefreshTimer = null
+        this.runSessionLimitAllocationRefresh()
+      }, delay)
+      return
     }
+    this.runSessionLimitAllocationRefresh()
+  }
+
+  private runSessionLimitAllocationRefresh = (): void => {
+    if (!this.sessionLimitAllocationRefreshPending || !this.visible) return
+    this.sessionLimitAllocationRefreshPending = false
+    this.lastSessionLimitAllocationRefreshAt = Date.now()
+    const generation = this.generation
+    const resultRevision = this.sessionLimitAllocationResultRevision
+    this.sessionLimitAllocationRefresh = getSessionLimitAllocations()
+      .then((sessionLimitAllocations) => {
+        if (
+          generation === this.generation &&
+          this.visible &&
+          resultRevision === this.sessionLimitAllocationResultRevision
+        ) {
+          this.update({ sessionLimitAllocations })
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        this.sessionLimitAllocationRefresh = null
+        if (this.sessionLimitAllocationRefreshPending) {
+          this.scheduleSessionLimitAllocationRefresh()
+        }
+      })
+  }
+
+  private cancelSessionLimitAllocationRefresh(): void {
+    if (this.sessionLimitAllocationRefreshTimer !== null) {
+      clearTimeout(this.sessionLimitAllocationRefreshTimer)
+      this.sessionLimitAllocationRefreshTimer = null
+    }
+    this.sessionLimitAllocationRefreshPending = false
   }
 
   private refreshRepositoryList = async (): Promise<void> => {


### PR DESCRIPTION
## User impact

Cached per-session allowance shares stay current without duplicate work from rapid activity events. Cumulative allocation history remains visible and locally recomputes when provider network collection is disabled.

PR #426 already removed allocation computation from the popover IPC path and introduced the durable cumulative ledger with bounded periods, observation intervals, and turn groups. This PR addresses the remaining audit finding 7 work: linear interval reduction, indexed range aggregation through read-only WAL connections, a shared reconciliation gate, and a bounded visible refresh floor.

## Validation

Merged `main` at `26e0ec9f` and combined the allocation-refresh and analytics test fixtures. Event meanings and analytics coverage are unchanged.

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (987 tests)
- `cargo clippy --all-targets --features analytics -- -D warnings`
- `cargo test --features analytics` (1030 tests)
- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop knip`
- `pnpm --filter @antiburn/desktop test` (94 files, 1202 tests)
- `pnpm --filter @antiburn/desktop build` (passes with the existing settings chunk-size warning)
- `pnpm run slop:all` (100, Healthy, no findings)
- `pnpm run secrets`
- `git diff --check`

Regression coverage includes exact interval endpoints, duplicate timestamps, long plateaus with and without a final rise, linear work bounds, account isolation, pricing/evidence/live invalidation, offline durable reconciliation, network-source gating, shared in-flight work, query-plan index use, writer-lock independence, hidden/stale responses, event storms, and disabled cached-history refreshes.

## Analytics

Product question: can users view current cumulative session allowance shares without repeated background work degrading responsiveness?

Measurement is unchanged. This is an internal performance and scheduling correction with no new deliberate user action or result meaning. Polling, retries, cache reads, and automatic reconciliation are background work, so adding analytics events would incorrectly count them as meaningful use. Existing feature analytics remain unchanged, and correctness/work-bound tests validate this change.

## Privacy and performance

No new data or network access. Provider network collection remains gated by the existing live-usage setting. Local durable allocation history continues to reconcile while offline so pricing and evidence changes do not leave cached cumulative results stale.

Allocation reconciliation now shares one in-flight pass across store clones, reads batches through one read-only WAL connection, uses indexed disjoint timestamp ranges, and visits each eligible turn once during interval allocation. Frontend activity events coalesce behind a 30-second visible refresh floor while initial load and reveal can still read cached history immediately.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

