### PR TITLE
feat(desktop): add main window and persistent Activity sidebar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       - "/crates/antiburn-local"
       - "/apps/desktop/src-tauri"
       - "/apps/desktop/src-tauri/crates/nudge"
+      - "/apps/desktop/src-tauri/crates/main-window"
       - "/apps/desktop/src-tauri/crates/sound"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test the CI control plane
-        run: node --test scripts/build-tool-catalog.test.mjs scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/mem-report.test.mjs scripts/verify-linux-appimage.test.mjs scripts/third-party-notices.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
+        run: node --test scripts/build-tool-catalog.test.mjs scripts/check-design-drift.test.mjs scripts/classify-ci-changes.test.mjs scripts/mem-report.test.mjs scripts/window-open-report.test.mjs scripts/verify-linux-appimage.test.mjs scripts/third-party-notices.test.mjs scripts/verify-app-engine-release.test.mjs scripts/wait-for-main-ci.test.mjs
 
       # The drift guard runs here, not in a classified job. It reads the
       # contract, the stylesheets, and the popover window's own corner
@@ -201,6 +201,10 @@ jobs:
         working-directory: apps/desktop/src-tauri/crates/hud
         run: cargo fmt --check
 
+      - name: Check main-window crate formatting
+        working-directory: apps/desktop/src-tauri/crates/main-window
+        run: cargo fmt --check
+
   desktop-backend-checks:
     name: desktop app (backend, ${{ matrix.check.name }}, ${{ matrix.workspace.name }}, ${{ matrix.platform.name }})
     needs: classify
@@ -231,6 +235,9 @@ jobs:
             tauri: false
           - name: HUD
             directory: apps/desktop/src-tauri/crates/hud
+            tauri: true
+          - name: main-window
+            directory: apps/desktop/src-tauri/crates/main-window
             tauri: true
     runs-on: ${{ matrix.platform.os }}
     steps:

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -484,6 +484,7 @@ objc2-core-data@0.3.2 | Zlib OR Apache-2.0 OR MIT | https://github.com/madsmtm/o
 objc2-core-foundation@0.3.2 | Zlib OR Apache-2.0 OR MIT | https://github.com/madsmtm/objc2
 objc2-core-graphics@0.3.2 | Zlib OR Apache-2.0 OR MIT | https://github.com/madsmtm/objc2
 objc2-core-image@0.3.2 | Zlib OR Apache-2.0 OR MIT | https://github.com/madsmtm/objc2
+objc2-core-services@0.3.2 | Zlib OR Apache-2.0 OR MIT | https://github.com/madsmtm/objc2
 objc2-core-text@0.3.2 | Zlib OR Apache-2.0 OR MIT | https://github.com/madsmtm/objc2
 objc2-core-video@0.3.2 | Zlib OR Apache-2.0 OR MIT | https://github.com/madsmtm/objc2
 objc2-encode@4.1.0 | MIT | https://github.com/madsmtm/objc2
@@ -649,6 +650,7 @@ tauri-plugin-dialog@2.7.3 | Apache-2.0 OR MIT | https://github.com/tauri-apps/pl
 tauri-plugin-fs@2.5.2 | Apache-2.0 OR MIT | https://github.com/tauri-apps/plugins-workspace
 tauri-plugin-opener@2.5.5 | Apache-2.0 OR MIT | https://github.com/tauri-apps/plugins-workspace
 tauri-plugin-prevent-default@5.0.2 | MIT | https://github.com/ferreira-tb/tauri-plugin-prevent-default
+tauri-plugin-single-instance@2.4.4 | Apache-2.0 OR MIT | https://github.com/tauri-apps/plugins-workspace
 tauri-plugin-updater@2.11.0 | Apache-2.0 OR MIT | https://github.com/tauri-apps/plugins-workspace
 tauri-plugin@2.6.3 | Apache-2.0 OR MIT | https://github.com/tauri-apps/tauri
 tauri-runtime-wry@2.11.4 | Apache-2.0 OR MIT | https://github.com/tauri-apps/tauri
@@ -2046,6 +2048,7 @@ Used by:
   objc2-core-foundation@0.3.2
   objc2-core-graphics@0.3.2
   objc2-core-image@0.3.2
+  objc2-core-services@0.3.2
   objc2-core-text@0.3.2
   objc2-core-video@0.3.2
   objc2-encode@4.1.0
@@ -2067,6 +2070,7 @@ Used by:
   tauri-plugin-dialog@2.7.3
   tauri-plugin-fs@2.5.2
   tauri-plugin-opener@2.5.5
+  tauri-plugin-single-instance@2.4.4
   tauri-plugin-updater@2.11.0
   tauri-plugin@2.6.3
   tauri-runtime-wry@2.11.4

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,7 +1,7 @@
 # antiburn desktop
 
-The antiburn desktop application: a menu-bar / system-tray shell around the
-local [`antiburn-local`](../../crates/antiburn-local) engine.
+The antiburn desktop application: a main window and menu-bar / system-tray
+companion around the local [`antiburn-local`](../../crates/antiburn-local) engine.
 
 The app discovers the coding-agent sessions already on this machine, analyzes
 them with the engine, and shows activity, per-session analysis, and
