### PR TITLE
feat(analytics): report coarse provider usage bands

### DIFF
--- a/apps/desktop/src-tauri/src/analytics/event.rs
+++ b/apps/desktop/src-tauri/src/analytics/event.rs
@@ -61,6 +61,9 @@ pub enum EventName {
     /// A provider state appeared on a visible usage surface.
     #[cfg(feature = "analytics")]
     LiveUsageStateObserved,
+    /// An ordinary live-usage refresh published a changed coarse usage band.
+    #[cfg(feature = "analytics")]
+    UsageObserved,
 }
 
 /// Every event this application may send.
@@ -87,6 +90,7 @@ pub const EVERY_EVENT: &[EventName] = &[
     EventName::SettingsPaneViewed,
     EventName::SurfaceStateObserved,
     EventName::LiveUsageStateObserved,
+    EventName::UsageObserved,
 ];
 
 #[cfg(feature = "analytics")]
@@ -107,6 +111,7 @@ impl EventName {
             EventName::SettingsPaneViewed => "antiburn.settings_pane_viewed",
             EventName::SurfaceStateObserved => "antiburn.surface_state_observed",
             EventName::LiveUsageStateObserved => "antiburn.live_usage_state_observed",
+            EventName::UsageObserved => "antiburn.usage_observed",
         }
     }
 }
@@ -546,6 +551,28 @@ wire_values!(LiveUsageProvider, {
 });
 
 #[cfg(feature = "analytics")]
