### PR TITLE
feat(desktop): refine the main-window Session Details layout

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -245,6 +245,7 @@ fonts:
   sans: "-apple-system, BlinkMacSystemFont, SF Pro Text, system-ui, sans-serif"
   mono: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" # via `font-mono`
 typography:
+  display: { fontSize: 40px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.36px" }
   # class .type-<name> · [fontSize, fontWeight, lineHeight, letterSpacing] · family = fonts.sans
   large-title: { fontSize: 26px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.36px" }
   title-1: { fontSize: 22px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.35px" }
@@ -277,6 +278,9 @@ sizes:
   --space-lg: 16px
   --space-xl: 20px
   --space-2xl: 24px # group separation in a settings-style pane
+  # Local geometry that stays in its component. The wide Session Detail
+  # (`layout="wide"` in src/components/session/SessionDetailPresentation.tsx)
+  # lets the context chart fill the tab, with a min-h-48 floor.
 rounded:
   small: 4px
   control: 5px
@@ -529,3 +533,41 @@ The main-window collection slot owns this presentation; menu-bar empty states re
 
 Apply this treatment to main-window session selection. Do not change the shared color
 tokens or the menu-bar list's default appearance to achieve it.
+
+- **Wide Session Detail** — the fixed toolbar holds the compact session summary and
+  callout-size section picker. The repo uses `font-mono`. The toolbar uses surface at
+  80% opacity, 16px backdrop blur, and 120% saturation. Reduced transparency uses a
+  solid surface-window with no blur. Rounded controls have no outline; the active
+  tab uses surface and the raised shadow. Tab labels use regular weight.
+  The section picker and action group are both 32px tall, with 24px inner controls.
+  Typography matches the session list: row names use body-large (13.5px), figures and
+  table rows use body (13px), and descriptions use callout (12px). Section headings
+  are screen-reader-only; caption is reserved for compact toolbar metadata.
+  There are no inherited size overrides. Content has 40px side padding.
+  Cost composition closes the Context tab, below the plot and its key.
+  The context plot fills available height with a 192px minimum. Both efficiency tracks
+  are 24px tall. Scale labels use the primary data size. The chart key uses three
+  equal columns. The composition legend stacks three rows beneath the bar, with
+  names on the left and percentages and ratings aligned on the right.
+  Cost, Checks, and Efficiency stack vertically. Checks use two equal columns when
+  the content reaches 40rem, and one column below that width. The top cost block pairs
+  a large-title total with a component table; it stacks below 40rem. The card fills
+  the content width, while its table caps at 640px. A shared surface-card/50 background,
+  rounded-popover corners, and 16px padding group the total and table. The table
+  label column fits its text up to 12rem, with 12px gaps before the numeric columns.
+  The table columns sit together at the card’s right edge. The whole cost card uses
+  font-mono, including the total, captions, row labels, and figures.
+  Checks show documentation as callout
+  subtext by default, with findings first and the status beside each name.
+  Efficiency guidance uses the full content width. Tools and efficiency figures use
+  display without a background. Tools uses brand orange; efficiency uses label ink
+  for good and ok readings, and brand orange only for bad readings. Tool cells use
+  16px padding.
+  These rules apply only to `.session-detail-wide`.
+
+  The Context chart updates geometry without animation when its measured size changes.
+  New bucket data can still animate together, without the entrance stagger.
+
+  Efficiency sits at the bottom of the Cost pane when content fits, and follows the
+  checks in normal scroll order otherwise. The total appears once in the top cost
+  block; the popover retains its total row.

--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { INITIAL_SESSION_HYGIENE } from "../../lib/presentation/sessionHygiene"
@@ -682,6 +682,138 @@ describe("SessionDetailPresentation — session facts", () => {
   })
 })
 
+describe("SessionDetailPresentation — wide layout", () => {
+  const efficiency = {
+    totalUsd: 10,
+    newWorkUsd: 3.4,
+    carryUsd: 5.4,
+    rewriteUsd: 1.2,
+    growthTokens: 200_000,
+    outputTokens: 50_000,
+    pricedTurns: 12,
+    unpricedTurns: 0,
+  }
+
+  function wideView(over: Partial<SessionDetailPresentationProps> = {}) {
+    const props = presentationProps({ layout: "wide", cost: cost(), efficiency, ...over })
+    delete props.onBack
+    return render(<SessionDetailPresentation {...props} />)
+  }
+
+  it("groups the section picker and host actions in the toolbar", () => {
+    const onDeleteSession = vi.fn()
+    const onRevealSource = vi.fn()
+    wideView({ onDeleteSession, onRevealSource, refreshing: true })
+
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull()
+    expect(screen.queryByText("Session Detail")).toBeNull()
+
+    const line = screen.getByRole("tablist").parentElement!
+    expect(line).toHaveClass("flex")
+    expect(within(line).getByText("Fix the flaky test")).toBeTruthy()
+    expect(within(line).getByLabelText("Session summary")).toBeTruthy()
+    fireEvent.click(within(line).getByLabelText("Delete this session"))
+    fireEvent.click(within(line).getByLabelText("Reveal in file manager"))
+    expect(onDeleteSession).toHaveBeenCalledTimes(1)
+    expect(onRevealSource).toHaveBeenCalledTimes(1)
+    expect(within(line).getByRole("status")).toBeTruthy()
+  })
+
+  it.each([
+    { loading: true, error: false },
+    { loading: false, error: true },
+    { loading: false, error: false },
+  ])("keeps the toolbar usable without analysis: %j", (state) => {
+    const onBack = vi.fn()
+    const onDeleteSession = vi.fn()
+    view({ layout: "wide", embedded: true, summary: null, onBack, onDeleteSession, ...state })
+    expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
+    expect(screen.queryByRole("tablist")).toBeNull()
+    fireEvent.click(screen.getByRole("button", { name: "Back" }))
+    fireEvent.click(screen.getByRole("button", { name: "Delete this session" }))
+    expect(onBack).toHaveBeenCalledOnce()
+    expect(onDeleteSession).toHaveBeenCalledOnce()
+  })
+
+  it("separates the toolbar and gives the tab bar its content width", () => {
+    const { container } = wideView()
+    expect(container.querySelector(".session-detail-toolbar")).toHaveClass("border-separator")
+    expect(screen.getByRole("tablist", { name: "Session detail sections" })).toHaveClass(
+      "inline-grid",
+    )
+  })
+
+  it("places composition below the growing chart and its key", () => {
+    const { container } = wideView()
+    const key = screen.getByTestId("chart-key")
+    expect(key.dataset.layout).toBe("wide")
+    expect(
+      Array.from(screen.getByRole("tabpanel").querySelectorAll("h3")).map(
+        (heading) => heading.textContent,
+      ),
+    ).toEqual(["Context over time", "Cost composition"])
+    expect(key).toHaveClass("grid")
+    expect(key).toHaveClass("grid-cols-3")
+    expect(container.querySelector(".min-h-48")).toHaveClass("flex-1")
+    expect(screen.getByTestId("efficiency-composition").dataset.height).toBe("bar")
+    expect(screen.getByTestId("composition-legend")).toHaveClass("flex-col")
+  })
+
+  it("keeps the Cost tab's sections apart with spacing, not rules", () => {
+    const { container } = wideView()
+    fireEvent.click(screen.getByRole("tab", { name: /^Cost/ }))
+    expect(screen.getByRole("heading", { name: "Checks" })).toHaveClass("sr-only")
+    expect(screen.getByText("Efficiency")).toBeTruthy()
+    // The cost table keeps the rule over its total row. The sections that
+    // hold the table, the checks, and the scale draw none of their own.
+    const sections = Array.from(container.querySelectorAll("section"))
+    expect(sections).toHaveLength(3)
+    expect(sections.map((section) => section.querySelector("h3")?.textContent)).toEqual([
+      "Cost",
+      "Checks",
+      "Efficiency",
+    ])
+    for (const section of sections) expect(section).not.toHaveClass("border-separator")
+  })
+
+  it("lays the Tools tab out in two columns", () => {
+    wideView({
+      summary: summary({
+        sessions: [
+          metrics({
+            initialContext: {
+              sources: [
+                {
+                  source: "skill_instructions",
+                  sourceName: "research",
+                  tokenCount: 12_000,
+                  useCount: 1,
+                },
+                {
+                  source: "skill_instructions",
+                  sourceName: "deploy",
+                  tokenCount: 8_000,
+                  useCount: 0,
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+    })
+    fireEvent.click(screen.getByRole("tab", { name: /^Tools/ }))
+    expect(screen.getByTestId("skills-mcp-list").dataset.columns).toBe("2")
+  })
+
+  it("leaves the popover layout as it was", () => {
+    const { container } = view({ cost: cost(), efficiency })
+    expect(screen.getByRole("button", { name: "Back" })).toBeTruthy()
+    expect(screen.getByTestId("chart-key").dataset.layout).toBe("popover")
+    expect(screen.getByRole("tablist", { name: "Session detail sections" })).toHaveClass("grid")
+    expect(container.querySelectorAll(".border-separator").length).toBeGreaterThan(0)
+  })
+})
+
 describe("SessionDetailPresentation — host actions", () => {
   it("always shows delete, but only shows reveal when it is available", () => {
     view()
@@ -722,63 +854,75 @@ describe("SessionDetailPresentation — host actions", () => {
   })
 })
 
-describe("SessionDetailPresentation — embedded pane", () => {
-  it("omits popover chrome and Back while retaining session content", () => {
-    const { container } = view({ embedded: true, onBack: undefined })
-    expect(screen.queryByRole("button", { name: "Back" })).toBeNull()
-    expect(container.firstElementChild).not.toHaveClass("rounded-popover")
-    expect(screen.queryByText("Session Detail")).toBeNull()
-    expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
-  })
+describe.each(["popover", "wide"] as const)(
+  "SessionDetailPresentation — embedded pane (%s)",
+  (layout) => {
+    it("omits popover chrome and Back while retaining session content", () => {
+      const { container } = view({ layout, embedded: true, onBack: undefined })
+      expect(screen.queryByRole("button", { name: "Back" })).toBeNull()
+      expect(container.firstElementChild).not.toHaveClass("rounded-popover")
+      expect(screen.queryByText("Session Detail")).toBeNull()
+      expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
+    })
 
-  it("limits adjacent navigation to the active detail pane", () => {
-    const onNext = vi.fn()
-    const props = presentationProps({ embedded: true, onNext })
-    const { container, rerender } = render(<SessionDetailPresentation {...props} />)
-    fireEvent.keyDown(window, { key: "ArrowRight" })
-    expect(onNext).not.toHaveBeenCalled()
-    fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
-    expect(onNext).toHaveBeenCalledOnce()
-    rerender(<SessionDetailPresentation {...props} active={false} />)
-    fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
-    expect(onNext).toHaveBeenCalledOnce()
-  })
-})
-
-describe("SessionDetailPresentation — deferred keyboard entry", () => {
-  it("accepts focus when a lazy detail replaces the focused loading pane", () => {
-    const { container, rerender } = render(<section data-detail-pane tabIndex={-1} />)
-    const pane = container.firstElementChild as HTMLElement
-    pane.focus()
-    rerender(
-      <section data-detail-pane tabIndex={-1}>
-        <SessionDetailPresentation {...presentationProps({ embedded: true })} />
-      </section>,
-    )
-    expect(container.querySelector("[data-detail-focus-target]")).toHaveFocus()
-  })
-})
-
-describe("SessionDetailPresentation — native drag toolbar", () => {
-  it("only enables the embedded macOS toolbar, leaving controls interactive", () => {
-    const agent = vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue("Macintosh")
-    try {
-      const props = presentationProps()
+    it("limits adjacent navigation to the active detail pane", () => {
+      const onNext = vi.fn()
+      const props = presentationProps({ layout, embedded: true, onNext })
       const { container, rerender } = render(<SessionDetailPresentation {...props} />)
-      expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
-      rerender(<SessionDetailPresentation {...props} embedded />)
-      const toolbar = screen
-        .getByRole("heading", { name: "Fix the flaky test" })
-        .closest("[data-tauri-drag-region]")
-      expect(toolbar).toHaveAttribute("data-tauri-drag-region", "deep")
-      expect(screen.getByRole("button", { name: "Delete this session" })).not.toHaveAttribute(
-        "data-tauri-drag-region",
+      fireEvent.keyDown(window, { key: "ArrowRight" })
+      expect(onNext).not.toHaveBeenCalled()
+      fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
+      expect(onNext).toHaveBeenCalledOnce()
+      rerender(<SessionDetailPresentation {...props} active={false} />)
+      fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
+      expect(onNext).toHaveBeenCalledOnce()
+    })
+  },
+)
+
+describe.each(["popover", "wide"] as const)(
+  "SessionDetailPresentation — deferred keyboard entry (%s)",
+  (layout) => {
+    it("accepts focus when a lazy detail replaces the focused loading pane", () => {
+      const { container, rerender } = render(<section data-detail-pane tabIndex={-1} />)
+      const pane = container.firstElementChild as HTMLElement
+      pane.focus()
+      rerender(
+        <section data-detail-pane tabIndex={-1}>
+          <SessionDetailPresentation {...presentationProps({ layout, embedded: true })} />
+        </section>,
       )
-      agent.mockReturnValue("Windows NT")
-      rerender(<SessionDetailPresentation {...props} embedded />)
-      expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
-    } finally {
-      agent.mockRestore()
-    }
-  })
-})
+      expect(container.querySelector("[data-detail-focus-target]")).toHaveFocus()
+    })
+  },
+)
+
+describe.each(["popover", "wide"] as const)(
+  "SessionDetailPresentation — native drag toolbar (%s)",
+  (layout) => {
+    it("only enables the embedded macOS toolbar, leaving controls interactive", () => {
+      const agent = vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue("Macintosh")
+      try {
+        const props = presentationProps({ layout })
+        const { container, rerender, unmount } = render(
+          <SessionDetailPresentation {...props} />,
+        )
+        expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
+        rerender(<SessionDetailPresentation {...props} embedded />)
+        const toolbar = screen
+          .getByRole("heading", { name: "Fix the flaky test" })
+          .closest("[data-tauri-drag-region]")
+        expect(toolbar).toHaveAttribute("data-tauri-drag-region", "deep")
+        expect(screen.getByRole("button", { name: "Delete this session" })).not.toHaveAttribute(
+          "data-tauri-drag-region",
+        )
+        unmount()
+        agent.mockReturnValue("Windows NT")
+        const windows = render(<SessionDetailPresentation {...props} embedded />)
+        expect(windows.container.querySelector("[data-tauri-drag-region]")).toBeNull()
+      } finally {
+        agent.mockRestore()
+      }
+    })
+  },
+)

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -88,6 +88,9 @@ interface SessionDetailSubject {
   }
 }
 
+/** The wide layout adapts to the main window detail pane. */
+export type SessionDetailLayout = "popover" | "wide"
+
 export interface SessionDetailPresentationProps {
   /** The analysis to render; null while loading or after a failure. */
   summary: ActiveSessionsSummary | null
@@ -125,6 +128,9 @@ export interface SessionDetailPresentationProps {
   modelRuns: PresentableModelRun[]
   /** Direct fork relations resolved from local transcripts. */
   relations: LocalSessionRelations | null
+  /** The wide layout uses a toolbar and larger content margins. The popover owns its back control. */
+  layout?: SessionDetailLayout
+  /** Return to the previous session when navigation history exists. */
   onBack?: (() => void) | undefined
   /** Navigate to the newer adjacent session; omit when none exists. */
   onPrev?: () => void
@@ -248,6 +254,65 @@ function RelationControl({
   )
 }
 
+/** The host actions sit in the title row or the wide toolbar. */
+function HostActions({
+  relations,
+  refreshing = false,
+  onOpenRelatedSession,
+  onRevealSource,
+  onDeleteSession,
+  className,
+}: {
+  relations: LocalSessionRelations | null
+  refreshing?: boolean
+  onOpenRelatedSession: (target: LocalSessionRelation, title: string) => void
+  onRevealSource: (() => void) | undefined
+  onDeleteSession: () => void
+  className?: string
+}) {
+  const hasRelations = !!relations && (!!relations.parent || relations.children.length > 0)
+  return (
+    <div className={cn("flex shrink-0 items-center gap-1", className)}>
+      {refreshing && <RefreshingIndicator />}
+      {hasRelations && relations && (
+        <RelationControl relations={relations} onOpen={onOpenRelatedSession} />
+      )}
+      {onRevealSource && (
+        <Tooltip label="Reveal in file manager">
+          <button
+            type="button"
+            onClick={onRevealSource}
+            aria-label="Reveal in file manager"
+            className="rounded-control p-1 text-label-tertiary hover:bg-surface-tertiary hover:text-label-secondary"
+          >
+            <FolderOpen size={14} aria-hidden="true" />
+          </button>
+        </Tooltip>
+      )}
+      <Tooltip label="Delete this session">
+        <button
+          type="button"
+          onClick={onDeleteSession}
+          aria-label="Delete this session"
+          className="rounded-control p-1 text-label-tertiary hover:bg-surface-tertiary hover:text-system-red-text"
+        >
+          <Trash2 size={14} aria-hidden="true" />
+        </button>
+      </Tooltip>
+    </div>
+  )
+}
+
+/** The quiet spinner that says a newer analysis is on its way. */
+function RefreshingIndicator() {
+  return (
+    <span role="status" className="inline-flex shrink-0 items-center text-label-tertiary">
+      <LoaderCircle size={12} strokeWidth={2} aria-hidden="true" className="animate-spin" />
+      <span className="sr-only">Refreshing session analysis</span>
+    </span>
+  )
+}
+
 /** The three views of one session's analysis. */
 type SessionDetailTab = "overview" | "cost" | "tools"
 
@@ -258,9 +323,15 @@ const DETAIL_TABS: ReadonlyArray<{ value: SessionDetailTab; label: string }> = [
 ]
 
 /** The name of one block inside a tab that holds more than one block. */
-function TabSectionHeading({ children }: { children: string }) {
+function TabSectionHeading({ children, wide = false }: { children: string; wide?: boolean }) {
   return (
-    <h3 className="mb-2 type-caption font-medium! text-label-tertiary uppercase">{children}</h3>
+    <h3
+      className={
+        wide ? "sr-only" : "mb-2 type-caption font-medium! text-label-tertiary uppercase"
+      }
+    >
+      {children}
+    </h3>
   )
 }
 
@@ -287,9 +358,9 @@ const KEY_CAPTIONS: Record<string, string> = {
  *
  * Each figure is a stat cell: a swatch in the color its chart layer takes
  * when it lights, the value in the label ink, and a caption under them.
- * The cells sit in a grid of three equal columns, so the key reads as one
- * table and not as six badges. The swatch alone carries the color, so the
- * text keeps its contrast on both surfaces.
+ * In the popover the cells sit in a grid of three equal columns, so the key
+ * reads as one table. The wide layout keeps three columns with more padding.
+ * The swatch carries the color. The text keeps its contrast on both surfaces.
  *
  * Pointing at a cell lights its layer in the plot above, and the cell takes
  * the hover wash. Clicking a cell pins that layer, so it stays lit when the
@@ -302,12 +373,14 @@ function ChartKey({
   pinned,
   onHighlight,
   onPin,
+  layout,
 }: {
   stats: ReadonlyArray<{
     label: string
     value: string
     series?: ChartSeries
   }>
+  layout: SessionDetailLayout
   /** The layer held lit by a click, or null. */
   pinned: ChartSeries | null
   /** Names the layer under the pointer, or null when the pointer leaves. */
@@ -316,7 +389,16 @@ function ChartKey({
   onPin: (series: ChartSeries) => void
 }) {
   return (
-    <div className="-mx-1.5 grid grid-cols-3 gap-x-1 gap-y-1">
+    <div
+      data-testid="chart-key"
+      data-layout={layout}
+      className={cn(
+        "-mx-1.5",
+        layout === "wide"
+          ? "session-detail-key grid grid-cols-3 gap-3"
+          : "grid grid-cols-3 gap-x-1 gap-y-1",
+      )}
+    >
       {stats.map((stat) => {
         const series = stat.series ?? null
         const isPinned = series != null && series === pinned
@@ -345,7 +427,12 @@ function ChartKey({
                 />
                 {stat.value}
               </span>
-              <span className="max-w-full truncate type-caption text-label-secondary">
+              <span
+                className={cn(
+                  "max-w-full truncate text-label-secondary",
+                  layout === "wide" ? "type-callout" : "type-caption",
+                )}
+              >
                 {KEY_CAPTIONS[stat.label] ?? stat.label}
               </span>
             </button>
@@ -510,6 +597,7 @@ export function SessionDetailPresentation({
   subagentCount,
   modelRuns,
   relations,
+  layout = "popover",
   onBack,
   onPrev,
   onNext,
@@ -523,6 +611,7 @@ export function SessionDetailPresentation({
   active = true,
 }: SessionDetailPresentationProps) {
   const subagent = session.subagent
+  const wide = layout === "wide"
   const [tab, setTab] = useState<SessionDetailTab>("overview")
   // Which chart layer the key points at. The pointer sets it and the pointer
   // clears it; a click pins a layer, which holds when the pointer leaves.
@@ -621,7 +710,132 @@ export function SessionDetailPresentation({
         ]
       : []
 
-  const hasRelations = !!relations && (!!relations.parent || relations.children.length > 0)
+  const heroTitle = relations?.title?.trim() || session.title?.trim() || "Session"
+  const hostActions = (
+    <HostActions
+      relations={relations}
+      refreshing={wide && refreshing}
+      onOpenRelatedSession={onOpenRelatedSession}
+      onRevealSource={onRevealSource}
+      onDeleteSession={onDeleteSession}
+      {...(wide
+        ? {
+            className: "session-detail-actions rounded-full bg-surface-card p-1",
+          }
+        : {})}
+    />
+  )
+
+  const sessionSummary = (
+    <div
+      className={cn(
+        "flex min-w-0 flex-col gap-y-0.5",
+        wide ? "session-detail-summary flex-1 basis-48 type-body" : "px-4 pt-3 pb-3",
+      )}
+      aria-label="Session summary"
+    >
+      {(session.repo || session.wslDistro) && (
+        <div className="flex min-w-0 items-center gap-1.5 type-caption text-label-tertiary">
+          {session.repo && (
+            <Tooltip label={session.repo}>
+              <span className="truncate font-mono">{session.repo}</span>
+            </Tooltip>
+          )}
+          <WslOriginBadge distro={session.wslDistro} />
+        </div>
+      )}
+
+      {wide ? (
+        <h2
+          data-view-heading
+          tabIndex={-1}
+          className="flex min-w-0 items-start gap-x-3 type-headline outline-none"
+        >
+          <TruncatedText
+            className="min-w-0 flex-1 font-semibold text-label break-words"
+            text={heroTitle}
+            lines={1}
+          />
+        </h2>
+      ) : (
+        <TruncatedText
+          className="min-w-0 type-body-large font-semibold text-label break-words"
+          text={heroTitle}
+          lines={2}
+        />
+      )}
+
+      {summary && (
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 type-caption text-label-secondary">
+          <Tooltip label={`Active time (${formatDuration(summary.avgDurationSecs)} overall)`}>
+            <span className="tabular-nums">{formatDuration(summary.avgActiveSecs)} active</span>
+          </Tooltip>
+          {session.timestamp && (
+            <>
+              <span aria-hidden="true" className="text-label-tertiary">
+                ·
+              </span>
+              <time dateTime={session.timestamp}>{relativeTime(session.timestamp)}</time>
+            </>
+          )}
+          {modelPairs.length > 0 && (
+            <>
+              <span aria-hidden="true" className="text-label-tertiary">
+                ·
+              </span>
+              <span className="min-w-0 truncate" title={modelRunNames(modelRuns).join("\n")}>
+                {modelPairs.map((pair, index) => (
+                  <span key={`${pair.model}/${pair.thinkingMode ?? ""}`}>
+                    {index > 0 && " · "}
+                    <span>{pair.model}</span>
+                    {pair.thinkingMode && <span> {pair.thinkingMode}</span>}
+                  </span>
+                ))}
+              </span>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  const compositionSection = efficiencyCard && (
+    <div className={cn(!wide && "border-t border-separator pt-3")}>
+      {wide && <TabSectionHeading wide={wide}>Cost composition</TabSectionHeading>}
+      <EfficiencyBreakdown metrics={efficiencyCard} section="composition" layout={layout} />
+    </div>
+  )
+
+  const costSection = (
+    <section
+      className={cn(
+        wide && "shrink-0",
+        hasAssessedHygieneChecks && !wide && "mt-4 border-t border-separator pt-4",
+        efficiencyCard && !wide && "pb-4",
+      )}
+    >
+      <TabSectionHeading wide={wide}>Cost</TabSectionHeading>
+      {cost && tokensCard ? (
+        <CostBreakdown
+          layout={layout}
+          cost={cost}
+          split={tokensCard.split}
+          onOpenSubagent={onOpenSubagent}
+        />
+      ) : (
+        <p className="type-callout text-label-tertiary">
+          No cost has been recorded for this session.
+        </p>
+      )}
+    </section>
+  )
+
+  const efficiencySection = efficiencyCard && (
+    <section className={cn("mt-auto shrink-0", !wide && "border-t border-separator pt-4")}>
+      <TabSectionHeading wide={wide}>Efficiency</TabSectionHeading>
+      <EfficiencyBreakdown metrics={efficiencyCard} section="cost" layout={layout} />
+    </section>
+  )
 
   return (
     <div
@@ -635,90 +849,89 @@ export function SessionDetailPresentation({
       onKeyDown={embedded ? handleAdjacentKey : undefined}
       className={cn(
         "flex h-full flex-col overflow-hidden text-label select-none",
-        !embedded && "rounded-popover bg-surface",
+        !embedded && "bg-surface",
+        wide ? "session-detail-wide type-body" : !embedded && "rounded-popover",
       )}
     >
-      <div
-        data-tauri-drag-region={embedded && isMacOS() ? "deep" : undefined}
-        className="flex items-center justify-between gap-2 border-b border-separator px-3 py-3"
-      >
-        {/* The control and the title are two things, not one. Wrapping the
-            heading text inside the back button made a screen reader announce
-            "Session Detail, button" for the control that leaves this view,
-            and left the view itself with no heading at all. */}
-        <div className="flex min-w-0 items-center gap-1.5">
+      {!wide && (
+        <div
+          data-tauri-drag-region={embedded && isMacOS() ? "deep" : undefined}
+          className="flex items-center justify-between gap-2 border-b border-separator px-3 py-3"
+        >
+          {/* The control and the title are two things, not one. Wrapping the
+              heading text inside the back button made a screen reader announce
+              "Session Detail, button" for the control that leaves this view,
+              and left the view itself with no heading at all. */}
+          <div className="flex min-w-0 items-center gap-1.5">
+            {onBack && (
+              <button
+                type="button"
+                onClick={onBack}
+                aria-label="Back"
+                className="-ml-1 inline-flex h-6 shrink-0 items-center rounded-control px-1 text-label hover:bg-surface-hover"
+              >
+                <ChevronLeft size={14} aria-hidden="true" className="shrink-0" />
+              </button>
+            )}
+            <h2
+              data-view-heading
+              tabIndex={-1}
+              className="truncate type-headline text-label outline-none"
+            >
+              {embedded ? session.title || "Session" : "Session Detail"}
+            </h2>
+            {subagent && (
+              <span className="shrink-0 rounded bg-system-indigo/15 px-1.5 py-px type-caption font-medium text-system-indigo-text">
+                Sub-agent
+              </span>
+            )}
+            {refreshing && <RefreshingIndicator />}
+          </div>
+          {hostActions}
+        </div>
+      )}
+
+      {wide && (
+        <div
+          data-tauri-drag-region={embedded && isMacOS() ? "deep" : undefined}
+          className="session-detail-toolbar flex shrink-0 flex-wrap items-center gap-4 border-b border-separator bg-surface/80 px-6 py-3"
+        >
           {onBack && (
             <button
               type="button"
               onClick={onBack}
               aria-label="Back"
-              className="-ml-1 inline-flex h-6 shrink-0 items-center rounded-control px-1 text-label hover:bg-surface-hover"
+              className="inline-flex h-6 shrink-0 items-center rounded-control px-1 text-label hover:bg-surface-hover"
             >
-              <ChevronLeft size={14} aria-hidden="true" className="shrink-0" />
+              <ChevronLeft size={14} aria-hidden="true" />
             </button>
           )}
-          <h2
-            data-view-heading
-            tabIndex={-1}
-            className="truncate type-headline text-label outline-none"
-          >
-            {embedded ? session.title || "Session" : "Session Detail"}
-          </h2>
-          {subagent && (
-            <span className="shrink-0 rounded bg-system-indigo/15 px-1.5 py-px type-caption font-medium text-system-indigo-text">
-              Sub-agent
-            </span>
+          {sessionSummary}
+          {ready && !error && !empty && (
+            <SegmentedControl
+              className="session-detail-tabs type-callout shrink-0 rounded-full! bg-surface-card! [&_button]:rounded-full!"
+              options={DETAIL_TABS}
+              value={tab}
+              onChange={setTab}
+              ariaLabel="Session detail sections"
+              semantics="tabs"
+              variant="native-tabs"
+              equalWidth={false}
+              idPrefix="session-detail-tabs"
+            />
           )}
-          {refreshing && (
-            <span
-              role="status"
-              className="inline-flex shrink-0 items-center text-label-tertiary"
-            >
-              <LoaderCircle
-                size={12}
-                strokeWidth={2}
-                aria-hidden="true"
-                className="animate-spin"
-              />
-              <span className="sr-only">Refreshing session analysis</span>
-            </span>
-          )}
+          {hostActions}
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          {hasRelations && relations && (
-            <RelationControl relations={relations} onOpen={onOpenRelatedSession} />
-          )}
-          {onRevealSource && (
-            <Tooltip label="Reveal in file manager">
-              <button
-                type="button"
-                onClick={onRevealSource}
-                aria-label="Reveal in file manager"
-                className="rounded-control p-1 text-label-tertiary hover:bg-surface-tertiary hover:text-label-secondary"
-              >
-                <FolderOpen size={14} aria-hidden="true" />
-              </button>
-            </Tooltip>
-          )}
-          <Tooltip label="Delete this session">
-            <button
-              type="button"
-              onClick={onDeleteSession}
-              aria-label="Delete this session"
-              className="rounded-control p-1 text-label-tertiary hover:bg-surface-tertiary hover:text-system-red-text"
-            >
-              <Trash2 size={14} aria-hidden="true" />
-            </button>
-          </Tooltip>
-        </div>
-      </div>
+      )}
 
       <div key={sessionIdentityKey(session)} className="flex min-h-0 flex-1 flex-col">
         {(showSkeleton || (ready && (error || empty))) && (
           <div className="min-h-0 flex-1 overflow-y-auto py-3">
             {showSkeleton && <SessionDetailSkeleton />}
             {ready && error && (
-              <p className="px-4 type-callout text-system-orange">
+              <p
+                className={cn("type-callout text-system-orange", wide ? "px-10 pb-10" : "px-4")}
+              >
                 Couldn't read this session.
               </p>
             )}
@@ -760,66 +973,7 @@ export function SessionDetailPresentation({
 
         {ready && !error && !empty && summary && (
           <>
-            <div className="flex flex-col gap-y-1 px-4 pt-3 pb-3" aria-label="Session summary">
-              {/* The repo comes first because it is the container: you are
-                  inside a repo, and the session is the work you do in it. */}
-              {(session.repo || session.wslDistro) && (
-                <div className="flex min-w-0 items-center gap-1.5 type-caption text-label-tertiary">
-                  {session.repo && (
-                    <Tooltip label={session.repo}>
-                      <span className="truncate">{session.repo}</span>
-                    </Tooltip>
-                  )}
-                  <WslOriginBadge distro={session.wslDistro} />
-                </div>
-              )}
-
-              <TruncatedText
-                className="min-w-0 type-body-large font-semibold text-label break-words"
-                text={relations?.title?.trim() || session.title?.trim() || "Session"}
-                lines={2}
-              />
-
-              {/* Active time, last activity, and the models on one quiet
-                  line. The figures that carry a reading live in the meter nav
-                  below; these three are context for the title. */}
-              <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 type-caption text-label-secondary">
-                <Tooltip
-                  label={`Active time (${formatDuration(summary.avgDurationSecs)} overall)`}
-                >
-                  <span className="tabular-nums">
-                    {formatDuration(summary.avgActiveSecs)} active
-                  </span>
-                </Tooltip>
-                {session.timestamp && (
-                  <>
-                    <span aria-hidden="true" className="text-label-tertiary">
-                      ·
-                    </span>
-                    <time dateTime={session.timestamp}>{relativeTime(session.timestamp)}</time>
-                  </>
-                )}
-                {modelPairs.length > 0 && (
-                  <>
-                    <span aria-hidden="true" className="text-label-tertiary">
-                      ·
-                    </span>
-                    <span
-                      className="min-w-0 truncate"
-                      title={modelRunNames(modelRuns).join("\n")}
-                    >
-                      {modelPairs.map((pair, index) => (
-                        <span key={`${pair.model}/${pair.thinkingMode ?? ""}`}>
-                          {index > 0 && " · "}
-                          <span>{pair.model}</span>
-                          {pair.thinkingMode && <span> {pair.thinkingMode}</span>}
-                        </span>
-                      ))}
-                    </span>
-                  </>
-                )}
-              </div>
-            </div>
+            {!wide && sessionSummary}
 
             {subagent && (
               <SubagentBadge
@@ -830,29 +984,34 @@ export function SessionDetailPresentation({
               />
             )}
 
-            <div className="border-b border-separator px-4 pb-3">
-              <SegmentedControl
-                options={DETAIL_TABS}
-                value={tab}
-                onChange={setTab}
-                ariaLabel="Session detail sections"
-                semantics="tabs"
-                variant="native-tabs"
-                idPrefix="session-detail-tabs"
-              />
-            </div>
+            {!wide && (
+              <div className="border-b border-separator px-4 pb-3">
+                <SegmentedControl
+                  options={DETAIL_TABS}
+                  value={tab}
+                  onChange={setTab}
+                  ariaLabel="Session detail sections"
+                  semantics="tabs"
+                  variant="native-tabs"
+                  idPrefix="session-detail-tabs"
+                />
+              </div>
+            )}
 
             <div
               id="session-detail-tabs-panel"
               role="tabpanel"
               aria-labelledby={`session-detail-tabs-${tab}`}
-              className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
+              className={cn(
+                "min-h-0 flex-1 overflow-y-auto py-4",
+                wide ? "px-10 pb-10" : "px-4",
+              )}
             >
-              {/* The chart takes every pixel the key leaves, so the tab
-                  never ends in empty space. */}
+              {/* The chart fills the remaining space around its fixed summaries. */}
               {tab === "overview" && tokensCard && (
-                <div className="flex h-full flex-col gap-y-3">
-                  <div className="min-h-0 flex-1">
+                <div className={cn("flex h-full flex-col", wide ? "gap-y-5" : "gap-y-3")}>
+                  {wide && <TabSectionHeading wide={wide}>Context over time</TabSectionHeading>}
+                  <div className={cn(wide ? "min-h-48 flex-1" : "min-h-0 flex-1")}>
                     <ContextTokensChart
                       buckets={summary.buckets}
                       contextWindow={summary.contextAvailable ? summary.contextWindow : null}
@@ -865,66 +1024,52 @@ export function SessionDetailPresentation({
                     pinned={pinned}
                     onHighlight={setHovered}
                     onPin={togglePin}
+                    layout={layout}
                   />
-                  {/* The composition says what the context above cost. */}
-                  {efficiencyCard && (
-                    <div className="border-t border-separator pt-3">
-                      <EfficiencyBreakdown metrics={efficiencyCard} section="composition" />
-                    </div>
-                  )}
+                  {compositionSection}
                 </div>
               )}
 
-              {/* The checks lead: a failing check is more use than the cost
-                  rows most of the time. */}
               {tab === "cost" && (
-                <div className="flex min-h-full flex-col">
+                <div
+                  className={cn(
+                    wide
+                      ? "session-detail-cost flex min-h-full flex-col gap-6"
+                      : "flex min-h-full flex-col",
+                  )}
+                >
+                  {wide && costSection}
                   {hasAssessedHygieneChecks && (
-                    <section>
-                      <TabSectionHeading>Checks</TabSectionHeading>
-                      <HygieneBreakdown checks={hygieneChecks} collapsePassing={false} />
-                    </section>
-                  )}
-                  <section
-                    className={cn(
-                      hasAssessedHygieneChecks && "mt-4 border-t border-separator pt-4",
-                      efficiencyCard && "pb-4",
-                    )}
-                  >
-                    <TabSectionHeading>Cost</TabSectionHeading>
-                    {cost && tokensCard ? (
-                      <CostBreakdown
-                        cost={cost}
-                        split={tokensCard.split}
-                        onOpenSubagent={onOpenSubagent}
+                    <section className={wide ? "shrink-0" : ""}>
+                      <TabSectionHeading wide={wide}>Checks</TabSectionHeading>
+                      <HygieneBreakdown
+                        checks={hygieneChecks}
+                        collapsePassing={false}
+                        inlineGuidance={wide}
                       />
-                    ) : (
-                      <p className="type-callout text-label-tertiary">
-                        No cost has been recorded for this session.
-                      </p>
-                    )}
-                  </section>
-                  {/* The $/MTok scale closes the money story. It sits at the
-                      foot of the tab, so a short tab keeps its slack between
-                      the cost rows and the scale, not after the scale. */}
-                  {efficiencyCard && (
-                    <section className="mt-auto border-t border-separator pt-4">
-                      <TabSectionHeading>Efficiency</TabSectionHeading>
-                      <EfficiencyBreakdown metrics={efficiencyCard} section="cost" />
                     </section>
                   )}
+                  {!wide && costSection}
+                  {efficiencySection}
                 </div>
               )}
 
               {tab === "tools" &&
                 (firstSession?.initialContext ? (
-                  <div className="flex flex-col gap-y-2">
+                  <div className={cn("flex flex-col", wide ? "gap-y-4" : "gap-y-2")}>
                     {/* The wasted tokens are the finding of this tab, so they
                         head the table they summarize. The figure has no
                         ceiling, so it is a headline and not a meter. */}
                     {toolsUsage != null && toolsUsage.wastedTokens > 0 && (
-                      <p className="my-1 flex items-center gap-x-3">
-                        <span className="type-large-title font-semibold! text-brand tabular-nums">
+                      <p
+                        className={cn("flex items-center gap-x-4", wide ? "my-2 py-3" : "my-1")}
+                      >
+                        <span
+                          className={cn(
+                            "font-semibold! text-brand tabular-nums",
+                            wide ? "type-display" : "type-large-title",
+                          )}
+                        >
                           {formatCompact(toolsUsage.wastedTokens)}
                         </span>
                         <span className="flex flex-col type-callout leading-tight">
@@ -935,7 +1080,10 @@ export function SessionDetailPresentation({
                         </span>
                       </p>
                     )}
-                    <SkillsMcpChart breakdown={firstSession.initialContext} />
+                    <SkillsMcpChart
+                      breakdown={firstSession.initialContext}
+                      columns={wide ? 2 : 1}
+                    />
                   </div>
                 ) : (
                   <p className="type-callout text-label-tertiary">

--- a/apps/desktop/src/components/session/analysis/ContextTokensChart.test.tsx
+++ b/apps/desktop/src/components/session/analysis/ContextTokensChart.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react"
+import { act, cleanup, render, screen } from "@testing-library/react"
 import {
   cloneElement,
   isValidElement,
@@ -13,6 +13,10 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type { ContextTokenPoint } from "../../../lib/presentation/sessionAnalysis"
 import type { SessionBucket } from "../../../lib/types/session"
 import { ContextTokensChart, ContextTokensTooltip } from "./ContextTokensChart"
+
+const resizeHarness = vi.hoisted(() => ({
+  onResize: undefined as ((width: number, height: number) => void) | undefined,
+}))
 
 afterEach(cleanup)
 
@@ -38,23 +42,28 @@ vi.mock("recharts", async (importOriginal) => {
       children,
       className,
       style,
+      onResize,
     }: {
+      onResize?: (width: number, height: number) => void
       children: ReactNode
       className?: string
       style?: CSSProperties
-    }) => (
-      <div
-        className={`recharts-responsive-container ${className ?? ""}`}
-        style={{ ...style, width: 600, height: 160 }}
-      >
-        {isValidElement(children)
-          ? cloneElement(children as ReactElement<{ width?: number; height?: number }>, {
-              width: 600,
-              height: 160,
-            })
-          : children}
-      </div>
-    ),
+    }) => {
+      resizeHarness.onResize = onResize
+      return (
+        <div
+          className={`recharts-responsive-container ${className ?? ""}`}
+          style={{ ...style, width: 600, height: 160 }}
+        >
+          {isValidElement(children)
+            ? cloneElement(children as ReactElement<{ width?: number; height?: number }>, {
+                width: 600,
+                height: 160,
+              })
+            : children}
+        </div>
+      )
+    },
   }
 })
 
@@ -86,6 +95,38 @@ function bucket(over: Partial<SessionBucket> = {}): SessionBucket {
 }
 
 describe("ContextTokensChart", () => {
+  it("updates resized geometry without replaying the entrance and animates new data together", () => {
+    const buckets = [bucket({ contextTokens: 100_000 }), bucket({ contextTokens: 120_000 })]
+    const { container, rerender } = render(
+      <ContextTokensChart buckets={buckets} contextWindow={200_000} />,
+    )
+    act(() => resizeHarness.onResize?.(600, 240))
+    expect(container.querySelectorAll('g[data-animation-active="true"]')).toHaveLength(4)
+    act(() => resizeHarness.onResize?.(600, 240))
+    expect(container.querySelectorAll('g[data-animation-active="true"]')).toHaveLength(4)
+    act(() => resizeHarness.onResize?.(720, 300))
+    expect(container.querySelectorAll('g[data-animation-active="false"]')).toHaveLength(4)
+    expect(
+      container
+        .querySelector<HTMLElement>(".recharts-responsive-container")
+        ?.style.getPropertyValue("--chart-mark-delay"),
+    ).toBe("0ms")
+    rerender(
+      <ContextTokensChart
+        buckets={[...buckets, bucket({ contextTokens: 140_000 })]}
+        contextWindow={200_000}
+      />,
+    )
+    expect(container.querySelectorAll('g[data-animation-active="true"]')).toHaveLength(4)
+    expect(
+      [...container.querySelectorAll("g[data-animation-begin]")].every(
+        (node) => node.getAttribute("data-animation-begin") === "0",
+      ),
+    ).toBe(true)
+    act(() => resizeHarness.onResize?.(720, 320))
+    expect(container.querySelectorAll('g[data-animation-active="false"]')).toHaveLength(4)
+  })
+
   it("plays the first bucket set in as a sequence and animates a replacement set", () => {
     const initialBuckets = [
       bucket({ contextTokens: 100_000 }),

--- a/apps/desktop/src/components/session/analysis/ContextTokensChart.tsx
+++ b/apps/desktop/src/components/session/analysis/ContextTokensChart.tsx
@@ -1,4 +1,4 @@
-import { useId, useState, type CSSProperties, type ReactElement } from "react"
+import { useId, useRef, useState, type CSSProperties, type ReactElement } from "react"
 import {
   Area,
   AreaChart,
@@ -571,14 +571,28 @@ export function ContextTokensChart({
   const data = contextTokenSeries(buckets)
   const fillId = `context-tokens-fill-${useId().replace(/:/g, "")}`
   const [initialBuckets] = useState(() => buckets)
-  const animate = !prefersReducedMotion()
+  const measuredSize = useRef<{ width: number; height: number } | null>(null)
+  const [resizedBuckets, setResizedBuckets] = useState<SessionBucket[] | null>(null)
+  const resizing = resizedBuckets === buckets
+  const animate = !resizing && !prefersReducedMotion()
+  const onResize = (width: number, height: number) => {
+    if (width <= 0 || height <= 0) return
+    const next = { width: Math.round(width), height: Math.round(height) }
+    const previous = measuredSize.current
+    measuredSize.current = next
+    if (previous && (previous.width !== next.width || previous.height !== next.height)) {
+      // Geometry changes must not replay the data's entrance animation.
+      setResizedBuckets(buckets)
+    }
+  }
   const animationDurationMs = slowAnimationDurationMs()
   // The first paint plays the session back in order: the context fill grows,
   // the token spikes follow it, and the rewrite marks land last, on top of a
   // chart that has finished drawing. A later bucket set comes from the live
   // poll, where a staggered replay would read as the panel redrawing itself,
   // so those updates animate together.
-  const entranceStepMs = buckets === initialBuckets ? Math.round(animationDurationMs / 2) : 0
+  const entranceStepMs =
+    animate && buckets === initialBuckets ? Math.round(animationDurationMs / 2) : 0
   const tokenRowStepMs = Math.round(entranceStepMs / 2)
   const markDelayMs =
     entranceStepMs === 0
@@ -662,6 +676,8 @@ export function ContextTokensChart({
       width="100%"
       height="100%"
       minHeight={CHART_MIN_HEIGHT}
+      onResize={onResize}
+      className={resizing ? "[&_.animate-chart-mark]:animate-none" : ""}
       style={{ "--chart-mark-delay": `${markDelayMs}ms` } as CSSProperties}
     >
       <AreaChart data={data} margin={{ top: 6, right: 12, bottom: 0, left: 0 }}>

--- a/apps/desktop/src/components/session/analysis/CostBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/CostBreakdown.test.tsx
@@ -39,6 +39,14 @@ function result(totalCostUsd = 2.4, over: Partial<LocalSessionCost> = {}): Local
 }
 
 describe("CostBreakdown", () => {
+  it("pairs a single total with component rows in the wide layout", () => {
+    render(<CostBreakdown cost={result()} layout="wide" />)
+    expect(screen.getAllByText("$2.40")).toHaveLength(1)
+    expect(screen.getByText("10 tokens")).toBeTruthy()
+    expect(screen.getByText("Input")).toBeTruthy()
+    expect(screen.getByText("Cache write")).toBeTruthy()
+  })
+
   it("renders the total and its four billable component rows", () => {
     render(<CostBreakdown cost={result()} />)
     expect(screen.getByText("Input")).toBeTruthy()

--- a/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
@@ -1,5 +1,7 @@
 import { ChevronDown, ChevronRight } from "lucide-react"
 
+import { cn } from "../../../lib/cn"
+
 import {
   costBreakdownRows,
   costFigureLabel,
@@ -36,6 +38,8 @@ export interface CostBreakdownProps {
    * subject, so the rows always sum to the total shown.
    */
   cost: LocalSessionCost
+  /** The wide layout pairs the total with its component table. */
+  layout?: "popover" | "wide"
   /**
    * Parent/sub-agents split, for an inclusive orchestration result. Omit it
    * for any other subject, where there is nothing to break apart.
@@ -248,12 +252,25 @@ function SubagentsSplitRow({
  * that do not add up. The token and percent columns share that same subject,
  * so every row's percent reads as a share of the one total shown in the footer.
  */
-export function CostBreakdown({ cost, split, onOpenSubagent }: CostBreakdownProps) {
+export function CostBreakdown({
+  cost,
+  split,
+  onOpenSubagent,
+  layout = "popover",
+}: CostBreakdownProps) {
+  const wide = layout === "wide"
   const rows = costBreakdownRows(resultComponentCost(cost))
   const totalUsd = cost.totalCostUsd
 
-  return (
-    <div className="grid grid-cols-[1fr_max-content_max-content_max-content] gap-x-3 gap-y-1">
+  const table = (
+    <div
+      className={cn(
+        "grid min-w-0 gap-x-3 gap-y-1",
+        wide
+          ? "w-full max-w-[640px] justify-self-end justify-end grid-cols-[fit-content(12rem)_max-content_max-content_max-content]"
+          : "grid-cols-[1fr_max-content_max-content_max-content]",
+      )}
+    >
       {split && (
         <div className="col-span-full grid grid-cols-subgrid mb-1 border-b border-separator pb-1">
           <CostRowLine
@@ -284,20 +301,40 @@ export function CostBreakdown({ cost, split, onOpenSubagent }: CostBreakdownProp
         />
       ))}
 
-      <div className="col-span-full grid grid-cols-subgrid mt-1 border-t border-separator pt-1 type-body">
-        <span className="text-label-tertiary">{costFigureLabel(cost.isActive)}</span>
-        <span className="text-right text-label-tertiary tabular-nums">
-          {formatTokensShort(cost.totalTokens)}
-        </span>
-        <span className="flex justify-end">
-          <span className="flex shrink-0 items-center rounded-full bg-surface-secondary px-1.5 py-px type-body font-medium text-label tabular-nums">
-            {formatCost(cost.totalCostUsd)}
+      {!wide && (
+        <div className="col-span-full grid grid-cols-subgrid mt-1 border-t border-separator pt-1 type-body">
+          <span className="text-label-tertiary">{costFigureLabel(cost.isActive)}</span>
+          <span className="text-right text-label-tertiary tabular-nums">
+            {formatTokensShort(cost.totalTokens)}
           </span>
+          <span className="flex justify-end">
+            <span className="flex shrink-0 items-center rounded-full bg-surface-secondary px-1.5 py-px type-body font-medium text-label tabular-nums">
+              {formatCost(cost.totalCostUsd)}
+            </span>
+          </span>
+          <span className="text-right text-label-tertiary tabular-nums">
+            {formatSharePct(cost.totalCostUsd, totalUsd)}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+  if (!wide) return table
+
+  return (
+    <div className="session-cost-summary grid w-full gap-6 rounded-popover bg-surface-card/50 p-4 font-mono">
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="type-large-title font-semibold! text-label tabular-nums">
+          {formatCost(totalUsd)}
         </span>
-        <span className="text-right text-label-tertiary tabular-nums">
-          {formatSharePct(cost.totalCostUsd, totalUsd)}
+        <span className="type-callout text-label-secondary">
+          {costFigureLabel(cost.isActive)}
+        </span>
+        <span className="type-callout text-label-tertiary">
+          {formatTokensShort(cost.totalTokens)} tokens
         </span>
       </div>
+      {table}
     </div>
   )
 }

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
@@ -22,6 +22,20 @@ function totals(over: Partial<SessionEfficiency> = {}): SessionEfficiency {
 }
 
 describe("EfficiencyBreakdown", () => {
+  it.each([
+    { totalUsd: 5, figure: "$20.00", band: "good", ink: "text-label" },
+    { totalUsd: 10, figure: "$40.00", band: "ok", ink: "text-label" },
+    { totalUsd: 25, figure: "$100.00", band: "bad", ink: "text-brand" },
+  ])("uses $ink for a $band efficiency hero", ({ totalUsd, figure, band, ink }) => {
+    const metrics = efficiencyMetrics(totals({ totalUsd }), "claude-code")
+    expect(metrics.costPerMTok?.band).toBe(band)
+    render(<EfficiencyBreakdown metrics={metrics} section="cost" layout="wide" />)
+    expect(screen.getByText(figure)).toHaveClass(ink)
+    expect(screen.getByText(figure)).not.toHaveClass(
+      ink === "text-label" ? "text-brand" : "text-label",
+    )
+  })
+
   it("renders the headline and three spend rows with their values", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
     expect(screen.getByText("$/MTok")).toBeTruthy()
@@ -150,18 +164,56 @@ describe("EfficiencyBreakdown", () => {
     expect(screen.queryByText(/fresh input and output/)).toBeNull()
   })
 
-  it("prints the cost reading's guidance inline under its scale", () => {
+  it("prints the cost reading's guidance inline under its scale as one paragraph", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
 
-    const guidance = within(screen.getByTestId("cost-guidance"))
-    expect(guidance.getByText(/average cost for each million tokens/)).toHaveClass(
-      "text-label-secondary",
+    const guidance = screen.getByTestId("cost-guidance")
+    // One quiet paragraph, so the sentences wrap at the pane's width instead
+    // of each taking a line.
+    expect(guidance.querySelectorAll("p")).toHaveLength(1)
+    const paragraph = within(guidance).getByText(/average cost for each million tokens/)
+    expect(paragraph).toHaveClass("text-label-tertiary")
+    expect(paragraph).not.toHaveClass("font-medium")
+    expect(paragraph).toHaveTextContent(
+      "For Claude, aim for below $33. Above $80 is too high. Craft tight workflows",
     )
-    expect(
-      guidance.getByText("For Claude, aim for below $33. Above $80 is too high."),
-    ).toHaveClass("text-label-tertiary")
-    expect(guidance.getByText(/Context tab shows/)).toBeInTheDocument()
+    expect(paragraph).toHaveTextContent(/Context tab shows/)
+    expect(guidance).not.toHaveClass("max-w-prose")
     // The cost row is plain text now, not a tooltip trigger.
     expect(screen.getByTestId("cost-row")).not.toHaveAttribute("tabindex")
+  })
+
+  it("draws the wide bar above stacked legend rows", () => {
+    render(
+      <EfficiencyBreakdown
+        metrics={efficiencyMetrics(totals(), "claude-code")}
+        layout="wide"
+      />,
+    )
+
+    const track = screen.getByTestId("efficiency-composition")
+    expect(track.dataset.height).toBe("bar")
+    expect(track).toHaveClass("h-6", "rounded-control")
+
+    const legend = screen.getByTestId("composition-legend")
+    expect(legend).toHaveClass("flex", "flex-col")
+    // Each cell keeps its share, its name, its band word, and its tooltip.
+    const realWork = screen.getByTestId("share-row-realWorkShare")
+    expect(realWork).toHaveTextContent("34%")
+    expect(realWork).toHaveTextContent("Real Work %")
+    expect(realWork).toHaveAttribute("tabindex", "0")
+    fireEvent.focus(realWork)
+    expect(screen.getAllByText(/fresh input and output/).length).toBeGreaterThan(0)
+
+    expect(screen.getByTestId("cost-guidance")).not.toHaveClass("max-w-prose")
+    expect(screen.getByText("per million tokens")).toBeTruthy()
+  })
+
+  it("keeps the popover's hairline track and stacked rows by default", () => {
+    render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
+    const track = screen.getByTestId("efficiency-composition")
+    expect(track.dataset.height).toBe("hairline")
+    expect(track).toHaveClass("h-1", "rounded-full")
+    expect(screen.getByTestId("composition-legend")).toHaveClass("flex-col")
   })
 })

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
@@ -18,6 +18,8 @@ export interface EfficiencyBreakdownProps {
    * composition under the context chart. Omit it to draw both.
    */
   section?: "cost" | "composition"
+  /** The wide layout uses taller bars and a hero figure. */
+  layout?: "popover" | "wide"
 }
 
 /* The fill for one band of the cost scale. The three bands are a fixed
@@ -154,9 +156,11 @@ function shareSegments(metrics: EfficiencyMetrics): ShareSegment[] {
 function CostScaleBar({
   metric,
   profile,
+  wide,
 }: {
   metric: EfficiencyMetric
   profile: EfficiencyProfile
+  wide: boolean
 }) {
   const scale = efficiencyThermometer(metric.value, "costPerMTok", profile)
   const [, low, high] = scale.ticks
@@ -171,7 +175,7 @@ function CostScaleBar({
       data-position={scale.position.toFixed(3)}
       aria-hidden
     >
-      <div className="relative flex h-3">
+      <div className={cn("relative flex", wide ? "h-6" : "h-3")}>
         {scale.segments.map((band, index) => (
           <span
             key={band}
@@ -202,7 +206,8 @@ function CostScaleBar({
             data-testid={`cost-band-word-${band}`}
             data-current={band === metric.band || undefined}
             className={cn(
-              "flex flex-1 flex-col type-caption text-label-tertiary tabular-nums",
+              "flex flex-1 flex-col text-label-tertiary tabular-nums",
+              wide ? "type-body" : "type-caption",
               index === 0 && "items-start",
               index === last && "items-end",
               index > 0 && index < last && "items-center",
@@ -223,14 +228,25 @@ function CostScaleBar({
  * The three shares as one composition. They are parts of a single whole, so
  * they draw as one track: each run takes its slice of the width, in that
  * slice's own color. Three separate meters hid the only fact that matters,
- * which is how the session divided its cost.
+ * which is how the session divided its cost. The popover draws a hairline;
+ * the wide pane draws a bar.
  */
-function CompositionTrack({ segments }: { segments: ShareSegment[] }) {
+function CompositionTrack({
+  segments,
+  height,
+}: {
+  segments: ShareSegment[]
+  height: "hairline" | "bar"
+}) {
   return (
     <div
       data-testid="efficiency-composition"
+      data-height={height}
       aria-hidden
-      className="flex h-1 gap-px overflow-hidden rounded-full bg-surface-secondary"
+      className={cn(
+        "flex gap-px overflow-hidden bg-surface-secondary",
+        height === "bar" ? "h-6 rounded-control" : "h-1 rounded-full",
+      )}
     >
       {segments.map((segment) => (
         <span
@@ -252,7 +268,8 @@ function CompositionTrack({ segments }: { segments: ShareSegment[] }) {
  * The composition rows keep their guidance in a tooltip so the block stays
  * the height of its readings. A panel that grows and shrinks under the rows
  * moves everything below it every time the pointer crosses a row. The cost
- * reading stands alone on its tab, so it prints the same guidance inline.
+ * reading stands alone on its tab, so it prints the same guidance inline, as
+ * one quiet paragraph that wraps at the width of its pane.
  */
 function MetricGuidance({
   metricKey,
@@ -263,22 +280,26 @@ function MetricGuidance({
   profile: EfficiencyProfile
   inline?: boolean
 }) {
-  const leadClass = inline ? "text-label-secondary" : "text-label"
-  const restClass = inline ? "text-label-tertiary" : "text-label-secondary"
+  const advice = [
+    ...efficiencyThresholdGuidance(metricKey, profile),
+    ...METRIC_GUIDANCE[metricKey],
+  ]
+  if (inline) {
+    return (
+      <p className="type-callout text-pretty text-label-tertiary">
+        {[...METRIC_SUMMARY[metricKey], ...advice].join(" ")}
+      </p>
+    )
+  }
   return (
-    <div className={cn("space-y-1 text-pretty", inline && "type-callout")}>
+    <div className="space-y-1 text-pretty">
       {METRIC_SUMMARY[metricKey].map((sentence) => (
-        <p key={sentence} className={leadClass}>
+        <p key={sentence} className="text-label">
           {sentence}
         </p>
       ))}
-      {efficiencyThresholdGuidance(metricKey, profile).map((sentence) => (
-        <p key={sentence} className={restClass}>
-          {sentence}
-        </p>
-      ))}
-      {METRIC_GUIDANCE[metricKey].map((sentence) => (
-        <p key={sentence} className={restClass}>
+      {advice.map((sentence) => (
+        <p key={sentence} className="text-label-secondary">
           {sentence}
         </p>
       ))}
@@ -298,19 +319,38 @@ const ROW_CLASS =
 function CostRowLine({
   metric,
   profile,
+  wide,
 }: {
   metric: EfficiencyMetric
   profile: EfficiencyProfile
+  wide: boolean
 }) {
   return (
     <div className="type-body" data-testid="cost-row">
-      <span className="flex items-baseline justify-between gap-2 pb-1">
-        <span className="truncate text-label-secondary">$/MTok</span>
-        <span className="shrink-0 text-label tabular-nums">
-          {formatCostPerMTok(metric.value)}
+      {wide ? (
+        <div className="my-2 flex flex-wrap items-center gap-x-4 gap-y-1 pb-3">
+          <span
+            className={cn(
+              "type-display font-semibold! tabular-nums",
+              metric.band === "bad" ? "text-brand" : "text-label",
+            )}
+          >
+            {formatCostPerMTok(metric.value)}
+          </span>
+          <span className="flex flex-col type-callout">
+            <span className="font-semibold text-label">per million tokens</span>
+            <span className="text-label-secondary">of context growth and output</span>
+          </span>
+        </div>
+      ) : (
+        <span className="flex items-baseline justify-between gap-3 pb-3">
+          <span className="truncate text-label-secondary">$/MTok</span>
+          <span className="shrink-0 text-label tabular-nums">
+            {formatCostPerMTok(metric.value)}
+          </span>
         </span>
-      </span>
-      <CostScaleBar metric={metric} profile={profile} />
+      )}
+      <CostScaleBar metric={metric} profile={profile} wide={wide} />
       <div className="mt-3" data-testid="cost-guidance">
         <MetricGuidance metricKey="costPerMTok" profile={profile} inline />
       </div>
@@ -366,10 +406,15 @@ function ShareRowPlaceholder({ row }: { row: ShareRow }) {
   )
 }
 
-export function EfficiencyBreakdown({ metrics, section }: EfficiencyBreakdownProps) {
+export function EfficiencyBreakdown({
+  metrics,
+  section,
+  layout = "popover",
+}: EfficiencyBreakdownProps) {
   const segments = shareSegments(metrics)
   const showCost = section !== "composition"
   const showComposition = section !== "cost"
+  const wide = layout === "wide"
 
   if (!metrics.costPerMTok) {
     return null
@@ -377,21 +422,26 @@ export function EfficiencyBreakdown({ metrics, section }: EfficiencyBreakdownPro
 
   return (
     <div className="flex flex-col" data-testid="efficiency-block">
-      {showCost && <CostRowLine metric={metrics.costPerMTok} profile={metrics.profile} />}
+      {showCost && (
+        <CostRowLine metric={metrics.costPerMTok} profile={metrics.profile} wide={wide} />
+      )}
       {showCost && showComposition && (
         <div className="my-3 border-b border-dashed border-separator" />
       )}
       {!showComposition ? null : segments.length > 0 ? (
         <>
-          <CompositionTrack segments={segments} />
-          <div className="mt-2 flex flex-col">
+          <CompositionTrack segments={segments} height={wide ? "bar" : "hairline"} />
+          <div
+            data-testid="composition-legend"
+            className={cn("flex flex-col", wide ? "mt-3" : "mt-2")}
+          >
             {segments.map((segment) => (
               <ShareRowLine key={segment.key} segment={segment} profile={metrics.profile} />
             ))}
           </div>
         </>
       ) : (
-        <div className="flex flex-col">
+        <div data-testid="composition-legend" className="flex flex-col">
           {SHARE_ROWS.map((row) => (
             <ShareRowPlaceholder key={row.key} row={row} />
           ))}

--- a/apps/desktop/src/components/session/analysis/HygieneBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/HygieneBreakdown.test.tsx
@@ -5,6 +5,7 @@ import type { SessionHygienePayload } from "../../../lib/insightsIpc"
 import {
   INITIAL_SESSION_HYGIENE,
   sessionHygieneChecks,
+  sessionHygieneDocumentation,
 } from "../../../lib/presentation/sessionHygiene"
 import { HygieneBreakdown } from "./HygieneBreakdown"
 
@@ -40,6 +41,23 @@ function view() {
 }
 
 describe("HygieneBreakdown", () => {
+  it("shows guidance for all assessed checks without disclosure controls in inline mode", () => {
+    const checks = sessionHygieneChecks(PAYLOAD)
+    render(<HygieneBreakdown checks={checks} inlineGuidance />)
+    expect(screen.queryByRole("button")).toBeNull()
+    expect(screen.getAllByRole("group")).toHaveLength(5)
+    for (const check of checks.filter((item) => item.status !== "notAssessed")) {
+      const documentation = sessionHygieneDocumentation(check)
+      expect(screen.getByRole("group", { name: check.name })).toHaveTextContent(
+        documentation.summary,
+      )
+      for (const advice of documentation.guidance) {
+        expect(screen.getByRole("group", { name: check.name })).toHaveTextContent(advice)
+      }
+    }
+    expect(screen.queryByText("Overpowered subagents")).toBeNull()
+  })
+
   it("omits unavailable checks from the summary and detail rows", () => {
     view()
 

--- a/apps/desktop/src/components/session/analysis/HygieneBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/HygieneBreakdown.tsx
@@ -17,6 +17,8 @@ export interface HygieneBreakdownProps {
    * own.
    */
   collapsePassing?: boolean
+  /** Show all assessed checks with guidance below each label. */
+  inlineGuidance?: boolean
 }
 
 interface HygieneStatusPresentation {
@@ -136,7 +138,37 @@ function HygieneRow({
   )
 }
 
-export function HygieneBreakdown({ checks, collapsePassing = true }: HygieneBreakdownProps) {
+function InlineHygieneRow({ check }: { check: AssessedHygieneCheck }) {
+  const status = STATUS_PRESENTATION[check.status]
+  const documentation = sessionHygieneDocumentation(check)
+  return (
+    <div className="py-2" role="group" aria-label={check.name}>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 type-body">
+        <span className="type-body-large text-label">{check.name}</span>
+        <span className={cn("inline-flex items-center gap-1 type-callout", status.wordClass)}>
+          <status.Icon
+            size={STATUS_ICON_SIZE}
+            aria-hidden="true"
+            className={status.textClass}
+          />
+          {status.label}
+        </span>
+      </div>
+      <div className="mt-1 space-y-1 type-callout text-label-secondary">
+        {documentation.findingDetails.length > 0 && (
+          <p className="text-share-waste-text">{documentation.findingDetails.join(" ")}</p>
+        )}
+        <p>{[documentation.summary, ...documentation.guidance].join(" ")}</p>
+      </div>
+    </div>
+  )
+}
+
+export function HygieneBreakdown({
+  checks,
+  collapsePassing = true,
+  inlineGuidance = false,
+}: HygieneBreakdownProps) {
   const [rollupOpen, setRollupOpen] = useState(false)
   const [openCheck, setOpenCheck] = useState<SessionHygieneCheck["id"] | null>(null)
   const assessedChecks = checks.filter(isAssessed)
@@ -171,6 +203,19 @@ export function HygieneBreakdown({ checks, collapsePassing = true }: HygieneBrea
   const shownChecks = collapsePassing ? findings : [...findings, ...rolledChecks]
 
   if (assessedCount === 0) return null
+
+  if (inlineGuidance) {
+    return (
+      <div
+        className="session-checks-grid grid gap-x-8 gap-y-2"
+        aria-label="Session hygiene checks"
+      >
+        {[...findings, ...passing].map((check) => (
+          <InlineHygieneRow key={check.id} check={check} />
+        ))}
+      </div>
+    )
+  }
 
   return (
     <div className="grid gap-y-0.5" aria-label="Session hygiene checks">

--- a/apps/desktop/src/components/session/analysis/SkillsMcpChart.test.tsx
+++ b/apps/desktop/src/components/session/analysis/SkillsMcpChart.test.tsx
@@ -135,4 +135,23 @@ describe("SkillsMcpChart", () => {
     expect(screen.getAllByText(/^(Skill|MCP|Tool)$/)).toHaveLength(total)
     expect(screen.queryByText(/^Show/)).toBeNull()
   })
+
+  it("keeps one column unless asked for two, and keeps rank order across them", () => {
+    const { unmount } = render(<SkillsMcpChart breakdown={breakdown(manyRows(3))} />)
+    const single = screen.getByTestId("skills-mcp-list")
+    expect(single.dataset.columns).toBe("1")
+    expect(single).toHaveClass("grid-cols-1")
+    unmount()
+
+    render(<SkillsMcpChart breakdown={breakdown(manyRows(3))} columns={2} />)
+    const double = screen.getByTestId("skills-mcp-list")
+    expect(double.dataset.columns).toBe("2")
+    expect(double).toHaveClass("grid-cols-2")
+    // A grid fills row by row, so the DOM order is the rank order.
+    expect(Array.from(double.children).map((cell) => cell.textContent)).toEqual([
+      expect.stringContaining("skill-0"),
+      expect.stringContaining("skill-1"),
+      expect.stringContaining("skill-2"),
+    ])
+  })
 })

--- a/apps/desktop/src/components/session/analysis/SkillsMcpChart.tsx
+++ b/apps/desktop/src/components/session/analysis/SkillsMcpChart.tsx
@@ -10,6 +10,8 @@ import type { InitialContextBreakdown } from "../../../lib/types/session"
 
 export interface SkillsMcpChartProps {
   breakdown: InitialContextBreakdown
+  /** How many columns the cells fill. Two suits a wide pane. */
+  columns?: 1 | 2
 }
 
 /** Kind label shown on a row's detail line. */
@@ -40,18 +42,30 @@ function statusClass(row: SkillMcpRow): string | null {
  * muted detail line. The cell shape matches the session list, at half the
  * card wash. Not a button and no hover wash — the row does nothing.
  */
-function SkillMcpRowLine({ row }: { row: SkillMcpRow }) {
+function SkillMcpRowLine({ row, wide }: { row: SkillMcpRow; wide: boolean }) {
   const statusInk = statusClass(row)
   const origin = skillMcpOriginLabel(row.origin)
   return (
     <div className="flex flex-col gap-y-0.5 rounded-[var(--radius-popover)] bg-surface-card/50 px-3 py-2 type-body">
       <span className="flex items-baseline justify-between gap-x-3">
-        <span className="min-w-0 truncate font-semibold text-label">{row.name}</span>
+        <span
+          className={cn(
+            "min-w-0 truncate text-label",
+            wide ? "type-body-large" : "font-semibold",
+          )}
+        >
+          {row.name}
+        </span>
         <span className="shrink-0 text-label-tertiary tabular-nums">
           {formatCompact(row.tokenCount)}
         </span>
       </span>
-      <span className="flex min-w-0 items-baseline gap-x-1 text-label-tertiary">
+      <span
+        className={cn(
+          "flex min-w-0 items-baseline gap-x-1 text-label-tertiary",
+          wide && "type-callout",
+        )}
+      >
         <span>{skillMcpKindLabel(row.kind)}</span>
         {origin && (
           <>
@@ -69,9 +83,10 @@ function SkillMcpRowLine({ row }: { row: SkillMcpRow }) {
 /**
  * The full skills, MCPs and tools list. Every source renders as a two-line
  * cell: the list is the tab's whole content, so it hides nothing behind a
- * disclosure and needs no column headers.
+ * disclosure and needs no column headers. The cells keep their rank order
+ * across `columns` columns, left to right and then down.
  */
-export function SkillsMcpChart({ breakdown }: SkillsMcpChartProps) {
+export function SkillsMcpChart({ breakdown, columns = 1 }: SkillsMcpChartProps) {
   const usage = skillMcpUsage(breakdown)
 
   if (usage.totalTokens === 0) {
@@ -79,9 +94,13 @@ export function SkillsMcpChart({ breakdown }: SkillsMcpChartProps) {
   }
 
   return (
-    <div className="flex flex-col gap-y-1.5">
+    <div
+      data-testid="skills-mcp-list"
+      data-columns={columns}
+      className={cn("grid gap-1.5", columns === 2 ? "grid-cols-2" : "grid-cols-1")}
+    >
       {usage.rows.map((row) => (
-        <SkillMcpRowLine key={row.key} row={row} />
+        <SkillMcpRowLine key={row.key} row={row} wide={columns === 2} />
       ))}
     </div>
   )

--- a/apps/desktop/src/components/ui/SegmentedControl.test.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.test.tsx
@@ -111,6 +111,37 @@ describe("SegmentedControl", () => {
     expect(document.querySelector(".ui-segmented-reduced-fill")).toBeTruthy()
   })
 
+  it("lets native tabs sit at their content width when equalWidth is false", () => {
+    const { unmount } = render(
+      <SegmentedControl
+        options={FOUR}
+        value="a"
+        onChange={() => {}}
+        ariaLabel="Sections"
+        variant="native-tabs"
+      />,
+    )
+    const stretched = screen.getByRole("radiogroup", { name: "Sections" })
+    expect(stretched).toHaveClass("grid")
+    expect(stretched.style.gridTemplateColumns).toBe("repeat(4, minmax(0, 1fr))")
+    unmount()
+
+    render(
+      <SegmentedControl
+        options={FOUR}
+        value="a"
+        onChange={() => {}}
+        ariaLabel="Sections"
+        variant="native-tabs"
+        equalWidth={false}
+      />,
+    )
+    const content = screen.getByRole("radiogroup", { name: "Sections" })
+    expect(content).toHaveClass("inline-grid")
+    expect(content.style.gridTemplateColumns).toBe("")
+    expect(screen.getByRole("radio", { name: "A" })).toHaveClass("px-4")
+  })
+
   it("renders content-width text tabs without segmented-control chrome", () => {
     const onChange = vi.fn()
     render(

--- a/apps/desktop/src/components/ui/SegmentedControl.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.tsx
@@ -23,15 +23,16 @@ export type SegmentedControlVariant = "segmented" | "text-tabs" | "raised-tabs" 
  *
  *  `variant="native-tabs"` is the macOS segmented control: a recessed neutral
  *  track with the selected segment raised on the surface in a semibold label.
- *  Quiet, so it sits under a hero without competing with it. It is always
- *  equal-width. */
+ *  Quiet, so it sits under a hero without competing with it. It fills its
+ *  row in equal columns unless `equalWidth` is `false`, which sizes each
+ *  segment to its label so the control sits at its content width. */
 export function SegmentedControl<T extends string>({
   options,
   value,
   onChange,
   ariaLabel,
   className = "",
-  equalWidth = false,
+  equalWidth,
   animatedIndicator = false,
   semantics = "radio",
   idPrefix,
@@ -53,6 +54,8 @@ export function SegmentedControl<T extends string>({
   const textTabs = variant === "text-tabs"
   const raisedTabs = variant === "raised-tabs"
   const nativeTabs = variant === "native-tabs"
+  // The native track fills its row unless the caller opts out.
+  const stretchNativeTabs = nativeTabs && equalWidth !== false
   const showAnimatedIndicator = animatedIndicator && !textTabs && !raisedTabs && !nativeTabs
   const selectedIndex = Math.max(
     0,
@@ -82,7 +85,11 @@ export function SegmentedControl<T extends string>({
               // outer curve matches them at any padding.
               cn("grid gap-0.5 rounded-full bg-surface-secondary p-0.5", className)
             : nativeTabs
-              ? cn("ui-segmented-native grid bg-surface-secondary p-0.5", className)
+              ? cn(
+                  "ui-segmented-native bg-surface-secondary p-0.5",
+                  stretchNativeTabs ? "grid" : "inline-grid auto-cols-max grid-flow-col",
+                  className,
+                )
               : cn(
                   showAnimatedIndicator && "relative",
                   equalWidth ? "grid" : "inline-flex",
@@ -91,7 +98,7 @@ export function SegmentedControl<T extends string>({
                 )
       }
       style={
-        (equalWidth || raisedTabs || nativeTabs) && !textTabs
+        (equalWidth || raisedTabs || stretchNativeTabs) && !textTabs
           ? {
               gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))`,
             }
@@ -152,6 +159,7 @@ export function SegmentedControl<T extends string>({
                 : nativeTabs
                   ? cn(
                       "ui-segmented-native-segment relative min-w-0 rounded-control py-0.5 type-caption transition-colors duration-[var(--duration-quick)] ease-out-quart disabled:opacity-50",
+                      !stretchNativeTabs && "px-4",
                       selected
                         ? "font-semibold! text-label shadow-raised"
                         : "font-medium! text-label-secondary hover:text-label",

--- a/apps/desktop/src/styles/session-detail.css
+++ b/apps/desktop/src/styles/session-detail.css
@@ -17,3 +17,90 @@
 .chart-key-stat:not(:disabled):active {
   transform: scale(0.98);
 }
+
+/* The toolbar groups the view picker and the session actions. */
+.session-detail-wide .session-detail-tabs,
+.session-detail-actions {
+  height: calc(var(--space-2xl) + var(--space-xs) * 2);
+  padding: var(--space-xs);
+}
+.session-detail-wide .session-detail-tabs button {
+  min-height: var(--space-2xl);
+  padding-inline: var(--space-md);
+}
+.session-detail-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--space-2xl);
+  padding: var(--space-xs);
+}
+.session-detail-actions svg {
+  width: var(--space-lg);
+  height: var(--space-lg);
+}
+.session-detail-key {
+  margin-inline: 0;
+}
+.session-detail-wide .chart-key-stat {
+  padding: var(--space-md);
+}
+.session-detail-wide [data-testid="skills-mcp-list"] {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: var(--space-md);
+}
+.session-detail-wide [data-testid="skills-mcp-list"] > div {
+  padding: var(--space-lg);
+  gap: var(--space-xs);
+}
+.session-detail-wide .session-detail-cost .group {
+  padding-block: var(--space-xs);
+}
+
+.session-detail-wide .session-detail-tabs button::before {
+  display: none;
+}
+.session-detail-wide .session-detail-tabs button[aria-selected="true"] {
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-raised);
+}
+.session-detail-wide .session-detail-tabs button {
+  font-weight: 400 !important;
+  font-size: inherit;
+  letter-spacing: inherit;
+}
+/* The toolbar uses a light material without an outlined control track. */
+.session-detail-toolbar {
+  backdrop-filter: blur(var(--space-lg)) saturate(120%);
+  -webkit-backdrop-filter: blur(var(--space-lg)) saturate(120%);
+}
+@media (prefers-reduced-transparency: reduce) {
+  .session-detail-toolbar {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: var(--color-surface-window);
+  }
+}
+
+/* Checks share a row only when each explanation has enough reading width. */
+.session-detail-cost {
+  container-type: inline-size;
+}
+.session-checks-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+@container (min-width: 40rem) {
+  .session-checks-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.session-cost-summary {
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+@container (min-width: 40rem) {
+  .session-cost-summary {
+    grid-template-columns: minmax(8rem, 1fr) minmax(0, 3fr);
+  }
+}

--- a/apps/desktop/src/styles/typography.css
+++ b/apps/desktop/src/styles/typography.css
@@ -86,3 +86,10 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: var(--truncated-text-lines);
 }
+
+/* The display step gives a standalone finding more emphasis than a title. */
+.type-display {
+  font-size: 40px;
+  font-weight: 400;
+  letter-spacing: 0.36px;
+}

--- a/apps/desktop/src/views/main-window/MainActivityView.tsx
+++ b/apps/desktop/src/views/main-window/MainActivityView.tsx
@@ -123,6 +123,7 @@ export function MainActivityView({
               </div>
             )}
             <SessionPane
+              layout="wide"
               embedded
               active={state.active}
               subject={item.subject}

--- a/apps/desktop/src/views/popover/SessionPane.tsx
+++ b/apps/desktop/src/views/popover/SessionPane.tsx
@@ -1,7 +1,10 @@
 import { confirm } from "@tauri-apps/plugin-dialog"
 import { useCallback } from "react"
 
-import { SessionDetailPresentation } from "../../components/session/SessionDetailPresentation"
+import {
+  SessionDetailPresentation,
+  type SessionDetailLayout,
+} from "../../components/session/SessionDetailPresentation"
 import type { TokensCostSplit } from "../../components/session/tokensCard"
 import { renderAgentIcon } from "../../lib/agentIcon"
 import {
@@ -45,6 +48,9 @@ export interface SessionPaneProps {
   refreshing: boolean
   /** Whether the load for this subject failed. */
   error: boolean
+  /** Which layout the detail draws. Defaults to the popover layout. */
+  layout?: SessionDetailLayout | undefined
+  /** Leave the pane; omitted when the host owns navigation. */
   onBack?: (() => void) | undefined
   /** Newer adjacent session; omitted when there is none. */
   onPrev?: (() => void) | undefined
@@ -186,6 +192,7 @@ export function SessionPane({
   loading,
   refreshing,
   error,
+  layout,
   onBack,
   onPrev,
   onNext,
@@ -317,6 +324,7 @@ export function SessionPane({
       subagentCount={payload?.orchestration?.subagentCount ?? 0}
       modelRuns={payload?.modelRuns ?? []}
       relations={relations}
+      {...(layout ? { layout } : {})}
       {...(onBack ? { onBack } : {})}
       {...(onPrev ? { onPrev } : {})}
       {...(onNext ? { onNext } : {})}


### PR DESCRIPTION
The main-window Sessions detail now uses a responsive desktop layout with a fixed toolbar, consistent typography, and more space around its content. This follows #451, which has merged into `main`.

- Context keeps its key beneath the growing chart and cost composition at the bottom. Resizing updates geometry without replaying the staggered entrance animation.
- Cost groups the total and a compact, right-aligned breakdown in a full-width monospace card, followed by responsive Checks and the Efficiency footer. Good and OK efficiency figures use neutral ink.
- Tools uses a larger orange tokens-burned figure and roomier cells. The toolbar keeps the repository in monospace and matches the tab and action control heights.
- Main-window focus, scoped shortcuts, related-session Back navigation, drag regions, and loading/error actions remain available. The popover retains its compact layout.

Validation: all 1,281 desktop tests pass, including chart resize, layout, efficiency color, toolbar loading states, keyboard focus, and platform drag-region coverage. Prettier, ESLint, TypeScript, Vite build, Knip, design drift, `slop:all`, and secret scanning pass. Native visual verification after integration is outstanding because Notate lacks Screen Recording permission.

Product question: does a desktop-sized detail make session context and cost easier to read? Existing `surface_viewed` session-detail coverage remains owned by the main-window session controller. This presentation-only change adds no analytics events; individual tab use and readability are intentionally unmeasured and need usability feedback. No new IPC, polling, network requests, or data collection. Resize handling retains one bucket reference and suppresses unnecessary animation.
