### PR TITLE
Reduce background work and remove dead paths

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -193,7 +193,6 @@ version = "0.1.0"
 dependencies = [
  "fundsp",
  "rodio",
- "serde",
  "tracing",
 ]
 

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
@@ -19,8 +19,7 @@ mod windows;
 pub use manager::AnchoredWindowManager;
 pub use model::{
     AnchorRegion, AnchoredWindowConfig, AnchoredWindowLifecycleEvent, AnchoredWindowRenderRequest,
-    AnchoredWindowRequest, AnchoredWindowState, HeightPolicy, InteractionPolicy, PlacementPolicy,
-    PointerExitPolicy, RevealPolicy, WindowMaterial,
+    AnchoredWindowRequest, AnchoredWindowState, PointerExitPolicy,
 };
 
 /// The event that carries each target generation to the active renderer.

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle.rs
@@ -1,6 +1,5 @@
 use crate::model::{
     AnchorRegion, AnchoredWindowRenderRequest, AnchoredWindowRequest, AnchoredWindowState,
-    RevealPolicy,
 };
 
 #[derive(Debug, PartialEq)]
@@ -102,7 +101,6 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
         &mut self,
         target: T,
         anchor_region: AnchorRegion,
-        reveal: RevealPolicy,
         initial_height: f64,
         initial_presentation: Option<P>,
     ) -> RequestTransition<T> {
@@ -125,7 +123,6 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
             target,
             stored_target,
             anchor_region,
-            reveal,
             initial_height,
             initial_presentation,
         )
@@ -136,7 +133,6 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
         target: T,
         stored_target: T,
         anchor_region: AnchorRegion,
