### PR TITLE
fix(desktop): keep sub-agent rows in the cost table columns

### DIFF
--- a/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
@@ -175,17 +175,20 @@ function SubagentMemberRow({
         wide ? "type-callout" : "type-body",
       )}
     >
-      <span className="col-span-full flex min-w-0 items-center gap-x-1 text-left">
+      {/* The title stays in the label column. A title that spans every column
+          makes the grid spread its width across the number columns, and the
+          label column then gets almost no width. */}
+      <span className="col-start-1 flex min-w-0 items-center gap-x-1 text-left">
         <span className="tabular-nums">
           [{formatMemberStart(member, sessionStartedAtEpoch)}]
         </span>
         <TruncatedText className="min-w-0 flex-1" text={member.label} />
-        <ChevronRight
-          size={12}
-          aria-hidden="true"
-          className="shrink-0 transition-transform duration-[var(--duration-fast)] ease-out group-hover:translate-x-0.5"
-        />
       </span>
+      <ChevronRight
+        size={12}
+        aria-hidden="true"
+        className="col-start-4 self-center justify-self-end transition-transform duration-[var(--duration-fast)] ease-out group-hover:translate-x-0.5"
+      />
 
       <span className="truncate text-left">{modelLabel}</span>
       <span className="text-right tabular-nums">
@@ -252,7 +255,7 @@ function SubagentsSplitRow({
       >
         <span className="min-w-0 flex items-center gap-x-1 text-label-tertiary">
           <Chevron size={12} aria-hidden="true" className="shrink-0" />
-          {label}
+          <span className="truncate">{label}</span>
         </span>
         <span className="text-right text-label-tertiary tabular-nums">
           {formatTokensShort(tokens)}
@@ -302,7 +305,7 @@ export function CostBreakdown({
       className={cn(
         "grid min-w-0 gap-y-1",
         wide
-          ? "w-full max-w-[640px] gap-x-2 justify-self-end justify-end grid-cols-[fit-content(12rem)_max-content_max-content_max-content]"
+          ? "w-full max-w-[640px] gap-x-2 justify-self-end justify-end grid-cols-[fit-content(24rem)_max-content_max-content_max-content]"
           : "gap-x-3 grid-cols-[1fr_max-content_max-content_max-content]",
       )}
     >


### PR DESCRIPTION

<img width="1607" height="674" alt="Screenshot 2026-09-09 at 17-05-29" src="https://github.com/user-attachments/assets/bd905302-3308-4937-956f-a64e42c929c4" />


## What

The expanded sub-agent rows in the session cost card broke the table. The label column collapsed to "Pa…" and "so…", the number columns spread across the card, and "4 sub-agents" wrapped onto two lines.

## Why

Each sub-agent row's title line spanned all four grid columns. The grid spread the title's width across the three `max-content` number columns and starved the label column.

## How

- The title now sits in the label column only, with the chevron placed in the last column, so the number columns keep their own width.
- The wide label column's cap rises from 12rem to 24rem so titles show before they truncate.
- The "N sub-agents" label truncates instead of wrapping at the minimum width.

## Screenshot

_(image: sub-agent rows at 700px, 460px and 328px, coming up)_

## Checks

- `pnpm --filter @antiburn/desktop lint`, `type-check`, and `test` pass (1294 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
