### PR TITLE
fix(install): bind install.ps1 parameters under `irm | iex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+### Fixed
+
+- The Windows install command `irm https://antiburn.ai/install.ps1 | iex`
+  now runs instead of failing with a parameter validation error.
+
 ## [0.4.1] - 2026-09-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ antiburn supports Claude Code, Codex, Cursor, GitHub Copilot, Cline, OpenCode, K
 macOS or Linux:
 
 ```sh
-curl -fsSL http://antiburn.ai/install.sh | sh
+curl -fsSL https://antiburn.ai/install.sh | sh
 ```
 
 Windows 11 PowerShell:
 
 ```powershell
-irm http://antiburn.ai/install.ps1 | iex
+irm https://antiburn.ai/install.ps1 | iex
 ```
 
 The installers verify release checksums. macOS also verifies the application

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter()]
-    [ValidatePattern('^[0-9A-Za-z.-]+$')]
-    [string] $Version = $env:ANTIBURN_VERSION
+    [string] $Version
 )
 
 $ErrorActionPreference = 'Stop'
@@ -38,6 +37,20 @@ function Write-InstallerBanner {
     $Host.UI.WriteLine('antiburn reads your coding agent sessions locally, finds what')
     $Host.UI.WriteLine('burns tokens, and nudges you before you hit a limit.')
     $Host.UI.WriteLine('')
+}
+
+# Read the version from the parameter, then from the environment.
+# The param block holds no validation attribute. The documented install
+# command pipes this file into `iex`. PowerShell then adds each param
+# attribute to a variable. PowerShell rejects an empty value.
+function Resolve-RequestedVersion {
+    param([string] $Version)
+
+    $requested = if ($Version) { $Version } else { $env:ANTIBURN_VERSION }
+    if ($requested -and $requested -notmatch '^[0-9A-Za-z.-]+$') {
+        throw "Invalid version: $requested"
+    }
+    return $requested
 }
 
 function Get-AntiburnRelease {
@@ -150,6 +163,8 @@ function Test-WindowsArchitecture {
 function Invoke-AntiburnInstall {
     param([string] $RequestedVersion)
 
+    $resolvedVersion = Resolve-RequestedVersion -Version $RequestedVersion
+
     if ($PSVersionTable.PSVersion.Major -lt 6) {
         $protocol = [Net.ServicePointManager]::SecurityProtocol
         [Net.ServicePointManager]::SecurityProtocol = $protocol -bor [Net.SecurityProtocolType]::Tls12
@@ -157,7 +172,7 @@ function Invoke-AntiburnInstall {
 
     Write-InstallerBanner
     Test-WindowsArchitecture
-    $release = Get-AntiburnRelease -RequestedVersion $RequestedVersion
+    $release = Get-AntiburnRelease -RequestedVersion $resolvedVersion
     $assetName = "antiburn_$($release.Version)_x64-setup.exe"
     $baseUrl = "$script:GitHubUrl/releases/download/$($release.Tag)"
     $temporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("antiburn-install-" + [guid]::NewGuid())

--- a/scripts/install-ps1.test.ps1
+++ b/scripts/install-ps1.test.ps1
@@ -102,4 +102,59 @@ Describe 'install.ps1' {
         $source | Should -Match 'not required to have an Authenticode signature yet'
         $source | Should -Match 'SmartScreen can warn'
     }
+
+    It 'binds the version parameter when the script runs through Invoke-Expression' {
+        # The documented Windows command pipes this file into Invoke-Expression.
+        # PowerShell then runs the file as a script block and adds each param
+        # attribute to a variable in the caller scope.
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:InstallerPath, [ref] $null, [ref] $null)
+        $paramBlock = $ast.ParamBlock.Extent.Text
+        $previous = $env:ANTIBURN_VERSION
+        try {
+            $env:ANTIBURN_VERSION = ''
+            { $paramBlock | Invoke-Expression } | Should -Not -Throw
+            $env:ANTIBURN_VERSION = '1.2.3'
+            { $paramBlock | Invoke-Expression } | Should -Not -Throw
+        }
+        finally {
+            $env:ANTIBURN_VERSION = $previous
+        }
+    }
+
+    Context 'Resolve-RequestedVersion' {
+        BeforeAll {
+            $script:PreviousRequestedVersion = $env:ANTIBURN_VERSION
+        }
+
+        AfterAll {
+            $env:ANTIBURN_VERSION = $script:PreviousRequestedVersion
+        }
+
+        It 'prefers the parameter over the environment variable' {
+            $env:ANTIBURN_VERSION = '9.9.9'
+            Resolve-RequestedVersion -Version '1.2.3' | Should -Be '1.2.3'
+        }
+
+        It 'reads the environment variable when the parameter is empty' {
+            $env:ANTIBURN_VERSION = '1.2.3'
+            Resolve-RequestedVersion -Version '' | Should -Be '1.2.3'
+        }
+
+        It 'returns nothing when neither source gives a version' {
+            $env:ANTIBURN_VERSION = ''
+            [string]::IsNullOrEmpty((Resolve-RequestedVersion -Version '')) | Should -BeTrue
+        }
+
+        It 'rejects a version that holds unsafe characters' {
+            $env:ANTIBURN_VERSION = ''
+            { Resolve-RequestedVersion -Version '1.2.3;calc' } |
+                Should -Throw '*Invalid version*'
+        }
+
+        It 'rejects an unsafe version from the environment variable' {
+            $env:ANTIBURN_VERSION = '1.2.3;calc'
+            { Resolve-RequestedVersion -Version '' } | Should -Throw '*Invalid version*'
+        }
+    }
 }


### PR DESCRIPTION
Fixes #428

## User impact

The documented Windows install command works again:

```powershell
irm https://antiburn.ai/install.ps1 | iex
```

It previously failed before printing the banner and before downloading
anything:

```
iex : The attribute cannot be added because variable Version with value  would no longer be valid.
```

`Invoke-Expression` runs a piped script as a *script block*, so PowerShell
attaches the `param` block's attributes to variables in the caller's scope. The
`[string]` cast makes `$Version` an empty string, and `^[0-9A-Za-z.-]+$`
rejects it, so attribute attachment threw before the first statement ran.

Removing the `$env:ANTIBURN_VERSION` default is not sufficient on its own —
tested on Windows PowerShell 5.1:

| `param` block | `\| iex` |
| --- | --- |
| `ValidatePattern` + env default (before) | throws |
| `ValidatePattern`, no default | throws |
| `AllowEmptyString` + `ValidatePattern` | throws |
| no validation attribute, no default (this PR) | works |

So the attribute itself leaves the `param` block. `Resolve-RequestedVersion`
now reads the parameter first and `ANTIBURN_VERSION` second, and validates the
result before any download — the same precedence, character set, and
`Invalid version:` message as `validate_version` in `install.sh`. `-Version`
and `ANTIBURN_VERSION` keep working.

**Known limit:** `antiburn.ai/install.ps1` is a 301 to
`releases/latest/download/install.ps1`, so this reaches users only when the next
`antiburn-v*` release publishes. Until then the workaround in #428 stands.

Also switches the README install commands from `http://` to `https://`. Both
URLs already serve over HTTPS and redirect to the same release asset, so macOS
and Linux users receive an identical script over a hardened first hop.

## Validation

**Real install, clean machine.** Windows 10 Pro 19045, Windows PowerShell
5.1.19041, no antiburn present. Piped the branch copy of the script into `iex`
exactly as the README documents. Complete output:

```
antiburn: Stop hitting your token limits - antiburn finds what burns tokens in your coding agent sessions.
antiburn: Resolving the latest release
antiburn: Downloading antiburn_0.4.0_x64-setup.exe
antiburn: Verified SHA-256 for antiburn_0.4.0_x64-setup.exe
WARNING: The Windows installer is not required to have an Authenticode signature yet. Windows SmartScreen can warn.
antiburn: Starting the passive installer
antiburn: Installed antiburn 0.4.0
antiburn: Open antiburn - it lives in your menu bar.
```

`antiburn.exe` 0.4.0 landed in `%LOCALAPPDATA%\antiburn` alongside
`uninstall.exe` and the notices, and the app started. Every stage that #428
blocked now runs: parameter binding, banner, architecture check, release
resolution, download, checksum verification, and installation.

Other checks:

- `Invoke-Pester scripts/install-ps1.test.ps1 -CI` on Windows PowerShell 5.1 —
  15/15 pass. Five tests are new: one extracts the `param` block with the
  PowerShell parser and runs it through `Invoke-Expression` (it throws on the
  old file and passes on this one), and four cover `Resolve-RequestedVersion`
  precedence, fallback, and rejection of unsafe values.
- `Invoke-ScriptAnalyzer -Path install.ps1 -Severity Error,Warning` — clean.
- `ANTIBURN_VERSION=1.2.3;calc` stops with `Invalid version: 1.2.3;calc` before
  any network request.
- `install.sh` is untouched and shares no code with `install.ps1`. `install.ps1`
  sits at the repository root, so `classifyPaths` still selects `full`, and the
  `installer-tests` matrix runs the POSIX leg unchanged.

### Observed during validation, not changed here

The install completes, but the script does not return while antiburn runs.
`Start-Process -Wait` waits for the whole process tree, and the NSIS `/R` flag
makes the installer launch the app, so `Start-Process` blocks on the app rather
than on setup. The two closing lines above appeared only after the app exited.
A user therefore sees a terminal that looks hung after a successful install.
This predates this change and is out of scope for #428.

## Analytics

None. This changes an install script that runs before the application exists on
the machine, so it emits no events and has no client to send them from. Install
success is already observable from release asset download counts.

## Privacy and performance

No change to data access, retained data, or background work. Network access is
unchanged in destination and hardened in transport: the README now sends users
to `https://` for the first hop instead of relying on the site's redirect.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
