### PR TITLE
chore(release): prepare antiburn-local 0.6.1

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -17,6 +17,13 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-09-08
+
+### Added
+
+- API support notes now identify the batch-analysis, repository-orchestration,
+  and serialized-metrics interfaces retained for external embeddings.
+
 ## [0.6.0] - 2026-09-07
 
 ### Added

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "antiburn-local"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MIT"


### PR DESCRIPTION
The engine subtree changed after 0.6.0, which blocks the desktop 0.4.1 release gate. This bumps `antiburn-local` to 0.6.1, records the retained external embedding APIs, and refreshes both lockfiles so the engine can be tagged before the app release.

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `node scripts/verify-release-version.mjs engine antiburn-local-v0.6.1`
- `git diff --check`

The release metadata change does not alter runtime behavior, privacy, analytics, or performance.
