### PR TITLE
docs: make README clearer for first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,123 @@
-# antiburn
+<h1 align="center">🔥 antiburn</h1>
 
-> Tiny, fast, local burn checks for all your coding sessions.
+<p align="center">
+  <strong>Find what burns through your coding-agent tokens.</strong><br />
+  A free, local desktop app for your menu bar or system tray.
+</p>
+
+<p align="center">
+  <a href="#install">Install</a> ·
+  <a href="#first-use">First use</a> ·
+  <a href="#checks">Checks</a> ·
+  <a href="#privacy">Privacy</a> ·
+  <a href="#help">Help</a>
+</p>
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3369144d-61b0-4b94-8373-41f2541cba95" />
   <img width="100%" alt="antiburn: the popover with live limit meters and today's sessions, a session's context chart with a compaction, and its cost and tools breakdowns" src="https://github.com/user-attachments/assets/d1c1404e-4e6e-4ef3-8dbd-726150888e3d" />
 </picture>
 
-[![License](https://img.shields.io/github/license/antiburn/antiburn)](LICENSE)
-[![Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-informational)](docs/support.md)
-[![Release](https://img.shields.io/github/v/release/antiburn/antiburn?filter=antiburn-v*)](https://github.com/antiburn/antiburn/releases/latest)
-[![CI](https://github.com/antiburn/antiburn/actions/workflows/ci.yml/badge.svg)](https://github.com/antiburn/antiburn/actions/workflows/ci.yml)
-[![GitHub stars](https://img.shields.io/github/stars/antiburn/antiburn)](https://github.com/antiburn/antiburn/stargazers)
-[![aislop score](https://badges.scanaislop.com/score/antiburn/antiburn.svg)](https://scanaislop.com/antiburn/antiburn)
-[![Tauri 2](https://img.shields.io/badge/Tauri-2-24C8DB?logo=tauri&logoColor=white)](https://tauri.app/)
-[![Slack](https://img.shields.io/badge/Slack-join-4A154B?logo=slack&logoColor=white)](https://antiburn.ai/slack)
+<p align="center">
+  <a href="https://github.com/antiburn/antiburn/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/antiburn/antiburn?filter=antiburn-v*" /></a>
+  <a href="https://github.com/antiburn/antiburn/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/antiburn/antiburn/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="docs/support.md"><img alt="Platforms: macOS, Windows, Linux" src="https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-informational" /></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/antiburn/antiburn" /></a>
+</p>
 
-A little free desktop app to check your sessions for the most common causes of token burn - sessions that go too deep, subagents that go too hard, skills and MCPs that go unused, etc etc etc.
+antiburn reads the session data your coding agents already save locally. Review
+context growth, token and cost breakdowns, and checks for common causes of token
+burn—from long-running sessions to unused tools and expensive subagents.
 
-antiburn supports Claude Code, Codex, Cursor, GitHub Copilot, Cline, OpenCode, Kiro, Amp, Antigravity, Windsurf, and Pi. See the [support matrix](docs/support.md) for platform limits, discovery details, and local data storage.
-
-## Checks
-
-- Excess cache rehydration - cache writes are expensive; let's all work out how to avoid too many of them.
-- Fast mode overuse - fast mode is great if you're not close to limit, but be careful if you are.
-- Model overthinking - I know `xhigh` and `ultra` sound cool but they're usually better avoided.
-- Old model usage - worth checking if you're still pinned to old models, especially in subagents.
-- Overpowered subagents - using subagents on premium models is generally a bad idea.
-- Session overdepth - compaction works now, friends don't let friends have 950k context windows.
-- Unused built-in tools - Claude (especially) has a bunch of heavy built-in tools that you should probably disable.
-- Unused MCP servers - MCPs are usually situational, just turn them on when you need them.
-- Unused skills - most of us have skills installed that cost tokens every session, but that we never use any more.
+It supports Claude Code, Codex, Cursor, GitHub Copilot, Cline, OpenCode, Kiro, Amp,
+Antigravity, Windsurf, and Pi. **Check coverage varies by agent and source format;
+it is broadest for Claude Code and Codex.** See [agent and platform support](docs/support.md)
+and [check coverage](docs/check-coverage.md#coverage-matrix). The support guide also
+explains discovery paths and [local data storage](docs/support.md).
 
 ## Install
 
-macOS or Linux:
+**Requirements:** macOS 13+ (Apple silicon or Intel), Windows 11 (x86-64), or a
+mainstream Linux desktop (x86-64) with a system tray or AppIndicator host.
+See [platform details](docs/support.md#platforms) for Linux display-server limits.
+
+**macOS or Linux**
 
 ```sh
 curl -fsSL https://antiburn.ai/install.sh | sh
 ```
 
-Windows 11 PowerShell:
+**Windows 11 — PowerShell**
 
 ```powershell
 irm https://antiburn.ai/install.ps1 | iex
 ```
 
 The installers verify release checksums. macOS also verifies the application
-signature with Gatekeeper. Manual packages are available from the
+signature with Gatekeeper. Prefer a manual install? Download a package from the
 [latest release](https://github.com/antiburn/antiburn/releases/latest).
+
+## First use
+
+1. Open antiburn and follow onboarding to review detected agents and session sources.
+2. Finish setup, then open antiburn from your **menu bar or system tray**.
+3. Open a discovered session to review the available analysis and check results.
+
+Missing session data can limit what antiburn can assess. **No finding does not
+necessarily mean a session is clean.** The [coverage guide](docs/check-coverage.md#status-rules)
+explains the evidence required for findings and clean results.
+
+## Checks
+
+| Check                 | What to review                                       |
+| --------------------- | ---------------------------------------------------- |
+| Session overdepth     | Sessions whose context has grown too large.          |
+| Model overthinking    | High reasoning settings that may not suit the task.  |
+| Overpowered subagents | Subagent work assigned to premium models.            |
+| Unused MCP servers    | Configured MCP tools that the session does not use.  |
+| Unused built-in tools | Built-in tools that the session does not use.        |
+| Unused skills         | Skills loaded into the session but not used.         |
+| Old model usage       | Sessions or subagents still using older models.      |
+| Fast mode overuse     | Fast-mode usage worth reviewing against your limits. |
+| Cache churn           | Repeated cache writes and rehydration.               |
+
+These are prompts to review your setup, not a claim that every flagged choice is
+wrong. Read the [check definitions and evidence boundaries](docs/check-coverage.md#evidence-boundaries)
+for what antiburn can establish from each source.
+
+## Privacy
+
+**Your session content stays local. No antiburn account is required.**
+
+- **Provider connections:** antiburn can use your existing provider credentials
+  to retrieve usage and plan limits. Background provider polling is enabled by
+  default. It also makes pricing-catalog requests to models.dev and checks
+  GitHub Releases for updates. See the [network details](docs/support.md#network).
+- **Product analytics:** official builds start with analytics enabled. Events
+  exclude transcripts, prompts, file paths, repository names, and credentials,
+  but include coarse usage and diagnostic categories. The
+  [analytics contract](docs/analytics.md) documents the fields, identifiers,
+  endpoint metadata, and retention limits.
+- **Your control:** turn analytics off in **Settings → Privacy**. Builds from a
+  clean checkout have no analytics endpoint and send no analytics.
+
+The code is open source. You can audit the
+[analytics implementation](apps/desktop/src-tauri/src/analytics) and the documented
+network behavior yourself—or ask your coding agent to review them.
+
+## Help
+
+- **No sessions appearing?** Check your agent's discovery paths and supported
+  source formats in the [support guide](docs/support.md#agents).
+- **No tray icon on Linux?** Your desktop needs a system tray or AppIndicator
+  host. Check the [platform requirements](docs/support.md#platforms).
+- **Something else?** See [support](SUPPORT.md) and the
+  [debugging guide](docs/debugging.md), or ask in [Slack](https://antiburn.ai/slack).
+
+Report bugs and request features in
+[GitHub issues](https://github.com/antiburn/antiburn/issues). For bugs, include your
+OS, antiburn version, agent, and reproduction steps. Do not post credentials or
+private session content. Report security issues through the [security policy](SECURITY.md).
 
 ## Development
 
@@ -72,30 +141,12 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
-See the [desktop guide](apps/desktop/README.md) for app commands and the
-[debugging guide](docs/debugging.md) for isolated profiles and developer tools.
+See the [desktop guide](apps/desktop/README.md) for app commands, the
+[debugging guide](docs/debugging.md) for isolated profiles and developer tools,
+and [Contributing](CONTRIBUTING.md) for the full validation and contribution requirements.
 
-## Privacy
+## License and project policies
 
-antiburn uses no account, server, or backend. It hits agent provider APIs from your machine, using the same methods your harnesses already do.
-
-antiburn has analytics that we use to improve the app, but analytics events never include anything you care about: sessions, prompts, file paths, repository names, credentials, etc. You can turn analytics off, and builds from a clean checkout have no analytics endpoint. See the complete [analytics contract](docs/analytics.md).
-
-Open source, so if you're worried, point your coding agent at this repo to audit exactly what data leaves the device.
-
-## Community
-
-Questions, fixes, what's burning: join the [antiburn Slack](https://antiburn.ai/slack).
-
-Bugs and feature requests go in [GitHub issues](https://github.com/antiburn/antiburn/issues).
-
-## Project links
-
-- [Contributing](CONTRIBUTING.md)
-- [Support](SUPPORT.md)
-- [Governance](GOVERNANCE.md)
-- [Code of Conduct](CODE_OF_CONDUCT.md)
-- [Security policy](SECURITY.md)
-- [MIT License](LICENSE)
-- [Copyright notice](NOTICE)
-- [Third-party notices](THIRD_PARTY_NOTICES)
+[MIT License](LICENSE) · [Copyright notice](NOTICE) ·
+[Third-party notices](THIRD_PARTY_NOTICES) · [Governance](GOVERNANCE.md) ·
+[Code of Conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## User impact

Reorganizes the README around first-time users, based on a review of awesome-readme examples and Best-README-Template, and the approved rendered preview.

- Adds a centered 🔥 antiburn header, compact task navigation, and a focused badge row.
- Preserves the screenshot, all eleven agents, nine checks, install/development commands, and community/legal destinations.
- Adds platform prerequisites, first-use instructions, coverage qualifications, and troubleshooting routes.
- Clarifies analytics defaults, opt-out, and network activity without changing product behavior.
- Retains explicit pointers to local data storage and developer debugging tools.

Only `README.md` changes. Research artifacts and the preview are not included. Browser preview used approximate GitHub styling; layout preferences are not claims of measured usability gains.

## Validation

- Prettier check on `README.md`: passed.
- `git diff --check`: passed.
- `pnpm run slop:all`: passed (no findings).
- `pnpm run secrets`: passed.
- Validated all 29 relative links and section anchors: passed.
- Verified README exactly matches the approved preview.
- Checked support/privacy wording against canonical docs and first-use steps against onboarding code.

Runtime tests and type checks were not run separately: this change only edits Markdown and introduces no application code.

## Analytics

Measurement is unchanged. This documentation-only change adds no feature, trigger, property, or network request. No README-view tracking was added. The existing analytics contract is linked and summarized more precisely.

## Privacy and performance

None. Documentation clarifies existing behavior; data access, network access, retention, and background work do not change.

## Checklist

- [x] I used synthetic test data. (No test data introduced.)
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths. (Only existing public project references.)
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