-        reveal: RevealPolicy,
         initial_height: f64,
         initial_presentation: Option<P>,
     ) -> RequestTransition<T> {
@@ -149,22 +145,14 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
         if !was_visible {
             self.height = initial_height;
         }
-        if reveal == RevealPolicy::AfterPresentation {
-            self.visible = false;
-        }
         self.awaiting_presentation = true;
         self.awaiting_concealment = false;
         self.delivery_pending = true;
-        self.placeholder_reveal_pending = reveal == RevealPolicy::ImmediatePlaceholder
-            && !was_visible
-            && self.initial_presentation.is_none();
-        let reveal_now = reveal == RevealPolicy::ImmediatePlaceholder
-            && self.renderer_ready
-            && self.placeholder_reveal_pending;
+        self.placeholder_reveal_pending = !was_visible && self.initial_presentation.is_none();
+        let reveal_now = self.renderer_ready && self.placeholder_reveal_pending;
         self.placeholder_reveal_pending &= !reveal_now;
         self.visible |= reveal_now;
-        self.awaiting_retarget_commit =
-            reveal == RevealPolicy::ImmediatePlaceholder && was_visible && self.visible;
+        self.awaiting_retarget_commit = was_visible && self.visible;
         RequestTransition::Retargeted {
             request: AnchoredWindowRequest {
                 generation,
@@ -175,20 +163,13 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
         }
     }
 
-    pub(crate) fn renderer_ready(
-        &mut self,
-        renderer_generation: u64,
-        reveal: RevealPolicy,
-    ) -> Option<bool> {
+    pub(crate) fn renderer_ready(&mut self, renderer_generation: u64) -> Option<bool> {
         if renderer_generation != self.renderer_generation {
             return None;
         }
         self.renderer_ready = true;
         self.delivery_pending = true;
-        let reveal_now = reveal == RevealPolicy::ImmediatePlaceholder
-            && self.placeholder_reveal_pending
-            && self.target.is_some()
-            && !self.visible;
+        let reveal_now = self.placeholder_reveal_pending && self.target.is_some() && !self.visible;
         self.placeholder_reveal_pending &= !reveal_now;
         self.visible |= reveal_now;
         Some(reveal_now)

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/concealment.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/concealment.rs
@@ -1,43 +1,25 @@
 use crate::lifecycle::{RequestTransition, ScheduledTask};
-use crate::model::{AnchorRegion, AnchoredWindowRequest, RevealPolicy};
+use crate::model::{AnchorRegion, AnchoredWindowRequest};
 
 use super::fixtures::{lifecycle, region, retargeted};
 
 #[test]
 fn generation_checks_cover_concealment_and_retargeting() {
     let mut lifecycle = lifecycle();
-    let (first, _) = retargeted(lifecycle.request(
-        "first",
-        region(),
-        RevealPolicy::AfterPresentation,
-        120.0,
-        None,
-    ));
+    let (first, _) = retargeted(lifecycle.request("first", region(), 120.0, None));
     let conceal = lifecycle.conceal();
 
     assert!(!lifecycle.presented(first.generation));
     assert!(lifecycle.concealed(conceal.generation));
     assert!(!lifecycle.visible);
 
-    let (second, _) = retargeted(lifecycle.request(
-        "second",
-        region(),
-        RevealPolicy::AfterPresentation,
-        120.0,
-        None,
-    ));
+    let (second, _) = retargeted(lifecycle.request("second", region(), 120.0, None));
     let stale_conceal = lifecycle.conceal();
     let latest_region = AnchorRegion {
         top: 180.0,
         height: 64.0,
     };
-    let (third, _) = retargeted(lifecycle.request(
-        "third",
-        latest_region,
-        RevealPolicy::AfterPresentation,
-        120.0,
-        None,
-    ));
+    let (third, _) = retargeted(lifecycle.request("third", latest_region, 120.0, None));
 
     assert!(!lifecycle.fallback_is_current(stale_conceal.generation));
     assert!(!lifecycle.presented(second.generation));
@@ -50,13 +32,7 @@ fn generation_checks_cover_concealment_and_retargeting() {
 fn renderer_retirement_requires_the_current_completed_concealment() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_ready = true;
-    let (first, _) = retargeted(lifecycle.request(
-        "first",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    ));
+    let (first, _) = retargeted(lifecycle.request("first", region(), 120.0, None));
     assert!(lifecycle.presented(first.generation));
 
     let conceal = lifecycle.conceal();
@@ -64,13 +40,7 @@ fn renderer_retirement_requires_the_current_completed_concealment() {
     assert!(lifecycle.concealed(conceal.generation));
     assert!(lifecycle.renderer_retirement_is_current(conceal.generation));
 
-    let (second, _) = retargeted(lifecycle.request(
-        "second",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    ));
+    let (second, _) = retargeted(lifecycle.request("second", region(), 120.0, None));
     assert!(!lifecycle.renderer_retirement_is_current(conceal.generation));
     assert!(!lifecycle.renderer_retirement_is_current(second.generation));
 }
@@ -80,37 +50,19 @@ fn late_renderer_destruction_preserves_a_new_target_for_rebuild() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_generation = 7;
     lifecycle.renderer_ready = true;
-    let (first, _) = retargeted(lifecycle.request(
-        "first",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    ));
+    let (first, _) = retargeted(lifecycle.request("first", region(), 120.0, None));
     assert!(lifecycle.presented(first.generation));
     let conceal = lifecycle.conceal();
     assert!(lifecycle.concealed(conceal.generation));
 
-    let (second, _) = retargeted(lifecycle.request(
-        "second",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    ));
+    let (second, _) = retargeted(lifecycle.request("second", region(), 120.0, None));
     assert!(!lifecycle.renderer_retirement_is_current(conceal.generation));
 
     lifecycle.renderer_destroyed();
     assert_eq!(lifecycle.state().target, Some("second"));
     assert!(lifecycle.awaiting_presentation);
-    assert_eq!(
-        lifecycle.renderer_ready(7, RevealPolicy::ImmediatePlaceholder),
-        None
-    );
-    assert_eq!(
-        lifecycle.renderer_ready(8, RevealPolicy::ImmediatePlaceholder),
-        Some(false)
-    );
+    assert_eq!(lifecycle.renderer_ready(7), None);
+    assert_eq!(lifecycle.renderer_ready(8), Some(false));
     let pending = lifecycle
         .pending_render_request()
         .expect("the new target needs the replacement renderer");
@@ -122,13 +74,7 @@ fn late_renderer_destruction_preserves_a_new_target_for_rebuild() {
 fn anchor_teardown_retires_a_renderer_that_is_still_loading() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_generation = 7;
-    let (request, _) = retargeted(lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    ));
+    let (request, _) = retargeted(lifecycle.request("target", region(), 120.0, None));
     assert!(lifecycle.awaiting_presentation);
 
     let conceal = lifecycle.conceal();
@@ -139,10 +85,7 @@ fn anchor_teardown_retires_a_renderer_that_is_still_loading() {
     lifecycle.renderer_destroyed();
     assert_eq!(lifecycle.state().target, None);
     assert!(!lifecycle.awaiting_presentation);
-    assert_eq!(
-        lifecycle.renderer_ready(7, RevealPolicy::ImmediatePlaceholder),
-        None
-    );
+    assert_eq!(lifecycle.renderer_ready(7), None);
     assert!(!lifecycle.presented(request.generation));
 }
 
@@ -150,13 +93,7 @@ fn anchor_teardown_retires_a_renderer_that_is_still_loading() {
 fn forced_anchor_conceal_makes_the_next_immediate_request_a_cold_reveal() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_ready = true;
-    let (first, reveal_now) = retargeted(lifecycle.request(
-        "first",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        320.0,
-        None,
-    ));
+    let (first, reveal_now) = retargeted(lifecycle.request("first", region(), 320.0, None));
     assert!(reveal_now);
     assert!(lifecycle.presented(first.generation));
     lifecycle.height = 500.0;
@@ -166,13 +103,7 @@ fn forced_anchor_conceal_makes_the_next_immediate_request_a_cold_reveal() {
     assert!(!lifecycle.visible);
     assert!(lifecycle.awaiting_concealment);
 
-    let (second, reveal_now) = retargeted(lifecycle.request(
-        "second",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        320.0,
-        None,
-    ));
+    let (second, reveal_now) = retargeted(lifecycle.request("second", region(), 320.0, None));
 
     assert_eq!(second.generation, conceal.generation + 1);
     assert!(reveal_now);
@@ -185,13 +116,7 @@ fn forced_anchor_conceal_makes_the_next_immediate_request_a_cold_reveal() {
 fn same_target_reentry_cancels_concealment_without_restarting_presentation() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_ready = true;
-    let (first, _) = retargeted(lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    ));
+    let (first, _) = retargeted(lifecycle.request("target", region(), 120.0, None));
     assert!(lifecycle.presented(first.generation));
     lifecycle.height = 240.0;
 
@@ -205,13 +130,7 @@ fn same_target_reentry_cancels_concealment_without_restarting_presentation() {
         height: 52.0,
     };
 
-    let retained = lifecycle.request(
-        "target",
-        next_region,
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    );
+    let retained = lifecycle.request("target", next_region, 120.0, None);
 
     assert_eq!(
         retained,

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/presentation.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/presentation.rs
@@ -1,5 +1,5 @@
 use crate::lifecycle::RequestTransition;
-use crate::model::{AnchorRegion, AnchoredWindowRequest, RevealPolicy};
+use crate::model::{AnchorRegion, AnchoredWindowRequest};
 
 use super::fixtures::{lifecycle, region, retargeted};
 
@@ -7,17 +7,12 @@ use super::fixtures::{lifecycle, region, retargeted};
 fn visible_immediate_retarget_waits_for_the_renderer_commit() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_generation = 7;
-    let (queued, reveal_before_ready) = retargeted(lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        320.0,
-        None,
-    ));
+    let (queued, reveal_before_ready) =
+        retargeted(lifecycle.request("target", region(), 320.0, None));
     assert!(!reveal_before_ready);
     assert!(!queued.retarget_commit_required);
 
-    let Some(reveal_ready) = lifecycle.renderer_ready(7, RevealPolicy::ImmediatePlaceholder) else {
+    let Some(reveal_ready) = lifecycle.renderer_ready(7) else {
         panic!("the renderer generation is current");
     };
     let delivered = lifecycle
@@ -35,13 +30,8 @@ fn visible_immediate_retarget_waits_for_the_renderer_commit() {
     assert_eq!(delivered.initial_presentation, None);
     lifecycle.height = 500.0;
 
-    let (retargeted, reveal_now) = retargeted(lifecycle.request(
-        "second",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        320.0,
-        Some("second presentation"),
-    ));
+    let (retargeted, reveal_now) =
+        retargeted(lifecycle.request("second", region(), 320.0, Some("second presentation")));
 
     assert_eq!(retargeted.generation, queued.generation + 1);
     assert!(retargeted.retarget_commit_required);
@@ -63,16 +53,11 @@ fn visible_immediate_retarget_waits_for_the_renderer_commit() {
 fn cold_seeded_request_waits_for_presentation_before_reveal() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_generation = 7;
-    let (queued, reveal_before_ready) = retargeted(lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        320.0,
-        Some("presentation"),
-    ));
+    let (queued, reveal_before_ready) =
+        retargeted(lifecycle.request("target", region(), 320.0, Some("presentation")));
 
     assert!(!reveal_before_ready);
-    let Some(reveal_ready) = lifecycle.renderer_ready(7, RevealPolicy::ImmediatePlaceholder) else {
+    let Some(reveal_ready) = lifecycle.renderer_ready(7) else {
         panic!("the renderer generation is current");
     };
     let delivered = lifecycle
@@ -92,13 +77,8 @@ fn seeded_renderer_recovery_rearms_the_presentation_barrier() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_generation = 7;
     lifecycle.renderer_ready = true;
-    let (request, reveal_now) = retargeted(lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        320.0,
-        Some("presentation"),
-    ));
+    let (request, reveal_now) =
+        retargeted(lifecycle.request("target", region(), 320.0, Some("presentation")));
     assert!(!reveal_now);
     assert!(lifecycle.presented(request.generation));
     assert!(lifecycle.visible);
@@ -108,7 +88,7 @@ fn seeded_renderer_recovery_rearms_the_presentation_barrier() {
 
     assert!(!lifecycle.visible);
     assert!(lifecycle.awaiting_presentation);
-    let Some(reveal_ready) = lifecycle.renderer_ready(8, RevealPolicy::ImmediatePlaceholder) else {
+    let Some(reveal_ready) = lifecycle.renderer_ready(8) else {
         panic!("the replacement renderer generation is current");
     };
     let delivered = lifecycle
@@ -126,13 +106,7 @@ fn unseeded_renderer_recovery_waits_for_replacement_presentation() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_generation = 7;
     lifecycle.renderer_ready = true;
-    let (request, reveal_now) = retargeted(lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        320.0,
-        None,
-    ));
+    let (request, reveal_now) = retargeted(lifecycle.request("target", region(), 320.0, None));
     assert!(reveal_now);
     assert!(lifecycle.presented(request.generation));
     assert!(lifecycle.visible);
@@ -142,10 +116,7 @@ fn unseeded_renderer_recovery_waits_for_replacement_presentation() {
 
     assert!(!lifecycle.visible);
     assert!(lifecycle.awaiting_presentation);
-    assert_eq!(
-        lifecycle.renderer_ready(8, RevealPolicy::ImmediatePlaceholder),
-        Some(false)
-    );
+    assert_eq!(lifecycle.renderer_ready(8), Some(false));
     let delivered = lifecycle
         .pending_render_request()
         .expect("the replacement renderer needs delivery");
@@ -159,13 +130,8 @@ fn unseeded_renderer_recovery_waits_for_replacement_presentation() {
 fn failed_delivery_remains_retryable_for_the_same_target() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_ready = true;
-    let (request, _) = retargeted(lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::AfterPresentation,
-        120.0,
-        Some("presentation"),
-    ));
+    let (request, _) =
+        retargeted(lifecycle.request("target", region(), 120.0, Some("presentation")));
 
     assert_eq!(
         lifecycle
@@ -174,13 +140,7 @@ fn failed_delivery_remains_retryable_for_the_same_target() {
             .generation,
         request.generation
     );
-    let retained = lifecycle.request(
-        "target",
-        region(),
-        RevealPolicy::AfterPresentation,
-        120.0,
-        Some("ignored replacement"),
-    );
+    let retained = lifecycle.request("target", region(), 120.0, Some("ignored replacement"));
     assert!(matches!(retained, RequestTransition::Retained { .. }));
     assert!(lifecycle.pending_render_request().is_some());
     assert!(lifecycle.mark_delivered(request.generation));
@@ -190,10 +150,7 @@ fn failed_delivery_remains_retryable_for_the_same_target() {
 
     lifecycle.renderer_destroyed();
     lifecycle.renderer_generation = 9;
-    assert_eq!(
-        lifecycle.renderer_ready(9, RevealPolicy::AfterPresentation),
-        Some(false)
-    );
+    assert_eq!(lifecycle.renderer_ready(9), Some(false));
     assert!(lifecycle.pending_render_request().is_some());
 }
 
@@ -201,33 +158,21 @@ fn failed_delivery_remains_retryable_for_the_same_target() {
 fn same_target_reentry_does_not_bypass_a_pending_retarget_commit() {
     let mut lifecycle = lifecycle();
     lifecycle.renderer_ready = true;
-    let (first, _) = retargeted(lifecycle.request(
-        "first",
-        region(),
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        None,
-    ));
+    let (first, _) = retargeted(lifecycle.request("first", region(), 120.0, None));
     assert!(lifecycle.presented(first.generation));
 
     let next_region = AnchorRegion {
         top: 80.0,
         height: 52.0,
     };
-    let (second, _) = retargeted(lifecycle.request(
-        "second",
-        next_region,
-        RevealPolicy::ImmediatePlaceholder,
-        120.0,
-        Some("second presentation"),
-    ));
+    let (second, _) =
+        retargeted(lifecycle.request("second", next_region, 120.0, Some("second presentation")));
     assert!(second.retarget_commit_required);
 
     assert_eq!(
         lifecycle.request(
             "second",
             next_region,
-            RevealPolicy::ImmediatePlaceholder,
             120.0,
             Some("replacement presentation"),
         ),

--- a/apps/desktop/src-tauri/crates/anchored-window/src/macos.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/macos.rs
@@ -4,12 +4,12 @@ use objc2_app_kit::{NSEvent, NSWindow};
 use tauri::window::{Effect, EffectState, EffectsBuilder};
 use tauri::{Manager, Runtime, WebviewWindow, WebviewWindowBuilder};
 
+use crate::AnchorRegion;
 use crate::geometry::{CursorProximity, Point, Rect, classify_cursor, place_left_preferred};
-use crate::{AnchorRegion, WindowMaterial};
 
 pub(crate) struct FrameRequest {
     pub width: f64,
-    pub height: Option<f64>,
+    pub height: f64,
     pub anchor_region: AnchorRegion,
     pub gap: f64,
     pub screen_margin: f64,
@@ -17,19 +17,15 @@ pub(crate) struct FrameRequest {
 
 pub(crate) fn configure<'a, R: Runtime, M: Manager<R>>(
     builder: WebviewWindowBuilder<'a, R, M>,
-    material: WindowMaterial,
+    corner_radius: f64,
 ) -> WebviewWindowBuilder<'a, R, M> {
-    let builder = builder.accept_first_mouse(true);
-    match material {
-        WindowMaterial::Popover { corner_radius } => builder.effects(
-            EffectsBuilder::new()
-                .effect(Effect::Popover)
-                .state(EffectState::Active)
-                .radius(corner_radius)
-                .build(),
-        ),
-        WindowMaterial::Opaque | WindowMaterial::Transparent => builder,
-    }
+    builder.accept_first_mouse(true).effects(
+        EffectsBuilder::new()
+            .effect(Effect::Popover)
+            .state(EffectState::Active)
+            .radius(corner_radius)
+            .build(),
+    )
 }
 
 pub(crate) fn show_without_activation(window: &WebviewWindow) -> tauri::Result<()> {
@@ -93,7 +89,7 @@ fn update_frame(
         return;
     };
     let work_frame = screen.visibleFrame();
-    let height = request.height.unwrap_or(anchor_frame.size.height);
+    let height = request.height;
     let x = horizontal_origin(
         frame_rect(
             anchor_frame.origin.x,

--- a/apps/desktop/src-tauri/crates/anchored-window/src/macos/tests.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/macos/tests.rs
@@ -25,7 +25,7 @@ fn horizontal_alignment_uses_anchor_and_work_area_in_order() {
     };
     let request = FrameRequest {
         width: 300.0,
-        height: Some(200.0),
+        height: 200.0,
         anchor_region: AnchorRegion {
             top: 0.0,
             height: 48.0,

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
@@ -10,7 +10,7 @@ use crate::geometry::Rect;
 use crate::lifecycle::{Lifecycle, RequestTransition};
 use crate::model::{
     AnchorRegion, AnchoredWindowConfig, AnchoredWindowLifecycleEvent, AnchoredWindowRenderRequest,
-    AnchoredWindowRequest, AnchoredWindowState, RevealPolicy, initial_height,
+    AnchoredWindowRequest, AnchoredWindowState, normalized_heights,
 };
 use crate::{REQUEST_EVENT, STATE_EVENT, platform};
 
@@ -37,7 +37,8 @@ where
 {
     /// Create one manager for a host-owned anchor and companion configuration.
     pub fn new(config: AnchoredWindowConfig) -> Self {
-        let initial_height = initial_height(config.height);
+        let (initial_height, _, _) =
+            normalized_heights(config.initial_height, config.min_height, config.max_height);
         Self {
             inner: Arc::new(Inner {
                 config,
@@ -51,6 +52,14 @@ where
         }
     }
 
+    fn normalized_heights(&self) -> (f64, f64, f64) {
+        normalized_heights(
+            self.inner.config.initial_height,
+            self.inner.config.min_height,
+            self.inner.config.max_height,
+        )
+    }
+
     /// Rebuild a destroyed renderer only while a target still owns it.
     pub fn rebuild_if_targeted(&self, app: &tauri::AppHandle) -> tauri::Result<bool> {
         let _frame_update = self.lock_frame_update();
@@ -58,16 +67,6 @@ where
             return Ok(false);
         }
         self.ensure_window(app).map(|_| true)
-    }
-
-    /// Retarget the active renderer and apply its configured reveal policy.
-    pub fn request(
-        &self,
-        app: &tauri::AppHandle,
-        target: T,
-        anchor_region: AnchorRegion,
-    ) -> tauri::Result<AnchoredWindowRequest<T>> {
-        self.request_with_presentation(app, target, anchor_region, None)
     }
 
     /// Retarget the active renderer with optional instigator-owned content.
@@ -101,8 +100,7 @@ where
         let transition = self.lock_lifecycle().request(
             target,
             anchor_region,
-            self.inner.config.reveal,
-            initial_height(self.inner.config.height),
+            self.normalized_heights().0,
             initial_presentation,
         );
         let render_request = self.lock_lifecycle().pending_render_request();
@@ -132,9 +130,7 @@ where
                 request,
                 reveal_now,
             } => {
-                if self.inner.config.reveal == RevealPolicy::AfterPresentation {
-                    platform::hide(window)
-                } else if reveal_now {
+                if reveal_now {
                     self.reveal_placeholder(app, window)
                 } else {
                     Ok(())
@@ -149,9 +145,6 @@ where
         app: &tauri::AppHandle,
         window: &WebviewWindow,
     ) -> tauri::Result<()> {
-        if self.inner.config.reveal == RevealPolicy::AfterPresentation {
-            return platform::hide(window);
-        }
         let should_reveal = {
             let lifecycle = self.lock_lifecycle();
             lifecycle.renderer_ready
@@ -176,15 +169,6 @@ where
         let delivered = self.lock_lifecycle().mark_delivered(request.generation);
         debug_assert!(delivered, "the frame update serializes renderer delivery");
         Ok(())
-    }
-
-    /// Apply the retained native frame after the renderer commits the new target shell.
-    pub fn retarget_committed(
-        &self,
-        app: &tauri::AppHandle,
-        generation: u64,
-    ) -> tauri::Result<bool> {
-        self.retarget_committed_with_height(app, generation, None)
     }
 
     /// Apply the retained frame after the renderer commits the new target.
@@ -269,7 +253,7 @@ where
         let _frame_update = self.lock_frame_update();
         let Some(reveal_now) = ({
             let mut lifecycle = self.lock_lifecycle();
-            lifecycle.renderer_ready(renderer_generation, self.inner.config.reveal)
+            lifecycle.renderer_ready(renderer_generation)
         }) else {
             return Ok(false);
         };
@@ -320,7 +304,7 @@ where
             }
             #[cfg(target_os = "linux")]
             self.inner.pointer_tracker.reset_for_show();
-            platform::show(&window, self.inner.config.interaction)?;
+            platform::show(&window)?;
         }
         let should_reveal = presentation_pending && self.lock_lifecycle().presented(generation);
         if should_reveal && let Err(error) = self.emit_state(app) {

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/tests/fixtures.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/tests/fixtures.rs
@@ -1,9 +1,6 @@
 use std::time::Duration;
 
-use crate::model::{
-    AnchoredWindowConfig, HeightPolicy, InteractionPolicy, PlacementPolicy, RevealPolicy,
-    WindowMaterial,
-};
+use crate::model::AnchoredWindowConfig;
 
 use super::super::AnchoredWindowManager;
 
@@ -14,18 +11,12 @@ pub(super) fn config() -> AnchoredWindowConfig {
         route: "index.html#/companion".to_string(),
         title: "companion".to_string(),
         width: 320.0,
-        material: WindowMaterial::Transparent,
-        interaction: InteractionPolicy::Passive,
-        reveal: RevealPolicy::AfterPresentation,
-        height: HeightPolicy::Content {
-            initial: 120.0,
-            min: 60.0,
-            max: 320.0,
-        },
-        placement: PlacementPolicy::LeftPreferred {
-            gap: 8.0,
-            screen_margin: 8.0,
-        },
+        corner_radius: 8.0,
+        initial_height: 120.0,
+        min_height: 60.0,
+        max_height: 320.0,
+        gap: 8.0,
+        screen_margin: 8.0,
         conceal_fallback: Duration::from_millis(80),
         pointer_exit: None,
     }

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/window.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/window.rs
@@ -9,7 +9,6 @@ use tauri::{PhysicalPosition, PhysicalSize};
 use crate::geometry::CursorProximity;
 #[cfg(not(target_os = "macos"))]
 use crate::geometry::{Point, Rect, classify_cursor, place_left_preferred};
-use crate::model::{HeightPolicy, PlacementPolicy, normalized_height_policy};
 use crate::platform;
 
 use super::AnchoredWindowManager;
@@ -54,9 +53,9 @@ where
         .skip_taskbar(true)
         .visible(false)
         .focused(false)
-        .transparent(platform::is_transparent(self.inner.config.material))
-        .focusable(self.inner.config.interaction == crate::model::InteractionPolicy::Interactive);
-        let window = platform::configure(builder, self.inner.config.material).build()?;
+        .transparent(cfg!(target_os = "macos"))
+        .focusable(false);
+        let window = platform::configure(builder, self.inner.config.corner_radius).build()?;
         #[cfg(target_os = "linux")]
         crate::linux::install_pointer_tracking(&window, Arc::clone(&self.inner.pointer_tracker))?;
         Ok(window)
@@ -70,8 +69,12 @@ where
         let Some(anchor) = app.get_webview_window(&self.inner.config.anchor_label) else {
             return Ok(());
         };
-        let PlacementPolicy::LeftPreferred { gap, screen_margin } = self.inner.config.placement;
-        self.apply_platform_frame(&anchor, companion, gap, screen_margin)
+        self.apply_platform_frame(
+            &anchor,
+            companion,
+            self.inner.config.gap,
+            self.inner.config.screen_margin,
+        )
     }
 
     #[cfg(target_os = "macos")]
@@ -84,10 +87,7 @@ where
     ) -> tauri::Result<()> {
         let (height, anchor_region) = {
             let lifecycle = self.lock_lifecycle();
-            let height = match self.inner.config.height {
-                HeightPolicy::Content { .. } => Some(lifecycle.height),
-                HeightPolicy::MatchAnchor => None,
-            };
+            let height = lifecycle.height;
             (height, lifecycle.anchor_region)
         };
         crate::macos::apply_frame(
@@ -121,10 +121,7 @@ where
         let area = monitor.work_area();
         let (height, anchor_region) = {
             let lifecycle = self.lock_lifecycle();
-            let height = match self.inner.config.height {
-                HeightPolicy::Content { .. } => lifecycle.height,
-                HeightPolicy::MatchAnchor => f64::from(size.height) / scale,
-            };
+            let height = lifecycle.height;
             (height, lifecycle.anchor_region)
         };
         companion.set_size(PhysicalSize::new(
@@ -223,15 +220,11 @@ where
     }
 
     pub(super) fn clamp_height(&self, requested: f64) -> f64 {
-        match normalized_height_policy(self.inner.config.height) {
-            HeightPolicy::Content { initial, min, max } => {
-                if requested.is_finite() {
-                    requested.clamp(min, max)
-                } else {
-                    initial
-                }
-            }
-            HeightPolicy::MatchAnchor => requested,
+        let (initial, min, max) = self.normalized_heights();
+        if requested.is_finite() {
+            requested.clamp(min, max)
+        } else {
+            initial
         }
     }
 
@@ -250,7 +243,7 @@ where
         }
         #[cfg(target_os = "linux")]
         self.inner.pointer_tracker.reset_for_show();
-        if let Err(error) = platform::show(window, self.inner.config.interaction) {
+        if let Err(error) = platform::show(window) {
             self.lock_lifecycle().force_hidden();
             return Err(error);
         }

--- a/apps/desktop/src-tauri/crates/anchored-window/src/model.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/model.rs
@@ -2,78 +2,6 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-/// Whether the companion can receive keyboard focus.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum InteractionPolicy {
-    /// The window displays information without taking focus.
-    Passive,
-    /// The window can become active for controls it owns.
-    Interactive,
-}
-
-/// When the manager reveals a ready companion.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum RevealPolicy {
-    /// Wait until the renderer confirms that it committed the requested content.
-    AfterPresentation,
-    /// Reveal the resident placeholder before the renderer handles the request.
-    ImmediatePlaceholder,
-}
-
-/// How the manager chooses the companion height.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(
-    tag = "kind",
-    rename_all = "camelCase",
-    rename_all_fields = "camelCase"
-)]
-pub enum HeightPolicy {
-    /// Use renderer measurements within fixed bounds.
-    Content {
-        /// The logical height before the first renderer measurement.
-        initial: f64,
-        /// The minimum logical content height.
-        min: f64,
-        /// The maximum logical content height.
-        max: f64,
-    },
-    /// Use the anchor window's current logical height.
-    MatchAnchor,
-}
-
-/// How the companion is placed around its anchor.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(
-    tag = "kind",
-    rename_all = "camelCase",
-    rename_all_fields = "camelCase"
-)]
-pub enum PlacementPolicy {
-    /// Prefer a full fit on the left, then use the right or clamp.
-    LeftPreferred {
-        /// The logical gap between the anchor and companion.
-        gap: f64,
-        /// The minimum logical margin inside the screen work area.
-        screen_margin: f64,
-    },
-}
-
-/// The native surface behind the companion renderer.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum WindowMaterial {
-    /// Use a normal opaque window surface.
-    Opaque,
-    /// Let the renderer paint over a transparent native window.
-    Transparent,
-    /// Use the platform popover material where it is available.
-    Popover {
-        /// The logical corner radius for the native popover material.
-        corner_radius: f64,
-    },
-}
-
 /// Pointer tolerance after the pointer enters a companion window.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PointerExitPolicy {
@@ -127,16 +55,18 @@ pub struct AnchoredWindowConfig {
     pub title: String,
     /// The companion's logical width.
     pub width: f64,
-    /// The native window surface material.
-    pub material: WindowMaterial,
-    /// The companion's focus behavior.
-    pub interaction: InteractionPolicy,
-    /// The companion's reveal behavior.
-    pub reveal: RevealPolicy,
-    /// The companion's height behavior.
-    pub height: HeightPolicy,
-    /// The companion's placement behavior.
-    pub placement: PlacementPolicy,
+    /// The corner radius for the native popover material.
+    pub corner_radius: f64,
+    /// The logical height before the first renderer measurement.
+    pub initial_height: f64,
+    /// The minimum logical content height.
+    pub min_height: f64,
+    /// The maximum logical content height.
+    pub max_height: f64,
+    /// The logical gap between the anchor and companion.
+    pub gap: f64,
+    /// The minimum logical margin inside the screen work area.
+    pub screen_margin: f64,
     /// The maximum wait for renderer-confirmed concealment.
     pub conceal_fallback: Duration,
     /// Optional pointer tolerance after the pointer enters the companion.
@@ -199,21 +129,11 @@ pub struct AnchoredWindowLifecycleEvent<T> {
     pub state: AnchoredWindowState<T>,
 }
 
-pub(crate) fn initial_height(policy: HeightPolicy) -> f64 {
-    match normalized_height_policy(policy) {
-        HeightPolicy::Content { initial, .. } => initial,
-        HeightPolicy::MatchAnchor => 1.0,
-    }
-}
-
-pub(crate) fn normalized_height_policy(policy: HeightPolicy) -> HeightPolicy {
-    let HeightPolicy::Content { initial, min, max } = policy else {
-        return policy;
-    };
+pub(crate) fn normalized_heights(initial: f64, min: f64, max: f64) -> (f64, f64, f64) {
     let min = finite_positive(min, 1.0);
     let max = finite_positive(max, min).max(min);
     let initial = finite_positive(initial, min).clamp(min, max);
-    HeightPolicy::Content { initial, min, max }
+    (initial, min, max)
 }
 
 fn finite_positive(value: f64, fallback: f64) -> f64 {

--- a/apps/desktop/src-tauri/crates/anchored-window/src/model/tests.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/model/tests.rs
@@ -1,19 +1,9 @@
-use super::{HeightPolicy, normalized_height_policy};
+use super::normalized_heights;
 
 #[test]
 fn content_height_configuration_is_safe_and_clamped() {
-    let normalized = normalized_height_policy(HeightPolicy::Content {
-        initial: f64::NAN,
-        min: 500.0,
-        max: 100.0,
-    });
-
     assert_eq!(
-        normalized,
-        HeightPolicy::Content {
-            initial: 500.0,
-            min: 500.0,
-            max: 500.0,
-        }
+        normalized_heights(f64::NAN, 500.0, 100.0),
+        (500.0, 500.0, 500.0)
     );
 }

--- a/apps/desktop/src-tauri/crates/anchored-window/src/platform.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/platform.rs
@@ -1,19 +1,17 @@
 use tauri::{Manager, WebviewWindow, WebviewWindowBuilder};
 
-use crate::model::{InteractionPolicy, WindowMaterial};
-
 #[cfg(target_os = "macos")]
 pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
     builder: WebviewWindowBuilder<'a, tauri::Wry, M>,
-    material: WindowMaterial,
+    corner_radius: f64,
 ) -> WebviewWindowBuilder<'a, tauri::Wry, M> {
-    crate::macos::configure(builder, material)
+    crate::macos::configure(builder, corner_radius)
 }
 
 #[cfg(target_os = "linux")]
 pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
     builder: WebviewWindowBuilder<'a, tauri::Wry, M>,
-    _material: WindowMaterial,
+    _corner_radius: f64,
 ) -> WebviewWindowBuilder<'a, tauri::Wry, M> {
     crate::linux::configure(builder)
 }
@@ -21,32 +19,12 @@ pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
 #[cfg(target_os = "windows")]
 pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
     builder: WebviewWindowBuilder<'a, tauri::Wry, M>,
-    _material: WindowMaterial,
+    _corner_radius: f64,
 ) -> WebviewWindowBuilder<'a, tauri::Wry, M> {
     crate::windows::configure(builder)
 }
 
-#[cfg(target_os = "macos")]
-pub(crate) fn is_transparent(material: WindowMaterial) -> bool {
-    material != WindowMaterial::Opaque
-}
-
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn is_transparent(material: WindowMaterial) -> bool {
-    material == WindowMaterial::Transparent
-}
-
-pub(crate) fn show(window: &WebviewWindow, interaction: InteractionPolicy) -> tauri::Result<()> {
-    if interaction == InteractionPolicy::Interactive {
-        window.show()?;
-        if let Err(error) = window.set_focus() {
-            if let Err(hide_error) = window.hide() {
-                tracing::warn!(%hide_error, "failed to roll back anchored-window focus failure");
-            }
-            return Err(error);
-        }
-        return Ok(());
-    }
+pub(crate) fn show(window: &WebviewWindow) -> tauri::Result<()> {
     #[cfg(target_os = "macos")]
     return crate::macos::show_without_activation(window);
     #[cfg(target_os = "linux")]

--- a/apps/desktop/src-tauri/crates/nudge/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/nudge/src/lib.rs
@@ -9,8 +9,7 @@
 //! the app's navigation — that is the app's **policy**.
 //!
 //! The seam between crate and app is intentionally tiny:
-//! - [`NudgeManager::new`] — created once at app setup with an `on_action`
-//!   callback (the only app-specific behavior injected in).
+//! - [`NudgeManager::with_placement`] — created once at app setup with callbacks.
 //! - [`NudgeManager::show`] / [`NudgeManager::dismiss`].
 //! - the [`commands::nudge_action`] / [`commands::nudge_dismiss`] commands the
 //!   notification webview calls.
@@ -150,19 +149,6 @@ pub struct NudgeManager {
 }
 
 impl NudgeManager {
-    /// Capture the app handle and the on-action callback. The (hidden)
-    /// notification window itself is created lazily on first [`Self::show`].
-    ///
-    /// `on_action` is invoked with `{ kind, action_id }` when the user clicks a
-    /// CTA; the notification is then dismissed automatically. The app implements
-    /// focus/navigation there.
-    pub fn new(
-        app: &AppHandle,
-        on_action: impl Fn(NudgeActionEvent) + Send + Sync + 'static,
-    ) -> tauri::Result<Self> {
-        Self::with_placement(app, on_action, || NudgePlacement::NativeCorner)
-    }
-
     /// Capture the app handle, on-action callback, and placement provider. The
     /// provider is evaluated at reveal time so it can reflect the latest user
     /// setting and current tray rect.

--- a/apps/desktop/src-tauri/crates/sound/Cargo.lock
+++ b/apps/desktop/src-tauri/crates/sound/Cargo.lock
@@ -49,7 +49,6 @@ dependencies = [
  "fundsp",
  "hound",
  "rodio",
- "serde",
  "tracing",
 ]
 
@@ -903,16 +902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.229"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
-dependencies = [
- "serde_core",
- "serde_derive",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/crates/sound/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/sound/Cargo.toml
@@ -31,8 +31,6 @@ rodio = { version = "0.22", default-features = false, features = ["playback"] }
 # swallowed rather than propagated, so the log is the only way to find out that
 # a machine has no working output device.
 tracing = "0.1"
-# Only for `Tuning`, which crosses the IPC boundary to the dev sound bench.
-serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 # WAV writing for the `dump_sounds_for_listening` test only — it exists so a

--- a/apps/desktop/src-tauri/crates/sound/src/chord.rs
+++ b/apps/desktop/src-tauri/crates/sound/src/chord.rs
@@ -1,467 +1,66 @@
-//! Turning a person's name into the notes you hear.
-//!
-//! Single pitches don't work: an earlier test put fourteen people into a 30-slot
-//! space and got eleven distinct sounds, and enlarging the space doesn't help
-//! because people can only hold five to nine absolute pitches. Several notes escape
-//! that limit, because a listener identifies a short figure by its **shape** rather
-//! than its absolute pitches — which is why ringtones are recognisable and single
-//! beeps are not.
-
 use crate::synth::{UNISON, Voice, finish_to, foundation_parts, note_gain, note_part};
 use fundsp::prelude32::Wave;
 
-/// Major pentatonic degrees within one octave. Positions past the fourth wrap into
-/// successive octaves, so the scale runs as far as [`Chord::octaves`] allows and no
-/// interval among the notes can clash. Every chord is consonant by construction,
-/// whatever the hash produces.
-pub const PENT: [f32; 5] = [0.0, 2.0, 4.0, 7.0, 9.0];
+const PENTATONIC: [f32; 5] = [0.0, 2.0, 4.0, 7.0, 9.0];
+pub(crate) const NOTIFICATION_CHORD: [usize; 3] = [1, 4, 9];
 
-/// Scale position to semitones above the root.
-pub fn semis(i: usize) -> f32 {
-    PENT[i % 5] + 12.0 * (i / 5) as f32
-}
-
-/// FNV-1a, hand-rolled on purpose. `DefaultHasher` is stable across neither
-/// platforms nor releases, and a person has to sound the same on every machine.
-///
-/// Both constants are written to a full 16 hex digits. Grouped any shorter, the
-/// prime is one keystroke away from `0x1000_0000_01b3`, which is a different number
-/// with an extra zero — it still scatters, so nothing looks broken until it is
-/// compared against another implementation. That is exactly how it was caught.
-pub fn stable_hash(s: &str) -> u64 {
-    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
-    const PRIME: u64 = 0x0000_0100_0000_01b3;
-    let mut h = OFFSET_BASIS;
-    for b in s.as_bytes() {
-        h ^= *b as u64;
-        h = h.wrapping_mul(PRIME);
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn notification_chord_stays_fixed() {
+        assert_eq!(super::NOTIFICATION_CHORD, [1, 4, 9]);
     }
-    h
 }
 
-/// How the person axis is laid out.
-///
-/// `octaves` says where chords may sit; `max_span` says how wide any one of them
-/// gets. Those are separate on purpose — a generous range gives variety in register
-/// while a tight span keeps each individual chord from sounding hollow.
 #[derive(Clone, Copy)]
-pub struct Chord {
-    pub notes: usize,
-    pub octaves: usize,
-    /// Fewest scale steps between adjacent notes.
-    pub min_gap: usize,
-    /// Most scale steps from a chord's lowest note to its highest.
-    pub max_span: usize,
-    /// Force the lowest note into the first octave.
-    pub anchor_low: bool,
-    /// Seconds between note onsets. Zero plays them together as a chord.
-    pub spread: f64,
-    /// Gain per octave above the lowest note. 1 leaves the chord untilted.
-    pub high_tilt: f32,
-    /// Play the notes highest-first.
-    pub descending: bool,
+pub(crate) struct Chord {
+    pub(crate) spread: f64,
+    pub(crate) high_tilt: f32,
+    pub(crate) descending: bool,
 }
 
-/// Three notes played together, over three octaves.
-///
-/// `min_gap: 2` is the tightest spacing that still rings. At 1 the hash is free to
-/// place two notes a whole tone apart, and high up that warbles like a trill rather
-/// than sounding like a chord — which is exactly what it did.
-///
-/// `max_span: 12` does double duty. It stops the opposite failure, three notes
-/// legally spaced but strung so far apart the middle falls out. And against a
-/// 15-position scale it also pins the register for free: a 12-wide chord cannot
-/// start above the third position, so every chord ends up with a low note under it
-/// without needing `anchor_low`.
-///
-/// The constraints cost address space: 455 chords unconstrained against 255 here.
-/// That takes the chance of two people in eight colliding from 6% to 10%, which is
-/// the price of every chord being one you would choose to hear.
-pub const DEFAULT_CHORD: Chord = Chord {
-    notes: 3,
-    octaves: 3,
-    min_gap: 2,
-    max_span: 12,
-    anchor_low: false,
-    spread: 0.0,
-    high_tilt: 1.0,
-    descending: false,
-};
-
-/// The chord every Notification plays, for everybody.
-///
-/// These are the degrees `"dave"` hashes to, picked by ear from the per-person
-/// renders. Held as literal degrees rather than by hashing the name, because a
-/// sound every user hears must not depend on the spelling of somebody's login, nor
-/// change if the hash or the chord constraints ever do. `notification_chord_is_daves`
-/// records where it came from.
-pub const NOTIFICATION_CHORD: [usize; 3] = [1, 4, 9];
-
-/// Every chord the constraints allow, ascending.
-///
-/// Enumerating and then indexing beats picking notes from the hash and repairing
-/// the result. Free picking let three notes clump at the top of the range a whole
-/// tone apart; repairing that afterwards biases the outcome in ways that are hard
-/// to reason about. Here a chord is either legal or absent, and the length of this
-/// list is the exact address space rather than an estimate.
-///
-/// At most C(20,4) = 4845 candidates, so brute force costs nothing.
-pub fn valid_chords(c: Chord) -> Vec<Vec<usize>> {
-    let span = c.octaves * 5;
-    let n = Ord::min(c.notes, span);
-    let gap = Ord::max(1, c.min_gap);
-    let mut out = Vec::new();
-    #[allow(clippy::too_many_arguments)]
-    fn walk(
-        start: usize,
-        acc: &mut Vec<usize>,
-        out: &mut Vec<Vec<usize>>,
-        span: usize,
-        n: usize,
-        gap: usize,
-        width: usize,
-        anchor: bool,
-    ) {
-        if acc.len() == n {
-            out.push(acc.clone());
-            return;
-        }
-        let mut i = start;
-        while i < span {
-            if acc.is_empty() && anchor && i >= 5 {
-                break;
-            }
-            if let Some(&lowest) = acc.first()
-                && i - lowest > width
-            {
-                break;
-            }
-            acc.push(i);
-            walk(i + gap, acc, out, span, n, gap, width, anchor);
-            acc.pop();
-            i += 1;
-        }
-    }
-    walk(
-        0,
-        &mut Vec::new(),
-        &mut out,
-        span,
-        n,
-        gap,
-        c.max_span,
-        c.anchor_low,
-    );
-    out
+fn semitones(degree: usize) -> f32 {
+    PENTATONIC[degree % 5] + 12.0 * (degree / 5) as f32
 }
 
-/// One chord per person, drawn from the legal set.
-pub fn chord_for(id: &str, c: Chord) -> Vec<usize> {
-    let list = valid_chords(c);
-    if list.is_empty() {
-        return (0..c.notes).collect();
-    }
-    list[(stable_hash(id) % list.len() as u64) as usize].clone()
-}
-
-/// Render a person's chord in one of the voices.
-pub fn render_chord(id: &str, base: &Voice, c: Chord) -> Wave {
-    render_degrees(&chord_for(id, c), base, c)
-}
-
-/// Render specific scale degrees, rather than whichever ones a name hashes to.
-///
-/// Used for the sounds that must be the same for everybody. A fixed sound holds
-/// its degrees directly instead of hashing a chosen name, so it can never drift if
-/// the hash or the chord constraints change — a sound every user hears should not
-/// depend on the spelling of somebody's login.
-///
-/// At `spread` zero every note starts together, so the result is one gesture of the
-/// same length however many notes it holds. Above roughly 60 ms it becomes an
-/// arpeggio instead: more distinguishable, because order starts carrying
-/// information, at the cost of taking longer to play.
-pub fn render_degrees(degrees: &[usize], base: &Voice, c: Chord) -> Wave {
-    let together = c.spread == 0.0;
-    let n = degrees.len();
-    // Arpeggio notes are shortened so they do not smear into each other; a chord
-    // has nothing to smear into and keeps its full length.
-    let note_len = if together { base.dur } else { base.dur * 0.62 };
-
+pub(crate) fn render_degrees(degrees: &[usize], base: &Voice, chord: Chord) -> Wave {
+    let together = chord.spread == 0.0;
+    let note_count = degrees.len();
+    let note_length = if together { base.dur } else { base.dur * 0.62 };
     let mut note_voice = *base;
     note_voice.chord = UNISON;
-    note_voice.dur = note_len;
-
-    // `degrees` is always ascending, so the lowest note is the reference the tilt
-    // measures from whichever direction the phrase is played in.
-    let lowest = base.root * 2.0_f32.powf(semis(degrees[0]) / 12.0);
-
-    // Descending reverses the order notes are *played* in, not which notes they are.
-    // The chord is the person's identity; the direction is the sound's character.
-    let order: Vec<usize> = if c.descending {
-        (0..n).rev().collect()
+    note_voice.dur = note_length;
+    let lowest = base.root * 2.0_f32.powf(semitones(degrees[0]) / 12.0);
+    let order: Vec<usize> = if chord.descending {
+        (0..note_count).rev().collect()
     } else {
-        (0..n).collect()
+        (0..note_count).collect()
     };
-
     let mut parts = Vec::new();
-    for (step, &idx) in order.iter().enumerate() {
-        let freq = base.root * 2.0_f32.powf(semis(degrees[idx]) / 12.0);
-        // Pull back the top of the chord. These chords span three octaves, and a
-        // note two octaves up reads far louder than the same gain does down low —
-        // it is what makes a chord sound shrill rather than what gives it identity.
+    for (step, &index) in order.iter().enumerate() {
+        let frequency = base.root * 2.0_f32.powf(semitones(degrees[index]) / 12.0);
         let octaves_up = if lowest > 1.0 {
-            (freq / lowest).log2()
+            (frequency / lowest).log2()
         } else {
             0.0
         };
-        let tilt = c.high_tilt.clamp(0.05, 1.0).powf(octaves_up);
-        // Later notes of an arpeggio back off slightly so the phrase leans forward.
-        // A chord has no order, so nothing to lean.
+        let tilt = chord.high_tilt.clamp(0.05, 1.0).powf(octaves_up);
         let lean = if together {
             1.0
         } else {
             1.0 - step as f32 * 0.12
         };
         parts.push((
-            note_part(&note_voice, freq, note_gain(n, idx) * tilt),
-            step as f64 * c.spread,
+            note_part(&note_voice, frequency, note_gain(note_count, index) * tilt),
+            step as f64 * chord.spread,
             lean,
         ));
     }
-
-    // One sub and one air layer for the whole chord, pitched an octave below the
-    // voice's own root rather than below any particular note — matching the lab,
-    // which builds these outside its note loop at `root / 2`. Every chord is drawn
-    // from a pentatonic scale on that root, so the root's octave is the correct
-    // bass under all of them.
-    //
-    // Giving every note its own sub instead put six tones in a three-note chord and
-    // made the two loudest partials both subs, burying the harmony under its own
-    // bass — which is what "it sounds like a unison" turned out to mean.
-    //
-    // Divided by the note count for the same reason the notes are. A voice's
-    // tone-to-bass balance was set by ear on a single note; spreading that same
-    // tone across three notes without touching the sub leaves the harmony at a
-    // third of its weight against an unchanged bass, and the bass wins. Scaling
-    // both together keeps a chord in the balance the voice was tuned to.
     parts.extend(
         foundation_parts(&note_voice, base.root)
             .into_iter()
-            .map(|(w, at, gain)| (w, at, gain / n as f32)),
+            .map(|(wave, at, gain)| (wave, at, gain / note_count as f32)),
     );
-
-    let total = c.spread * (n - 1) as f64 + note_len + 0.3;
+    let total = chord.spread * (note_count - 1) as f64 + note_length + 0.3;
     finish_to(total, parts, base.level)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Energy at one frequency, measured over the sustain. Goertzel rather than a
-    /// full FFT — a handful of known frequencies is all this needs.
-    fn energy_at(w: &Wave, freq: f32) -> f32 {
-        let sr = crate::synth::SR as f32;
-        let from = Ord::min((0.25 * sr) as usize, w.len());
-        let to = Ord::min((0.65 * sr) as usize, w.len());
-        if to <= from {
-            return 0.0;
-        }
-        let k = 2.0 * std::f32::consts::PI * freq / sr;
-        let (c, s) = (k.cos(), k.sin());
-        let (mut q1, mut q2) = (0.0f32, 0.0f32);
-        for i in from..to {
-            let v = (w.at(0, i) + w.at(1, i)) * 0.5;
-            let q0 = 2.0 * c * q1 - q2 + v;
-            q2 = q1;
-            q1 = q0;
-        }
-        (q1 - c * q2).hypot(s * q2) / (to - from) as f32
-    }
-
-    /// A chord has to be audible *as a chord* — its notes must carry more energy
-    /// than the bass underneath them.
-    ///
-    /// This exists because of a real bug that shipped past every other test here.
-    /// The port gave each note its own sub an octave below, so a three-note chord
-    /// came out as six tones and the two loudest partials were both subs. Every
-    /// assertion still passed: it rendered, it was audible, it did not clip, and two
-    /// people still differed. It just sounded like one low drone rather than a
-    /// chord, which is the only thing about it that mattered.
-    ///
-    /// Measuring the notes is the difference between "it makes a sound" and "it
-    /// makes the right sound".
-    #[test]
-    fn a_chord_is_louder_than_the_bass_under_it() {
-        for name in ["keith", "Marty", "jordan", "dave"] {
-            let w = render_chord(name, &crate::voices::SOFT_UPDATE, DEFAULT_CHORD);
-            let root = crate::voices::SOFT_UPDATE.root;
-            let sub = energy_at(&w, root / 2.0);
-            let notes: Vec<f32> = chord_for(name, DEFAULT_CHORD)
-                .iter()
-                .map(|&d| energy_at(&w, root * 2.0_f32.powf(semis(d) / 12.0)))
-                .collect();
-            let total: f32 = notes.iter().sum();
-            let loudest = notes.iter().fold(0.0f32, |a, &b| a.max(b));
-
-            assert!(
-                total > sub * 2.0,
-                "{name}: notes {total:.5} vs sub {sub:.5} — the bass is drowning the chord"
-            );
-            assert!(
-                loudest > sub,
-                "{name}: loudest partial is the sub ({sub:.5}), not a note ({loudest:.5})"
-            );
-        }
-    }
-
-    // Deliberately not asserted here: that each individual note clears some
-    // threshold. These voices carry 219 Hz of FM deviation, which spreads a note's
-    // energy across sidebands rather than leaving it on the carrier — measured on
-    // dave's chord, the bins 10 Hz either side of his 220 Hz note read as strong as
-    // the note itself. Energy at one frequency is simply not a measure of whether a
-    // note is present in an FM sound, so a per-note assertion would be measuring its
-    // own instrument. The totals above survive that smearing because it moves energy
-    // around within the notes rather than into the sub.
-
-    /// Turning `high_tilt` down must actually pull the top of the chord back.
-    ///
-    /// Checked as a ratio between the top and bottom note *within* each render,
-    /// never by comparing one render's absolute levels to another's — the finish
-    /// normalises every sound to the same loudness, so lowering one note quietly
-    /// raises everything else and absolute levels say nothing.
-    ///
-    /// Comparing the same note across the two renders is also the only way to see
-    /// this: energy at a carrier frequency is not comparable *between* notes here,
-    /// because the FM index is `fm_amount / freq` and so a low note has far more of
-    /// its energy pushed into sidebands than a high one.
-    #[test]
-    fn pulling_high_tilt_down_quietens_the_top_of_the_chord() {
-        // chris — the chord that prompted this, with a note two octaves up.
-        let degrees = chord_for("chris", DEFAULT_CHORD);
-        let root = crate::voices::SOFT_UPDATE.root;
-        let low = root * 2.0_f32.powf(semis(degrees[0]) / 12.0);
-        let high = root * 2.0_f32.powf(semis(degrees[2]) / 12.0);
-
-        let ratio_at = |tilt: f32| {
-            let c = Chord {
-                high_tilt: tilt,
-                spread: 0.09,
-                ..DEFAULT_CHORD
-            };
-            let w = render_degrees(&degrees, &crate::voices::SOFT_UPDATE, c);
-            energy_at(&w, high) / energy_at(&w, low).max(1e-9)
-        };
-
-        let even = ratio_at(1.0);
-        let tilted = ratio_at(0.55);
-        assert!(
-            tilted < even * 0.8,
-            "high_tilt 0.55 barely moved the top note: {tilted:.3} against {even:.3} even"
-        );
-    }
-
-    /// The browser lab and this crate must derive the same chord from the same
-    /// name, or a person previewed in the lab sounds like someone else in the app.
-    /// These values were read out of the lab (`chordFor`) and pasted here, so the
-    /// test fails if either side drifts.
-    ///
-    /// This is not ceremony. It is how a one-keystroke typo in the FNV prime was
-    /// caught in the prototype — "jordan" matched by luck in the low byte while
-    /// "keith" did not, which no amount of reading the code had revealed.
-    #[test]
-    fn chords_match_the_browser_lab() {
-        assert_eq!(stable_hash("keith"), 0xfd3f_bdf2_e5ca_7d70);
-        for (name, expected) in [
-            ("Marty", [0, 5, 8]),
-            ("keith", [3, 5, 12]),
-            ("jordan", [2, 8, 12]),
-            ("sam", [2, 6, 11]),
-            ("alex", [0, 4, 12]),
-            ("chris", [2, 8, 14]),
-            ("dave", [1, 4, 9]),
-        ] {
-            assert_eq!(chord_for(name, DEFAULT_CHORD), expected.to_vec(), "{name}");
-        }
-    }
-
-    /// Every chord the enumerator emits must satisfy every constraint. This is the
-    /// property the old pick-then-repair approach could not guarantee.
-    #[test]
-    fn every_valid_chord_obeys_the_constraints() {
-        for octaves in 1..=4 {
-            for min_gap in 1..=4 {
-                for max_span in [4, 8, 10, 20] {
-                    for anchor_low in [false, true] {
-                        let c = Chord {
-                            octaves,
-                            min_gap,
-                            max_span,
-                            anchor_low,
-                            ..DEFAULT_CHORD
-                        };
-                        let span = octaves * 5;
-                        for chord in valid_chords(c) {
-                            assert_eq!(chord.len(), Ord::min(c.notes, span));
-                            assert!(
-                                chord.windows(2).all(|w| w[1] - w[0] >= min_gap),
-                                "{chord:?}"
-                            );
-                            assert!(chord[chord.len() - 1] - chord[0] <= max_span, "{chord:?}");
-                            assert!(chord.iter().all(|&x| x < span), "{chord:?}");
-                            if anchor_low {
-                                assert!(chord[0] < 5, "{chord:?}");
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /// No interval tighter than a minor third at the default spacing. A whole tone
-    /// between two high notes is what made the earlier chords warble.
-    #[test]
-    fn default_spacing_admits_no_trills() {
-        for chord in valid_chords(DEFAULT_CHORD) {
-            for w in chord.windows(2) {
-                let interval = semis(w[1]) - semis(w[0]);
-                assert!(interval >= 3.0, "{chord:?} has a {interval} semitone gap");
-            }
-        }
-    }
-
-    /// Constraints tight enough to admit nothing must return an empty list rather
-    /// than looping or panicking, and `chord_for` must still hand back something.
-    #[test]
-    fn impossible_constraints_degrade_gracefully() {
-        let c = Chord {
-            octaves: 1,
-            min_gap: 4,
-            max_span: 4,
-            ..DEFAULT_CHORD
-        };
-        assert!(valid_chords(c).is_empty());
-        assert_eq!(chord_for("anyone", c).len(), 3);
-    }
-
-    /// The arpeggio must draw the *same* notes as the chord — it is the same person,
-    /// laid out in time rather than stacked. Spread, tilt and direction change how
-    /// a chord is *played*; they must never change which notes it is.
-    #[test]
-    fn playing_options_do_not_change_which_notes_a_person_gets() {
-        let played = Chord {
-            spread: 0.09,
-            high_tilt: 0.55,
-            descending: true,
-            ..DEFAULT_CHORD
-        };
-        for name in ["keith", "Marty", "jordan", "chris"] {
-            assert_eq!(
-                chord_for(name, played),
-                chord_for(name, DEFAULT_CHORD),
-                "{name}"
-            );
-        }
-    }
 }

--- a/apps/desktop/src-tauri/crates/sound/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/sound/src/lib.rs
@@ -1,7 +1,7 @@
 //! `antiburn-sound` — programmatic notification sounds for the antiburn desktop app.
 //!
-//! This crate is the **mechanism**: it knows how to turn a [`SoundKind`] and an
-//! optional person's name into audio, and how to get that audio to the speaker. It
+//! This crate is the **mechanism**: it knows how to create the notification sound
+//! and get that audio to the speaker. It
 //! knows nothing about *why* a sound plays, about nudges, or about user
 //! preferences — that is the app's **policy**, the same mechanism/policy split the
 //! rest of the shell already uses.
@@ -9,15 +9,12 @@
 //! The seam is one call:
 //!
 //! ```no_run
-//! # use antiburn_sound::{SoundPlayer, SoundKind};
+//! # use antiburn_sound::SoundPlayer;
 //! let player = SoundPlayer::new();
-//! player.play(SoundKind::ActorUpdate, Some("marty"));   // marty's three notes
-//! player.play(SoundKind::Notification, None);     // the same notes for everybody
+//! player.play();
 //! ```
 //!
-//! Every sound is three notes stepped through quickly. What varies is *which*
-//! three: a person's name picks them for the actor update sounds, while Notification
-//! plays a fixed set so it means the same thing on every machine.
+//! The sound uses three fixed notes so it means the same thing on every machine.
 //!
 //! ## Two rules this crate holds itself to
 //!
@@ -42,56 +39,12 @@ use std::time::Duration;
 
 use rodio::buffer::SamplesBuffer;
 
-pub use chord::{DEFAULT_CHORD, chord_for, semis, stable_hash};
-pub use synth::SR;
-pub use tuning::Tuning;
+use synth::SR;
+use tuning::Tuning;
 
-/// What happened. One per sound the app can make.
-///
-/// Deliberately *not* a mirror of `NudgeKind`: several nudge kinds can share a
-/// sound, and the mapping between them is policy that belongs in the app. Keeping
-/// this list short is the point — a person can learn three sounds, not eight.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SoundKind {
-    /// A teammate shared a actor update update relevant to you. Their name picks the chord.
-    ActorUpdate,
-    /// Your own actor update draft is ready to share. Your name picks the chord.
-    OwnUpdateReady,
-    /// Something needs attention. The same for everybody — see
-    /// [`chord::NOTIFICATION_CHORD`].
-    Notification,
-}
-
-impl SoundKind {
-    /// Whether a name changes what this sound plays.
-    ///
-    /// [`SoundKind::Notification`] is about a session rather than a person, so it
-    /// ignores any name passed to it — worth checking before going to the trouble of
-    /// looking one up.
-    pub fn uses_actor(self) -> bool {
-        !matches!(self, SoundKind::Notification)
-    }
-}
-
-/// Render one sound to an interleaved stereo buffer.
-///
-/// `actor` is whoever caused it. Their name picks the three notes, so the same
-/// person always sounds the same on every machine. `None` falls back to the voice
-/// at its own root — a reserved unison meaning "nobody in particular".
-///
-/// [`SoundKind::Notification`] ignores `actor` entirely and plays a fixed set of
-/// notes, because it is about a session rather than a person and has to mean the
-/// same thing to everybody who hears it.
-pub fn render(kind: SoundKind, actor: Option<&str>) -> Vec<f32> {
-    render_tuned(kind, actor, Tuning::default_for(kind))
-}
-
-/// Render with tuning other than the settled values.
-///
-/// Exists for the dev sound bench, so the knobs can be turned while listening
-/// instead of edited and rebuilt. Whatever settings win there get written into
-/// [`Tuning::default_for`], which is the record of what was decided by ear.
-pub fn render_tuned(kind: SoundKind, actor: Option<&str>, tuning: Tuning) -> Vec<f32> {
+/// Render the notification sound to an interleaved stereo buffer.
+fn render() -> Vec<f32> {
+    let tuning = Tuning::default();
     let mut voice = voices::SOFT_UPDATE;
     voice.root *= 2.0_f32.powf(tuning.transpose / 12.0);
     voice.cutoff = (voice.cutoff * tuning.brightness.max(0.05)).clamp(60.0, 18_000.0);
@@ -101,19 +54,9 @@ pub fn render_tuned(kind: SoundKind, actor: Option<&str>, tuning: Tuning) -> Vec
         spread: (tuning.spread_ms.max(0.0) / 1000.0) as f64,
         high_tilt: tuning.high_tilt,
         descending: tuning.descending,
-        ..chord::DEFAULT_CHORD
     };
 
-    let named = actor.map(str::trim).filter(|a| !a.is_empty());
-    let wave = match (kind, named) {
-        // The same three notes for everybody, whoever is passed in.
-        (SoundKind::Notification, _) => {
-            chord::render_degrees(&chord::NOTIFICATION_CHORD, &voice, shape)
-        }
-        (_, Some(name)) => chord::render_chord(name, &voice, shape),
-        // No name to work with: the reserved unison, meaning nobody in particular.
-        (_, None) => synth::render_voice(&voice),
-    };
+    let wave = chord::render_degrees(&chord::NOTIFICATION_CHORD, &voice, shape);
 
     let mut out = Vec::with_capacity(wave.len() * 2);
     for i in 0..wave.len() {
@@ -121,15 +64,6 @@ pub fn render_tuned(kind: SoundKind, actor: Option<&str>, tuning: Tuning) -> Vec
         out.push(wave.at(1, i));
     }
     out
-}
-
-/// A request handed to the audio thread.
-struct Request {
-    kind: SoundKind,
-    actor: Option<String>,
-    /// `None` means the settled tuning for this sound. Only the dev bench sends
-    /// anything else.
-    tuning: Option<Tuning>,
 }
 
 /// How long the output device stays open after the last sound.
@@ -157,7 +91,7 @@ const IDLE_CLOSE: Duration = Duration::from_secs(5);
 /// Create one at app setup and keep it in Tauri managed state. Dropping it closes
 /// the audio thread and releases the device.
 pub struct SoundPlayer {
-    tx: Option<SyncSender<Request>>,
+    tx: Option<SyncSender<()>>,
 }
 
 impl SoundPlayer {
@@ -170,7 +104,7 @@ impl SoundPlayer {
         // Bounded, and deliberately shallow. If sounds are arriving faster than they
         // can play, the right behaviour is to drop the newest rather than queue a
         // backlog that plays long after whatever caused it left the screen.
-        let (tx, rx) = sync_channel::<Request>(4);
+        let (tx, rx) = sync_channel::<()>(4);
 
         let spawned = std::thread::Builder::new()
             .name("antiburn-sound".into())
@@ -190,7 +124,7 @@ impl SoundPlayer {
                     // With nothing open there is nothing to time out for, so wait
                     // indefinitely: an idle app should cost no wakeups at all, which
                     // is the whole point of closing the device in the first place.
-                    let request = match &sink {
+                    match &sink {
                         None => match rx.recv() {
                             Ok(request) => request,
                             Err(_) => return,
@@ -226,13 +160,7 @@ impl SoundPlayer {
                         continue;
                     };
 
-                    let Request {
-                        kind,
-                        actor,
-                        tuning,
-                    } = request;
-                    let tuning = tuning.unwrap_or_else(|| Tuning::default_for(kind));
-                    let samples = render_tuned(kind, actor.as_deref(), tuning);
+                    let samples = render();
                     let Some(channels) = std::num::NonZero::new(2u16) else {
                         continue;
                     };
@@ -253,30 +181,18 @@ impl SoundPlayer {
         }
     }
 
-    /// Play `kind`, optionally in `actor`'s voice.
-    ///
     /// Returns immediately: rendering and playback both happen on the audio thread.
     /// Silently does nothing if audio is unavailable or a sound is already queued —
     /// see the type-level note on why there is no error to handle.
-    pub fn play(&self, kind: SoundKind, actor: Option<&str>) {
-        self.play_tuned(kind, actor, None);
-    }
-
-    /// Play with tuning other than the settled values. For the dev bench.
-    pub fn play_tuned(&self, kind: SoundKind, actor: Option<&str>, tuning: Option<Tuning>) {
+    pub fn play(&self) {
         let Some(tx) = &self.tx else {
             return;
-        };
-        let request = Request {
-            kind,
-            actor: actor.map(str::to_owned),
-            tuning,
         };
         // `try_send` rather than `send`: a full queue means sounds are already
         // backing up, and blocking here would stall whichever thread is trying to
         // show a notification.
-        if tx.try_send(request).is_err() {
-            tracing::debug!(?kind, "dropped a sound; queue full or audio thread gone");
+        if tx.try_send(()).is_err() {
+            tracing::debug!("dropped a sound; queue full or audio thread gone");
         }
     }
 }
@@ -307,106 +223,25 @@ mod tests {
             bits_per_sample: 16,
             sample_format: hound::SampleFormat::Int,
         };
-        for (kind, name) in [
-            (SoundKind::ActorUpdate, "actor_update"),
-            (SoundKind::OwnUpdateReady, "my-actor_update-ready"),
-            (SoundKind::Notification, "notification"),
-        ] {
-            for actor in [Some("keith"), Some("Marty"), None] {
-                let samples = render(kind, actor);
-                let label = actor.unwrap_or("nobody");
-                let path = dir.join(format!("{name}--{label}.wav"));
-                let mut w = hound::WavWriter::create(&path, spec).expect("create wav");
-                for s in &samples {
-                    w.write_sample((s.clamp(-1.0, 1.0) * 32767.0) as i16)
-                        .expect("write");
-                }
-                w.finalize().expect("finalize");
-                println!("wrote {}", path.display());
-            }
+        let samples = render();
+        let path = dir.join("notification.wav");
+        let mut w = hound::WavWriter::create(&path, spec).expect("create wav");
+        for s in &samples {
+            w.write_sample((s.clamp(-1.0, 1.0) * 32767.0) as i16)
+                .expect("write");
         }
+        w.finalize().expect("finalize");
+        println!("wrote {}", path.display());
     }
 
-    /// Every sound must produce audio, with and without a name. This is the check
-    /// that a voice or chord constant has not been left in a state that renders
-    /// silence — which no compiler catches.
+    /// The notification must produce finite, audible stereo samples.
     #[test]
-    fn every_sound_renders_something_audible() {
-        for kind in [
-            SoundKind::ActorUpdate,
-            SoundKind::OwnUpdateReady,
-            SoundKind::Notification,
-        ] {
-            for actor in [Some("keith"), None] {
-                let samples = render(kind, actor);
-                assert!(!samples.is_empty(), "{kind:?} / {actor:?} rendered nothing");
-                let peak = samples.iter().fold(0.0f32, |a, s| a.max(s.abs()));
-                assert!(peak > 0.01, "{kind:?} / {actor:?} is silent (peak {peak})");
-                assert!(peak <= 1.0, "{kind:?} / {actor:?} clips (peak {peak})");
-            }
-        }
-    }
-
-    /// Two different people must not get the same audio out of the same sound,
-    /// otherwise the whole per-person idea is decoration.
-    #[test]
-    fn different_people_sound_different() {
-        let a = render(SoundKind::ActorUpdate, Some("keith"));
-        let b = render(SoundKind::ActorUpdate, Some("Marty"));
-        assert_ne!(a, b);
-    }
-
-    /// A blank or whitespace name is treated as no name rather than hashed as one,
-    /// so an empty string from a payload can't invent a bogus chord.
-    #[test]
-    fn blank_actors_fall_back_to_the_unison() {
-        let nobody = render(SoundKind::ActorUpdate, None);
-        for blank in ["", "   "] {
-            assert_eq!(
-                render(SoundKind::ActorUpdate, Some(blank)),
-                nobody,
-                "{blank:?}"
-            );
-        }
-    }
-
-    /// Notification is about a session, not a person, so a name must not change it.
-    #[test]
-    fn notification_ignores_the_actor() {
-        let plain = render(SoundKind::Notification, None);
-        assert_eq!(render(SoundKind::Notification, Some("keith")), plain);
-        assert!(!SoundKind::Notification.uses_actor());
-    }
-
-    /// Notification plays the same three notes for everybody, so it is the one sound
-    /// a person's chord can collide with. Whoever hashes to those degrees hears their
-    /// own actor update and every Notification as the same sound.
-    ///
-    /// That is one name in 255 and accepted rather than designed out — removing the
-    /// chord from the per-person pool would renumber every other person's, and the
-    /// lab would have to be changed in lockstep to keep matching. This test records
-    /// the exposure and fails loudly if the fixed chord is ever changed to one that
-    /// somebody on the current roster already owns.
-    #[test]
-    fn notification_does_not_collide_with_a_known_teammate() {
-        for name in ["keith", "Marty", "chris", "jordan", "sam", "alex"] {
-            assert_ne!(
-                chord_for(name, DEFAULT_CHORD),
-                chord::NOTIFICATION_CHORD.to_vec(),
-                "{name} would hear their own actor update as every Notification"
-            );
-        }
-    }
-
-    /// Where the fixed Notification chord came from: it is what `"dave"` hashes to,
-    /// picked by ear. Held as literal degrees so the sound cannot drift, with this
-    /// test as the record of its provenance — if the hash ever changes, this fails
-    /// and says so rather than the sound silently becoming somebody else's.
-    #[test]
-    fn notification_chord_is_daves() {
-        assert_eq!(
-            chord_for("dave", DEFAULT_CHORD),
-            chord::NOTIFICATION_CHORD.to_vec()
-        );
+    fn notification_renders_something_audible() {
+        let samples = render();
+        assert_eq!(samples.len(), 112_762);
+        assert!(samples.iter().all(|sample| sample.is_finite()));
+        let peak = samples.iter().fold(0.0f32, |a, sample| a.max(sample.abs()));
+        assert!(peak > 0.01, "the notification is silent (peak {peak})");
+        assert!(peak <= 1.0, "the notification clips (peak {peak})");
     }
 }

--- a/apps/desktop/src-tauri/crates/sound/src/synth.rs
+++ b/apps/desktop/src-tauri/crates/sound/src/synth.rs
@@ -148,11 +148,6 @@ fn note_layer(v: &Voice, f: f32, gain: f32) -> Wave {
     acc.expect("the fixed three-voice array always produces a wave")
 }
 
-/// Render one voice at its own root — the "nobody in particular" sound.
-pub fn render_voice(v: &Voice) -> Wave {
-    finish_to(v.dur + 0.35, voice_parts(v), v.level)
-}
-
 /// One pitched note at `freq`, with no sub and no air.
 ///
 /// Exposed so a chord can place its notes itself — at their own start times for an
@@ -175,27 +170,6 @@ pub fn note_part(v: &Voice, freq: f32, gain: f32) -> Wave {
 /// already a sub underneath it.
 pub fn note_gain(n: usize, _i: usize) -> f32 {
     (1.0 / (n * 3) as f32) * 0.5
-}
-
-/// The layers one voice is made of, before any mixing or finishing decision.
-fn voice_parts(v: &Voice) -> Vec<(Wave, f64, f32)> {
-    let mut parts = tone_parts(v);
-    parts.extend(foundation_parts(v, v.root));
-    parts
-}
-
-/// Just the pitched layers — the notes themselves, with no sub and no air.
-///
-/// Separated out because a chord needs these **per note** while it needs the
-/// foundation below only **once**. See [`foundation_parts`].
-pub fn tone_parts(v: &Voice) -> Vec<(Wave, f64, f32)> {
-    let n_notes = v.chord.len();
-    let mut parts: Vec<(Wave, f64, f32)> = Vec::new();
-    for (i, semi) in v.chord.iter().enumerate() {
-        let f = v.root * 2.0_f32.powf(semi / 12.0);
-        parts.push((note_layer(v, f, note_gain(n_notes, i)), 0.0, 1.0));
-    }
-    parts
 }
 
 /// The sub an octave below `root`, plus the band-passed air on top.

--- a/apps/desktop/src-tauri/crates/sound/src/tuning.rs
+++ b/apps/desktop/src-tauri/crates/sound/src/tuning.rs
@@ -5,15 +5,12 @@
 //! baseline; these adjust how a set of notes is laid out over one, which is the part
 //! that only shows up once real chords are playing through real speakers.
 //!
-//! [`Tuning::default_for`] holds the current settled values. When a number here
+//! [`Tuning::default`] holds the current settled values. When a number here
 //! changes, that is the record of a decision made by listening.
 
-use crate::SoundKind;
-
 /// How a sound's notes are laid out over its voice.
-#[derive(Debug, Clone, Copy, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
-pub struct Tuning {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Tuning {
     /// Milliseconds between note onsets. Zero plays them together as a chord.
     ///
     /// Every sound is stepped rather than simultaneous. Played together, three
@@ -46,52 +43,12 @@ pub struct Tuning {
 impl Default for Tuning {
     fn default() -> Self {
         Self {
-            spread_ms: 90.0,
-            high_tilt: 1.0,
-            detune_track: 0.0,
-            transpose: 0.0,
-            brightness: 1.0,
-            descending: false,
-        }
-    }
-}
-
-impl Tuning {
-    /// The settled tuning for each sound. **Every number here was chosen by ear in
-    /// the sound bench.** Change them there and paste the result back, rather than
-    /// editing values that look like they could be rounder.
-    ///
-    /// **actor update and Own-update ready** carry `high_tilt` and `detune_track` because a
-    /// three-octave chord needs both: without the tilt the top note dominates, and
-    /// without the tracking it warbles at roughly 6 Hz, which is heard as a trill.
-    ///
-    /// **Notification** (settled 26 Jul) is separated from a actor update mostly by
-    /// **pace and brightness**, not by pitch. Its notes are 180 ms apart against
-    /// actor update's 90 — half the speed, so it lands as a deliberate three-part phrase
-    /// where a actor update is a quick flick — and it is half again as bright. It also
-    /// falls rather than rises, which is the conventional shape for "something
-    /// needs attention". The one-semitone drop is small enough to be a colouring
-    /// rather than a signal; the pace is what does the work.
-    ///
-    /// Its `detune_track` sits at 0.85 rather than 1.0, leaving a trace of the
-    /// warble that was tuned out of actor update entirely — a slight unsteadiness, which
-    /// suits a sound that means something wants looking at.
-    pub fn default_for(kind: SoundKind) -> Self {
-        let base = Self {
-            high_tilt: 0.55,
-            detune_track: 1.0,
-            ..Self::default()
-        };
-        match kind {
-            SoundKind::ActorUpdate | SoundKind::OwnUpdateReady => base,
-            SoundKind::Notification => Self {
-                spread_ms: 180.0,
-                high_tilt: 0.45,
-                detune_track: 0.85,
-                transpose: -1.0,
-                brightness: 1.5,
-                descending: true,
-            },
+            spread_ms: 180.0,
+            high_tilt: 0.45,
+            detune_track: 0.85,
+            transpose: -1.0,
+            brightness: 1.5,
+            descending: true,
         }
     }
 }
@@ -109,38 +66,12 @@ mod tests {
     /// should be updated with it, or something got edited that shouldn't have been.
     #[test]
     fn the_settled_tuning_is_what_was_chosen_by_ear() {
-        let notification = Tuning::default_for(SoundKind::Notification);
+        let notification = Tuning::default();
         assert_eq!(notification.spread_ms, 180.0);
         assert_eq!(notification.high_tilt, 0.45);
         assert_eq!(notification.detune_track, 0.85);
         assert_eq!(notification.transpose, -1.0);
         assert_eq!(notification.brightness, 1.5);
         assert!(notification.descending);
-
-        let actor_update = Tuning::default_for(SoundKind::ActorUpdate);
-        assert_eq!(actor_update.spread_ms, 90.0);
-        assert_eq!(actor_update.high_tilt, 0.55);
-        assert_eq!(actor_update.detune_track, 1.0);
-        assert!(!actor_update.descending);
-
-        // Own-update ready is the same sound as actor update on your own notes. If these ever
-        // diverge it is a decision, not a detail.
-        assert_eq!(Tuning::default_for(SoundKind::OwnUpdateReady), actor_update);
-    }
-
-    /// Notification has to be tellable from a actor update by ear alone, and both are now
-    /// the same instrument on the same voice. This asserts the separation actually
-    /// exists in the settings rather than only in the intent.
-    #[test]
-    fn notification_is_clearly_apart_from_an_actor_update() {
-        let actor_update = Tuning::default_for(SoundKind::ActorUpdate);
-        let notification = Tuning::default_for(SoundKind::Notification);
-
-        assert!(
-            notification.spread_ms >= actor_update.spread_ms * 1.5,
-            "pace is the main thing separating them and it has narrowed"
-        );
-        assert_ne!(notification.descending, actor_update.descending);
-        assert!(notification.brightness > actor_update.brightness);
     }
 }

--- a/apps/desktop/src-tauri/crates/sound/src/voices.rs
+++ b/apps/desktop/src-tauri/crates/sound/src/voices.rs
@@ -9,8 +9,7 @@
 
 use crate::synth::{UNISON, Voice};
 
-/// Warm and low, opening rather than striking. Used for ActorUpdate, Own-update ready and
-/// Tune up — the three that are informational rather than a problem.
+/// Warm and low, opening rather than striking. Used for the notification sound.
 ///
 /// The long 239 ms attack is what keeps it from reading as an alert: it arrives
 /// gradually instead of hitting, so it registers without demanding that you stop.

--- a/apps/desktop/src-tauri/src/insights_worker.rs
+++ b/apps/desktop/src-tauri/src/insights_worker.rs
@@ -9,7 +9,7 @@ use antiburn_local::analysis::{SessionEvidence, TurnRowStore};
 use antiburn_local::insights::{DetectorId, eligible};
 use antiburn_local::model::AgentKind;
 use tauri::{Emitter, Manager};
-use tokio::sync::{Notify, Semaphore};
+use tokio::sync::Notify;
 
 use crate::analysis::{self, EvidencePass, PassOutcome, PassSignal, UnreadableReason};
 use crate::commands;
@@ -39,27 +39,10 @@ pub(crate) const EVIDENCE_ERROR_UNSUPPORTED: &str = "source-unsupported";
 /// this suffix safely.
 const UNREADABLE_REASON_SEPARATOR: &str = ":";
 
-struct Permits {
-    cpu: Semaphore,
-    source: Semaphore,
-    provider_db: Semaphore,
-}
-
-impl Default for Permits {
-    fn default() -> Self {
-        Self {
-            cpu: Semaphore::new(1),
-            source: Semaphore::new(1),
-            provider_db: Semaphore::new(1),
-        }
-    }
-}
-
-/// This handle wakes the worker and limits its shared processing resources.
+/// This handle wakes the worker.
 #[derive(Default)]
 pub struct WorkerHandle {
     wake: Notify,
-    permits: Permits,
 }
 
 pub(crate) type PassFuture = Pin<Box<dyn Future<Output = EvidencePass> + Send>>;
@@ -80,12 +63,6 @@ type RecordAnalyzer<'a> = dyn Fn(
     + Send
     + Sync
     + 'a;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PermitKind {
-    Source,
-    ProviderDb,
-}
 
 /// `store` is a cheap handle (see [`Store`]'s doc comment): this clones it
 /// once per pass into a [`FencedTurnRowStore`] stamped with `claim_fence`,
@@ -200,13 +177,6 @@ pub(crate) fn backoff_secs(retry_count: i64) -> i64 {
     BACKOFF_BASE_SECS
         .saturating_mul(1_i64.checked_shl(exponent).unwrap_or(i64::MAX))
         .min(BACKOFF_MAX_SECS)
-}
-
-pub(crate) fn permit_for_source_kind(source_kind: &str) -> PermitKind {
-    match source_kind {
-        "providerDb" => PermitKind::ProviderDb,
-        _ => PermitKind::Source,
-    }
 }
 
 /// Classifies a provider against the shipped detector fact
@@ -349,7 +319,6 @@ fn lease_renew_interval() -> Duration {
 
 pub(crate) async fn process_next(
     store: &Store,
-    handle: &WorkerHandle,
     clock: &(dyn Fn() -> i64 + Send + Sync),
     run_pass: &PassRunner<'_>,
     announce: &(dyn Fn(ActivityEntry) + Send + Sync),
@@ -367,20 +336,6 @@ pub(crate) async fn process_next(
         apply_outcome(store, &claim, &pass, clock())?;
         return Ok(true);
     };
-    let _cpu = handle
-        .permits
-        .cpu
-        .acquire()
-        .await
-        .map_err(|_| anyhow::anyhow!("CPU permit closed"))?;
-    let permit = match permit_for_source_kind(&record.source_kind) {
-        PermitKind::Source => &handle.permits.source,
-        PermitKind::ProviderDb => &handle.permits.provider_db,
-    };
-    let _source = permit
-        .acquire()
-        .await
-        .map_err(|_| anyhow::anyhow!("source permit closed"))?;
     let signal = PassSignal::new();
     let mut pass = run_pass(&record, signal.clone(), claim.claim_fence);
     let mut progress = signal.progress();
@@ -426,7 +381,7 @@ pub(crate) async fn worker_loop(
 ) {
     let mut processed = false;
     loop {
-        match process_next(store, handle, clock, run_pass, announce).await {
+        match process_next(store, clock, run_pass, announce).await {
             Ok(true) => {
                 processed = true;
                 continue;

--- a/apps/desktop/src-tauri/src/insights_worker/tests.rs
+++ b/apps/desktop/src-tauri/src/insights_worker/tests.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use antiburn_local::analysis::{
@@ -231,13 +231,12 @@ async fn a_generic_agent_session_completes_terminally_through_process_next() {
     store
         .upsert_sessions(&[copilot_record], &crate::agents::evidence_cohort())
         .unwrap();
-    let handle = WorkerHandle::default();
     let runner = |record: &SessionRecord, _: PassSignal, _: i64| {
         let pass = generic_published_pass(record);
         Box::pin(async move { pass }) as PassFuture
     };
 
-    let processed = process_next(&store, &handle, &|| 100, &runner, &|_| {})
+    let processed = process_next(&store, &|| 100, &runner, &|_| {})
         .await
         .unwrap();
     assert!(processed);
@@ -504,12 +503,10 @@ async fn progress_renews_the_lease() {
     store
         .upsert_sessions(&[record("progress")], &crate::agents::evidence_cohort())
         .unwrap();
-    let handle = Arc::new(WorkerHandle::default());
     let clock = Arc::new(AtomicI64::new(100));
     let signal = Arc::new(Mutex::new(None::<PassSignal>));
     let release = Arc::new(Notify::new());
     let task_store = Arc::clone(&store);
-    let task_handle = Arc::clone(&handle);
     let task_clock = Arc::clone(&clock);
     let task_signal = Arc::clone(&signal);
     let task_release = Arc::clone(&release);
@@ -524,7 +521,6 @@ async fn progress_renews_the_lease() {
         };
         process_next(
             &task_store,
-            &task_handle,
             &|| task_clock.load(Ordering::SeqCst),
             &runner,
             &|_| {},
@@ -568,12 +564,10 @@ async fn a_stalled_pass_stops_renewing() {
     store
         .upsert_sessions(&[record("stalled")], &crate::agents::evidence_cohort())
         .unwrap();
-    let handle = Arc::new(WorkerHandle::default());
     let clock = Arc::new(AtomicI64::new(100));
     let entered = Arc::new(AtomicBool::new(false));
     let release = Arc::new(Notify::new());
     let task_store = Arc::clone(&store);
-    let task_handle = Arc::clone(&handle);
     let task_clock = Arc::clone(&clock);
     let task_entered = Arc::clone(&entered);
     let task_release = Arc::clone(&release);
@@ -588,7 +582,6 @@ async fn a_stalled_pass_stops_renewing() {
         };
         process_next(
             &task_store,
-            &task_handle,
             &|| task_clock.load(Ordering::SeqCst),
             &runner,
             &|_| {},
@@ -627,12 +620,10 @@ async fn a_lost_renewal_cancels_without_a_post_claim_write() {
     store
         .upsert_sessions(&[record("lost")], &crate::agents::evidence_cohort())
         .unwrap();
-    let handle = Arc::new(WorkerHandle::default());
     let clock = Arc::new(AtomicI64::new(100));
     let signal = Arc::new(Mutex::new(None::<PassSignal>));
     let release = Arc::new(Notify::new());
     let task_store = Arc::clone(&store);
-    let task_handle = Arc::clone(&handle);
     let task_clock = Arc::clone(&clock);
     let task_signal = Arc::clone(&signal);
     let task_release = Arc::clone(&release);
@@ -647,7 +638,6 @@ async fn a_lost_renewal_cancels_without_a_post_claim_write() {
         };
         process_next(
             &task_store,
-            &task_handle,
             &|| task_clock.load(Ordering::SeqCst),
             &runner,
             &|_| {},
@@ -680,12 +670,10 @@ async fn a_stale_pass_cannot_affect_the_next_claim() {
     store
         .upsert_sessions(&[record("stale-pass")], &crate::agents::evidence_cohort())
         .unwrap();
-    let handle = Arc::new(WorkerHandle::default());
     let clock = Arc::new(AtomicI64::new(100));
     let first_signal_slot = Arc::new(Mutex::new(None::<PassSignal>));
     let first_release = Arc::new(Notify::new());
     let first_store = Arc::clone(&store);
-    let first_handle = Arc::clone(&handle);
     let first_clock = Arc::clone(&clock);
     let first_task_signal = Arc::clone(&first_signal_slot);
     let first_task_release = Arc::clone(&first_release);
@@ -700,7 +688,6 @@ async fn a_stale_pass_cannot_affect_the_next_claim() {
         };
         process_next(
             &first_store,
-            &first_handle,
             &|| first_clock.load(Ordering::SeqCst),
             &runner,
             &|_| {},
@@ -723,7 +710,6 @@ async fn a_stale_pass_cannot_affect_the_next_claim() {
     let second_signal_slot = Arc::new(Mutex::new(None::<PassSignal>));
     let second_release = Arc::new(Notify::new());
     let second_store = Arc::clone(&store);
-    let second_handle = Arc::clone(&handle);
     let second_clock = Arc::clone(&clock);
     let second_task_signal = Arc::clone(&second_signal_slot);
     let second_task_release = Arc::clone(&second_release);
@@ -739,7 +725,6 @@ async fn a_stale_pass_cannot_affect_the_next_claim() {
         };
         process_next(
             &second_store,
-            &second_handle,
             &|| second_clock.load(Ordering::SeqCst),
             &runner,
             &|_| {},
@@ -779,28 +764,51 @@ async fn a_stale_pass_cannot_affect_the_next_claim() {
 }
 
 #[tokio::test]
-async fn permits_are_held_before_the_pass_is_scheduled() {
-    let store = store();
+async fn the_worker_loop_runs_one_pass_at_a_time() {
+    let store = Arc::new(store());
     store
-        .upsert_sessions(&[record("permit")], &crate::agents::evidence_cohort())
+        .upsert_sessions(
+            &[record("serial-one"), record("serial-two")],
+            &crate::agents::evidence_cohort(),
+        )
         .unwrap();
-    let handle = WorkerHandle::default();
-    let permit = handle.permits.cpu.acquire().await.unwrap();
-    let entered = Arc::new(AtomicBool::new(false));
-    let entered_by_pass = entered.clone();
-    let runner = move |_: &SessionRecord, _: PassSignal, _: i64| {
-        entered_by_pass.store(true, Ordering::SeqCst);
-        Box::pin(async { failed_pass(PassOutcome::SourceMissing) }) as PassFuture
-    };
-    let future = process_next(&store, &handle, &|| 100, &runner, &|_| {});
-    tokio::pin!(future);
-    assert!(
-        tokio::time::timeout(Duration::from_millis(10), &mut future)
-            .await
-            .is_err()
-    );
-    assert!(!entered.load(Ordering::SeqCst));
-    drop(permit);
+    let handle = Arc::new(WorkerHandle::default());
+    let active = Arc::new(AtomicUsize::new(0));
+    let maximum = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+    let all_completed = Arc::new(Notify::new());
+
+    let task_store = Arc::clone(&store);
+    let task_handle = Arc::clone(&handle);
+    let task_active = Arc::clone(&active);
+    let task_maximum = Arc::clone(&maximum);
+    let task_completed = Arc::clone(&completed);
+    let task_all_completed = Arc::clone(&all_completed);
+    let task = tokio::spawn(async move {
+        let runner = move |_: &SessionRecord, _: PassSignal, _: i64| {
+            let active = Arc::clone(&task_active);
+            let maximum = Arc::clone(&task_maximum);
+            let completed = Arc::clone(&task_completed);
+            let all_completed = Arc::clone(&task_all_completed);
+            Box::pin(async move {
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                maximum.fetch_max(current, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                if completed.fetch_add(1, Ordering::SeqCst) + 1 == 2 {
+                    all_completed.notify_one();
+                }
+                failed_pass(PassOutcome::SourceMissing)
+            }) as PassFuture
+        };
+        worker_loop(&task_store, &task_handle, &|| 100, &runner, &|_| {}, &|| {}).await;
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), all_completed.notified())
+        .await
+        .expect("both passes complete");
+    task.abort();
+    assert_eq!(maximum.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -818,8 +826,7 @@ async fn the_store_is_lockable_while_a_pass_runs() {
             failed_pass(PassOutcome::SourceMissing)
         }) as PassFuture
     };
-    let handle = WorkerHandle::default();
-    let future = process_next(&store, &handle, &|| 100, &runner, &|_| {});
+    let future = process_next(&store, &|| 100, &runner, &|_| {});
     tokio::pin!(future);
     assert!(
         tokio::time::timeout(Duration::from_millis(10), &mut future)
@@ -849,15 +856,9 @@ async fn a_published_completion_announces_one_list_entry() {
     let announced = Mutex::new(Vec::new());
 
     assert!(
-        process_next(
-            &store,
-            &WorkerHandle::default(),
-            &|| 100,
-            &runner,
-            &|entry| {
-                announced.lock().unwrap().push(entry);
-            }
-        )
+        process_next(&store, &|| 100, &runner, &|entry| {
+            announced.lock().unwrap().push(entry);
+        })
         .await
         .unwrap()
     );
@@ -882,15 +883,9 @@ async fn a_backed_off_outcome_announces_nothing() {
     let announced = Mutex::new(Vec::new());
 
     assert!(
-        process_next(
-            &store,
-            &WorkerHandle::default(),
-            &|| 100,
-            &runner,
-            &|entry| {
-                announced.lock().unwrap().push(entry);
-            }
-        )
+        process_next(&store, &|| 100, &runner, &|entry| {
+            announced.lock().unwrap().push(entry);
+        })
         .await
         .unwrap()
     );
@@ -910,7 +905,7 @@ async fn a_changed_source_backs_off_through_the_worker() {
         Box::pin(async { failed_pass(PassOutcome::SourceChanged) }) as PassFuture
     };
 
-    process_next(&store, &WorkerHandle::default(), &|| 100, &runner, &|_| {})
+    process_next(&store, &|| 100, &runner, &|_| {})
         .await
         .unwrap();
     let key = SessionKey::new("native", "claude-code", "worker-changed");
@@ -933,7 +928,7 @@ async fn an_unsupported_pass_is_terminal_through_the_worker() {
         Box::pin(async { failed_pass(PassOutcome::Unsupported) }) as PassFuture
     };
 
-    process_next(&store, &WorkerHandle::default(), &|| 100, &runner, &|_| {})
+    process_next(&store, &|| 100, &runner, &|_| {})
         .await
         .unwrap();
     let key = SessionKey::new("native", "claude-code", "worker-unsupported");
@@ -955,7 +950,7 @@ async fn a_missing_source_stops_being_claimed_through_the_worker() {
         Box::pin(async { failed_pass(PassOutcome::SourceMissing) }) as PassFuture
     };
 
-    process_next(&store, &WorkerHandle::default(), &|| 100, &runner, &|_| {})
+    process_next(&store, &|| 100, &runner, &|_| {})
         .await
         .unwrap();
     let key = SessionKey::new("native", "claude-code", "worker-missing");
@@ -986,15 +981,9 @@ async fn an_unreadable_source_reaches_the_cap_through_the_worker() {
     let key = SessionKey::new("native", "claude-code", "worker-unreadable");
 
     for attempt in 0..=MAX_EVIDENCE_ATTEMPTS {
-        process_next(
-            &store,
-            &WorkerHandle::default(),
-            &|| clock.load(Ordering::SeqCst),
-            &runner,
-            &|_| {},
-        )
-        .await
-        .unwrap();
+        process_next(&store, &|| clock.load(Ordering::SeqCst), &runner, &|_| {})
+            .await
+            .unwrap();
         let row = store.evidence(&key).unwrap().unwrap();
         if attempt == MAX_EVIDENCE_ATTEMPTS {
             assert_eq!(row.status, EvidenceStatus::Failed);
@@ -1065,7 +1054,7 @@ async fn a_published_pass_leaves_the_expected_turn_rows_under_its_claim_fence() 
     };
 
     assert!(
-        process_next(&store, &WorkerHandle::default(), &|| 100, &runner, &|_| {})
+        process_next(&store, &|| 100, &runner, &|_| {})
             .await
             .unwrap()
     );
@@ -1166,7 +1155,7 @@ async fn a_linked_forks_pass_publishes_turn_rows_only_for_its_own_turns() {
     };
 
     assert!(
-        process_next(&store, &WorkerHandle::default(), &|| 100, &runner, &|_| {})
+        process_next(&store, &|| 100, &runner, &|_| {})
             .await
             .unwrap()
     );
@@ -1264,15 +1253,9 @@ async fn pi_file_flows_through_worker_persistence_and_report() {
     };
 
     assert!(
-        process_next(
-            &store,
-            &WorkerHandle::default(),
-            &|| 1_767_225_610,
-            &runner,
-            &|_| {},
-        )
-        .await
-        .unwrap()
+        process_next(&store, &|| 1_767_225_610, &runner, &|_| {},)
+            .await
+            .unwrap()
     );
     let stored = store.evidence(&pi.key).unwrap().unwrap();
     assert_eq!(stored.status, EvidenceStatus::Ready);
@@ -1348,13 +1331,6 @@ fn errors_carry_no_transcript_content() {
         assert!(allowed.contains(&error.as_str()));
         assert!(!error.contains(SOURCE_CONTENT));
     }
-}
-
-#[test]
-fn a_permit_is_chosen_per_source_kind() {
-    assert_eq!(permit_for_source_kind("file"), PermitKind::Source);
-    assert_eq!(permit_for_source_kind("inline"), PermitKind::Source);
-    assert_eq!(permit_for_source_kind("providerDb"), PermitKind::ProviderDb);
 }
 
 #[tokio::test]

--- a/apps/desktop/src-tauri/src/insights_worker/tests/resume_tests.rs
+++ b/apps/desktop/src-tauri/src/insights_worker/tests/resume_tests.rs
@@ -137,7 +137,7 @@ async fn run_worker_step(
         )
     };
     assert!(
-        process_next(store, &WorkerHandle::default(), &|| now, &runner, &|_| {})
+        process_next(store, &|| now, &runner, &|_| {})
             .await
             .unwrap(),
         "the worker must claim and publish this step"

--- a/apps/desktop/src-tauri/src/nudges.rs
+++ b/apps/desktop/src-tauri/src/nudges.rs
@@ -105,10 +105,10 @@ pub fn deliver(app: &AppHandle, mut nudge: Nudge) {
         .as_ref()
         .is_none_or(|settings| settings.notification_sound);
     if sound_allowed
-        && let Some(kind) = sound_for(nudge.kind)
+        && sound_for(nudge.kind)
         && let Some(player) = app.try_state::<antiburn_sound::SoundPlayer>()
     {
-        player.play(kind, nudge.actor.as_deref());
+        player.play();
     }
 
     if let Some(manager) = app.try_state::<NudgeManager>() {
@@ -118,11 +118,8 @@ pub fn deliver(app: &AppHandle, mut nudge: Nudge) {
 
 /// Which kinds carry the chime. The test plays it so the toggle is auditable.
 /// Updates, scans, disk, and milestones stay quiet.
-fn sound_for(kind: NudgeKind) -> Option<antiburn_sound::SoundKind> {
-    match kind {
-        NudgeKind::Test => Some(antiburn_sound::SoundKind::Notification),
-        _ => None,
-    }
+fn sound_for(kind: NudgeKind) -> bool {
+    kind == NudgeKind::Test
 }
 
 /// Where the window appears, read fresh at reveal time so a placement change

--- a/apps/desktop/src-tauri/src/popover_peek.rs
+++ b/apps/desktop/src-tauri/src/popover_peek.rs
@@ -4,8 +4,7 @@ use std::time::Duration;
 
 use antiburn_anchored_window::{
     AnchorRegion, AnchoredWindowConfig, AnchoredWindowManager, AnchoredWindowRequest,
-    AnchoredWindowState, HeightPolicy, InteractionPolicy, PlacementPolicy, PointerExitPolicy,
-    RevealPolicy, WindowMaterial,
+    AnchoredWindowState, PointerExitPolicy,
 };
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
@@ -85,20 +84,12 @@ pub fn manager() -> PopoverPeekManager {
         route: "index.html#/popover-peek".to_string(),
         title: "antiburn".to_string(),
         width: 380.0,
-        material: WindowMaterial::Popover {
-            corner_radius: crate::popover::CORNER_RADIUS,
-        },
-        interaction: InteractionPolicy::Passive,
-        reveal: RevealPolicy::ImmediatePlaceholder,
-        height: HeightPolicy::Content {
-            initial: 320.0,
-            min: 60.0,
-            max: MAX_CONTENT_HEIGHT,
-        },
-        placement: PlacementPolicy::LeftPreferred {
-            gap: 8.0,
-            screen_margin: 8.0,
-        },
+        corner_radius: crate::popover::CORNER_RADIUS,
+        initial_height: 320.0,
+        min_height: 60.0,
+        max_height: MAX_CONTENT_HEIGHT,
+        gap: 8.0,
+        screen_margin: 8.0,
         conceal_fallback: Duration::from_millis(80),
         pointer_exit: Some(PointerExitPolicy {
             edge_tolerance: 12.0,

--- a/apps/desktop/src-tauri/src/scan/mod.rs
+++ b/apps/desktop/src-tauri/src/scan/mod.rs
@@ -881,18 +881,16 @@ async fn pass(
     // Every write below is routed through the storage-health check, so a
     // database that has stopped accepting writes becomes a banner in the
     // popover rather than a list that silently stops changing.
-    checked(
+    let persisted = checked(
         app,
         "The session index",
-        store.upsert_sessions(
-            &records_to_persist(&records, &changed, &returned),
-            &evidence_agents,
-        ),
+        persist_changed_records(&records, &changed, &returned, |records| {
+            store.upsert_sessions(records, &evidence_agents)
+        }),
     )?;
-    crate::insights_worker::wake(app);
-    // A write may have added a session the idle task was not yet watching,
-    // or moved one's deadline later; either way its sleep needs recomputing.
-    idle::wake(app);
+    if persisted {
+        wake_session_workers(app);
+    }
 
     announce_changed_rows(&store, &changed, &previous_records, now, announce);
 
@@ -900,11 +898,10 @@ async fn pass(
     // version of the app that did not gate; the row is removed rather than
     // left to mislead indefinitely.
     for key in &rejected {
-        checked(
-            app,
-            "The session index",
-            store.delete_session(key).map(|_| ()),
-        )?;
+        let removed = checked(app, "The session index", store.delete_session(key))?;
+        if removed {
+            wake_session_workers(app);
+        }
     }
 
     // `records` already holds only the scoped agents' sessions when `scope`
@@ -964,6 +961,26 @@ fn records_to_persist(
         .filter(|record| worth_writing.contains(&record.key))
         .cloned()
         .collect()
+}
+
+fn persist_changed_records(
+    records: &[SessionRecord],
+    changed: &[SessionKey],
+    returned: &[SessionKey],
+    persist: impl FnOnce(&[SessionRecord]) -> anyhow::Result<()>,
+) -> anyhow::Result<bool> {
+    let records = records_to_persist(records, changed, returned);
+    let persisted = !records.is_empty();
+    if persisted {
+        persist(&records)?;
+    }
+    Ok(persisted)
+}
+
+fn wake_session_workers(app: &AppHandle) {
+    crate::insights_worker::wake(app);
+    // A changed session can add, remove, or move an idle deadline.
+    idle::wake(app);
 }
 
 /// [`PassScope::Agents`]'s discovery: only the named agents, concurrently,

--- a/apps/desktop/src-tauri/src/scan/scoped.rs
+++ b/apps/desktop/src-tauri/src/scan/scoped.rs
@@ -575,20 +575,31 @@ async fn refresh_sessions_locked(
     };
 
     let described = super::describe_with_states(logs, &home, &ignored, &previous_map).await;
-    checked(
+    let record_keys = described
+        .records
+        .iter()
+        .map(|record| record.key.clone())
+        .collect::<Vec<_>>();
+    let returned = store.sessions_with_missing_source_for(&record_keys)?;
+    let persisted = checked(
         app,
         "The session index",
-        store.upsert_sessions(&described.records, &agents::evidence_cohort()),
+        super::persist_changed_records(
+            &described.records,
+            &described.changed,
+            &returned,
+            |records| store.upsert_sessions(records, &agents::evidence_cohort()),
+        ),
     )?;
-    crate::insights_worker::wake(app);
-    super::idle::wake(app);
+    if persisted {
+        super::wake_session_workers(app);
+    }
     super::announce_changed_rows(&store, &described.changed, &previous_map, now, &announce);
     for key in &described.rejected {
-        checked(
-            app,
-            "The session index",
-            store.delete_session(key).map(|_| ()),
-        )?;
+        let removed = checked(app, "The session index", store.delete_session(key))?;
+        if removed {
+            super::wake_session_workers(app);
+        }
     }
 
     Ok(ScopedSummary {

--- a/apps/desktop/src-tauri/src/scan/tests.rs
+++ b/apps/desktop/src-tauri/src/scan/tests.rs
@@ -1429,6 +1429,48 @@ fn records_to_persist_keeps_only_changed_or_returned_rows() {
 }
 
 #[test]
+fn scoped_persistence_skips_unchanged_rows_without_calling_the_store() {
+    let records = vec![record("claude-code", "steady", Some(1_000))];
+    let calls = std::cell::Cell::new(0);
+
+    let persisted = persist_changed_records(&records, &[], &[], |_| {
+        calls.set(calls.get() + 1);
+        Ok(())
+    })
+    .unwrap();
+
+    assert!(!persisted);
+    assert_eq!(calls.get(), 0);
+}
+
+#[test]
+fn scoped_persistence_writes_changed_new_and_returned_rows_once() {
+    let changed = record("claude-code", "changed", Some(1_000));
+    let new = record("claude-code", "new", Some(2_000));
+    let returned = record("codex", "returned", Some(3_000));
+    let unchanged = record("codex", "steady", Some(4_000));
+    let records = vec![changed.clone(), new.clone(), returned.clone(), unchanged];
+    let writes = Mutex::new(Vec::new());
+
+    let persisted = persist_changed_records(
+        &records,
+        &[changed.key.clone(), new.key.clone()],
+        std::slice::from_ref(&returned.key),
+        |batch| {
+            writes.lock().unwrap().push(batch.to_vec());
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert!(persisted);
+    assert_eq!(
+        writes.into_inner().unwrap(),
+        vec![vec![changed, new, returned]]
+    );
+}
+
+#[test]
 fn per_agent_totals_count_sessions_and_keep_the_newest_activity() {
     let records = vec![
         record("claude-code", "a", Some(1_000)),

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -2822,15 +2822,9 @@ async fn analysis_from_rows_serves_a_published_pass_without_reading_a_transcript
         Box::pin(async move { pass }) as crate::insights_worker::PassFuture
     };
     assert!(
-        crate::insights_worker::process_next(
-            &store,
-            &crate::insights_worker::WorkerHandle::default(),
-            &|| 1_100,
-            &runner,
-            &|_| {},
-        )
-        .await
-        .unwrap()
+        crate::insights_worker::process_next(&store, &|| 1_100, &runner, &|_| {},)
+            .await
+            .unwrap()
     );
     assert_eq!(
         store.evidence(&record.key).unwrap().unwrap().status,
@@ -2902,15 +2896,9 @@ async fn analysis_from_rows_still_serves_a_published_pass_after_a_requeue() {
         Box::pin(async move { pass }) as crate::insights_worker::PassFuture
     };
     assert!(
-        crate::insights_worker::process_next(
-            &store,
-            &crate::insights_worker::WorkerHandle::default(),
-            &|| 1_100,
-            &runner,
-            &|_| {},
-        )
-        .await
-        .unwrap()
+        crate::insights_worker::process_next(&store, &|| 1_100, &runner, &|_| {},)
+            .await
+            .unwrap()
     );
 
     // The transcript grew: the drilldown's own nudge requeues the session
@@ -3043,15 +3031,9 @@ async fn reprocessing_a_revision_one_row_leaves_no_placeholder_in_stored_evidenc
         Box::pin(async move { pass }) as crate::insights_worker::PassFuture
     };
     assert!(
-        crate::insights_worker::process_next(
-            &store,
-            &crate::insights_worker::WorkerHandle::default(),
-            &|| 1_100,
-            &runner,
-            &|_| {},
-        )
-        .await
-        .unwrap()
+        crate::insights_worker::process_next(&store, &|| 1_100, &runner, &|_| {},)
+            .await
+            .unwrap()
     );
 
     let ready = store.evidence(&record.key).unwrap().unwrap();
@@ -3085,15 +3067,9 @@ async fn a_terminal_failure_clears_an_outdated_placeholder_payload() {
         }) as crate::insights_worker::PassFuture
     };
     assert!(
-        crate::insights_worker::process_next(
-            &store,
-            &crate::insights_worker::WorkerHandle::default(),
-            &|| 1_100,
-            &runner,
-            &|_| {},
-        )
-        .await
-        .unwrap()
+        crate::insights_worker::process_next(&store, &|| 1_100, &runner, &|_| {},)
+            .await
+            .unwrap()
     );
 
     let failed = store.evidence(&record.key).unwrap().unwrap();

--- a/apps/desktop/src/views/settings/AboutPane.test.tsx
+++ b/apps/desktop/src/views/settings/AboutPane.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { expect, it, vi } from "vitest"
+
+import { DEFAULT_SETTINGS } from "../../lib/ipc"
+import { AboutPane } from "./AboutPane"
+
+const documentModuleLoaded = vi.hoisted(() => vi.fn())
+
+vi.mock("./AboutDocumentView", () => {
+  documentModuleLoaded()
+  return {
+    AboutDocumentView: ({ id }: { id: string }) => <h1>{id}</h1>,
+  }
+})
+
+it("loads the legal document module only after a reader opens a document", async () => {
+  render(<AboutPane settings={DEFAULT_SETTINGS} loaded={false} update={vi.fn()} info={null} />)
+
+  expect(documentModuleLoaded).not.toHaveBeenCalled()
+
+  fireEvent.click(screen.getByRole("button", { name: "Open third-party attributions" }))
+
+  expect(await screen.findByRole("heading", { name: "attributions" })).toBeInTheDocument()
+  expect(documentModuleLoaded).toHaveBeenCalledOnce()
+})

--- a/apps/desktop/src/views/settings/AboutPane.tsx
+++ b/apps/desktop/src/views/settings/AboutPane.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { lazy, Suspense, useState } from "react"
 
 import { Card } from "../../components/ui/Card"
 import { Pane } from "../../components/ui/Pane"
@@ -8,9 +8,15 @@ import { revealSource, type AppInfo } from "../../lib/ipc"
 import { detectPlatform, type Platform } from "../../lib/platform"
 import type { SettingsPane } from "../../lib/settingsPanes"
 import { PushButton } from "../../components/ui/PushButton"
-import { AboutDocumentView, type AboutDocumentId } from "./AboutDocumentView"
+import type { AboutDocumentId } from "./AboutDocumentView"
 import { UpdatesSection } from "./UpdatesSection"
 import type { AppSettingsController } from "./useAppSettings"
+
+const AboutDocumentView = lazy(() =>
+  import("./AboutDocumentView").then(({ AboutDocumentView }) => ({
+    default: AboutDocumentView,
+  })),
+)
 
 /** Display names for the masthead; `detectPlatform` reports lowercase ids. */
 const PLATFORM_LABELS: Record<Platform, string> = {
@@ -55,13 +61,21 @@ export function AboutPane({ settings, update, loaded, info, onOpenPane }: AboutP
 
   if (openDocument) {
     return (
-      <AboutDocumentView
-        id={openDocument}
-        onBack={() => {
-          setReturnFocusTo(openDocument)
-          setOpenDocument(null)
-        }}
-      />
+      <Suspense
+        fallback={
+          <p role="status" className="type-body text-label-secondary">
+            Loading document…
+          </p>
+        }
+      >
+        <AboutDocumentView
+          id={openDocument}
+          onBack={() => {
+            setReturnFocusTo(openDocument)
+            setOpenDocument(null)
+          }}
+        />
+      </Suspense>
     )
   }
 

--- a/crates/antiburn-local/API-SUPPORT.md
+++ b/crates/antiburn-local/API-SUPPORT.md
@@ -1,0 +1,35 @@
+# API support notes
+
+The desktop application is not the complete usage boundary for this crate.
+Release archives support external embeddings that pin an engine release tag.
+Repository-wide caller searches therefore do not prove that a public item is
+dead.
+
+## Retained compatibility APIs
+
+- The batch analysis path (`analyze_sources`, `analyze_sources_with`,
+  `normalize_source`, `NormalizedSession`, `SessionCollector`, and
+  `analyze_session`) remains supported. The changelog introduced the streaming
+  interface as a way to rebuild the same batch result, and engine integration
+  tests and benchmarks still use both paths for characterization and parity.
+- The repository orchestration exports remain supported. The 0.5.0 changelog
+  explicitly retains `resolve_granted_repos` and `scan_roots_for_repos` as
+  embedding building blocks. The repository module documents the matching,
+  progress, root-derivation, and session-working-directory contracts used to
+  assemble an external discovery pipeline.
+- `SessionMetrics.context_available` remains part of the serialized metrics
+  contract. Aggregate analysis uses it to distinguish an empty cohort from a
+  cohort with context metrics, and parity tests compare the field across the
+  live and row-replay paths.
+- `SessionMetrics.context_window_source` remains part of the serialized
+  metrics contract. Version 0.6.0 added it as diagnostic evidence and records
+  the addition as a breaking schema change.
+
+Removing or narrowing these items requires a versioned compatibility decision,
+not only evidence that the desktop has no current caller.
+
+## Deleted internal work
+
+- Git command execution no longer constructs an unused display-only argument
+  vector. Structured tracing already records the sanitized repository path,
+  argument slice, and environment variable names without recording values.

--- a/crates/antiburn-local/README.md
+++ b/crates/antiburn-local/README.md
@@ -15,7 +15,9 @@ Consumers pin the full commit SHA for an `antiburn-local-v*` release tag. See
 the [release guide](../../docs/runbooks/release.md#how-consumers-pin-the-engine).
 
 Public modules and compatibility changes are documented in the
-[crate changelog](CHANGELOG.md). Run the standalone checks with:
+[crate changelog](CHANGELOG.md). The [API support notes](API-SUPPORT.md)
+classify public surfaces that the desktop application does not call directly.
+Run the standalone checks with:
 
 ```bash
 cargo fmt --check

--- a/crates/antiburn-local/src/platform/git.rs
+++ b/crates/antiburn-local/src/platform/git.rs
@@ -104,13 +104,6 @@ pub async fn run_git_output_in_environment(
     envs: &[(&str, &str)],
 ) -> Result<Output> {
     let mut cmd = environment::configure_command_for_environment(environment, "git", repo)?;
-    let mut display_parts = vec!["git".to_string()];
-
-    if let Some(repo) = repo {
-        let repo_str = repo.to_string_lossy().to_string();
-        display_parts.push("-C".to_string());
-        display_parts.push(repo_str);
-    }
 
     for (key, value) in envs {
         cmd.env(key, value);
@@ -121,7 +114,6 @@ pub async fn run_git_output_in_environment(
         .iter()
         .map(|(key, _)| (*key).to_string())
         .collect::<Vec<_>>();
-    display_parts.extend(args.iter().map(|s| s.to_string()));
     ::tracing::trace!(
         event = "git_command_started",
         repo = repo_for_log.as_deref().unwrap_or(""),


### PR DESCRIPTION
## User impact

This change addresses audit findings 12, 16, 23, and 24 with internal performance and maintenance improvements. User-facing behavior stays the same.

- Session discovery now writes only new, changed, or returned session rows. It skips empty store writes and wakes the insights and idle workers only after a write or deletion changes indexed session state. Full and scoped scans use the same persistence rule.
- Settings no longer loads the 515 KB third-party notice source through its initial import graph. The production Settings chunk is 91.40 KB (30.65 KB gzip), while the 518.94 KB legal-document chunk (78.14 KB gzip) loads only after a reader opens a legal document. Existing content, navigation, heading focus, Back focus restoration, and accessibility remain intact.
- The serial insights worker no longer takes redundant CPU and source-kind semaphores around each job. Its single worker loop remains the concurrency boundary.
- Dead sound synthesis, tuning, per-actor variation, native-window convenience wrappers, speculative anchored-window policy enums and branches, and an unused Git display-vector allocation are removed. Direct native-window configuration preserves the behavior the application ships and keeps its IPC shapes unchanged. The notification test chime remains fixed and uses the same playback path.
- The engine's externally supported public APIs remain available. `API-SUPPORT.md` documents why desktop caller searches are not an API-removal boundary and identifies the retained batch analysis, repository orchestration, and serialized metrics contracts.

Known limits: live CPU and RSS were not measured. Public engine compatibility is intentionally retained, so this change does not claim a full audit 24 public-API purge. This cleanup deliberately does not redesign scan scheduling, legal-document presentation, insights concurrency, or notification sound behavior.

## Validation

Confirmed:

- `pnpm --filter @antiburn/desktop format`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test` (95 files, 1,216 tests)
- `pnpm --filter @antiburn/desktop build`
- `pnpm --filter @antiburn/desktop knip`
- `pnpm run slop:all` (score 100)
- `pnpm run secrets`
- `pnpm run notices:check`
- Design drift checks
- Final diff checks
- `crates/antiburn-local: cargo fmt --check`
- `crates/antiburn-local: cargo clippy --all-targets -- -D warnings`
- `crates/antiburn-local: cargo test`
- `apps/desktop/src-tauri: cargo fmt --check`
- `apps/desktop/src-tauri: cargo clippy --all-targets -- -D warnings`
- `apps/desktop/src-tauri: cargo test` (999 tests)
- `apps/desktop/src-tauri: cargo clippy --all-targets --features analytics -- -D warnings`
- `apps/desktop/src-tauri: cargo test --features analytics` (1,042 tests)
- `apps/desktop/src-tauri/crates/sound: cargo fmt --check`
- `apps/desktop/src-tauri/crates/sound: cargo clippy --all-targets -- -D warnings`
- `apps/desktop/src-tauri/crates/sound: cargo test` (3 passed, 1 ignored, plus doctests)
- `apps/desktop/src-tauri/crates/nudge: cargo fmt --check`
- `apps/desktop/src-tauri/crates/nudge: cargo clippy --all-targets -- -D warnings`
- `apps/desktop/src-tauri/crates/nudge: cargo test` (36 tests, plus doctests)
- `apps/desktop/src-tauri/crates/anchored-window: cargo fmt --check`
- `apps/desktop/src-tauri/crates/anchored-window: cargo clippy --all-targets -- -D warnings`
- `apps/desktop/src-tauri/crates/anchored-window: cargo test` (31 tests, plus doctests)
- Final exact-files shell rerun: format, default clippy, 999 default tests, analytics clippy, and 1,042 analytics tests
- Production bundle inspection: legal notice text occurs only in the dynamic `AboutDocumentView` chunk, not the initial Settings chunk.

## Analytics

Analytics are unchanged. These findings concern internal persistence, wake scheduling, bundle loading, redundant synchronization, and dead code. Existing product events keep their current triggers and properties; no new product question or user-visible action needs instrumentation.

## Privacy and performance

No new data access, network access, or retained data is introduced. The legal files remain bundled locally and are loaded only when requested.

Background work decreases: unchanged scans avoid empty database writes and unnecessary worker wake-ups, the insights worker removes redundant permit acquisition, Git commands avoid an unused argument-vector allocation, and Settings defers the large legal text until use. Removed sound and native-wrapper code does not change stored content or network behavior.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
