### PR TITLE
chore(release): prepare antiburn 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,23 +20,35 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
-### Fixed
+## [0.5.0] - 2026-09-09
 
-- The Windows install command `irm https://antiburn.ai/install.ps1 | iex`
-  now runs instead of failing with a parameter validation error.
+### Added
 
-## [0.4.1] - 2026-09-08
+- A persistent main window now provides an Activity sidebar and a Sessions
+  workspace. Sessions can be browsed beside their details, opened from the tray
+  popover, navigated by keyboard, and followed through related-session links.
 
 ### Changed
 
-- Session limit badges now retain cumulative estimates across provider resets,
-  keeping usage attributed in earlier periods visible alongside the current
-  provider period.
+- Session limit badges now use learned estimates for each provider account and
+  limit window. Estimates cover sessions from before installation and while
+  antiburn was closed, retain cumulative use across provider resets, and
+  distinguish an unknown share from a provider without that limit.
+- Session Details in the main window uses a responsive desktop layout with a
+  fixed toolbar, more room for Context, Cost, and Tools, and clearer cost
+  breakdowns.
+- Settings diagnostics exports now include coarse learned provider-limit
+  details without account keys to help investigate session estimates.
 
 ### Fixed
 
 - Session rows now show `0%` when valid provider usage remains flat during a
   percentage plateau instead of treating the allocation as missing.
+- Expired Codex and Claude credentials now refresh through their owning CLI
+  before antiburn retries live usage.
+- The Windows install command `irm https://antiburn.ai/install.ps1 | iex`
+  now runs instead of failing with a parameter validation error, and the
+  installation instructions use HTTPS.
 
 ## [0.4.0] - 2026-09-07
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "antiburn-anchored-window",
  "antiburn-hud",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/anchored-window", "crates/hud", "crates/main-window", "crates
 
 [package]
 name = "antiburn"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
Desktop 0.5.0 introduces the persistent main window and Sessions workspace, improves learned session-limit estimates, refreshes expired Claude and Codex credentials through their owning CLIs, and fixes the documented Windows installer command.

The 0.4.1 draft will not be published, so these notes include its cumulative-limit changes for readers upgrading from 0.4.0.

Validation:

- `node scripts/verify-release-version.mjs app antiburn-v0.5.0`
- `node scripts/verify-app-engine-release.mjs`
- locked desktop `cargo metadata`
- `git diff --check`

The release diff is limited to the four app version declarations and `CHANGELOG.md`. The shipped feature changes passed their full checks before merging to `main`.
