### PR TITLE
feat(desktop): add reusable main-window collection and detail panes

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -131,11 +131,12 @@ Settings teardown, and the memory rules behind those policies.
   window that was closed or minimized earlier. Restoration uses the native
   unminimize operation. Tray interactions and login startup stay quiet.
   The initial content size is
-  900×600 logical pixels with a normal minimum of 800×560. The initial outer
+  1100×600 logical pixels with a normal minimum of 1000×560. The initial outer
   frame is capped at 85% of each usable display dimension. Saved user sizes
   retain their dimensions within the available work area. The navigation shell
   uses a persistent 220px sidebar with dense desktop rows. Activity is the only main sidebar item and contains
-  placeholders until product views migrate; see the
+  placeholders until product views migrate. The sidebar Settings action and Command+,
+  (Control+, on Windows and Linux) open the existing Settings window; see the
   [main-window validation runbook](../../docs/runbooks/main-window.md).
 - **Tray item.** Primary click toggles the popover. Secondary click opens a
   menu with Open antiburn, Pin Window, Settings, and Quit. Native application
@@ -247,3 +248,16 @@ These build-level limits affect desktop development:
   agents with a recorded vendor logo, a letter tile for known agents without
   one, and a neutral surface glyph only for `generic-agent`. Original
   per-agent artwork beyond vendor marks is a later stream.
+
+### Main window feature boundary
+
+`MainWindowView` registers sections with a renderer that receives an `active` flag. Unvisited
+sections do not mount; visited sections stay mounted while hidden. Future feature adapters
+must combine this flag with window visibility before doing presentation work.
+
+`MainWindowLayout` supplies the persistent sidebar and workspace. `CollectionDetailPane`
+supplies independent collection/detail viewports and selection by stable item ID. Features
+provide `items` and `renderDetail`; an optional `renderCollection` slot receives `selectedId`,
+`select`, and `openDetail` and owns its viewport. The default list supports keyboard selection
+and Enter-to-detail-region focus. Controlled `selection` and `onSelectionChange` let a feature
+own navigation history. `detailOwnsViewport` embeds a view with an existing scroll container.

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -467,18 +467,34 @@ Notes for what isn't expressible as a token:
   where it means a category: blue for context, the token series colors for in/out, yellow and
   pink for cache marks, brand orange for a compaction, teal for real work, red for waste.
   Everything else stays greyscale until the pointer names a layer.
-- **Main window** — the retained main window opens at 900 × 600 logical pixels with a normal
-  minimum of 800 × 560. The initial outer frame uses at most 85% of each usable display dimension,
+- **Main window** — the retained main window opens at 1100 × 600 logical pixels with a normal
+  minimum of 1000 × 560. The initial outer frame uses at most 85% of each usable display dimension,
   including native chrome. A smaller work area takes precedence over the normal minimum. Saved
   user sizes can exceed the initial cap and remain constrained to the usable work area. It paints the opaque
-  `surface-window` canvas. On macOS its 40px overlay titlebar remains a drag region and leaves the
-  native traffic lights visible. Double-clicking this strip toggles maximize and restore through
+  `surface-window` canvas. On macOS its 40px overlay drag region spans only the sidebar and leaves the
+  native traffic lights visible. The collection and detail panes start at the top of the window,
+  without titlebar clearance or an overlaid drag region. Double-clicking this strip toggles maximize and restore through
   Tauri's drag-region handler. Windows and Linux retain their native bars, so this surface adds no
   top strip there. Multi-pane content keeps the documented 220px sidebar visible at every size.
   Main navigation uses 28px rows, 2px vertical gaps, 14px icons, and 8px icon-to-label gaps.
   These local geometry rules use the spacing tokens in `main-window.css`; other source lists
-  retain their current density. Activity is the only main sidebar item. Settings remains available through the tray and native menus.
-  The first main row starts at 48px on macOS, clear of the drag strip. The content region scrolls
+  retain their current density. Activity is the main sidebar section. A Settings action at the bottom opens the existing Settings window. Command+, (Control+, on Windows and Linux) also opens Settings without changing the selected section.
+  The first sidebar row starts at 48px on macOS, clear of the drag strip. The content region scrolls
   independently of the title strip. A view switch is immediate: the window does not animate navigation. Use the
   documented type scale and keyboard-only focus treatment. Hidden or minimized main windows suspend
   presentation work; blur alone does not suspend it. Native close hides this renderer for reuse.
