### PR TITLE
docs: link the antiburn Slack from the README and support doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/antiburn/antiburn)](https://github.com/antiburn/antiburn/stargazers)
 [![aislop score](https://badges.scanaislop.com/score/antiburn/antiburn.svg)](https://scanaislop.com/antiburn/antiburn)
 [![Tauri 2](https://img.shields.io/badge/Tauri-2-24C8DB?logo=tauri&logoColor=white)](https://tauri.app/)
+[![Slack](https://img.shields.io/badge/Slack-join-4A154B?logo=slack&logoColor=white)](https://antiburn.ai/slack)
 
 A little free desktop app to check your sessions for the most common causes of token burn - sessions that go too deep, subagents that go too hard, skills and MCPs that go unused, etc etc etc.
 
@@ -79,6 +80,12 @@ See the [desktop guide](apps/desktop/README.md) for app commands and the
 antiburn needs no account, server, or backend operated by the project. It can contact coding-agent providers with credentials already held by your tools to read current usage. Release builds also check GitHub Releases for updates.
 
 antiburn has analytics that we use to improve the app, but analytics events never include sessions, prompts, file paths, repository names, or credentials. Builds from a clean checkout have no analytics endpoint. Point your coding agent at this repo to check exactly what data leaves the device, if you're worried. See the complete [analytics contract](docs/analytics.md).
+
+## Community
+
+Questions, fixes, what's burning: join the
+[antiburn Slack](https://antiburn.ai/slack). Bugs and feature requests go in
+[GitHub issues](https://github.com/antiburn/antiburn/issues).
 
 ## Project links
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -246,5 +246,6 @@ rather than staying silent.
 
 If an agent on this list is not discovered on a supported platform, that is a bug —
 please open an issue with the agent, its version, your platform, and where its
-session files live. Security issues go to the private channel in
-[`SECURITY.md`](../SECURITY.md) instead.
+session files live. Not sure it is a bug? Ask in the
+[antiburn Slack](https://antiburn.ai/slack) first. Security issues go to the
+private channel in [`SECURITY.md`](../SECURITY.md) instead.


### PR DESCRIPTION
## User impact

The README gets a Slack badge and a short Community section, and `docs/support.md` points people to Slack before they file a bug. All links go to `antiburn.ai/slack`, a redirect page on the site that knows the current invite, so the README never carries an expiring invite URL.

The `antiburn.ai/slack` page ships in a separate site PR. Merge that first or the links 404 until it deploys.

## Validation

- Rendered the README locally and checked the badge and the two links.
- Docs only; no code change.

## Privacy and performance

None.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)