### PR TITLE
feat(analytics): send sanitized unrecognized record type names

### DIFF
--- a/apps/desktop/src-tauri/src/analytics/event.rs
+++ b/apps/desktop/src-tauri/src/analytics/event.rs
@@ -1,11 +1,16 @@
 //! The event payload: every field that may ever leave this machine, named once.
 //!
-//! This module is the enforcement point for the promise the Privacy pane makes.
-//! [`Event`] has no free-form field — no map, no `serde_json::Value`, no
-//! `String` a caller chooses the contents of — so there is nowhere for a path,
-//! a repository name, a session title, or a credential to be put. Adding a
-//! field here is the only way to widen what is sent, which makes widening it a
-//! visible act in review rather than an accident at a call site.
+//! This module enforces the promise the Privacy pane makes. Almost every
+//! [`Event`] field is a `&'static str` the caller passes in. No caller can put
+//! a path, a repository name, a session title, or a credential here. There
+//! are two bounded exceptions, not a free-form map or a `serde_json::Value`.
+//! `properties.resourceUsage` is a closed nested struct.
+//! `properties.unrecognizedTypes` is a sanitized `Vec<String>` of transcript
+//! record type names. `analytics::sanitize_unrecognized_types` caps its count
+//! and length and filters it to a fixed character set before it reaches this
+//! struct. Adding a field here is the only way to widen what antiburn sends.
+//! That makes widening it a visible act in review, not an accident at a call
+//! site.
 //!
 //! Counts are bucketed for the same reason. An exact session count, reported
 //! repeatedly over weeks, is a fingerprint even without an identifier attached
@@ -234,6 +239,15 @@ pub struct Properties {
     /// These bands describe process and local-store resource use for one bounded window.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource_usage: Option<super::resources::schema::ResourceUsageSummary>,
+    /// Sanitized transcript record type names. This field appears only on
+    /// `antiburn.unrecognized_records_observed`.
+    /// `analytics::sanitize_unrecognized_types` checks each name before it
+    /// reaches this struct. It keeps at most 16 names. Each name must be
+    /// non-empty, ASCII, at most 64 bytes long, and made only of characters
+    /// in `[A-Za-z0-9_.:/-]`. A name that fails this check becomes the fixed
+    /// sentinel `<rejected>`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unrecognized_types: Option<Vec<String>>,
 }
 
 /// What a caller may attach to an event.