+impl LiveUsageProvider {
+    /// The provider category for a canonical provider id, from
+    /// [`crate::provider_usage::providers`].
+    ///
+    /// `antiburn.usage_observed` reports for the same providers
+    /// `antiburn.live_usage_state_observed` does, so both read this one
+    /// closed mapping rather than keeping two vocabularies in step by hand.
+    /// An id outside the three known providers returns `None`, so a future
+    /// source cannot silently widen what a label can say.
+    pub fn from_provider_id(provider: &str) -> Option<LiveUsageProvider> {
+        match provider {
+            id if id == crate::provider_usage::providers::ANTHROPIC => {
+                Some(LiveUsageProvider::Anthropic)
+            }
+            id if id == crate::provider_usage::providers::OPENAI => Some(LiveUsageProvider::Openai),
+            id if id == crate::provider_usage::providers::GOOGLE => Some(LiveUsageProvider::Google),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "analytics")]
 wire_values!(LiveUsageState, {
     LiveUsageState::Fresh => "fresh",
     LiveUsageState::Stale => "stale",
@@ -791,12 +818,13 @@ mod tests {
                 | EventName::SettingsPaneViewed
                 | EventName::SurfaceStateObserved
                 | EventName::LiveUsageStateObserved
-                | EventName::ClaudeLimitResetObserved => true,
+                | EventName::ClaudeLimitResetObserved
+                | EventName::UsageObserved => true,
             }
         }
         assert_eq!(
             EVERY_EVENT.len(),
-            14,
+            15,
             "a variant was added to the match above but not to EVERY_EVENT"
         );
         assert!(EVERY_EVENT.iter().copied().all(listed));
@@ -913,6 +941,30 @@ mod tests {
         assert_eq!(facts.label, Some("google"));
         assert_eq!(facts.detail, Some("rate_limited"));
         assert_eq!(facts.origin, None);
+    }
+
+    /// `usage_observed` reads the same closed vocabulary
+    /// `live_usage_state_observed` does, rather than trusting a new source's
+    /// provider id outright. A provider this build does not recognize maps to
+    /// `None`, so the caller skips it instead of inventing a fourth label.
+    #[test]
+    fn an_unrecognised_provider_id_has_no_usage_observed_label() {
+        assert_eq!(
+            LiveUsageProvider::from_provider_id(crate::provider_usage::providers::ANTHROPIC),
+            Some(LiveUsageProvider::Anthropic)
+        );
+        assert_eq!(
+            LiveUsageProvider::from_provider_id(crate::provider_usage::providers::OPENAI),
+            Some(LiveUsageProvider::Openai)
+        );
+        assert_eq!(
+            LiveUsageProvider::from_provider_id(crate::provider_usage::providers::GOOGLE),
+            Some(LiveUsageProvider::Google)
+        );
+        assert_eq!(
+            LiveUsageProvider::from_provider_id("some-future-provider"),
+            None
+        );
     }
 
     /// The renderer cannot invent a value. This is the whole reason the IPC

--- a/apps/desktop/src-tauri/src/analytics/mod.rs
+++ b/apps/desktop/src-tauri/src/analytics/mod.rs
@@ -128,6 +128,13 @@ pub fn record_unrecognized_records(
 }
 
 #[cfg(not(feature = "analytics"))]
+pub fn record_usage_observed(
+    _app: &tauri::AppHandle,
+    _snapshots: &[crate::provider_usage::live::ProviderUsageSnapshot],
+) {
+}
+
+#[cfg(not(feature = "analytics"))]
 pub fn handle_settings_transition(
     _app: &tauri::AppHandle,
     _previous: &crate::store::AppSettings,
@@ -138,10 +145,13 @@ pub fn handle_settings_transition(
 #[cfg(feature = "analytics")]
 mod enabled {
 
+    use std::collections::BTreeMap;
     use std::time::{Duration, Instant};
 
     use antiburn_local::insights::UnrecognizedRecords;
     use tauri::Manager as _;
+
+    use crate::provider_usage::live::{ProviderUsageSnapshot, WindowRole, band_for_percent};
 
     use super::delivery::{DeliverySchedule, FlushOutcome};
     use super::event::{
@@ -297,6 +307,87 @@ mod enabled {
         }
     }
 
+    /// Record a coarse usage band for every provider window an ordinary
+    /// live-usage refresh just published, when analytics allows it.
+    ///
+    /// `snapshots` is expected to already carry only online, visible
+    /// providers — see [`crate::provider_usage::live::sources::collect`] —
+    /// so no further gate is applied here beyond [`allowed`]. A provider that
+    /// failed this pass has no snapshot in the slice, so it contributes no
+    /// observation and its last reported band is left exactly as it was.
+    pub fn record_usage_observed(app: &tauri::AppHandle, snapshots: &[ProviderUsageSnapshot]) {
+        if !allowed(app) {
+            return;
+        }
+        let candidates = usage_observed_candidates(snapshots);
+        if candidates.is_empty() {
+            return;
+        }
+        let mut last = LAST_USAGE_OBSERVED
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for (label, detail, band) in candidates {
+            if !usage_observed_is_new(&last, label, detail, band) {
+                continue;
+            }
+            if record_event(
+                app,
+                EventName::UsageObserved,
+                Facts {
+                    label: Some(label),
+                    detail: Some(detail),
+                    usage_band: Some(band),
+                    ..Facts::default()
+                },
+            ) {
+                last.insert((label, detail), band);
+            }
+        }
+    }
+
+    /// Every `(provider, window role, band)` this build can report for one
+    /// collected pass.
+    ///
+    /// Only the two windows that make up a provider's primary allowance
+    /// count: the short rolling window and the long weekly or billing-period
+    /// one. A supplemental or provider-named window is not part of this
+    /// coarse picture, the same narrowing the milestone engine applies. A
+    /// provider id this build does not recognize is skipped rather than
+    /// given an invented label. `authoritative` is not checked — the band is
+    /// coarse enough that even a derived figure stays useful here.
+    fn usage_observed_candidates(
+        snapshots: &[ProviderUsageSnapshot],
+    ) -> Vec<(&'static str, &'static str, &'static str)> {
+        snapshots
+            .iter()
+            .filter_map(|snapshot| {
+                let label = LiveUsageProvider::from_provider_id(snapshot.provider)?.as_str();
+                Some(snapshot.windows.iter().filter_map(move |window| {
+                    let detail = match &window.role {
+                        WindowRole::PrimaryShort => "short",
+                        WindowRole::PrimaryLong => "long",
+                        WindowRole::Supplemental | WindowRole::Other(_) => return None,
+                    };
+                    Some((label, detail, band_for_percent(window.used_percent)))
+                }))
+            })
+            .flatten()
+            .collect()
+    }
+
+    /// Whether `(label, detail)`'s band differs from the last one reported.
+    ///
+    /// A pure lookup rather than a mutating check, so the duplicate rule can
+    /// be tested without the process-wide static behind it.
+    fn usage_observed_is_new(
+        last: &BTreeMap<(&'static str, &'static str), &'static str>,
+        label: &'static str,
+        detail: &'static str,
+        band: &'static str,
+    ) -> bool {
+        last.get(&(label, detail)) != Some(&band)
+    }
+
     /// Record an interaction reported by the renderer.
     ///
     /// The renderer names a shape, not an event. See [`Interaction`] for why.
@@ -423,6 +514,14 @@ mod enabled {
     static LAST_CLAUDE_LIMIT_RESET: std::sync::Mutex<
         Option<crate::provider_usage::live::anthropic::LimitResetDiagnostic>,
     > = std::sync::Mutex::new(None);
+
+    /// The last band reported for each `(provider, window role)` pair queued
+    /// during this run. In memory only, for the same reason every other
+    /// suppression hint here is: it is a dedup key, not a fact worth keeping
+    /// past this process.
+    static LAST_USAGE_OBSERVED: std::sync::Mutex<
+        BTreeMap<(&'static str, &'static str), &'static str>,
+    > = std::sync::Mutex::new(BTreeMap::new());
 
     #[derive(Debug, Clone, Copy, Default)]
     struct OnboardingCapture {
@@ -685,6 +784,10 @@ mod enabled {
         *LAST_CLAUDE_LIMIT_RESET
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        LAST_USAGE_OBSERVED
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
         *DELIBERATE_VISIT
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = DeliberateVisit::default();
@@ -1111,6 +1214,144 @@ mod enabled {
             assert!(visit.live_usage_states.is_empty());
         }
 
+        /// A minimal snapshot for one provider, with one window per
+        /// `(role, used_percent)` pair given.
+        fn usage_snapshot(
+            provider: &'static str,
+            windows: Vec<(WindowRole, Option<f64>)>,
+        ) -> ProviderUsageSnapshot {
+            ProviderUsageSnapshot {
+                provider,
+                account: None,
+                account_uuid: None,
+                account_email: None,
+                plan: None,
+                plan_tier: None,
+                observed_at: time::OffsetDateTime::UNIX_EPOCH,
+                source: crate::provider_usage::live::model::UsageSource {
+                    id: "fixture",
+                    label: "fixture".into(),
+                    confidence: crate::provider_usage::live::Confidence::High,
+                    freshness: crate::provider_usage::live::Freshness::Fresh,
+                },
+                windows: windows
+                    .into_iter()
+                    .enumerate()
+                    .map(
+                        |(index, (role, used_percent))| crate::provider_usage::live::UsageWindow {
+                            id: format!("window-{index}"),
+                            role,
+                            kind: crate::provider_usage::live::UsageWindowKind::Rolling,
+                            scope: crate::provider_usage::live::UsageScope::Account,
+                            used_percent,
+                            starts_at: None,
+                            resets_at: None,
+                            authoritative: true,
+                        },
+                    )
+                    .collect(),
+                supplemental: None,
+                reset_credits: None,
+            }
+        }
+
+        #[test]
+        fn a_window_at_eighty_five_percent_reports_the_under_hundred_band() {
+            let snapshot = usage_snapshot(
+                crate::provider_usage::providers::ANTHROPIC,
+                vec![(WindowRole::PrimaryShort, Some(85.0))],
+            );
+            assert_eq!(
+                usage_observed_candidates(std::slice::from_ref(&snapshot)),
+                vec![("anthropic", "short", "80_to_under_100")]
+            );
+        }
+
+        #[test]
+        fn short_and_long_windows_each_report_their_own_role() {
+            let snapshot = usage_snapshot(
+                crate::provider_usage::providers::OPENAI,
+                vec![
+                    (WindowRole::PrimaryShort, Some(10.0)),
+                    (WindowRole::PrimaryLong, Some(100.0)),
+                ],
+            );
+            assert_eq!(
+                usage_observed_candidates(std::slice::from_ref(&snapshot)),
+                vec![
+                    ("openai", "short", "below_80"),
+                    ("openai", "long", "at_limit"),
+                ]
+            );
+        }
+
+        #[test]
+        fn a_supplemental_or_unrecognized_window_role_is_not_part_of_the_coarse_picture() {
+            let snapshot = usage_snapshot(
+                crate::provider_usage::providers::ANTHROPIC,
+                vec![
+                    (WindowRole::Supplemental, Some(95.0)),
+                    (WindowRole::Other("daily".into()), Some(50.0)),
+                ],
+            );
+            assert!(usage_observed_candidates(std::slice::from_ref(&snapshot)).is_empty());
+        }
+
+        #[test]
+        fn a_provider_this_build_does_not_recognize_reports_nothing() {
+            let snapshot = usage_snapshot(
+                "some-future-provider",
+                vec![(WindowRole::PrimaryShort, Some(50.0))],
+            );
+            assert!(usage_observed_candidates(std::slice::from_ref(&snapshot)).is_empty());
+        }
+
+        #[test]
+        fn a_missing_percentage_is_unknown_rather_than_zero() {
+            let snapshot = usage_snapshot(
+                crate::provider_usage::providers::GOOGLE,
+                vec![(WindowRole::PrimaryShort, None)],
+            );
+            assert_eq!(
+                usage_observed_candidates(std::slice::from_ref(&snapshot)),
+                vec![("google", "short", "unknown")]
+            );
+        }
+
+        #[test]
+        fn a_failed_providers_absent_snapshot_contributes_no_candidate() {
+            // `collect` never puts a failed source's provider in `snapshots` —
+            // see `provider_usage::live::sources::collect`. An empty slice is
+            // what a pass where every source failed looks like here.
+            assert!(usage_observed_candidates(&[]).is_empty());
+        }
+
+        #[test]
+        fn a_repeated_band_is_not_worth_a_second_event_but_a_changed_one_is() {
+            let mut last = BTreeMap::new();
+            assert!(usage_observed_is_new(
+                &last,
+                "anthropic",
+                "short",
+                "below_80"
+            ));
+            last.insert(("anthropic", "short"), "below_80");
+            assert!(!usage_observed_is_new(
+                &last,
+                "anthropic",
+                "short",
+                "below_80"
+            ));
+            assert!(usage_observed_is_new(
+                &last,
+                "anthropic",
+                "short",
+                "80_to_under_100"
+            ));
+            // A second provider's pair is judged independently of the first.
+            assert!(usage_observed_is_new(&last, "openai", "short", "below_80"));
+        }
+
         #[test]
         fn a_hidden_hud_cannot_consume_its_pending_origin() {
             let _lock = SUPPRESSION_TEST_LOCK.lock().unwrap();
@@ -1310,12 +1551,17 @@ mod enabled {
                     "success", "null",
                 ),
             );
+            LAST_USAGE_OBSERVED
+                .lock()
+                .unwrap()
+                .insert(("anthropic", "short"), "below_80");
 
             reset_suppression();
 
             assert!(scan_outcome_is_new(Some("1-9")));
             assert!(unrecognized_outcome_is_new(inert));
             assert_eq!(*LAST_CLAUDE_LIMIT_RESET.lock().unwrap(), None);
+            assert!(LAST_USAGE_OBSERVED.lock().unwrap().is_empty());
             reset_suppression();
         }
 

--- a/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/anthropic.rs
@@ -143,21 +143,12 @@ fn usage_band(value: &Value) -> &'static str {
     let Ok(usage) = parse_usage_value(value) else {
         return "unknown";
     };
-    let Some(percent) = usage
+    let percent = usage
         .windows
         .iter()
         .find(|window| matches!(window.role, WindowRole::PrimaryShort))
-        .and_then(|window| window.used_percent)
-    else {
-        return "unknown";
-    };
-    if percent >= 100.0 {
-        "at_limit"
-    } else if percent >= 80.0 {
-        "80_to_under_100"
-    } else {
-        "below_80"
-    }
+        .and_then(|window| window.used_percent);
+    super::model::band_for_percent(percent)
 }
 
 #[cfg(feature = "analytics")]

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -56,6 +56,8 @@ pub mod sources;
 mod tests;
 
 pub use milestones::{MilestoneContent, MilestoneLedger, milestone_content};
+#[cfg(feature = "analytics")]
+pub use model::band_for_percent;
 pub use model::{
     Confidence, Freshness, ProviderUsageError, ProviderUsageSnapshot, UsageScope, UsageWindow,
     UsageWindowKind, WindowRole,

--- a/apps/desktop/src-tauri/src/provider_usage/live/model.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/model.rs
@@ -93,6 +93,27 @@ impl ProviderUsageError {
     }
 }
 
+/// Reduce a consumed-capacity percentage to the coarse band two analytics
+/// events share: the Claude reset diagnostic, and the per-provider usage
+/// event.
+///
+/// `None` stays `unknown`. A window at 100% or more is `at_limit`; at 80% or
+/// more it is `80_to_under_100`; below that it is `below_80`. Sharing this one
+/// function keeps the two events' bands from silently drifting apart.
+#[cfg(feature = "analytics")]
+pub fn band_for_percent(percent: Option<f64>) -> &'static str {
+    let Some(percent) = percent else {
+        return "unknown";
+    };
+    if percent >= 100.0 {
+        "at_limit"
+    } else if percent >= 80.0 {
+        "80_to_under_100"
+    } else {
+        "below_80"
+    }
+}
+
 /// How important a window is when several apply at once.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WindowRole {
@@ -266,5 +287,15 @@ mod tests {
             "schema"
         );
         assert_eq!(ProviderUsageError::Unavailable.category(), "unavailable");
+    }
+
+    #[cfg(feature = "analytics")]
+    #[test]
+    fn the_usage_band_boundaries_match_what_the_reader_sees() {
+        assert_eq!(band_for_percent(None), "unknown");
+        assert_eq!(band_for_percent(Some(79.9)), "below_80");
+        assert_eq!(band_for_percent(Some(80.0)), "80_to_under_100");
+        assert_eq!(band_for_percent(Some(99.9)), "80_to_under_100");
+        assert_eq!(band_for_percent(Some(100.0)), "at_limit");
     }
 }

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -270,6 +270,11 @@ pub(crate) fn refresh_publish_and_evaluate(
     let collected = provider_usage::live::sources::collect(&live.sources, online, &hidden, max_age);
     let snapshots: Vec<provider_usage::live::milestones::LiveUsageSnapshot> =
         collected.snapshots.iter().map(milestone_snapshot).collect();
+    // Every provider this pass actually published a snapshot for, not only
+    // Claude — `collected.snapshots` already excludes a hidden or offline
+    // provider (see `sources::collect`), and a provider that failed this
+    // pass has no entry here at all.
+    crate::analytics::record_usage_observed(app, &collected.snapshots);
     let summary = provider_usage::live::summarize_collected(
         collected,
         provider_usage::live::roster(&live.sources, &hidden),

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,10 +1,11 @@
 # Anonymised analytics
 
 antiburn sends anonymised product events — which features get used, what
-breaks, and a coarse diagnostic of Claude's session-limit reset. This document is the complete account of
-that: every field, every event, what is deliberately excluded, what antiburn
-cannot promise, and how to verify all of it yourself without trusting this
-page.
+breaks, a coarse diagnostic of Claude's session-limit reset, and how close a
+connected provider's own usage windows run to their limit. This document is
+the complete account of that: every field, every event, what is deliberately
+excluded, what antiburn cannot promise, and how to verify all of it yourself
+without trusting this page.
 
 Official release builds start with analytics on. This includes the launch and
 fixed onboarding-step events. The first-run Ready screen explains the channel,
@@ -45,9 +46,9 @@ be put.
 | `properties.arch`    | CPU architecture.                                                                                                                                          | `aarch64`                 |
 | `properties.bucket`  | A count rounded into a range. Never exact.                                                                                                                 | `10-49`                   |
 | `properties.label`   | A key from a closed vocabulary — which surface, Settings pane, provider, setting, agent category, or failure category. Never work content or a user-selected value. | `activity`                |
-| `properties.detail`  | A second value from a closed vocabulary, such as a visible state, `user` or `automatic` origin, or `native` versus `wsl`.                                   | `ready`                   |
+| `properties.detail`  | A second value from a closed vocabulary, such as a visible state, `user` or `automatic` origin, `native` versus `wsl`, or a usage window's `short` or `long` role. | `ready`                   |
 | `properties.origin`  | Whether a state appeared after a `user` or `automatic` exposure. Optional and present only on `antiburn.surface_state_observed`.                             | `user`                    |
-| `properties.usageBand` | Claude's five-hour usage from the same reset-check response: `below_80`, `80_to_under_100`, `at_limit`, or `unknown`. | `80_to_under_100` |
+| `properties.usageBand` | How close a usage window runs to its limit: `below_80`, `80_to_under_100`, `at_limit`, or `unknown`. On the Claude reset event, Claude's five-hour usage from the same reset-check response; on `antiburn.usage_observed`, the window named by `detail`. | `80_to_under_100` |
 | `properties.responseShape` | Whether `juniper_tide` was an `object`, `missing`, `null`, or `malformed`; also `invalid_json`, `malformed_envelope`, `not_received`, `unreadable`, or `not_requested` for request and envelope outcomes. | `object` |
 | `properties.eligibility` | Claude's `eligible` boolean as `eligible` or `ineligible`, or `missing`, `null`, or `malformed`. | `eligible` |
 | `properties.ineligibleReason` | An allowlisted Claude reason: `tier`, `tenure`, `surface`, `mobile`, `cli_version`, `not_at_wall`, `weekly_limit`, `no_weekly_limit`, `other_experiment`, `extra_usage`, `unavailable`, `unknown`, or `other`; also `missing`, `null`, or `malformed`. | `not_at_wall` |
@@ -88,11 +89,13 @@ antiburn knows how to read. Nothing else about the session travels with it: not
 its title, not its repository, not its path, and not the name of your WSL
 distribution, which you chose and which would identify your machine.
 
-`antiburn.live_usage_state_observed` carries one of three provider categories:
-`anthropic`, `openai`, or `google`. The Claude reset event also reveals that
-Claude is enabled. These are the only analytics fields that identify an agent or
-provider category. If that is more than you want to share, the switch turns all
-analytics off.
+`antiburn.live_usage_state_observed` and `antiburn.usage_observed` each carry
+one of three provider categories: `anthropic`, `openai`, or `google`. The
+Claude reset event reveals that Claude is enabled; `usage_observed` reveals
+more broadly which of the three providers are enabled and visible, since it
+fires for whichever ones an ordinary refresh publishes a reading for. These
+are the only analytics fields that identify an agent or provider category. If
+that is more than you want to share, the switch turns all analytics off.
 
 ### Why counts are bucketed
 
@@ -133,6 +136,7 @@ Event names are namespaced `antiburn.*`.
 | `antiburn.error_occurred`      | A full discovery pass fails, and the previous full pass had not already reported the same failure.                                                                                                          | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                           |
 | `antiburn.unrecognized_records_observed` | Settings → Insights returns a cohort containing unknown record vocabulary, and its outcome differs from the last one reported during this run. | `bucket` — sessions containing unknown types. `label` — `inert_only`, `inert_capped`, or `evidence_bearing`. No discriminator, payload, session identifier, or second dimension. |
 | `antiburn.claude_limit_reset_observed` | After an ordinary Claude usage refresh, when analytics and Claude live usage are both enabled and the observation differs from the last one queued during this run. The probe uses a separate five-minute cooldown. | `label` — `success`, `authentication`, `rateLimited`, `unavailable`, `credential_absent`, `credential_expired`, or `credential_unavailable`. The nine reset fields listed above. No response body, credential, account identifier, exact usage percentage, or date. |
+| `antiburn.usage_observed`      | An ordinary live-usage refresh — a background tick or a visible one — publishes a usage window for a provider that is online and not hidden. Reports the first observation for each `(provider, window role)` pair in a run, then only when that pair's band changes. A provider that fails this pass has no window to report and its last reported band is left alone. Reveals which providers are enabled, at worst a handful of times per install per day. | `label` — `anthropic`, `openai`, or `google`, the same vocabulary `live_usage_state_observed` uses. `detail` — `short` or `long`, the window's role. `usageBand` — `below_80`, `80_to_under_100`, `at_limit`, or `unknown`. A window without an authoritative figure still reports; the band is coarse enough to stay useful either way. No percentage, timestamp, window id, scope, account, or model name. |
 
 Several events are deliberately not sent once per occurrence. A full scan result
 that repeats the last bucket is dropped, so a machine left running does not
@@ -177,6 +181,23 @@ event preserves missing, null, and malformed field states, and keeps eligibility
 experiment membership, arm, and availability separate so contradictory server
 states remain visible. It sends only the presence of `next_available_at`, because
 the exact date adds little diagnostic value and reveals more timing detail.
+
+`antiburn.usage_observed` answers a narrower, provider-agnostic question the
+Claude reset diagnostic cannot: how often installs run near or at a limit, per
+provider and per window, across every provider antiburn can meter — not only
+Claude. It fires wherever the Claude reset probe's own gates already fire —
+analytics configured and enabled, live usage active, the provider not
+hidden — but at the boundary every ordinary refresh publishes its snapshot
+from, background ticks and popover-triggered refreshes alike. Only a
+provider's short (five-hour or session) and long (weekly or billing-period)
+windows are in scope; a supplemental or provider-specific window is not part
+of this coarse picture. A provider with both windows reports both, once each,
+the first time they are seen in a run and again only when a window's band
+changes; a provider that fails a pass contributes nothing and does not clear
+what was last reported for it, so a transient failure cannot be mistaken for a
+drop back below the limit. Windows the provider marked non-authoritative —
+derived rather than stated — still report, because a coarse band tolerates
+that imprecision better than the exact percentage the Usage surface shows.
 
 The `inert_capped` label covers either too many distinct unknown types or one
 type name that exceeds the local string limit. The event never sends those


### PR DESCRIPTION
## Product question

How often are installs near or at a provider limit, per provider and per window? Nothing answers this today. The only band data rides on `antiburn.claude_limit_reset_observed`, which is Claude-only and fires on the reset probe's own cadence, not on an ordinary refresh.

## Event contract: `antiburn.usage_observed`

- **Trigger:** an ordinary live-usage refresh (a background tick or a visible, user-triggered one) publishes a `ProviderUsageSnapshot` for a provider. Instrumented in `usage_alerts.rs::refresh_publish_and_evaluate`, the one boundary every refresh path already funnels through — right after `sources::collect()` produces snapshots and before `summarize_collected()` consumes them — so it covers every provider, not only Claude.
- **Properties** (all `&'static str`, all from closed vocabularies):
  - `label` — `anthropic`, `openai`, or `google`: the exact vocabulary `antiburn.live_usage_state_observed` already uses, validated through a new `LiveUsageProvider::from_provider_id` closed mapping so a future provider id can't silently widen what a label can say.
  - `detail` — `short` or `long`, mapped from `UsageWindow`'s `WindowRole` (`PrimaryShort`/`PrimaryLong` only — a supplemental or provider-named window is out of scope, the same narrowing the milestone engine already applies). A provider with both windows reports both.
  - `usageBand` — `below_80`, `80_to_under_100`, `at_limit`, or `unknown`, from a new shared `band_for_percent(Option<f64>) -> &'static str` that both this event and the Claude reset diagnostic's `usage_band` now call, so the two bands can't drift apart.
  - Nothing else — no percentage, timestamp, window id, scope, account, or model name.
- **Duplicate rule:** first observation per `(provider, window role)` in a run, then only when that pair's band changes. Kept in an in-memory `Mutex<BTreeMap<(&'static str, &'static str), &'static str>>` (`LAST_USAGE_OBSERVED`), cleared on opt-out like every other suppression hint in the module. A failed refresh has no snapshot for that provider, so it records nothing and leaves the memory untouched — a transient failure can't be mistaken for a drop back under the limit. Non-authoritative windows still report, since the band is coarse enough to tolerate a derived figure.
- **Gates:** the same `allowed(app)` gate as every other event, plus the same conditions the Claude reset probe already applies (live usage active, provider not hidden) — satisfied for free, since `sources::collect()` already excludes an offline or hidden provider's snapshot before this code ever sees it.
- **Owner/rate:** worst case a handful of events per install per day.
- **What it reveals:** which of the three providers are enabled and visible on an install, more broadly than the Claude reset event's narrower "Claude is enabled" signal.

## Analytics coverage

Closes the gap `docs/analytics-measurement.md` calls out: the Claude reset diagnostic "answers a narrow provider experiment question" and nothing covered usage-band prevalence for the other providers at all. Tests cover trigger/outcome (a window at 85% yields the `80_to_under_100` band), duplicate suppression (same band → nothing, changed band → one event, a second provider independent), a failed refresh (no snapshot → nothing, memory kept), the band boundaries (79.9/80/99.9/100/`None`), the closed label vocabulary rejecting an unknown provider id, and role filtering (short/long only; supplemental, provider-named, and unrecognized roles skipped).

## Docs

`docs/analytics.md` gets a catalog row for `antiburn.usage_observed`, updated `label`/`detail`/`usageBand` field descriptions, an updated "Agent and provider categories" section, and an explanatory paragraph mirroring the Claude-reset one. `apps/desktop/src/views/settings/PrivacyPane.tsx` was checked and left unchanged: it names property categories generically ("provider") rather than enumerating individual events or provider ids, so nothing there goes stale.

## Test plan

From `apps/desktop/src-tauri`:
- [x] `cargo fmt --check` — pass
- [x] `cargo clippy --all-targets -- -D warnings` — pass, 0 warnings
- [x] `cargo clippy --all-targets --features analytics -- -D warnings` — pass, 0 warnings
- [x] `cargo test --no-fail-fast` — 998 passed, 0 failed
- [x] `ANTIBURN_ANALYTICS_URL=http://127.0.0.1:8787 ANTIBURN_ANALYTICS_OPERATOR="Local development" cargo test --features analytics --no-fail-fast` — 1050 passed, 0 failed

From the repo root:
- [x] `pnpm run slop:all` — score 100, 0 issues
- [x] `pnpm run secrets` — clean, no findings

No TypeScript was touched, so the frontend `lint`/`type-check` checks do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgb9MRK64vLCyxbHaSasqe