### PR TITLE
chore(release): prepare antiburn 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-08
+
+### Changed
+
+- Session limit badges now retain cumulative estimates across provider resets,
+  keeping usage attributed in earlier periods visible alongside the current
+  provider period.
+
+### Fixed
+
+- Session rows now show `0%` when valid provider usage remains flat during a
+  percentage plateau instead of treating the allocation as missing.
+
 ## [0.4.0] - 2026-09-07
 
 ### Added

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "antiburn-anchored-window",
  "antiburn-hud",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/anchored-window", "crates/hud", "crates/nudge", "crates/sound
 
 [package]
 name = "antiburn"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
This prepares desktop 0.4.1 after the prerequisite `antiburn-local` 0.6.1 release. Session limit badges retain cumulative estimates across provider resets, and valid flat usage plateaus now display as `0%` instead of missing.

Validation:

- `node scripts/verify-release-version.mjs app antiburn-v0.4.1`
- `git diff --check`
- The release metadata diff is limited to the four app version declarations and `CHANGELOG.md`.

`node scripts/verify-app-engine-release.mjs` will pass after the prerequisite 0.6.1 engine PR is merged and tagged.

The shipped feature changes already passed their full frontend, shell, engine, analytics, privacy, and performance checks before merging to `main`. This PR changes release metadata only.