+
+### Main window collection and detail architecture
+
+The 220px navigation sidebar, 340px collection pane, and flexible detail pane remain visible
+at every supported window size. Each pane owns its scroll viewport. Generic pane labels are visually hidden;
+features can supply their own toolbar and scroll area. At the 1000px minimum window width,
+the detail retains 440px; at the 1100px default width, it receives 540px.
+Selection is immediate, with no navigation animation. The generic collection does not auto-select.
+The default collection uses 40px minimum rows, semantic selected fills, and the shared
+keyboard-only focus treatment. Arrow keys, Home, and End select rows; Enter focuses the detail
+region. Visited sections retain their state and scroll position while hidden.
+
+`MainWindowLayout` owns chrome and columns. `CollectionDetailPane` owns selection and detail
+slots; a custom collection slot owns its own viewport, including any virtualization. These
+components do not load data or subscribe to events.

--- a/apps/desktop/src-tauri/capabilities/main.json
+++ b/apps/desktop/src-tauri/capabilities/main.json
@@ -9,6 +9,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-internal-toggle-maximize",
     "allow-get-settings",
+    "allow-open-settings-window",
     "allow-main-window-ready"
   ]
 }

--- a/apps/desktop/src-tauri/crates/main-window/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/main-window/src/lib.rs
@@ -11,11 +11,11 @@ pub const LABEL: &str = "main";
 /// The dedicated frontend entry.
 pub const URL: &str = "main.html";
 /// The first inner width in logical pixels.
-pub const DEFAULT_WIDTH: f64 = 900.0;
+pub const DEFAULT_WIDTH: f64 = 1100.0;
 /// The first inner height in logical pixels.
 pub const DEFAULT_HEIGHT: f64 = 600.0;
 /// The minimum inner width in logical pixels.
-pub const MIN_WIDTH: f64 = 800.0;
+pub const MIN_WIDTH: f64 = 1000.0;
 /// The minimum inner height in logical pixels.
 pub const MIN_HEIGHT: f64 = 560.0;
 
@@ -394,9 +394,9 @@ mod tests {
         assert_eq!(
             validated_placement(None, &[PRIMARY], Some(PRIMARY), 1.0, 0, 0),
             Placement {
-                x: 270,
+                x: 170,
                 y: 162,
-                width: 900,
+                width: 1100,
                 height: 600,
                 maximized: false,
                 scale_factor: 1.0,
@@ -438,7 +438,7 @@ mod tests {
             scale_factor: 1.0,
         };
         let restored = validated_placement(Some(&saved), &[PRIMARY], Some(PRIMARY), 1.0, 0, 0);
-        assert_eq!((restored.width, restored.height), (800, 560));
+        assert_eq!((restored.width, restored.height), (1000, 560));
     }
 
     #[test]
@@ -518,7 +518,7 @@ mod tests {
             height: 1_920,
         };
         let placement = validated_placement(None, &[retina], Some(retina), 2.0, 0, 0);
-        assert_eq!((placement.width, placement.height), (1_800, 1_200));
+        assert_eq!((placement.width, placement.height), (2_200, 1_200));
         assert!(!placement.maximized);
     }
 
@@ -593,7 +593,10 @@ mod tests {
                 0,
                 0
             ),
-            normalized
+            Placement {
+                width: 2_000,
+                ..normalized
+            }
         );
     }
 }

--- a/apps/desktop/src/styles/main-window.css
+++ b/apps/desktop/src/styles/main-window.css
@@ -10,11 +10,12 @@
   background-color: var(--color-bg-window);
 }
 
-/* This matches the macOS overlay clearance used by the window chrome. */
+/* Keep the drag region above the sidebar and clear of feature controls. */
 .main-window-titlebar {
   position: absolute;
   z-index: 20;
-  inset: 0 0 auto;
+  inset: 0 auto auto 0;
+  inline-size: var(--sidebar-width);
   block-size: var(--main-window-titlebar-height);
 }
 
@@ -48,33 +49,60 @@
   block-size: 14px;
 }
 