@@ -56,7 +56,7 @@ Run from the repository root:
 
 ```bash
 pnpm install
-pnpm --filter @antiburn/desktop dev          # Tauri dev build (tray + popover)
+pnpm --filter @antiburn/desktop dev          # Tauri dev build (main window + tray)
 pnpm --filter @antiburn/desktop dev:web      # frontend only, in a browser
 pnpm --filter @antiburn/desktop dev:bundle   # bundled debug .app / installer
 pnpm --filter @antiburn/desktop lint
@@ -97,6 +97,11 @@ The macOS-only [memory reporting runbook](../../docs/runbooks/memory-reporting.m
 documents the probe-enabled release measurement, Steve setup, and result
 interpretation.
 
+The [main-window validation runbook](../../docs/runbooks/main-window.md) covers
+native lifecycle checks, opening latency, and hidden-window resource use. Run
+Rust formatting, Clippy, and tests from `src-tauri/crates/main-window` as well
+as the shell when changing the main-window mechanism.
+
 `rusqlite` is compiled from bundled sources, so neither CI nor a checkout needs
 a system SQLite.
 
@@ -119,12 +124,23 @@ See [Desktop window renderer lifecycle](../../docs/window-renderer-lifecycle.md)
 for the shared readiness handshake, onboarding prewarm, popover eviction,
 Settings teardown, and the memory rules behind those policies.
 
+- **Main window.** Explicit launch opens the main window after onboarding.
+  It uses native window controls and participates in application switching.
+  Closing hides it while monitoring continues; opening it again reuses the
+  renderer. On macOS, switching away and Command-Tabbing back restores a main
+  window that was closed or minimized earlier. Restoration uses the native
+  unminimize operation. Tray interactions and login startup stay quiet.
+  The initial content size is
+  900×600 logical pixels with a normal minimum of 800×560. The initial outer
+  frame is capped at 85% of each usable display dimension. Saved user sizes
+  retain their dimensions within the available work area. The navigation shell
+  uses a persistent 220px sidebar with dense desktop rows. Activity is the only main sidebar item and contains
+  placeholders until product views migrate; see the
+  [main-window validation runbook](../../docs/runbooks/main-window.md).
 - **Tray item.** Primary click toggles the popover. Secondary click opens a
-  menu with Pin Window, Settings, and Quit. The Settings sidebar ends in the
-  same Quit action — an agent application has no Dock icon and no application
-  menu, so those two are the only places a reader can look for the way out.
-  Both go through the shell's `exit(0)`, which is what distinguishes a
-  deliberate quit from the window closes the shell suppresses. On macOS the
+  menu with Open antiburn, Pin Window, Settings, and Quit. Native application
+  menus also provide Quit. Explicit Quit stops the
+  application; closing the main window does not. On macOS the
   item stays highlighted for as long as the popover is open: the system's own
   highlight is momentary and lets go on mouse-up, so the shell drives it, and
   clears it again on every path that puts the popover away.
@@ -150,8 +166,8 @@ Settings teardown, and the memory rules behind those policies.
   it is unfinished the tray click goes here rather than to the popover, which
   has nothing to show yet, and antiburn is an ordinary Dock application so the
   window can be reached again once something else takes focus. Finishing it
-  puts the window away, drops the Dock icon, and posts the one notification
-  that says where the app now lives, anchored under that glyph.
+  puts the onboarding window away, opens the main window, and retains the Dock
+  icon. The existing notification still identifies the menu-bar companion.
 - **Settings.** An ordinary decorated window, created on demand and destroyed
   on close. A source list on the left, one pane on the right; every control
   writes through immediately, so there is no Save button and no dirty state.

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -11,6 +11,7 @@ sources:
   - src/styles/motion.css
   - src/styles/platform-controls.css
   - src/styles/hud.css
+  - src/styles/main-window.css
   - src/styles/session-analysis-colors.css
   - src/styles/session-rows.css
   - src/styles/session-detail.css
@@ -466,3 +467,18 @@ Notes for what isn't expressible as a token:
   where it means a category: blue for context, the token series colors for in/out, yellow and
   pink for cache marks, brand orange for a compaction, teal for real work, red for waste.
   Everything else stays greyscale until the pointer names a layer.
+- **Main window** — the retained main window opens at 900 × 600 logical pixels with a normal
+  minimum of 800 × 560. The initial outer frame uses at most 85% of each usable display dimension,
+  including native chrome. A smaller work area takes precedence over the normal minimum. Saved
+  user sizes can exceed the initial cap and remain constrained to the usable work area. It paints the opaque
+  `surface-window` canvas. On macOS its 40px overlay titlebar remains a drag region and leaves the
+  native traffic lights visible. Double-clicking this strip toggles maximize and restore through
+  Tauri's drag-region handler. Windows and Linux retain their native bars, so this surface adds no
+  top strip there. Multi-pane content keeps the documented 220px sidebar visible at every size.
+  Main navigation uses 28px rows, 2px vertical gaps, 14px icons, and 8px icon-to-label gaps.
+  These local geometry rules use the spacing tokens in `main-window.css`; other source lists
+  retain their current density. Activity is the only main sidebar item. Settings remains available through the tray and native menus.
+  The first main row starts at 48px on macOS, clear of the drag strip. The content region scrolls
+  independently of the title strip. A view switch is immediate: the window does not animate navigation. Use the
+  documented type scale and keyboard-only focus treatment. Hidden or minimized main windows suspend
+  presentation work; blur alone does not suspend it. Native close hides this renderer for reuse.

--- a/apps/desktop/knip.json
+++ b/apps/desktop/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["src/settings.tsx", "src/onboarding.tsx", "src/styles.css"],
+  "entry": ["src/main-window.tsx", "src/settings.tsx", "src/onboarding.tsx", "src/styles.css"],
   "project": ["src/**/*.{ts,tsx,css}"],
   "ignoreDependencies": ["@tauri-apps/cli"]
 }

--- a/apps/desktop/main.html
+++ b/apps/desktop/main.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>antiburn</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main-window.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "license": "MIT",
-  "description": "antiburn desktop application: menu-bar/tray shell over the local antiburn engine.",
+  "description": "antiburn desktop application for local coding-agent session analysis.",
   "scripts": {
     "dev": "node scripts/run-tauri.mjs dev --config src-tauri/tauri.debug.conf.json",
     "dev:bundle": "node scripts/run-tauri.mjs build --debug --config src-tauri/tauri.debug.conf.json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@
 # neither member nor excluded aborts resolution outright ("multiple workspace
 # roots found in the same workspace").
 [workspace]
-exclude = ["crates/anchored-window", "crates/hud", "crates/nudge", "crates/sound", "crates/trace"]
+exclude = ["crates/anchored-window", "crates/hud", "crates/main-window", "crates/nudge", "crates/sound", "crates/trace"]
 
 [package]
 name = "antiburn"
@@ -59,6 +59,9 @@ antiburn-nudge = { path = "crates/nudge" }
 # The floating usage HUD window: mechanism only. The shell owns its session
 # activity policy and IPC commands.
 antiburn-hud = { path = "crates/hud" }
+# The ordinary application window mechanism. The shell owns persistence,
+# readiness, startup intent, and IPC policy.
+antiburn-main-window = { path = "crates/main-window" }
 # Reusable anchored companion window mechanism. The shell owns targets and IPC policy.
 antiburn-anchored-window = { path = "crates/anchored-window" }
 # The notification chime uses samples synthesized in-process. It has no audio
@@ -120,6 +123,9 @@ tauri-plugin-opener = "2"
 # The plugin prevents browser-only menus and shortcuts in application webviews.
 # The explicit policy in `src/webview_defaults.rs` keeps focus traversal intact.
 tauri-plugin-prevent-default = "5"
+# Must be registered before other plugins so a repeated launch exits before it
+# can start another background scan scheduler.
+tauri-plugin-single-instance = "2"
 # Emits structured shell events through the process subscriber.
 tracing = "0.1"
 # RFC 3339 stamps for the store's own timestamps.
@@ -162,11 +168,11 @@ smappservice-rs = "0.1"
 # popover (`src/global_click.rs`). Feature lists are the exact set those files
 # touch.
 objc2 = "0.6"
-# Block construction for the global monitor and the resign-active observer
+# Block construction for the global monitor and the activation observers
 # (the `block2` features below).
 block2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSCell", "NSControl", "NSView", "NSResponder", "NSColor", "NSFont", "NSFontDescriptor", "NSAttributedString", "NSEvent", "block2"] }
-objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSAttributedString", "NSDictionary", "NSValue", "NSObject", "NSURL", "NSError", "NSNotification", "NSOperation", "block2"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSAppleEventDescriptor", "NSAppleEventManager", "NSAttributedString", "NSDictionary", "NSValue", "NSObject", "NSURL", "NSError", "NSNotification", "NSOperation", "block2", "objc2-core-services"] }
 # Subclasses the popover into a non-activating NSPanel (`src/popover/panel.rs`),
 # so opening it does not deactivate the frontmost application. The rev must
 # match the nudge crate's pin so both share one plugin registration.

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -3,11 +3,6 @@
 <!--
   Merged into the generated macOS bundle Info.plist by tauri-bundler.
 
-  LSUIElement makes antiburn an agent application: it lives in the menu bar
-  with no Dock icon and no menu-bar app menu. The shell applies the same
-  policy at runtime (NSApplication accessory activation policy) so unbundled
-  development runs behave identically.
-
   The three folder usage descriptions are the text macOS shows inside its own
   consent dialog. Without them the system falls back to generic copy at
   precisely the moment the reader is deciding whether to trust the request, so
@@ -21,8 +16,6 @@
 -->
 <plist version="1.0">
   <dict>
-    <key>LSUIElement</key>
-    <true/>
     <key>NSDocumentsFolderUsageDescription</key>
     <string>antiburn looks for the git repositories your coding agents worked in. It reads repository names and locations only, and nothing leaves this Mac.</string>
     <key>NSDesktopFolderUsageDescription</key>

--- a/apps/desktop/src-tauri/capabilities/main.json
+++ b/apps/desktop/src-tauri/capabilities/main.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-window",
+  "description": "Minimal permissions for the ordinary main window. Data and privileged work stay behind explicit shell commands.",
+  "windows": ["main"],
+  "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
+    "core:window:allow-start-dragging",
+    "core:window:allow-internal-toggle-maximize",
+    "allow-get-settings",
+    "allow-main-window-ready"
+  ]
+}

--- a/apps/desktop/src-tauri/crates/main-window/Cargo.lock
+++ b/apps/desktop/src-tauri/crates/main-window/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,128 +33,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "alsa"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
-dependencies = [
- "alsa-sys",
- "bitflags 2.13.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "alsa-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "antiburn"
-version = "0.4.1"
-dependencies = [
- "antiburn-anchored-window",
- "antiburn-hud",
- "antiburn-local",
- "antiburn-main-window",
- "antiburn-nudge",
- "antiburn-sound",
- "antiburn-trace",
- "anyhow",
- "async-trait",
- "base64 0.23.1",
- "block2",
- "getrandom 0.4.3",
- "hmac",
- "libc",
- "notify",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "reqwest",
- "rusqlite",
- "rustls",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "smappservice-rs",
- "tauri",
- "tauri-build",
- "tauri-nspanel",
- "tauri-plugin-dialog",
- "tauri-plugin-opener",
- "tauri-plugin-prevent-default",
- "tauri-plugin-single-instance",
- "tauri-plugin-updater",
- "tempfile",
- "time",
- "tokio",
- "tracing",
- "windows-sys 0.61.2",
- "winreg 0.56.0",
-]
-
-[[package]]
-name = "antiburn-anchored-window"
-version = "0.1.0"
-dependencies = [
- "gtk",
- "objc2-app-kit",
- "serde",
- "tauri",
- "tokio",
- "tracing",
- "windows 0.62.2",
-]
-
-[[package]]
-name = "antiburn-hud"
-version = "0.1.0"
-dependencies = [
- "objc2-app-kit",
- "serde",
- "serde_json",
- "tauri",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "antiburn-local"
-version = "0.6.1"
-dependencies = [
- "anyhow",
- "async-trait",
- "libc",
- "postcard",
- "rusqlite",
- "serde",
- "serde_json",
- "time",
- "tokio",
- "tracing",
- "uuid",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -178,195 +50,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "antiburn-nudge"
-version = "0.1.0"
-dependencies = [
- "block2",
- "core-foundation 0.10.1",
- "core-graphics",
- "gio 0.22.9",
- "gtk",
- "objc2",
- "objc2-foundation",
- "objc2-intents",
- "objc2-user-notifications",
- "serde",
- "tauri",
- "tauri-nspanel",
- "tracing",
- "windows 0.62.2",
- "zbus",
-]
-
-[[package]]
-name = "antiburn-sound"
-version = "0.1.0"
-dependencies = [
- "fundsp",
- "rodio",
- "tracing",
-]
-
-[[package]]
-name = "antiburn-trace"
-version = "0.1.0"
-dependencies = [
- "time",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "async-trait"
-version = "0.1.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
 
 [[package]]
 name = "atk"
@@ -375,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
 dependencies = [
  "atk-sys",
- "glib 0.18.5",
+ "glib",
  "libc",
 ]
 
@@ -385,10 +72,10 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
 dependencies = [
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "glib-sys",
+ "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -457,16 +144,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -476,19 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -540,12 +205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,7 +221,7 @@ checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
  "bitflags 2.13.1",
  "cairo-sys-rs",
- "glib 0.18.5",
+ "glib",
  "libc",
  "once_cell",
  "thiserror 1.0.69",
@@ -574,9 +233,9 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
- "glib-sys 0.18.1",
+ "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -623,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -655,17 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
-dependencies = [
- "smallvec",
- "target-lexicon 0.13.5",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -687,44 +336,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.20",
-]
-
-[[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
 ]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
@@ -734,16 +353,6 @@ checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -769,7 +378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -782,52 +391,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
-]
-
-[[package]]
-name = "coreaudio-rs"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "objc2-audio-toolbox",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "cpal"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
-dependencies = [
- "alsa",
- "coreaudio-rs",
- "dasp_sample",
- "jni 0.21.1",
- "js-sys",
- "libc",
- "mach2",
- "ndk",
- "ndk-context",
- "num-derive",
- "num-traits",
- "objc2",
- "objc2-audio-toolbox",
- "objc2-avf-audio",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-foundation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows 0.62.2",
 ]
 
 [[package]]
@@ -840,37 +405,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crypto-common"
@@ -878,17 +434,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -931,15 +478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,12 +510,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "dasp_sample"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dbus"
@@ -1031,17 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,20 +589,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "const-oid",
- "crypto-common 0.2.2",
- "ctutils",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1125,7 +634,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1218,12 +727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "either"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
-
-[[package]]
 name = "embed-resource"
 version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,9 +735,9 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "vswhom",
- "winreg 0.55.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1242,54 +745,6 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "equivalent"
@@ -1309,54 +764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
-dependencies = [
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
-name = "extended"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,17 +779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fft-convolver"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb4fbed063c755ecaa4cd1356cd82cc48e9d5c7edd5c30cd144656833fc0661"
-dependencies = [
- "realfft",
- "rtsan-standalone",
- "thiserror 2.0.20",
-]
-
-[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,29 +789,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1448,7 +835,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1467,56 +854,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "fundsp"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6969e5c9d5c5c704723f547237494fde9b1addf16f718f65cd786b3b6e320a4f"
-dependencies = [
- "dyn-clone",
- "fft-convolver",
- "funutd",
- "hashbrown 0.16.1",
- "libm",
- "microfft",
- "num-complex",
- "numeric-array",
- "once_cell",
- "resampler",
- "symphonia",
- "thingbuf",
- "tinyvec",
- "wide",
-]
-
-[[package]]
-name = "funutd"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f658de1fbeca3b70faf090e33d1ecf32b0efd1805bede4a8fd6ef562b7ab83"
-dependencies = [
- "dyn-clone",
- "glam",
- "hashbrown 0.14.5",
- "libm",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1543,19 +886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +893,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1603,8 +933,8 @@ dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
  "gdk-sys",
- "gio 0.18.4",
- "glib 0.18.5",
+ "gio",
+ "glib",
  "libc",
  "pango",
 ]
@@ -1616,8 +946,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
 dependencies = [
  "gdk-pixbuf-sys",
- "gio 0.18.4",
- "glib 0.18.5",
+ "gio",
+ "glib",
  "libc",
  "once_cell",
 ]
@@ -1628,11 +958,11 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
 dependencies = [
- "gio-sys 0.18.1",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -1643,13 +973,13 @@ checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
- "gio-sys 0.18.1",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -1659,11 +989,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
 dependencies = [
  "gdk-sys",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "glib-sys",
+ "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -1674,8 +1004,8 @@ checksum = "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe"
 dependencies = [
  "gdk",
  "gdkx11-sys",
- "gio 0.18.4",
- "glib 0.18.5",
+ "gio",
+ "glib",
  "libc",
  "x11",
 ]
@@ -1687,9 +1017,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
 dependencies = [
  "gdk-sys",
- "glib-sys 0.18.1",
+ "glib-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
  "x11",
 ]
 
@@ -1701,16 +1031,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "generic-array"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337d46834ee672ab3e48caca2cb0c78cc174fb12b3a68d0d88f99a0519a5e36e"
-dependencies = [
- "rustversion",
- "typenum",
 ]
 
 [[package]]
@@ -1757,8 +1077,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "gio-sys 0.18.1",
- "glib 0.18.5",
+ "gio-sys",
+ "glib",
  "libc",
  "once_cell",
  "pin-project-lite",
@@ -1767,55 +1087,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "gio"
-version = "0.22.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b399f4650bb52c051f3fdf49a234e8a27ab5725c8cd774556c55eee64b2c0350"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "gio-sys 0.22.9",
- "glib 0.22.9",
- "libc",
- "pin-project-lite",
- "smallvec",
-]
-
-[[package]]
 name = "gio-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "glib-sys",
+ "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
  "winapi",
-]
-
-[[package]]
-name = "gio-sys"
-version = "0.22.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28739f914c15b87a9856000bed9cbd5b3a8afbca5e982d9a299e1601422cb5"
-dependencies = [
- "glib-sys 0.22.9",
- "gobject-sys 0.22.9",
- "libc",
- "system-deps 9.0.0",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "glam"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -1830,35 +1111,15 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
- "gio-sys 0.18.1",
- "glib-macros 0.18.5",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
  "libc",
  "memchr",
  "once_cell",
  "smallvec",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "glib"
-version = "0.22.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b9b8d350db41f690ec1b87109f202782748bbd8ab2f2ede17cb40d29e2838c"
-dependencies = [
- "bitflags 2.13.1",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-task",
- "futures-util",
- "glib-macros 0.22.9",
- "glib-sys 0.22.9",
- "gobject-sys 0.22.9",
- "libc",
- "memchr",
- "smallvec",
 ]
 
 [[package]]
@@ -1876,35 +1137,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "glib-macros"
-version = "0.22.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9597c68fa7bdf4154a3079642cd21c4dccac0b0bdd2897d82861523bf91e7b9"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "glib-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps 6.2.2",
-]
-
-[[package]]
-name = "glib-sys"
-version = "0.22.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b38907e67e40dec9b60f858bcada952598719cb512a13eb13d6cdcd16f8295"
-dependencies = [
- "libc",
- "system-deps 9.0.0",
+ "system-deps",
 ]
 
 [[package]]
@@ -1919,20 +1158,9 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
- "glib-sys 0.18.1",
+ "glib-sys",
  "libc",
- "system-deps 6.2.2",
-]
-
-[[package]]
-name = "gobject-sys"
-version = "0.22.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07595c9ba696bd9819cb6a8df39f08078f3dd679508fe052dd558492c2053834"
-dependencies = [
- "glib-sys 0.22.9",
- "libc",
- "system-deps 9.0.0",
+ "system-deps",
 ]
 
 [[package]]
@@ -1947,8 +1175,8 @@ dependencies = [
  "futures-channel",
  "gdk",
  "gdk-pixbuf",
- "gio 0.18.4",
- "glib 0.18.5",
+ "gio",
+ "glib",
  "gtk-sys",
  "gtk3-macros",
  "libc",
@@ -1966,12 +1194,12 @@ dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk-sys",
- "gio-sys 0.18.1",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -1995,39 +1223,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -2042,25 +1240,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.3",
-]
 
 [[package]]
 name = "html5ever"
@@ -2112,19 +1295,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2138,21 +1312,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -2173,11 +1332,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2216,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2230,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2243,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2257,16 +1414,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2277,15 +1435,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2324,19 +1482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png 0.18.1",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2369,58 +1514,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
-dependencies = [
- "bitflags 2.13.1",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
-
-[[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "itoa"
@@ -2435,7 +1532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc"
 dependencies = [
  "bitflags 1.3.2",
- "glib 0.18.5",
+ "glib",
  "javascriptcore-rs-sys",
 ]
 
@@ -2445,10 +1542,10 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124"
 dependencies = [
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "glib-sys",
+ "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -2521,36 +1618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.20",
- "walkdir",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2623,38 +1690,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
 dependencies = [
- "glib 0.18.5",
+ "glib",
  "gtk",
  "gtk-sys",
  "libappindicator-sys",
@@ -2698,42 +1739,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2746,18 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "mach2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
-dependencies = [
- "libc",
-]
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "markup5ever"
@@ -2768,15 +1777,6 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -2795,27 +1795,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "microfft"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b6673eb0cc536241d6734c2ca45abfdbf90e9e7791c66a36a7ba3c315b76cf"
-dependencies = [
- "cfg-if",
- "num-complex",
- "static_assertions",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minisign-verify"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2828,25 +1811,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.2"
+name = "miniz_oxide"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.61.2",
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
+name = "mio"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
- "num-traits",
- "pxfm",
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2886,12 +1868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,96 +1883,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "notify"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
-dependencies = [
- "bitflags 2.13.1",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -3005,17 +1895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -3041,16 +1920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numeric-array"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a6096447d657bfba01c49d38338b6c8e68e0e34d595360345375b798a4a765"
-dependencies = [
- "generic-array 1.4.5",
- "num-traits",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,41 +1937,8 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "libc",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
-]
-
-[[package]]
-name = "objc2-audio-toolbox"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "objc2",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-avf-audio"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
-dependencies = [
- "objc2",
  "objc2-foundation",
 ]
 
@@ -3118,35 +1954,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-audio"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
-dependencies = [
- "dispatch2",
- "objc2",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-audio-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
-dependencies = [
- "bitflags 2.13.1",
- "objc2",
-]
-
-[[package]]
 name = "objc2-core-data"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3158,9 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
 ]
 
@@ -3198,18 +2008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-services"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
-dependencies = [
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-security",
-]
-
-[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,19 +2017,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.13.1",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -3257,21 +2042,8 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "libc",
  "objc2",
  "objc2-core-foundation",
- "objc2-core-services",
-]
-
-[[package]]
-name = "objc2-intents"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fac082e6de12282b24ea745e9707cd374363c7ae0b2f813bf1813cfc289325"
-dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
 ]
 
 [[package]]
@@ -3286,18 +2058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-osa-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
-dependencies = [
- "bitflags 2.13.1",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
-]
-
-[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3307,30 +2067,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-security"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
-dependencies = [
- "bitflags 2.13.1",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-service-management"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
-dependencies = [
- "block2",
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
- "objc2-security",
 ]
 
 [[package]]
@@ -3360,8 +2096,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
- "bitflags 2.13.1",
- "block2",
  "objc2",
  "objc2-foundation",
 ]
@@ -3387,51 +2121,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "open"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
-dependencies = [
- "dunce",
- "is-wsl",
- "libc",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "osakit"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
-dependencies = [
- "objc2",
- "objc2-foundation",
- "objc2-osa-kit",
- "serde",
- "serde_json",
- "thiserror 2.0.20",
-]
 
 [[package]]
 name = "pango"
@@ -3439,8 +2132,8 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
 dependencies = [
- "gio 0.18.4",
- "glib 0.18.5",
+ "gio",
+ "glib",
  "libc",
  "once_cell",
  "pango-sys",
@@ -3452,17 +2145,11 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
 dependencies = [
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "glib-sys",
+ "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3486,12 +2173,6 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "pastey"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -3553,41 +2234,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkg-config"
@@ -3597,12 +2247,12 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+checksum = "2896bade328c13f7042a297ea5ac5b0951f6cf989dea5f32c2fd98da398195cb"
 dependencies = [
- "base64 0.22.1",
- "indexmap 2.14.0",
+ "base64 0.23.1",
+ "indexmap 2.14.2",
  "quick-xml",
  "serde",
  "time",
@@ -3618,7 +2268,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3631,21 +2281,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3656,30 +2292,18 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
-]
-
-[[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3695,15 +2319,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "primal-check"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
-dependencies = [
- "num-integer",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3768,16 +2383,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
-
-[[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -3810,15 +2419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "realfft"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
-dependencies = [
- "rustfft",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,22 +2440,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3895,28 +2495,21 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3926,109 +2519,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "resampler"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f5ab61459422b1a350caae1aadef48ebae234b12e80248e9ba9557018ef060"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "rfd"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
-dependencies = [
- "block2",
- "dispatch2",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
- "gtk-sys",
- "js-sys",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
- "raw-window-handle",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rodio"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
-dependencies = [
- "cpal",
- "dasp_sample",
- "num-rational",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "rtsan-standalone"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd1b6d61d69481a68e555916d3a52213846f5c2d2140bdc74ebc308e2338fc3"
-dependencies = [
- "rtsan-standalone-macros",
- "rtsan-standalone-sys",
-]
-
-[[package]]
-name = "rtsan-standalone-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8320af894782374141c8e0d4521ee613a8f24d7ab08b6ad359881311e37b9ef"
-dependencies = [
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "rtsan-standalone-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362a9c531f731e574a870cdb28ee7d81178ba7a87ed54380eb9b8d8f0c3b5301"
-dependencies = [
- "num_cpus",
- "tempfile",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
-dependencies = [
- "bitflags 2.13.1",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]
@@ -4047,125 +2537,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustfft"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "primal-check",
- "strength_reduce",
- "transpose",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.13.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.22.4",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "safe_arch"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "same-file"
@@ -4174,15 +2549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4241,29 +2607,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "selectors"
@@ -4333,7 +2676,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4368,7 +2711,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4390,18 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_with"
 version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,7 +2743,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -4472,28 +2803,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.1",
- "digest 0.11.3",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4503,36 +2814,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4548,21 +2833,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "smappservice-rs"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52703b97a53101cf5d4580e0737aaa634ce1fdcfc123c16b2a9658e358013488"
-dependencies = [
- "objc2",
- "objc2-foundation",
- "objc2-service-management",
- "thiserror 2.0.20",
-]
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -4603,8 +2876,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f"
 dependencies = [
  "futures-channel",
- "gio 0.18.4",
- "glib 0.18.5",
+ "gio",
+ "glib",
  "libc",
  "soup3-sys",
 ]
@@ -4615,11 +2888,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27"
 dependencies = [
- "gio-sys 0.18.1",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
  "libc",
- "system-deps 6.2.2",
+ "system-deps",
 ]
 
 [[package]]
@@ -4627,18 +2900,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -4671,236 +2932,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "swift-rs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7"
+checksum = "e45c444e496845d3f2a351146bff59aae4975b2280238df1dfaa0c7d1846f38e"
 dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "symphonia"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
-dependencies = [
- "lazy_static",
- "symphonia-bundle-flac",
- "symphonia-bundle-mp3",
- "symphonia-codec-aac",
- "symphonia-codec-adpcm",
- "symphonia-codec-alac",
- "symphonia-codec-pcm",
- "symphonia-codec-vorbis",
- "symphonia-core",
- "symphonia-format-caf",
- "symphonia-format-isomp4",
- "symphonia-format-mkv",
- "symphonia-format-ogg",
- "symphonia-format-riff",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-bundle-flac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-bundle-mp3"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-codec-aac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-adpcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
-dependencies = [
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-alac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
-dependencies = [
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-pcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
-dependencies = [
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-vorbis"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-core"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "bytemuck",
- "lazy_static",
- "log",
-]
-
-[[package]]
-name = "symphonia-format-caf"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-format-isomp4"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
-dependencies = [
- "encoding_rs",
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-mkv"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-ogg"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-riff"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
-dependencies = [
- "extended",
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-metadata"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
-dependencies = [
- "encoding_rs",
- "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
@@ -4926,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4956,49 +2995,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr 0.15.8",
+ "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
- "version-compare",
-]
-
-[[package]]
-name = "system-deps"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0dae2cbca1f0ff93795713cfe0a4c02f760e3c0b8ae2ab4ec4045808ff429f"
-dependencies = [
- "cfg-expr 0.20.9",
- "heck 0.5.0",
- "pkg-config",
- "toml 1.1.4+spec-1.1.0",
  "version-compare",
 ]
 
@@ -5010,7 +3015,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -5020,7 +3025,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "ndk",
@@ -5036,7 +3041,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5054,27 +3059,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -5093,8 +3081,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "image",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "mime",
@@ -5125,7 +3112,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -5166,7 +3153,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "syn 2.0.119",
  "tauri-utils",
  "thiserror 2.0.20",
@@ -5191,161 +3178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-nspanel"
-version = "2.1.0"
-source = "git+https://github.com/ahkohd/tauri-nspanel?rev=a3122e894383aa068ec5365a42994e3ac94ba1b6#a3122e894383aa068ec5365a42994e3ac94ba1b6"
-dependencies = [
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "pastey",
- "tauri",
-]
-
-[[package]]
-name = "tauri-plugin"
-version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
-dependencies = [
- "anyhow",
- "glob",
- "plist",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri-utils",
- "walkdir",
-]
-
-[[package]]
-name = "tauri-plugin-dialog"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
-dependencies = [
- "log",
- "raw-window-handle",
- "rfd",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "tauri-plugin-fs",
- "thiserror 2.0.20",
- "url",
-]
-
-[[package]]
-name = "tauri-plugin-fs"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
-dependencies = [
- "anyhow",
- "dunce",
- "glob",
- "log",
- "objc2-foundation",
- "percent-encoding",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_repr",
- "tauri",
- "tauri-plugin",
- "tauri-utils",
- "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
- "url",
-]
-
-[[package]]
-name = "tauri-plugin-opener"
-version = "2.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d60366174b745b4ef5824b8bbc1c457fd08f0ce101ff643c0a49181a9f4e91"
-dependencies = [
- "dunce",
- "glob",
- "objc2-app-kit",
- "objc2-foundation",
- "open",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.20",
- "url",
- "windows 0.61.3",
- "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-prevent-default"
-version = "5.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674bac5c9831f4ca7ae42840768ac968b76353dcbe30bb0aad149c56f0be1389"
-dependencies = [
- "bitflags 2.13.1",
- "itertools",
- "serde",
- "strum",
- "tauri",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "tauri-plugin-single-instance"
-version = "2.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0cb5c412a5071b69bab6a6df1583cbb89460d4a83b6a24769b08d15b6b1e1"
-dependencies = [
- "serde",
- "serde_json",
- "tauri",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "windows-sys 0.60.2",
- "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-updater"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
-dependencies = [
- "base64 0.22.1",
- "dirs",
- "flate2",
- "futures-util",
- "http",
- "infer",
- "log",
- "minisign-verify",
- "osakit",
- "percent-encoding",
- "reqwest",
- "rustls",
- "semver",
- "serde",
- "serde_json",
- "tar",
- "tauri",
- "tauri-plugin",
- "tempfile",
- "thiserror 2.0.20",
- "time",
- "tokio",
- "url",
- "windows-sys 0.60.2",
- "zip",
-]
-
-[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5355,7 +3187,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni 0.21.1",
+ "jni",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5367,7 +3199,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -5378,7 +3210,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni 0.21.1",
+ "jni",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5392,7 +3224,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "wry",
 ]
 
@@ -5427,7 +3259,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -5442,20 +3274,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.4+spec-1.1.0",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -5465,15 +3284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
-]
-
-[[package]]
-name = "thingbuf"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662b54ef6f7b4e71f683dadc787bbb2d8e8ef2f91b682ebed3164a5a7abca905"
-dependencies = [
- "pin-project",
 ]
 
 [[package]]
@@ -5513,16 +3323,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
-dependencies = [
- "cfg-if",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5557,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5567,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5590,31 +3391,8 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]
@@ -5648,7 +3426,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5659,11 +3437,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5705,7 +3483,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -5716,7 +3494,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -5729,7 +3507,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -5802,19 +3580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -5824,52 +3590,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "serde",
- "serde_json",
- "sharded-slab",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-serde",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
 ]
 
 [[package]]
 name = "tray-icon"
-version = "0.24.1"
-source = "git+https://github.com/tauri-apps/tray-icon.git?rev=0ada43072646fe4454b1f969f4f446dc401fa1aa#0ada43072646fe4454b1f969f4f446dc401fa1aa"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -5904,17 +3631,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "unic-char-property"
@@ -5970,12 +3686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6017,18 +3727,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -6098,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6111,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6121,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6131,22 +3829,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6166,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6196,11 +3894,11 @@ dependencies = [
  "cairo-rs",
  "gdk",
  "gdk-sys",
- "gio 0.18.4",
- "gio-sys 0.18.1",
- "glib 0.18.5",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "gio",
+ "gio-sys",
+ "glib",
+ "glib-sys",
+ "gobject-sys",
  "gtk",
  "gtk-sys",
  "javascriptcore-rs",
@@ -6219,24 +3917,15 @@ dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
  "gdk-sys",
- "gio-sys 0.18.1",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
  "gtk-sys",
  "javascriptcore-rs-sys",
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps 6.2.2",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
+ "system-deps",
 ]
 
 [[package]]
@@ -6247,7 +3936,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6271,18 +3960,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.20",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "wide"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]
@@ -6337,23 +4016,11 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -6363,15 +4030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6408,18 +4066,7 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading 0.1.0",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6464,27 +4111,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6534,29 +4160,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -6592,28 +4200,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6623,15 +4214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6656,12 +4238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6672,12 +4248,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6692,22 +4262,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6722,12 +4280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6738,12 +4290,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6758,12 +4304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6774,12 +4314,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6816,16 +4350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
-dependencies = [
- "cfg-if",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6833,9 +4357,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wry"
@@ -6855,7 +4379,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni 0.21.1",
+ "jni",
  "libc",
  "ndk",
  "objc2",
@@ -6867,7 +4391,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2 0.10.9",
+ "sha2",
  "soup3",
  "tao-macros",
  "thiserror 2.0.20",
@@ -6875,7 +4399,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -6903,16 +4427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6933,96 +4447,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "5.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-lite",
- "hex",
- "libc",
- "ordered-stream",
- "rustix",
- "serde",
- "serde_repr",
- "tracing",
- "uds_windows",
- "uuid",
- "windows-sys 0.61.2",
- "winnow 1.0.4",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
-dependencies = [
- "serde",
- "winnow 1.0.4",
- "zvariant",
-]
-
-[[package]]
-name = "zcheapstr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -7047,16 +4471,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-
-[[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7065,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7076,70 +4494,23 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
-name = "zip"
-version = "4.6.1"
+name = "zlib-rs"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "indexmap 2.14.0",
- "memchr",
-]
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
-
-[[package]]
-name = "zvariant"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "winnow 1.0.4",
- "zcheapstr",
- "zvariant_derive",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 3.0.3",
- "winnow 1.0.4",
-]

--- a/apps/desktop/src-tauri/crates/main-window/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/main-window/Cargo.toml
@@ -1,0 +1,21 @@
+# Standalone package. The shell excludes this nested workspace and uses it as a
+# path dependency. This crate owns only the ordinary main window mechanism.
+[workspace]
+
+[package]
+name = "antiburn-main-window"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.97"
+description = "The ordinary main window mechanism for the antiburn desktop app."
+license = "MIT"
+repository = "https://github.com/antiburn/antiburn"
+publish = false
+
+[lib]
+name = "antiburn_main_window"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+tauri = { version = "2", features = ["macos-private-api"] }

--- a/apps/desktop/src-tauri/crates/main-window/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/main-window/src/lib.rs
@@ -1,0 +1,599 @@
+//! The native mechanism for the ordinary antiburn window.
+//!
+//! The desktop shell owns renderer readiness, persistence, and launch policy.
+
+use serde::{Deserialize, Serialize};
+use tauri::webview::PageLoadPayload;
+use tauri::{AppHandle, PhysicalRect, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+
+/// The stable label used by native events and capabilities.
+pub const LABEL: &str = "main";
+/// The dedicated frontend entry.
+pub const URL: &str = "main.html";
+/// The first inner width in logical pixels.
+pub const DEFAULT_WIDTH: f64 = 900.0;
+/// The first inner height in logical pixels.
+pub const DEFAULT_HEIGHT: f64 = 600.0;
+/// The minimum inner width in logical pixels.
+pub const MIN_WIDTH: f64 = 800.0;
+/// The minimum inner height in logical pixels.
+pub const MIN_HEIGHT: f64 = 560.0;
+
+const INITIAL_WORK_AREA_FRACTION: f64 = 0.85;
+
+/// The last normal bounds and maximized state, in physical pixels.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Placement {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub maximized: bool,
+    #[serde(default = "unit_scale")]
+    pub scale_factor: f64,
+}
+
+/// A new hidden renderer and the normal bounds applied before maximization.
+pub struct BuiltWindow {
+    pub window: WebviewWindow,
+    pub placement: Option<Placement>,
+}
+
+const fn unit_scale() -> f64 {
+    1.0
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Frame {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+}
+
+impl From<&PhysicalRect<i32, u32>> for Frame {
+    fn from(rect: &PhysicalRect<i32, u32>) -> Self {
+        Self {
+            x: rect.position.x,
+            y: rect.position.y,
+            width: rect.size.width,
+            height: rect.size.height,
+        }
+    }
+}
+
+/// Build a hidden decorated window and apply a valid saved placement.
+pub fn build<F>(
+    app: &AppHandle,
+    initialization_script: String,
+    placement: Option<&Placement>,
+    on_page_load: F,
+) -> tauri::Result<BuiltWindow>
+where
+    F: Fn(WebviewWindow, PageLoadPayload<'_>) + Send + Sync + 'static,
+{
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
+    let mut builder = WebviewWindowBuilder::new(app, LABEL, WebviewUrl::App(URL.into()))
+        .initialization_script(initialization_script)
+        .title("antiburn")
+        .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        .resizable(true)
+        .maximizable(true)
+        .decorations(true)
+        .skip_taskbar(false)
+        .visible(false)
+        .on_page_load(on_page_load);
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true);
+    }
+
+    let window = builder.build()?;
+    // Geometry failure must not leak a hidden label that blocks every retry.
+    // Keep the usable default window and let the shell persist its later move.
+    let applied = apply_placement(&window, placement).ok();
+    Ok(BuiltWindow {
+        window,
+        placement: applied,
+    })
+}
+
+/// Show and focus an existing renderer.
+pub fn reveal(window: &WebviewWindow) -> tauri::Result<()> {
+    window.show()?;
+    window.unminimize()?;
+    window.set_focus()
+}
+
+/// Hide the window without destroying its renderer.
+pub fn conceal(window: &WebviewWindow) -> tauri::Result<()> {
+    window.hide()
+}
+
+/// Capture normal bounds without replacing them with maximized bounds.
+pub fn capture(window: &WebviewWindow, previous: Option<&Placement>) -> Option<Placement> {
+    let maximized = window.is_maximized().ok()?;
+    if maximized {
+        return previous.cloned().map(|mut placement| {
+            placement.maximized = true;
+            placement
+        });
+    }
+    let position = window.outer_position().ok()?;
+    let size = window.inner_size().ok()?;
+    let scale_factor = window.scale_factor().ok()?;
+    Some(Placement {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+        maximized: false,
+        scale_factor,
+    })
+}
+
+fn apply_placement(
+    window: &WebviewWindow,
+    placement: Option<&Placement>,
+) -> tauri::Result<Placement> {
+    let monitors = window.available_monitors()?;
+    let frames: Vec<Frame> = monitors
+        .iter()
+        .map(|monitor| Frame::from(monitor.work_area()))
+        .collect();
+    let primary = window
+        .primary_monitor()?
+        .map(|monitor| Frame::from(monitor.work_area()));
+    let active = window.cursor_position().ok().and_then(|cursor| {
+        #[cfg(target_os = "macos")]
+        {
+            let primary_scale = window.primary_monitor().ok()??.scale_factor();
+            let monitor = window
+                .monitor_from_point(cursor.x / primary_scale, cursor.y / primary_scale)
+                .ok()??;
+            let frame = Frame::from(monitor.work_area());
+            frames.iter().position(|item| *item == frame)
+        }
+        #[cfg(not(target_os = "macos"))]
+        monitors.iter().position(|monitor| {
+            let area = monitor.work_area();
+            cursor.x >= f64::from(area.position.x)
+                && cursor.x < f64::from(area.position.x) + f64::from(area.size.width)
+                && cursor.y >= f64::from(area.position.y)
+                && cursor.y < f64::from(area.position.y) + f64::from(area.size.height)
+        })
+    });
+    #[cfg(target_os = "macos")]
+    let saved_monitor = placement.and_then(|saved| {
+        monitor_for_saved_scaled(
+            saved,
+            &frames,
+            &monitors
+                .iter()
+                .map(tauri::Monitor::scale_factor)
+                .collect::<Vec<_>>(),
+        )
+    });
+    #[cfg(not(target_os = "macos"))]
+    let saved_monitor = placement.and_then(|saved| monitor_for_saved(saved, &frames));
+    let target_index = saved_monitor
+        .or(active)
+        .or_else(|| primary.and_then(|frame| frames.iter().position(|item| *item == frame)))
+        .unwrap_or(0);
+    let scale = monitors
+        .get(target_index)
+        .map_or(1.0, tauri::Monitor::scale_factor);
+    let outer = window.outer_size()?;
+    let inner = window.inner_size()?;
+    let current_scale = window.scale_factor()?;
+    let chrome_width =
+        (f64::from(outer.width.saturating_sub(inner.width)) / current_scale * scale).round() as u32;
+    let chrome_height = (f64::from(outer.height.saturating_sub(inner.height)) / current_scale
+        * scale)
+        .round() as u32;
+
+    let fallback = frames.get(target_index).copied().or(primary);
+    #[cfg(target_os = "macos")]
+    let normalized = placement
+        .filter(|_| saved_monitor.is_some())
+        .map(|saved| placement_at_scale(saved, scale));
+    #[cfg(target_os = "macos")]
+    let placement = normalized.as_ref();
+    let target_frames: Vec<Frame> = fallback.into_iter().collect();
+    let target = validated_placement(
+        placement,
+        &target_frames,
+        fallback,
+        scale,
+        chrome_width,
+        chrome_height,
+    );
+    #[cfg(target_os = "macos")]
+    {
+        // AppKit uses logical dimensions before an asynchronous display move completes.
+        let size = tauri::LogicalSize::new(
+            f64::from(target.width) / target.scale_factor,
+            f64::from(target.height) / target.scale_factor,
+        );
+        window.set_min_size(Some(tauri::LogicalSize::new(
+            MIN_WIDTH.min(size.width),
+            MIN_HEIGHT.min(size.height),
+        )))?;
+        window.set_size(size)?;
+        window.set_position(tauri::LogicalPosition::new(
+            f64::from(target.x) / target.scale_factor,
+            f64::from(target.y) / target.scale_factor,
+        ))?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let min_width = ((MIN_WIDTH * scale).round() as u32).min(target.width.max(1));
+        let min_height = ((MIN_HEIGHT * scale).round() as u32).min(target.height.max(1));
+        window.set_min_size(Some(tauri::PhysicalSize::new(min_width, min_height)))?;
+        window.set_size(tauri::PhysicalSize::new(target.width, target.height))?;
+        window.set_position(tauri::PhysicalPosition::new(target.x, target.y))?;
+    }
+    if target.maximized {
+        window.maximize()?;
+    }
+    Ok(target)
+}
+
+fn validated_placement(
+    saved: Option<&Placement>,
+    monitors: &[Frame],
+    primary: Option<Frame>,
+    scale: f64,
+    chrome_width: u32,
+    chrome_height: u32,
+) -> Placement {
+    let fallback = primary
+        .or_else(|| monitors.first().copied())
+        .unwrap_or(Frame {
+            x: 0,
+            y: 0,
+            width: DEFAULT_WIDTH as u32,
+            height: DEFAULT_HEIGHT as u32,
+        });
+    let scale = if scale.is_finite() && scale > 0.0 {
+        scale
+    } else {
+        1.0
+    };
+    let min_width = (MIN_WIDTH * scale).round() as u32;
+    let min_height = (MIN_HEIGHT * scale).round() as u32;
+
+    let Some(saved) = saved else {
+        return centered_default(fallback, scale, chrome_width, chrome_height);
+    };
+    let Some(frame) = monitor_for_saved(saved, monitors).map(|index| monitors[index]) else {
+        return centered_default(fallback, scale, chrome_width, chrome_height);
+    };
+
+    let saved_scale = if saved.scale_factor.is_finite() && saved.scale_factor > 0.0 {
+        saved.scale_factor
+    } else {
+        1.0
+    };
+    let max_width = frame.width.saturating_sub(chrome_width).max(1);
+    let max_height = frame.height.saturating_sub(chrome_height).max(1);
+    let restored_width = (f64::from(saved.width) / saved_scale * scale).round() as u32;
+    let restored_height = (f64::from(saved.height) / saved_scale * scale).round() as u32;
+    let width = restored_width.clamp(min_width.min(max_width), max_width);
+    let height = restored_height.clamp(min_height.min(max_height), max_height);
+    let outer_width = width.saturating_add(chrome_width).min(frame.width);
+    let outer_height = height.saturating_add(chrome_height).min(frame.height);
+    let max_x = i64::from(frame.x) + i64::from(frame.width.saturating_sub(outer_width));
+    let max_y = i64::from(frame.y) + i64::from(frame.height.saturating_sub(outer_height));
+    Placement {
+        x: i64::from(saved.x).clamp(i64::from(frame.x), max_x) as i32,
+        y: i64::from(saved.y).clamp(i64::from(frame.y), max_y) as i32,
+        width,
+        height,
+        maximized: saved.maximized,
+        scale_factor: scale,
+    }
+}
+
+fn centered_default(frame: Frame, scale: f64, chrome_width: u32, chrome_height: u32) -> Placement {
+    let max_width = ((f64::from(frame.width) * INITIAL_WORK_AREA_FRACTION).floor() as u32)
+        .saturating_sub(chrome_width)
+        .max(1);
+    let max_height = ((f64::from(frame.height) * INITIAL_WORK_AREA_FRACTION).floor() as u32)
+        .saturating_sub(chrome_height)
+        .max(1);
+    let width = ((DEFAULT_WIDTH * scale).round() as u32).min(max_width);
+    let height = ((DEFAULT_HEIGHT * scale).round() as u32).min(max_height);
+    let outer_width = width.saturating_add(chrome_width).min(frame.width);
+    let outer_height = height.saturating_add(chrome_height).min(frame.height);
+    Placement {
+        x: frame.x + ((frame.width - outer_width) / 2) as i32,
+        y: frame.y + ((frame.height - outer_height) / 2) as i32,
+        width,
+        height,
+        maximized: false,
+        scale_factor: scale,
+    }
+}
+
+fn monitor_for_saved(saved: &Placement, monitors: &[Frame]) -> Option<usize> {
+    monitors
+        .iter()
+        .enumerate()
+        .map(|(index, frame)| (index, overlap(saved, *frame)))
+        .filter(|(_, area)| *area > 0)
+        .max_by_key(|(_, area)| *area)
+        .map(|(index, _)| index)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn placement_at_scale(saved: &Placement, scale: f64) -> Placement {
+    let previous_scale = if saved.scale_factor.is_finite() && saved.scale_factor > 0.0 {
+        saved.scale_factor
+    } else {
+        1.0
+    };
+    let ratio = scale / previous_scale;
+    Placement {
+        x: (f64::from(saved.x) * ratio).round() as i32,
+        y: (f64::from(saved.y) * ratio).round() as i32,
+        width: (f64::from(saved.width) * ratio).round() as u32,
+        height: (f64::from(saved.height) * ratio).round() as u32,
+        maximized: saved.maximized,
+        scale_factor: scale,
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn monitor_for_saved_scaled(
+    saved: &Placement,
+    monitors: &[Frame],
+    scales: &[f64],
+) -> Option<usize> {
+    monitors
+        .iter()
+        .zip(scales)
+        .enumerate()
+        .map(|(index, (frame, scale))| {
+            let area = overlap(&placement_at_scale(saved, *scale), *frame) as f64 / scale.powi(2);
+            (index, area)
+        })
+        .filter(|(_, area)| *area > 0.0)
+        .max_by(|(_, left), (_, right)| left.total_cmp(right))
+        .map(|(index, _)| index)
+}
+
+fn overlap(saved: &Placement, frame: Frame) -> u64 {
+    let left = i64::from(saved.x).max(i64::from(frame.x));
+    let top = i64::from(saved.y).max(i64::from(frame.y));
+    let right = (i64::from(saved.x) + i64::from(saved.width))
+        .min(i64::from(frame.x) + i64::from(frame.width));
+    let bottom = (i64::from(saved.y) + i64::from(saved.height))
+        .min(i64::from(frame.y) + i64::from(frame.height));
+    u64::try_from((right - left).max(0)).unwrap_or_default()
+        * u64::try_from((bottom - top).max(0)).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRIMARY: Frame = Frame {
+        x: 0,
+        y: 24,
+        width: 1_440,
+        height: 876,
+    };
+
+    #[test]
+    fn default_geometry_centers_inside_the_work_area() {
+        assert_eq!(
+            validated_placement(None, &[PRIMARY], Some(PRIMARY), 1.0, 0, 0),
+            Placement {
+                x: 270,
+                y: 162,
+                width: 900,
+                height: 600,
+                maximized: false,
+                scale_factor: 1.0,
+            }
+        );
+    }
+
+    #[test]
+    fn restored_geometry_is_clamped_to_its_visible_work_area() {
+        let saved = Placement {
+            x: -200,
+            y: -100,
+            width: 2_000,
+            height: 200,
+            maximized: true,
+            scale_factor: 1.0,
+        };
+        assert_eq!(
+            validated_placement(Some(&saved), &[PRIMARY], Some(PRIMARY), 1.0, 0, 0),
+            Placement {
+                x: 0,
+                y: 24,
+                width: 1_440,
+                height: 560,
+                maximized: true,
+                scale_factor: 1.0,
+            }
+        );
+    }
+
+    #[test]
+    fn saved_small_window_expands_to_the_desktop_minimum() {
+        let saved = Placement {
+            x: 100,
+            y: 100,
+            width: 560,
+            height: 420,
+            maximized: false,
+            scale_factor: 1.0,
+        };
+        let restored = validated_placement(Some(&saved), &[PRIMARY], Some(PRIMARY), 1.0, 0, 0);
+        assert_eq!((restored.width, restored.height), (800, 560));
+    }
+
+    #[test]
+    fn disconnected_monitor_geometry_uses_the_primary_default() {
+        let saved = Placement {
+            x: 8_000,
+            y: 5_000,
+            width: 900,
+            height: 600,
+            maximized: false,
+            scale_factor: 1.0,
+        };
+        assert_eq!(
+            validated_placement(Some(&saved), &[PRIMARY], Some(PRIMARY), 1.0, 0, 0),
+            validated_placement(None, &[PRIMARY], Some(PRIMARY), 1.0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn overlap_selects_the_monitor_with_most_of_the_window() {
+        let secondary = Frame {
+            x: 1_440,
+            y: 0,
+            width: 1_920,
+            height: 1_080,
+        };
+        let saved = Placement {
+            x: 1_300,
+            y: 100,
+            width: 1_000,
+            height: 700,
+            maximized: false,
+            scale_factor: 1.0,
+        };
+        assert_eq!(monitor_for_saved(&saved, &[PRIMARY, secondary]), Some(1));
+    }
+
+    #[test]
+    fn logical_size_survives_a_scale_factor_change() {
+        let saved = Placement {
+            x: 10,
+            y: 40,
+            width: 1_100,
+            height: 720,
+            maximized: false,
+            scale_factor: 1.0,
+        };
+        let retina = Frame {
+            x: 0,
+            y: 0,
+            width: 3_000,
+            height: 2_000,
+        };
+        let restored = validated_placement(Some(&saved), &[retina], Some(retina), 2.0, 0, 0);
+        assert_eq!((restored.width, restored.height), (2_200, 1_440));
+    }
+
+    #[test]
+    fn tiny_work_area_takes_precedence_over_the_normal_minimum() {
+        let tiny = Frame {
+            x: 20,
+            y: 30,
+            width: 640,
+            height: 440,
+        };
+        let placement = validated_placement(None, &[tiny], Some(tiny), 1.0, 16, 40);
+        assert_eq!((placement.x, placement.y), (68, 63));
+        assert_eq!((placement.width, placement.height), (528, 334));
+    }
+
+    #[test]
+    fn retina_default_keeps_its_logical_dimensions() {
+        let retina = Frame {
+            x: 0,
+            y: 66,
+            width: 3_024,
+            height: 1_920,
+        };
+        let placement = validated_placement(None, &[retina], Some(retina), 2.0, 0, 0);
+        assert_eq!((placement.width, placement.height), (1_800, 1_200));
+        assert!(!placement.maximized);
+    }
+
+    #[test]
+    fn saved_user_size_is_not_limited_by_the_initial_cap() {
+        let saved = Placement {
+            x: 0,
+            y: 24,
+            width: 1_400,
+            height: 850,
+            maximized: false,
+            scale_factor: 1.0,
+        };
+        assert_eq!(
+            validated_placement(Some(&saved), &[PRIMARY], Some(PRIMARY), 1.0, 0, 0),
+            saved
+        );
+    }
+
+    #[test]
+    fn mixed_scale_monitor_selection_uses_logical_overlap() {
+        let primary = Frame {
+            x: 0,
+            y: 0,
+            width: 2_880,
+            height: 1_800,
+        };
+        let external = Frame {
+            x: 1_440,
+            y: 0,
+            width: 1_920,
+            height: 1_080,
+        };
+        let saved = Placement {
+            x: 1_500,
+            y: 40,
+            width: 900,
+            height: 600,
+            maximized: false,
+            scale_factor: 1.0,
+        };
+        assert_eq!(
+            monitor_for_saved_scaled(&saved, &[primary, external], &[2.0, 1.0]),
+            Some(1)
+        );
+        let scaled_external = Frame {
+            x: 2_880,
+            y: 0,
+            width: 3_840,
+            height: 2_160,
+        };
+        assert_eq!(
+            monitor_for_saved_scaled(&saved, &[primary, scaled_external], &[2.0, 2.0]),
+            Some(1)
+        );
+        let normalized = placement_at_scale(&saved, 2.0);
+        assert_eq!(
+            (
+                normalized.x,
+                normalized.y,
+                normalized.width,
+                normalized.height
+            ),
+            (3_000, 80, 1_800, 1_200)
+        );
+        assert_eq!(
+            validated_placement(
+                Some(&normalized),
+                &[scaled_external],
+                Some(scaled_external),
+                2.0,
+                0,
+                0
+            ),
+            normalized
+        );
+    }
+}

--- a/apps/desktop/src-tauri/permissions/autogenerated/main_window_ready.toml
+++ b/apps/desktop/src-tauri/permissions/autogenerated/main_window_ready.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-main-window-ready"
+description = "Enables the main_window_ready command without any pre-configured scope."
+commands.allow = ["main_window_ready"]
+
+[[permission]]
+identifier = "deny-main-window-ready"
+description = "Denies the main_window_ready command without any pre-configured scope."
+commands.deny = ["main_window_ready"]

--- a/apps/desktop/src-tauri/src/app_commands.rs
+++ b/apps/desktop/src-tauri/src/app_commands.rs
@@ -42,6 +42,7 @@ macro_rules! with_app_commands {
             commands::list_recent_sessions => "list_recent_sessions",
             commands::list_repositories => "list_repositories",
             commands::list_scan_roots => "list_scan_roots",
+            commands::main_window_ready => "main_window_ready",
             commands::note_interaction => "note_interaction",
             commands::open_analytics_documentation => "open_analytics_documentation",
             commands::open_folder_access_settings => "open_folder_access_settings",

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -78,6 +78,16 @@ pub fn window_ready(window: tauri::WebviewWindow, generation: u64) {
     }
 }
 
+/// Reveal the main window after its renderer commits its shell.
+#[tauri::command]
+pub fn main_window_ready(window: tauri::WebviewWindow, generation: u64) {
+    if window.label() == crate::main_window::LABEL {
+        crate::main_window::renderer_ready(&window, generation);
+    } else {
+        ::tracing::debug!(event = "main_window_ready_ignored", window = window.label());
+    }
+}
+
 /// Record when the popover's first activity and cached usage state settle.
 #[tauri::command]
 pub fn popover_content_ready(window: tauri::WebviewWindow, generation: u64) {
@@ -110,6 +120,7 @@ pub fn take_settings_pane(app: tauri::AppHandle) -> Option<String> {
 /// background tasks are aborted on the way out.
 #[tauri::command]
 pub fn quit_app(app: tauri::AppHandle) {
+    crate::main_window::flush_placement(&app);
     app.exit(0);
 }
 

--- a/apps/desktop/src-tauri/src/global_click.rs
+++ b/apps/desktop/src-tauri/src/global_click.rs
@@ -30,15 +30,18 @@
 //!
 //! macOS-only; a no-op elsewhere.
 
-/// Install the global mouse-down monitor and the resign-active observer for
-/// the app's lifetime.
+/// Install the global mouse monitor and the activation observers for the app's
+/// lifetime.
 ///
 /// Call once from `setup`, on the main thread, after the tray and the popover
 /// exist.
 #[cfg(target_os = "macos")]
 pub fn install(app: &tauri::AppHandle) {
     use block2::RcBlock;
-    use objc2_app_kit::{NSApplicationDidResignActiveNotification, NSEvent, NSEventMask};
+    use objc2_app_kit::{
+        NSApplicationDidBecomeActiveNotification, NSApplicationDidResignActiveNotification,
+        NSEvent, NSEventMask,
+    };
     use objc2_foundation::{NSNotification, NSNotificationCenter};
 
     let click_app = app.clone();
@@ -77,6 +80,23 @@ pub fn install(app: &tauri::AppHandle) {
     };
     // Kept for the app's lifetime, for the same reason as the monitor token
     // above. The notification center holds its own copy of the block.
+    std::mem::forget(observer);
+
+    let activate_app = app.clone();
+    let activate_handler =
+        RcBlock::new(move |_notification: core::ptr::NonNull<NSNotification>| {
+            crate::main_window::restore_after_activation(&activate_app);
+        });
+    // SAFETY: the notification name and the block's signature match
+    // Foundation's API. AppKit posts this notification on the main thread.
+    let observer = unsafe {
+        center.addObserverForName_object_queue_usingBlock(
+            Some(NSApplicationDidBecomeActiveNotification),
+            None,
+            None,
+            &activate_handler,
+        )
+    };
     std::mem::forget(observer);
 }
 

--- a/apps/desktop/src-tauri/src/launch_intent.rs
+++ b/apps/desktop/src-tauri/src/launch_intent.rs
@@ -1,0 +1,97 @@
+//! Distinguish explicit opens from background startup without changing preferences.
+
+use std::ffi::OsStr;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LaunchIntent {
+    Explicit,
+    Background,
+}
+
+/// Read launch arguments, including the executable at index zero.
+pub(crate) fn from_args<I, S>(arguments: I) -> LaunchIntent
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    if arguments
+        .into_iter()
+        .skip(1)
+        .take_while(|argument| argument.as_ref() != OsStr::new("--"))
+        .any(|argument| argument.as_ref() == OsStr::new("--background"))
+    {
+        LaunchIntent::Background
+    } else {
+        LaunchIntent::Explicit
+    }
+}
+
+/// Call during Tauri setup while the macOS launch event remains current.
+pub(crate) fn current() -> LaunchIntent {
+    if from_args(std::env::args_os()) == LaunchIntent::Background || launched_at_login() {
+        LaunchIntent::Background
+    } else {
+        LaunchIntent::Explicit
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn launched_at_login() -> bool {
+    use objc2_foundation::NSAppleEventManager;
+
+    let Some(event) = NSAppleEventManager::sharedAppleEventManager().currentAppleEvent() else {
+        return false;
+    };
+    let property = event
+        .paramDescriptorForKeyword(u32::from_be_bytes(*b"prdt"))
+        .map(|descriptor| descriptor.enumCodeValue());
+    is_login_event(event.eventID(), property)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn launched_at_login() -> bool {
+    false
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn is_login_event(event_id: u32, property: Option<u32>) -> bool {
+    event_id == u32::from_be_bytes(*b"oapp") && property == Some(u32::from_be_bytes(*b"lgit"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LaunchIntent, from_args, is_login_event};
+
+    #[test]
+    fn explicit_launch_does_not_depend_on_saved_login_preferences() {
+        assert_eq!(from_args(["antiburn"]), LaunchIntent::Explicit);
+        assert_eq!(from_args(["antiburn", "--other"]), LaunchIntent::Explicit);
+    }
+
+    #[test]
+    fn background_flag_is_an_exact_option_after_the_executable() {
+        assert_eq!(
+            from_args(["antiburn", "--background"]),
+            LaunchIntent::Background
+        );
+        assert_eq!(from_args(["--background"]), LaunchIntent::Explicit);
+        assert_eq!(
+            from_args(["antiburn", "--background=false"]),
+            LaunchIntent::Explicit
+        );
+        assert_eq!(
+            from_args(["antiburn", "--", "--background"]),
+            LaunchIntent::Explicit
+        );
+    }
+
+    #[test]
+    fn only_the_login_open_event_selects_background_startup() {
+        let open = u32::from_be_bytes(*b"oapp");
+        let login = u32::from_be_bytes(*b"lgit");
+        assert!(is_login_event(open, Some(login)));
+        assert!(!is_login_event(open, None));
+        assert!(!is_login_event(open, Some(0)));
+        assert!(!is_login_event(u32::from_be_bytes(*b"rapp"), Some(login)));
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -63,6 +63,8 @@ mod hud;
 mod insights_ipc;
 mod insights_report;
 mod insights_worker;
+mod launch_intent;
+mod main_window;
 #[cfg(feature = "memory-probe")]
 mod memory_probe;
 mod notifications;
@@ -98,6 +100,7 @@ mod window_readiness;
 include!("app_commands.rs");
 
 use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tauri::{Manager, RunEvent, WindowEvent};
@@ -113,6 +116,12 @@ pub(crate) struct Schedulers(Mutex<Vec<tauri::async_runtime::JoinHandle<()>>>);
 #[derive(Default)]
 struct WindowRebuildState(AtomicUsize);
 
+#[derive(Default)]
+struct RepeatedLaunch {
+    pending: AtomicBool,
+    setup_ready: AtomicBool,
+}
+
 impl WindowRebuildState {
     fn begin(&self) {
         self.0.fetch_add(1, Ordering::AcqRel);
@@ -120,10 +129,6 @@ impl WindowRebuildState {
 
     fn finish(&self) {
         self.0.fetch_sub(1, Ordering::AcqRel);
-    }
-
-    fn is_pending(&self) -> bool {
-        self.0.load(Ordering::Acquire) != 0
     }
 }
 
@@ -164,159 +169,180 @@ pub fn run() {
 
     // `register` installs the non-activating-panel support the notification
     // window needs on macOS; a no-op elsewhere.
-    let builder = antiburn_nudge::register(tauri::Builder::default())
-        .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_opener::init())
-        .plugin(webview_defaults::plugin())
-        .invoke_handler(with_app_commands!(command_handlers))
-        .on_window_event(on_window_event)
-        .setup(|app| {
-            // A menu-bar app owns no Dock icon and no application menu. The
-            // bundle declares LSUIElement, but development runs are unbundled,
-            // so the policy is also applied here.
-            //
-            // Unconditional on purpose, and applied before the store is even
-            // open: a completed install must never flash a Dock icon while its
-            // settings are being read. The first run overrides it a few lines
-            // below — see `onboarding::policy_for` for why it has to.
-            #[cfg(target_os = "macos")]
-            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
-
-            // Local state lives under the app's own data directory. The engine
-            // never chooses this location; the shell does, and hands it to the
-            // engine's state helpers as an explicit argument.
-            let data_dir = app.path().app_data_dir()?;
-            app.manage(store::Store::open(&data_dir)?);
-            app.manage(runtime_pricing::PricingState::load(&data_dir));
-            app.manage(insights_worker::WorkerHandle::default());
-            app.manage(insights_ipc::InsightsController::default());
-            if let Err(error) = app.state::<store::Store>().reconcile_evidence_revisions(
-                &agents::evidence_cohort(),
-                analysis::projection_revisions(),
-            ) {
-                ::tracing::error!(event = "evidence_reconcile_failed", error = %error);
-            }
-            if let Err(error) = app
-                .state::<store::Store>()
-                .purge_stale_source_resume(analysis::resume_revisions())
-            {
-                ::tracing::error!(event = "source_resume_purge_failed", error = %error);
-            }
-
-            // Apply the persisted theme before any window shows, so the first
-            // paint is already in the reader's chosen appearance. "system" and
-            // anything unrecognized mean: follow the OS.
-            if let Ok(settings) = app.state::<store::Store>().settings() {
-                app.set_theme(match settings.theme.as_str() {
-                    "light" => Some(tauri::Theme::Light),
-                    "dark" => Some(tauri::Theme::Dark),
-                    _ => None,
-                });
-                if settings.onboarding_completed {
-                    startup_registration::reconcile(app.handle(), settings.launch_at_login);
+    let builder = antiburn_nudge::register(
+        tauri::Builder::default()
+            .manage(RepeatedLaunch::default())
+            // Register first so a second process exits before it starts any
+            // background scheduler or scan.
+            .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+                if launch_intent::from_args(&args) == launch_intent::LaunchIntent::Background {
+                    return;
                 }
-            }
-            app.manage(scan::ScanController::default());
-            app.manage(scan::idle::IdleWake::default());
-            app.manage(Schedulers::default());
-            app.manage(popover::PopoverState::default());
-            app.manage(popover_peek::manager());
-            app.manage(updates::UpdaterState::default());
-            app.manage(notifications::NotificationState::default());
-            app.manage(storage_health::StorageHealth::default());
-            app.manage(settings::PendingPane::default());
-            app.manage(settings::SettingsWindowState::default());
-            app.manage(onboarding::OnboardingWindowState::default());
-            app.manage(WindowRebuildState::default());
-            app.manage(nudges::AnchorOverride::default());
-            app.manage(antiburn_nudge::NotificationGate::default());
-
-            tray::create(app.handle())?;
-            tray::install_usage_meter(app.handle());
-            // After the tray, and on the main thread: the monitor reaches the
-            // menu-bar item to unlight it. The popover itself is lazy, and its
-            // dismissal path already treats a missing window as idle.
-            global_click::install(app.handle());
-
-            // The HUD follows the desk it is on: a display that disconnects
-            // sends it to one still connected, and the display coming back
-            // takes it again. The watcher idles while the HUD is closed.
-            hud::spawn_display_watcher(app.handle());
-
-            // The first run gets a window rather than silence. Everything above
-            // is in place by now, so the flow's first paint can already read
-            // settings and ask the engine for its default roots.
-            //
-            // Best-effort on purpose, unlike the four `?`s above: a window that
-            // will not build is not a reason to refuse to start, and the
-            // menu-bar item still reaches the flow (see `popover::toggle`).
-            if onboarding::is_pending(app.handle()) {
-                // Before the window, not after: it should be born into an
-                // application that already has a Dock presence rather than
-                // acquiring one underneath it. The accessory policy applied
-                // above stands for every completed install, so nothing flashes
-                // a Dock icon while the store is being read.
-                onboarding::apply_activation_policy(app.handle(), true);
-                if let Err(error) = onboarding::open(app.handle()) {
-                    ::tracing::warn!(
-                        event = "onboarding_window_open_failed",
-                        trigger = "startup",
-                        error = %error
-                    );
+                let repeated = app.state::<RepeatedLaunch>();
+                repeated.pending.store(true, Ordering::Release);
+                if repeated.setup_ready.load(Ordering::Acquire) {
+                    repeated.pending.store(false, Ordering::Release);
+                    if let Err(error) =
+                        open_launch_surface(app, main_window::OpenTrigger::Interaction)
+                    {
+                        ::tracing::warn!(
+                            event = "launch_surface_open_failed",
+                            trigger = "second_instance",
+                            error = %error
+                        );
+                    }
                 }
+            })),
+    )
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_opener::init())
+    .plugin(webview_defaults::plugin())
+    .invoke_handler(with_app_commands!(command_handlers))
+    .on_window_event(on_window_event)
+    .setup(|app| {
+        // The main window makes antiburn an ordinary application. Apply
+        // this before any window exists so macOS never changes identity.
+        #[cfg(target_os = "macos")]
+        app.set_activation_policy(tauri::ActivationPolicy::Regular);
+
+        // Capture the platform launch event while setup still runs inside
+        // applicationDidFinishLaunching on macOS.
+        let launch_intent = launch_intent::current();
+
+        // Local state lives under the app's own data directory. The engine
+        // never chooses this location; the shell does, and hands it to the
+        // engine's state helpers as an explicit argument.
+        let data_dir = app.path().app_data_dir()?;
+        app.manage(store::Store::open(&data_dir)?);
+        let main_window_state = main_window::MainWindowState::load(&app.state::<store::Store>());
+        app.manage(main_window_state);
+        app.manage(runtime_pricing::PricingState::load(&data_dir));
+        app.manage(insights_worker::WorkerHandle::default());
+        app.manage(insights_ipc::InsightsController::default());
+        if let Err(error) = app.state::<store::Store>().reconcile_evidence_revisions(
+            &agents::evidence_cohort(),
+            analysis::projection_revisions(),
+        ) {
+            ::tracing::error!(event = "evidence_reconcile_failed", error = %error);
+        }
+        if let Err(error) = app
+            .state::<store::Store>()
+            .purge_stale_source_resume(analysis::resume_revisions())
+        {
+            ::tracing::error!(event = "source_resume_purge_failed", error = %error);
+        }
+
+        // Apply the persisted theme before any window shows, so the first
+        // paint is already in the reader's chosen appearance. "system" and
+        // anything unrecognized mean: follow the OS.
+        if let Ok(settings) = app.state::<store::Store>().settings() {
+            app.set_theme(match settings.theme.as_str() {
+                "light" => Some(tauri::Theme::Light),
+                "dark" => Some(tauri::Theme::Dark),
+                _ => None,
+            });
+            if settings.onboarding_completed {
+                startup_registration::reconcile(app.handle(), settings.launch_at_login);
             }
+        }
+        app.manage(scan::ScanController::default());
+        app.manage(scan::idle::IdleWake::default());
+        app.manage(Schedulers::default());
+        app.manage(popover::PopoverState::default());
+        app.manage(popover_peek::manager());
+        app.manage(updates::UpdaterState::default());
+        app.manage(notifications::NotificationState::default());
+        app.manage(storage_health::StorageHealth::default());
+        app.manage(settings::PendingPane::default());
+        app.manage(settings::SettingsWindowState::default());
+        app.manage(onboarding::OnboardingWindowState::default());
+        app.manage(WindowRebuildState::default());
+        app.manage(nudges::AnchorOverride::default());
+        app.manage(antiburn_nudge::NotificationGate::default());
 
-            // Registered before the update scheduler starts, so the first
-            // automatic check can see whether there is anything to check with.
-            install_updater(app.handle());
+        tray::create(app.handle())?;
+        tray::install_usage_meter(app.handle());
+        // After the tray, and on the main thread: the monitor reaches the
+        // menu-bar item to unlight it. The popover itself is lazy, and its
+        // dismissal path already treats a missing window as idle.
+        global_click::install(app.handle());
 
-            // Both calls are inert unless the build configuration is complete
-            // and the reader permits analytics. See `analytics::allowed`.
-            analytics::install(app.handle());
-            analytics::record(
-                app.handle(),
-                analytics::event::EventName::AppLaunched,
-                analytics::event::Facts::default(),
-            );
+        // The HUD follows the desk it is on: a display that disconnects
+        // sends it to one still connected, and the display coming back
+        // takes it again. The watcher idles while the HUD is closed.
+        hud::spawn_display_watcher(app.handle());
 
-            // The notification window's manager and the chime player. The
-            // webview itself is created only when policy delivers a nudge.
-            nudges::init(app.handle())?;
-            // On macOS, ask for the Focus-status authorization when a
-            // completed setup already permits notifications. First runs wait:
-            // apply_settings_transition asks again when onboarding finishes.
-            notifications::maybe_initialize_authorization(app.handle());
-            // The live-usage registry: the sources that can prove a
-            // provider's own limit figures, and the milestone ledger they
-            // feed. Registered before the schedulers so the first pass sees
-            // a populated registry rather than an empty one.
-            let live_usage = {
-                let store = app.state::<store::Store>();
-                usage_alerts::LiveUsage::from_store(&store)
+        // Registered before the update scheduler starts, so the first
+        // automatic check can see whether there is anything to check with.
+        install_updater(app.handle());
+
+        // Both calls are inert unless the build configuration is complete
+        // and the reader permits analytics. See `analytics::allowed`.
+        analytics::install(app.handle());
+        analytics::record(
+            app.handle(),
+            analytics::event::EventName::AppLaunched,
+            analytics::event::Facts::default(),
+        );
+
+        // The notification window's manager and the chime player. The
+        // webview itself is created only when policy delivers a nudge.
+        nudges::init(app.handle())?;
+        // On macOS, ask for the Focus-status authorization when a
+        // completed setup already permits notifications. First runs wait:
+        // apply_settings_transition asks again when onboarding finishes.
+        notifications::maybe_initialize_authorization(app.handle());
+        // The live-usage registry: the sources that can prove a
+        // provider's own limit figures, and the milestone ledger they
+        // feed. Registered before the schedulers so the first pass sees
+        // a populated registry rather than an empty one.
+        let live_usage = {
+            let store = app.state::<store::Store>();
+            usage_alerts::LiveUsage::from_store(&store)
+        };
+        app.manage(live_usage);
+        let settings = app.state::<store::Store>().settings().ok();
+        let snapshot = app.state::<usage_alerts::LiveUsage>().snapshot();
+        tray::sync_usage(
+            app.handle(),
+            &snapshot,
+            settings.is_some_and(|settings| settings.live_usage_active()),
+            true,
+        );
+        if let Some(schedulers) = app.try_state::<Schedulers>() {
+            analytics::install_schedulers(app.handle(), &schedulers);
+            schedulers.push(runtime_pricing::spawn_scheduler(app.handle()));
+            schedulers.push(scan::spawn_scheduler(app.handle()));
+            schedulers.push(scan::idle::spawn(app.handle()));
+            schedulers.push(retention::spawn_scheduler(app.handle()));
+            schedulers.push(insights_worker::spawn(app.handle()));
+            schedulers.push(updates::spawn_scheduler(app.handle()));
+            schedulers.push(usage_alerts::spawn_scheduler(app.handle()));
+            schedulers.push(disk_monitor::spawn_disk_monitor(app.handle().clone()));
+        }
+
+        // Publish setup completion before consuming a launch queued by a
+        // second process. The callback can now use every managed state.
+        let repeated = app.state::<RepeatedLaunch>();
+        repeated.setup_ready.store(true, Ordering::Release);
+        let repeated_launch = repeated.pending.swap(false, Ordering::AcqRel);
+        if launch_intent == launch_intent::LaunchIntent::Explicit || repeated_launch {
+            let trigger = if launch_intent == launch_intent::LaunchIntent::Explicit {
+                main_window::OpenTrigger::ColdLaunch
+            } else {
+                main_window::OpenTrigger::Interaction
             };
-            app.manage(live_usage);
-            let settings = app.state::<store::Store>().settings().ok();
-            let snapshot = app.state::<usage_alerts::LiveUsage>().snapshot();
-            tray::sync_usage(
-                app.handle(),
-                &snapshot,
-                settings.is_some_and(|settings| settings.live_usage_active()),
-                true,
-            );
-            if let Some(schedulers) = app.try_state::<Schedulers>() {
-                analytics::install_schedulers(app.handle(), &schedulers);
-                schedulers.push(runtime_pricing::spawn_scheduler(app.handle()));
-                schedulers.push(scan::spawn_scheduler(app.handle()));
-                schedulers.push(scan::idle::spawn(app.handle()));
-                schedulers.push(retention::spawn_scheduler(app.handle()));
-                schedulers.push(insights_worker::spawn(app.handle()));
-                schedulers.push(updates::spawn_scheduler(app.handle()));
-                schedulers.push(usage_alerts::spawn_scheduler(app.handle()));
-                schedulers.push(disk_monitor::spawn_disk_monitor(app.handle().clone()));
+            if let Err(error) = open_launch_surface(app.handle(), trigger) {
+                ::tracing::warn!(
+                    event = "launch_surface_open_failed",
+                    trigger = "startup",
+                    error = %error
+                );
             }
+        }
 
-            Ok(())
-        });
+        Ok(())
+    });
 
     #[cfg(not(feature = "memory-probe"))]
     let app = builder.build(tauri::generate_context!());
@@ -332,18 +358,13 @@ pub fn run() {
         })
     });
     app.run(move |app, event| match event {
-        RunEvent::ExitRequested { api, code, .. }
-            if should_prevent_exit(
-                onboarding::is_pending(app),
-                app.state::<WindowRebuildState>().is_pending(),
-                code,
-            ) =>
-        {
+        RunEvent::ExitRequested { api, code, .. } if should_prevent_exit(code) => {
             api.prevent_exit();
         }
         // A deliberate quit: stop the background tasks before the store
         // they write to is dropped.
         RunEvent::Exit => {
+            main_window::flush_placement(app);
             // Ask a running report reduction to stop at its next probe.
             // The reduction is read-only, so even a task that never sees
             // the flag cannot corrupt durable evidence state.
@@ -356,19 +377,12 @@ pub fn run() {
                 guard.flush();
             }
         }
-        // Clicking the Dock icon. Only reachable while the first run is
-        // pending, because that is the only time antiburn has a Dock icon
-        // (see `onboarding::policy_for`) — and it is exactly then that
-        // somebody who closed the window early has no other way back to it.
-        // A visible affordance that did nothing would be a worse failure
-        // than the one the Dock icon is here to fix.
+        // Clicking the Dock icon restores the surface the current install owns.
         #[cfg(target_os = "macos")]
         RunEvent::Reopen { .. } => {
-            if onboarding::is_pending(app)
-                && let Err(error) = onboarding::open(app)
-            {
+            if let Err(error) = open_launch_surface(app, main_window::OpenTrigger::Interaction) {
                 ::tracing::warn!(
-                    event = "onboarding_window_open_failed",
+                    event = "launch_surface_open_failed",
                     trigger = "dock",
                     error = %error
                 );
@@ -378,26 +392,24 @@ pub fn run() {
     });
 }
 
-/// Whether an exit request should be swallowed.
+/// Keep the tray process alive when a window is destroyed.
 ///
-/// A menu-bar app outlives its windows: closing settings, or the popover, must
-/// not quit antiburn, and those arrive here with no exit code. Only the shell's
-/// own `exit(0)` — the tray menu, the settings sidebar — carries one, which is
-/// what distinguishes a deliberate quit from a window close.
-///
-/// The exception is the first run. While it is pending antiburn is an ordinary
-/// Dock application (again, `onboarding::policy_for`), so it has an application
-/// menu and a Dock context menu, both offering Quit, and both arriving here
-/// with `code: None`. Swallowing those would give the reader a Quit item that
-/// silently does nothing at the one moment they have no other way to get rid of
-/// the app. During the first run it quits like the ordinary application it is
-/// pretending to be.
-fn should_prevent_exit(
-    onboarding_pending: bool,
-    window_rebuild_pending: bool,
-    code: Option<i32>,
-) -> bool {
-    code.is_none() && (!onboarding_pending || window_rebuild_pending)
+/// `AppHandle::exit` carries a code and remains the explicit cross-platform
+/// quit path. AppKit termination bypasses this window-destruction request.
+fn should_prevent_exit(code: Option<i32>) -> bool {
+    code.is_none()
+}
+
+/// Open onboarding while it is owed, or the ordinary main window afterwards.
+pub(crate) fn open_launch_surface(
+    app: &tauri::AppHandle,
+    trigger: main_window::OpenTrigger,
+) -> tauri::Result<()> {
+    if onboarding::is_pending(app) {
+        onboarding::open(app)
+    } else {
+        main_window::open(app, trigger)
+    }
 }
 
 /// Stop every background task. Safe to call when none ever started.
@@ -429,13 +441,16 @@ fn finish_retention_cleanup(handle: &mut Option<tauri::async_runtime::JoinHandle
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClosePolicy {
     Allow,
+    HideMain,
     HidePopover,
     HidePendingOnboarding,
     HideNudge,
 }
 
 fn close_policy(label: &str, onboarding_pending: bool) -> ClosePolicy {
-    if label == popover::LABEL {
+    if label == main_window::LABEL {
+        ClosePolicy::HideMain
+    } else if label == popover::LABEL {
         ClosePolicy::HidePopover
     } else if label == antiburn_nudge::NUDGE_LABEL {
         ClosePolicy::HideNudge
@@ -448,6 +463,7 @@ fn close_policy(label: &str, onboarding_pending: bool) -> ClosePolicy {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ManagedWindow {
+    Main,
     Popover,
     Settings,
     Onboarding,
@@ -456,6 +472,7 @@ enum ManagedWindow {
 impl ManagedWindow {
     fn rebuild_after_destroy(self, app: &tauri::AppHandle) {
         match self {
+            Self::Main => main_window::rebuild_after_destroy(app),
             Self::Popover => popover::rebuild_after_destroy(app),
             Self::Settings => settings::rebuild_after_destroy(app),
             Self::Onboarding => onboarding::rebuild_after_destroy(app),
@@ -465,6 +482,7 @@ impl ManagedWindow {
 
 fn rebuild_after_destroy_for_label(label: &str) -> Option<ManagedWindow> {
     match label {
+        main_window::LABEL => Some(ManagedWindow::Main),
         popover::LABEL => Some(ManagedWindow::Popover),
         settings::LABEL => Some(ManagedWindow::Settings),
         onboarding::LABEL => Some(ManagedWindow::Onboarding),
@@ -526,6 +544,13 @@ fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
         WindowEvent::CloseRequested { api, .. } => {
             match close_policy(window.label(), onboarding::is_pending(window.app_handle())) {
                 ClosePolicy::Allow => {}
+                ClosePolicy::HideMain => {
+                    api.prevent_close();
+                    if let Some(window) = window.app_handle().get_webview_window(main_window::LABEL)
+                    {
+                        main_window::close(&window);
+                    }
+                }
                 ClosePolicy::HidePopover => {
                     api.prevent_close();
                     // Through `popover::hide` rather than `window.hide()`, so
@@ -553,6 +578,9 @@ fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
             if let Some(rebuild) = rebuild_after_destroy_for_label(window.label()) {
                 defer_rebuild_after_destroy(window.app_handle(), rebuild);
             }
+        }
+        WindowEvent::Moved(_) | WindowEvent::Resized(_) if window.label() == main_window::LABEL => {
+            main_window::schedule_placement_save(window.app_handle());
         }
         _ => {}
     }
@@ -615,26 +643,33 @@ mod tests {
     }
 
     #[test]
-    fn a_window_close_never_quits_the_finished_menu_bar_app() {
-        // Settings and the popover both close with no exit code, and the tray
-        // item is the app's real lifetime.
-        assert!(should_prevent_exit(false, false, None));
-        // The shell's own `exit(0)` is the deliberate quit and always lands.
-        assert!(!should_prevent_exit(false, false, Some(0)));
-        assert!(!should_prevent_exit(true, true, Some(0)));
+    fn main_window_capability_includes_titlebar_actions_without_broad_defaults() {
+        let capability = include_str!("../capabilities/main.json");
+        for expected in [
+            "\"core:event:allow-listen\"",
+            "\"core:event:allow-unlisten\"",
+            "\"core:window:allow-start-dragging\"",
+            "\"core:window:allow-internal-toggle-maximize\"",
+            "\"allow-get-settings\"",
+            "\"allow-main-window-ready\"",
+        ] {
+            assert!(capability.contains(expected), "missing {expected}");
+        }
+        for excluded in ["\"default\"", "dialog:default", "opener:default"] {
+            assert!(!capability.contains(excluded), "unexpected {excluded}");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn bundled_app_is_not_an_lsui_element_agent() {
+        assert!(!include_str!("../Info.plist").contains("LSUIElement"));
     }
 
     #[test]
-    fn cmd_q_works_while_the_first_run_owns_a_dock_icon() {
-        // The case that matters. A Regular app's application menu and Dock
-        // context menu both offer Quit and both arrive with no code; swallowing
-        // them would ship a Quit item that does nothing.
-        assert!(!should_prevent_exit(true, false, None));
-    }
-
-    #[test]
-    fn a_pending_rebuild_keeps_the_first_run_alive() {
-        assert!(should_prevent_exit(true, true, None));
+    fn window_destruction_stays_resident_but_explicit_exit_lands() {
+        assert!(should_prevent_exit(None));
+        assert!(!should_prevent_exit(Some(0)));
     }
 
     #[test]
@@ -762,6 +797,10 @@ mod tests {
     #[test]
     fn only_transient_or_incomplete_windows_intercept_close() {
         assert_eq!(
+            close_policy(super::main_window::LABEL, false),
+            ClosePolicy::HideMain
+        );
+        assert_eq!(
             close_policy(super::popover::LABEL, false),
             ClosePolicy::HidePopover
         );
@@ -786,6 +825,7 @@ mod tests {
     #[test]
     fn only_managed_windows_select_their_deferred_rebuild_handler() {
         let cases = [
+            (super::main_window::LABEL, super::ManagedWindow::Main),
             (super::popover::LABEL, super::ManagedWindow::Popover),
             (super::settings::LABEL, super::ManagedWindow::Settings),
             (super::onboarding::LABEL, super::ManagedWindow::Onboarding),

--- a/apps/desktop/src-tauri/src/main_window.rs
+++ b/apps/desktop/src-tauri/src/main_window.rs
@@ -1,0 +1,474 @@
+//! Shell policy for the ordinary main window.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+use antiburn_main_window::Placement;
+use tauri::{AppHandle, Manager, WebviewWindow};
+
+use crate::store::Store;
+use crate::window_lifecycle::{self, ManagedWindowReadiness};
+use crate::window_readiness::{OpenAction, WindowReadiness, renderer_generation_script};
+
+pub use antiburn_main_window::LABEL;
+
+const PLACEMENT_KEY: &str = "internal:mainWindowPlacementV1";
+const PLACEMENT_WRITE_DELAY: Duration = Duration::from_millis(350);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenTrigger {
+    ColdLaunch,
+    Interaction,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OpenKind {
+    ColdLaunch,
+    FirstOpen,
+    WarmReopen,
+}
+
+impl OpenKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::ColdLaunch => "cold_launch",
+            Self::FirstOpen => "first_open",
+            Self::WarmReopen => "warm_reopen",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Presentation {
+    has_revealed: bool,
+    restore_after_activation: bool,
+    pending: Option<(OpenKind, Instant)>,
+}
+
+/// Renderer, presentation, and persisted placement state.
+pub struct MainWindowState {
+    readiness: Mutex<WindowReadiness>,
+    presentation: Mutex<Presentation>,
+    placement: Mutex<Option<Placement>>,
+    placement_generation: AtomicU64,
+}
+
+impl MainWindowState {
+    pub fn load(store: &Store) -> Self {
+        Self {
+            readiness: Mutex::new(WindowReadiness::default()),
+            presentation: Mutex::new(Presentation::default()),
+            placement: Mutex::new(
+                store
+                    .internal_value(PLACEMENT_KEY)
+                    .and_then(|raw| serde_json::from_str(&raw).ok()),
+            ),
+            placement_generation: AtomicU64::new(0),
+        }
+    }
+
+    fn note_open_request(&self, trigger: OpenTrigger, now: Instant) -> OpenKind {
+        let mut presentation = lock(&self.presentation);
+        let kind = if presentation.has_revealed {
+            OpenKind::WarmReopen
+        } else if trigger == OpenTrigger::ColdLaunch {
+            OpenKind::ColdLaunch
+        } else {
+            OpenKind::FirstOpen
+        };
+        presentation.pending.get_or_insert((kind, now)).0
+    }
+
+    fn cancel_open_request(&self) {
+        lock(&self.presentation).pending = None;
+    }
+
+    fn note_closed(&self) {
+        let mut presentation = lock(&self.presentation);
+        presentation.restore_after_activation = presentation.has_revealed;
+    }
+
+    #[cfg(any(target_os = "macos", test))]
+    fn should_restore_after_activation(
+        &self,
+        main_visible: bool,
+        main_minimized: bool,
+        another_window_owns_activation: bool,
+    ) -> bool {
+        let presentation = lock(&self.presentation);
+        presentation.has_revealed
+            && (main_minimized || (presentation.restore_after_activation && !main_visible))
+            && !another_window_owns_activation
+    }
+
+    fn finish_reveal(&self, now: Instant) -> (OpenKind, Duration) {
+        let mut presentation = lock(&self.presentation);
+        presentation.has_revealed = true;
+        presentation.restore_after_activation = false;
+        let (kind, requested_at) = presentation
+            .pending
+            .take()
+            .unwrap_or((OpenKind::WarmReopen, now));
+        (kind, now.saturating_duration_since(requested_at))
+    }
+
+    fn request_details(&self, now: Instant) -> (OpenKind, Duration) {
+        let presentation = lock(&self.presentation);
+        let (kind, requested_at) = presentation.pending.unwrap_or((OpenKind::WarmReopen, now));
+        (kind, now.saturating_duration_since(requested_at))
+    }
+
+    fn placement(&self) -> Option<Placement> {
+        lock(&self.placement).clone()
+    }
+
+    fn remember_placement(&self, applied: Option<Placement>) {
+        let mut placement = lock(&self.placement);
+        if placement.is_none() {
+            *placement = applied;
+        }
+    }
+}
+
+impl ManagedWindowReadiness for MainWindowState {
+    fn readiness(&self) -> MutexGuard<'_, WindowReadiness> {
+        lock(&self.readiness)
+    }
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Open the main window or coalesce with its active renderer load.
+pub fn open(app: &AppHandle, trigger: OpenTrigger) -> tauri::Result<()> {
+    let now = Instant::now();
+    let state = app.state::<MainWindowState>();
+    let open_kind = state.note_open_request(trigger, now);
+    ::tracing::info!(
+        event = "main_window_open_requested",
+        window = LABEL,
+        open_kind = open_kind.as_str()
+    );
+
+    let action = state.readiness().request_open(now);
+    match action {
+        OpenAction::Reveal => reveal(app.get_webview_window(LABEL).as_ref()),
+        OpenAction::AwaitReady => Ok(()),
+        OpenAction::StartLoading { generation } => build(app, generation),
+        OpenAction::Rebuild { generation } => {
+            let Some(window) = app.get_webview_window(LABEL) else {
+                return build(app, generation);
+            };
+            if !state.readiness().defer_build_until_destroyed(generation) {
+                return Ok(());
+            }
+            if let Err(error) = window.destroy() {
+                window_lifecycle::cancel_load::<MainWindowState>(app, generation);
+                state.cancel_open_request();
+                return Err(error);
+            }
+            Ok(())
+        }
+    }
+}
+
+fn build(app: &AppHandle, generation: u64) -> tauri::Result<()> {
+    let state = app.state::<MainWindowState>();
+    let placement = state.placement();
+    let (open_kind, elapsed) = state.request_details(Instant::now());
+    ::tracing::info!(
+        event = "main_window_create_started",
+        window = LABEL,
+        generation,
+        open_kind = open_kind.as_str(),
+        elapsed_ms = elapsed.as_millis() as u64
+    );
+    window_lifecycle::arm_stale_warning::<MainWindowState>(app, generation, LABEL);
+    match antiburn_main_window::build(
+        app,
+        renderer_generation_script(generation),
+        placement.as_ref(),
+        |window, payload| {
+            window_lifecycle::trace_page_load::<MainWindowState>(window, payload, LABEL);
+        },
+    ) {
+        Ok(built) => {
+            let applied = built
+                .placement
+                .or_else(|| antiburn_main_window::capture(&built.window, None));
+            state.remember_placement(applied);
+            Ok(())
+        }
+        Err(error) => {
+            window_lifecycle::cancel_load::<MainWindowState>(app, generation);
+            state.cancel_open_request();
+            Err(error)
+        }
+    }
+}
+
+/// Build a deferred stale-load replacement after its old label is removed.
+pub fn rebuild_after_destroy(app: &AppHandle) {
+    let generation = window_lifecycle::begin_deferred_build::<MainWindowState>(app, Instant::now());
+    let Some(generation) = generation else {
+        return;
+    };
+    if let Err(error) = build(app, generation) {
+        ::tracing::error!(event = "window_rebuild_failed", window = LABEL, error = %error);
+    }
+}
+
+/// Accept readiness only from the main renderer's active generation.
+pub fn renderer_ready(window: &WebviewWindow, generation: u64) {
+    let app = window.app_handle();
+    if !window_lifecycle::renderer_ready::<MainWindowState>(app, LABEL, generation, Instant::now())
+    {
+        return;
+    }
+    let (open_kind, elapsed) = app
+        .state::<MainWindowState>()
+        .request_details(Instant::now());
+    ::tracing::info!(
+        event = "main_window_renderer_ready",
+        window = LABEL,
+        generation,
+        open_kind = open_kind.as_str(),
+        elapsed_ms = elapsed.as_millis() as u64
+    );
+    if let Err(error) = reveal(Some(window)) {
+        ::tracing::error!(event = "window_reveal_failed", window = LABEL, error = %error);
+    }
+}
+
+fn reveal(window: Option<&WebviewWindow>) -> tauri::Result<()> {
+    let Some(window) = window else {
+        return Ok(());
+    };
+    antiburn_main_window::reveal(window)?;
+    let (open_kind, elapsed) = window
+        .app_handle()
+        .state::<MainWindowState>()
+        .finish_reveal(Instant::now());
+    // This marks native show and focus completion. It does not mark a painted frame.
+    ::tracing::info!(
+        event = "main_window_revealed",
+        window = LABEL,
+        open_kind = open_kind.as_str(),
+        elapsed_ms = elapsed.as_millis() as u64
+    );
+    Ok(())
+}
+
+/// Cancel a pending reveal and hide the renderer.
+pub fn close(window: &WebviewWindow) {
+    let state = window.app_handle().state::<MainWindowState>();
+    state.readiness().cancel_pending_reveal();
+    state.cancel_open_request();
+    state.note_closed();
+    flush_placement(window.app_handle());
+    let _ = antiburn_main_window::conceal(window);
+}
+
+/// Restore a closed or minimized main window after the app becomes active.
+#[cfg(target_os = "macos")]
+pub(crate) fn restore_after_activation(app: &AppHandle) {
+    let Some(state) = app.try_state::<MainWindowState>() else {
+        return;
+    };
+    let main_visible = window_is_visible(app, LABEL);
+    let main_minimized = app
+        .get_webview_window(LABEL)
+        .is_some_and(|window| window.is_minimized().unwrap_or(false));
+    let another_window_owns_activation = crate::onboarding::is_pending(app)
+        || window_is_visible(app, crate::onboarding::LABEL)
+        || window_is_visible(app, crate::settings::LABEL)
+        || [
+            crate::popover::LABEL,
+            crate::popover_peek::LABEL,
+            antiburn_hud::OVERLAY_LABEL,
+            antiburn_hud::DETAIL_LABEL,
+            antiburn_nudge::NUDGE_LABEL,
+        ]
+        .into_iter()
+        .any(|label| window_is_focused(app, label));
+    if !state.should_restore_after_activation(
+        main_visible,
+        main_minimized,
+        another_window_owns_activation,
+    ) {
+        return;
+    }
+    if let Err(error) = open(app, OpenTrigger::Interaction) {
+        ::tracing::warn!(event = "main_window_activation_restore_failed", error = %error);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn window_is_visible(app: &AppHandle, label: &str) -> bool {
+    app.get_webview_window(label)
+        .is_some_and(|window| window.is_visible().unwrap_or(true))
+}
+
+#[cfg(target_os = "macos")]
+fn window_is_focused(app: &AppHandle, label: &str) -> bool {
+    app.get_webview_window(label)
+        .is_some_and(|window| window.is_focused().unwrap_or(false))
+}
+
+/// Debounce a move or resize into one durable placement write.
+pub fn schedule_placement_save(app: &AppHandle) {
+    let generation = app
+        .state::<MainWindowState>()
+        .placement_generation
+        .fetch_add(1, Ordering::AcqRel)
+        .wrapping_add(1);
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(PLACEMENT_WRITE_DELAY).await;
+        if app
+            .state::<MainWindowState>()
+            .placement_generation
+            .load(Ordering::Acquire)
+            != generation
+        {
+            return;
+        }
+        let persist_app = app.clone();
+        let _ = app.run_on_main_thread(move || persist_current(&persist_app));
+    });
+}
+
+/// Persist the latest normal bounds before hide or quit.
+pub fn flush_placement(app: &AppHandle) {
+    app.state::<MainWindowState>()
+        .placement_generation
+        .fetch_add(1, Ordering::AcqRel);
+    persist_current(app);
+}
+
+fn persist_current(app: &AppHandle) {
+    let Some(window) = app.get_webview_window(LABEL) else {
+        return;
+    };
+    let state = app.state::<MainWindowState>();
+    let previous = state.placement();
+    let Some(placement) = antiburn_main_window::capture(&window, previous.as_ref()) else {
+        return;
+    };
+    if previous.as_ref() == Some(&placement) {
+        return;
+    }
+    let Ok(encoded) = serde_json::to_string(&placement) else {
+        return;
+    };
+    *lock(&state.placement) = Some(placement);
+    app.state::<Store>()
+        .set_internal_value(PLACEMENT_KEY, &encoded);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::window_readiness::ReadyAction;
+
+    #[test]
+    fn open_kind_moves_from_first_request_to_warm_reopen() {
+        let state = MainWindowState {
+            readiness: Mutex::new(WindowReadiness::default()),
+            presentation: Mutex::new(Presentation::default()),
+            placement: Mutex::new(None),
+            placement_generation: AtomicU64::new(0),
+        };
+        let now = Instant::now();
+        assert_eq!(
+            state.note_open_request(OpenTrigger::Interaction, now),
+            OpenKind::FirstOpen
+        );
+        assert_eq!(state.finish_reveal(now).0, OpenKind::FirstOpen);
+        assert_eq!(
+            state.note_open_request(OpenTrigger::Interaction, now),
+            OpenKind::WarmReopen
+        );
+    }
+
+    #[test]
+    fn coalesced_open_keeps_the_first_request_kind_and_time() {
+        let state = MainWindowState {
+            readiness: Mutex::new(WindowReadiness::default()),
+            presentation: Mutex::new(Presentation::default()),
+            placement: Mutex::new(None),
+            placement_generation: AtomicU64::new(0),
+        };
+        let first = Instant::now();
+        assert_eq!(
+            state.note_open_request(OpenTrigger::ColdLaunch, first),
+            OpenKind::ColdLaunch
+        );
+        assert_eq!(
+            state.note_open_request(OpenTrigger::Interaction, first + Duration::from_secs(1)),
+            OpenKind::ColdLaunch
+        );
+        let (kind, elapsed) = state.finish_reveal(first + Duration::from_secs(2));
+        assert_eq!(kind, OpenKind::ColdLaunch);
+        assert_eq!(elapsed, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn close_during_load_cancels_the_pending_reveal() {
+        let state = MainWindowState {
+            readiness: Mutex::new(WindowReadiness::default()),
+            presentation: Mutex::new(Presentation::default()),
+            placement: Mutex::new(None),
+            placement_generation: AtomicU64::new(0),
+        };
+        let started = Instant::now();
+        let OpenAction::StartLoading { generation } = state.readiness().request_open(started)
+        else {
+            panic!("an idle main window starts loading")
+        };
+
+        assert!(state.readiness().cancel_pending_reveal());
+        assert_eq!(
+            state
+                .readiness()
+                .renderer_ready(generation, started + Duration::from_secs(1)),
+            ReadyAction::StayHidden {
+                loading_for: Duration::from_secs(1)
+            }
+        );
+    }
+
+    #[test]
+    fn activation_restores_closed_or_minimized_main_without_interrupting_other_surfaces() {
+        let state = MainWindowState {
+            readiness: Mutex::new(WindowReadiness::default()),
+            presentation: Mutex::new(Presentation::default()),
+            placement: Mutex::new(None),
+            placement_generation: AtomicU64::new(0),
+        };
+        let now = Instant::now();
+
+        assert!(!state.should_restore_after_activation(false, false, false));
+        assert!(!state.should_restore_after_activation(false, true, false));
+        state.note_open_request(OpenTrigger::Interaction, now);
+        state.finish_reveal(now);
+        assert!(state.should_restore_after_activation(true, true, false));
+        assert!(state.should_restore_after_activation(false, true, false));
+        assert!(!state.should_restore_after_activation(true, true, true));
+        assert!(!state.should_restore_after_activation(true, false, false));
+        state.note_closed();
+
+        assert!(lock(&state.presentation).pending.is_none());
+        assert!(!state.should_restore_after_activation(true, false, false));
+        assert!(!state.should_restore_after_activation(false, false, true));
+        assert!(state.should_restore_after_activation(false, false, false));
+
+        state.note_open_request(OpenTrigger::Interaction, now);
+        state.finish_reveal(now);
+        assert!(!state.should_restore_after_activation(false, false, false));
+    }
+}

--- a/apps/desktop/src-tauri/src/onboarding.rs
+++ b/apps/desktop/src-tauri/src/onboarding.rs
@@ -52,12 +52,14 @@ const FINISH_TEARDOWN_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FinishHandoffAction {
+    OpenMain,
     PrewarmPopover,
     DestroyOnboarding,
 }
 
-fn finish_handoff_schedule() -> [(Duration, FinishHandoffAction); 2] {
+fn finish_handoff_schedule() -> [(Duration, FinishHandoffAction); 3] {
     [
+        (Duration::ZERO, FinishHandoffAction::OpenMain),
         (Duration::ZERO, FinishHandoffAction::PrewarmPopover),
         (
             FINISH_TEARDOWN_DELAY,
@@ -96,7 +98,6 @@ impl ManagedWindowReadiness for OnboardingWindowState {
 
 /// Start setup again at Welcome and give it the first-run app presence.
 pub fn restart(app: &AppHandle) -> tauri::Result<()> {
-    apply_activation_policy(app, true);
     let Some(existing) = app.get_webview_window(LABEL) else {
         return open(app);
     };
@@ -267,17 +268,9 @@ pub fn finish(app: &AppHandle) {
     if let Some(window) = app.get_webview_window(LABEL) {
         let _ = window.hide();
     }
-    // The Dock icon goes at the same moment the notification says where the
-    // app went, which is the whole choreography: one presence is exchanged for
-    // the other in front of the reader rather than behind their back. The nudge
-    // is non-activating, so it survives the policy change instead of being
-    // ordered out by it — hence this line before that one, not after.
-    apply_activation_policy(app, false);
     crate::notifications::note_menu_bar_home(app);
-
-    // `finish` runs inside the onboarding webview's final `set_settings` IPC.
-    // Queue the prewarm after this command yields. Destroy onboarding later so
-    // the command response can leave its renderer.
+    // `finish` runs inside the onboarding webview's final command. Queue the
+    // main window after the response can leave this renderer.
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         for (delay, action) in finish_handoff_schedule() {
@@ -292,6 +285,18 @@ pub fn finish(app: &AppHandle) {
                     return;
                 }
                 match action {
+                    FinishHandoffAction::OpenMain => {
+                        if let Err(error) = crate::main_window::open(
+                            &check_app,
+                            crate::main_window::OpenTrigger::Interaction,
+                        ) {
+                            ::tracing::warn!(
+                                event = "main_window_open_failed",
+                                trigger = "onboarding_finished",
+                                error = %error
+                            );
+                        }
+                    }
                     FinishHandoffAction::PrewarmPopover => {
                         crate::popover::prewarm(&check_app);
                     }
@@ -304,49 +309,6 @@ pub fn finish(app: &AppHandle) {
             });
         }
     });
-}
-
-/// Which kind of application antiburn is while the first run is pending.
-///
-/// The accessory policy — no Dock icon, no ⌘-Tab entry, no application menu —
-/// is right for a finished menu-bar app and a trap for this one. A reader on
-/// step two who clicks another application has no route back: not the Dock, not
-/// ⌘-Tab, not Mission Control, only the menu-bar glyph they have not been told
-/// about yet, because being told about it is what finishing this window *does*.
-///
-/// So antiburn is an ordinary application for exactly as long as it owes
-/// somebody the flow, and an accessory afterwards.
-///
-/// Pure, so the rule is testable without AppKit.
-#[cfg(target_os = "macos")]
-pub fn policy_for(pending: bool) -> tauri::ActivationPolicy {
-    if pending {
-        tauri::ActivationPolicy::Regular
-    } else {
-        tauri::ActivationPolicy::Accessory
-    }
-}
-
-/// Apply [`policy_for`].
-///
-/// Keyed on whether onboarding is *pending*, deliberately, and never on whether
-/// the window is visible: closing the window early hides rather than destroys
-/// it, and a visibility-keyed rule would take the Dock icon away at exactly the
-/// moment the reader most needs it to get back.
-///
-/// A no-op off macOS, where the window carries no `skip_taskbar` and is
-/// therefore already in the taskbar and already alt-tabbable.
-pub fn apply_activation_policy(app: &AppHandle, pending: bool) {
-    #[cfg(target_os = "macos")]
-    {
-        if let Err(error) = app.set_activation_policy(policy_for(pending)) {
-            // Best-effort: the wrong Dock presence is a worse first run, not a
-            // broken one, and there is nothing useful to do about it here.
-            ::tracing::warn!(event = "activation_policy_set_failed", error = %error);
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    let _ = (app, pending);
 }
 
 /// Whether the first-run flow still owes the reader something.
@@ -376,10 +338,11 @@ mod tests {
     }
 
     #[test]
-    fn the_finish_handoff_schedules_prewarm_before_renderer_teardown() {
+    fn the_finish_handoff_schedules_main_and_prewarm_before_teardown() {
         assert_eq!(
             finish_handoff_schedule(),
             [
+                (Duration::ZERO, FinishHandoffAction::OpenMain),
                 (Duration::ZERO, FinishHandoffAction::PrewarmPopover),
                 (
                     FINISH_TEARDOWN_DELAY,
@@ -387,17 +350,5 @@ mod tests {
                 ),
             ]
         );
-    }
-
-    /// Small, but it is the whole rule: antiburn is an ordinary application
-    /// for as long as it owes somebody the first run, and an accessory after.
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn the_app_has_a_dock_icon_for_exactly_as_long_as_the_flow_is_owed() {
-        assert!(matches!(policy_for(true), tauri::ActivationPolicy::Regular));
-        assert!(matches!(
-            policy_for(false),
-            tauri::ActivationPolicy::Accessory
-        ));
     }
 }

--- a/apps/desktop/src-tauri/src/startup_registration.rs
+++ b/apps/desktop/src-tauri/src/startup_registration.rs
@@ -158,9 +158,8 @@ fn reconcile_windows<R: Runtime>(app: &tauri::AppHandle<R>, desired: bool) -> an
 
 #[cfg(any(target_os = "windows", test))]
 fn windows_run_command(executable: &str) -> String {
-    // Windows filenames cannot contain a quote, so surrounding the complete
-    // executable path is sufficient when no startup arguments are passed.
-    format!("\"{executable}\"")
+    // Keep the background flag outside the quoted executable path.
+    format!("\"{executable}\" --background")
 }
 
 #[cfg(target_os = "linux")]
@@ -209,7 +208,7 @@ fn reconcile_linux<R: Runtime>(app: &tauri::AppHandle<R>, desired: bool) -> anyh
 #[cfg(any(target_os = "linux", test))]
 fn linux_desktop_entry(executable: &str) -> String {
     format!(
-        "[Desktop Entry]\nType=Application\nVersion=1.0\nName=antiburn\nComment=Start antiburn at login\nExec={}\nStartupNotify=false\nTerminal=false\n",
+        "[Desktop Entry]\nType=Application\nVersion=1.0\nName=antiburn\nComment=Start antiburn at login\nExec={} --background\nStartupNotify=false\nTerminal=false\n",
         desktop_exec_quote(executable)
     )
 }
@@ -219,6 +218,9 @@ fn desktop_exec_quote(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len() + 2);
     escaped.push('"');
     for character in value.chars() {
+        if character == '%' {
+            escaped.push('%');
+        }
         if matches!(character, '"' | '`' | '$' | '\\') {
             escaped.push('\\');
         }
