### PR TITLE
Learn a per-account dollars-per-percent limit factor (phase 1)

### DIFF
--- a/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/allocation/tests.rs
@@ -135,6 +135,8 @@ fn reduced_observation_series_keeps_the_full_reported_delta() {
             source_id: "test".to_string(),
             reported_starts_at_epoch: Some(0),
             reported_resets_at_epoch: Some(100),
+            plan: None,
+            plan_tier: None,
         })
         .collect::<Vec<_>>();
     let history = ProviderUsagePeriodHistory {

--- a/apps/desktop/src-tauri/src/provider_usage/factor.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/factor.rs
@@ -1,0 +1,535 @@
+//! Learn the dollars-per-percent limit factor from meter readings and priced
+//! turns.
+//!
+//! See `docs/plans/limit-factor-estimation.md` for the full design. This
+//! module writes `store::provider_limit`'s samples and points. Nothing reads
+//! them outside tests yet; the session badge still prices from the durable
+//! allocator until phase 2.
+
+use std::collections::BTreeMap;
+
+use crate::store::Store;
+use crate::store::provider_limit::{
+    AttributedSessionDollars, FactorPoint, FactorSample, lane_duration_seconds,
+    lane_for_window_role,
+};
+use crate::store::provider_usage_history::{ProviderUsageObservation, ProviderUsagePeriod};
+
+/// Observation pairs one pass may create or recompute.
+///
+/// Matches `ledger::reconcile`'s own per-pass ceiling: a bounded amount of
+/// durable work per tick, with the remainder picked up on the next one.
+const MAX_OBSERVATION_PAIRS: usize = 64;
+
+/// How recently a period must have been observed to enter a pass, and how
+/// close to now a sample's `to_epoch` must be to stay open to recompute.
+const RECOMPUTE_WINDOW_SECS: i64 = 900;
+
+/// How far back the weighted median looks for delta samples.
+const FACTOR_WINDOW_SECS: i64 = 14 * 86_400;
+
+/// How much a newly computed factor must move before it earns a new point.
+const FACTOR_CHANGE_THRESHOLD: f64 = 0.02;
+
+/// A candidate factor: its value, method, the samples behind it, and the
+/// plan it carries.
+type FactorEstimate = (f64, &'static str, usize, (Option<String>, Option<String>));
+
+/// Learn the dollars-per-percent factor from durable meter readings.
+///
+/// Bounded the same way `ledger::reconcile` is: one shared gate across store
+/// clones skips a pass already running, and a fixed ceiling on observation
+/// pairs caps the work. Call this wherever `ledger::reconcile` runs today.
+pub fn learn(store: &Store, now_epoch: i64) {
+    let Some(_in_flight) = store.try_begin_limit_factor_learn() else {
+        return;
+    };
+    let recompute_since = now_epoch - RECOMPUTE_WINDOW_SECS;
+    let Ok(periods) = store.provider_limit_candidate_periods(recompute_since) else {
+        ::tracing::warn!(event = "limit_factor_candidate_periods_failed");
+        return;
+    };
+
+    let mut pairs_used = 0usize;
+    // `periods` is ordered by `last_observed_epoch` descending, so the first
+    // period seen for a lane is already its current one.
+    let mut current_period: BTreeMap<(String, String, &'static str), i64> = BTreeMap::new();
+    for period in &periods {
+        if pairs_used >= MAX_OBSERVATION_PAIRS {
+            break;
+        }
+        let Some(lane) = lane_for_window_role(&period.window_role) else {
+            continue;
+        };
+        let Ok(Some(history)) = store.provider_usage_period_history(period.id) else {
+            continue;
+        };
+        let Ok(existing) = store.factor_samples_for_period(period.id) else {
+            continue;
+        };
+        let has_delta_before = store
+            .has_delta_factor_sample(&period.provider, &period.account_key, lane)
+            .unwrap_or(true);
+        let pass = SamplePass {
+            existing: &existing,
+            recompute_since,
+            now_epoch,
+            budget: MAX_OBSERVATION_PAIRS - pairs_used,
+        };
+        pairs_used += build_period_samples(
+            store,
+            period,
+            lane,
+            &history.observations,
+            has_delta_before,
+            &pass,
+        );
+        current_period
+            .entry((period.provider.clone(), period.account_key.clone(), lane))
+            .or_insert(period.id);
+    }
+
+    for ((provider, account_key, lane), period_id) in current_period {
+        recompute_point(store, &provider, &account_key, lane, now_epoch);
+        compute_residual(store, &provider, &account_key, lane, period_id, now_epoch);
+    }
+}
+
+/// The state one call to [`build_period_samples`] needs beyond the period
+/// itself: which pairs already have a sample, and how much work is left.
+struct SamplePass<'a> {
+    existing: &'a std::collections::HashMap<(i64, i64), FactorSample>,
+    recompute_since: i64,
+    now_epoch: i64,
+    budget: usize,
+}
+
+/// Build delta and window-start samples for one period's observations.
+///
+/// Returns the number of samples this call created or recomputed, so the
+/// caller can stop once the pass budget runs out.
+fn build_period_samples(
+    store: &Store,
+    period: &ProviderUsagePeriod,
+    lane: &'static str,
+    observations: &[ProviderUsageObservation],
+    has_delta_before: bool,
+    pass: &SamplePass<'_>,
+) -> usize {
+    let authoritative: Vec<&ProviderUsageObservation> = observations
+        .iter()
+        .filter(|observation| observation.is_authoritative && observation.used_percent.is_some())
+        .collect();
+    let pairs = delta_pairs(&authoritative);
+    let mut used = 0usize;
+
+    // A window-start sample only ever forms while no delta sample exists yet
+    // for this lane, and only for a period that cannot form one of its own:
+    // one with a pair already has a real measurement and needs no fallback.
+    let first_positive = authoritative.iter().find(|observation| {
+        observation
+            .used_percent
+            .is_some_and(|percent| percent > 0.0)
+    });
+    if !has_delta_before
+        && pairs.is_empty()
+        && used < pass.budget
+        && let Some(first_positive) = first_positive
+        && let Some(window_start) = window_start_epoch(period, lane)
+        && window_start < first_positive.observed_at_epoch
+        && should_recompute(
+            pass.existing,
+            window_start,
+            first_positive.observed_at_epoch,
+            pass.recompute_since,
+        )
+        && let Ok(Some(dollars)) = store.attributed_turn_dollars_between(
+            &period.provider,
+            &period.account_key,
+            window_start,
+            first_positive.observed_at_epoch,
+        )
+    {
+        let totals = sum_dollars(&dollars);
+        let sample = FactorSample {
+            provider: period.provider.clone(),
+            account_key: period.account_key.clone(),
+            lane: lane.to_string(),
+            kind: "window_start".to_string(),
+            period_id: Some(period.id),
+            from_epoch: window_start,
+            to_epoch: first_positive.observed_at_epoch,
+            from_percent: 0.0,
+            to_percent: first_positive.used_percent.unwrap_or(0.0),
+            input_usd: totals.0,
+            output_usd: totals.1,
+            cache_read_usd: totals.2,
+            cache_write_usd: totals.3,
+            turn_count: totals.4,
+            plan: first_positive.plan.clone(),
+            plan_tier: first_positive.plan_tier.clone(),
+            source_id: first_positive.source_id.clone(),
+            computed_at_epoch: pass.now_epoch,
+        };
+        if store.upsert_factor_sample(&sample).is_ok() {
+            used += 1;
+        }
+    }
+
+    // Delta samples: adjacent readings inside the period, as `delta_pairs`
+    // found them.
+    for (base, observation) in pairs {
+        if used >= pass.budget {
+            break;
+        }
+        let base_percent = base.used_percent.unwrap_or(f64::NAN);
+        let percent = observation.used_percent.unwrap_or(f64::NAN);
+        if !should_recompute(
+            pass.existing,
+            base.observed_at_epoch,
+            observation.observed_at_epoch,
+            pass.recompute_since,
+        ) {
+            continue;
+        }
+        let Ok(Some(dollars)) = store.attributed_turn_dollars_between(
+            &period.provider,
+            &period.account_key,
+            base.observed_at_epoch,
+            observation.observed_at_epoch,
+        ) else {
+            continue;
+        };
+        let totals = sum_dollars(&dollars);
+        let attributed_total = totals.0 + totals.1 + totals.2 + totals.3;
+        let kind = if attributed_total > 0.0 {
+            "delta"
+        } else {
+            "unattributed"
+        };
+        let sample = FactorSample {
+            provider: period.provider.clone(),
+            account_key: period.account_key.clone(),
+            lane: lane.to_string(),
+            kind: kind.to_string(),
+            period_id: Some(period.id),
+            from_epoch: base.observed_at_epoch,
+            to_epoch: observation.observed_at_epoch,
+            from_percent: base_percent,
+            to_percent: percent,
+            input_usd: totals.0,
+            output_usd: totals.1,
+            cache_read_usd: totals.2,
+            cache_write_usd: totals.3,
+            turn_count: totals.4,
+            plan: observation.plan.clone(),
+            plan_tier: observation.plan_tier.clone(),
+            source_id: observation.source_id.clone(),
+            computed_at_epoch: pass.now_epoch,
+        };
+        if store.upsert_factor_sample(&sample).is_ok() {
+            used += 1;
+        }
+    }
+    used
+}
+
+/// Pair adjacent readings inside one period into delta candidates.
+///
+/// A later reading strictly greater than the running baseline closes a pair
+/// and becomes the new baseline. An equal reading merges into the baseline
+/// without closing a pair, so a plateau spans the whole interval once it
+/// finally rises. A drop restarts the baseline: it is not a valid delta.
+fn delta_pairs<'a>(
+    authoritative: &[&'a ProviderUsageObservation],
+) -> Vec<(&'a ProviderUsageObservation, &'a ProviderUsageObservation)> {
+    let mut pairs = Vec::new();
+    let mut baseline: Option<&ProviderUsageObservation> = None;
+    for &observation in authoritative {
+        let Some(base) = baseline else {
+            baseline = Some(observation);
+            continue;
+        };
+        let base_percent = base.used_percent.unwrap_or(f64::NAN);
+        let percent = observation.used_percent.unwrap_or(f64::NAN);
+        match percent.partial_cmp(&base_percent) {
+            Some(std::cmp::Ordering::Greater) => {
+                pairs.push((base, observation));
+                baseline = Some(observation);
+            }
+            Some(std::cmp::Ordering::Equal) => {
+                // Merge: keep the original baseline in place.
+            }
+            _ => {
+                // A drop mid-period is not a valid delta. Restart from here.
+                baseline = Some(observation);
+            }
+        }
+    }
+    pairs
+}
+
+/// Whether a pair should be (re)computed: it is new, or its close is recent
+/// enough that a late turn could still change it.
+fn should_recompute(
+    existing: &std::collections::HashMap<(i64, i64), FactorSample>,
+    from_epoch: i64,
+    to_epoch: i64,
+    recompute_since: i64,
+) -> bool {
+    !existing.contains_key(&(from_epoch, to_epoch)) || to_epoch >= recompute_since
+}
+
+fn window_start_epoch(period: &ProviderUsagePeriod, lane: &str) -> Option<i64> {
+    period.starts_at_epoch.or_else(|| {
+        period
+            .resets_at_epoch
+            .map(|reset| reset - lane_duration_seconds(lane))
+    })
+}
+
+fn sum_dollars(rows: &[AttributedSessionDollars]) -> (f64, f64, f64, f64, i64) {
+    rows.iter()
+        .fold((0.0, 0.0, 0.0, 0.0, 0), |mut totals, row| {
+            totals.0 += row.input_usd;
+            totals.1 += row.output_usd;
+            totals.2 += row.cache_read_usd;
+            totals.3 += row.cache_write_usd;
+            totals.4 += row.turn_count;
+            totals
+        })
+}
+
+/// Recompute the factor for one account and lane, and append a point when it
+/// moved enough, the method changed, or the plan changed.
+fn recompute_point(store: &Store, provider: &str, account_key: &str, lane: &str, now_epoch: i64) {
+    let current_point = store
+        .latest_factor_point(provider, account_key, lane)
+        .ok()
+        .flatten();
+    let latest_plan = store
+        .latest_observation_plan(provider, account_key, lane)
+        .ok()
+        .flatten();
+    let plan_changed = match (&current_point, &latest_plan) {
+        (Some(point), Some((plan, _))) => point.plan.as_deref() != plan.as_deref(),
+        _ => false,
+    };
+
+    let recent = store
+        .delta_factor_samples_since(provider, account_key, lane, now_epoch - FACTOR_WINDOW_SECS)
+        .unwrap_or_default();
+    let recent = filter_by_plan(recent, plan_changed, latest_plan.as_ref());
+
+    let computed = if recent.len() >= 3 {
+        Some((
+            weighted_median(&recent, now_epoch),
+            "delta",
+            recent.len(),
+            newest_plan(&recent),
+        ))
+    } else {
+        let all = store
+            .all_delta_factor_samples(provider, account_key, lane)
+            .unwrap_or_default();
+        let all = filter_by_plan(all, plan_changed, latest_plan.as_ref());
+        if !all.is_empty() {
+            Some((
+                weighted_median(&all, now_epoch),
+                "delta",
+                all.len(),
+                newest_plan(&all),
+            ))
+        } else {
+            window_start_factor(
+                store,
+                provider,
+                account_key,
+                lane,
+                plan_changed,
+                latest_plan.as_ref(),
+            )
+        }
+    };
+
+    let Some((value, method, sample_count, (plan, plan_tier))) = computed else {
+        return;
+    };
+    if !value.is_finite() || value <= 0.0 {
+        return;
+    }
+
+    let should_append = match &current_point {
+        None => true,
+        Some(point) => {
+            plan_changed
+                || point.method != method
+                || relative_change(point.usd_per_percent, value) > FACTOR_CHANGE_THRESHOLD
+        }
+    };
+    if !should_append {
+        return;
+    }
+    let _ = store.upsert_factor_point(&FactorPoint {
+        id: 0,
+        provider: provider.to_string(),
+        account_key: account_key.to_string(),
+        lane: lane.to_string(),
+        effective_at_epoch: now_epoch,
+        usd_per_percent: value,
+        method: method.to_string(),
+        sample_count: sample_count as i64,
+        plan,
+        plan_tier,
+    });
+}
+
+fn window_start_factor(
+    store: &Store,
+    provider: &str,
+    account_key: &str,
+    lane: &str,
+    plan_changed: bool,
+    latest_plan: Option<&(Option<String>, Option<String>)>,
+) -> Option<FactorEstimate> {
+    let sample = store
+        .latest_window_start_factor_sample(provider, account_key, lane)
+        .ok()
+        .flatten()?;
+    if plan_changed
+        && let Some((plan, _)) = latest_plan
+        && sample.plan.as_deref() != plan.as_deref()
+    {
+        return None;
+    }
+    let delta = sample.percent_delta();
+    if delta.is_nan() || delta <= 0.0 {
+        return None;
+    }
+    Some((
+        sample.total_usd() / delta,
+        "window_start",
+        1,
+        (sample.plan.clone(), sample.plan_tier.clone()),
+    ))
+}
+
+fn relative_change(previous: f64, current: f64) -> f64 {
+    if previous.abs() <= f64::EPSILON {
+        return f64::INFINITY;
+    }
+    ((current - previous) / previous).abs()
+}
+
+fn filter_by_plan(
+    samples: Vec<FactorSample>,
+    plan_changed: bool,
+    latest_plan: Option<&(Option<String>, Option<String>)>,
+) -> Vec<FactorSample> {
+    if !plan_changed {
+        return samples;
+    }
+    let Some((plan, _)) = latest_plan else {
+        return samples;
+    };
+    samples
+        .into_iter()
+        .filter(|sample| sample.plan.as_deref() == plan.as_deref())
+        .collect()
+}
+
+fn newest_plan(samples: &[FactorSample]) -> (Option<String>, Option<String>) {
+    samples
+        .iter()
+        .max_by_key(|sample| sample.to_epoch)
+        .map(|sample| (sample.plan.clone(), sample.plan_tier.clone()))
+        .unwrap_or((None, None))
+}
+
+/// The weighted median of delta samples' dollars-per-percent values.
+///
+/// Weight is `percent_delta * 0.5^(age_days / 7)`. A single interval whose
+/// dollars include outside use pulls a mean down for every later session;
+/// the median ignores it as long as it is not the majority of the weight.
+fn weighted_median(samples: &[FactorSample], now_epoch: i64) -> f64 {
+    let mut values: Vec<(f64, f64)> = samples
+        .iter()
+        .filter_map(|sample| {
+            let delta = sample.percent_delta();
+            if delta.is_nan() || delta <= 0.0 {
+                return None;
+            }
+            let value = sample.total_usd() / delta;
+            let age_days = (now_epoch - sample.to_epoch).max(0) as f64 / 86_400.0;
+            let weight = delta * 0.5_f64.powf(age_days / 7.0);
+            (value.is_finite() && weight > 0.0).then_some((value, weight))
+        })
+        .collect();
+    if values.is_empty() {
+        return f64::NAN;
+    }
+    values.sort_by(|left, right| left.0.total_cmp(&right.0));
+    let total_weight: f64 = values.iter().map(|(_, weight)| weight).sum();
+    let half = total_weight / 2.0;
+    let mut cumulative = 0.0;
+    for (value, weight) in &values {
+        cumulative += weight;
+        if cumulative >= half {
+            return *value;
+        }
+    }
+    values.last().map(|(value, _)| *value).unwrap_or(f64::NAN)
+}
+
+/// For each account and lane touched this pass, the current period's residual:
+/// meter percent against the factor's own estimate for the same span.
+fn compute_residual(
+    store: &Store,
+    provider: &str,
+    account_key: &str,
+    lane: &str,
+    period_id: i64,
+    now_epoch: i64,
+) {
+    let Ok(Some(history)) = store.provider_usage_period_history(period_id) else {
+        return;
+    };
+    let Some(latest) = history
+        .observations
+        .iter()
+        .rev()
+        .find(|observation| observation.is_authoritative && observation.used_percent.is_some())
+    else {
+        return;
+    };
+    // The point in effect when the meter took this reading, not necessarily
+    // the newest point overall: a later plan change should not restate an
+    // older period's residual under today's factor.
+    let Ok(Some(point)) =
+        store.factor_point_at(provider, account_key, lane, latest.observed_at_epoch)
+    else {
+        return;
+    };
+    if point.usd_per_percent.is_nan() || point.usd_per_percent <= 0.0 {
+        return;
+    }
+    let Some(window_start) = window_start_epoch(&history.period, lane) else {
+        return;
+    };
+    let Ok(Some(dollars)) = store.attributed_turn_dollars_between(
+        provider,
+        account_key,
+        window_start,
+        latest.observed_at_epoch,
+    ) else {
+        return;
+    };
+    let totals = sum_dollars(&dollars);
+    let attributed_total = totals.0 + totals.1 + totals.2 + totals.3;
+    let estimated_percent = attributed_total / point.usd_per_percent;
+    let meter_percent = latest.used_percent.unwrap_or(0.0);
+    let _ = store.upsert_limit_residual(period_id, now_epoch, meter_percent, estimated_percent);
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/desktop/src-tauri/src/provider_usage/factor.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/factor.rs
@@ -31,9 +31,17 @@ const FACTOR_WINDOW_SECS: i64 = 14 * 86_400;
 /// How much a newly computed factor must move before it earns a new point.
 const FACTOR_CHANGE_THRESHOLD: f64 = 0.02;
 
-/// A candidate factor: its value, method, the samples behind it, and the
-/// plan it carries.
-type FactorEstimate = (f64, &'static str, usize, (Option<String>, Option<String>));
+/// A candidate factor: its value, method, the samples behind it, the plan it
+/// carries, and the epoch it takes effect from — the `to_epoch` of the
+/// newest sample it used, so a bootstrapped or backfilled point is dated by
+/// the data it came from rather than by the moment it was computed.
+type FactorEstimate = (
+    f64,
+    &'static str,
+    usize,
+    (Option<String>, Option<String>),
+    i64,
+);
 
 /// Learn the dollars-per-percent factor from durable meter readings.
 ///
@@ -67,8 +75,22 @@ pub fn learn(store: &Store, now_epoch: i64) {
         let Ok(existing) = store.factor_samples_for_period(period.id) else {
             continue;
         };
+        // Scope "a delta sample already exists" to the account's current
+        // plan and tier, so a fresh plan can still seed its own window-start
+        // sample instead of being blocked by an older plan's delta history.
+        let (plan, plan_tier) = store
+            .latest_observation_plan(&period.provider, &period.account_key, lane)
+            .ok()
+            .flatten()
+            .unwrap_or((None, None));
         let has_delta_before = store
-            .has_delta_factor_sample(&period.provider, &period.account_key, lane)
+            .has_delta_factor_sample(
+                &period.provider,
+                &period.account_key,
+                lane,
+                plan.as_deref(),
+                plan_tier.as_deref(),
+            )
             .unwrap_or(true);
         let pass = SamplePass {
             existing: &existing,
@@ -76,7 +98,7 @@ pub fn learn(store: &Store, now_epoch: i64) {
             now_epoch,
             budget: MAX_OBSERVATION_PAIRS - pairs_used,
         };
-        pairs_used += build_period_samples(
+        let (produced, complete) = build_period_samples(
             store,
             period,
             lane,
@@ -84,6 +106,12 @@ pub fn learn(store: &Store, now_epoch: i64) {
             has_delta_before,
             &pass,
         );
+        pairs_used += produced;
+        // A pass that stopped mid-period on its budget must not advance the
+        // cursor: the period stays a candidate so the next pass finishes it.
+        if complete {
+            let _ = store.advance_learn_cursor(period.id, period.last_observed_epoch);
+        }
         current_period
             .entry((period.provider.clone(), period.account_key.clone(), lane))
             .or_insert(period.id);
@@ -106,8 +134,10 @@ struct SamplePass<'a> {
 
 /// Build delta and window-start samples for one period's observations.
 ///
-/// Returns the number of samples this call created or recomputed, so the
-/// caller can stop once the pass budget runs out.
+/// Returns the number of samples this call created or recomputed, and
+/// whether it considered every sample the period could yet yield. The
+/// second is `false` only when the pass budget cut the delta-pair loop off
+/// early; the caller must not advance that period's learn cursor then.
 fn build_period_samples(
     store: &Store,
     period: &ProviderUsagePeriod,
@@ -115,13 +145,14 @@ fn build_period_samples(
     observations: &[ProviderUsageObservation],
     has_delta_before: bool,
     pass: &SamplePass<'_>,
-) -> usize {
+) -> (usize, bool) {
     let authoritative: Vec<&ProviderUsageObservation> = observations
         .iter()
         .filter(|observation| observation.is_authoritative && observation.used_percent.is_some())
         .collect();
     let pairs = delta_pairs(&authoritative);
     let mut used = 0usize;
+    let mut complete = true;
 
     // A window-start sample only ever forms while no delta sample exists yet
     // for this lane, and only for a period that cannot form one of its own:
@@ -180,6 +211,7 @@ fn build_period_samples(
     // found them.
     for (base, observation) in pairs {
         if used >= pass.budget {
+            complete = false;
             break;
         }
         let base_percent = base.used_percent.unwrap_or(f64::NAN);
@@ -231,7 +263,7 @@ fn build_period_samples(
             used += 1;
         }
     }
-    used
+    (used, complete)
 }
 
 /// Pair adjacent readings inside one period into delta candidates.
@@ -312,7 +344,10 @@ fn recompute_point(store: &Store, provider: &str, account_key: &str, lane: &str,
         .ok()
         .flatten();
     let plan_changed = match (&current_point, &latest_plan) {
-        (Some(point), Some((plan, _))) => point.plan.as_deref() != plan.as_deref(),
+        (Some(point), Some((plan, plan_tier))) => {
+            point.plan.as_deref() != plan.as_deref()
+                || point.plan_tier.as_deref() != plan_tier.as_deref()
+        }
         _ => false,
     };
 
@@ -322,23 +357,27 @@ fn recompute_point(store: &Store, provider: &str, account_key: &str, lane: &str,
     let recent = filter_by_plan(recent, plan_changed, latest_plan.as_ref());
 
     let computed = if recent.len() >= 3 {
-        Some((
-            weighted_median(&recent, now_epoch),
-            "delta",
-            recent.len(),
-            newest_plan(&recent),
-        ))
+        newest_sample(&recent).map(|newest| {
+            (
+                weighted_median(&recent, now_epoch),
+                "delta",
+                recent.len(),
+                (newest.plan.clone(), newest.plan_tier.clone()),
+                newest.to_epoch,
+            )
+        })
     } else {
         let all = store
             .all_delta_factor_samples(provider, account_key, lane)
             .unwrap_or_default();
         let all = filter_by_plan(all, plan_changed, latest_plan.as_ref());
-        if !all.is_empty() {
+        if let Some(newest) = newest_sample(&all) {
             Some((
                 weighted_median(&all, now_epoch),
                 "delta",
                 all.len(),
-                newest_plan(&all),
+                (newest.plan.clone(), newest.plan_tier.clone()),
+                newest.to_epoch,
             ))
         } else {
             window_start_factor(
@@ -352,7 +391,8 @@ fn recompute_point(store: &Store, provider: &str, account_key: &str, lane: &str,
         }
     };
 
-    let Some((value, method, sample_count, (plan, plan_tier))) = computed else {
+    let Some((value, method, sample_count, (plan, plan_tier), effective_at_epoch)) = computed
+    else {
         return;
     };
     if !value.is_finite() || value <= 0.0 {
@@ -375,7 +415,7 @@ fn recompute_point(store: &Store, provider: &str, account_key: &str, lane: &str,
         provider: provider.to_string(),
         account_key: account_key.to_string(),
         lane: lane.to_string(),
-        effective_at_epoch: now_epoch,
+        effective_at_epoch,
         usd_per_percent: value,
         method: method.to_string(),
         sample_count: sample_count as i64,
@@ -397,8 +437,9 @@ fn window_start_factor(
         .ok()
         .flatten()?;
     if plan_changed
-        && let Some((plan, _)) = latest_plan
-        && sample.plan.as_deref() != plan.as_deref()
+        && let Some((plan, plan_tier)) = latest_plan
+        && (sample.plan.as_deref() != plan.as_deref()
+            || sample.plan_tier.as_deref() != plan_tier.as_deref())
     {
         return None;
     }
@@ -411,6 +452,7 @@ fn window_start_factor(
         "window_start",
         1,
         (sample.plan.clone(), sample.plan_tier.clone()),
+        sample.to_epoch,
     ))
 }
 
@@ -429,21 +471,22 @@ fn filter_by_plan(
     if !plan_changed {
         return samples;
     }
-    let Some((plan, _)) = latest_plan else {
+    let Some((plan, plan_tier)) = latest_plan else {
         return samples;
     };
     samples
         .into_iter()
-        .filter(|sample| sample.plan.as_deref() == plan.as_deref())
+        .filter(|sample| {
+            sample.plan.as_deref() == plan.as_deref()
+                && sample.plan_tier.as_deref() == plan_tier.as_deref()
+        })
         .collect()
 }
 
-fn newest_plan(samples: &[FactorSample]) -> (Option<String>, Option<String>) {
-    samples
-        .iter()
-        .max_by_key(|sample| sample.to_epoch)
-        .map(|sample| (sample.plan.clone(), sample.plan_tier.clone()))
-        .unwrap_or((None, None))
+/// The sample with the latest `to_epoch`, whose plan and close date the
+/// point they produce should carry.
+fn newest_sample(samples: &[FactorSample]) -> Option<&FactorSample> {
+    samples.iter().max_by_key(|sample| sample.to_epoch)
 }
 
 /// The weighted median of delta samples' dollars-per-percent values.

--- a/apps/desktop/src-tauri/src/provider_usage/factor/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/factor/tests.rs
@@ -355,10 +355,7 @@ fn a_point_is_appended_only_when_the_factor_actually_changes() {
         "an unchanged factor earns no new point"
     );
 
-    // A late-arriving turn more than triples the dollars behind the same
-    // pair, moving the factor well past the 2% threshold. The point is dated
-    // by the sample's own to_epoch (200), same as before, so this replaces
-    // the existing point rather than appending a second one.
+    // A late turn changes the same interval, so the point is replaced.
     insert_turn(&store, &key, 180_000, 400_000); // +$2.00
     learn(&store, 500);
     assert_eq!(

--- a/apps/desktop/src-tauri/src/provider_usage/factor/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/factor/tests.rs
@@ -112,17 +112,28 @@ fn push_observation(
     used_percent: f64,
     plan: Option<&str>,
 ) {
+    push_observation_with_tier(store, period_id, observed_at, used_percent, plan, None);
+}
+
+fn push_observation_with_tier(
+    store: &Store,
+    period_id: i64,
+    observed_at: i64,
+    used_percent: f64,
+    plan: Option<&str>,
+    plan_tier: Option<&str>,
+) {
     let connection = store.lock();
     connection
         .execute(
             "INSERT INTO provider_usage_observation (
                  period_id, provider, account_key, window_id, window_kind, window_role,
                  scope_key, scope_label, observed_at_epoch, used_percent, is_fresh,
-                 is_authoritative, confidence, source_id, plan
+                 is_authoritative, confidence, source_id, plan, plan_tier
              ) SELECT id, provider, account_key, window_id, window_kind, window_role,
-                      scope_key, scope_label, ?2, ?3, 1, 1, 'high', 'test', ?4
+                      scope_key, scope_label, ?2, ?3, 1, 1, 'high', 'test', ?4, ?5
                  FROM provider_usage_period WHERE id = ?1",
-            params![period_id, observed_at, used_percent, plan],
+            params![period_id, observed_at, used_percent, plan, plan_tier],
         )
         .expect("stores a synthetic observation");
     connection
@@ -276,7 +287,7 @@ fn window_start_only_forms_while_no_delta_sample_exists_yet() {
     assert_eq!(window_start.to_epoch, 500);
     assert!(
         !store
-            .has_delta_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .has_delta_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR, None, None)
             .unwrap()
     );
     let point = store
@@ -294,7 +305,7 @@ fn window_start_only_forms_while_no_delta_sample_exists_yet() {
     learn(&store, 18_300);
     assert!(
         store
-            .has_delta_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .has_delta_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR, None, None)
             .unwrap()
     );
 
@@ -345,15 +356,25 @@ fn a_point_is_appended_only_when_the_factor_actually_changes() {
     );
 
     // A late-arriving turn more than triples the dollars behind the same
-    // pair, moving the factor well past the 2% threshold.
+    // pair, moving the factor well past the 2% threshold. The point is dated
+    // by the sample's own to_epoch (200), same as before, so this replaces
+    // the existing point rather than appending a second one.
     insert_turn(&store, &key, 180_000, 400_000); // +$2.00
     learn(&store, 500);
-    assert_eq!(count_points(&store), 2, "a real move earns a new point");
+    assert_eq!(
+        count_points(&store),
+        1,
+        "a recompute of the same interval replaces its point, not duplicates it"
+    );
     let latest = store
         .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
         .unwrap()
         .unwrap();
     assert!((latest.usd_per_percent - 0.6).abs() < 1e-9);
+    assert_eq!(
+        latest.effective_at_epoch, 200,
+        "the point is dated by the sample's to_epoch, not the moment it was computed"
+    );
 }
 
 #[test]
@@ -511,6 +532,120 @@ fn learning_records_one_residual_row_per_period() {
         )
         .unwrap();
     assert_eq!(row_count, 1);
+}
+
+#[test]
+fn a_plan_tier_change_with_the_same_plan_drops_earlier_samples_and_appends_a_point() {
+    let store = memory_store();
+    observe_account(&store);
+    let key = insert_session(&store, "s1");
+    let period_id = insert_period(&store, 0, 18_000);
+
+    // Three "max" / "standard"-tier delta pairs, $1.00 each for a 5-point
+    // delta: factor 0.2. The plan itself never changes.
+    push_observation_with_tier(&store, period_id, 100, 10.0, Some("max"), Some("standard"));
+    push_observation_with_tier(&store, period_id, 200, 15.0, Some("max"), Some("standard"));
+    push_observation_with_tier(&store, period_id, 300, 20.0, Some("max"), Some("standard"));
+    push_observation_with_tier(&store, period_id, 400, 25.0, Some("max"), Some("standard"));
+    insert_turn(&store, &key, 150_000, 200_000); // $1.00
+    insert_turn(&store, &key, 250_000, 200_000); // $1.00
+    insert_turn(&store, &key, 350_000, 200_000); // $1.00
+    learn(&store, 450);
+
+    let standard_point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the standard-tier samples seed a point");
+    assert_eq!(standard_point.plan.as_deref(), Some("max"));
+    assert_eq!(standard_point.plan_tier.as_deref(), Some("standard"));
+    assert!((standard_point.usd_per_percent - 0.2).abs() < 1e-9);
+
+    // A tier change alone (plan stays "max") priced twice as expensive per
+    // token: the factor should reflect only the new-tier sample.
+    push_observation_with_tier(&store, period_id, 500, 30.0, Some("max"), Some("pro"));
+    insert_turn(&store, &key, 450_000, 400_000); // $2.00
+    learn(&store, 600);
+
+    let pro_point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the tier change appends a new point");
+    assert_eq!(pro_point.plan.as_deref(), Some("max"));
+    assert_eq!(pro_point.plan_tier.as_deref(), Some("pro"));
+    assert!(
+        (pro_point.usd_per_percent - 0.4).abs() < 1e-9,
+        "expected the new-tier sample alone (0.4), got {}",
+        pro_point.usd_per_percent
+    );
+    assert_eq!(count_points(&store), 2);
+}
+
+#[test]
+fn a_point_computed_from_old_observations_is_dated_by_their_epoch_not_by_now() {
+    let store = memory_store();
+    observe_account(&store);
+    let key = insert_session(&store, "s1");
+    // Readings from two days ago, as a bootstrap or backfill pass would see.
+    let two_days_ago = 2 * 86_400;
+    let period_id = insert_period(&store, two_days_ago, two_days_ago + 18_000);
+    insert_turn(&store, &key, (two_days_ago + 150) * 1_000, 200_000); // $1.00
+    push_observation(&store, period_id, two_days_ago + 100, 10.0, None);
+    push_observation(&store, period_id, two_days_ago + 200, 15.0, None);
+
+    // The pass itself runs today, long after the data it is learning from.
+    let today = 5 * 86_400;
+    learn(&store, today);
+
+    let point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the old sample seeds a point");
+    assert_eq!(
+        point.effective_at_epoch,
+        two_days_ago + 200,
+        "the point is dated by the sample it came from, not by when the pass ran"
+    );
+}
+
+#[test]
+fn a_tier_change_with_no_delta_yet_seeds_a_window_start_sample_and_point() {
+    let store = memory_store();
+    observe_account(&store);
+
+    // Period 1: two "standard"-tier readings form a delta sample and point.
+    let key1 = insert_session(&store, "s1");
+    insert_turn(&store, &key1, 150_000, 200_000); // $1.00
+    let period1 = insert_period(&store, 0, 18_000);
+    push_observation_with_tier(&store, period1, 100, 10.0, Some("max"), Some("standard"));
+    push_observation_with_tier(&store, period1, 200, 15.0, Some("max"), Some("standard"));
+    learn(&store, 300);
+    let standard_point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the standard-tier delta seeds a point");
+    assert_eq!(standard_point.method, "delta");
+
+    // Period 2: the account moves to the "pro" tier. Its first reading has
+    // no partner yet, so only a window-start sample can form for this tier
+    // — and it can, because the delta check is scoped to (plan, plan_tier).
+    let key2 = insert_session(&store, "s2");
+    insert_turn(&store, &key2, 18_050_000, 200_000); // $1.00
+    let period2 = insert_period(&store, 18_000, 36_000);
+    push_observation_with_tier(&store, period2, 18_100, 5.0, Some("max"), Some("pro"));
+    learn(&store, 18_200);
+
+    let window_start = store
+        .latest_window_start_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the new tier's first positive reading seeds a window-start sample");
+    assert_eq!(window_start.plan_tier.as_deref(), Some("pro"));
+
+    let pro_point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the window-start sample seeds a new point");
+    assert_eq!(pro_point.method, "window_start");
+    assert_eq!(pro_point.plan_tier.as_deref(), Some("pro"));
 }
 
 fn count_points(store: &Store) -> i64 {

--- a/apps/desktop/src-tauri/src/provider_usage/factor/tests.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/factor/tests.rs
@@ -1,0 +1,525 @@
+use std::path::Path;
+
+use rusqlite::params;
+
+use super::*;
+use crate::store::provider_limit::LANE_FIVE_HOUR;
+use crate::store::{SessionKey, SessionRecord};
+
+const PROVIDER: &str = "anthropic";
+const AGENT: &str = "claude-code";
+const MODEL: &str = "claude-opus-4-6";
+
+fn account() -> String {
+    "a".repeat(64)
+}
+
+fn memory_store() -> Store {
+    Store::open_in_memory(Path::new("/tmp/antiburn-limit-factor-test")).expect("opens store")
+}
+
+fn observe_account(store: &Store) {
+    store
+        .lock()
+        .execute(
+            "INSERT INTO provider_account_seen (agent, provider, account_key,
+                 first_seen_epoch, last_seen_epoch)
+             VALUES (?1, ?2, ?3, 1, 1)",
+            params![AGENT, PROVIDER, account()],
+        )
+        .expect("records a seen account");
+}
+
+fn insert_session(store: &Store, session_id: &str) -> SessionKey {
+    let key = SessionKey::new("native", AGENT, session_id);
+    store
+        .upsert_sessions(
+            &[SessionRecord {
+                key: key.clone(),
+                source_kind: "inline".to_string(),
+                source_label: "synthetic".to_string(),
+                wsl_distro: None,
+                title: None,
+                title_source: None,
+                cwd: None,
+                surface: "unknown".to_string(),
+                updated_at_epoch: Some(1),
+                activity_cursor: "synthetic".to_string(),
+                activity_source: "event".to_string(),
+                subagent_count: 0,
+                fork_parent_session_id: None,
+                source_fingerprint: Some("synthetic".to_string()),
+            }],
+            &[],
+        )
+        .expect("stores synthetic session");
+    key
+}
+
+/// Publish one turn at `ts_ms`, with its session evidence published, so the
+/// attribution query's `session_evidence` join matches it.
+fn insert_turn(store: &Store, key: &SessionKey, ts_ms: i64, input_tokens: i64) {
+    let connection = store.lock();
+    connection
+        .execute(
+            "INSERT OR IGNORE INTO session_evidence (
+                 environment_key, agent, session_id, status, published_fence
+             ) VALUES (?1, ?2, ?3, 'ready', 1)",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .expect("publishes synthetic evidence");
+    connection
+        .execute(
+            "INSERT INTO turn (
+                 environment_key, agent, session_id, claim_fence, source_key,
+                 thread_id, turn_index, scope, role, ts_ms, model, effort, speed,
+                 input_tokens, cache_read_tokens, cache_write_tokens, output_tokens,
+                 is_compaction_boundary, message_id, uuid, parent_uuid
+             ) VALUES (?1, ?2, ?3, 1, 'synthetic', 'synthetic', 0, 'main', 'assistant',
+                       ?4, ?5, NULL, NULL, ?6, 0, 0, 0, 0, NULL, NULL, NULL)",
+            params![
+                key.environment_key,
+                key.agent,
+                key.session_id,
+                ts_ms,
+                MODEL,
+                input_tokens
+            ],
+        )
+        .expect("stores synthetic turn");
+}
+
+fn insert_period(store: &Store, start: i64, reset: i64) -> i64 {
+    let connection = store.lock();
+    connection
+        .execute(
+            "INSERT INTO provider_usage_period (
+                 provider, account_key, window_id, window_kind, window_role,
+                 scope_key, scope_label, duration_seconds, starts_at_epoch,
+                 resets_at_epoch, first_observed_epoch, last_observed_epoch
+             ) VALUES (?1, ?2, 'five-hour', 'rolling', 'primaryShort',
+                       'account', 'account', ?3, ?4, ?5, ?4, ?4)",
+            params![PROVIDER, account(), reset - start, start, reset],
+        )
+        .expect("inserts a synthetic period");
+    connection.last_insert_rowid()
+}
+
+fn push_observation(
+    store: &Store,
+    period_id: i64,
+    observed_at: i64,
+    used_percent: f64,
+    plan: Option<&str>,
+) {
+    let connection = store.lock();
+    connection
+        .execute(
+            "INSERT INTO provider_usage_observation (
+                 period_id, provider, account_key, window_id, window_kind, window_role,
+                 scope_key, scope_label, observed_at_epoch, used_percent, is_fresh,
+                 is_authoritative, confidence, source_id, plan
+             ) SELECT id, provider, account_key, window_id, window_kind, window_role,
+                      scope_key, scope_label, ?2, ?3, 1, 1, 'high', 'test', ?4
+                 FROM provider_usage_period WHERE id = ?1",
+            params![period_id, observed_at, used_percent, plan],
+        )
+        .expect("stores a synthetic observation");
+    connection
+        .execute(
+            "UPDATE provider_usage_period
+                SET first_observed_epoch = MIN(first_observed_epoch, ?2),
+                    last_observed_epoch = MAX(last_observed_epoch, ?2)
+              WHERE id = ?1",
+            params![period_id, observed_at],
+        )
+        .expect("advances the period's observed range");
+}
+
+fn sample_at(total_usd: f64, percent_delta: f64, to_epoch: i64) -> FactorSample {
+    FactorSample {
+        provider: PROVIDER.to_string(),
+        account_key: account(),
+        lane: LANE_FIVE_HOUR.to_string(),
+        kind: "delta".to_string(),
+        period_id: None,
+        from_epoch: to_epoch - 100,
+        to_epoch,
+        from_percent: 0.0,
+        to_percent: percent_delta,
+        input_usd: total_usd,
+        output_usd: 0.0,
+        cache_read_usd: 0.0,
+        cache_write_usd: 0.0,
+        turn_count: 1,
+        plan: None,
+        plan_tier: None,
+        source_id: "test".to_string(),
+        computed_at_epoch: to_epoch,
+    }
+}
+
+#[test]
+fn delta_sample_arithmetic_prices_turns_between_two_readings() {
+    let store = memory_store();
+    observe_account(&store);
+    let key = insert_session(&store, "s1");
+    insert_turn(&store, &key, 150_000, 200_000); // 200,000 * 5e-6 = $1.00
+    let period_id = insert_period(&store, 0, 18_000);
+    push_observation(&store, period_id, 100, 10.0, None);
+    push_observation(&store, period_id, 200, 15.0, None);
+
+    learn(&store, 300);
+
+    let samples = store
+        .all_delta_factor_samples(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    let sample = &samples[0];
+    assert_eq!(sample.from_epoch, 100);
+    assert_eq!(sample.to_epoch, 200);
+    assert!((sample.from_percent - 10.0).abs() < 1e-9);
+    assert!((sample.to_percent - 15.0).abs() < 1e-9);
+    assert!((sample.total_usd() - 1.0).abs() < 1e-9);
+    assert_eq!(sample.turn_count, 1);
+
+    let point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("a point is learned from the one delta sample");
+    assert!((point.usd_per_percent - 0.2).abs() < 1e-9);
+    assert_eq!(point.method, "delta");
+    assert_eq!(point.sample_count, 1);
+}
+
+#[test]
+fn equal_readings_merge_into_one_interval_spanning_the_whole_plateau() {
+    let store = memory_store();
+    observe_account(&store);
+    let key = insert_session(&store, "s1");
+    insert_turn(&store, &key, 120_000, 100_000); // $0.50, before the plateau's end
+    insert_turn(&store, &key, 180_000, 100_000); // $0.50, after the plateau
+    let period_id = insert_period(&store, 0, 18_000);
+    push_observation(&store, period_id, 100, 10.0, None);
+    push_observation(&store, period_id, 150, 10.0, None); // equal: merges with 100
+    push_observation(&store, period_id, 200, 15.0, None);
+
+    learn(&store, 300);
+
+    let samples = store
+        .all_delta_factor_samples(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap();
+    assert_eq!(
+        samples.len(),
+        1,
+        "the plateau produces one interval, not two"
+    );
+    assert_eq!(samples[0].from_epoch, 100);
+    assert_eq!(samples[0].to_epoch, 200);
+    assert!((samples[0].total_usd() - 1.0).abs() < 1e-9);
+    assert_eq!(samples[0].turn_count, 2);
+}
+
+#[test]
+fn a_positive_delta_with_no_local_turns_is_stored_as_unattributed() {
+    let store = memory_store();
+    observe_account(&store);
+    let period_id = insert_period(&store, 0, 18_000);
+    push_observation(&store, period_id, 100, 10.0, None);
+    push_observation(&store, period_id, 200, 20.0, None);
+
+    learn(&store, 300);
+
+    assert!(
+        store
+            .all_delta_factor_samples(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .unwrap()
+            .is_empty(),
+        "no dollars behind the delta means no 'delta' sample"
+    );
+    let kind: String = store
+        .lock()
+        .query_row(
+            "SELECT kind FROM provider_limit_factor_sample WHERE from_epoch = 100 AND to_epoch = 200",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(kind, "unattributed");
+    assert!(
+        store
+            .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .unwrap()
+            .is_none(),
+        "zero dollars behind every sample earns no factor"
+    );
+}
+
+#[test]
+fn window_start_only_forms_while_no_delta_sample_exists_yet() {
+    let store = memory_store();
+    observe_account(&store);
+
+    // Period 1: one positive reading, no pair possible. Window start is the
+    // only sample this lane can produce yet.
+    let key1 = insert_session(&store, "s1");
+    insert_turn(&store, &key1, 250_000, 100_000); // $0.50
+    let period1 = insert_period(&store, 0, 18_000);
+    push_observation(&store, period1, 500, 8.0, None);
+    learn(&store, 600);
+
+    let window_start = store
+        .latest_window_start_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the first positive reading seeds a window-start sample");
+    assert_eq!(window_start.from_epoch, 0);
+    assert_eq!(window_start.to_epoch, 500);
+    assert!(
+        !store
+            .has_delta_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .unwrap()
+    );
+    let point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("a window-start point seeds the badge before any delta exists");
+    assert_eq!(point.method, "window_start");
+
+    // Period 2: two readings in one lane, so a real delta sample appears.
+    let key2 = insert_session(&store, "s2");
+    insert_turn(&store, &key2, 18_150_000, 100_000); // $0.50
+    let period2 = insert_period(&store, 18_000, 36_000);
+    push_observation(&store, period2, 18_100, 5.0, None);
+    push_observation(&store, period2, 18_200, 10.0, None);
+    learn(&store, 18_300);
+    assert!(
+        store
+            .has_delta_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .unwrap()
+    );
+
+    // Period 3: another single positive reading. No new window-start sample
+    // forms now that a delta sample exists for the lane.
+    let period3 = insert_period(&store, 36_000, 54_000);
+    push_observation(&store, period3, 36_100, 6.0, None);
+    learn(&store, 36_200);
+
+    let still_the_first_window_start = store
+        .latest_window_start_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the earlier window-start sample is untouched");
+    assert_eq!(still_the_first_window_start.to_epoch, 500);
+}
+
+#[test]
+fn the_weighted_median_is_not_pulled_by_one_outlier() {
+    let now = 1_000;
+    let mut samples: Vec<FactorSample> = (0..5).map(|_| sample_at(5.0, 5.0, now)).collect();
+    samples.push(sample_at(500.0, 5.0, now)); // value 100.0, same weight as the rest
+    let median = weighted_median(&samples, now);
+    assert!(
+        (median - 1.0).abs() < 1e-9,
+        "median should stay at 1.0, not the mean's ~17.5, got {median}"
+    );
+}
+
+#[test]
+fn a_point_is_appended_only_when_the_factor_actually_changes() {
+    let store = memory_store();
+    observe_account(&store);
+    let key = insert_session(&store, "s1");
+    insert_turn(&store, &key, 150_000, 200_000); // $1.00
+    let period_id = insert_period(&store, 0, 18_000);
+    push_observation(&store, period_id, 100, 10.0, None);
+    push_observation(&store, period_id, 200, 15.0, None);
+
+    learn(&store, 300);
+    assert_eq!(count_points(&store), 1);
+
+    // Recomputing the same pair with nothing new changes nothing.
+    learn(&store, 400);
+    assert_eq!(
+        count_points(&store),
+        1,
+        "an unchanged factor earns no new point"
+    );
+
+    // A late-arriving turn more than triples the dollars behind the same
+    // pair, moving the factor well past the 2% threshold.
+    insert_turn(&store, &key, 180_000, 400_000); // +$2.00
+    learn(&store, 500);
+    assert_eq!(count_points(&store), 2, "a real move earns a new point");
+    let latest = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .unwrap();
+    assert!((latest.usd_per_percent - 0.6).abs() < 1e-9);
+}
+
+#[test]
+fn the_recompute_window_upserts_a_late_arriving_turn_into_the_same_sample() {
+    let store = memory_store();
+    observe_account(&store);
+    let period_id = insert_period(&store, 0, 18_000);
+    push_observation(&store, period_id, 100, 10.0, None);
+    push_observation(&store, period_id, 200, 15.0, None);
+
+    learn(&store, 300);
+    let kind: String = store
+        .lock()
+        .query_row(
+            "SELECT kind FROM provider_limit_factor_sample WHERE from_epoch = 100 AND to_epoch = 200",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(kind, "unattributed", "no turns exist for this pair yet");
+
+    let key = insert_session(&store, "s1");
+    insert_turn(&store, &key, 150_000, 200_000); // $1.00, arrives late
+    learn(&store, 400);
+
+    let row_count: i64 = store
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM provider_limit_factor_sample
+              WHERE from_epoch = 100 AND to_epoch = 200",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(row_count, 1, "the pair is upserted, not duplicated");
+    let samples = store
+        .all_delta_factor_samples(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert!((samples[0].total_usd() - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn a_zero_percent_reading_never_seeds_a_sample() {
+    let store = memory_store();
+    observe_account(&store);
+    // A Codex reading at 0% with a projected reset carries no meaningful
+    // window boundary; `is_sliding_reset_projection` upstream already drops
+    // the stated reset. Whether or not a reset survived, a zero reading must
+    // never seed a window-start or delta sample.
+    let period_id = insert_period(&store, 0, 18_000);
+    push_observation(&store, period_id, 100, 0.0, None);
+
+    learn(&store, 200);
+
+    assert!(
+        store
+            .latest_window_start_factor_sample(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        store
+            .all_delta_factor_samples(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        store
+            .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn a_plan_change_drops_earlier_samples_and_appends_a_point() {
+    let store = memory_store();
+    observe_account(&store);
+    let key = insert_session(&store, "s1");
+    let period_id = insert_period(&store, 0, 18_000);
+
+    // Three "pro" delta pairs, $1.00 each for a 5-point delta: factor 0.2.
+    push_observation(&store, period_id, 100, 10.0, Some("pro"));
+    push_observation(&store, period_id, 200, 15.0, Some("pro"));
+    push_observation(&store, period_id, 300, 20.0, Some("pro"));
+    push_observation(&store, period_id, 400, 25.0, Some("pro"));
+    insert_turn(&store, &key, 150_000, 200_000); // $1.00
+    insert_turn(&store, &key, 250_000, 200_000); // $1.00
+    insert_turn(&store, &key, 350_000, 200_000); // $1.00
+    learn(&store, 450);
+
+    let pro_point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the pro-plan samples seed a point");
+    assert_eq!(pro_point.plan.as_deref(), Some("pro"));
+    assert!((pro_point.usd_per_percent - 0.2).abs() < 1e-9);
+
+    // A new "max"-plan reading, priced twice as expensive per token: factor
+    // should reflect only this new-plan sample, not blend with the old plan.
+    push_observation(&store, period_id, 500, 30.0, Some("max"));
+    insert_turn(&store, &key, 450_000, 400_000); // $2.00
+    learn(&store, 600);
+
+    let max_point = store
+        .latest_factor_point(PROVIDER, &account(), LANE_FIVE_HOUR)
+        .unwrap()
+        .expect("the plan change appends a new point");
+    assert_eq!(max_point.plan.as_deref(), Some("max"));
+    assert!(
+        (max_point.usd_per_percent - 0.4).abs() < 1e-9,
+        "expected the new-plan sample alone (0.4), got {}",
+        max_point.usd_per_percent
+    );
+    assert_eq!(count_points(&store), 2);
+}
+
+#[test]
+fn learning_records_one_residual_row_per_period() {
+    let store = memory_store();
+    observe_account(&store);
+    let key = insert_session(&store, "s1");
+    insert_turn(&store, &key, 150_000, 200_000); // $1.00
+    let period_id = insert_period(&store, 0, 18_000);
+    push_observation(&store, period_id, 100, 10.0, None);
+    push_observation(&store, period_id, 200, 15.0, None);
+
+    learn(&store, 300);
+
+    let (meter_percent, estimated_percent): (f64, f64) = store
+        .lock()
+        .query_row(
+            "SELECT meter_percent, estimated_percent FROM provider_limit_residual
+              WHERE period_id = ?1",
+            [period_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("one residual row exists for the period");
+    assert!((meter_percent - 15.0).abs() < 1e-9);
+    // Attributed dollars from the window start (epoch 0) through the latest
+    // observation (epoch 200) is the same $1.00 turn, divided by the 0.2
+    // factor: 5.0 estimated percent.
+    assert!(
+        (estimated_percent - 5.0).abs() < 1e-9,
+        "expected 5.0, got {estimated_percent}"
+    );
+
+    let row_count: i64 = store
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM provider_limit_residual WHERE period_id = ?1",
+            [period_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(row_count, 1);
+}
+
+fn count_points(store: &Store) -> i64 {
+    store
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM provider_limit_factor_point",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+}

--- a/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/live/mod.rs
@@ -319,14 +319,20 @@ pub fn summarize_collected(
         let result = store.record_provider_usage_snapshots(&collected.snapshots);
         if let Some(app) = storage_app {
             match crate::storage_health::checked(app, "provider usage history", result) {
-                Ok(_) => crate::provider_usage::ledger::reconcile(store, now),
+                Ok(_) => {
+                    crate::provider_usage::ledger::reconcile(store, now);
+                    crate::provider_usage::factor::learn(store, now);
+                }
                 Err(_) => {
                     ::tracing::warn!(event = "provider_usage_history_write_failed");
                 }
             }
         } else {
             match result {
-                Ok(_) => crate::provider_usage::ledger::reconcile(store, now),
+                Ok(_) => {
+                    crate::provider_usage::ledger::reconcile(store, now);
+                    crate::provider_usage::factor::learn(store, now);
+                }
                 Err(error) => {
                     ::tracing::warn!(event = "provider_usage_history_write_failed", error = %error);
                 }

--- a/apps/desktop/src-tauri/src/provider_usage/mod.rs
+++ b/apps/desktop/src-tauri/src/provider_usage/mod.rs
@@ -26,6 +26,7 @@
 //!    touched. The views say so.
 
 pub(crate) mod allocation;
+pub(crate) mod factor;
 pub(crate) mod ledger;
 pub mod live;
 pub mod providers;
@@ -307,7 +308,7 @@ fn state_of(accumulator: &Accumulator) -> ProviderUsageState {
     }
 }
 
-fn has_tokens(tokens: &ModelTokens) -> bool {
+pub(crate) fn has_tokens(tokens: &ModelTokens) -> bool {
     tokens.input_tokens > 0
         || tokens.output_tokens > 0
         || tokens.cache_read_tokens > 0
@@ -386,8 +387,8 @@ fn account_for(record: &UsageEvidenceRecord, provider: &str) -> Option<String> {
 }
 
 #[derive(Debug, Default)]
-struct Attributed {
-    models: BTreeMap<String, ModelTokens>,
+pub(crate) struct Attributed {
+    pub(crate) models: BTreeMap<String, ModelTokens>,
     explicit: bool,
 }
 
@@ -426,7 +427,7 @@ fn explicit_providers<'a>(hints: impl IntoIterator<Item = &'a ProviderHint>) -> 
 /// A fixed-route agent puts every model under its vendor; a bring-your-own
 /// agent splits them, so one session can appear under two providers with the
 /// tokens divided between them rather than double-counted.
-fn attribute(
+pub(crate) fn attribute(
     agent: &str,
     breakdown: BTreeMap<String, ModelTokens>,
     hints: &[ProviderHint],

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -22,6 +22,7 @@
 //! come here only to write the result.
 
 pub mod model;
+pub(crate) mod provider_limit;
 pub(crate) mod provider_usage_history;
 pub(crate) mod provider_usage_ledger;
 mod schema;
@@ -235,6 +236,7 @@ pub fn open_read_only(data_dir: &Path, busy_timeout: Duration) -> Result<Connect
 pub struct Store {
     connection: Arc<Mutex<Connection>>,
     allocation_reconcile: Arc<Mutex<()>>,
+    limit_factor_learn: Arc<Mutex<()>>,
     database_path: Option<PathBuf>,
     /// The directory the engine's own state files (scan roots, ignored paths)
     /// live in. The engine never chooses this; the shell does.
@@ -368,6 +370,7 @@ impl Store {
         let store = Store {
             connection: Arc::new(Mutex::new(connection)),
             allocation_reconcile: Arc::new(Mutex::new(())),
+            limit_factor_learn: Arc::new(Mutex::new(())),
             database_path,
             state_dir,
         };
@@ -438,7 +441,12 @@ impl Store {
 
     /// A poisoned lock still holds a usable connection: the panic that poisoned
     /// it happened in a caller, not inside SQLite.
-    fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
+    ///
+    /// `pub(crate)` rather than private: [`crate::provider_usage::factor`]'s
+    /// tests build synthetic turns, periods, and observations directly, the
+    /// same way the store's own lifecycle tests do, from outside the `store`
+    /// module tree.
+    pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.connection
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -447,6 +455,16 @@ impl Store {
     /// Start one shared allocation pass, or skip work another clone already owns.
     pub(crate) fn try_begin_allocation_reconcile(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
         match self.allocation_reconcile.try_lock() {
+            Ok(guard) => Some(guard),
+            Err(TryLockError::Poisoned(poisoned)) => Some(poisoned.into_inner()),
+            Err(TryLockError::WouldBlock) => None,
+        }
+    }
+
+    /// Start one shared limit-factor learning pass, or skip work another
+    /// clone already owns.
+    pub(crate) fn try_begin_limit_factor_learn(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
+        match self.limit_factor_learn.try_lock() {
             Ok(guard) => Some(guard),
             Err(TryLockError::Poisoned(poisoned)) => Some(poisoned.into_inner()),
             Err(TryLockError::WouldBlock) => None,

--- a/apps/desktop/src-tauri/src/store/provider_limit.rs
+++ b/apps/desktop/src-tauri/src/store/provider_limit.rs
@@ -261,24 +261,30 @@ impl Store {
 
     /// Active provider periods a factor-learning pass should examine.
     ///
-    /// A period qualifies when it carries a primary lane and received an
-    /// observation at or after `since_epoch`. Bootstrapping a new period and
-    /// recomputing a recent one are the same query: both leave a fresh
-    /// `last_observed_epoch`.
+    /// A period qualifies when it carries a primary lane and either: has no
+    /// learn cursor yet, has a reading newer than its cursor, or was
+    /// observed at or after `since_epoch`. The first two admit a period
+    /// whose readings are old — from bootstrap on upgrade or from a
+    /// backfill — that a "recently observed" rule alone would never pick up;
+    /// the third keeps a just-updated period in the recompute window even
+    /// once its cursor catches up to it.
     pub(crate) fn provider_limit_candidate_periods(
         &self,
         since_epoch: i64,
     ) -> Result<Vec<ProviderUsagePeriod>> {
         let connection = self.lock();
         let mut statement = connection.prepare(
-            "SELECT id, provider, account_key, window_id, window_kind, window_role,
-                    scope_key, scope_label, duration_seconds, starts_at_epoch,
-                    resets_at_epoch, first_observed_epoch, last_observed_epoch
-               FROM provider_usage_period
-              WHERE scope_key = 'account'
-                AND window_role IN ('primaryShort', 'primaryLong')
-                AND last_observed_epoch >= ?1
-              ORDER BY last_observed_epoch DESC
+            "SELECT p.id, p.provider, p.account_key, p.window_id, p.window_kind, p.window_role,
+                    p.scope_key, p.scope_label, p.duration_seconds, p.starts_at_epoch,
+                    p.resets_at_epoch, p.first_observed_epoch, p.last_observed_epoch
+               FROM provider_usage_period p
+               LEFT JOIN provider_limit_learn_cursor c ON c.period_id = p.id
+              WHERE p.scope_key = 'account'
+                AND p.window_role IN ('primaryShort', 'primaryLong')
+                AND (c.period_id IS NULL
+                     OR p.last_observed_epoch > c.learned_through_epoch
+                     OR p.last_observed_epoch >= ?1)
+              ORDER BY p.last_observed_epoch DESC
               LIMIT ?2",
         )?;
         let periods = statement
@@ -288,6 +294,27 @@ impl Store {
             )?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(periods)
+    }
+
+    /// Record how far one period's observations have been read into samples.
+    ///
+    /// Call this only after a pass considers every sample the period could
+    /// yet produce; a pass that stops mid-period on its budget must leave
+    /// the cursor where it was, so the period stays a candidate next time.
+    pub(crate) fn advance_learn_cursor(
+        &self,
+        period_id: i64,
+        learned_through_epoch: i64,
+    ) -> Result<()> {
+        let connection = self.lock();
+        connection.execute(
+            "INSERT INTO provider_limit_learn_cursor (period_id, learned_through_epoch)
+                 VALUES (?1, ?2)
+                 ON CONFLICT (period_id) DO UPDATE SET
+                     learned_through_epoch = excluded.learned_through_epoch",
+            params![period_id, learned_through_epoch],
+        )?;
+        Ok(())
     }
 
     /// Insert or replace one factor sample, keyed by its interval.
@@ -354,22 +381,28 @@ impl Store {
             .collect())
     }
 
-    /// Whether a delta sample exists at all for one account and lane.
+    /// Whether a delta sample exists for one account and lane under the
+    /// given plan and plan tier.
     ///
-    /// A window-start sample is only ever taken while this is false.
+    /// A window-start sample is only ever taken while this is false. Scoping
+    /// to the plan pair lets a fresh plan or tier form its own window-start
+    /// sample rather than being blocked by an older plan's delta history.
     pub(crate) fn has_delta_factor_sample(
         &self,
         provider: &str,
         account_key: &str,
         lane: &str,
+        plan: Option<&str>,
+        plan_tier: Option<&str>,
     ) -> Result<bool> {
         let connection = self.lock();
         Ok(connection.query_row(
             "SELECT EXISTS(
                  SELECT 1 FROM provider_limit_factor_sample
                   WHERE provider = ?1 AND account_key = ?2 AND lane = ?3 AND kind = 'delta'
+                    AND plan IS ?4 AND plan_tier IS ?5
              )",
-            params![provider, account_key, lane],
+            params![provider, account_key, lane, plan, plan_tier],
             |row| row.get::<_, i64>(0),
         )? != 0)
     }
@@ -579,16 +612,14 @@ impl Store {
     }
 }
 
-/// Null a sample's `period_id` before its period is deleted by retention.
+/// Null a sample's `period_id`, and delete its learn cursor, before its
+/// period is deleted by retention.
 ///
 /// The period-deletion query in [`super::provider_usage_history`] stays
 /// exactly as it was before samples existed: this runs first, in the same
 /// transaction, against the identical set of about-to-be-removed periods.
 pub(crate) fn detach_samples_pending_period_deletion_in(connection: &Connection) -> Result<()> {
-    connection.execute(
-        "UPDATE provider_limit_factor_sample
-            SET period_id = NULL
-          WHERE period_id IN (
+    const PENDING_DELETION: &str = "
               SELECT id FROM provider_usage_period p
                WHERE NOT EXISTS (
                        SELECT 1 FROM provider_usage_observation o WHERE o.period_id = p.id
@@ -598,8 +629,17 @@ pub(crate) fn detach_samples_pending_period_deletion_in(connection: &Connection)
                    )
                  AND NOT EXISTS (
                        SELECT 1 FROM provider_usage_allocation_dirty d WHERE d.period_id = p.id
-                   )
-          )",
+                   )";
+    connection.execute(
+        &format!(
+            "UPDATE provider_limit_factor_sample
+                SET period_id = NULL
+              WHERE period_id IN ({PENDING_DELETION})"
+        ),
+        [],
+    )?;
+    connection.execute(
+        &format!("DELETE FROM provider_limit_learn_cursor WHERE period_id IN ({PENDING_DELETION})"),
         [],
     )?;
     Ok(())

--- a/apps/desktop/src-tauri/src/store/provider_limit.rs
+++ b/apps/desktop/src-tauri/src/store/provider_limit.rs
@@ -1,0 +1,785 @@
+//! Storage for the learned dollars-per-percent limit factor.
+//!
+//! [`crate::provider_usage::factor`] is this module's only caller. It reads
+//! priced, account-attributed turn dollars and account bindings from here,
+//! and writes factor samples, factor points, and residual rows here.
+//!
+//! # Account resolution
+//!
+//! One rule serves every query in this module. A session belongs to an
+//! account when it has exactly one [`session_provider_account`] row for the
+//! provider, or, absent that, when [`provider_account_seen`] holds exactly
+//! one account for the session's agent and provider. This is the rule from
+//! branch `fix/single-account-allocation-fallback` (`provider_known_accounts`),
+//! lifted here so learning and reading cannot disagree about an account.
+//!
+//! [`session_provider_account`]: super::schema
+//! [`provider_account_seen`]: super::schema
+
+use std::collections::{BTreeSet, HashMap};
+
+use anyhow::Result;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Deserialize;
+
+use antiburn_local::analysis::{ProviderHint, lookup_turn_pricing};
+use antiburn_local::pricing::ModelTokens;
+use antiburn_local::pricing::calc::calculate_cache_write_cost;
+
+use crate::provider_usage::{attribute, has_tokens};
+
+use super::provider_usage_history::ProviderUsagePeriod;
+use super::{SessionKey, Store};
+
+/// Session/model/speed groups one attribution query may return before it
+/// gives up rather than load an unbounded result.
+const MAX_ATTRIBUTION_GROUPS: usize = 20_000;
+
+/// Provider periods one candidate scan may return.
+const MAX_CANDIDATE_PERIODS: usize = 64;
+
+/// Ceiling on sample retention, independent of the session-data setting.
+const SAMPLE_RETENTION_DAYS_CAP: i64 = 365;
+
+/// The two lanes the learner and the badge track. Anthropic's supplemental
+/// per-model windows, and any role a provider stated that this app declines
+/// to guess the meaning of, carry no factor.
+pub(crate) const LANE_FIVE_HOUR: &str = "fiveHour";
+pub(crate) const LANE_WEEKLY: &str = "weekly";
+
+/// A lane's nominal length, used to derive a window start the provider did
+/// not state directly.
+pub(crate) fn lane_duration_seconds(lane: &str) -> i64 {
+    if lane == LANE_WEEKLY { 604_800 } else { 18_000 }
+}
+
+/// Map a period's stated role to the lane the learner tracks, or `None` for a
+/// role this app does not attribute a factor to.
+pub(crate) fn lane_for_window_role(window_role: &str) -> Option<&'static str> {
+    match window_role {
+        "primaryShort" => Some(LANE_FIVE_HOUR),
+        "primaryLong" => Some(LANE_WEEKLY),
+        _ => None,
+    }
+}
+
+/// The stated role that carries one lane's observations. The inverse of
+/// [`lane_for_window_role`].
+fn window_role_for_lane(lane: &str) -> &'static str {
+    if lane == LANE_WEEKLY {
+        "primaryLong"
+    } else {
+        "primaryShort"
+    }
+}
+
+/// Priced, provider- and account-attributed turn dollars for one session,
+/// inside a queried interval.
+///
+/// Kept split by session rather than summed so a later contribution chart can
+/// read the same query unsummed; the learner sums these rows itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AttributedSessionDollars {
+    pub key: SessionKey,
+    pub input_usd: f64,
+    pub output_usd: f64,
+    pub cache_read_usd: f64,
+    pub cache_write_usd: f64,
+    pub turn_count: i64,
+}
+
+impl AttributedSessionDollars {
+    fn empty(key: SessionKey) -> Self {
+        AttributedSessionDollars {
+            key,
+            input_usd: 0.0,
+            output_usd: 0.0,
+            cache_read_usd: 0.0,
+            cache_write_usd: 0.0,
+            turn_count: 0,
+        }
+    }
+}
+
+/// One measurement of the factor: a meter delta, or a first window reading,
+/// with the priced dollars behind it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FactorSample {
+    pub provider: String,
+    pub account_key: String,
+    pub lane: String,
+    pub kind: String,
+    pub period_id: Option<i64>,
+    pub from_epoch: i64,
+    pub to_epoch: i64,
+    pub from_percent: f64,
+    pub to_percent: f64,
+    pub input_usd: f64,
+    pub output_usd: f64,
+    pub cache_read_usd: f64,
+    pub cache_write_usd: f64,
+    pub turn_count: i64,
+    pub plan: Option<String>,
+    pub plan_tier: Option<String>,
+    pub source_id: String,
+    pub computed_at_epoch: i64,
+}
+
+impl FactorSample {
+    pub fn total_usd(&self) -> f64 {
+        self.input_usd + self.output_usd + self.cache_read_usd + self.cache_write_usd
+    }
+
+    pub fn percent_delta(&self) -> f64 {
+        self.to_percent - self.from_percent
+    }
+}
+
+/// The factor in effect from `effective_at_epoch`, for one account and lane.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FactorPoint {
+    pub id: i64,
+    pub provider: String,
+    pub account_key: String,
+    pub lane: String,
+    pub effective_at_epoch: i64,
+    pub usd_per_percent: f64,
+    pub method: String,
+    pub sample_count: i64,
+    pub plan: Option<String>,
+    pub plan_tier: Option<String>,
+}
+
+const ATTRIBUTED_TURN_SQL: &str = "SELECT t.environment_key, t.agent, t.session_id,
+            a.provider_hints_json,
+            COALESCE((
+                SELECT json_group_array(json_object(
+                    'provider', spa.provider,
+                    'accountKey', spa.account_key
+                ))
+                  FROM session_provider_account spa
+                 WHERE spa.environment_key = s.environment_key
+                   AND spa.agent = s.agent AND spa.session_id = s.session_id
+                   AND spa.provider = ?4
+            ), '[]'),
+            t.model, t.speed,
+            SUM(t.input_tokens), SUM(t.cache_read_tokens), SUM(t.cache_write_tokens),
+            SUM(t.output_tokens), COUNT(*)
+       FROM turn t INDEXED BY turn_usage_timestamp
+       JOIN session_evidence e
+         ON e.environment_key = t.environment_key
+        AND e.agent = t.agent AND e.session_id = t.session_id
+        AND e.published_fence = t.claim_fence
+       JOIN session s
+         ON s.environment_key = t.environment_key
+        AND s.agent = t.agent AND s.session_id = t.session_id
+       LEFT JOIN session_analysis a
+         ON a.environment_key = s.environment_key
+        AND a.agent = s.agent AND a.session_id = s.session_id
+      WHERE t.ts_ms > ?1 AND t.ts_ms <= ?2
+      GROUP BY t.environment_key, t.agent, t.session_id, t.model, t.speed
+      LIMIT ?3";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AccountObservation {
+    account_key: String,
+}
+
+/// Resolve one session's account for `provider` under the two-step rule.
+fn resolve_account(bound_accounts_json: &str, known: Option<&BTreeSet<String>>) -> Option<String> {
+    let bound: BTreeSet<String> =
+        serde_json::from_str::<Vec<AccountObservation>>(bound_accounts_json)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|observation| observation.account_key)
+            .filter(|account| account.len() == 64)
+            .collect();
+    if bound.len() == 1 {
+        return bound.into_iter().next();
+    }
+    if !bound.is_empty() {
+        return None;
+    }
+    let known = known?;
+    if known.len() == 1 {
+        known.iter().next().cloned()
+    } else {
+        None
+    }
+}
+
+impl Store {
+    /// Every account this app has observed for a provider, by agent.
+    ///
+    /// The two-step account rule falls back to this when a session has no
+    /// direct `session_provider_account` binding for the provider.
+    pub(crate) fn provider_known_accounts(
+        &self,
+        provider: &str,
+    ) -> Result<HashMap<String, BTreeSet<String>>> {
+        let connection = self.lock();
+        let mut statement = connection
+            .prepare("SELECT agent, account_key FROM provider_account_seen WHERE provider = ?1")?;
+        let mut known: HashMap<String, BTreeSet<String>> = HashMap::new();
+        let mut rows = statement.query([provider])?;
+        while let Some(row) = rows.next()? {
+            let agent: String = row.get(0)?;
+            let account_key: String = row.get(1)?;
+            known.entry(agent).or_default().insert(account_key);
+        }
+        Ok(known)
+    }
+
+    /// Priced, attributed turn dollars for one account, grouped by session.
+    ///
+    /// The range is `(from_epoch, to_epoch]`. Dollars are priced through
+    /// [`antiburn_local::analysis::lookup_turn_pricing`], the same catalog
+    /// [`crate::provider_usage::allocation`] uses. `None` means the bounded
+    /// group limit overflowed; the caller tries again on a later pass.
+    pub(crate) fn attributed_turn_dollars_between(
+        &self,
+        provider: &str,
+        account_key: &str,
+        from_epoch: i64,
+        to_epoch: i64,
+    ) -> Result<Option<Vec<AttributedSessionDollars>>> {
+        if to_epoch <= from_epoch {
+            return Ok(Some(Vec::new()));
+        }
+        let known = self.provider_known_accounts(provider)?;
+        let connection = self.lock();
+        attributed_turn_dollars_between_in(
+            &connection,
+            provider,
+            account_key,
+            from_epoch,
+            to_epoch,
+            &known,
+        )
+    }
+
+    /// Active provider periods a factor-learning pass should examine.
+    ///
+    /// A period qualifies when it carries a primary lane and received an
+    /// observation at or after `since_epoch`. Bootstrapping a new period and
+    /// recomputing a recent one are the same query: both leave a fresh
+    /// `last_observed_epoch`.
+    pub(crate) fn provider_limit_candidate_periods(
+        &self,
+        since_epoch: i64,
+    ) -> Result<Vec<ProviderUsagePeriod>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(
+            "SELECT id, provider, account_key, window_id, window_kind, window_role,
+                    scope_key, scope_label, duration_seconds, starts_at_epoch,
+                    resets_at_epoch, first_observed_epoch, last_observed_epoch
+               FROM provider_usage_period
+              WHERE scope_key = 'account'
+                AND window_role IN ('primaryShort', 'primaryLong')
+                AND last_observed_epoch >= ?1
+              ORDER BY last_observed_epoch DESC
+              LIMIT ?2",
+        )?;
+        let periods = statement
+            .query_map(
+                params![since_epoch, MAX_CANDIDATE_PERIODS as i64],
+                row_to_period,
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(periods)
+    }
+
+    /// Insert or replace one factor sample, keyed by its interval.
+    pub(crate) fn upsert_factor_sample(&self, sample: &FactorSample) -> Result<()> {
+        let connection = self.lock();
+        connection.execute(
+            "INSERT INTO provider_limit_factor_sample (
+                    provider, account_key, lane, kind, period_id, from_epoch, to_epoch,
+                    from_percent, to_percent, input_usd, output_usd, cache_read_usd,
+                    cache_write_usd, turn_count, plan, plan_tier, source_id, computed_at_epoch
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+                ON CONFLICT (provider, account_key, lane, from_epoch, to_epoch) DO UPDATE SET
+                    kind = excluded.kind,
+                    period_id = excluded.period_id,
+                    from_percent = excluded.from_percent,
+                    to_percent = excluded.to_percent,
+                    input_usd = excluded.input_usd,
+                    output_usd = excluded.output_usd,
+                    cache_read_usd = excluded.cache_read_usd,
+                    cache_write_usd = excluded.cache_write_usd,
+                    turn_count = excluded.turn_count,
+                    plan = excluded.plan,
+                    plan_tier = excluded.plan_tier,
+                    source_id = excluded.source_id,
+                    computed_at_epoch = excluded.computed_at_epoch",
+            params![
+                sample.provider,
+                sample.account_key,
+                sample.lane,
+                sample.kind,
+                sample.period_id,
+                sample.from_epoch,
+                sample.to_epoch,
+                sample.from_percent,
+                sample.to_percent,
+                sample.input_usd,
+                sample.output_usd,
+                sample.cache_read_usd,
+                sample.cache_write_usd,
+                sample.turn_count,
+                sample.plan,
+                sample.plan_tier,
+                sample.source_id,
+                sample.computed_at_epoch,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Samples already recorded for one period, keyed by their interval.
+    pub(crate) fn factor_samples_for_period(
+        &self,
+        period_id: i64,
+    ) -> Result<HashMap<(i64, i64), FactorSample>> {
+        let connection = self.lock();
+        let mut statement =
+            connection.prepare(&format!("{FACTOR_SAMPLE_SELECT} WHERE period_id = ?1"))?;
+        let samples = statement
+            .query_map([period_id], row_to_sample)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(samples
+            .into_iter()
+            .map(|sample| ((sample.from_epoch, sample.to_epoch), sample))
+            .collect())
+    }
+
+    /// Whether a delta sample exists at all for one account and lane.
+    ///
+    /// A window-start sample is only ever taken while this is false.
+    pub(crate) fn has_delta_factor_sample(
+        &self,
+        provider: &str,
+        account_key: &str,
+        lane: &str,
+    ) -> Result<bool> {
+        let connection = self.lock();
+        Ok(connection.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM provider_limit_factor_sample
+                  WHERE provider = ?1 AND account_key = ?2 AND lane = ?3 AND kind = 'delta'
+             )",
+            params![provider, account_key, lane],
+            |row| row.get::<_, i64>(0),
+        )? != 0)
+    }
+
+    /// Delta samples for one account and lane, at or after `since_epoch`,
+    /// ordered oldest first.
+    pub(crate) fn delta_factor_samples_since(
+        &self,
+        provider: &str,
+        account_key: &str,
+        lane: &str,
+        since_epoch: i64,
+    ) -> Result<Vec<FactorSample>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(&format!(
+            "{FACTOR_SAMPLE_SELECT} WHERE provider = ?1 AND account_key = ?2 AND lane = ?3
+               AND kind = 'delta' AND to_epoch >= ?4
+              ORDER BY to_epoch"
+        ))?;
+        let samples = statement
+            .query_map(
+                params![provider, account_key, lane, since_epoch],
+                row_to_sample,
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(samples)
+    }
+
+    /// Every delta sample for one account and lane, ordered oldest first.
+    ///
+    /// Used only when fewer than three fall inside the recent window.
+    pub(crate) fn all_delta_factor_samples(
+        &self,
+        provider: &str,
+        account_key: &str,
+        lane: &str,
+    ) -> Result<Vec<FactorSample>> {
+        let connection = self.lock();
+        let mut statement = connection.prepare(&format!(
+            "{FACTOR_SAMPLE_SELECT} WHERE provider = ?1 AND account_key = ?2 AND lane = ?3
+               AND kind = 'delta'
+              ORDER BY to_epoch"
+        ))?;
+        let samples = statement
+            .query_map(params![provider, account_key, lane], row_to_sample)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(samples)
+    }
+
+    /// The most recent window-start sample for one account and lane.
+    pub(crate) fn latest_window_start_factor_sample(
+        &self,
+        provider: &str,
+        account_key: &str,
+        lane: &str,
+    ) -> Result<Option<FactorSample>> {
+        let connection = self.lock();
+        connection
+            .query_row(
+                &format!(
+                    "{FACTOR_SAMPLE_SELECT} WHERE provider = ?1 AND account_key = ?2 AND lane = ?3
+                       AND kind = 'window_start'
+                      ORDER BY to_epoch DESC LIMIT 1"
+                ),
+                params![provider, account_key, lane],
+                row_to_sample,
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    /// Append or replace the factor point effective at `effective_at_epoch`.
+    pub(crate) fn upsert_factor_point(&self, point: &FactorPoint) -> Result<()> {
+        let connection = self.lock();
+        connection.execute(
+            "INSERT INTO provider_limit_factor_point (
+                    provider, account_key, lane, effective_at_epoch, usd_per_percent,
+                    method, sample_count, plan, plan_tier
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                ON CONFLICT (provider, account_key, lane, effective_at_epoch) DO UPDATE SET
+                    usd_per_percent = excluded.usd_per_percent,
+                    method = excluded.method,
+                    sample_count = excluded.sample_count,
+                    plan = excluded.plan,
+                    plan_tier = excluded.plan_tier",
+            params![
+                point.provider,
+                point.account_key,
+                point.lane,
+                point.effective_at_epoch,
+                point.usd_per_percent,
+                point.method,
+                point.sample_count,
+                point.plan,
+                point.plan_tier,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// The newest factor point for one account and lane.
+    pub(crate) fn latest_factor_point(
+        &self,
+        provider: &str,
+        account_key: &str,
+        lane: &str,
+    ) -> Result<Option<FactorPoint>> {
+        let connection = self.lock();
+        connection
+            .query_row(
+                &format!(
+                    "{FACTOR_POINT_SELECT} WHERE provider = ?1 AND account_key = ?2 AND lane = ?3
+                      ORDER BY effective_at_epoch DESC LIMIT 1"
+                ),
+                params![provider, account_key, lane],
+                row_to_point,
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    /// The factor point in effect at `at_epoch`: the latest point at or
+    /// before it, else the earliest point of all.
+    pub(crate) fn factor_point_at(
+        &self,
+        provider: &str,
+        account_key: &str,
+        lane: &str,
+        at_epoch: i64,
+    ) -> Result<Option<FactorPoint>> {
+        let connection = self.lock();
+        let current = connection
+            .query_row(
+                &format!(
+                    "{FACTOR_POINT_SELECT} WHERE provider = ?1 AND account_key = ?2 AND lane = ?3
+                       AND effective_at_epoch <= ?4
+                      ORDER BY effective_at_epoch DESC LIMIT 1"
+                ),
+                params![provider, account_key, lane, at_epoch],
+                row_to_point,
+            )
+            .optional()?;
+        if current.is_some() {
+            return Ok(current);
+        }
+        connection
+            .query_row(
+                &format!(
+                    "{FACTOR_POINT_SELECT} WHERE provider = ?1 AND account_key = ?2 AND lane = ?3
+                      ORDER BY effective_at_epoch ASC LIMIT 1"
+                ),
+                params![provider, account_key, lane],
+                row_to_point,
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    /// The plan and plan tier the newest observation reported for one
+    /// account and lane, so the learner can notice a plan change.
+    pub(crate) fn latest_observation_plan(
+        &self,
+        provider: &str,
+        account_key: &str,
+        lane: &str,
+    ) -> Result<Option<(Option<String>, Option<String>)>> {
+        let connection = self.lock();
+        connection
+            .query_row(
+                "SELECT plan, plan_tier FROM provider_usage_observation
+                  WHERE provider = ?1 AND account_key = ?2 AND window_role = ?3
+                    AND used_percent IS NOT NULL
+                  ORDER BY observed_at_epoch DESC LIMIT 1",
+                params![provider, account_key, window_role_for_lane(lane)],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    /// Replace one period's residual: meter percent against the factor's own
+    /// estimate for the same span.
+    pub(crate) fn upsert_limit_residual(
+        &self,
+        period_id: i64,
+        computed_at_epoch: i64,
+        meter_percent: f64,
+        estimated_percent: f64,
+    ) -> Result<()> {
+        let connection = self.lock();
+        connection.execute(
+            "INSERT INTO provider_limit_residual (
+                    period_id, computed_at_epoch, meter_percent, estimated_percent
+                ) VALUES (?1, ?2, ?3, ?4)
+                ON CONFLICT (period_id) DO UPDATE SET
+                    computed_at_epoch = excluded.computed_at_epoch,
+                    meter_percent = excluded.meter_percent,
+                    estimated_percent = excluded.estimated_percent",
+            params![
+                period_id,
+                computed_at_epoch,
+                meter_percent,
+                estimated_percent
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+/// Null a sample's `period_id` before its period is deleted by retention.
+///
+/// The period-deletion query in [`super::provider_usage_history`] stays
+/// exactly as it was before samples existed: this runs first, in the same
+/// transaction, against the identical set of about-to-be-removed periods.
+pub(crate) fn detach_samples_pending_period_deletion_in(connection: &Connection) -> Result<()> {
+    connection.execute(
+        "UPDATE provider_limit_factor_sample
+            SET period_id = NULL
+          WHERE period_id IN (
+              SELECT id FROM provider_usage_period p
+               WHERE NOT EXISTS (
+                       SELECT 1 FROM provider_usage_observation o WHERE o.period_id = p.id
+                   )
+                 AND NOT EXISTS (
+                       SELECT 1 FROM provider_usage_session_allocation a WHERE a.period_id = p.id
+                   )
+                 AND NOT EXISTS (
+                       SELECT 1 FROM provider_usage_allocation_dirty d WHERE d.period_id = p.id
+                   )
+          )",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Delete factor samples older than the session-data retention setting,
+/// capped at 365 days. Points are never deleted.
+pub(crate) fn apply_sample_retention_in(
+    connection: &Connection,
+    retention_days: i32,
+    now_epoch: i64,
+) -> Result<()> {
+    let bounded_days = match retention_days {
+        days if days > 0 => i64::from(days).min(SAMPLE_RETENTION_DAYS_CAP),
+        _ => SAMPLE_RETENTION_DAYS_CAP,
+    };
+    let cutoff = now_epoch.saturating_sub(bounded_days.saturating_mul(86_400));
+    connection.execute(
+        "DELETE FROM provider_limit_factor_sample WHERE to_epoch < ?1",
+        [cutoff],
+    )?;
+    Ok(())
+}
+
+const FACTOR_SAMPLE_SELECT: &str = "SELECT provider, account_key, lane, kind, period_id,
+            from_epoch, to_epoch, from_percent, to_percent, input_usd, output_usd,
+            cache_read_usd, cache_write_usd, turn_count, plan, plan_tier, source_id,
+            computed_at_epoch
+       FROM provider_limit_factor_sample";
+
+const FACTOR_POINT_SELECT: &str = "SELECT id, provider, account_key, lane, effective_at_epoch,
+            usd_per_percent, method, sample_count, plan, plan_tier
+       FROM provider_limit_factor_point";
+
+fn row_to_sample(row: &rusqlite::Row<'_>) -> rusqlite::Result<FactorSample> {
+    Ok(FactorSample {
+        provider: row.get(0)?,
+        account_key: row.get(1)?,
+        lane: row.get(2)?,
+        kind: row.get(3)?,
+        period_id: row.get(4)?,
+        from_epoch: row.get(5)?,
+        to_epoch: row.get(6)?,
+        from_percent: row.get(7)?,
+        to_percent: row.get(8)?,
+        input_usd: row.get(9)?,
+        output_usd: row.get(10)?,
+        cache_read_usd: row.get(11)?,
+        cache_write_usd: row.get(12)?,
+        turn_count: row.get(13)?,
+        plan: row.get(14)?,
+        plan_tier: row.get(15)?,
+        source_id: row.get(16)?,
+        computed_at_epoch: row.get(17)?,
+    })
+}
+
+fn row_to_point(row: &rusqlite::Row<'_>) -> rusqlite::Result<FactorPoint> {
+    Ok(FactorPoint {
+        id: row.get(0)?,
+        provider: row.get(1)?,
+        account_key: row.get(2)?,
+        lane: row.get(3)?,
+        effective_at_epoch: row.get(4)?,
+        usd_per_percent: row.get(5)?,
+        method: row.get(6)?,
+        sample_count: row.get(7)?,
+        plan: row.get(8)?,
+        plan_tier: row.get(9)?,
+    })
+}
+
+fn row_to_period(row: &rusqlite::Row<'_>) -> rusqlite::Result<ProviderUsagePeriod> {
+    Ok(ProviderUsagePeriod {
+        id: row.get(0)?,
+        provider: row.get(1)?,
+        account_key: row.get(2)?,
+        window_id: row.get(3)?,
+        window_kind: row.get(4)?,
+        window_role: row.get(5)?,
+        scope_key: row.get(6)?,
+        scope_label: row.get(7)?,
+        duration_seconds: row.get(8)?,
+        starts_at_epoch: row.get(9)?,
+        resets_at_epoch: row.get(10)?,
+        first_observed_epoch: row.get(11)?,
+        last_observed_epoch: row.get(12)?,
+    })
+}
+
+fn attributed_turn_dollars_between_in(
+    connection: &Connection,
+    provider: &str,
+    account_key: &str,
+    from_epoch: i64,
+    to_epoch: i64,
+    known_accounts: &HashMap<String, BTreeSet<String>>,
+) -> Result<Option<Vec<AttributedSessionDollars>>> {
+    let start_ms = from_epoch.saturating_mul(1_000).saturating_add(1);
+    let end_ms = to_epoch.saturating_mul(1_000);
+    let mut statement = connection.prepare(ATTRIBUTED_TURN_SQL)?;
+    let mut rows = statement.query(params![
+        start_ms,
+        end_ms,
+        (MAX_ATTRIBUTION_GROUPS + 1) as i64,
+        provider,
+    ])?;
+    let mut by_session: HashMap<SessionKey, AttributedSessionDollars> = HashMap::new();
+    let mut group_count = 0usize;
+    while let Some(row) = rows.next()? {
+        group_count += 1;
+        if group_count > MAX_ATTRIBUTION_GROUPS {
+            return Ok(None);
+        }
+        let key = SessionKey::new(
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        );
+        let hints_json: Option<String> = row.get(3)?;
+        let accounts_json: String = row.get(4)?;
+        let model: Option<String> = row.get(5)?;
+        let speed: Option<String> = row.get(6)?;
+        let input_tokens: i64 = row.get(7)?;
+        let cache_read_tokens: i64 = row.get(8)?;
+        let cache_write_tokens: i64 = row.get(9)?;
+        let output_tokens: i64 = row.get(10)?;
+        let turn_count: i64 = row.get(11)?;
+
+        let resolved = resolve_account(&accounts_json, known_accounts.get(&key.agent));
+        if resolved.as_deref() != Some(account_key) {
+            continue;
+        }
+        let Some(model) = model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+        else {
+            continue;
+        };
+        let tokens = ModelTokens {
+            input_tokens: input_tokens.max(0) as u64,
+            output_tokens: output_tokens.max(0) as u64,
+            cache_read_tokens: cache_read_tokens.max(0) as u64,
+            cache_creation_tokens: cache_write_tokens.max(0) as u64,
+            cache_creation_1h_tokens: 0,
+        };
+        if !has_tokens(&tokens) {
+            continue;
+        }
+        let hints: Vec<ProviderHint> = hints_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str(json).ok())
+            .unwrap_or_default();
+        let attributed = attribute(
+            &key.agent,
+            std::collections::BTreeMap::from([(model.to_string(), tokens)]),
+            &hints,
+        );
+        let Some(model_tokens) = attributed
+            .get(provider)
+            .and_then(|entry| entry.models.get(model))
+        else {
+            continue;
+        };
+        let rates = lookup_turn_pricing(model, speed.as_deref());
+        let totals = by_session
+            .entry(key.clone())
+            .or_insert_with(|| AttributedSessionDollars::empty(key.clone()));
+        totals.turn_count += turn_count;
+        if let Some(rates) = rates {
+            totals.input_usd += model_tokens.input_tokens as f64 * rates.input_cost_per_token;
+            totals.output_usd += model_tokens.output_tokens as f64 * rates.output_cost_per_token;
+            totals.cache_read_usd +=
+                model_tokens.cache_read_tokens as f64 * rates.cache_read_cost_per_token;
+            totals.cache_write_usd += calculate_cache_write_cost(model_tokens, &rates);
+        }
+    }
+    Ok(Some(by_session.into_values().collect()))
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/desktop/src-tauri/src/store/provider_limit/tests.rs
+++ b/apps/desktop/src-tauri/src/store/provider_limit/tests.rs
@@ -1,0 +1,360 @@
+use std::path::Path;
+
+use rusqlite::params;
+
+use super::*;
+use crate::store::SessionRecord;
+
+const PROVIDER: &str = "anthropic";
+const AGENT: &str = "claude-code";
+const MODEL: &str = "claude-opus-4-6";
+
+fn account(character: char) -> String {
+    character.to_string().repeat(64)
+}
+
+fn memory_store() -> Store {
+    Store::open_in_memory(Path::new("/tmp/antiburn-provider-limit-test")).expect("opens store")
+}
+
+fn insert_session(store: &Store, session_id: &str) -> SessionKey {
+    let key = SessionKey::new("native", AGENT, session_id);
+    store
+        .upsert_sessions(
+            &[SessionRecord {
+                key: key.clone(),
+                source_kind: "inline".to_string(),
+                source_label: "synthetic".to_string(),
+                wsl_distro: None,
+                title: None,
+                title_source: None,
+                cwd: None,
+                surface: "unknown".to_string(),
+                updated_at_epoch: Some(1),
+                activity_cursor: "synthetic".to_string(),
+                activity_source: "event".to_string(),
+                subagent_count: 0,
+                fork_parent_session_id: None,
+                source_fingerprint: Some("synthetic".to_string()),
+            }],
+            &[],
+        )
+        .expect("stores synthetic session");
+    key
+}
+
+/// Publish one turn at `ts_ms` and mark its session evidence published, so
+/// the attribution query's `session_evidence` join matches it.
+fn insert_turn(store: &Store, key: &SessionKey, ts_ms: i64, input_tokens: i64) {
+    let connection = store.lock();
+    connection
+        .execute(
+            "INSERT OR IGNORE INTO session_evidence (
+                 environment_key, agent, session_id, status, published_fence
+             ) VALUES (?1, ?2, ?3, 'ready', 1)",
+            params![key.environment_key, key.agent, key.session_id],
+        )
+        .expect("publishes synthetic evidence");
+    connection
+        .execute(
+            "INSERT INTO turn (
+                 environment_key, agent, session_id, claim_fence, source_key,
+                 thread_id, turn_index, scope, role, ts_ms, model, effort, speed,
+                 input_tokens, cache_read_tokens, cache_write_tokens, output_tokens,
+                 is_compaction_boundary, message_id, uuid, parent_uuid
+             ) VALUES (?1, ?2, ?3, 1, 'synthetic', 'synthetic', 0, 'main', 'assistant',
+                       ?4, ?5, NULL, NULL, ?6, 0, 0, 0, 0, NULL, NULL, NULL)",
+            params![
+                key.environment_key,
+                key.agent,
+                key.session_id,
+                ts_ms,
+                MODEL,
+                input_tokens
+            ],
+        )
+        .expect("stores synthetic turn");
+}
+
+fn bind_account(store: &Store, key: &SessionKey, account_key: &str) {
+    store
+        .lock()
+        .execute(
+            "INSERT INTO session_provider_account (
+                 environment_key, agent, session_id, provider, account_key,
+                 provenance, confidence, first_seen_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, 'provider_live', 'direct', '2026-01-01T00:00:00Z')",
+            params![
+                key.environment_key,
+                key.agent,
+                key.session_id,
+                PROVIDER,
+                account_key
+            ],
+        )
+        .expect("binds session account");
+}
+
+fn observe_account(store: &Store, account_key: &str) {
+    store
+        .lock()
+        .execute(
+            "INSERT INTO provider_account_seen (agent, provider, account_key,
+                 first_seen_epoch, last_seen_epoch)
+             VALUES (?1, ?2, ?3, 1, 1)",
+            params![AGENT, PROVIDER, account_key],
+        )
+        .expect("records a seen account");
+}
+
+#[test]
+fn an_unbound_session_with_two_known_accounts_attributes_nothing() {
+    let store = memory_store();
+    let key = insert_session(&store, "session");
+    insert_turn(&store, &key, 150_000, 200_000);
+    observe_account(&store, &account('a'));
+    observe_account(&store, &account('b'));
+
+    let dollars = store
+        .attributed_turn_dollars_between(PROVIDER, &account('a'), 0, 1_000)
+        .expect("query succeeds")
+        .expect("stays within the group bound");
+    assert!(
+        dollars.is_empty(),
+        "an ambiguous account set attributes no session"
+    );
+}
+
+#[test]
+fn an_unbound_session_with_one_known_account_falls_back_to_it() {
+    let store = memory_store();
+    let key = insert_session(&store, "session");
+    insert_turn(&store, &key, 150_000, 200_000);
+    observe_account(&store, &account('a'));
+
+    let dollars = store
+        .attributed_turn_dollars_between(PROVIDER, &account('a'), 0, 1_000)
+        .expect("query succeeds")
+        .expect("stays within the group bound");
+    assert_eq!(dollars.len(), 1);
+    assert_eq!(dollars[0].key, key);
+    // claude-opus-4-6 test pricing: 5e-6 dollars per input token.
+    assert!((dollars[0].input_usd - 1.0).abs() < 1e-9);
+    assert_eq!(dollars[0].turn_count, 1);
+}
+
+#[test]
+fn a_directly_bound_session_ignores_the_single_account_fallback() {
+    let store = memory_store();
+    let key = insert_session(&store, "session");
+    insert_turn(&store, &key, 150_000, 200_000);
+    bind_account(&store, &key, &account('a'));
+    observe_account(&store, &account('b'));
+
+    let dollars = store
+        .attributed_turn_dollars_between(PROVIDER, &account('b'), 0, 1_000)
+        .expect("query succeeds")
+        .expect("stays within the group bound");
+    assert!(
+        dollars.is_empty(),
+        "a session bound to a different account never falls back"
+    );
+
+    let dollars = store
+        .attributed_turn_dollars_between(PROVIDER, &account('a'), 0, 1_000)
+        .expect("query succeeds")
+        .expect("stays within the group bound");
+    assert_eq!(dollars.len(), 1);
+}
+
+#[test]
+fn point_lookup_at_an_epoch_uses_the_latest_point_at_or_before_it_else_the_earliest() {
+    let store = memory_store();
+    let lane = LANE_FIVE_HOUR;
+    store
+        .upsert_factor_point(&FactorPoint {
+            id: 0,
+            provider: PROVIDER.to_string(),
+            account_key: account('a'),
+            lane: lane.to_string(),
+            effective_at_epoch: 1_000,
+            usd_per_percent: 0.2,
+            method: "delta".to_string(),
+            sample_count: 3,
+            plan: None,
+            plan_tier: None,
+        })
+        .unwrap();
+    store
+        .upsert_factor_point(&FactorPoint {
+            id: 0,
+            provider: PROVIDER.to_string(),
+            account_key: account('a'),
+            lane: lane.to_string(),
+            effective_at_epoch: 2_000,
+            usd_per_percent: 0.3,
+            method: "delta".to_string(),
+            sample_count: 4,
+            plan: None,
+            plan_tier: None,
+        })
+        .unwrap();
+
+    let before_any = store
+        .factor_point_at(PROVIDER, &account('a'), lane, 500)
+        .unwrap()
+        .expect("falls back to the earliest point");
+    assert_eq!(before_any.effective_at_epoch, 1_000);
+
+    let between = store
+        .factor_point_at(PROVIDER, &account('a'), lane, 1_500)
+        .unwrap()
+        .expect("uses the latest point at or before the epoch");
+    assert_eq!(between.effective_at_epoch, 1_000);
+
+    let after_both = store
+        .factor_point_at(PROVIDER, &account('a'), lane, 5_000)
+        .unwrap()
+        .expect("uses the newest point");
+    assert_eq!(after_both.effective_at_epoch, 2_000);
+}
+
+#[test]
+fn sample_retention_deletes_old_samples_but_never_points() {
+    let store = memory_store();
+    let lane = LANE_FIVE_HOUR;
+    let sample = FactorSample {
+        provider: PROVIDER.to_string(),
+        account_key: account('a'),
+        lane: lane.to_string(),
+        kind: "delta".to_string(),
+        period_id: None,
+        from_epoch: 0,
+        to_epoch: 100,
+        from_percent: 0.0,
+        to_percent: 5.0,
+        input_usd: 1.0,
+        output_usd: 0.0,
+        cache_read_usd: 0.0,
+        cache_write_usd: 0.0,
+        turn_count: 1,
+        plan: None,
+        plan_tier: None,
+        source_id: "test".to_string(),
+        computed_at_epoch: 100,
+    };
+    store.upsert_factor_sample(&sample).unwrap();
+    store
+        .upsert_factor_point(&FactorPoint {
+            id: 0,
+            provider: PROVIDER.to_string(),
+            account_key: account('a'),
+            lane: lane.to_string(),
+            effective_at_epoch: 100,
+            usd_per_percent: 0.2,
+            method: "delta".to_string(),
+            sample_count: 1,
+            plan: None,
+            plan_tier: None,
+        })
+        .unwrap();
+
+    // 200 days elapsed, 400-day retention capped at 365: the sample's
+    // to_epoch (100) is far short of the cutoff, so nothing is removed yet.
+    let now = 200 * 86_400;
+    apply_sample_retention_in(&store.lock(), 400, now).unwrap();
+    assert_eq!(
+        store
+            .all_delta_factor_samples(PROVIDER, &account('a'), lane)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Past the (capped) 365-day cutoff, the sample goes; the point does not.
+    let now = 400 * 86_400;
+    apply_sample_retention_in(&store.lock(), 400, now).unwrap();
+    assert!(
+        store
+            .all_delta_factor_samples(PROVIDER, &account('a'), lane)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        store
+            .latest_factor_point(PROVIDER, &account('a'), lane)
+            .unwrap()
+            .is_some(),
+        "retention never deletes factor points"
+    );
+}
+
+#[test]
+fn a_sample_s_period_reference_is_nulled_before_its_period_is_deleted() {
+    let store = memory_store();
+    let account_key = account('a');
+    let period_id = {
+        let connection = store.lock();
+        connection
+            .execute(
+                "INSERT INTO provider_usage_period (
+                     provider, account_key, window_id, window_kind, window_role,
+                     scope_key, scope_label, duration_seconds, starts_at_epoch,
+                     resets_at_epoch, first_observed_epoch, last_observed_epoch
+                 ) VALUES (?1, ?2, 'five-hour', 'rolling', 'primaryShort',
+                           'account', 'account', 18000, 0, 18000, 10, 10)",
+                params![PROVIDER, account_key],
+            )
+            .unwrap();
+        let period_id = connection.last_insert_rowid();
+        connection
+            .execute(
+                "INSERT INTO provider_usage_observation (
+                     period_id, provider, account_key, window_id, window_kind, window_role,
+                     scope_key, scope_label, observed_at_epoch, used_percent, is_fresh,
+                     is_authoritative, confidence, source_id
+                 ) VALUES (?1, ?2, ?3, 'five-hour', 'rolling', 'primaryShort',
+                           'account', 'account', 10, 5.0, 1, 1, 'high', 'test')",
+                params![period_id, PROVIDER, account_key],
+            )
+            .unwrap();
+        period_id
+    };
+    store
+        .upsert_factor_sample(&FactorSample {
+            provider: PROVIDER.to_string(),
+            account_key: account_key.clone(),
+            lane: LANE_FIVE_HOUR.to_string(),
+            kind: "delta".to_string(),
+            period_id: Some(period_id),
+            from_epoch: 0,
+            to_epoch: 10,
+            from_percent: 0.0,
+            to_percent: 5.0,
+            input_usd: 1.0,
+            output_usd: 0.0,
+            cache_read_usd: 0.0,
+            cache_write_usd: 0.0,
+            turn_count: 1,
+            plan: None,
+            plan_tier: None,
+            source_id: "test".to_string(),
+            computed_at_epoch: 10,
+        })
+        .unwrap();
+
+    // 90-day observation retention removes the period; the (uncapped-by-this
+    // call) 365-day sample cutoff sits before epoch zero, so the sample
+    // itself survives and must not keep a dangling period id.
+    let now = 200 * 86_400;
+    Store::apply_provider_usage_retention_in(&store.lock(), 400, now).unwrap();
+
+    let samples = store
+        .all_delta_factor_samples(PROVIDER, &account_key, LANE_FIVE_HOUR)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert_eq!(
+        samples[0].period_id, None,
+        "the deleted period's id is nulled, not left dangling"
+    );
+}

--- a/apps/desktop/src-tauri/src/store/provider_limit/tests.rs
+++ b/apps/desktop/src-tauri/src/store/provider_limit/tests.rs
@@ -95,6 +95,35 @@ fn bind_account(store: &Store, key: &SessionKey, account_key: &str) {
         .expect("binds session account");
 }
 
+fn insert_period(
+    store: &Store,
+    account_key: &str,
+    start: i64,
+    reset: i64,
+    last_observed: i64,
+) -> i64 {
+    let connection = store.lock();
+    connection
+        .execute(
+            "INSERT INTO provider_usage_period (
+                 provider, account_key, window_id, window_kind, window_role,
+                 scope_key, scope_label, duration_seconds, starts_at_epoch,
+                 resets_at_epoch, first_observed_epoch, last_observed_epoch
+             ) VALUES (?1, ?2, 'five-hour', 'rolling', 'primaryShort',
+                       'account', 'account', ?3, ?4, ?5, ?6, ?6)",
+            params![
+                PROVIDER,
+                account_key,
+                reset - start,
+                start,
+                reset,
+                last_observed
+            ],
+        )
+        .expect("inserts a synthetic period");
+    connection.last_insert_rowid()
+}
+
 fn observe_account(store: &Store, account_key: &str) {
     store
         .lock()
@@ -356,5 +385,99 @@ fn a_sample_s_period_reference_is_nulled_before_its_period_is_deleted() {
     assert_eq!(
         samples[0].period_id, None,
         "the deleted period's id is nulled, not left dangling"
+    );
+}
+
+#[test]
+fn a_period_with_no_learn_cursor_is_a_candidate_however_old_its_last_reading() {
+    let store = memory_store();
+    // Last observed two days ago: a "recently observed" rule alone would
+    // never pick this up. Bootstrap on upgrade relies on it being a
+    // candidate anyway, since it has no cursor row yet.
+    let period_id = insert_period(&store, &account('a'), 0, 18_000, 2 * 86_400);
+
+    let now = 3 * 86_400;
+    let periods = store
+        .provider_limit_candidate_periods(now - 900)
+        .expect("query succeeds");
+    assert_eq!(periods.len(), 1);
+    assert_eq!(periods[0].id, period_id);
+}
+
+#[test]
+fn a_period_whose_cursor_has_caught_up_and_gone_stale_is_not_a_candidate() {
+    let store = memory_store();
+    let last_observed = 2 * 86_400;
+    let period_id = insert_period(&store, &account('a'), 0, 18_000, last_observed);
+    store
+        .advance_learn_cursor(period_id, last_observed)
+        .expect("advances the cursor");
+
+    let now = 3 * 86_400;
+    let periods = store
+        .provider_limit_candidate_periods(now - 900)
+        .expect("query succeeds");
+    assert!(
+        periods.is_empty(),
+        "a cursor already at the period's last reading, outside the recompute window, is not re-read"
+    );
+}
+
+#[test]
+fn a_period_with_a_cursor_behind_its_last_reading_is_a_candidate() {
+    let store = memory_store();
+    let last_observed = 2 * 86_400;
+    let period_id = insert_period(&store, &account('a'), 0, 18_000, last_observed);
+    // A backfill (or an earlier partial pass) left the cursor behind the
+    // period's newest reading.
+    store
+        .advance_learn_cursor(period_id, last_observed - 1)
+        .expect("advances the cursor");
+
+    let now = 3 * 86_400;
+    let periods = store
+        .provider_limit_candidate_periods(now - 900)
+        .expect("query succeeds");
+    assert_eq!(periods.len(), 1);
+    assert_eq!(periods[0].id, period_id);
+}
+
+#[test]
+fn a_period_s_learn_cursor_is_deleted_before_its_period_is_deleted() {
+    let store = memory_store();
+    let account_key = account('a');
+    let period_id = {
+        let connection = store.lock();
+        connection
+            .execute(
+                "INSERT INTO provider_usage_period (
+                     provider, account_key, window_id, window_kind, window_role,
+                     scope_key, scope_label, duration_seconds, starts_at_epoch,
+                     resets_at_epoch, first_observed_epoch, last_observed_epoch
+                 ) VALUES (?1, ?2, 'five-hour', 'rolling', 'primaryShort',
+                           'account', 'account', 18000, 0, 18000, 10, 10)",
+                params![PROVIDER, account_key],
+            )
+            .unwrap();
+        connection.last_insert_rowid()
+    };
+    store
+        .advance_learn_cursor(period_id, 10)
+        .expect("advances the cursor");
+
+    let now = 200 * 86_400;
+    Store::apply_provider_usage_retention_in(&store.lock(), 400, now).unwrap();
+
+    let remaining: i64 = store
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM provider_limit_learn_cursor WHERE period_id = ?1",
+            [period_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        remaining, 0,
+        "the cursor is deleted, not left pointing at a removed period"
     );
 }

--- a/apps/desktop/src-tauri/src/store/provider_usage_history.rs
+++ b/apps/desktop/src-tauri/src/store/provider_usage_history.rs
@@ -56,6 +56,8 @@ pub struct ProviderUsageObservation {
     pub source_id: String,
     pub reported_starts_at_epoch: Option<i64>,
     pub reported_resets_at_epoch: Option<i64>,
+    pub plan: Option<String>,
+    pub plan_tier: Option<String>,
 }
 
 /// A complete period and its ordered readings.
@@ -90,6 +92,8 @@ struct Reading<'a> {
     source_id: &'a str,
     starts_at_epoch: Option<i64>,
     resets_at_epoch: Option<i64>,
+    plan: Option<&'a str>,
+    plan_tier: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -205,7 +209,7 @@ impl Store {
                 SELECT id, period_id, provider, account_key, window_id, window_kind,
                        window_role, scope_key, scope_label, observed_at_epoch, used_percent,
                        is_fresh, is_authoritative, confidence, source_id,
-                       reported_starts_at_epoch, reported_resets_at_epoch,
+                       reported_starts_at_epoch, reported_resets_at_epoch, plan, plan_tier,
                        ROW_NUMBER() OVER (ORDER BY observed_at_epoch, id) AS row_number,
                        COUNT(*) OVER () AS total_rows
                  FROM provider_usage_observation
@@ -217,7 +221,7 @@ impl Store {
              SELECT id, period_id, provider, account_key, window_id, window_kind,
                     window_role, scope_key, scope_label, observed_at_epoch, used_percent,
                     is_fresh, is_authoritative, confidence, source_id,
-                    reported_starts_at_epoch, reported_resets_at_epoch
+                    reported_starts_at_epoch, reported_resets_at_epoch, plan, plan_tier
                FROM numbered
               WHERE row_number = 1 OR row_number = total_rows
                  OR (row_number - 1) % ?4 = 0
@@ -300,6 +304,10 @@ impl Store {
             "DELETE FROM provider_usage_observation WHERE observed_at_epoch < ?1",
             [cutoff],
         )?;
+        // A sample references its period only for provenance. Null the
+        // reference before the period disappears, so the deletion below stays
+        // exactly the query it was before samples existed.
+        super::provider_limit::detach_samples_pending_period_deletion_in(connection)?;
         connection.execute(
             "DELETE FROM provider_usage_period
               WHERE NOT EXISTS (
@@ -316,6 +324,7 @@ impl Store {
                 )",
             [],
         )?;
+        super::provider_limit::apply_sample_retention_in(connection, retention_days, now_epoch)?;
         Ok(removed)
     }
 
@@ -378,6 +387,8 @@ impl<'a> Reading<'a> {
             source_id: snapshot.source.id,
             starts_at_epoch,
             resets_at_epoch,
+            plan: snapshot.plan.as_deref(),
+            plan_tier: snapshot.plan_tier.as_deref(),
         }
     }
 }
@@ -529,7 +540,7 @@ fn existing_observation(
             "SELECT id, period_id, provider, account_key, window_id, window_kind, window_role,
                     scope_key, scope_label, observed_at_epoch, used_percent, is_fresh,
                     is_authoritative, confidence, source_id, reported_starts_at_epoch,
-                    reported_resets_at_epoch
+                    reported_resets_at_epoch, plan, plan_tier
                FROM provider_usage_observation
               WHERE provider = ?1 AND account_key = ?2 AND window_id = ?3
                 AND window_kind = ?4 AND window_role = ?5 AND scope_key = ?6
@@ -600,8 +611,8 @@ fn write_observation(
                 period_id, provider, account_key, window_id, window_kind, window_role,
                 scope_key, scope_label, observed_at_epoch, used_percent, is_fresh,
                 is_authoritative, confidence, source_id, reported_starts_at_epoch,
-                reported_resets_at_epoch
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+                reported_resets_at_epoch, plan, plan_tier
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?18, ?19)
             ON CONFLICT (
                 provider, account_key, window_id, window_kind, window_role, scope_key,
                 observed_at_epoch
@@ -624,7 +635,9 @@ fn write_observation(
                     WHEN excluded.reported_resets_at_epoch IS NULL
                         THEN provider_usage_observation.reported_resets_at_epoch
                     ELSE excluded.reported_resets_at_epoch
-                END",
+                END,
+                plan = excluded.plan,
+                plan_tier = excluded.plan_tier",
         params![
             period_id,
             reading.provider,
@@ -643,6 +656,8 @@ fn write_observation(
             reading.starts_at_epoch,
             reading.resets_at_epoch,
             i64::from(detaches_existing),
+            reading.plan,
+            reading.plan_tier,
         ],
     )?;
     if let Some(period_id) = period_id {
@@ -690,7 +705,7 @@ fn query_observations(
         "SELECT id, period_id, provider, account_key, window_id, window_kind, window_role,
                 scope_key, scope_label, observed_at_epoch, used_percent, is_fresh,
                 is_authoritative, confidence, source_id, reported_starts_at_epoch,
-                reported_resets_at_epoch
+                reported_resets_at_epoch, plan, plan_tier
            FROM provider_usage_observation
           WHERE period_id = ?1
           ORDER BY observed_at_epoch, id",
@@ -737,6 +752,8 @@ fn row_to_observation(row: &rusqlite::Row<'_>) -> rusqlite::Result<ProviderUsage
         source_id: row.get(14)?,
         reported_starts_at_epoch: row.get(15)?,
         reported_resets_at_epoch: row.get(16)?,
+        plan: row.get(17)?,
+        plan_tier: row.get(18)?,
     })
 }
 

--- a/apps/desktop/src-tauri/src/store/provider_usage_history/tests.rs
+++ b/apps/desktop/src-tauri/src/store/provider_usage_history/tests.rs
@@ -603,4 +603,33 @@ mod history_tests {
         let new_id = store.record_provider_usage_snapshots(&[new]).unwrap()[0];
         assert!(new_id > old_id);
     }
+
+    #[test]
+    fn the_plan_and_plan_tier_a_snapshot_states_are_stored_on_its_observation() {
+        let store = store();
+        store.upsert_sessions(&[session()], &[]).unwrap();
+        let mut reading = snapshot(
+            ACCOUNT_A,
+            NOW,
+            "five-hour",
+            Some(NOW - 18_000),
+            Some(NOW),
+            Some(40.0),
+        );
+        reading.plan = Some("pro".to_string());
+        reading.plan_tier = Some("standard".to_string());
+
+        let period_id = store.record_provider_usage_snapshots(&[reading]).unwrap()[0];
+
+        let history = store
+            .provider_usage_period_history(period_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(history.observations.len(), 1);
+        assert_eq!(history.observations[0].plan.as_deref(), Some("pro"));
+        assert_eq!(
+            history.observations[0].plan_tier.as_deref(),
+            Some("standard")
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -12,7 +12,7 @@
 /// `user_version` it leaves behind.
 pub const MIGRATIONS: &[&str] = &[
     V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,
-    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36, V37, V38,
+    V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32, V33, V34, V35, V36, V37, V38, V39,
 ];
 
 /// v1 — sessions, derived analysis, relations, settings, sources.
@@ -740,4 +740,69 @@ CREATE INDEX provider_usage_session_allocation_session_metric
 const V38: &str = r#"
 CREATE INDEX session_source_lookup
     ON session (source_label, environment_key, agent, source_kind);
+"#;
+
+/// v39 adds plan tracking to observations, and the tables the learned
+/// dollars-per-percent factor lives in.
+///
+/// A sample and a point outlive the observations that produced them. Sample
+/// retention deletes rows older than the session retention setting, capped at
+/// 365 days; points are never deleted. `store::provider_limit` nulls a
+/// sample's `period_id` before period retention removes the period, so that
+/// deletion needs no `ON DELETE` action here.
+const V39: &str = r#"
+ALTER TABLE provider_usage_observation ADD COLUMN plan TEXT;
+ALTER TABLE provider_usage_observation ADD COLUMN plan_tier TEXT;
+
+CREATE TABLE provider_limit_factor_sample (
+    id                  INTEGER PRIMARY KEY,
+    provider            TEXT NOT NULL,
+    account_key         TEXT NOT NULL,
+    lane                TEXT NOT NULL CHECK (lane IN ('weekly', 'fiveHour')),
+    kind                TEXT NOT NULL CHECK (kind IN ('delta', 'window_start', 'unattributed', 'rollout')),
+    period_id           INTEGER REFERENCES provider_usage_period(id),
+    from_epoch          INTEGER NOT NULL,
+    to_epoch            INTEGER NOT NULL,
+    from_percent        REAL NOT NULL,
+    to_percent          REAL NOT NULL,
+    input_usd           REAL NOT NULL,
+    output_usd          REAL NOT NULL,
+    cache_read_usd      REAL NOT NULL,
+    cache_write_usd     REAL NOT NULL,
+    turn_count          INTEGER NOT NULL,
+    plan                TEXT,
+    plan_tier           TEXT,
+    source_id           TEXT NOT NULL,
+    computed_at_epoch   INTEGER NOT NULL,
+    UNIQUE (provider, account_key, lane, from_epoch, to_epoch)
+) STRICT;
+
+CREATE INDEX provider_limit_factor_sample_lane_recent
+    ON provider_limit_factor_sample (provider, account_key, lane, to_epoch DESC);
+CREATE INDEX provider_limit_factor_sample_period
+    ON provider_limit_factor_sample (period_id);
+
+CREATE TABLE provider_limit_factor_point (
+    id                  INTEGER PRIMARY KEY,
+    provider            TEXT NOT NULL,
+    account_key         TEXT NOT NULL,
+    lane                TEXT NOT NULL CHECK (lane IN ('weekly', 'fiveHour')),
+    effective_at_epoch  INTEGER NOT NULL,
+    usd_per_percent     REAL NOT NULL,
+    method              TEXT NOT NULL CHECK (method IN ('delta', 'window_start')),
+    sample_count        INTEGER NOT NULL,
+    plan                TEXT,
+    plan_tier           TEXT,
+    UNIQUE (provider, account_key, lane, effective_at_epoch)
+) STRICT;
+
+CREATE INDEX provider_limit_factor_point_lane_recent
+    ON provider_limit_factor_point (provider, account_key, lane, effective_at_epoch DESC);
+
+CREATE TABLE provider_limit_residual (
+    period_id           INTEGER PRIMARY KEY REFERENCES provider_usage_period(id),
+    computed_at_epoch   INTEGER NOT NULL,
+    meter_percent       REAL NOT NULL,
+    estimated_percent   REAL NOT NULL
+) STRICT;
 "#;

--- a/apps/desktop/src-tauri/src/store/schema.rs
+++ b/apps/desktop/src-tauri/src/store/schema.rs
@@ -749,7 +749,13 @@ CREATE INDEX session_source_lookup
 /// retention deletes rows older than the session retention setting, capped at
 /// 365 days; points are never deleted. `store::provider_limit` nulls a
 /// sample's `period_id` before period retention removes the period, so that
-/// deletion needs no `ON DELETE` action here.
+/// deletion needs no `ON DELETE` action here. The same step deletes that
+/// period's cursor row, so period retention itself needs no change.
+///
+/// `provider_limit_learn_cursor` marks how far a period's observations have
+/// been read into samples, so a pass can find a period whose readings are
+/// old — from bootstrap on upgrade or from a backfill — instead of only one
+/// observed in the last 15 minutes.
 const V39: &str = r#"
 ALTER TABLE provider_usage_observation ADD COLUMN plan TEXT;
 ALTER TABLE provider_usage_observation ADD COLUMN plan_tier TEXT;
@@ -804,5 +810,10 @@ CREATE TABLE provider_limit_residual (
     computed_at_epoch   INTEGER NOT NULL,
     meter_percent       REAL NOT NULL,
     estimated_percent   REAL NOT NULL
+) STRICT;
+
+CREATE TABLE provider_limit_learn_cursor (
+    period_id            INTEGER PRIMARY KEY REFERENCES provider_usage_period(id),
+    learned_through_epoch INTEGER NOT NULL
 ) STRICT;
 "#;

--- a/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
@@ -11,10 +11,10 @@ use super::*;
 #[test]
 fn the_migration_ladder_reaches_the_turn_row_schema() {
     // Pin the count so each new migration requires an explicit test update.
-    assert_eq!(super::schema::MIGRATIONS.len(), 38);
+    assert_eq!(super::schema::MIGRATIONS.len(), 39);
 
     let store = store();
-    assert_eq!(store.schema_version().unwrap(), 38);
+    assert_eq!(store.schema_version().unwrap(), 39);
     let index_exists = store
         .lock()
         .query_row(

--- a/apps/desktop/src-tauri/src/usage_alerts.rs
+++ b/apps/desktop/src-tauri/src/usage_alerts.rs
@@ -223,10 +223,12 @@ fn run_pass(app: &AppHandle, _blocking: blocking::Thread) {
 }
 
 fn background_pass(app: &AppHandle, settings: &crate::store::AppSettings) {
-    // Reconciliation uses only local durable inputs.
-    // It must run without provider network collection.
+    // Reconciliation and factor learning use only local durable inputs.
+    // Both must run without provider network collection.
     if let Some(store) = app.try_state::<Store>() {
-        crate::provider_usage::ledger::reconcile(store.inner(), crate::scan::unix_now());
+        let now = crate::scan::unix_now();
+        crate::provider_usage::ledger::reconcile(store.inner(), now);
+        crate::provider_usage::factor::learn(store.inner(), now);
     }
     if !settings.live_usage_active() {
         return;

--- a/docs/plans/limit-factor-estimation.md
+++ b/docs/plans/limit-factor-estimation.md
@@ -1,0 +1,367 @@
+---
+title: "Limit share from a learned dollars-per-percent factor"
+created_at: "2026-09-08"
+status: planned
+---
+
+# Limit share from a learned dollars-per-percent factor
+
+- **Date:** 2026-09-08
+- **Issue:** none. Opened from the 0.4.1 "no limit" badge report.
+- **Status:** planned. Phases below, built in stacked worktrees.
+
+## Problem
+
+The session list shows "% 5h" and "% week" for each session. Release 0.4.1
+(PR #426) computes these from a durable ledger: it stores one period per
+provider allowance window, splits each observed percent delta across the turns
+that fall inside the observation interval, and writes one allocation row per
+session and period.
+
+Three faults follow from that shape.
+
+- A session gets a percent only if a period covered it while the app ran. Every
+  session from before the install, and every session from a stretch when the
+  app was closed, shows "no limit" forever.
+- A session gets a percent only if a live poll bound it to an account within
+  ten minutes of its last write. Sessions that finish while the app is closed
+  never bind. The single-account fallback from 0.4.0 was dropped.
+- A window that the meter reports as 0% gets no allocation, because the delta
+  rounds to zero. The 5-hour lane starts every window in this state.
+
+The arithmetic in the allocator is correct. A reproduction matched the stored
+rows bit for bit. The shape is the problem, not the code.
+
+A fleet constant is not a substitute. Cadence data for the same question shows
+per-plan dollars-per-percent constants wrong by 2x to 10x for individuals, a
+15x swing for one user across weeks, and 2x to 4x drift across months. The only
+precise calibration source is the live meter that the app already polls.
+
+## Target shape
+
+One number per provider account and lane: the **factor**, in dollars per one
+percent of the limit. The app learns the factor from the meter. Every session,
+including sessions from before the install, shows `dollars / factor`.
+
+```
+meter reading a ─┐
+                 ├─ percent delta ─┐
+meter reading b ─┘                 ├─ sample = dollars / percent delta
+turns between a and b ─ dollars ───┘
+
+samples ─ weighted median ─ factor point (effective_at, usd_per_percent)
+
+session dollars / factor in effect at session end ─ badge percent
+Σ(estimates in current window) vs meter ─ residual
+```
+
+The factor belongs to the account and lane, not to the window. The limit does
+not change when a window resets. A new window starts with the last factor. A
+restart starts with the last saved factor. Only a true first install has none.
+
+The factor drifts when the provider changes the limit or the pricing, or when
+the user changes plan. New samples move it. The stored history of the factor
+is itself a product: it shows when a provider tightened a limit.
+
+### Inputs
+
+| Input | Source | Already durable |
+|---|---|---|
+| Meter readings with reset time | `provider_usage_observation` joined to `provider_usage_period` | yes (90-day retention) |
+| Turn dollars with timestamps | turn rows priced through `lookup_turn_pricing` | yes |
+| Session dollars, inclusive of subagents | `session_analysis.pricing_breakdown_json` via `price_cached_breakdown` | yes |
+| Session to account | `session_provider_account`, else single `provider_account_seen` row for the agent | yes, plus the fallback rule |
+| Plan name | `ProviderUsageSnapshot.plan` / `plan_tier` | no, dropped before the observation is written; V39 adds it |
+
+### Account resolution
+
+One rule, used by learning and by reading. A turn or session belongs to an
+account when:
+
+1. its session has exactly one `session_provider_account` row for the
+   provider, or
+2. it has none, and `provider_account_seen` holds exactly one account for the
+   session's agent and provider.
+
+Otherwise it is unattributed. Unattributed turns do not enter samples.
+Unattributed sessions show "unknown". This is the rule from branch
+`fix/single-account-allocation-fallback` (`provider_known_accounts`), lifted
+into one store helper so the two paths cannot disagree.
+
+### Samples
+
+A sample is one measurement of the factor. Three kinds.
+
+**delta**: two observations `a` and `b` in the same period, where `b` is the
+first later observation with `used_percent` greater than `a.used_percent`.
+Percent delta is `b.percent - a.percent`. Dollars are the priced turns with
+`a.observed_at < turn_at <= b.observed_at` that resolve to the period's
+account. Then `a := b` and the search continues. Consecutive readings with an
+equal percent are merged into one interval, so integer meters do not produce
+zero deltas.
+
+A delta interval with a positive percent delta and zero attributed dollars
+means usage from another device. It is stored with kind `unattributed` and
+excluded from the factor. The residual uses it.
+
+**window_start**: one observation with `used_percent > 0` and no delta sample
+yet for the lane. Dollars are the attributed turns from the window start to
+the observation. Window start is `starts_at_epoch`, else `resets_at_epoch`
+minus the lane duration (18 000 s or 604 800 s). The sample carries every
+outside use in the window, so it is only used while no delta sample exists.
+
+A Codex reading at 0% reports a projected reset (`is_sliding_reset_projection`).
+Zero readings never form a window_start sample and never define a window start.
+
+**rollout** (phase 4): a delta sample whose observations came from a Codex
+rollout file instead of a live poll. Same arithmetic, different `source_id`.
+
+Each sample stores the dollar split by token kind (input, output, cache read,
+cache write). Without it, a later chart cannot tell a provider change from a
+workload change.
+
+### Plan tracking
+
+Every live source reports the plan on the snapshot (Claude: subscription type
+and rate-limit tier; Codex: plan type; Antigravity: plan and tier). V39 adds
+`plan` and `plan_tier` to `provider_usage_observation`, stored as given. A
+sample takes the plan of its closing observation. A factor point carries the
+plan. Points are never pruned, so plan history survives the observation cap.
+
+A plan change is a step in the factor, not a drift. When the latest
+observation's plan differs from the current point's plan, the median uses only
+samples from after the change and a new point is appended even if the value
+is within 2%. Codex rollout files carry the plan on every turn, so phase 4
+backfills plan history too.
+
+Plan strings map to a closed vocabulary only at the analytics boundary.
+
+### The factor
+
+For each (provider, account, lane), the factor is the weighted median of delta
+samples from the last 14 days. Weight is `percent_delta × 0.5^(age_days / 7)`.
+Fewer than three samples in 14 days: use all delta samples. No delta samples:
+use the most recent window_start sample. Nothing: no factor, badge "unknown".
+
+Median, not mean, because a single interval that includes outside use pulls
+the factor down and every session up. The median ignores it.
+
+The app appends a **factor point** whenever the computed factor differs from
+the last point by more than 2%, the method changes, or the plan changes. Points are the history.
+The latest point is the current factor. A session uses the point in effect at
+its end time, the earliest point for sessions before the first point.
+
+### Recompute window
+
+Turn rows can arrive after the observation that closes their interval, because
+transcript ingest lags. Every learning pass recomputes samples whose `to_epoch`
+is within the last 15 minutes and upserts them by observation pair. Older
+samples are final. A pass handles at most 64 new observation pairs.
+
+### Reading
+
+`get_session_limit_allocations` returns one row per session and lane:
+
+```
+percent    = session.cost.total_usd / factor_point(account, lane, session.updated_at).usd_per_percent
+confidence = "learned" | "seeded"    (delta vs window_start method)
+```
+
+No row when the session is unattributed or the lane has no factor. The
+frontend shows "unknown" for a missing row, and "no limit" at the current
+opacity only when the live summary for that provider has no window of that
+kind (commit `4e7a7528`, `providerConfirmsNoWindow`).
+
+The dollars are the inclusive session cost, subagents included. The meter
+counts subagent turns. Subagent rows in the list keep their own cost and get
+their own percent.
+
+A percent above 100 is valid for a long session and shows as is.
+
+### Residual
+
+For each (provider, account, lane) and the current period: `meter_percent -
+Σ(attributed turn dollars since window start) / factor`. Stored on each
+learning pass as one row per period. It is the accuracy check. A large
+positive residual means outside use. A large negative one means the factor
+has drifted. Diagnostics export and analytics report it as a band.
+
+## What is kept, what goes
+
+Kept: `provider_usage_period`, `provider_usage_observation`,
+`record_provider_usage_snapshots`, `period_for`, retention,
+`session_provider_account`, `provider_account_seen`, `observe_provider_account`.
+
+Removed: `provider_usage_session_allocation`, `provider_usage_allocation_dirty`,
+`provider_usage_allocation_revision`, `allocation_frozen`, the
+`provider_usage::allocation` module, `ledger::reconcile` and `reconcile_period`,
+`cumulative_session_limit_allocations`, `cumulative_lane_allocation`, the
+`coverage` field on the payload, and the retention branches that check those
+tables.
+
+Branch `fix/single-account-allocation-fallback` is not merged. Commit
+`4e7a7528` (frontend unknown badge) is cherry-picked in phase 2. The
+`provider_known_accounts` query and its tests from `fb321855` move into the
+account resolution helper in phase 1. The `allocation.rs` changes are dropped.
+
+## Schema
+
+**V39** (phase 1):
+
+```sql
+ALTER TABLE provider_usage_observation ADD COLUMN plan TEXT;
+ALTER TABLE provider_usage_observation ADD COLUMN plan_tier TEXT;
+
+CREATE TABLE provider_limit_factor_sample (
+    id                  INTEGER PRIMARY KEY,
+    provider            TEXT NOT NULL,
+    account_key         TEXT NOT NULL,
+    lane                TEXT NOT NULL CHECK (lane IN ('weekly', 'fiveHour')),
+    kind                TEXT NOT NULL CHECK (kind IN ('delta', 'window_start', 'unattributed', 'rollout')),
+    period_id           INTEGER REFERENCES provider_usage_period(id),
+    from_epoch          INTEGER NOT NULL,
+    to_epoch            INTEGER NOT NULL,
+    from_percent        REAL NOT NULL,
+    to_percent          REAL NOT NULL,
+    input_usd           REAL NOT NULL,
+    output_usd          REAL NOT NULL,
+    cache_read_usd      REAL NOT NULL,
+    cache_write_usd     REAL NOT NULL,
+    turn_count          INTEGER NOT NULL,
+    plan                TEXT,
+    plan_tier           TEXT,
+    source_id           TEXT NOT NULL,
+    computed_at_epoch   INTEGER NOT NULL,
+    UNIQUE (provider, account_key, lane, from_epoch, to_epoch)
+) STRICT;
+
+CREATE TABLE provider_limit_factor_point (
+    id                  INTEGER PRIMARY KEY,
+    provider            TEXT NOT NULL,
+    account_key         TEXT NOT NULL,
+    lane                TEXT NOT NULL CHECK (lane IN ('weekly', 'fiveHour')),
+    effective_at_epoch  INTEGER NOT NULL,
+    usd_per_percent     REAL NOT NULL,
+    method              TEXT NOT NULL CHECK (method IN ('delta', 'window_start')),
+    sample_count        INTEGER NOT NULL,
+    plan                TEXT,
+    plan_tier           TEXT,
+    UNIQUE (provider, account_key, lane, effective_at_epoch)
+) STRICT;
+
+CREATE TABLE provider_limit_residual (
+    period_id           INTEGER PRIMARY KEY REFERENCES provider_usage_period(id),
+    computed_at_epoch   INTEGER NOT NULL,
+    meter_percent       REAL NOT NULL,
+    estimated_percent   REAL NOT NULL
+) STRICT;
+```
+
+Samples and points outlive observations. Retention deletes samples older than
+the session retention setting, capped at 365 days, and never deletes points.
+`period_id` on a sample is `ON DELETE SET NULL` in effect: the learner nulls
+it before the period retention pass runs, so the period retention query stays
+as it is.
+
+**V40** (phase 2): drop the four allocation objects listed above.
+
+## Phases
+
+Each phase is one PR from a stacked worktree, built by a Sonnet builder from
+this document, reviewed here, then merged. Phase 2 cannot ship without phase 1.
+Phases 1 and 2 ship in the same release; there is no release between them.
+
+### Phase 1: learn the factor
+
+- V39 schema.
+- `store::provider_limit` module: account resolution helper (SQL that returns
+  the account for a session under the two-step rule, plus the reverse:
+  attributed turn dollars for an account between two epochs, grouped by
+  session and split by token kind, priced through the existing turn pricing
+  key), sample upsert, point append, point lookup at an epoch, residual
+  upsert. The learner sums the per-session rows. The later contribution chart
+  reads the same query unsummed, so keep the session grouping from the start.
+- `provider_usage::factor` module: `learn(store, now_epoch)`. Called where
+  `ledger::reconcile` is called today (`live/mod.rs` after
+  `record_provider_usage_snapshots`, and `usage_alerts::background_pass`).
+  Bounded per pass as above.
+- The old allocator keeps running in this phase. Nothing reads the new tables
+  yet.
+- Tests: synthetic observations and turn rows for one account; delta sample
+  arithmetic; merged equal readings; unattributed interval; window_start only
+  while no delta exists; weighted median with one outlier; point appended only
+  on change; recompute window upserts a late turn; two accounts on one agent
+  produce no fallback attribution; Codex 0% projected reset ignored; plan
+  stored on the observation; plan change drops earlier samples and appends a
+  point.
+
+### Phase 2: read from the factor, delete the allocator
+
+- `get_session_limit_allocations` computes from session cost and factor
+  points. DTO: `coverage` becomes `confidence`. TypeScript payload updated.
+- Cherry-pick `4e7a7528`. Reconcile the "unknown" / "no limit" split with the
+  new missing-row semantics.
+- V40. Delete the removed list above. No lint suppressions; dead code goes.
+- Tests: command returns percent from cost and point-at-end-time; earliest
+  point for older sessions; missing factor gives no row; subagent rows priced
+  on their own cost; frontend badge tests from the cherry-pick still pass.
+
+### Phase 3: residual, diagnostics, analytics
+
+- Residual row per period on each learning pass.
+- Diagnostics export: one entry per (provider, lane) with factor, method,
+  sample count, point count, latest residual. No account keys, per the
+  export's content notice; update the notice text.
+- Analytics event `antiburn.limit_factor_observed`: provider, lane, plan (closed
+  vocabulary: mapped known plan names, else `other`), factor band (closed
+  vocabulary, log-spaced: `under_2`, `2_to_under_8`, `8_to_under_32`,
+  `32_and_over` dollars per percent), residual band (`within_5`, `within_20`,
+  `over_20`, `unknown`). Fire on first computation and on band change, at most
+  once per day per (provider, lane). Follow the catalogue steps in
+  `docs/analytics.md` and the review contract in
+  `docs/analytics-measurement.md`.
+- Tests per the analytics review contract.
+
+### Phase 4: Codex rollout observations
+
+- Resurrect the bounded rollout reader from closed PR #427
+  (`provider_usage/backfill.rs`, `store/usage_backfill.rs`,
+  `read_rollout_batch`, checkpoints, retry backoff). Skip its legacy
+  `internal:liveUsageHistoryV2` import; that history has no reset times.
+- Rollout readings become observations with `source_id`
+  `codex-rollout-backfill`. The learner treats them as any other observation;
+  samples from them carry kind `rollout`.
+- Effect: a Codex account has a factor from history on first install, without
+  waiting for a live poll.
+
+### Later, not in this round
+
+- A factor history chart per account, from `provider_limit_factor_point` and
+  the token-kind split on samples.
+- A limit-over-time chart per account and lane, from
+  `provider_usage_observation`. Needs the 90-day observation cap raised or a
+  downsampled copy that survives it. Phase 1 must not depend on the cap.
+- A contribution chart: which sessions used the most of a bucket. Per-session
+  attributed dollars inside the bucket, divided by the factor in effect, from
+  the phase 1 query. The meter line drawn over the stacked estimates shows the
+  residual as the gap.
+- Seed the 5-hour factor from the weekly factor and a per-plan ratio while no
+  5-hour sample exists.
+- Cadence: read the coarse factor and residual bands per plan in Metabase.
+
+## Known limits
+
+- The first-open estimate comes from one window_start sample. It includes
+  every outside use in the window, so early percentages run high. Delta
+  samples correct it within a few polls.
+- The provider does not meter every token at list price. A cache-heavy session
+  and an output-heavy session with the same dollars get the same percent. The
+  residual shows the error. The token-kind split on samples is the data a
+  later model would need to fix it.
+- An account with no local usage in the current window has no window_start
+  sample. The badge stays "unknown" until the first local session moves the
+  meter.
+- Session cost is repriced on read against the current pricing table. Samples
+  hold dollars priced at learning time. A pricing table update shifts the
+  two apart until new samples land. Acceptable; the drift is small and
+  self-correcting.

--- a/docs/plans/limit-factor-estimation.md
+++ b/docs/plans/limit-factor-estimation.md
@@ -337,13 +337,44 @@ build and kept for phase 2 to build on.
   period seen per lane in a pass is already its current one; reusing it keeps
   the residual step inside the same bounded per-pass work instead of adding
   another unbounded query.
-- **Candidate-period selection uses one rule for both bootstrap and
-  recompute:** a period qualifies when it carries a primary lane and its
-  `last_observed_epoch` is at or after `now - 15 minutes`. A brand-new period
-  and a just-refreshed one both leave a fresh `last_observed_epoch`, so one
-  query serves both cases. This assumes `learn` runs close to when
-  observations are written, which holds today: it runs right after
-  `record_provider_usage_snapshots` and on every background tick.
+- **Candidate-period selection is cursor-based, not "observed in the last 15
+  minutes."** The original rule never learned from a period whose readings
+  were older than 15 minutes, which breaks bootstrap on upgrade (90 days of
+  stored observations sit unread until a new reading lands) and phase 4's
+  rollout backfill (it writes observations timestamped in the past, so those
+  periods would never enter a pass). `provider_limit_learn_cursor
+  (period_id, learned_through_epoch)` now tracks how far each period has been
+  read. A period is a candidate when it carries a primary lane and account
+  scope, and either has no cursor row, has a reading newer than its cursor, or
+  was observed at or after `now - 15 minutes` (so a just-touched period stays
+  open to recompute even once its cursor catches up). A pass advances a
+  period's cursor to its `last_observed_epoch` only after considering every
+  sample it could yield; stopping mid-period on the pass budget leaves the
+  cursor where it was, so the period stays a candidate next time. A cursor row
+  is deleted in the same place, and against the same about-to-be-removed set
+  of periods, that samples are detached before period retention runs.
+- **Plan comparison uses the (plan, plan_tier) pair, not `plan` alone.** On
+  Claude, moving between tiers of the same plan (Max 5x to Max 20x) changes
+  only `plan_tier`; `plan` stays `"max"`. Comparing `plan` alone would miss a
+  tier change entirely. `recompute_point`'s `plan_changed` check,
+  `filter_by_plan`, and `window_start_factor`'s plan guard all compare the
+  full pair.
+- **A factor point's `effective_at_epoch` is the `to_epoch` of the newest
+  sample its estimate used** (for a `window_start` estimate, that sample's own
+  `to_epoch`), not the epoch `learn` happened to run at. Bootstrapped or
+  backfilled history needs to date its points by the data, not by when the
+  pass computing them ran, so that "the factor in effect at a session's end
+  time" resolves correctly for historical sessions. The point upsert stays
+  keyed on `(provider, account_key, lane, effective_at_epoch)`, so recomputing
+  the same interval replaces its point rather than appending a duplicate.
+- **`has_delta_factor_sample` is scoped to the account's current
+  `(plan, plan_tier)`,** not asked lane-wide. Read lane-wide, a plan or tier
+  change would find the *old* plan's delta history, conclude a delta sample
+  already exists, and block a `window_start` sample from ever seeding the new
+  plan's own factor — leaving the point stuck on the old plan indefinitely.
+  Scoping the check to the pair the latest observation reports lets a fresh
+  plan or tier seed its own `window_start` sample immediately; the median path
+  already prefers delta samples over `window_start` once they exist.
 
 ### Phase 2: read from the factor, delete the allocator
 

--- a/docs/plans/limit-factor-estimation.md
+++ b/docs/plans/limit-factor-estimation.md
@@ -295,6 +295,56 @@ Phases 1 and 2 ship in the same release; there is no release between them.
   stored on the observation; plan change drops earlier samples and appends a
   point.
 
+#### Decisions (implementation, 2026-09-08)
+
+The document above did not settle these; they were decided during the phase 1
+build and kept for phase 2 to build on.
+
+- **`window_start` gating checks the period, not only the lane.** The
+  document's rule is "no delta sample yet for the lane." Read literally, a
+  period whose own two readings already form a delta pair would *also* emit a
+  `window_start` sample from its first reading, because the lane-wide "a delta
+  exists" flag is only checked once, before that period is processed. Phase 1
+  adds one clause: a period only produces `window_start` when it cannot
+  produce a delta pair of its own (zero or one usable reading). A period with
+  a real pair never needs the fallback its own data has already outgrown.
+- **`store::Store::lock` widened from private to `pub(crate)`.** The plan asks
+  for factor-learning tests that build synthetic turns, periods, and
+  observations the way the store's own lifecycle tests do. Those existing
+  tests live inside the `store` module tree and can already reach the private
+  connection lock; `provider_usage::factor`'s tests live outside it. Widening
+  `lock` to `pub(crate)` (still crate-only, no new public surface) let the
+  factor tests reuse the same direct-SQL fixture style instead of duplicating
+  it through a second accessor.
+- **`provider_usage::attribute`, `has_tokens`, and `Attributed::models` widened
+  to `pub(crate)`.** `store::provider_limit`'s attributed-dollars query needs
+  the same per-model provider routing `provider_usage::allocation::weighted_turns`
+  already does, so it calls the same function rather than re-implementing
+  routing rules a second place they could drift apart.
+- **`factor_point_at` (point lookup at an epoch) is used by phase 1, not left
+  for phase 2 alone.** The document lists it as a phase 1 storage primitive
+  with no phase 1 caller, which is dead code under this repository's
+  no-suppression rule. `compute_residual` uses it to price a period's residual
+  against the factor in effect at that period's own latest observation, rather
+  than always the newest point overall — arguably more correct than reading
+  the single newest point directly, since a plan change between the reading
+  and "now" would otherwise restate an old period's residual under today's
+  factor.
+- **Residual is computed once per (provider, account, lane) touched in a
+  pass, from the most-recently-observed period among those already loaded**,
+  not from a separate "current period per lane" scan. Candidate-period
+  selection already sorts by `last_observed_epoch` descending, so the first
+  period seen per lane in a pass is already its current one; reusing it keeps
+  the residual step inside the same bounded per-pass work instead of adding
+  another unbounded query.
+- **Candidate-period selection uses one rule for both bootstrap and
+  recompute:** a period qualifies when it carries a primary lane and its
+  `last_observed_epoch` is at or after `now - 15 minutes`. A brand-new period
+  and a just-refreshed one both leave a fresh `last_observed_epoch`, so one
+  query serves both cases. This assumes `learn` runs close to when
+  observations are written, which holds today: it runs right after
+  `record_provider_usage_snapshots` and on every background tick.
+
 ### Phase 2: read from the factor, delete the allocator
 
 - `get_session_limit_allocations` computes from session cost and factor


### PR DESCRIPTION
Phase 1 of `docs/plans/limit-factor-estimation.md` (the plan document is the first commit on this branch).

## User impact

None yet. This phase learns a per-account, per-lane dollars-per-percent factor from the meter readings the app already stores, and persists it. Nothing reads the new tables outside tests. The session badge still prices from the durable allocator until phase 2 switches the read path and deletes the allocator.

## What it adds

- Schema V39: `plan` and `plan_tier` on `provider_usage_observation`; new tables `provider_limit_factor_sample`, `provider_limit_factor_point`, `provider_limit_residual`, `provider_limit_learn_cursor`.
- `store::provider_limit`: the two-step account rule (session binding, else the single known account for the agent), attributed turn dollars grouped by session and split by token kind, sample/point/residual/cursor storage, sample retention.
- `provider_usage::factor::learn`: delta samples from rising meter readings inside one period (equal readings merge), `unattributed` samples when the meter rose with no local dollars, a `window_start` sample while no delta exists for the current plan, a weighted median with 7-day half-life, factor points appended on a 2% move, a method change, or a plan or tier change, and a residual per current period. Points are dated by the data that produced them.
- Runs alongside `ledger::reconcile` after every live refresh and on every background tick, bounded to 64 observation pairs per pass, with a per-period cursor so bootstrap and backfilled history are learned too.

Implementation decisions the plan did not settle are recorded at the end of the plan document.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings` (with and without `--features analytics`)
- `cargo test --no-fail-fast` (1023 passed) and `--features analytics` (1075 passed)

## Privacy and performance

No new network requests. Samples and points store opaque account keys, dollar totals, plan strings as reported by the provider, and epochs. No transcript content. Per pass: at most 64 candidate periods and 64 observation pairs; the attribution query caps at 20 000 turn groups and yields `None` beyond that.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xa8PzmoJCThUoi63kCDZ9j