-.main-window-content {
+.main-window-workspace,
+.main-window-section {
   display: flex;
   min-inline-size: 0;
   min-block-size: 0;
   flex: 1;
-  flex-direction: column;
 }
 
-.main-window-scroll-viewport {
+.main-window-section[hidden] {
+  display: none;
+}
+
+.main-window-collection,
+.main-window-detail {
+  display: flex;
+  flex-direction: column;
+  min-block-size: 0;
   min-inline-size: 0;
 }
 
+.main-window-collection {
+  flex: 0 0 340px;
+  border-inline-end: 1px solid var(--color-border);
+}
+
+.main-window-detail {
+  flex: 1;
+}
+
 .main-window-pane {
-  min-block-size: 100%;
   padding: var(--space-2xl);
 }
 
-.main-window-content-macos .main-window-pane {
-  padding-block-start: calc(var(--main-window-titlebar-height) + var(--space-2xl));
+.main-window-list-empty {
+  padding: var(--space-lg);
 }
 
-.main-window-placeholder {
-  display: grid;
-  max-inline-size: 480px;
-  gap: var(--space-sm);
+.main-window-collection-list {
+  padding: var(--space-sm);
 }
 
-.main-window-placeholder p {
-  max-inline-size: 52ch;
+.main-window-collection-row {
+  min-block-size: calc(var(--space-2xl) + var(--space-lg));
+  padding: var(--space-sm);
+}
+
+.main-window-collection-row:hover {
+  background-color: var(--color-bg-row-hover);
+}
+
+.main-window-collection-row[aria-selected="true"] {
+  background-color: var(--color-bg-selected);
+}
+
+.main-window-collection-row:active {
+  background-color: var(--color-bg-selected);
 }

--- a/apps/desktop/src/views/MainWindowView.test.tsx
+++ b/apps/desktop/src/views/MainWindowView.test.tsx
@@ -1,7 +1,17 @@
 import { fireEvent, render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
+import { Activity } from "lucide-react"
+import { CollectionDetailPane } from "./main-window/CollectionDetailPane"
+import type * as IpcModule from "../lib/ipc"
+import capability from "../../src-tauri/capabilities/main.json"
+import { openSettingsWindow } from "../lib/ipc"
 import { MainWindowView } from "./MainWindowView"
+
+vi.mock("../lib/ipc", async (importOriginal) => ({
+  ...(await importOriginal<typeof IpcModule>()),
+  openSettingsWindow: vi.fn().mockResolvedValue(undefined),
+}))
 
 const userAgent = Object.getOwnPropertyDescriptor(window.navigator, "userAgent")
 const innerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth")
@@ -15,6 +25,7 @@ function setWindowWidth(value: number): void {
 }
 
 afterEach(() => {
+  vi.clearAllMocks()
   if (userAgent) Object.defineProperty(window.navigator, "userAgent", userAgent)
   if (innerWidth) Object.defineProperty(window, "innerWidth", innerWidth)
 })
@@ -44,7 +55,7 @@ describe("MainWindowView", () => {
   })
 
   it("shows only Activity in the persistent sidebar", () => {
-    setWindowWidth(800)
+    setWindowWidth(1000)
     render(<MainWindowView />)
     expect(screen.getAllByRole("tab")).toHaveLength(1)
     expect(screen.getByRole("tab", { name: "Activity" })).toHaveAttribute(
@@ -52,10 +63,76 @@ describe("MainWindowView", () => {
       "true",
     )
     expect(screen.getByRole("tabpanel", { name: "Activity" })).toBeVisible()
-    expect(screen.queryByRole("button", { name: "Settings" })).toBeNull()
+    expect(screen.getByRole("button", { name: "Settings" })).toBeVisible()
     setWindowWidth(900)
     fireEvent(window, new Event("resize"))
     expect(screen.getByRole("tablist", { name: "Main sections" })).toBeVisible()
     expect(screen.queryByRole("button", { name: "Open navigation" })).toBeNull()
+  })
+  it("opens the existing Settings window without changing the selected section", () => {
+    render(<MainWindowView />)
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+    expect(openSettingsWindow).toHaveBeenCalledExactlyOnceWith()
+    expect(screen.getByRole("tab", { name: "Activity" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    )
+    expect(capability.permissions).toContain("allow-open-settings-window")
+  })
+
+  it("shows a recoverable Settings error", async () => {
+    vi.mocked(openSettingsWindow).mockRejectedValueOnce(new Error("Unavailable"))
+    render(<MainWindowView />)
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not open Settings")
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it.each(["metaKey", "ctrlKey"])(
+    "opens Settings with %s+comma from the detail pane",
+    (modifier) => {
+      render(<MainWindowView />)
+      fireEvent.keyDown(screen.getByRole("tabpanel", { name: "Activity" }), {
+        key: ",",
+        [modifier]: true,
+      })
+      expect(openSettingsWindow).toHaveBeenCalledExactlyOnceWith()
+      fireEvent.keyDown(document, { key: ",", [modifier]: true, repeat: true })
+      fireEvent.keyDown(document, { key: "," })
+      fireEvent.keyDown(document, { key: ",", [modifier]: true, shiftKey: true })
+      expect(openSettingsWindow).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it("opens a section's collection and detail without mounting unvisited sections", () => {
+    const other = vi.fn(() => <p>Other workspace</p>)
+    const sections = [
+      {
+        id: "activity",
+        label: "Activity",
+        icon: Activity,
+        render: () => (
+          <CollectionDetailPane
+            title="Items"
+            items={[{ id: "test", label: "Example" }]}
+            emptyMessage="Empty"
+            detailEmptyMessage="Choose an item"
+            renderDetail={() => <p>Example detail</p>}
+          />
+        ),
+      },
+      { id: "other", label: "Other", icon: Activity, render: other },
+    ]
+    render(<MainWindowView sections={sections} />)
+    expect(other).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole("option", { name: "Example" }))
+    expect(screen.getByText("Example detail")).toBeVisible()
+    fireEvent.click(screen.getByRole("tab", { name: "Activity" }))
+    expect(screen.getByText("Example detail")).toBeVisible()
+    fireEvent.click(screen.getByRole("tab", { name: "Other" }))
+    expect(screen.getByText("Other workspace")).toBeVisible()
+    fireEvent.click(screen.getByRole("tab", { name: "Activity" }))
+    expect(screen.getByText("Example detail")).toBeVisible()
   })
 })

--- a/apps/desktop/src/views/MainWindowView.tsx
+++ b/apps/desktop/src/views/MainWindowView.tsx
@@ -1,60 +1,107 @@
-import { Activity } from "lucide-react"
+import { Activity, Settings } from "lucide-react"
+import { useState, type ReactNode } from "react"
 
-import { ScrollPane } from "../components/ui/ScrollPane"
+import { openSettingsWindow } from "../lib/ipc"
+import { useGlobalKeydown } from "../lib/useGlobalKeydown"
 import { SidebarNav, type SidebarNavItem } from "../components/ui/SidebarNav"
-import { isMacOS } from "../lib/platform"
+import { CollectionDetailPane } from "./main-window/CollectionDetailPane"
+import { MainWindowLayout } from "./main-window/MainWindowLayout"
 
-const NAVIGATION_ITEMS = [
-  { id: "activity", label: "Activity", icon: Activity },
-] as const satisfies readonly SidebarNavItem[]
+export interface MainWindowSection extends SidebarNavItem {
+  render: (context: { active: boolean }) => ReactNode
+}
 
-/** The retained application window shell. Feature views replace its honest placeholders later. */
-export function MainWindowView() {
-  const macOS = isMacOS()
-
+/** A section supplies its panes without changing the main window's native lifecycle. */
+export function MainWindowView({ sections }: { sections?: readonly MainWindowSection[] }) {
+  const [settingsError, setSettingsError] = useState(false)
+  async function openSettings(): Promise<void> {
+    setSettingsError(false)
+    try {
+      await openSettingsWindow()
+    } catch {
+      setSettingsError(true)
+    }
+  }
+  useGlobalKeydown(true, (event) => {
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      event.key === "," &&
+      !event.altKey &&
+      !event.shiftKey
+    ) {
+      event.preventDefault()
+      if (!event.repeat) void openSettings()
+    }
+  })
+  const availableSections: readonly MainWindowSection[] = sections ?? [
+    {
+      id: "activity",
+      label: "Activity",
+      icon: Activity,
+      render: () => (
+        <CollectionDetailPane
+          title="Activity"
+          items={[]}
+          emptyMessage="No activity yet"
+          detailEmptyMessage="Select an item to view its details."
+          renderDetail={() => null}
+        />
+      ),
+    },
+  ]
+  const [selectedId, setSelectedId] = useState(() => availableSections[0]?.id ?? "")
+  const [visited, setVisited] = useState(
+    () => new Set(availableSections.slice(0, 1).map((section) => section.id)),
+  )
+  function selectSection(id: string): void {
+    if (!availableSections.some((section) => section.id === id)) return
+    setSelectedId(id)
+    setVisited((previous) => new Set(previous).add(id))
+  }
+  const selected =
+    availableSections.find((section) => section.id === selectedId) ?? availableSections[0]
   return (
-    <main
-      className={`main-window${macOS ? " main-window-macos" : ""}`}
-      aria-label="antiburn main window"
-    >
-      {macOS && (
-        <div className="main-window-titlebar" data-tauri-drag-region aria-hidden="true" />
-      )}
-
-      <div className="main-window-navigation">
+    <MainWindowLayout
+      sidebar={
         <SidebarNav
-          items={NAVIGATION_ITEMS}
-          value="activity"
-          onChange={() => {}}
+          items={availableSections}
+          value={selected?.id ?? ""}
+          onChange={selectSection}
           ariaLabel="Main sections"
           className="main-window-sidebar min-h-0 flex-1"
+          footer={
+            <>
+              {settingsError && (
+                <p role="alert" className="px-2 pb-2 type-caption text-label-secondary">
+                  Could not open Settings. Try again.
+                </p>
+              )}
+              <button
+                type="button"
+                onClick={() => void openSettings()}
+                className="flex h-7 w-full items-center gap-2 rounded-control px-2 type-body text-label hover:bg-surface-hover"
+              >
+                <Settings size={14} strokeWidth={2} aria-hidden="true" />
+                <span>Settings</span>
+              </button>
+            </>
+          }
         />
-      </div>
-
-      <div className={`main-window-content${macOS ? " main-window-content-macos" : ""}`}>
-        <ScrollPane className="min-h-0" viewportClassName="main-window-scroll-viewport">
-          <section
-            id="activity-panel"
-            role="tabpanel"
-            aria-labelledby="activity-tab"
-            tabIndex={0}
-            className="main-window-pane"
-          >
-            <div className="main-window-placeholder">
-              <Activity
-                size={24}
-                strokeWidth={1.5}
-                className="text-label-secondary"
-                aria-hidden="true"
-              />
-              <h1 className="type-title-2 text-label">Activity</h1>
-              <p className="type-body text-label-secondary">
-                Activity will appear here. Current activity remains available from the menu bar.
-              </p>
-            </div>
-          </section>
-        </ScrollPane>
-      </div>
-    </main>
+      }
+    >
+      {availableSections.map((section) => (
+        <div
+          key={section.id}
+          id={`${section.id}-panel`}
+          role="tabpanel"
+          aria-labelledby={`${section.id}-tab`}
+          hidden={section.id !== selected?.id}
+          className="main-window-section"
+        >
+          {(visited.has(section.id) || section.id === selected?.id) &&
+            section.render({ active: section.id === selected?.id })}
+        </div>
+      ))}
+    </MainWindowLayout>
   )
 }

--- a/apps/desktop/src/views/main-window/CollectionDetailPane.test.tsx
+++ b/apps/desktop/src/views/main-window/CollectionDetailPane.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { CollectionDetailPane, type CollectionItem } from "./CollectionDetailPane"
+
+const items = [
+  { id: "one", label: "First item", description: "First description" },
+  { id: "two", label: "Second item", description: "Second description" },
+  { id: "three", label: "Third item" },
+]
+function Workspace({ entries = items }: { entries?: CollectionItem[] }) {
+  return (
+    <CollectionDetailPane
+      title="Collection"
+      items={entries}
+      emptyMessage="Nothing here"
+      detailEmptyMessage="Select an item"
+      renderDetail={(item) => <p>Content for {item.label}</p>}
+    />
+  )
+}
+
+describe("CollectionDetailPane", () => {
+  it("reserves the detail region without auto-selecting or rendering detail", () => {
+    const renderDetail = vi.fn()
+    render(
+      <CollectionDetailPane
+        title="Collection"
+        items={items}
+        emptyMessage="Nothing here"
+        detailEmptyMessage="Select an item"
+        renderDetail={renderDetail}
+      />,
+    )
+    expect(screen.getByRole("region", { name: "Details" })).toBeVisible()
+    expect(screen.getByText("Select an item")).toBeVisible()
+    expect(
+      screen
+        .getAllByRole("option")
+        .filter((row) => row.getAttribute("aria-selected") === "true"),
+    ).toHaveLength(0)
+    expect(renderDetail).not.toHaveBeenCalled()
+  })
+
+  it("selects on click while keeping focus and the collection viewport", () => {
+    const { container } = render(<Workspace />)
+    const viewport = container.querySelector(".main-window-collection-scroll")
+    const row = screen.getByRole("option", { name: "Second item" })
+    fireEvent.click(row)
+    expect(row).toHaveFocus()
+    expect(row).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByText("Content for Second item")).toBeVisible()
+    expect(container.querySelector(".main-window-collection-scroll")).toBe(viewport)
+  })
+
+  it("keeps arrow selection in the list and moves focus to detail with Enter", async () => {
+    render(<Workspace />)
+    const first = screen.getAllByRole("option")[0]!
+    first.focus()
+    fireEvent.keyDown(first, { key: "ArrowDown" })
+    const second = screen.getAllByRole("option")[1]!
+    expect(second).toHaveFocus()
+    expect(second).toHaveAttribute("aria-selected", "true")
+    fireEvent.keyDown(second, { key: "End" })
+    const last = screen.getAllByRole("option")[2]!
+    expect(last).toHaveFocus()
+    fireEvent.keyDown(last, { key: "Home" })
+    expect(first).toHaveFocus()
+    fireEvent.keyDown(first, { key: "Enter" })
+    await waitFor(() =>
+      expect(screen.getByRole("region", { name: "First item" })).toHaveFocus(),
+    )
+  })
+
+  it("tracks identity across reordering and preserves the detail when filtered out", () => {
+    const { rerender } = render(<Workspace />)
+    fireEvent.click(screen.getAllByRole("option")[1]!)
+    rerender(
+      <Workspace entries={[items[2]!, { ...items[1]!, label: "Updated item" }, items[0]!]} />,
+    )
+    expect(screen.getByRole("heading", { name: "Updated item" })).toBeVisible()
+    expect(screen.getByRole("option", { name: "Updated item" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    )
+    rerender(<Workspace entries={[items[0]!]} />)
+    expect(screen.getByRole("status")).toHaveTextContent("outside the current list")
+    expect(screen.getByRole("heading", { name: "Second item" })).toBeVisible()
+  })
+
+  it("lets a feature supply a collection without nesting another viewport", () => {
+    const { container } = render(
+      <CollectionDetailPane
+        title="Custom"
+        items={items}
+        emptyMessage="Empty"
+        detailEmptyMessage="Select"
+        renderCollection={({ select }) => (
+          <button onClick={() => select(items[0]!)}>Custom item</button>
+        )}
+        renderDetail={(item) => item.label}
+      />,
+    )
+    expect(container.querySelector(".main-window-collection-scroll")).toBeNull()
+    fireEvent.click(screen.getByRole("button", { name: "Custom item" }))
+    expect(screen.getByRole("heading", { name: "First item" })).toBeVisible()
+  })
+
+  it("shows an empty collection beside the unselected detail region", () => {
+    render(<Workspace entries={[]} />)
+    expect(screen.getByText("Nothing here")).toBeVisible()
+    expect(screen.getByText("Select an item")).toBeVisible()
+    expect(screen.queryByRole("listbox")).toBeNull()
+  })
+})

--- a/apps/desktop/src/views/main-window/CollectionDetailPane.tsx
+++ b/apps/desktop/src/views/main-window/CollectionDetailPane.tsx
@@ -1,0 +1,199 @@
+import { useId, useRef, useState, type ReactNode, type KeyboardEvent } from "react"
+
+import { ScrollPane } from "../../components/ui/ScrollPane"
+
+export interface CollectionItem {
+  id: string
+  label: string
+  description?: string
+}
+
+interface CollectionSelection<T extends CollectionItem> {
+  selectedId: string | null
+  select: (item: T) => void
+  openDetail: (item: T) => void
+}
+
+interface CollectionDetailPaneProps<T extends CollectionItem> {
+  title: string
+  items: readonly T[]
+  emptyMessage: string
+  detailEmptyMessage: string
+  /** A feature may supply its own unselected detail presentation. */
+  detailEmptyContent?: ReactNode
+  renderDetail: (item: T) => ReactNode
+  selection?: T | null
+  onSelectionChange?: (item: T) => void
+  detailOwnsViewport?: boolean
+  /** Feature lists own their viewport when this slot is supplied. */
+  renderCollection?: (selection: CollectionSelection<T>) => ReactNode
+}
+
+/** Provide stable collection and detail columns without owning feature data. */
+export function CollectionDetailPane<T extends CollectionItem>({
+  title,
+  items,
+  emptyMessage,
+  detailEmptyMessage,
+  detailEmptyContent,
+  renderDetail,
+  renderCollection,
+  selection: controlledSelection,
+  onSelectionChange,
+  detailOwnsViewport = false,
+}: CollectionDetailPaneProps<T>) {
+  const id = useId()
+  const [localSelection, setSelection] = useState<T | null>(null)
+  const selection = controlledSelection === undefined ? localSelection : controlledSelection
+  const selected = items.find((item) => item.id === selection?.id) ?? selection
+  const selectedId = selected?.id ?? null
+  const select = (item: T) => {
+    if (onSelectionChange) onSelectionChange(item)
+    else setSelection(item)
+  }
+  const openDetail = (item: T) => {
+    select(item)
+    queueMicrotask(() => document.getElementById(`${id}-detail`)?.focus())
+  }
+
+  return (
+    <>
+      <section className="main-window-collection" aria-labelledby={`${id}-collection-title`}>
+        <h1 id={`${id}-collection-title`} className="sr-only">
+          {title}
+        </h1>
+        {renderCollection ? (
+          renderCollection({ selectedId, select, openDetail })
+        ) : (
+          <ScrollPane className="min-h-0" viewportClassName="main-window-collection-scroll">
+            <CollectionList
+              items={items}
+              selectedId={selectedId}
+              select={select}
+              openDetail={openDetail}
+              label={title}
+              emptyMessage={emptyMessage}
+            />
+          </ScrollPane>
+        )}
+      </section>
+      <section
+        data-detail-pane
+        onFocus={(event) => {
+          if (event.target === event.currentTarget)
+            event.currentTarget
+              .querySelector<HTMLElement>("[data-detail-focus-target]")
+              ?.focus()
+        }}
+        id={`${id}-detail`}
+        tabIndex={-1}
+        className="main-window-detail"
+        aria-labelledby={`${id}-detail-title`}
+      >
+        <h2 id={`${id}-detail-title`} tabIndex={-1} className="sr-only">
+          {selected?.label ?? "Details"}
+        </h2>
+        {selected && !items.some((item) => item.id === selected.id) && (
+          <p role="status" className="type-callout text-label-secondary px-4 py-2">
+            This item is outside the current list.
+          </p>
+        )}
+        {!selected && detailEmptyContent ? (
+          detailEmptyContent
+        ) : detailOwnsViewport && selected ? (
+          renderDetail(selected)
+        ) : (
+          <ScrollPane
+            key={selectedId}
+            className="min-h-0"
+            viewportClassName="main-window-detail-scroll"
+          >
+            <div className="main-window-pane">
+              {selected ? (
+                renderDetail(selected)
+              ) : (
+                <p className="type-body text-label-secondary">{detailEmptyMessage}</p>
+              )}
+            </div>
+          </ScrollPane>
+        )}
+      </section>
+    </>
+  )
+}
+
+/** The default collection has one focus target and no nested controls per row. */
+function CollectionList<T extends CollectionItem>({
+  items,
+  selectedId,
+  select,
+  openDetail,
+  label,
+  emptyMessage,
+}: CollectionSelection<T> & { items: readonly T[]; label: string; emptyMessage: string }) {
+  const listId = useId()
+  const refs = useRef(new Map<string, HTMLDivElement>())
+  const tabStop = items.some((item) => item.id === selectedId) ? selectedId : items[0]?.id
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>, index: number): void {
+    let next: number
+    if (event.key === "ArrowDown") next = Math.min(index + 1, items.length - 1)
+    else if (event.key === "ArrowUp") next = Math.max(index - 1, 0)
+    else if (event.key === "Home") next = 0
+    else if (event.key === "End") next = items.length - 1
+    else if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      const item = items[index]
+      if (item) {
+        if (event.key === "Enter") openDetail(item)
+        else select(item)
+      }
+      return
+    } else return
+    event.preventDefault()
+    const item = items[next]
+    if (!item) return
+    select(item)
+    refs.current.get(item.id)?.focus()
+  }
+  if (!items.length)
+    return (
+      <p className="main-window-list-empty type-body text-label-secondary">{emptyMessage}</p>
+    )
+  return (
+    <div role="listbox" aria-label={label} className="main-window-collection-list">
+      {items.map((item, index) => (
+        <div
+          key={item.id}
+          ref={(node) => {
+            if (node) refs.current.set(item.id, node)
+            else refs.current.delete(item.id)
+          }}
+          role="option"
+          aria-selected={item.id === selectedId}
+          aria-label={item.label}
+          aria-describedby={item.description ? `${listId}-${item.id}-description` : undefined}
+          tabIndex={item.id === tabStop ? 0 : -1}
+          className="main-window-collection-row rounded-control text-label"
+          onClick={(event) => {
+            event.currentTarget.focus()
+            select(item)
+          }}
+          onKeyDown={(event) => onKeyDown(event, index)}
+        >
+          <span className="type-body block truncate" title={item.label}>
+            {item.label}
+          </span>
+          {item.description && (
+            <span
+              id={`${listId}-${item.id}-description`}
+              className="type-footnote block truncate text-label-secondary"
+              title={item.description}
+            >
+              {item.description}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/views/main-window/MainWindowLayout.tsx
+++ b/apps/desktop/src/views/main-window/MainWindowLayout.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react"
+
+import { isMacOS } from "../../lib/platform"
+
+/** Keep navigation and feature panes beneath the native window controls. */
+export function MainWindowLayout({
+  sidebar,
+  children,
+}: {
+  sidebar: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <main
+      className={`main-window${isMacOS() ? " main-window-macos" : ""}`}
+      aria-label="antiburn main window"
+    >
+      {isMacOS() && (
+        <div className="main-window-titlebar" data-tauri-drag-region aria-hidden="true" />
+      )}
+      <div className="main-window-navigation">{sidebar}</div>
+      <div className="main-window-workspace">{children}</div>
+    </main>
+  )
+}

--- a/docs/runbooks/main-window.md
+++ b/docs/runbooks/main-window.md
@@ -76,15 +76,15 @@ quiet login on an upgraded installation. macOS uses the native login event.
 
 ## Navigation shell
 
-Check the 900×600 default and 800×560 minimum with light and dark themes.
+Check the 1100×600 default and 1000×560 minimum with light and dark themes.
 
 - The sidebar remains visible throughout resizing; no compact navigation mode appears.
-- Activity is the only selected main section; no Settings or Quit sidebar action appears.
-- The existing Settings window remains accessible through the tray and native menus.
+- Activity is the main section with an empty collection and detail workspace. Settings appears at the bottom; no Quit action appears.
+- The Settings sidebar action and Command+, (Control+, on Windows/Linux) open the existing Settings window.
 - Check readable 28px rows and independent vertical content scrolling without horizontal overflow.
-- Restore an older saved 560×420 window; it expands to at least 800×560 when the display allows.
+- Restore an older saved 560×420 window; it expands to at least 1000×560 when the display allows.
 - Close and reopen the main window; the selected section persists.
-- The first macOS row starts below the 40px drag strip. Buttons must not drag the window.
+- The first macOS sidebar row starts below the 40px drag strip. The collection and detail panes have no top gap. Buttons must not drag the window.
 - The title strip still drags and toggles maximize on double-click.
 
 ## Opening measurements


### PR DESCRIPTION
## Stack

1. [PR #449 — main-window foundation](https://github.com/antiburn/antiburn/pull/449)
2. **PR #450 — collection/detail navigation** (this PR, targets `feat/desktop-pr1-main-window`)
3. [PR #451 — Sessions integration](https://github.com/antiburn/antiburn/pull/451)

## Summary

- Add the persistent main-window navigation and workspace layout.
- Add reusable collection/detail pane infrastructure.
- Support stable controlled selection and independent collection/detail scrolling.
- Add keyboard selection and detail-region focus behavior.
- Keep visited sections mounted while allowing inactive sections to suspend work.
- Wire the sidebar Settings action and platform keyboard shortcut to the existing Settings window.
- Increase the main-window default and minimum sizes for the collection/detail layout.

## Scope

This PR provides reusable navigation and layout infrastructure. It does not migrate Sessions into the main window; that happens in PR #3.

## Validation

- Frontend formatting, lint, type-check, and component tests.
- Rust formatting, Clippy, and main-window geometry tests.
- Light/dark, keyboard, resizing, and native title-bar behavior covered by the validation runbook.