@@ -275,11 +277,11 @@ mod tests {
     fn platform_commands_quote_paths_with_spaces_and_reserved_characters() {
         assert_eq!(
             windows_run_command(r"C:\Program Files\antiburn\antiburn.exe"),
-            r#""C:\Program Files\antiburn\antiburn.exe""#
+            r#""C:\Program Files\antiburn\antiburn.exe" --background"#
         );
         assert!(
-            linux_desktop_entry("/opt/anti burn/$stable`/antiburn")
-                .contains(r#"Exec="/opt/anti burn/\$stable\`/antiburn""#)
+            linux_desktop_entry("/opt/100%real/anti burn/$stable`/antiburn")
+                .contains("Exec=\"/opt/100%%real/anti burn/\\$stable\\`/antiburn\" --background\n")
         );
     }
 

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -88,9 +88,9 @@ impl Default for UsageMeter {
     }
 }
 
-/// Linux only: the item that stands in for the click the backend never reports.
+const MENU_MAIN: &str = "open-main";
 #[cfg(target_os = "linux")]
-const MENU_OPEN: &str = "open";
+const MENU_OPEN_POPOVER: &str = "open-popover";
 const MENU_PIN: &str = "pin";
 const MENU_SETTINGS: &str = "settings";
 #[cfg(debug_assertions)]
@@ -103,9 +103,9 @@ const MENU_QUIT: &str = "quit";
 const PIN_LABEL: &str = "Pin Window";
 const UNPIN_LABEL: &str = "Unpin Window";
 
-/// Linux only, and title case for the same reason the pin labels are.
-#[cfg(target_os = "linux")]
 const OPEN_LABEL: &str = "Open antiburn";
+#[cfg(target_os = "linux")]
+const OPEN_POPOVER_LABEL: &str = "Open Usage Popover";
 #[cfg(debug_assertions)]
 const RESET_ONBOARDING_LABEL: &str = "Reset Onboarding";
 #[cfg(debug_assertions)]
@@ -494,12 +494,20 @@ fn build_menu(app: &AppHandle) -> tauri::Result<BuiltMenu> {
     )?;
     let separator = PredefinedMenuItem::separator(app)?;
     let quit_item = MenuItem::with_id(app, MENU_QUIT, "Quit antiburn", true, None::<&str>)?;
+    let main_item = MenuItem::with_id(app, MENU_MAIN, OPEN_LABEL, true, None::<&str>)?;
     #[cfg(target_os = "linux")]
-    let open_item = MenuItem::with_id(app, MENU_OPEN, OPEN_LABEL, true, None::<&str>)?;
+    let open_popover_item = MenuItem::with_id(
+        app,
+        MENU_OPEN_POPOVER,
+        OPEN_POPOVER_LABEL,
+        true,
+        None::<&str>,
+    )?;
 
     let items: Vec<&dyn IsMenuItem<Wry>> = vec![
+        &main_item,
         #[cfg(target_os = "linux")]
-        &open_item,
+        &open_popover_item,
         &pin_item,
         &settings_item,
         #[cfg(debug_assertions)]
@@ -535,10 +543,15 @@ fn on_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
 
 fn on_menu_event(app: &AppHandle, event: MenuEvent) {
     match event.id().as_ref() {
-        // The AppIndicator backend reports no click events, so this item is the
-        // popover's entry point on Linux.
+        MENU_MAIN => {
+            if let Err(error) =
+                crate::open_launch_surface(app, crate::main_window::OpenTrigger::Interaction)
+            {
+                ::tracing::error!(event = "main_window_open_failed", trigger = "tray", error = %error);
+            }
+        }
         #[cfg(target_os = "linux")]
-        MENU_OPEN => popover::open_from_tray_menu(app),
+        MENU_OPEN_POPOVER => popover::open_from_tray_menu(app),
         MENU_PIN => {
             // The item names the action, so choosing it always means "do the
             // other thing"; the popover is re-shown by `set_pinned`, because
@@ -584,6 +597,7 @@ fn on_menu_event(app: &AppHandle, event: MenuEvent) {
         MENU_QUIT => {
             // Exit code 0 distinguishes a deliberate quit from the window
             // closes the shell suppresses (see `on_window_event`).
+            crate::main_window::flush_placement(app);
             app.exit(0);
         }
         _ => {}

--- a/apps/desktop/src/bootstrap.tsx
+++ b/apps/desktop/src/bootstrap.tsx
@@ -1,12 +1,16 @@
 import { StrictMode, type ReactNode } from "react"
 import { createRoot } from "react-dom/client"
 
-import { WindowReadyBoundary } from "./components/WindowReadyMarker"
+import { WindowReadyBoundary, type WindowReadyReporter } from "./components/WindowReadyMarker"
 import { installFocusModality } from "./lib/focusModality"
 import { applyPlatformAttribute } from "./lib/platform"
 import { applyRouteAttribute, type Route } from "./lib/route"
 
-export function mountWindow(view: ReactNode, route?: Route): void {
+export function mountWindow(
+  view: ReactNode,
+  route?: Route,
+  reporter?: WindowReadyReporter,
+): void {
   const container = document.getElementById("root")
   if (!container) {
     throw new Error("The window entry is missing the #root mount point")
@@ -17,9 +21,11 @@ export function mountWindow(view: ReactNode, route?: Route): void {
   applyRouteAttribute(document.documentElement, route)
   installFocusModality()
 
-  createRoot(container).render(
-    <StrictMode>
-      <WindowReadyBoundary>{view}</WindowReadyBoundary>
-    </StrictMode>,
+  const content = reporter ? (
+    <WindowReadyBoundary reporter={reporter}>{view}</WindowReadyBoundary>
+  ) : (
+    <WindowReadyBoundary>{view}</WindowReadyBoundary>
   )
+
+  createRoot(container).render(<StrictMode>{content}</StrictMode>)
 }

--- a/apps/desktop/src/components/WindowReadyMarker.test.tsx
+++ b/apps/desktop/src/components/WindowReadyMarker.test.tsx
@@ -65,4 +65,17 @@ describe("WindowReadyMarker", () => {
 
     expect(windowReady).not.toHaveBeenCalled()
   })
+
+  it("uses a window-specific readiness reporter", () => {
+    const reporter = vi.fn(async () => {})
+
+    render(
+      <WindowReadyBoundary reporter={reporter}>
+        <div />
+      </WindowReadyBoundary>,
+    )
+
+    expect(reporter).toHaveBeenCalledWith(7)
+    expect(windowReady).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/components/WindowReadyMarker.tsx
+++ b/apps/desktop/src/components/WindowReadyMarker.tsx
@@ -8,24 +8,39 @@ declare global {
   }
 }
 
-function reportReady(node: HTMLSpanElement | null): void {
+export type WindowReadyReporter = (generation: number) => Promise<void>
+
+function reportReady(node: HTMLSpanElement | null, reporter: WindowReadyReporter): void {
   const generation = window.__ANTIBURN_WINDOW_GENERATION__
   if (node && typeof generation === "number" && Number.isSafeInteger(generation)) {
-    void windowReady(generation).catch(() => undefined)
+    void reporter(generation).catch(() => undefined)
   }
 }
 
 /** Reports readiness after React commits the window shell. */
-function WindowReadyMarker() {
-  return <span ref={reportReady} hidden aria-hidden data-window-ready-marker />
+function WindowReadyMarker({ reporter }: { reporter: WindowReadyReporter }) {
+  return (
+    <span
+      ref={(node) => reportReady(node, reporter)}
+      hidden
+      aria-hidden
+      data-window-ready-marker
+    />
+  )
 }
 
 /** Places the readiness marker after every callback ref in the window view. */
-export function WindowReadyBoundary({ children }: { children: ReactNode }) {
+export function WindowReadyBoundary({
+  children,
+  reporter = windowReady,
+}: {
+  children: ReactNode
+  reporter?: WindowReadyReporter
+}) {
   return (
     <>
       {children}
-      <WindowReadyMarker />
+      <WindowReadyMarker reporter={reporter} />
     </>
   )
 }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -500,6 +500,12 @@ export async function windowReady(generation: number): Promise<void> {
   await invoke("window_ready", { generation })
 }
 
+/** Tell the shell that the retained main window committed this renderer generation. */
+export async function mainWindowReady(generation: number): Promise<void> {
+  if (!hasShell()) return
+  await invoke("main_window_ready", { generation })
+}
+
 /** Tell the shell that the popover's initial activity and usage state settled. */
 export async function popoverContentReady(generation: number): Promise<void> {
   if (!hasShell()) return

--- a/apps/desktop/src/lib/route.test.ts
+++ b/apps/desktop/src/lib/route.test.ts
@@ -60,4 +60,12 @@ describe("applyRouteAttribute", () => {
 
     expect(root.getAttribute("data-route")).toBe("settings")
   })
+
+  it("publishes the dedicated main-window route", () => {
+    const root = document.createElement("html")
+
+    applyRouteAttribute(root, "main")
+
+    expect(root.getAttribute("data-route")).toBe("main")
+  })
 })

--- a/apps/desktop/src/lib/route.ts
+++ b/apps/desktop/src/lib/route.ts
@@ -6,9 +6,16 @@ import { useSyncExternalStore } from "react"
  * windows use dedicated entries and pass their route directly.
  */
 export type Route =
-  "popover" | "popover-peek" | "settings" | "nudge" | "onboarding" | "overlay" | "hud-detail"
+  | "popover"
+  | "popover-peek"
+  | "settings"
+  | "nudge"
+  | "onboarding"
+  | "overlay"
+  | "hud-detail"
+  | "main"
 
-type ShellRoute = Exclude<Route, "settings" | "onboarding">
+type ShellRoute = Exclude<Route, "settings" | "onboarding" | "main">
 
 /** Fragment the nudge crate opens the notification window with. */
 export const NUDGE_FRAGMENT = "#/nudge"

--- a/apps/desktop/src/main-window.tsx
+++ b/apps/desktop/src/main-window.tsx
@@ -1,0 +1,3 @@
+import { mountMainWindow } from "./mainWindowBootstrap"
+
+void mountMainWindow()

--- a/apps/desktop/src/mainWindowBootstrap.test.tsx
+++ b/apps/desktop/src/mainWindowBootstrap.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { MainWindowThemeSession } from "./mainWindowBootstrap"
+
+const getSettings = vi.hoisted(() => vi.fn())
+const onSettingsChanged = vi.hoisted(() => vi.fn())
+const applyTheme = vi.hoisted(() => vi.fn())
+const visibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState")
+type ThemeListener = (settings: { theme: "system" | "light" | "dark" }) => void
+
+vi.mock("./lib/ipc", () => {
+  return { getSettings, mainWindowReady: vi.fn(), onSettingsChanged, windowReady: vi.fn() }
+})
+vi.mock("./lib/appearance", () => ({ applyTheme }))
+
+describe("MainWindowThemeSession", () => {
+  beforeEach(() => {
+    getSettings.mockReset()
+    onSettingsChanged.mockReset()
+    applyTheme.mockReset()
+    onSettingsChanged.mockImplementation(async () => () => {})
+  })
+
+  afterEach(() => {
+    if (visibilityState) Object.defineProperty(document, "visibilityState", visibilityState)
+    else Reflect.deleteProperty(document, "visibilityState")
+  })
+
+  it("sets the stored theme before the main window mounts", async () => {
+    getSettings.mockResolvedValue({ theme: "dark" })
+
+    await new MainWindowThemeSession().start()
+
+    expect(applyTheme).toHaveBeenCalledWith("dark")
+  })
+
+  it.each(["visible", "hidden"] as const)(
+    "applies settings changes while the retained window is %s",
+    async (visibility) => {
+      const subscription: { listener: ThemeListener | null } = { listener: null }
+      onSettingsChanged.mockImplementation(async (next) => {
+        subscription.listener = next
+        return () => {}
+      })
+      getSettings.mockResolvedValue({ theme: "light" })
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: visibility,
+      })
+
+      await new MainWindowThemeSession().start()
+      subscription.listener?.({ theme: "dark" })
+
+      expect(applyTheme).toHaveBeenLastCalledWith("dark")
+    },
+  )
+
+  it("keeps a settings event when a stale initial snapshot arrives later", async () => {
+    const subscription: { listener: ThemeListener | null } = { listener: null }
+    let resolveSettings: (settings: { theme: "light" }) => void
+    getSettings.mockImplementation(
+      () => new Promise<{ theme: "light" }>((resolve) => (resolveSettings = resolve)),
+    )
+    onSettingsChanged.mockImplementation(async (next) => {
+      subscription.listener = next
+      return () => {}
+    })
+    const session = new MainWindowThemeSession()
+    const start = session.start()
+
+    await vi.waitFor(() => expect(subscription.listener).not.toBeNull())
+    subscription.listener?.({ theme: "dark" })
+    resolveSettings!({ theme: "light" })
+    await start
+
+    expect(applyTheme).toHaveBeenCalledTimes(1)
+    expect(applyTheme).toHaveBeenCalledWith("dark")
+  })
+
+  it("registers one listener when startup runs again", async () => {
+    getSettings.mockResolvedValue({ theme: "light" })
+    const session = new MainWindowThemeSession()
+
+    await Promise.all([session.start(), session.start()])
+
+    expect(onSettingsChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it("stops applying changes after page teardown", async () => {
+    const unlisten = vi.fn()
+    const subscription: { listener: ThemeListener | null } = { listener: null }
+    onSettingsChanged.mockImplementation(async (next) => {
+      subscription.listener = next
+      return unlisten
+    })
+    getSettings.mockResolvedValue({ theme: "light" })
+    const session = new MainWindowThemeSession()
+
+    await session.start()
+    session.dispose()
+    subscription.listener?.({ theme: "dark" })
+
+    expect(unlisten).toHaveBeenCalledOnce()
+    expect(applyTheme).toHaveBeenCalledTimes(1)
+    expect(applyTheme).toHaveBeenCalledWith("light")
+  })
+
+  it("keeps the system theme when settings are unavailable", async () => {
+    getSettings.mockRejectedValue(new Error("shell unavailable"))
+
+    await new MainWindowThemeSession().start()
+
+    expect(applyTheme).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/mainWindowBootstrap.tsx
+++ b/apps/desktop/src/mainWindowBootstrap.tsx
@@ -1,0 +1,58 @@
+import { mountWindow } from "./bootstrap"
+import { applyTheme } from "./lib/appearance"
+import { getSettings, mainWindowReady, onSettingsChanged } from "./lib/ipc"
+import { MainWindowView } from "./views/MainWindowView"
+
+/** Synchronizes the retained renderer with the stored theme preference. */
+export class MainWindowThemeSession {
+  private active = true
+  private started = false
+  private settingsVersion = 0
+  private unlisten: (() => void) | null = null
+
+  async start(): Promise<void> {
+    if (!this.active || this.started) return
+    this.started = true
+
+    try {
+      const unlisten = await onSettingsChanged((settings) => {
+        if (!this.active) return
+        this.settingsVersion += 1
+        applyTheme(settings.theme)
+      })
+      if (!this.active) {
+        unlisten()
+        return
+      }
+      this.unlisten = unlisten
+    } catch {
+      // The stored snapshot below still supplies an initial theme.
+    }
+
+    const settings = await getSettings().catch(() => null)
+    if (this.active && this.settingsVersion === 0 && settings) applyTheme(settings.theme)
+  }
+
+  dispose(): void {
+    if (!this.active) return
+    this.active = false
+    this.unlisten?.()
+    this.unlisten = null
+  }
+}
+
+export async function mountMainWindow(): Promise<void> {
+  const themeSession = new MainWindowThemeSession()
+  const dispose = () => themeSession.dispose()
+  window.addEventListener("pagehide", dispose, { once: true })
+  if (import.meta.hot) {
+    import.meta.hot.dispose(() => {
+      window.removeEventListener("pagehide", dispose)
+      dispose()
+    })
+  }
+
+  await themeSession.start()
+
+  mountWindow(<MainWindowView />, "main", mainWindowReady)
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -25,6 +25,7 @@
 @import "./styles/controls.css";
 @import "./styles/platform-controls.css";
 @import "./styles/hud.css";
+@import "./styles/main-window.css";
 @import "./styles/motion.css";
 
 /*

--- a/apps/desktop/src/styles/main-window.css
+++ b/apps/desktop/src/styles/main-window.css
@@ -1,0 +1,80 @@
+/* The retained window paints an opaque canvas over the native window surface. */
+.main-window {
+  --main-window-titlebar-height: calc(var(--space-2xl) + var(--space-lg));
+
+  position: relative;
+  display: flex;
+  block-size: 100%;
+  min-block-size: 0;
+  overflow: hidden;
+  background-color: var(--color-bg-window);
+}
+
+/* This matches the macOS overlay clearance used by the window chrome. */
+.main-window-titlebar {
+  position: absolute;
+  z-index: 20;
+  inset: 0 0 auto;
+  block-size: var(--main-window-titlebar-height);
+}
+
+.main-window-navigation {
+  display: flex;
+  min-block-size: 0;
+  inline-size: var(--sidebar-width);
+  flex: 0 0 var(--sidebar-width);
+  flex-direction: column;
+}
+
+.main-window-macos .main-window-sidebar {
+  padding-block-start: calc(var(--main-window-titlebar-height) - var(--space-xs));
+}
+
+.main-window-sidebar > [role="tablist"] {
+  gap: calc(var(--space-xs) / 2);
+  padding: var(--space-md) var(--space-sm);
+}
+
+/* Main navigation uses a denser rhythm than the Settings source list. */
+.main-window-sidebar [role="tab"] {
+  block-size: calc(var(--space-2xl) + var(--space-xs));
+  flex-shrink: 0;
+  gap: var(--space-sm);
+  padding-inline: var(--space-sm);
+}
+
+.main-window-sidebar [role="tab"] svg {
+  inline-size: 14px;
+  block-size: 14px;
+}
+
+.main-window-content {
+  display: flex;
+  min-inline-size: 0;
+  min-block-size: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.main-window-scroll-viewport {
+  min-inline-size: 0;
+}
+
+.main-window-pane {
+  min-block-size: 100%;
+  padding: var(--space-2xl);
+}
+
+.main-window-content-macos .main-window-pane {
+  padding-block-start: calc(var(--main-window-titlebar-height) + var(--space-2xl));
+}
+
+.main-window-placeholder {
+  display: grid;
+  max-inline-size: 480px;
+  gap: var(--space-sm);
+}
+
+.main-window-placeholder p {
+  max-inline-size: 52ch;
+}

--- a/apps/desktop/src/views/MainWindowView.test.tsx
+++ b/apps/desktop/src/views/MainWindowView.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { MainWindowView } from "./MainWindowView"
+
+const userAgent = Object.getOwnPropertyDescriptor(window.navigator, "userAgent")
+const innerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth")
+
+function setUserAgent(value: string): void {
+  Object.defineProperty(window.navigator, "userAgent", { configurable: true, value })
+}
+
+function setWindowWidth(value: number): void {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value })
+}
+
+afterEach(() => {
+  if (userAgent) Object.defineProperty(window.navigator, "userAgent", userAgent)
+  if (innerWidth) Object.defineProperty(window, "innerWidth", innerWidth)
+})
+
+describe("MainWindowView", () => {
+  it("keeps the macOS title-bar clearance as the drag region", () => {
+    setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X)")
+    setWindowWidth(900)
+
+    const { container } = render(<MainWindowView />)
+
+    expect(screen.getByRole("main", { name: "antiburn main window" })).toHaveClass(
+      "main-window",
+    )
+    expect(container.querySelector("[data-tauri-drag-region]")).toHaveClass(
+      "main-window-titlebar",
+    )
+  })
+
+  it("keeps native title bars clear on other platforms", () => {
+    setUserAgent("Mozilla/5.0 (Windows NT 10.0)")
+    setWindowWidth(900)
+
+    const { container } = render(<MainWindowView />)
+
+    expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
+  })
+
+  it("shows only Activity in the persistent sidebar", () => {
+    setWindowWidth(800)
+    render(<MainWindowView />)
+    expect(screen.getAllByRole("tab")).toHaveLength(1)
+    expect(screen.getByRole("tab", { name: "Activity" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    )
+    expect(screen.getByRole("tabpanel", { name: "Activity" })).toBeVisible()
+    expect(screen.queryByRole("button", { name: "Settings" })).toBeNull()
+    setWindowWidth(900)
+    fireEvent(window, new Event("resize"))
+    expect(screen.getByRole("tablist", { name: "Main sections" })).toBeVisible()
+    expect(screen.queryByRole("button", { name: "Open navigation" })).toBeNull()
+  })
+})

--- a/apps/desktop/src/views/MainWindowView.tsx
+++ b/apps/desktop/src/views/MainWindowView.tsx
@@ -1,0 +1,60 @@
+import { Activity } from "lucide-react"
+
+import { ScrollPane } from "../components/ui/ScrollPane"
+import { SidebarNav, type SidebarNavItem } from "../components/ui/SidebarNav"
+import { isMacOS } from "../lib/platform"
+
+const NAVIGATION_ITEMS = [
+  { id: "activity", label: "Activity", icon: Activity },
+] as const satisfies readonly SidebarNavItem[]
+
+/** The retained application window shell. Feature views replace its honest placeholders later. */
+export function MainWindowView() {
+  const macOS = isMacOS()
+
+  return (
+    <main
+      className={`main-window${macOS ? " main-window-macos" : ""}`}
+      aria-label="antiburn main window"
+    >
+      {macOS && (
+        <div className="main-window-titlebar" data-tauri-drag-region aria-hidden="true" />
+      )}
+
+      <div className="main-window-navigation">
+        <SidebarNav
+          items={NAVIGATION_ITEMS}
+          value="activity"
+          onChange={() => {}}
+          ariaLabel="Main sections"
+          className="main-window-sidebar min-h-0 flex-1"
+        />
+      </div>
+
+      <div className={`main-window-content${macOS ? " main-window-content-macos" : ""}`}>
+        <ScrollPane className="min-h-0" viewportClassName="main-window-scroll-viewport">
+          <section
+            id="activity-panel"
+            role="tabpanel"
+            aria-labelledby="activity-tab"
+            tabIndex={0}
+            className="main-window-pane"
+          >
+            <div className="main-window-placeholder">
+              <Activity
+                size={24}
+                strokeWidth={1.5}
+                className="text-label-secondary"
+                aria-hidden="true"
+              />
+              <h1 className="type-title-2 text-label">Activity</h1>
+              <p className="type-body text-label-secondary">
+                Activity will appear here. Current activity remains available from the menu bar.
+              </p>
+            </div>
+          </section>
+        </ScrollPane>
+      </div>
+    </main>
+  )
+}

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -1065,14 +1065,9 @@ describe("SettingsView", () => {
     expect(screen.getByText(/· aarch64$/)).toBeInTheDocument()
   })
 
-  it("quits antiburn from the sidebar, through the shell", async () => {
+  it("keeps application Quit out of the Settings sidebar", () => {
     render(<SettingsView />)
-
-    fireEvent.click(await screen.findByRole("button", { name: "Quit antiburn" }))
-
-    // Through the shell, not by closing a window: a menu-bar app outlives its
-    // windows, and only `exit(0)` is a deliberate quit.
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith("quit_app"))
+    expect(screen.queryByRole("button", { name: /quit/i })).toBeNull()
   })
 
   it("opens on the pane the shell was asked for, when the window is new", async () => {

--- a/apps/desktop/src/views/SettingsView.tsx
+++ b/apps/desktop/src/views/SettingsView.tsx
@@ -2,7 +2,6 @@ import {
   Bell,
   Info,
   Lightbulb,
-  LogOut,
   Palette,
   ShieldCheck,
   SlidersHorizontal,
@@ -13,7 +12,7 @@ import { useState, useSyncExternalStore } from "react"
 
 import { ScrollPane } from "../components/ui/ScrollPane"
 import { SidebarNav, type SidebarNavItem } from "../components/ui/SidebarNav"
-import { closeCurrentWindow, quitApp } from "../lib/ipc"
+import { closeCurrentWindow } from "../lib/ipc"
 import { useGlobalKeydown } from "../lib/useGlobalKeydown"
 import { isMacOS } from "../lib/platform"
 import { isSettingsPane, type SettingsPane } from "../lib/settingsPanes"
@@ -44,9 +43,6 @@ import { useAppSettings } from "./settings/useAppSettings"
  *   because it is never re-mounted.
  * - **Nothing else.** There is no deep-link scheme and no route.
  *
- * The sidebar ends in Quit because a menu-bar application has no Dock icon and
- * no application menu: Settings and the tray menu are the only two places a
- * reader can reasonably look for the way out.
  */
 
 // Everyday panes first, provenance last: Privacy and Notifications sit ahead
@@ -122,16 +118,6 @@ export function SettingsView() {
         // strip — while the sidebar material still fills to the window's top
         // edge behind the traffic lights.
         className={isMacOS() ? "pt-7" : ""}
-        footer={
-          <button
-            type="button"
-            onClick={() => void quitApp()}
-            className="type-body flex h-9 w-full items-center gap-3 rounded-control px-3 text-label transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover"
-          >
-            <LogOut size={16} strokeWidth={2} className="shrink-0" aria-hidden="true" />
-            <span className="truncate">Quit antiburn</span>
-          </button>
-        }
       />
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig(({ command, mode }) => ({
     rollupOptions: {
       input: {
         main: fileURLToPath(new URL("./index.html", import.meta.url)),
+        mainWindow: fileURLToPath(new URL("./main.html", import.meta.url)),
         onboarding: fileURLToPath(new URL("./onboarding.html", import.meta.url)),
         settings: fileURLToPath(new URL("./settings.html", import.meta.url)),
       },

--- a/docs/reviews/desktop-main-window-pr1.md
+++ b/docs/reviews/desktop-main-window-pr1.md
@@ -1,0 +1,103 @@
+# PR 1: desktop main-window review
+
+Review date: 2026-09-07. This is a local review of the first planned change,
+not a published pull request or a merge approval.
+
+## Decision
+
+**Ratified as the implementation foundation for PR 2.** The final frontend and
+independent native integration reviews found no actionable source blockers.
+Architecture, lifecycle, security boundaries, and CI coverage are approved for
+the next planned change.
+
+**Cross-platform release acceptance remains conditional.** The platform and
+performance gates below remain open. This ratification does not claim that those
+checks passed, authorize publication, or start PR 2.
+
+## Reviewed baseline
+
+Base commit: `cdd8a58e5e5084a55b62d4837e5eafcf6066df1e`.
+The implementation is an uncommitted working tree. No branch publication,
+pull request creation, or PR 2 implementation is part of this review.
+
+The reviewed non-Markdown snapshot contains 39 changed or untracked files.
+Its SHA-256 is
+`7ca4a09055e9b6816fcab4d56a47135d5dbcb5740b1f0e661dfbb11c14f637d1`.
+The digest covers sorted paths from `git ls-files -m -o --exclude-standard`,
+excluding Markdown. Each path, byte length, and file content is added in order,
+with NUL separators after the path and length. This review record and subsequent
+documentation-only ratification edits are outside that snapshot.
+
+## Scope assessment
+
+| Area                          | Assessment                                                                                                                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Native boundary               | The main-window crate owns window mechanics and geometry; the shell owns launch intent, readiness, persistence, and activation policy.                                    |
+| Frontend boundary             | A dedicated entry mounts an empty, accessible themed canvas. Navigation and product views remain deferred.                                                                |
+| Existing surfaces             | Tray/popover, Settings, HUD, notifications, and shared monitoring remain in place. The new entry adds no scan or provider polling loop.                                   |
+| Ordinary application behavior | Regular macOS activation and Dock presence replace agent-only mode. Main close hides the retained renderer; explicit Quit exits.                                          |
+| Geometry                      | 900×600 logical default, 560×420 normal minimum, initial outer frame capped at 85% of usable dimensions. Saved user sizes are preserved.                                  |
+| macOS chrome                  | Native traffic lights remain; the custom drag strip supports dragging and double-click maximize/restore through Tauri.                                                    |
+| macOS activation              | Previously closed or minimized main windows restore on activation. Startup and other surface interactions have explicit guards.                                           |
+| Permissions                   | The main window has a dedicated capability for theme bootstrap, events, readiness, and titlebar actions. It does not inherit the broad interactive-window capability.     |
+| Design system                 | The shared semantic tokens remain authoritative. The future sidebar is 220px and collapses below 800px; neither navigation nor view layouts are implemented here.         |
+| Performance foundation        | Lazy background creation, retained reopening, a small dedicated entry, and separate cold/first/warm instrumentation are present. Measured performance remains unverified. |
+
+## Validation evidence
+
+Reuse successful checks while their relevant files remain unchanged. This review
+does not claim a fresh all-platform CI run.
+
+- Frontend: formatting, lint, type checking, 1,154 tests, production build,
+  design drift, and unused-code checks passed during implementation. Subsequent
+  fixes changed native behavior and documentation, not the frontend source.
+- Native: the initial full shell suite passed with its two sandbox-sensitive
+  filesystem watcher tests rerun successfully outside the sandbox. Later changes
+  passed their relevant tests, including nine geometry tests and four main-window
+  lifecycle tests. Rust formatting and all-target Clippy passed.
+- Reporting: reveal-report tests cover sample classification, nearest-rank p95,
+  invalid input, insufficient samples, and missed targets. CI includes this script
+  and the new crate in its existing check structure.
+- macOS packaged debug builds passed. Native checks observed onboarding-to-main,
+  a fresh 900×600 main window, double-click expansion/restoration, close followed
+  by activation, and actual Command-Tab restoration after minimization.
+- Minimized restoration was confirmed with the window server: the main window
+  was absent from the on-screen list before activation and present afterward.
+  System Events retained a stale `AXMinimized` value and was not treated as the
+  authoritative post-restoration result.
+- Focused independent reviews approved the geometry, titlebar permission, closed
+  activation, and minimized activation changes. The frontend integration review
+  found no blocking issues. The final full native integration review approved the
+  complete local change, including launch intent, single-instance ordering,
+  onboarding handoff, lifecycle recovery, placement, permissions, and CI coverage.
+
+## Open release-validation gates
+
+These are unverified conditions, not successful checks:
+
+1. Run the installed Windows and Linux native matrix, including taskbar grouping,
+   switching, close/reopen, quit, startup, display scaling, and Linux compositor
+   differences. CI configuration alone does not establish native behavior.
+2. Complete the remaining macOS matrix for login startup, Settings/tray/HUD/
+   notification interactions, monitor removal, and native keyboard/menu paths.
+   Source guards and unit tests do not replace those interaction checks.
+3. Measure optimized cold launch, first open, and at least 30 warm reopens.
+   Establish native reveal p95 ≤100ms separately from presented-frame and input
+   readiness timings. No latency target is ratified by this review.
+4. Measure process-tree memory and hidden idle CPU before and after repeated
+   hide/show cycles. Retention is intentional; bounded resource use still needs
+   measured evidence.
+
+Existing Windows/Linux login registrations without `--background` have a known
+upgrade limitation: their first unreconciled launch is indistinguishable from a
+manual launch. The updated app rewrites enabled registrations for later logins.
+The [validation runbook](../runbooks/main-window.md) documents this behavior.
+
+## Boundary for PR 2
+
+Keep the main-window mechanism, shared services, retained renderer, and capability
+boundary intact. PR 2 owns navigation and layout only. Confirm destination names
+and order in its IA review before adding views, and preserve compact layout,
+keyboard access, theme behavior, and visibility-based presentation work.
+
+Starting PR 2 does not close any release-validation gate listed above.

--- a/docs/runbooks/main-window.md
+++ b/docs/runbooks/main-window.md
@@ -1,0 +1,143 @@
+# Main-window validation
+
+Use this runbook for changes to the main window and for each subsequent view
+migration. The first main-window change contains no product views. Preserve
+this baseline as real content is added.
+
+## Build and isolate
+
+Build with `pnpm --filter @antiburn/desktop dev:bundle` for native smoke tests.
+Use a separate debug profile as described in [debugging](../debugging.md).
+For performance measurements, use an optimized packaged build with the debug
+bundle identifier and without the `distribution` feature:
+
+```bash
+pnpm --filter @antiburn/desktop tauri build --config src-tauri/tauri.debug.conf.json
+```
+
+Record the commit, OS build, CPU, RAM, display scale and usable work area, build
+profile, and fixture size. Never compare debug timings with optimized timings.
+Use synthetic sessions and retain reports outside the repository. Do not
+combine logs from different machines, builds, or benchmark intervals.
+
+## Native smoke matrix
+
+Test a fresh profile separately from saved placement. The default content size
+is 900×600 logical pixels; the normal minimum is 800×560. The initial outer frame,
+including native chrome, occupies at most 85% of each usable display dimension.
+Small work areas may reduce the effective minimum. A valid saved user size can
+exceed this initial cap. Do not reset a user's placement to test the default.
+
+Check a Retina display, a non-Retina display, and movement between displays with
+different scale factors. On a 2× display, the uncapped default content size is
+1800×1200 physical pixels and still appears as 900×600 logical pixels. Test both
+fresh placement on the secondary display and restoration after relaunch.
+
+For macOS minimize/restore tests, confirm that the main window leaves the window
+server's on-screen list before activation and returns afterward. Match the app
+PID and the main window's layer and bounds. System Events can retain a stale
+`AXMinimized` value after programmatic restoration, and an accessibility window
+list can include minimized windows. Neither alone establishes on-screen state.
+
+Run the following on macOS, Windows, and Linux. On Linux record the desktop
+environment and X11/XWayland/Wayland backend; compositor policy can control
+position and focus. Test an installed build for taskbar icon grouping.
+
+| Scenario                                     | Expected result                                                                      |
+| -------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Explicit launch after onboarding             | One main window opens with an opaque themed canvas                                   |
+| First launch                                 | Onboarding appears; completing it opens the main window                              |
+| Background/login launch                      | Monitoring and tray start without creating the main webview or taking focus          |
+| Launch again                                 | The existing process opens or restores its main window; no second scan scheduler     |
+| Close then Open antiburn                     | The same renderer reappears; navigation state will remain when views exist           |
+| macOS close, switch away, Command-Tab back   | The retained main window reappears; closing alone never immediately reopens it       |
+| macOS close, then open Settings or popover   | The requested surface appears without reopening the main window                      |
+| Close during initial load                    | Readiness does not unexpectedly reopen the closed window                             |
+| Minimize then open                           | The window restores and becomes usable                                               |
+| macOS minimize, switch away, activate        | The main window restores through native unminimize; minimizing alone stays minimized |
+| Switch applications                          | Normal Dock/taskbar switching works; the main window does not hide on blur           |
+| Resize, maximize, tile                       | Native controls and OS window management work                                        |
+| Reopen after monitor removal or scale change | Usable bounds are restored with title controls reachable                             |
+| macOS chrome                                 | Traffic lights work; the empty title strip drags; native title text stays hidden     |
+| macOS title-strip double-click               | First double-click expands the window; the second restores its previous size         |
+| Windows/Linux chrome                         | Native title bar remains; no duplicate webview drag strip                            |
+| Light/dark and accessibility preferences     | No white startup flash; readable opaque surface; no opening animation                |
+| Explicit Quit from each menu                 | Process and monitoring stop, including with no visible windows                       |
+| Existing tray primary/secondary clicks       | Popover toggle and existing menu actions retain their behavior                       |
+| Existing settings, HUD, and notifications    | Each supported surface opens and behaves as before                                   |
+
+Windows/Linux login registration now adds `--background`. Existing registrations
+are rewritten when the updated app reconciles the enabled preference. An old
+registration that launches the new binary before reconciliation still has no
+argument, so that first launch opens the main window. The old command is
+indistinguishable from a manual launch; the app does not guess from login
+preferences or elapsed boot time. Launch the updated app once before testing
+quiet login on an upgraded installation. macOS uses the native login event.
+
+## Navigation shell
+
+Check the 900×600 default and 800×560 minimum with light and dark themes.
+
+- The sidebar remains visible throughout resizing; no compact navigation mode appears.
+- Activity is the only selected main section; no Settings or Quit sidebar action appears.
+- The existing Settings window remains accessible through the tray and native menus.
+- Check readable 28px rows and independent vertical content scrolling without horizontal overflow.
+- Restore an older saved 560×420 window; it expands to at least 800×560 when the display allows.
+- Close and reopen the main window; the selected section persists.
+- The first macOS row starts below the 40px drag strip. Buttons must not drag the window.
+- The title strip still drags and toggles maximize on double-click.
+
+## Opening measurements
+
+Measure three separate paths:
+
+1. **Cold launch:** quit the app, then explicitly launch it with onboarding done.
+2. **First open:** launch in the background, then select **Open antiburn** once.
+3. **Warm reopen:** close the main window, then select **Open antiburn** at least
+   30 times. Wait for each reveal before closing it again.
+
+The shell writes `main_window_revealed` JSON events containing `open_kind`,
+`elapsed_ms`, and `window: main`. Summarize one benchmark interval with:
+
+```bash
+node scripts/window-open-report.mjs /absolute/path/to/benchmark.jsonl
+```
+
+The report uses nearest-rank p95 and keeps cold, first, and warm samples apart.
+Its warm native target is p95 ≤100ms with at least 30 samples. Fewer samples are
+inconclusive. The script returns an analysis report; `status: missed` is a
+target miss, even though the report command itself completed successfully.
+
+These events measure the request to native reveal completion, not process
+launch to first frame. Measure process-launch latency separately with an
+external timer. Use screen recording or a platform presentation trace to
+measure request-to-visible and verify that controls accept input. Record these
+values beside the native timing report; do not equate `show()` completion with
+pixels on screen or successful focus activation.
+
+Record the generated frontend entry and imported chunk sizes from the build.
+The navigation-only main entry must not load session analysis or chart code.
+
+## Hidden resources
+
+Record process-tree memory and idle CPU before opening, after first open,
+after hiding, and after 30 hide/show cycles. Include associated webview
+processes; the shell process alone misses renderer cost. Use the same settling
+interval and sample count in each state. Use five samples after 10 seconds of
+settling as the initial protocol, with one second between samples.
+
+Confirm one resident main renderer, no growing renderer count, no accumulating
+listeners or timers, and no additional scan or provider polling loop. Hidden
+CPU should return to its background baseline. Retained memory is expected;
+monotonic growth across repeated cycles needs investigation.
+
+The [popover memory report](memory-reporting.md) measures a different surface.
+Do not describe its shell-plus-popover measurements as a main-window memory
+measurement.
+
+## Evidence to attach to a PR
+
+Include platform smoke results, native timing summaries, observed frame/input
+timings, bundle sizes, and resource samples. Mark an unavailable platform or
+measurement as unverified. Unit tests and a successful bundle build do not
+establish native app-switching behavior or the latency target.

--- a/docs/window-renderer-lifecycle.md
+++ b/docs/window-renderer-lifecycle.md
@@ -3,14 +3,14 @@
 _Contributor reference for when desktop webview renderers are created, reused,
 hidden, and destroyed._
 
-The desktop shell stays resident because antiburn is a menu-bar application.
+The desktop shell stays resident to support monitoring and the menu-bar companion.
 The main popover renderer also stays resident after its first use, so the
 application's primary surface can reopen immediately. Other renderers remain
 bounded by their interaction or handoff.
 
-This document covers the popover, its peek companion, onboarding, and Settings
-renderers. The HUD and nudge windows have separate ownership rules. See
-[HUD states](hud-states.md) for the HUD and its detail window.
+This document covers the main window, popover, its peek companion, onboarding,
+and Settings renderers. The HUD and nudge windows have separate ownership rules.
+See [HUD states](hud-states.md) for the HUD and its detail window.
 
 ## The shared lifecycle
 
@@ -43,16 +43,36 @@ This handshake gives the lifecycle these properties:
 The shared Tauri adapters in
 [`window_lifecycle.rs`](../apps/desktop/src-tauri/src/window_lifecycle.rs) record
 load timing, warn about the current stale generation, and reset failed loads.
-The popover, Settings, and onboarding modules own their window-specific reveal
+The main-window, popover, Settings, and onboarding modules own their window-specific reveal
 and destruction policies.
+
+## Main window
+
+The main window uses a dedicated frontend entry with an empty themed shell.
+An explicit launch creates it after onboarding. Background startup does not
+construct its webview. After first use, closing hides the window and preserves
+its renderer for the next open. Quit stops the application and all renderers.
+
+The native mechanism crate owns creation, reveal, and placement geometry. The
+shell owns the shared readiness state machine, persisted placement, launch
+intent, and close policy. Repeated opens join the same load; a matching shell
+readiness report permits reveal without waiting for data or network requests.
+
+The main window adds no scans or provider polling. Future views must gate
+presentation work on visibility rather than focus, and consume existing native
+state. An unfocused window can still be visible beside another application.
+
+Opening timing is local diagnostic evidence. Native reveal completion does not
+prove a frame was presented. See the [validation runbook](runbooks/main-window.md)
+for separate cold, first-open, and warm measurements.
 
 ## Onboarding handoff and popover prewarm
 
 Completing onboarding performs a deliberate handoff from the first-run window
 to the menu-bar surface:
 
-1. The shell hides onboarding immediately, changes macOS to accessory mode,
-   and shows the menu-bar-location notification.
+1. The shell hides onboarding immediately, opens the main window, and shows
+   the menu-bar-location notification. macOS retains regular application mode.
 2. On the next main-loop turn, the shell requests one hidden popover renderer.
    This moves renderer startup out of the first menu-bar click.
 3. It waits one second before destroying onboarding. This lets the final

--- a/scripts/window-open-report.mjs
+++ b/scripts/window-open-report.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { createReadStream } from "node:fs";
+import { resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { pathToFileURL } from "node:url";
+
+const KINDS = ["cold_launch", "first_open", "warm_reopen"];
+const REQUIRED_WARM_SAMPLES = 30;
+const WARM_TARGET_MS = 100;
+
+export function collectSample(samples, line) {
+  if (!line.trim()) return;
+  const { fields } = JSON.parse(line);
+  if (fields?.event !== "main_window_revealed") return;
+  if (fields.window !== "main") throw new Error("unexpected benchmark window");
+  if (!KINDS.includes(fields.open_kind)) throw new Error("unknown open kind");
+  if (
+    typeof fields.elapsed_ms !== "number" ||
+    !Number.isFinite(fields.elapsed_ms) ||
+    fields.elapsed_ms < 0
+  ) {
+    throw new Error("invalid reveal duration");
+  }
+  if (samples.length >= 100_000)
+    throw new Error("select a smaller benchmark log interval");
+  samples.push({ kind: fields.open_kind, milliseconds: fields.elapsed_ms });
+}
+
+function distribution(values) {
+  values.sort((left, right) => left - right);
+  const count = values.length;
+  if (!count) return { count: 0, median_ms: null, p95_ms: null, max_ms: null };
+  const middle = Math.floor(count / 2);
+  const median =
+    count % 2 ? values[middle] : (values[middle - 1] + values[middle]) / 2;
+  return {
+    count,
+    median_ms: median,
+    p95_ms: values[Math.ceil(count * 0.95) - 1],
+    max_ms: values[count - 1],
+  };
+}
+
+export function summarize(samples) {
+  const groups = Object.fromEntries(
+    KINDS.map((kind) => [
+      kind,
+      distribution(
+        samples
+          .filter((sample) => sample.kind === kind)
+          .map((sample) => sample.milliseconds),
+      ),
+    ]),
+  );
+  const warm = groups.warm_reopen;
+  return {
+    metric: "request_to_native_reveal_ms",
+    presented_frame_measured: false,
+    groups,
+    warm_native_target: {
+      required_samples: REQUIRED_WARM_SAMPLES,
+      p95_limit_ms: WARM_TARGET_MS,
+      status:
+        warm.count < REQUIRED_WARM_SAMPLES
+          ? "insufficient_samples"
+          : warm.p95_ms <= WARM_TARGET_MS
+            ? "met"
+            : "missed",
+    },
+  };
+}
+
+async function main(args) {
+  if (args.length !== 1 || args[0] === "--help") {
+    process.stdout.write(
+      "Usage: node scripts/window-open-report.mjs <hourly-json-log|->\nUse one platform, build, and benchmark interval. '-' reads standard input.\n",
+    );
+    if (args[0] !== "--help") process.exitCode = 1;
+    return;
+  }
+  const input =
+    args[0] === "-"
+      ? process.stdin
+      : createReadStream(args[0], { encoding: "utf8" });
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  const samples = [];
+  try {
+    for await (const line of lines) collectSample(samples, line);
+  } finally {
+    lines.close();
+    if (input !== process.stdin) input.destroy();
+  }
+  if (!samples.length) throw new Error("no main-window reveal samples found");
+  process.stdout.write(`${JSON.stringify(summarize(samples), null, 2)}\n`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/window-open-report.test.mjs
+++ b/scripts/window-open-report.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { collectSample, summarize } from "./window-open-report.mjs";
+
+const event = (kind, elapsed, extra = {}) =>
+  JSON.stringify({
+    fields: {
+      event: "main_window_revealed",
+      window: "main",
+      open_kind: kind,
+      elapsed_ms: elapsed,
+      ...extra,
+    },
+  });
+
+test("ignores unrelated diagnostics and rejects malformed benchmark events", () => {
+  const samples = [];
+  collectSample(
+    samples,
+    JSON.stringify({ fields: { event: "scan_finished" } }),
+  );
+  collectSample(samples, "");
+  assert.deepEqual(samples, []);
+  assert.throws(() => collectSample(samples, "not JSON"), /JSON/);
+  assert.throws(
+    () => collectSample(samples, event("warm_reopen", -1)),
+    /duration/,
+  );
+  assert.throws(
+    () => collectSample(samples, event("warm_reopen", "25")),
+    /duration/,
+  );
+  assert.throws(() => collectSample(samples, event("unknown", 25)), /kind/);
+  assert.throws(
+    () =>
+      collectSample(samples, event("warm_reopen", 25, { window: "settings" })),
+    /window/,
+  );
+});
+
+test("keeps first opens separate from warm samples and uses nearest-rank p95", () => {
+  const samples = [];
+  collectSample(samples, event("cold_launch", 600));
+  collectSample(samples, event("first_open", 400));
+  for (let index = 1; index <= 30; index += 1) {
+    collectSample(samples, event("warm_reopen", index));
+  }
+  const report = summarize(samples);
+  assert.equal(report.groups.cold_launch.count, 1);
+  assert.equal(report.groups.first_open.p95_ms, 400);
+  assert.equal(report.groups.warm_reopen.median_ms, 15.5);
+  assert.equal(report.groups.warm_reopen.p95_ms, 29);
+  assert.equal(report.warm_native_target.status, "met");
+  assert.equal(report.metric, "request_to_native_reveal_ms");
+  assert.equal(report.presented_frame_measured, false);
+});
+
+test("does not pass a target with too few samples or no events", () => {
+  assert.equal(summarize([]).warm_native_target.status, "insufficient_samples");
+  const samples = [];
+  for (let index = 0; index < 29; index += 1)
+    collectSample(samples, event("warm_reopen", 1));
+  assert.equal(
+    summarize(samples).warm_native_target.status,
+    "insufficient_samples",
+  );
+  collectSample(samples, event("warm_reopen", 1));
+  assert.equal(summarize(samples).warm_native_target.status, "met");
+});
+
+test("reports a slow warm distribution without mixing cold launch data", () => {
+  const samples = [];
+  for (let index = 0; index < 30; index += 1)
+    collectSample(samples, event("warm_reopen", 101));
+  assert.equal(summarize(samples).warm_native_target.status, "missed");
+});


### PR DESCRIPTION
## Stack

1. **PR #449 — main-window foundation** (this PR, targets `main`)
2. [PR #450 — collection/detail navigation](https://github.com/antiburn/antiburn/pull/450)
3. [PR #451 — Sessions integration](https://github.com/antiburn/antiburn/pull/451)

## Summary

- Add the retained desktop main-window lifecycle and dedicated renderer.
- Add native window controls, placement persistence, readiness handling, and activation behavior.
- Keep background/login launches quiet while explicit launches open the main window.
- Add the persistent Activity sidebar foundation.
- Preserve existing tray, popover, Settings, HUD, notification, and monitoring behavior.
- Add lifecycle diagnostics, CI coverage, and the main-window validation runbook.

## Platform behavior

- macOS uses native traffic lights and restores closed or minimized windows on activation.
- Windows and Linux retain native title bars and taskbar behavior.
- Login registration uses an explicit background launch argument where required.

## Validation

- Frontend formatting, lint, type-check, tests, and production build.
- Rust formatting, Clippy, and tests for the shell and main-window crate.
- Packaged macOS debug build and lifecycle smoke testing.
- Windows/Linux native release validation remains required and is documented in the runbook.