@@ -242,7 +256,7 @@ pub struct Properties {
 /// which are indistinguishable to the compiler and so silently swappable at a
 /// call site. Naming them makes a mix-up a compile error instead of a wrong
 /// value arriving in a dashboard nobody cross-checks.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Facts {
     /// A bucketed magnitude, never an exact count.
     pub bucket: Option<&'static str>,
@@ -266,6 +280,8 @@ pub struct Facts {
     pub residual_band: Option<&'static str>,
     #[cfg(feature = "analytics")]
     pub resource_usage: Option<super::resources::schema::ResourceUsageSummary>,
+    /// Sanitized transcript record type names. See [`Properties::unrecognized_types`].
+    pub unrecognized_types: Option<Vec<String>>,
 }
 
 #[cfg(feature = "analytics")]
@@ -795,6 +811,7 @@ mod tests {
                 factor_band: Some("2_to_under_4"),
                 residual_band: Some("within_5"),
                 resource_usage: Some(resource_summary()),
+                unrecognized_types: Some(vec!["custom_event".to_string()]),
             },
             context: Context {
                 app_version: "antiburn:1.2.3".into(),
@@ -882,7 +899,7 @@ mod tests {
     /// `apps/desktop/src/views/settings/PrivacyPane.tsx` is the bug this
     /// comment exists to prevent.
     #[test]
-    fn the_wire_payload_is_exactly_these_twenty_seven_fields() {
+    fn the_wire_payload_is_exactly_these_twenty_eight_fields() {
         let json = serde_json::to_value(sample()).expect("serializes");
         let object = json.as_object().expect("an object");
         let mut keys: Vec<_> = object.keys().map(String::as_str).collect();
@@ -928,6 +945,7 @@ mod tests {
                 "residualBand",
                 "resourceUsage",
                 "responseShape",
+                "unrecognizedTypes",
                 "usageBand",
             ]
         );
@@ -983,6 +1001,7 @@ mod tests {
         event.properties.factor_band = None;
         event.properties.residual_band = None;
         event.properties.resource_usage = None;
+        event.properties.unrecognized_types = None;
         let json = serde_json::to_string(&event).expect("serializes");
         assert!(!json.contains("bucket"), "{json}");
         assert!(!json.contains("label"), "{json}");
@@ -992,6 +1011,27 @@ mod tests {
         assert!(!json.contains("factorBand"), "{json}");
         assert!(!json.contains("residualBand"), "{json}");
         assert!(!json.contains("resourceUsage"), "{json}");
+        assert!(!json.contains("unrecognizedTypes"), "{json}");
+    }
+
+    /// `unrecognizedTypes` appears as a JSON array only on the event it
+    /// belongs to. Every other event carries `None` for this field, so the
+    /// key is absent from its wire payload.
+    #[test]
+    fn unrecognized_types_appears_only_on_its_own_event() {
+        let mut carrying = sample();
+        carrying.event = EventName::UnrecognizedRecordsObserved.as_str().into();
+        carrying.properties.unrecognized_types = Some(vec!["custom_event".to_string()]);
+        let json = serde_json::to_value(&carrying).expect("serializes");
+        let types = json["properties"]["unrecognizedTypes"]
+            .as_array()
+            .expect("unrecognizedTypes is an array");
+        assert_eq!(types, &[serde_json::json!("custom_event")]);
+
+        let mut other = sample();
+        other.properties.unrecognized_types = None;
+        let json = serde_json::to_string(&other).expect("serializes");
+        assert!(!json.contains("unrecognizedTypes"), "{json}");
     }
 
     #[test]
@@ -1117,6 +1157,7 @@ mod tests {
             22 => "twenty-two",
             23 => "twenty-three",
             27 => "twenty-seven",
+            28 => "twenty-eight",
             other => panic!("no word for {other} fields; add one and update the documents"),
         };
 

--- a/apps/desktop/src-tauri/src/analytics/mod.rs
+++ b/apps/desktop/src-tauri/src/analytics/mod.rs
@@ -69,6 +69,7 @@ pub fn record(_app: &tauri::AppHandle, _name: event::EventName, facts: event::Fa
         facts.plan,
         facts.factor_band,
         facts.residual_band,
+        facts.unrecognized_types,
     );
 }
 
@@ -160,7 +161,7 @@ pub fn handle_settings_transition(
 #[cfg(feature = "analytics")]
 mod enabled {
 
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::time::{Duration, Instant};
 
     use antiburn_local::insights::UnrecognizedRecords;
@@ -295,6 +296,7 @@ mod enabled {
                 factor_band: facts.factor_band,
                 residual_band: facts.residual_band,
                 resource_usage: facts.resource_usage,
+                unrecognized_types: facts.unrecognized_types,
             },
             context: event::Context {
                 app_version: format!("antiburn:{}", app.package_info().version),
@@ -799,26 +801,76 @@ mod enabled {
             .take()
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// Maximum sanitized type names carried on one
+    /// `antiburn.unrecognized_records_observed` event.
+    const MAX_UNRECOGNIZED_TYPE_NAMES: usize = 16;
+
+    /// Maximum bytes allowed for one sanitized type name.
+    const MAX_UNRECOGNIZED_TYPE_NAME_BYTES: usize = 64;
+
+    /// Stands in for a type name antiburn will not carry verbatim. It makes
+    /// a rejection visible without leaking the value.
+    const REJECTED_TYPE_NAME: &str = "<rejected>";
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
     enum UnrecognizedOutcome {
         None,
         Observed {
             label: &'static str,
             bucket: &'static str,
+            types: Vec<String>,
         },
     }
 
     impl UnrecognizedOutcome {
         fn facts(self) -> Option<Facts> {
-            let Self::Observed { label, bucket } = self else {
+            let Self::Observed {
+                label,
+                bucket,
+                types,
+            } = self
+            else {
                 return None;
             };
             Some(Facts {
                 bucket: Some(bucket),
                 label: Some(label),
+                unrecognized_types: Some(types),
                 ..Facts::default()
             })
         }
+    }
+
+    /// Reduce a report's unknown record type names to the bounded, sanitized
+    /// list an event may carry.
+    ///
+    /// Keeps at most [`MAX_UNRECOGNIZED_TYPE_NAMES`] names. Each name must be
+    /// non-empty, ASCII, and at most [`MAX_UNRECOGNIZED_TYPE_NAME_BYTES`]
+    /// bytes long. Each name must use only letters, digits, `_`, `.`, `:`,
+    /// `/`, and `-`. A name that fails this check becomes the fixed sentinel
+    /// [`REJECTED_TYPE_NAME`]. This keeps a rejection visible without the
+    /// value itself. The sentinel appears at most once. The result is
+    /// sorted and has no duplicates.
+    fn sanitize_unrecognized_types(types: &BTreeSet<String>) -> Vec<String> {
+        let mut sanitized = BTreeSet::new();
+        for name in types.iter().take(MAX_UNRECOGNIZED_TYPE_NAMES) {
+            if is_safe_unrecognized_type_name(name) {
+                sanitized.insert(name.clone());
+            } else {
+                sanitized.insert(REJECTED_TYPE_NAME.to_string());
+            }
+        }
+        sanitized.into_iter().collect()
+    }
+
+    /// Whether a type name is safe to carry verbatim on an analytics event.
+    fn is_safe_unrecognized_type_name(name: &str) -> bool {
+        !name.is_empty()
+            && name.len() <= MAX_UNRECOGNIZED_TYPE_NAME_BYTES
+            && name.is_ascii()
+            && name.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b':' | b'/' | b'-')
+            })
     }
 
     /// Record a discovery pass, if it says anything the previous one did not.
@@ -893,7 +945,7 @@ mod enabled {
             return;
         }
         let outcome = unrecognized_records_outcome(summary);
-        if !unrecognized_outcome_is_new(outcome) {
+        if !unrecognized_outcome_is_new(outcome.clone()) {
             return;
         }
         let Some(facts) = outcome.facts() else {
@@ -916,14 +968,19 @@ mod enabled {
         UnrecognizedOutcome::Observed {
             label,
             bucket: event::bucket(summary.sessions_with_types),
+            types: sanitize_unrecognized_types(&summary.types),
         }
     }
 
+    /// Whether this outcome differs from the last one reported. Remembers
+    /// the new outcome when it does. A changed sanitized type list counts
+    /// as a change, the same as a changed label or bucket. A new unknown
+    /// record name is exactly what this event exists to surface.
     fn unrecognized_outcome_is_new(outcome: UnrecognizedOutcome) -> bool {
         let mut guard = LAST_UNRECOGNIZED
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if *guard == Some(outcome) {
+        if guard.as_ref() == Some(&outcome) {
             return false;
         }
         *guard = Some(outcome);
@@ -1306,11 +1363,22 @@ mod enabled {
             capped: u64,
             truncated: u64,
         ) -> UnrecognizedRecords {
+            unrecognized_summary_with_types(sessions, evidence_bearing, capped, truncated, &[])
+        }
+
+        fn unrecognized_summary_with_types(
+            sessions: u64,
+            evidence_bearing: u64,
+            capped: u64,
+            truncated: u64,
+            types: &[&str],
+        ) -> UnrecognizedRecords {
             UnrecognizedRecords {
                 sessions_with_types: sessions,
                 evidence_bearing_sessions: evidence_bearing,
                 capped_sessions: capped,
                 truncated_sessions: truncated,
+                types: types.iter().map(|name| name.to_string()).collect(),
                 ..UnrecognizedRecords::default()
             }
         }
@@ -1809,6 +1877,7 @@ mod enabled {
                 .unwrap();
             assert_eq!(inert.label, Some("inert_only"));
             assert_eq!(inert.bucket, Some("1-9"));
+            assert_eq!(inert.unrecognized_types, Some(Vec::new()));
 
             let capped = unrecognized_records_outcome(&unrecognized_summary(12, 0, 1, 0))
                 .facts()
@@ -1828,6 +1897,69 @@ mod enabled {
             );
         }
 
+        /// The event carries the sanitizer's own output: sorted,
+        /// deduplicated, and never the raw report order.
+        #[test]
+        fn the_outcome_carries_the_sanitized_sorted_type_names() {
+            let summary = unrecognized_summary_with_types(
+                7,
+                0,
+                0,
+                0,
+                &["zzz_custom", "aaa_custom", "aaa_custom"],
+            );
+            let facts = unrecognized_records_outcome(&summary).facts().unwrap();
+            assert_eq!(
+                facts.unrecognized_types,
+                Some(vec!["aaa_custom".to_string(), "zzz_custom".to_string()])
+            );
+        }
+
+        #[test]
+        fn a_normal_type_name_passes_the_sanitizer_unchanged() {
+            let types = sanitize_unrecognized_types(&BTreeSet::from(["custom_event".to_string()]));
+            assert_eq!(types, vec!["custom_event".to_string()]);
+        }
+
+        #[test]
+        fn an_unsafe_type_name_becomes_the_rejected_sentinel() {
+            let with_space =
+                sanitize_unrecognized_types(&BTreeSet::from(["has space".to_string()]));
+            assert_eq!(with_space, vec![REJECTED_TYPE_NAME.to_string()]);
+
+            let with_non_ascii = sanitize_unrecognized_types(&BTreeSet::from(["café".to_string()]));
+            assert_eq!(with_non_ascii, vec![REJECTED_TYPE_NAME.to_string()]);
+
+            let too_long = sanitize_unrecognized_types(&BTreeSet::from(["a".repeat(65)]));
+            assert_eq!(too_long, vec![REJECTED_TYPE_NAME.to_string()]);
+
+            let empty = sanitize_unrecognized_types(&BTreeSet::from([String::new()]));
+            assert_eq!(empty, vec![REJECTED_TYPE_NAME.to_string()]);
+        }
+
+        /// More than one rejected name still yields one sentinel. The
+        /// sentinel shows that a rejection happened. It does not show how
+        /// many names were rejected.
+        #[test]
+        fn multiple_rejected_names_collapse_to_one_sentinel() {
+            let types = sanitize_unrecognized_types(&BTreeSet::from([
+                "has space".to_string(),
+                "café".to_string(),
+                "custom_event".to_string(),
+            ]));
+            assert_eq!(
+                types,
+                vec![REJECTED_TYPE_NAME.to_string(), "custom_event".to_string()]
+            );
+        }
+
+        #[test]
+        fn the_sanitizer_keeps_at_most_sixteen_names() {
+            let many: BTreeSet<String> = (0..20).map(|index| format!("type_{index:02}")).collect();
+            let types = sanitize_unrecognized_types(&many);
+            assert_eq!(types.len(), MAX_UNRECOGNIZED_TYPE_NAMES);
+        }
+
         #[test]
         fn only_a_changed_unrecognized_outcome_is_worth_an_event() {
             let _lock = SUPPRESSION_TEST_LOCK.lock().unwrap();
@@ -1835,13 +1967,23 @@ mod enabled {
             let inert = UnrecognizedOutcome::Observed {
                 label: "inert_only",
                 bucket: "1-9",
+                types: Vec::new(),
             };
 
-            assert!(unrecognized_outcome_is_new(inert));
-            assert!(!unrecognized_outcome_is_new(inert));
+            assert!(unrecognized_outcome_is_new(inert.clone()));
+            assert!(!unrecognized_outcome_is_new(inert.clone()));
             assert!(unrecognized_outcome_is_new(UnrecognizedOutcome::None));
             assert!(!unrecognized_outcome_is_new(UnrecognizedOutcome::None));
-            assert!(unrecognized_outcome_is_new(inert));
+            assert!(unrecognized_outcome_is_new(inert.clone()));
+
+            // Same label and bucket, a new type name: still a new outcome.
+            let inert_new_type = UnrecognizedOutcome::Observed {
+                label: "inert_only",
+                bucket: "1-9",
+                types: vec!["custom_event".to_string()],
+            };
+            assert!(unrecognized_outcome_is_new(inert_new_type.clone()));
+            assert!(!unrecognized_outcome_is_new(inert_new_type));
             reset_suppression();
         }
 
@@ -1852,9 +1994,10 @@ mod enabled {
             let inert = UnrecognizedOutcome::Observed {
                 label: "inert_only",
                 bucket: "1-9",
+                types: Vec::new(),
             };
             assert!(scan_outcome_is_new(Some("1-9")));
-            assert!(unrecognized_outcome_is_new(inert));
+            assert!(unrecognized_outcome_is_new(inert.clone()));
             *LAST_CLAUDE_LIMIT_RESET.lock().unwrap() = Some(
                 crate::provider_usage::live::anthropic::empty_limit_reset_diagnostic(
                     "success", "null",

--- a/apps/desktop/src/views/SettingsView.test.tsx
+++ b/apps/desktop/src/views/SettingsView.test.tsx
@@ -802,7 +802,7 @@ describe("SettingsView", () => {
     // earlier version of this test sampled two of them, which is how five
     // fields went unnamed in the pane while the copy claimed to list them all.
     // `analytics::event::Event` is the other half of this pair, and its
-    // `the_wire_payload_is_exactly_these_twenty_seven_fields` pins the same number
+    // `the_wire_payload_is_exactly_these_twenty_eight_fields` pins the same number
     // from the Rust side.
     const enumeration = screen.getByRole("button", { name: "Exactly what is sent" })
     fireEvent.click(enumeration)
@@ -810,7 +810,7 @@ describe("SettingsView", () => {
     // `every_document_that_counts_the_fields_counts_the_same_number` greps
     // this pane for that phrase, so it has to survive edits to this section.
     expect(
-      screen.getByText(/schema has twenty-seven fields, and these are all of them/i),
+      screen.getByText(/schema has twenty-eight fields, and these are all of them/i),
     ).toBeInTheDocument()
     for (const field of [
       /the word .desktop./i,
@@ -829,6 +829,7 @@ describe("SettingsView", () => {
       /that factor.s dollars-per-percent value, reduced to a coarse band/i,
       /how far that factor.s estimate and the provider.s own meter disagree/i,
       /an hourly summary of antiburn’s own CPU, memory, process I\/O/i,
+      /up to 16 unknown transcript record type names, sanitized/i,
       /the app version/i,
       /your operating system/i,
     ]) {
@@ -843,7 +844,7 @@ describe("SettingsView", () => {
     // neighbouring paragraph: the body is a sibling of nothing predictable,
     // and the id is the component's actual contract.
     const body = document.getElementById(enumeration.getAttribute("aria-controls") ?? "")
-    expect(body?.querySelectorAll("li")).toHaveLength(27)
+    expect(body?.querySelectorAll("li")).toHaveLength(28)
     // The exclusions live in the same body as the list, so a reader checking
     // one against the other does not have to open a second row to find them.
     expect(

--- a/apps/desktop/src/views/settings/PrivacyPane.tsx
+++ b/apps/desktop/src/views/settings/PrivacyPane.tsx
@@ -244,7 +244,7 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                   the promise below stops being true.
 
                   The list lets a reader count every field. */}
-              <p>The schema has twenty-seven fields, and these are all of them:</p>
+              <p>The schema has twenty-eight fields, and these are all of them:</p>
               {/* `pl-7`, not the `pl-4` this started as. Root font-size here
                   is 13px, so `pl-4` is 13px of padding — less than the disc
                   marker's own 17.5px advance, which left the bullets painting
@@ -293,6 +293,11 @@ export function PrivacyPane({ settings, update, loaded, info }: PrivacyPaneProps
                   An hourly summary of antiburn&rsquo;s own CPU, memory, process I/O, local
                   database size, and database log size. Every value is a fixed range, with a
                   coverage state that distinguishes missing measurements from zero.
+                </li>
+                <li>
+                  Up to 16 unknown transcript record type names, sanitized before they leave
+                  this machine &mdash; a rejected name is replaced by a fixed placeholder rather
+                  than sent as typed.
                 </li>
                 <li>The app version.</li>
                 <li>Your operating system.</li>

--- a/docs/analytics-measurement.md
+++ b/docs/analytics-measurement.md
@@ -157,6 +157,18 @@ or `automatic`, inherited from its exposure. This optional wire field lets
 reports separate deliberate value from passive display without guessing from
 neighboring timestamps. It stays absent on unrelated events.
 
+`unrecognized_records_observed` also carries `properties.unrecognizedTypes`,
+from the next release after 0.5.0: up to 16 unknown transcript record type
+names, sanitized (ASCII, bounded length, a fixed character set, a shared
+`<rejected>` sentinel for anything that fails that check) rather than mapped
+to a reviewed closed vocabulary. This is the one field on the closed catalog
+that is not a reviewed enum value, because the product question it answers —
+which new record type names an agent has started writing — cannot be answered
+by a value chosen in advance. Change-only suppression now compares the
+sanitized type list alongside the label and bucket, so a newly observed name
+is a reportable change even when both stay the same. It stays absent on every
+other event, and on an event from an app version that predates it.
+
 Define the start classification from the explicit restart path and existing
 onboarding state, not from whether the analytics identifier has been seen.
 Analyze setup progress by distinct installation and ordered times; repeated

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -29,15 +29,17 @@ process-level opt-out.
 
 ## Exactly what the event schema can carry
 
-Twenty-seven fields, and this is the whole list. Fourteen are the established
+Twenty-eight fields, and this is the whole list. Fourteen are the established
 event envelope and general properties. The nine Claude reset fields are optional
 and appear only on `antiburn.claude_limit_reset_observed`. The three limit-factor
 fields are optional and appear only on `antiburn.limit_factor_observed`. One
-nested resource summary appears only on `antiburn.resource_usage_observed`. The
-payload is a closed Rust struct
+nested resource summary appears only on `antiburn.resource_usage_observed`. One
+sanitized list of record type names is optional and appears only on
+`antiburn.unrecognized_records_observed`. The payload is a closed Rust struct
 ([`analytics/event.rs`](../apps/desktop/src-tauri/src/analytics/event.rs))
-with no map and no free-form string, so there is nowhere for anything else to
-be put.
+with no map and almost no free-form string — see `properties.unrecognizedTypes`
+below for the one bounded, sanitized exception — so there is nowhere for
+anything else to be put.
 
 | Field                           | What it is                                                                                                                                                                                                                                                                      | Example                                 |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
@@ -66,6 +68,7 @@ be put.
 | `properties.factorBand`         | A learned limit factor's dollars-per-percent value, banded by powers of two: `under_1`, `1_to_under_2`, `2_to_under_4`, `4_to_under_8`, `8_to_under_16`, `16_to_under_32`, `32_to_under_64`, `64_to_under_128`, or `128_and_over`. Optional and present only on `antiburn.limit_factor_observed`. | `4_to_under_8`                          |
 | `properties.residualBand`       | How far the meter and the factor's own estimate for the current period disagree: `within_5`, `within_20`, `over_20`, or `unknown` (no residual yet). Optional and present only on `antiburn.limit_factor_observed`.                                                            | `within_5`                              |
 | `properties.resourceUsage`      | A closed hourly summary of antiburn's own process CPU, memory, read/write I/O, and logical database and WAL file sizes. Every measurement is a fixed band; coverage is `none`, `partial`, or `full`. The complete nested shape and bands are below.                             | `{ "cpuAverage": "under1_percent", … }` |
+| `properties.unrecognizedTypes`  | Up to 16 unknown transcript record type names, sanitized and sent verbatim: each is non-empty, ASCII, at most 64 bytes, and matches `[A-Za-z0-9_.:/-]`; a name that fails any of those checks is replaced by the fixed sentinel `<rejected>` (sent at most once, however many names failed). Sorted and deduplicated. Optional and present only on `antiburn.unrecognized_records_observed`. See the `inert_capped` paragraph below for the app-version boundary. | `["custom_tool_call", "<rejected>"]`    |
 | `context.appVersion`            | The application version.                                                                                                                                                                                                                                                        | `antiburn:0.1.0`                        |
 | `context.os`                    | Operating-system family.                                                                                                                                                                                                                                                        | `macos`                                 |
 
@@ -210,7 +213,7 @@ Event names are namespaced `antiburn.*`.
 | `antiburn.surface_state_observed`        | A `ready`, `empty`, `error`, or ten-second visible `loading_timeout` state is presented on a visible surface. Each distinct state is reported at most once per exposure; a later `ready` state can follow a timeout.                                                                                                                                                                                                                                                                                                                                                                                                         | `label` — the `surface_viewed` surface list plus `insights`. `detail` — `ready`, `empty`, `error`, or `loading_timeout`. `origin` — `user` or `automatic`.                                                                                                                                                                                                                                                   |
 | `antiburn.live_usage_state_observed`     | A provider state is presented on Activity, in a provider preview, or in a user-opened HUD. Automatic HUD restoration emits nothing.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `label` — `anthropic`, `openai`, or `google`. `detail` — `fresh`, `stale`, `authentication`, `rate_limited`, `unavailable`, or `no_credentials`. The last value is reserved but no current call site emits it.                                                                                                                                                                                               |
 | `antiburn.error_occurred`                | A full discovery pass fails, and the previous full pass had not already reported the same failure.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `label` — a category, currently `scan_failed`. No message, no path, no backtrace.                                                                                                                                                                                                                                                                                                                            |
-| `antiburn.unrecognized_records_observed` | Settings → Insights returns a cohort containing unknown record vocabulary, and its outcome differs from the last one reported during this run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `bucket` — sessions containing unknown types. `label` — `inert_only`, `inert_capped`, or `evidence_bearing`. No discriminator, payload, session identifier, or second dimension.                                                                                                                                                                                                                             |
+| `antiburn.unrecognized_records_observed` | Settings → Insights returns a cohort containing unknown record vocabulary, and its outcome differs from the last one reported during this run.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `bucket` — sessions containing unknown types. `label` — `inert_only`, `inert_capped`, or `evidence_bearing`. `unrecognizedTypes` — up to 16 sanitized record type names, from the next release after 0.5.0. No payload, session identifier, or second dimension.                                                                                                                                                                                                                             |
 | `antiburn.claude_limit_reset_observed`   | After an ordinary Claude usage refresh, when analytics and Claude live usage are both enabled and the observation differs from the last one queued during this run. The probe uses a separate five-minute cooldown.                                                                                                                                                                                                                                                                                                                                                                                                          | `label` — `success`, `authentication`, `rateLimited`, `unavailable`, `credential_absent`, `credential_expired`, or `credential_unavailable`. The nine reset fields listed above. No response body, credential, account identifier, exact usage percentage, or date.                                                                                                                                          |
 | `antiburn.usage_observed`                | An ordinary live-usage refresh — a background tick or a visible one — publishes a usage window for a provider that is online and not hidden. Reports the first observation for each `(provider, window role)` pair in a run, then only when that pair's band changes. A provider that fails this pass has no window to report and its last reported band is left alone. Reveals which providers are enabled, at worst a handful of times per install per day.                                                                                                                                                                | `label` — `anthropic`, `openai`, or `google`, the same vocabulary `live_usage_state_observed` uses. `detail` — `short` or `long`, the window's role. `usageBand` — `below_80`, `80_to_under_100`, `at_limit`, or `unknown`. A window without an authoritative figure still reports; the band is coarse enough to stay useful either way. No percentage, timestamp, window id, scope, account, or model name. |
 | `antiburn.limit_factor_observed` | A background factor-learning pass produces a learned dollars-per-percent factor for a `(provider, lane)` pair. Reports the first observation for each pair in this run, then only when its `(plan, factor band, residual band)` tuple changes, and never more than once every 24 hours for the same pair even across a genuine change. Reveals a coarse sense of plan mix and estimate accuracy per provider and lane, at worst a handful of times per install per day. | `label` — `anthropic`, `openai`, or `google`. `detail` — `short` or `long`, the lane. `plan` — the mapped plan vocabulary. `factorBand` — the log-spaced dollars-per-percent band. `residualBand` — how far the meter and the estimate disagree. No dollar amount, percentage, account, or timestamp. |
@@ -223,9 +226,10 @@ does not report the same failure after every full pass. What survives is the
 first full pass of each run, every crossing of a bucket boundary, and every move
 into or out of failure. Scoped watcher passes emit neither scan event and do not
 change this comparison. The unrecognized-record event likewise reports only a
-changed `(label, bucket)` outcome. A clean cohort updates that in-memory
-comparison without sending an event, so a later return to unknown vocabulary is
-visible.
+changed `(label, bucket, unrecognizedTypes)` outcome, so a newly observed type
+name is a reportable change even when the label and bucket stay the same. A
+clean cohort updates that in-memory comparison without sending an event, so a
+later return to unknown vocabulary is visible.
 
 Visible-use events start only after native visibility succeeds. A surface state
 is reported at most once per distinct state in one exposure, and hidden or stale
@@ -292,10 +296,19 @@ holds even across a genuine band change, so a factor bouncing between two
 adjacent bands cannot report more than once a day.
 
 The `inert_capped` label covers either too many distinct unknown types or one
-type name that exceeds the local string limit. The event never sends those
-names. They are runtime schema vocabulary, while analytics properties use a
-closed vocabulary reviewed in this file. New names remain visible in the local
-Insights coverage note and diagnostics only.
+type name that exceeds the local string limit. From the next release after
+0.5.0, `unrecognizedTypes` carries up to 16 of those names, sanitized rather
+than reviewed against a closed vocabulary: each must be non-empty, ASCII, at
+most 64 bytes, and drawn from `[A-Za-z0-9_.:/-]`, or it is replaced by the
+fixed sentinel `<rejected>` before it leaves this machine. This is a
+deliberate, narrow exception to the closed-vocabulary rule the rest of this
+file describes — the names are runtime schema vocabulary the local engine
+already reports in the Insights coverage note and diagnostics, not text a
+reader typed, so sending the sanitized name itself is how a maintainer learns
+which new record type an agent has started writing. Earlier app versions sent
+no names at all; an event from one of those versions has no
+`unrecognizedTypes` field, and its absence must not be read as "no unknown
+types were observed" — it means the version predates this field.
 
 This event is sampled only when a reader opens Settings → Insights. A request
 can also join a report reduction already in flight. Its buckets are therefore

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -23,7 +23,7 @@ which features are used, and coarse hourly ranges for the application's own
 resource use. This includes application launch and progress through the fixed
 onboarding steps.
 
-The event schema contains twenty-seven fields:
+The event schema contains twenty-eight fields:
 
 - the constant product surface `desktop`;
 - random message, installation, and analytics-session identifiers;
@@ -43,10 +43,13 @@ The event schema contains twenty-seven fields:
   provider's own plan string;
 - that factor's dollars-per-percent value, reduced to a coarse band;
 - how far the factor's estimate and the provider's own meter disagree,
-  reduced to a coarse band; and
+  reduced to a coarse band;
 - a nested hourly summary containing fixed bands for antiburn's own shell CPU,
   memory, process read and write I/O, local database size, and database log
-  size, plus `none`, `partial`, or `full` coverage for each measurement.
+  size, plus `none`, `partial`, or `full` coverage for each measurement; and
+- up to 16 sanitized unknown transcript record type names, each checked
+  against a fixed character set and length before it is sent, with a
+  rejected name replaced by a fixed placeholder rather than sent verbatim.
 
 Resource summaries can reveal coarse application work intensity and local data
 volume. They contain no work content, paths, credentials, renderer-process

--- a/docs/support.md
+++ b/docs/support.md
@@ -156,7 +156,7 @@ signed bundle and restarts antiburn. The app never depends on either connection.
   and require the next package to be installed manually.
 - **Anonymised product analytics** are the one thing antiburn reports to us.
   Official release builds start with it on, including during onboarding. The Ready
-  screen explains it, and the switch is in Settings → Privacy. The event schema has twenty-seven fields and
+  screen explains it, and the switch is in Settings → Privacy. The event schema has twenty-eight fields and
   no others: the constant `desktop`; a random per-message id used to discard
   duplicate deliveries; a random installation identifier replaced every 30 days;
   a random analytics-session identifier; the event name; the time it happened and the time it was delivered; the
@@ -172,7 +172,10 @@ signed bundle and restarts antiburn. The app never depends on either connection.
   reduced to a coarse band; how far that factor's estimate and the provider's
   own meter disagree, also reduced to a coarse band; a nested hourly summary of
   fixed bands and coverage for antiburn's own shell CPU, memory, process I/O,
-  database size, and database-log size; the app version; and the operating system. The payload has no
+  database size, and database-log size; up to 16 sanitized unknown transcript
+  record type names, each checked against a fixed character set and length,
+  with a rejected name replaced by a fixed placeholder instead of being sent;
+  the app version; and the operating system. The payload has no
   field able to carry anything else. The analytics-session identifier changes
   after 30 minutes without a captured analytics event, when the app restarts,
   or when the installation identifier rotates.


### PR DESCRIPTION
`antiburn.unrecognized_records_observed` carried only a label and a bucket, so we could see that unknown transcript record types existed but never which ones. This adds `properties.unrecognizedTypes`: up to 16 sorted, deduplicated type names, each checked against `[A-Za-z0-9_.:/-]` and a 64-byte limit before it leaves the machine. A name that fails is replaced by a single `<rejected>` sentinel. Change-only suppression now compares the sanitized list alongside label and bucket, so a newly seen name emits.

Docs, privacy policy, support page and the Privacy pane are updated for the twenty-eight-field schema and the app-version boundary (names appear from the release after 0.5.0; an absent field on an older version does not mean no names). The matching Metabase card is in TeamCadenceAI/cadence#1616.

## Event review contract
1. **Question / metric / decision:** which unrecognized record type names are agents newly writing, so a maintainer can decide whether to add parser support. Denominator: sessions in the unrecognized cohort (existing `bucket`).
2. **Trigger / boundary:** unchanged. Settings → Insights report reduction, at the existing `record_unrecognized_records` call site, gated on analytics being allowed and `sessions_with_types > 0`.
3. **Properties / shape / exclusions:** new optional `unrecognizedTypes` array, ≤16 entries, sanitized as above, `skip_serializing_if` none. Names are runtime schema vocabulary (record type discriminators), not reader-entered text; no user or work identifiers.
4. **Suppression / volume:** change-only keyed on `(label, bucket, types)`; sampled only when Insights is opened, as before.
5. **Disclosure / version boundary:** `docs/analytics.md`, `docs/privacy-policy.md`, `docs/support.md`, `docs/analytics-measurement.md`, `PrivacyPane.tsx` updated; boundary stated explicitly.
6. **Validation:** unit tests cover the sanitizer (accept, reject, sentinel collapse, cap at 16, sort and dedupe), the outcome-to-facts mapping, change detection on a changed type list, and wire serialization (array present only on this event, absent elsewhere). Frontend test updated for the new copy and count.

Local note: 42 `store::` tests fail on this machine with `missing field schemaRevision` on a clean main checkout too, so they are a local environment issue and not part of this change. CI on main is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmLvovHaLKWzZ541YLpSu8