### PR TITLE
Simplify session detail layout and restore development inspector access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ node_modules/
 # packages. The repository keeps only the root config.yml.
 **/.aislop/*
 !/.aislop/config.yml
+
+/worktrees

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -279,7 +279,7 @@ sizes:
   --space-xl: 20px
   --space-2xl: 24px # group separation in a settings-style pane
   # Local geometry that stays in its component. The wide Session Detail
-  # (`layout="wide"` in src/components/session/SessionDetailPresentation.tsx)
+  # (src/components/session/SessionDetailPresentation.tsx)
   # lets the context chart fill the tab, with a min-h-48 floor.
 rounded:
   small: 4px
@@ -552,8 +552,8 @@ tokens or the menu-bar list's default appearance to achieve it.
   There are no inherited size overrides. Content has 40px side padding.
   Cost composition closes the Context tab, below the plot and its key.
   The context plot fills available height with a 192px minimum. Both efficiency tracks
-  are 24px tall. Scale labels use the primary data size. The chart key uses three
-  equal columns. The composition legend stacks three rows beneath the bar, with
+  are 24px tall. Scale labels use the primary data size. The chart key fits as many 8rem columns as the pane allows,
+  then shares the remaining width evenly. Columns shrink below 8rem when necessary. The composition legend stacks three rows beneath the bar, with
   names on the left and percentages and ratings aligned on the right.
   Cost, Checks, and Efficiency stack vertically. Checks use two equal columns when
   the content reaches 40rem, and one column below that width. The top cost block pairs
@@ -561,6 +561,7 @@ tokens or the menu-bar list's default appearance to achieve it.
   the content width, while its table caps at 640px. A shared surface-card/50 background,
   rounded-popover corners, and 16px padding group the total and table. The table
   label column fits its text up to 12rem, with 12px gaps before the numeric columns.
+  The gap between the total and the component table is 48px.
   The table columns sit together at the card’s right edge. The whole cost card uses
   font-mono, including the total, captions, row labels, and figures.
   Checks show documentation as callout
@@ -576,4 +577,4 @@ tokens or the menu-bar list's default appearance to achieve it.
 
   Efficiency sits at the bottom of the Cost pane when content fits, and follows the
   checks in normal scroll order otherwise. The total appears once in the top cost
-  block; the popover retains its total row.
+  block.

--- a/apps/desktop/src-tauri/capabilities/main.json
+++ b/apps/desktop/src-tauri/capabilities/main.json
@@ -4,6 +4,7 @@
   "description": "Bounded permissions for the ordinary main window. Data and privileged work stay behind explicit shell commands.",
   "windows": ["main"],
   "permissions": [
+    "core:webview:allow-internal-toggle-devtools",
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "core:window:allow-start-dragging",

--- a/apps/desktop/src-tauri/src/fork_lineage/tests.rs
+++ b/apps/desktop/src-tauri/src/fork_lineage/tests.rs
@@ -105,7 +105,7 @@ fn publish_turns(store: &Store, session_id: &str, uuid: &str, row_count: u64) ->
         claim_fence: claim.claim_fence,
         status: PublishedEvidence::Ready,
         evidence_schema_revision: 1,
-        evidence_json: "{}".into(),
+        evidence_json: crate::store::test_support::evidence_json(&claim.key),
     };
     assert!(
         store

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -659,9 +659,10 @@ mod tests {
     }
 
     #[test]
-    fn main_window_capability_includes_titlebar_actions_without_broad_defaults() {
+    fn main_window_capability_includes_window_actions_without_broad_defaults() {
         let capability = include_str!("../capabilities/main.json");
         for expected in [
+            "\"core:webview:allow-internal-toggle-devtools\"",
             "\"core:event:allow-listen\"",
             "\"core:event:allow-unlisten\"",
             "\"core:window:allow-start-dragging\"",

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -33,6 +33,8 @@ mod privacy_tests;
 #[cfg(test)]
 mod publish_tests;
 #[cfg(test)]
+pub(crate) mod test_support;
+#[cfg(test)]
 mod tests;
 
 use std::collections::{BTreeSet, HashMap, HashSet};

--- a/apps/desktop/src-tauri/src/store/publish_tests.rs
+++ b/apps/desktop/src-tauri/src/store/publish_tests.rs
@@ -162,8 +162,11 @@ fn a_lost_race_from_a_zero_baseline_publishes_no_evidence_no_analysis_and_no_tur
     advance_source_generation_past(&store, &key);
     let evidence_before = store.evidence(&key).unwrap().unwrap();
     assert_eq!(evidence_before.evidence_json, None);
-    let completion =
-        evidence_completion(&claim, PublishedEvidence::Ready, "{\"lost\":true}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     let published = store
         .publish_projections(&record, None, &completion, &[], &[])
@@ -203,8 +206,11 @@ fn a_lost_race_leaves_relations_untouched() {
     let relations_before = store.relations(&key).unwrap();
 
     advance_source_generation_past(&store, &key);
-    let completion =
-        evidence_completion(&claim, PublishedEvidence::Ready, "{\"lost\":true}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     let losing_relations = [RelationRecord {
         kind: RelationKind::Subagent,
         related_id: "should-not-land".into(),
@@ -250,7 +256,11 @@ fn a_won_race_removes_turn_rows_from_every_superseded_fence_and_keeps_only_its_o
     writer
         .write_turn_rows(&[turn_row(0), turn_row(1), turn_row(2)])
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -298,7 +308,11 @@ fn published_turn_rows_returns_the_winning_pass_rows_in_order() {
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     let written = [turn_row(2), turn_row(0), turn_row(1)];
     writer.write_turn_rows(&written).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -328,7 +342,11 @@ fn published_turn_rows_serves_the_last_published_fence_while_a_newer_claim_is_in
     let key = record.key.clone();
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -414,7 +432,11 @@ fn published_fence_equals_claim_fence_for_every_terminal_status() {
         let key = record.key.clone();
         let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
         writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
-        let completion = evidence_completion(&claim, status, "{}".into());
+        let completion = evidence_completion(
+            &claim,
+            status,
+            crate::store::test_support::evidence_json(&claim.key),
+        );
         assert!(
             store
                 .publish_projections(&record, None, &completion, &[], &[])
@@ -445,7 +467,11 @@ fn a_second_publish_supersedes_the_first_in_published_turn_rows() {
     let key = record.key.clone();
     let first_writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     first_writer.write_turn_rows(&[turn_row(0)]).unwrap();
-    let first_completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let first_completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &first_completion, &[], &[])
@@ -470,7 +496,11 @@ fn a_second_publish_supersedes_the_first_in_published_turn_rows() {
     next_writer
         .write_turn_rows(&[turn_row(0), turn_row(1)])
         .unwrap();
-    let next_completion = evidence_completion(&next_claim, PublishedEvidence::Ready, "{}".into());
+    let next_completion = evidence_completion(
+        &next_claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&next_claim.key),
+    );
     assert!(
         store
             .publish_projections(&next_record, None, &next_completion, &[], &[])
@@ -494,7 +524,11 @@ fn publish_projections_stamps_published_fence_with_the_completion_claim_fence() 
     let key = record.key.clone();
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -515,8 +549,11 @@ fn a_lost_race_does_not_stamp_published_fence() {
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0)]).unwrap();
     advance_source_generation_past(&store, &key);
-    let completion =
-        evidence_completion(&claim, PublishedEvidence::Ready, "{\"lost\":true}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         !store
@@ -534,7 +571,11 @@ fn a_requeue_and_a_reclaim_leave_published_fence_intact() {
     let key = record.key.clone();
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -571,7 +612,11 @@ fn fail_evidence_leaves_published_fence_intact() {
     let key = record.key.clone();
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -614,7 +659,11 @@ fn published_turn_rows_serves_the_last_published_fence_after_a_requeue() {
     let key = record.key.clone();
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])

--- a/apps/desktop/src-tauri/src/store/test_support.rs
+++ b/apps/desktop/src-tauri/src/store/test_support.rs
@@ -1,0 +1,16 @@
+use antiburn_local::analysis::{
+    EvidenceSource, SessionEvidenceAccumulator, SourceCapabilities, SourceKind, TurnFacts,
+};
+
+use super::SessionKey;
+
+pub(crate) fn evidence_json(key: &SessionKey) -> String {
+    let evidence = SessionEvidenceAccumulator::new(EvidenceSource {
+        agent: key.agent.clone(),
+        session_id: key.session_id.clone(),
+        kind: SourceKind::Jsonl,
+        capabilities: SourceCapabilities::claude(),
+    })
+    .evidence(&TurnFacts::default());
+    serde_json::to_string(&evidence).expect("serialize test evidence")
+}

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -1808,7 +1808,11 @@ fn publish_projections_writes_the_generation_and_revision_columns() {
         metrics_schema_revision: 3,
         ..record
     };
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -1836,7 +1840,11 @@ fn publish_projections_round_trips_initial_context_json() {
         source_summaries_json: None,
         ..record
     };
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -1867,7 +1875,11 @@ fn publish_projections_round_trips_source_summaries_json() {
         ),
         ..record
     };
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -1892,7 +1904,11 @@ fn publish_projections_round_trips_provider_hints_json() {
         provider_hints_json: Some(r#"[{"provider":"anthropic","model":"claude-opus-4-6"}]"#.into()),
         ..record
     };
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -1915,7 +1931,11 @@ fn publish_projections_round_trips_provider_hints_json() {
 fn publish_projections_never_clears_a_known_start_time() {
     let store = store();
     let (record, claim) = claimed_projection(&store, "known-start", 100, 60);
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, Some(800), &completion, &[], &[])
@@ -1933,7 +1953,11 @@ fn publish_projections_never_clears_a_known_start_time() {
         analyzed_generation: claim.source_generation,
         ..record
     };
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -2828,7 +2852,11 @@ fn analysis_from_rows_serves_a_pass_published_unsupported() {
     let key = record.key.clone();
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Unsupported, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Unsupported,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -3384,7 +3412,7 @@ fn publishing_session_evidence_writes_both_projections_and_the_start_time() {
     let completion = evidence_completion(
         &claim,
         PublishedEvidence::Unsupported,
-        "{\"unsupported\":true}".into(),
+        crate::store::test_support::evidence_json(&claim.key),
     );
 
     assert!(
@@ -3427,7 +3455,11 @@ fn publishing_session_evidence_writes_both_projections_and_the_start_time() {
 fn published_session_evidence_and_analysis_describe_the_same_pass() {
     let store = store();
     let (record, claim) = claimed_projection(&store, "same-pass", 100, 60);
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -3470,7 +3502,11 @@ fn a_stale_generation_publishes_no_session_evidence_and_no_analysis() {
     let source_before = store.session_source_state(&record.key).unwrap().unwrap();
     let analysis_before = store.analysis(&record.key).unwrap().unwrap();
     let evidence_before = store.evidence(&record.key).unwrap().unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         !store
@@ -3506,7 +3542,11 @@ fn a_stale_fence_publishes_no_session_evidence_and_no_analysis() {
     let source_before = store.session_source_state(&record.key).unwrap().unwrap();
     let analysis_before = store.analysis(&record.key).unwrap().unwrap();
     let evidence_before = store.evidence(&record.key).unwrap().unwrap();
-    let completion = evidence_completion(&first_claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &first_claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&first_claim.key),
+    );
 
     assert!(
         !store
@@ -3539,7 +3579,7 @@ fn a_stale_claim_cannot_change_projections_or_relations() {
     let current_completion = evidence_completion(
         &current_claim,
         PublishedEvidence::Ready,
-        "{\"new\":true}".into(),
+        crate::store::test_support::evidence_json(&current_claim.key),
     );
     let current_relations = [RelationRecord {
         kind: RelationKind::Subagent,
@@ -3559,7 +3599,7 @@ fn a_stale_claim_cannot_change_projections_or_relations() {
     let stale_completion = evidence_completion(
         &first_claim,
         PublishedEvidence::Ready,
-        "{\"old\":true}".into(),
+        crate::store::test_support::evidence_json(&first_claim.key),
     );
     let stale_relations = [RelationRecord {
         kind: RelationKind::Subagent,
@@ -3609,7 +3649,11 @@ fn publication_replaces_subagent_relations_in_one_transaction() {
             }],
         )
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     let new_relations = [RelationRecord {
         kind: RelationKind::Subagent,
         related_id: "new-child".into(),

--- a/apps/desktop/src-tauri/src/store/tests/coverage_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/coverage_tests.rs
@@ -65,7 +65,11 @@ fn publishing_evidence_keeps_only_the_current_fence_coverage_record() {
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     let current = coverage_record("publish-current-fence-coverage");
     writer.write_coverage_record(&current).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -133,7 +137,11 @@ fn a_lost_publish_race_deletes_only_its_own_fences_coverage_record() {
             params![key.environment_key, key.agent, key.session_id],
         )
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         !store

--- a/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
@@ -35,7 +35,11 @@ fn a_winning_publish_writes_the_resume_snapshot_named_for_its_source() {
     let store = store();
     let (record, claim) = claimed_projection(&store, "resume-write", 100, 60);
     let key = record.key.clone();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     let sources = [SourcePublishOutcome {
         source_key: "resume-write".into(),
         mode: SourcePublishMode::Full,
@@ -70,7 +74,11 @@ fn a_source_with_no_resume_has_its_stored_snapshot_dropped() {
         )
         .unwrap();
     }
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     let sources = [SourcePublishOutcome {
         source_key: "resume-drop".into(),
         mode: SourcePublishMode::Full,
@@ -107,7 +115,11 @@ fn a_lost_publish_race_writes_no_resume_snapshot() {
             params![key.environment_key, key.agent, key.session_id],
         )
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     let sources = [SourcePublishOutcome {
         source_key: "resume-lost-race".into(),
         mode: SourcePublishMode::Full,
@@ -140,7 +152,11 @@ fn a_resumed_source_re_stamps_only_its_own_appended_rows() {
             turn_row_for("child-1", 0),
         ])
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -166,7 +182,11 @@ fn a_resumed_source_re_stamps_only_its_own_appended_rows() {
     next_writer
         .write_turn_rows(&[turn_row_for("resume-restamp", 1)])
         .unwrap();
-    let next_completion = evidence_completion(&next_claim, PublishedEvidence::Ready, "{}".into());
+    let next_completion = evidence_completion(
+        &next_claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&next_claim.key),
+    );
     let sources = [
         SourcePublishOutcome {
             source_key: "resume-restamp".into(),
@@ -225,7 +245,11 @@ fn a_full_read_source_replaces_only_its_own_published_rows() {
             turn_row_for("child-1", 0),
         ])
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -251,7 +275,11 @@ fn a_full_read_source_replaces_only_its_own_published_rows() {
     next_writer
         .write_turn_rows(&[turn_row_for("resume-full-replace", 0)])
         .unwrap();
-    let next_completion = evidence_completion(&next_claim, PublishedEvidence::Ready, "{}".into());
+    let next_completion = evidence_completion(
+        &next_claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&next_claim.key),
+    );
     let sources = [
         SourcePublishOutcome {
             source_key: "resume-full-replace".into(),
@@ -301,7 +329,11 @@ fn a_vanished_source_has_its_rows_and_resume_dropped_on_the_next_publish() {
     writer
         .write_turn_rows(&[turn_row_for("resume-vanish", 0), turn_row_for("child-1", 0)])
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     let sources = [
         SourcePublishOutcome {
             source_key: "resume-vanish".into(),
@@ -336,7 +368,11 @@ fn a_vanished_source_has_its_rows_and_resume_dropped_on_the_next_publish() {
     next_writer
         .write_turn_rows(&[turn_row_for("resume-vanish", 1)])
         .unwrap();
-    let next_completion = evidence_completion(&next_claim, PublishedEvidence::Ready, "{}".into());
+    let next_completion = evidence_completion(
+        &next_claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&next_claim.key),
+    );
     let next_sources = [SourcePublishOutcome {
         source_key: "resume-vanish".into(),
         mode: SourcePublishMode::Resumed,

--- a/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/turn_row_tests.rs
@@ -129,7 +129,11 @@ fn publish_turn_row_with_uuid(store: &Store, session_id: &str, uuid: &str) -> Se
     FencedTurnRowStore::new(store.clone(), record.key.clone(), claim.claim_fence)
         .write_turn_rows(&[row])
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
     assert!(
         store
             .publish_projections(&record, None, &completion, &[], &[])
@@ -257,7 +261,11 @@ fn publishing_evidence_keeps_only_the_current_fence_turn_rows() {
     }
     let writer = FencedTurnRowStore::new(store.clone(), key.clone(), claim.claim_fence);
     writer.write_turn_rows(&[turn_row(0), turn_row(1)]).unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         store
@@ -303,7 +311,11 @@ fn a_lost_publish_race_deletes_only_its_own_fences_turn_rows() {
             params![key.environment_key, key.agent, key.session_id],
         )
         .unwrap();
-    let completion = evidence_completion(&claim, PublishedEvidence::Ready, "{}".into());
+    let completion = evidence_completion(
+        &claim,
+        PublishedEvidence::Ready,
+        crate::store::test_support::evidence_json(&claim.key),
+    );
 
     assert!(
         !store

--- a/apps/desktop/src-tauri/src/webview_defaults.rs
+++ b/apps/desktop/src-tauri/src/webview_defaults.rs
@@ -10,8 +10,7 @@ use tauri_plugin_prevent_default::{
 };
 
 fn flags_for(debug: bool) -> Flags {
-    let app_flags = Flags::CONTEXT_MENU
-        | Flags::FIND
+    let app_flags = Flags::FIND
         | Flags::CARET_BROWSING
         | Flags::DOWNLOADS
         | Flags::SOURCE
@@ -21,7 +20,7 @@ fn flags_for(debug: bool) -> Flags {
     if debug {
         app_flags
     } else {
-        app_flags | Flags::DEV_TOOLS | Flags::RELOAD
+        app_flags | Flags::CONTEXT_MENU | Flags::DEV_TOOLS | Flags::RELOAD
     }
 }
 
@@ -104,10 +103,9 @@ mod tests {
     }
 
     #[test]
-    fn debug_keeps_reload_and_developer_tools_available() {
+    fn debug_keeps_context_menu_reload_and_developer_tools_available() {
         let flags = flags_for(true);
-        let expected = Flags::CONTEXT_MENU
-            | Flags::FIND
+        let expected = Flags::FIND
             | Flags::CARET_BROWSING
             | Flags::DOWNLOADS
             | Flags::SOURCE
@@ -115,7 +113,7 @@ mod tests {
             | Flags::PRINT;
 
         assert_eq!(flags, expected);
-        assert!(flags.contains(Flags::CONTEXT_MENU));
+        assert!(!flags.contains(Flags::CONTEXT_MENU));
         assert!(!flags.contains(Flags::DEV_TOOLS));
         assert!(!flags.contains(Flags::RELOAD));
         assert!(!flags.contains(Flags::FOCUS_MOVE));

--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -195,25 +195,25 @@ describe("SessionDetailPresentation — chrome", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: /^Cost/ }))
 
-    // Every check shows with its own verdict mark. No rollup count restates
-    // the list. Each row carries an info button that holds its explainer, so
-    // nothing changes elsewhere on the tab when the pointer moves.
+    // Each assessed check shows its verdict and opens its explanation on focus.
     const hygiene = screen.getByLabelText("Session hygiene checks")
     expect(hygiene.children).toHaveLength(5)
     expect(screen.queryByRole("button", { name: "4/5 passed" })).toBeNull()
-    fireEvent.focus(screen.getByRole("button", { name: "Overpowered subagents details" }))
+    fireEvent.focus(screen.getByRole("group", { name: "Overpowered subagents" }))
     expect(screen.queryByText(/Past about 200k tokens/)).toBeNull()
-    expect(screen.getByRole("button", { name: "About Overpowered subagents" })).toBeTruthy()
-    // The row button is an invisible layer, so the verdict is read from the row.
-    expect(
-      screen.getByRole("button", { name: "Overpowered subagents details" }).parentElement,
-    ).toHaveTextContent("Failed")
+    expect(screen.getByRole("group", { name: "Overpowered subagents" })).toHaveAttribute(
+      "tabindex",
+      "0",
+    )
+    expect(screen.getByRole("group", { name: "Overpowered subagents" })).toHaveTextContent(
+      "Failed",
+    )
 
     // A check nobody could assess leaves the list rather than claiming a verdict.
-    expect(screen.queryByRole("button", { name: "Session overdepth details" })).toBeNull()
-    expect(
-      screen.getByRole("button", { name: "Model overthinking details" }).parentElement,
-    ).toHaveTextContent("Passed")
+    expect(screen.queryByRole("group", { name: "Session overdepth" })).toBeNull()
+    expect(screen.getByRole("group", { name: "Model overthinking" })).toHaveTextContent(
+      "Passed",
+    )
   })
 
   it("keeps the Cost tab free of evidence-state chrome", () => {
@@ -278,9 +278,9 @@ describe("SessionDetailPresentation — chrome", () => {
     // The composition sits under the chart it explains. The $/MTok scale
     // lives with the cost rows.
     expect(screen.getByText("Real Work %")).toBeTruthy()
-    expect(screen.queryByText("$/MTok")).toBeNull()
+    expect(screen.queryByText("$/MTOK")).toBeNull()
     fireEvent.click(screen.getByRole("tab", { name: /^Cost/ }))
-    expect(screen.getByText("$/MTok")).toBeTruthy()
+    expect(screen.getByText("$/MTOK")).toBeTruthy()
     expect(screen.queryByText("Real Work %")).toBeNull()
     expect(screen.getByText("Efficiency")).toBeTruthy()
     expect(
@@ -291,10 +291,10 @@ describe("SessionDetailPresentation — chrome", () => {
   it("omits the efficiency readings when the session is unpriced", () => {
     view({ cost: null, efficiency: null })
     fireEvent.click(screen.getByRole("tab", { name: /^Cost/ }))
-    expect(screen.queryByText("$/MTok")).toBeNull()
+    expect(screen.queryByText("$/MTOK")).toBeNull()
   })
 
-  it("shows the session title on no more than two lines", () => {
+  it("keeps the session title on one line", () => {
     view({
       session: {
         agent: "claude-code",
@@ -306,9 +306,9 @@ describe("SessionDetailPresentation — chrome", () => {
     const title = screen.getByText(
       "A session title that can continue across more than one line",
     )
-    expect(title.className).toContain("truncated-text-lines")
+    expect(title.className).toContain("truncate")
     expect(title.className).toContain("break-words")
-    expect(title.style.getPropertyValue("--truncated-text-lines")).toBe("2")
+    expect(title.style.getPropertyValue("--truncated-text-lines")).toBe("")
   })
 
   it("arranges the session facts in the hero and each figure at the head of its tab", () => {
@@ -338,28 +338,26 @@ describe("SessionDetailPresentation — chrome", () => {
     fireEvent.click(screen.getByRole("tab", { name: /^Cost/ }))
     expect(screen.getByRole("tabpanel")).toHaveTextContent("Estimated cost")
     expect(screen.queryByRole("button", { name: "6/6 passed" })).toBeNull()
-    expect(screen.getByRole("button", { name: "Session overdepth details" })).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Model overthinking details" })).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Overpowered subagents details" })).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Obsolete model details" })).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Fast mode overuse details" })).toBeTruthy()
-    expect(
-      screen.getByRole("button", { name: "Excess cache rehydration details" }),
-    ).toBeTruthy()
+    expect(screen.getByRole("group", { name: "Session overdepth" })).toBeTruthy()
+    expect(screen.getByRole("group", { name: "Model overthinking" })).toBeTruthy()
+    expect(screen.getByRole("group", { name: "Overpowered subagents" })).toBeTruthy()
+    expect(screen.getByRole("group", { name: "Obsolete model" })).toBeTruthy()
+    expect(screen.getByRole("group", { name: "Fast mode overuse" })).toBeTruthy()
+    expect(screen.getByRole("group", { name: "Excess cache rehydration" })).toBeTruthy()
   })
 
   it("names the back control for what it does, not for the view it leaves", () => {
     view()
     // The heading and the back control are separate elements.
     // The screen reader announces the view and the control correctly.
-    expect(screen.getByRole("heading", { name: "Session Detail" })).toBeTruthy()
+    expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
     expect(screen.getByRole("button", { name: "Back" })).toBeTruthy()
   })
 
   it("shows a header spinner while a newer analysis is on its way", () => {
     view({ refreshing: true })
     expect(screen.getByRole("status")).toHaveTextContent("Refreshing session analysis")
-    expect(screen.getByRole("heading", { name: "Session Detail" })).toBeTruthy()
+    expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
   })
 
   it("navigates back through the callback", () => {
@@ -588,7 +586,7 @@ describe("SessionDetailPresentation — session facts", () => {
         },
       },
     })
-    expect(screen.getByText("Sub-agent")).toBeTruthy()
+    expect(screen.getByText("Autonomous sub-agent")).toBeTruthy()
     fireEvent.click(screen.getByText("Autonomous sub-agent"))
     fireEvent.click(screen.getByText("Ship the release"))
     expect(onOpenOrchestrator).toHaveBeenCalledOnce()
@@ -682,7 +680,7 @@ describe("SessionDetailPresentation — session facts", () => {
   })
 })
 
-describe("SessionDetailPresentation — wide layout", () => {
+describe("SessionDetailPresentation — presentation", () => {
   const efficiency = {
     totalUsd: 10,
     newWorkUsd: 3.4,
@@ -694,8 +692,8 @@ describe("SessionDetailPresentation — wide layout", () => {
     unpricedTurns: 0,
   }
 
-  function wideView(over: Partial<SessionDetailPresentationProps> = {}) {
-    const props = presentationProps({ layout: "wide", cost: cost(), efficiency, ...over })
+  function detailView(over: Partial<SessionDetailPresentationProps> = {}) {
+    const props = presentationProps({ cost: cost(), efficiency, ...over })
     delete props.onBack
     return render(<SessionDetailPresentation {...props} />)
   }
@@ -703,7 +701,7 @@ describe("SessionDetailPresentation — wide layout", () => {
   it("keeps the summary and host actions in the toolbar and floats the section picker over the content", () => {
     const onDeleteSession = vi.fn()
     const onRevealSource = vi.fn()
-    const { container } = wideView({ onDeleteSession, onRevealSource, refreshing: true })
+    const { container } = detailView({ onDeleteSession, onRevealSource, refreshing: true })
 
     expect(screen.queryByRole("button", { name: "Back" })).toBeNull()
     expect(screen.queryByText("Session Detail")).toBeNull()
@@ -737,7 +735,7 @@ describe("SessionDetailPresentation — wide layout", () => {
   ])("keeps the toolbar usable without analysis: %j", (state) => {
     const onBack = vi.fn()
     const onDeleteSession = vi.fn()
-    view({ layout: "wide", embedded: true, summary: null, onBack, onDeleteSession, ...state })
+    view({ embedded: true, summary: null, onBack, onDeleteSession, ...state })
     expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
     expect(screen.queryByRole("tablist")).toBeNull()
     fireEvent.click(screen.getByRole("button", { name: "Back" }))
@@ -747,7 +745,7 @@ describe("SessionDetailPresentation — wide layout", () => {
   })
 
   it("separates the toolbar and gives the tab bar its content width", () => {
-    const { container } = wideView()
+    const { container } = detailView()
     expect(container.querySelector(".session-detail-toolbar")).toHaveClass("border-separator")
     expect(screen.getByRole("tablist", { name: "Session detail sections" })).toHaveClass(
       "inline-grid",
@@ -755,28 +753,25 @@ describe("SessionDetailPresentation — wide layout", () => {
   })
 
   it("places composition below the growing chart and its key", () => {
-    const { container } = wideView()
+    const { container } = detailView()
     const key = screen.getByTestId("chart-key")
-    expect(key.dataset.layout).toBe("wide")
     expect(
       Array.from(screen.getByRole("tabpanel").querySelectorAll("h3")).map(
         (heading) => heading.textContent,
       ),
     ).toEqual(["Context over time", "Cost composition"])
     expect(key).toHaveClass("grid")
-    expect(key).toHaveClass("grid-cols-3")
     expect(container.querySelector(".min-h-48")).toHaveClass("flex-1")
     expect(screen.getByTestId("efficiency-composition").dataset.height).toBe("bar")
     expect(screen.getByTestId("composition-legend")).toHaveClass("flex-col")
   })
 
   it("keeps the Cost tab's sections apart with spacing, not rules", () => {
-    const { container } = wideView()
+    const { container } = detailView()
     fireEvent.click(screen.getByRole("tab", { name: /^Cost/ }))
     expect(screen.getByRole("heading", { name: "Checks" })).toHaveClass("sr-only")
     expect(screen.getByText("Efficiency")).toBeTruthy()
-    // The cost table keeps the rule over its total row. The sections that
-    // hold the table, the checks, and the scale draw none of their own.
+    // Spacing separates the cost, checks, and efficiency sections.
     const sections = Array.from(container.querySelectorAll("section"))
     expect(sections).toHaveLength(3)
     expect(sections.map((section) => section.querySelector("h3")?.textContent)).toEqual([
@@ -788,7 +783,7 @@ describe("SessionDetailPresentation — wide layout", () => {
   })
 
   it("lays the Tools tab out in two columns", () => {
-    wideView({
+    detailView({
       summary: summary({
         sessions: [
           metrics({
@@ -814,14 +809,6 @@ describe("SessionDetailPresentation — wide layout", () => {
     })
     fireEvent.click(screen.getByRole("tab", { name: /^Tools/ }))
     expect(screen.getByTestId("skills-mcp-list").dataset.columns).toBe("2")
-  })
-
-  it("leaves the popover layout as it was", () => {
-    const { container } = view({ cost: cost(), efficiency })
-    expect(screen.getByRole("button", { name: "Back" })).toBeTruthy()
-    expect(screen.getByTestId("chart-key").dataset.layout).toBe("popover")
-    expect(screen.getByRole("tablist", { name: "Session detail sections" })).toHaveClass("grid")
-    expect(container.querySelectorAll(".border-separator").length).toBeGreaterThan(0)
   })
 })
 
@@ -865,75 +852,64 @@ describe("SessionDetailPresentation — host actions", () => {
   })
 })
 
-describe.each(["popover", "wide"] as const)(
-  "SessionDetailPresentation — embedded pane (%s)",
-  (layout) => {
-    it("omits popover chrome and Back while retaining session content", () => {
-      const { container } = view({ layout, embedded: true, onBack: undefined })
-      expect(screen.queryByRole("button", { name: "Back" })).toBeNull()
-      expect(container.firstElementChild).not.toHaveClass("rounded-popover")
-      expect(screen.queryByText("Session Detail")).toBeNull()
-      expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
-    })
+describe("SessionDetailPresentation — embedded pane", () => {
+  it("omits popover chrome and Back while retaining session content", () => {
+    const { container } = view({ embedded: true, onBack: undefined })
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull()
+    expect(container.firstElementChild).not.toHaveClass("rounded-popover")
+    expect(screen.queryByText("Session Detail")).toBeNull()
+    expect(screen.getByRole("heading", { name: "Fix the flaky test" })).toBeTruthy()
+  })
 
-    it("limits adjacent navigation to the active detail pane", () => {
-      const onNext = vi.fn()
-      const props = presentationProps({ layout, embedded: true, onNext })
-      const { container, rerender } = render(<SessionDetailPresentation {...props} />)
-      fireEvent.keyDown(window, { key: "ArrowRight" })
-      expect(onNext).not.toHaveBeenCalled()
-      fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
-      expect(onNext).toHaveBeenCalledOnce()
-      rerender(<SessionDetailPresentation {...props} active={false} />)
-      fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
-      expect(onNext).toHaveBeenCalledOnce()
-    })
-  },
-)
+  it("limits adjacent navigation to the active detail pane", () => {
+    const onNext = vi.fn()
+    const props = presentationProps({ embedded: true, onNext })
+    const { container, rerender } = render(<SessionDetailPresentation {...props} />)
+    fireEvent.keyDown(window, { key: "ArrowRight" })
+    expect(onNext).not.toHaveBeenCalled()
+    fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
+    expect(onNext).toHaveBeenCalledOnce()
+    rerender(<SessionDetailPresentation {...props} active={false} />)
+    fireEvent.keyDown(container.firstElementChild!, { key: "ArrowRight" })
+    expect(onNext).toHaveBeenCalledOnce()
+  })
+})
 
-describe.each(["popover", "wide"] as const)(
-  "SessionDetailPresentation — deferred keyboard entry (%s)",
-  (layout) => {
-    it("accepts focus when a lazy detail replaces the focused loading pane", () => {
-      const { container, rerender } = render(<section data-detail-pane tabIndex={-1} />)
-      const pane = container.firstElementChild as HTMLElement
-      pane.focus()
-      rerender(
-        <section data-detail-pane tabIndex={-1}>
-          <SessionDetailPresentation {...presentationProps({ layout, embedded: true })} />
-        </section>,
+describe("SessionDetailPresentation — deferred keyboard entry", () => {
+  it("accepts focus when a lazy detail replaces the focused loading pane", () => {
+    const { container, rerender } = render(<section data-detail-pane tabIndex={-1} />)
+    const pane = container.firstElementChild as HTMLElement
+    pane.focus()
+    rerender(
+      <section data-detail-pane tabIndex={-1}>
+        <SessionDetailPresentation {...presentationProps({ embedded: true })} />
+      </section>,
+    )
+    expect(container.querySelector("[data-detail-focus-target]")).toHaveFocus()
+  })
+})
+
+describe("SessionDetailPresentation — native drag toolbar", () => {
+  it("only enables the embedded macOS toolbar, leaving controls interactive", () => {
+    const agent = vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue("Macintosh")
+    try {
+      const props = presentationProps({})
+      const { container, rerender, unmount } = render(<SessionDetailPresentation {...props} />)
+      expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
+      rerender(<SessionDetailPresentation {...props} embedded />)
+      const toolbar = screen
+        .getByRole("heading", { name: "Fix the flaky test" })
+        .closest("[data-tauri-drag-region]")
+      expect(toolbar).toHaveAttribute("data-tauri-drag-region", "deep")
+      expect(screen.getByRole("button", { name: "Delete this session" })).not.toHaveAttribute(
+        "data-tauri-drag-region",
       )
-      expect(container.querySelector("[data-detail-focus-target]")).toHaveFocus()
-    })
-  },
-)
-
-describe.each(["popover", "wide"] as const)(
-  "SessionDetailPresentation — native drag toolbar (%s)",
-  (layout) => {
-    it("only enables the embedded macOS toolbar, leaving controls interactive", () => {
-      const agent = vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue("Macintosh")
-      try {
-        const props = presentationProps({ layout })
-        const { container, rerender, unmount } = render(
-          <SessionDetailPresentation {...props} />,
-        )
-        expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
-        rerender(<SessionDetailPresentation {...props} embedded />)
-        const toolbar = screen
-          .getByRole("heading", { name: "Fix the flaky test" })
-          .closest("[data-tauri-drag-region]")
-        expect(toolbar).toHaveAttribute("data-tauri-drag-region", "deep")
-        expect(screen.getByRole("button", { name: "Delete this session" })).not.toHaveAttribute(
-          "data-tauri-drag-region",
-        )
-        unmount()
-        agent.mockReturnValue("Windows NT")
-        const windows = render(<SessionDetailPresentation {...props} embedded />)
-        expect(windows.container.querySelector("[data-tauri-drag-region]")).toBeNull()
-      } finally {
-        agent.mockRestore()
-      }
-    })
-  },
-)
+      unmount()
+      agent.mockReturnValue("Windows NT")
+      const windows = render(<SessionDetailPresentation {...props} embedded />)
+      expect(windows.container.querySelector("[data-tauri-drag-region]")).toBeNull()
+    } finally {
+      agent.mockRestore()
+    }
+  })
+})

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -88,9 +88,6 @@ interface SessionDetailSubject {
   }
 }
 
-/** The wide layout adapts to the main window detail pane. */
-export type SessionDetailLayout = "popover" | "wide"
-
 export interface SessionDetailPresentationProps {
   /** The analysis to render; null while loading or after a failure. */
   summary: ActiveSessionsSummary | null
@@ -128,8 +125,6 @@ export interface SessionDetailPresentationProps {
   modelRuns: PresentableModelRun[]
   /** Direct fork relations resolved from local transcripts. */
   relations: LocalSessionRelations | null
-  /** The wide layout uses a toolbar and larger content margins. The popover owns its back control. */
-  layout?: SessionDetailLayout
   /** Return to the previous session when navigation history exists. */
   onBack?: (() => void) | undefined
   /** Navigate to the newer adjacent session; omit when none exists. */
@@ -254,7 +249,7 @@ function RelationControl({
   )
 }
 
-/** The host actions sit in the title row or the wide toolbar. */
+/** The toolbar holds the host actions. */
 function HostActions({
   relations,
   refreshing = false,
@@ -323,16 +318,8 @@ const DETAIL_TABS: ReadonlyArray<{ value: SessionDetailTab; label: string }> = [
 ]
 
 /** The name of one block inside a tab that holds more than one block. */
-function TabSectionHeading({ children, wide = false }: { children: string; wide?: boolean }) {
-  return (
-    <h3
-      className={
-        wide ? "sr-only" : "mb-2 type-caption font-medium! text-label-tertiary uppercase"
-      }
-    >
-      {children}
-    </h3>
-  )
+function TabSectionHeading({ children }: { children: string }) {
+  return <h3 className="sr-only">{children}</h3>
 }
 
 /**
@@ -358,8 +345,7 @@ const KEY_CAPTIONS: Record<string, string> = {
  *
  * Each figure is a stat cell: a swatch in the color its chart layer takes
  * when it lights, the value in the label ink, and a caption under them.
- * In the popover the cells sit in a grid of three equal columns, so the key
- * reads as one table. The wide layout keeps three columns with more padding.
+ * The cells wrap into columns that share the available width.
  * The swatch carries the color. The text keeps its contrast on both surfaces.
  *
  * Pointing at a cell lights its layer in the plot above, and the cell takes
@@ -373,14 +359,12 @@ function ChartKey({
   pinned,
   onHighlight,
   onPin,
-  layout,
 }: {
   stats: ReadonlyArray<{
     label: string
     value: string
     series?: ChartSeries
   }>
-  layout: SessionDetailLayout
   /** The layer held lit by a click, or null. */
   pinned: ChartSeries | null
   /** Names the layer under the pointer, or null when the pointer leaves. */
@@ -389,54 +373,39 @@ function ChartKey({
   onPin: (series: ChartSeries) => void
 }) {
   return (
-    <div
-      data-testid="chart-key"
-      data-layout={layout}
-      className={cn(
-        "-mx-1.5",
-        layout === "wide"
-          ? "session-detail-key grid grid-cols-3 gap-3"
-          : "grid grid-cols-3 gap-x-1 gap-y-1",
-      )}
-    >
+    <div data-testid="chart-key" className="session-detail-key grid">
       {stats.map((stat) => {
         const series = stat.series ?? null
         const isPinned = series != null && series === pinned
         return (
-          <Tooltip key={stat.label} label={stat.label}>
-            <button
-              type="button"
-              aria-pressed={series != null ? isPinned : undefined}
-              disabled={series == null}
-              data-series={series ?? undefined}
-              className={cn(
-                "chart-key-stat flex min-w-0 flex-col items-start rounded-control px-1.5 py-1 text-left disabled:opacity-100",
-                isPinned && "bg-surface-secondary",
-              )}
-              onMouseEnter={() => onHighlight(series)}
-              onMouseLeave={() => onHighlight(null)}
-              onClick={() => series != null && onPin(series)}
-            >
-              <span className="flex items-center gap-x-1.5 type-body font-medium text-label tabular-nums">
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    "size-2 shrink-0 rounded-full",
-                    series != null ? SERIES_SWATCH_CLASS[series] : "bg-surface-tertiary",
-                  )}
-                />
-                {stat.value}
-              </span>
+          <button
+            key={stat.label}
+            type="button"
+            aria-pressed={series != null ? isPinned : undefined}
+            disabled={series == null}
+            data-series={series ?? undefined}
+            className={cn(
+              "chart-key-stat flex min-w-0 flex-col items-start rounded-control text-left disabled:opacity-100",
+              isPinned && "bg-surface-secondary",
+            )}
+            onMouseEnter={() => onHighlight(series)}
+            onMouseLeave={() => onHighlight(null)}
+            onClick={() => series != null && onPin(series)}
+          >
+            <span className="flex items-center gap-x-1.5 type-body font-medium text-label tabular-nums">
               <span
+                aria-hidden="true"
                 className={cn(
-                  "max-w-full truncate text-label-secondary",
-                  layout === "wide" ? "type-callout" : "type-caption",
+                  "size-2 shrink-0 rounded-full",
+                  series != null ? SERIES_SWATCH_CLASS[series] : "bg-surface-tertiary",
                 )}
-              >
-                {KEY_CAPTIONS[stat.label] ?? stat.label}
-              </span>
-            </button>
-          </Tooltip>
+              />
+              {stat.value}
+            </span>
+            <span className="max-w-full truncate text-label-secondary type-callout">
+              {KEY_CAPTIONS[stat.label] ?? stat.label}
+            </span>
+          </button>
         )
       })}
     </div>
@@ -597,7 +566,6 @@ export function SessionDetailPresentation({
   subagentCount,
   modelRuns,
   relations,
-  layout = "popover",
   onBack,
   onPrev,
   onNext,
@@ -611,7 +579,6 @@ export function SessionDetailPresentation({
   active = true,
 }: SessionDetailPresentationProps) {
   const subagent = session.subagent
-  const wide = layout === "wide"
   const [tab, setTab] = useState<SessionDetailTab>("overview")
   // Which chart layer the key points at. The pointer sets it and the pointer
   // clears it; a click pins a layer, which holds when the pointer leaves.
@@ -714,24 +681,17 @@ export function SessionDetailPresentation({
   const hostActions = (
     <HostActions
       relations={relations}
-      refreshing={wide && refreshing}
+      refreshing={refreshing}
       onOpenRelatedSession={onOpenRelatedSession}
       onRevealSource={onRevealSource}
       onDeleteSession={onDeleteSession}
-      {...(wide
-        ? {
-            className: "session-detail-actions rounded-full bg-surface-card p-1",
-          }
-        : {})}
+      className="session-detail-actions rounded-full bg-surface-card p-1"
     />
   )
 
   const sessionSummary = (
     <div
-      className={cn(
-        "flex min-w-0 flex-col gap-y-0.5",
-        wide ? "session-detail-summary flex-1 basis-48 type-body" : "px-4 pt-3 pb-3",
-      )}
+      className="flex min-w-0 flex-col gap-y-0.5 session-detail-summary flex-1 basis-48 type-body"
       aria-label="Session summary"
     >
       {(session.repo || session.wslDistro) && (
@@ -745,25 +705,17 @@ export function SessionDetailPresentation({
         </div>
       )}
 
-      {wide ? (
-        <h2
-          data-view-heading
-          tabIndex={-1}
-          className="flex min-w-0 items-start gap-x-3 type-headline outline-none"
-        >
-          <TruncatedText
-            className="min-w-0 flex-1 font-semibold text-label break-words"
-            text={heroTitle}
-            lines={1}
-          />
-        </h2>
-      ) : (
+      <h2
+        data-view-heading
+        tabIndex={-1}
+        className="flex min-w-0 items-start gap-x-3 type-headline outline-none"
+      >
         <TruncatedText
-          className="min-w-0 type-body-large font-semibold text-label break-words"
+          className="min-w-0 flex-1 font-semibold text-label break-words"
           text={heroTitle}
-          lines={2}
+          lines={1}
         />
-      )}
+      </h2>
 
       {summary && (
         <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 type-caption text-label-secondary">
@@ -800,28 +752,17 @@ export function SessionDetailPresentation({
   )
 
   const compositionSection = efficiencyCard && (
-    <div className={cn(!wide && "border-t border-separator pt-3")}>
-      {wide && <TabSectionHeading wide={wide}>Cost composition</TabSectionHeading>}
-      <EfficiencyBreakdown metrics={efficiencyCard} section="composition" layout={layout} />
+    <div>
+      <TabSectionHeading>Cost composition</TabSectionHeading>
+      <EfficiencyBreakdown metrics={efficiencyCard} section="composition" />
     </div>
   )
 
   const costSection = (
-    <section
-      className={cn(
-        wide && "shrink-0",
-        hasAssessedHygieneChecks && !wide && "mt-4 border-t border-separator pt-4",
-        efficiencyCard && !wide && "pb-4",
-      )}
-    >
-      <TabSectionHeading wide={wide}>Cost</TabSectionHeading>
+    <section className="shrink-0">
+      <TabSectionHeading>Cost</TabSectionHeading>
       {cost && tokensCard ? (
-        <CostBreakdown
-          layout={layout}
-          cost={cost}
-          split={tokensCard.split}
-          onOpenSubagent={onOpenSubagent}
-        />
+        <CostBreakdown cost={cost} split={tokensCard.split} onOpenSubagent={onOpenSubagent} />
       ) : (
         <p className="type-callout text-label-tertiary">
           No cost has been recorded for this session.
@@ -831,9 +772,9 @@ export function SessionDetailPresentation({
   )
 
   const efficiencySection = efficiencyCard && (
-    <section className={cn("mt-auto shrink-0", !wide && "border-t border-separator pt-4")}>
-      <TabSectionHeading wide={wide}>Efficiency</TabSectionHeading>
-      <EfficiencyBreakdown metrics={efficiencyCard} section="cost" layout={layout} />
+    <section className="mt-auto shrink-0">
+      <TabSectionHeading>Efficiency</TabSectionHeading>
+      <EfficiencyBreakdown metrics={efficiencyCard} section="cost" />
     </section>
   )
 
@@ -850,75 +791,33 @@ export function SessionDetailPresentation({
       className={cn(
         "flex h-full flex-col overflow-hidden text-label select-none",
         !embedded && "bg-surface",
-        wide ? "session-detail-wide type-body" : !embedded && "rounded-popover",
+        "session-detail-wide type-body",
       )}
     >
-      {!wide && (
-        <div
-          data-tauri-drag-region={embedded && isMacOS() ? "deep" : undefined}
-          className="flex items-center justify-between gap-2 border-b border-separator px-3 py-3"
-        >
-          {/* The control and the title are two things, not one. Wrapping the
-              heading text inside the back button made a screen reader announce
-              "Session Detail, button" for the control that leaves this view,
-              and left the view itself with no heading at all. */}
-          <div className="flex min-w-0 items-center gap-1.5">
-            {onBack && (
-              <button
-                type="button"
-                onClick={onBack}
-                aria-label="Back"
-                className="-ml-1 inline-flex h-6 shrink-0 items-center rounded-control px-1 text-label hover:bg-surface-hover"
-              >
-                <ChevronLeft size={14} aria-hidden="true" className="shrink-0" />
-              </button>
-            )}
-            <h2
-              data-view-heading
-              tabIndex={-1}
-              className="truncate type-headline text-label outline-none"
-            >
-              {embedded ? session.title || "Session" : "Session Detail"}
-            </h2>
-            {subagent && (
-              <span className="shrink-0 rounded bg-system-indigo/15 px-1.5 py-px type-caption font-medium text-system-indigo-text">
-                Sub-agent
-              </span>
-            )}
-            {refreshing && <RefreshingIndicator />}
-          </div>
-          {hostActions}
-        </div>
-      )}
-
-      {wide && (
-        <div
-          data-tauri-drag-region={embedded && isMacOS() ? "deep" : undefined}
-          className="session-detail-toolbar flex shrink-0 flex-wrap items-center gap-4 border-b border-separator bg-surface/80 px-10 py-3"
-        >
-          {onBack && (
-            <button
-              type="button"
-              onClick={onBack}
-              aria-label="Back"
-              className="inline-flex h-6 shrink-0 items-center rounded-control px-1 text-label hover:bg-surface-hover"
-            >
-              <ChevronLeft size={14} aria-hidden="true" />
-            </button>
-          )}
-          {sessionSummary}
-          {hostActions}
-        </div>
-      )}
+      <div
+        data-tauri-drag-region={embedded && isMacOS() ? "deep" : undefined}
+        className="session-detail-toolbar flex shrink-0 flex-wrap items-center gap-4 border-b border-separator bg-surface/80 px-10 py-3"
+      >
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back"
+            className="inline-flex h-6 shrink-0 items-center rounded-control px-1 text-label hover:bg-surface-hover"
+          >
+            <ChevronLeft size={14} aria-hidden="true" />
+          </button>
+        )}
+        {sessionSummary}
+        {hostActions}
+      </div>
 
       <div key={sessionIdentityKey(session)} className="relative flex min-h-0 flex-1 flex-col">
         {(showSkeleton || (ready && (error || empty))) && (
           <div className="min-h-0 flex-1 overflow-y-auto py-3">
             {showSkeleton && <SessionDetailSkeleton />}
             {ready && error && (
-              <p
-                className={cn("type-callout text-system-orange", wide ? "px-10 pb-10" : "px-4")}
-              >
+              <p className="type-callout text-system-orange px-10 pb-10">
                 Couldn't read this session.
               </p>
             )}
@@ -960,8 +859,6 @@ export function SessionDetailPresentation({
 
         {ready && !error && !empty && summary && (
           <>
-            {!wide && sessionSummary}
-
             {subagent && (
               <SubagentBadge
                 parentAgent={session.agent}
@@ -971,36 +868,17 @@ export function SessionDetailPresentation({
               />
             )}
 
-            {!wide && (
-              <div className="border-b border-separator px-4 pb-3">
-                <SegmentedControl
-                  options={DETAIL_TABS}
-                  value={tab}
-                  onChange={setTab}
-                  ariaLabel="Session detail sections"
-                  semantics="tabs"
-                  variant="native-tabs"
-                  idPrefix="session-detail-tabs"
-                />
-              </div>
-            )}
-
             <div
               id="session-detail-tabs-panel"
               role="tabpanel"
               aria-labelledby={`session-detail-tabs-${tab}`}
-              className={cn(
-                "min-h-0 flex-1 overflow-y-auto py-4",
-                // The wide pane leaves room under the last row for the
-                // floating section picker that overlays its bottom edge.
-                wide ? "px-10 pb-20" : "px-4",
-              )}
+              className="min-h-0 flex-1 overflow-y-auto py-4 px-10 pb-20"
             >
               {/* The chart fills the remaining space around its fixed summaries. */}
               {tab === "overview" && tokensCard && (
-                <div className={cn("flex h-full flex-col", wide ? "gap-y-5" : "gap-y-3")}>
-                  {wide && <TabSectionHeading wide={wide}>Context over time</TabSectionHeading>}
-                  <div className={cn(wide ? "min-h-48 flex-1" : "min-h-0 flex-1")}>
+                <div className="flex h-full flex-col gap-y-5">
+                  <TabSectionHeading>Context over time</TabSectionHeading>
+                  <div className="min-h-48 flex-1">
                     <ContextTokensChart
                       buckets={summary.buckets}
                       contextWindow={summary.contextAvailable ? summary.contextWindow : null}
@@ -1013,52 +891,38 @@ export function SessionDetailPresentation({
                     pinned={pinned}
                     onHighlight={setHovered}
                     onPin={togglePin}
-                    layout={layout}
                   />
                   {compositionSection}
                 </div>
               )}
 
               {tab === "cost" && (
-                <div
-                  className={cn(
-                    wide
-                      ? "session-detail-cost flex min-h-full flex-col gap-6"
-                      : "flex min-h-full flex-col",
-                  )}
-                >
-                  {wide && costSection}
+                <div className="session-detail-cost flex min-h-full flex-col gap-x-6">
+                  {costSection}
                   {hasAssessedHygieneChecks && (
-                    <section className={wide ? "shrink-0" : ""}>
-                      <TabSectionHeading wide={wide}>Checks</TabSectionHeading>
+                    <section className="shrink-0">
+                      <TabSectionHeading>Checks</TabSectionHeading>
                       <HygieneBreakdown
                         checks={hygieneChecks}
                         collapsePassing={false}
-                        inlineGuidance={wide}
+                        inlineGuidance
                       />
                     </section>
                   )}
-                  {!wide && costSection}
+
                   {efficiencySection}
                 </div>
               )}
 
               {tab === "tools" &&
                 (firstSession?.initialContext ? (
-                  <div className={cn("flex flex-col", wide ? "gap-y-4" : "gap-y-2")}>
+                  <div className="flex flex-col gap-y-4">
                     {/* The wasted tokens are the finding of this tab, so they
                         head the table they summarize. The figure has no
                         ceiling, so it is a headline and not a meter. */}
                     {toolsUsage != null && toolsUsage.wastedTokens > 0 && (
-                      <p
-                        className={cn("flex items-center gap-x-4", wide ? "my-2 py-3" : "my-1")}
-                      >
-                        <span
-                          className={cn(
-                            "font-semibold! text-brand tabular-nums",
-                            wide ? "type-display" : "type-large-title",
-                          )}
-                        >
+                      <p className="flex items-center gap-x-4 my-2 py-3">
+                        <span className="font-semibold! text-brand tabular-nums type-display">
                           {formatCompact(toolsUsage.wastedTokens)}
                         </span>
                         <span className="flex flex-col type-callout leading-tight">
@@ -1069,10 +933,7 @@ export function SessionDetailPresentation({
                         </span>
                       </p>
                     )}
-                    <SkillsMcpChart
-                      breakdown={firstSession.initialContext}
-                      columns={wide ? 2 : 1}
-                    />
+                    <SkillsMcpChart breakdown={firstSession.initialContext} columns={2} />
                   </div>
                 ) : (
                   <p className="type-callout text-label-tertiary">
@@ -1085,21 +946,19 @@ export function SessionDetailPresentation({
                 content, in reach of the reading it switches, instead of in
                 the toolbar beside the title. The wrapper lets pointer events
                 through to the content on either side of the pill. */}
-            {wide && (
-              <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-6">
-                <SegmentedControl
-                  className="session-detail-tabs session-detail-floating-tabs pointer-events-auto type-callout shrink-0 rounded-full! bg-surface/80! shadow-raised [&_button]:rounded-full!"
-                  options={DETAIL_TABS}
-                  value={tab}
-                  onChange={setTab}
-                  ariaLabel="Session detail sections"
-                  semantics="tabs"
-                  variant="native-tabs"
-                  equalWidth={false}
-                  idPrefix="session-detail-tabs"
-                />
-              </div>
-            )}
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-6">
+              <SegmentedControl
+                className="session-detail-tabs session-detail-floating-tabs pointer-events-auto type-callout shrink-0 rounded-full! bg-surface/80! shadow-raised [&_button]:rounded-full!"
+                options={DETAIL_TABS}
+                value={tab}
+                onChange={setTab}
+                ariaLabel="Session detail sections"
+                semantics="tabs"
+                variant="native-tabs"
+                equalWidth={false}
+                idPrefix="session-detail-tabs"
+              />
+            </div>
           </>
         )}
       </div>

--- a/apps/desktop/src/components/session/analysis/CostBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/CostBreakdown.test.tsx
@@ -39,16 +39,16 @@ function result(totalCostUsd = 2.4, over: Partial<LocalSessionCost> = {}): Local
 }
 
 describe("CostBreakdown", () => {
-  it("pairs a single total with component rows in the wide layout", () => {
-    render(<CostBreakdown cost={result()} layout="wide" />)
+  it("pairs a single total with component rows", () => {
+    render(<CostBreakdown cost={result()} />)
     expect(screen.getAllByText("$2.40")).toHaveLength(1)
     expect(screen.getByText("10 tokens")).toBeTruthy()
     expect(screen.getByText("Input")).toBeTruthy()
     expect(screen.getByText("Cache write")).toBeTruthy()
   })
 
-  it("explains a wide row from a tooltip on the row, not an info button", () => {
-    render(<CostBreakdown cost={result()} layout="wide" />)
+  it("explains a component row from a tooltip on the row, not an info button", () => {
+    render(<CostBreakdown cost={result()} />)
     expect(screen.queryByRole("button", { name: "About Input" })).toBeNull()
     const row = screen.getByText("Input").closest("[tabindex]")!
     expect(row).toHaveAttribute("tabindex", "0")
@@ -135,12 +135,11 @@ describe("CostBreakdown", () => {
     expect(screen.getByText("950")).toBeTruthy()
     expect(screen.getByText("1.2k")).toBeTruthy()
     expect(screen.getByText("14k")).toBeTruthy()
-    // Cache write tokens and the footer's total both round to the same "2.1M".
-    expect(screen.getAllByText("2.1M")).toHaveLength(2)
+    // The summary labels its total token count.
+    expect(screen.getByText("2.1M")).toBeTruthy()
+    expect(screen.getByText("2.1M tokens")).toBeTruthy()
     // Input is $0.30 of a $2.40 total.
     expect(screen.getByText("13%")).toBeTruthy()
-    // The footer always reads the full share.
-    expect(screen.getByText("100%")).toBeTruthy()
   })
 
   it("shows each split row's own token count", () => {
@@ -177,8 +176,8 @@ describe("CostBreakdown", () => {
         })}
       />,
     )
-    // Four component rows plus the footer, all sharing an undefined percent.
-    expect(screen.getAllByText("—")).toHaveLength(5)
+    // Each component has an undefined share when the total is zero.
+    expect(screen.getAllByText("—")).toHaveLength(4)
   })
 })
 

--- a/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
@@ -149,9 +149,9 @@ function SubagentMemberRow({
       type="button"
       aria-label={`Open the analysis for ${member.label}`}
       onClick={() => onOpenSubagent?.(member.subagentId, member.label)}
-      className="group col-span-full grid grid-cols-subgrid gap-y-0.5 text-label-tertiary py-2 border-t border-separator transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover type-callout"
+      className="group col-span-full grid grid-cols-subgrid gap-y-0.5 text-label-tertiary pl-4 mb-2.5 border-t border-separator transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover type-callout"
     >
-      <span className="col-start-1 col-end-5 flex min-w-0 gap-x-2 items-center text-left">
+      <span className="mt-2.5 col-start-1 col-end-5 flex min-w-0 gap-x-2 items-center text-left">
         <span className="tabular-nums">
           [{formatMemberStart(member, sessionStartedAtEpoch)}]
         </span>

--- a/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/CostBreakdown.tsx
@@ -1,7 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react"
 
-import { cn } from "../../../lib/cn"
-
 import {
   costBreakdownRows,
   costFigureLabel,
@@ -16,8 +14,6 @@ import {
 import { modelRunShortNames } from "../../../lib/presentation/models"
 import type { SubagentMember } from "../../../lib/types/session"
 import { Tooltip } from "../../presentation/Tooltip"
-import { TruncatedText } from "../../presentation/TruncatedText"
-import { RowInfo } from "./RowInfo"
 import { toggleSubagentsExpanded, useSubagentsExpanded } from "./subagentsExpandedStore"
 
 interface CostBreakdownSplit {
@@ -39,8 +35,6 @@ export interface CostBreakdownProps {
    * subject, so the rows always sum to the total shown.
    */
   cost: LocalSessionCost
-  /** The wide layout pairs the total with its component table. */
-  layout?: "popover" | "wide"
   /**
    * Parent/sub-agents split, for an inclusive orchestration result. Omit it
    * for any other subject, where there is nothing to break apart.
@@ -50,8 +44,7 @@ export interface CostBreakdownProps {
   onOpenSubagent?: (subagentId: string, label: string) => void
 }
 
-/* One sentence per billable component. The popover row shows it from an
-   info button. The wide row shows it from a tooltip on the whole row. */
+/** Each component row shows its help in a tooltip. */
 const COST_ROW_HELP: Record<string, string> = {
   Input: "Fresh tokens sent to the model, billed at the full input price.",
   Output: "Tokens the model wrote back. The highest price per token.",
@@ -76,38 +69,26 @@ function formatSharePct(usd: number, totalUsd: number): string {
   return `${Math.round(pct)}%`
 }
 
-/**
- * One row: a label, its token count, its USD cost, and its share of the total.
- *
- * The wide row is one type step smaller than the popover row, and it carries
- * its help as a tooltip on the whole row instead of an info button. Both
- * changes let the table sit beside the total at the minimum window width.
- */
+/** The compact row keeps the component table beside the total at the minimum window width. */
 function CostRowLine({
   label,
   usd,
   tokens,
   totalUsd,
-  wide = false,
 }: {
   label: string
   usd: number
   tokens: number
   totalUsd: number
-  wide?: boolean
 }) {
   const help = COST_ROW_HELP[label]
   const row = (
     <div
-      tabIndex={wide && help ? 0 : undefined}
-      className={cn(
-        "group col-span-full grid grid-cols-subgrid rounded-control -mx-1 px-1 py-0.5 transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover",
-        wide ? "type-callout focus-visible:bg-surface-hover" : "type-body",
-      )}
+      tabIndex={help ? 0 : undefined}
+      className="group col-span-full grid grid-cols-subgrid rounded-control -mx-1 px-1 py-0.5 transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover type-callout focus-visible:bg-surface-hover"
     >
       <span className="flex min-w-0 items-center gap-1 text-label-tertiary">
         <span className="truncate">{label}</span>
-        {help && !wide && <RowInfo label={label} body={help} />}
       </span>
       <span className="text-right text-label-tertiary tabular-nums">
         {formatTokensShort(tokens)}
@@ -118,7 +99,7 @@ function CostRowLine({
       </span>
     </div>
   )
-  if (!wide || !help) return row
+  if (!help) return row
   return (
     <Tooltip label={help} delayMs={150}>
       {row}
@@ -153,13 +134,11 @@ function SubagentMemberRow({
   totalUsd,
   sessionStartedAtEpoch,
   onOpenSubagent,
-  wide = false,
 }: {
   member: SubagentMember
   totalUsd: number
   sessionStartedAtEpoch: number | null
   onOpenSubagent?: ((subagentId: string, label: string) => void) | undefined
-  wide?: boolean
 }) {
   const modelLabel = modelRunShortNames(member.modelRuns).join(" · ")
   const tokens = memberTokenTotal(member)
@@ -170,25 +149,19 @@ function SubagentMemberRow({
       type="button"
       aria-label={`Open the analysis for ${member.label}`}
       onClick={() => onOpenSubagent?.(member.subagentId, member.label)}
-      className={cn(
-        "group col-span-full grid grid-cols-subgrid gap-y-0.5 text-label-tertiary py-2 border-t border-separator transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover",
-        wide ? "type-callout" : "type-body",
-      )}
+      className="group col-span-full grid grid-cols-subgrid gap-y-0.5 text-label-tertiary py-2 border-t border-separator transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover type-callout"
     >
-      {/* The title stays in the label column. A title that spans every column
-          makes the grid spread its width across the number columns, and the
-          label column then gets almost no width. */}
-      <span className="col-start-1 flex min-w-0 items-center gap-x-1 text-left">
+      <span className="col-start-1 col-end-5 flex min-w-0 gap-x-2 items-center text-left">
         <span className="tabular-nums">
           [{formatMemberStart(member, sessionStartedAtEpoch)}]
         </span>
-        <TruncatedText className="min-w-0 flex-1" text={member.label} />
+        <span className="min-w-0 flex-1 truncate">{member.label}</span>
+        <ChevronRight
+          size={12}
+          aria-hidden="true"
+          className="self-center justify-self-end transition-transform duration-[var(--duration-fast)] ease-out group-hover:translate-x-0.5"
+        />
       </span>
-      <ChevronRight
-        size={12}
-        aria-hidden="true"
-        className="col-start-4 self-center justify-self-end transition-transform duration-[var(--duration-fast)] ease-out group-hover:translate-x-0.5"
-      />
 
       <span className="truncate text-left">{modelLabel}</span>
       <span className="text-right tabular-nums">
@@ -221,7 +194,6 @@ function SubagentsSplitRow({
   members,
   sessionStartedAtEpoch,
   onOpenSubagent,
-  wide = false,
 }: {
   label: string
   usd: number
@@ -230,14 +202,11 @@ function SubagentsSplitRow({
   members: SubagentMember[]
   sessionStartedAtEpoch: number | null
   onOpenSubagent?: ((subagentId: string, label: string) => void) | undefined
-  wide?: boolean
 }) {
   const expanded = useSubagentsExpanded()
 
   if (members.length === 0) {
-    return (
-      <CostRowLine label={label} usd={usd} tokens={tokens} totalUsd={totalUsd} wide={wide} />
-    )
+    return <CostRowLine label={label} usd={usd} tokens={tokens} totalUsd={totalUsd} />
   }
 
   const Chevron = expanded ? ChevronDown : ChevronRight
@@ -248,10 +217,7 @@ function SubagentsSplitRow({
         type="button"
         onClick={toggleSubagentsExpanded}
         aria-expanded={expanded}
-        className={cn(
-          "col-span-full grid grid-cols-subgrid rounded-control -mx-1 my-1 px-1 transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover",
-          wide ? "type-callout" : "type-body",
-        )}
+        className="col-span-full grid grid-cols-subgrid rounded-control -mx-1 my-1 px-1 transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover type-callout"
       >
         <span className="min-w-0 flex items-center gap-x-1 text-label-tertiary">
           <Chevron size={12} aria-hidden="true" className="shrink-0" />
@@ -274,7 +240,6 @@ function SubagentsSplitRow({
             totalUsd={totalUsd}
             sessionStartedAtEpoch={sessionStartedAtEpoch}
             onOpenSubagent={onOpenSubagent}
-            wide={wide}
           />
         ))}
     </>
@@ -288,27 +253,14 @@ function SubagentsSplitRow({
  * only appears when the caller has parent and sub-agent results drawn from the
  * same computation as the headline, because mixing sources would produce rows
  * that do not add up. The token and percent columns share that same subject,
- * so every row's percent reads as a share of the one total shown in the footer.
+ * so every row's percent reads as a share of the one total shown beside the table.
  */
-export function CostBreakdown({
-  cost,
-  split,
-  onOpenSubagent,
-  layout = "popover",
-}: CostBreakdownProps) {
-  const wide = layout === "wide"
+export function CostBreakdown({ cost, split, onOpenSubagent }: CostBreakdownProps) {
   const rows = costBreakdownRows(resultComponentCost(cost))
   const totalUsd = cost.totalCostUsd
 
   const table = (
-    <div
-      className={cn(
-        "grid min-w-0 gap-y-1",
-        wide
-          ? "w-full max-w-[640px] gap-x-2 justify-self-end justify-end grid-cols-[fit-content(24rem)_max-content_max-content_max-content]"
-          : "gap-x-3 grid-cols-[1fr_max-content_max-content_max-content]",
-      )}
-    >
+    <div className="grid min-w-0 gap-y-1 w-full max-w-[640px] gap-x-6 justify-self-end justify-end grid-cols-[1fr_auto_auto_auto]">
       {split && (
         <div className="col-span-full grid grid-cols-subgrid mb-1 border-b border-separator pb-1">
           <CostRowLine
@@ -316,7 +268,6 @@ export function CostBreakdown({
             usd={split.parent.totalCostUsd}
             tokens={split.parent.totalTokens}
             totalUsd={totalUsd}
-            wide={wide}
           />
           <SubagentsSplitRow
             label={`${split.subagentCount} sub-agent${split.subagentCount === 1 ? "" : "s"}`}
@@ -326,7 +277,6 @@ export function CostBreakdown({
             members={split.members}
             sessionStartedAtEpoch={split.sessionStartedAtEpoch}
             onOpenSubagent={onOpenSubagent}
-            wide={wide}
           />
         </div>
       )}
@@ -338,32 +288,13 @@ export function CostBreakdown({
           usd={row.usd}
           tokens={row.tokens ?? 0}
           totalUsd={totalUsd}
-          wide={wide}
         />
       ))}
-
-      {!wide && (
-        <div className="col-span-full grid grid-cols-subgrid mt-1 border-t border-separator pt-1 type-body">
-          <span className="text-label-tertiary">{costFigureLabel(cost.isActive)}</span>
-          <span className="text-right text-label-tertiary tabular-nums">
-            {formatTokensShort(cost.totalTokens)}
-          </span>
-          <span className="flex justify-end">
-            <span className="flex shrink-0 items-center rounded-full bg-surface-secondary px-1.5 py-px type-body font-medium text-label tabular-nums">
-              {formatCost(cost.totalCostUsd)}
-            </span>
-          </span>
-          <span className="text-right text-label-tertiary tabular-nums">
-            {formatSharePct(cost.totalCostUsd, totalUsd)}
-          </span>
-        </div>
-      )}
     </div>
   )
-  if (!wide) return table
 
   return (
-    <div className="session-cost-summary grid w-full gap-x-4 gap-y-3 rounded-popover bg-surface-card/50 p-4 font-mono">
+    <div className="session-cost-summary grid w-full gap-x-12 gap-y-3 rounded-popover bg-surface-card/50 p-4 font-mono">
       <div className="flex min-w-0 flex-col gap-1">
         <span className="type-large-title font-semibold! text-label tabular-nums">
           {formatCost(totalUsd)}
@@ -375,6 +306,7 @@ export function CostBreakdown({
           {formatTokensShort(cost.totalTokens)} tokens
         </span>
       </div>
+
       {table}
     </div>
   )

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
@@ -29,7 +29,7 @@ describe("EfficiencyBreakdown", () => {
   ])("uses $ink for a $band efficiency hero", ({ totalUsd, figure, band, ink }) => {
     const metrics = efficiencyMetrics(totals({ totalUsd }), "claude-code")
     expect(metrics.costPerMTok?.band).toBe(band)
-    render(<EfficiencyBreakdown metrics={metrics} section="cost" layout="wide" />)
+    render(<EfficiencyBreakdown metrics={metrics} section="cost" />)
     expect(screen.getByText(figure)).toHaveClass(ink)
     expect(screen.getByText(figure)).not.toHaveClass(
       ink === "text-label" ? "text-brand" : "text-label",
@@ -38,7 +38,7 @@ describe("EfficiencyBreakdown", () => {
 
   it("renders the headline and three spend rows with their values", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
-    expect(screen.getByText("$/MTok")).toBeTruthy()
+    expect(screen.getByText("$/MTOK")).toBeTruthy()
     expect(screen.getByText("Real Work %")).toBeTruthy()
     expect(screen.getByText("Rewrite Waste %")).toBeTruthy()
     expect(screen.getByText("Carry %")).toBeTruthy()
@@ -71,20 +71,15 @@ describe("EfficiencyBreakdown", () => {
     const good = within(cost).getByTestId("cost-band-word-good")
     const ok = within(cost).getByTestId("cost-band-word-ok")
     expect(good).toHaveTextContent("under $33")
-    expect(ok).toHaveTextContent("$33 – $80")
+    expect(ok).toHaveTextContent("ok")
     expect(within(cost).getByTestId("cost-band-word-bad")).toHaveTextContent("over $80")
     expect(ok.dataset.current).toBe("true")
     expect(good.dataset.current).toBeUndefined()
     expect(screen.getByTestId("cost-row").querySelector(".rounded")).toBeNull()
   })
 
-  it("drops the middle range in the wide pane, where the picker floats", () => {
-    render(
-      <EfficiencyBreakdown
-        metrics={efficiencyMetrics(totals(), "claude-code")}
-        layout="wide"
-      />,
-    )
+  it("drops the middle range where the picker floats", () => {
+    render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
 
     const cost = screen.getByTestId("thermometer-costPerMTok")
     const ok = within(cost).getByTestId("cost-band-word-ok")
@@ -181,32 +176,8 @@ describe("EfficiencyBreakdown", () => {
     expect(screen.queryByText(/fresh input and output/)).toBeNull()
   })
 
-  it("prints the cost reading's guidance inline under its scale as one paragraph", () => {
+  it("draws the bar above stacked legend rows", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
-
-    const guidance = screen.getByTestId("cost-guidance")
-    // One quiet paragraph, so the sentences wrap at the pane's width instead
-    // of each taking a line.
-    expect(guidance.querySelectorAll("p")).toHaveLength(1)
-    const paragraph = within(guidance).getByText(/average cost for each million tokens/)
-    expect(paragraph).toHaveClass("text-label-tertiary")
-    expect(paragraph).not.toHaveClass("font-medium")
-    expect(paragraph).toHaveTextContent(
-      "For Claude, aim for below $33. Above $80 is too high. Craft tight workflows",
-    )
-    expect(paragraph).toHaveTextContent(/Context tab shows/)
-    expect(guidance).not.toHaveClass("max-w-prose")
-    // The cost row is plain text now, not a tooltip trigger.
-    expect(screen.getByTestId("cost-row")).not.toHaveAttribute("tabindex")
-  })
-
-  it("draws the wide bar above stacked legend rows", () => {
-    render(
-      <EfficiencyBreakdown
-        metrics={efficiencyMetrics(totals(), "claude-code")}
-        layout="wide"
-      />,
-    )
 
     const track = screen.getByTestId("efficiency-composition")
     expect(track.dataset.height).toBe("bar")
@@ -222,8 +193,7 @@ describe("EfficiencyBreakdown", () => {
     fireEvent.focus(realWork)
     expect(screen.getAllByText(/fresh input and output/).length).toBeGreaterThan(0)
 
-    // The wide pane keeps the cost guidance in a tooltip on the hero figure,
-    // so at rest the scale and its labels are the whole reading.
+    // The hero figure shows cost guidance on focus.
     expect(screen.queryByTestId("cost-guidance")).toBeNull()
     expect(screen.queryByText(/average cost for each million tokens/)).toBeNull()
     const hero = screen.getByTestId("cost-hero")
@@ -238,13 +208,5 @@ describe("EfficiencyBreakdown", () => {
     ).toBeGreaterThan(0)
     fireEvent.blur(hero)
     expect(screen.queryByText(/average cost for each million tokens/)).toBeNull()
-  })
-
-  it("keeps the popover's hairline track and stacked rows by default", () => {
-    render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
-    const track = screen.getByTestId("efficiency-composition")
-    expect(track.dataset.height).toBe("hairline")
-    expect(track).toHaveClass("h-1", "rounded-full")
-    expect(screen.getByTestId("composition-legend")).toHaveClass("flex-col")
   })
 })

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
@@ -18,8 +18,6 @@ export interface EfficiencyBreakdownProps {
    * composition under the context chart. Omit it to draw both.
    */
   section?: "cost" | "composition"
-  /** The wide layout uses taller bars and a hero figure. */
-  layout?: "popover" | "wide"
 }
 
 /* The fill for one band of the cost scale. The three bands are a fixed
@@ -156,17 +154,14 @@ function shareSegments(metrics: EfficiencyMetrics): ShareSegment[] {
 function CostScaleBar({
   metric,
   profile,
-  wide,
 }: {
   metric: EfficiencyMetric
   profile: EfficiencyProfile
-  wide: boolean
 }) {
   const scale = efficiencyThermometer(metric.value, "costPerMTok", profile)
   const [, low, high] = scale.ticks
-  // The wide pane drops the middle range. It printed under the floating
-  // section picker, and the two outer ranges already name both of its edges.
-  const ranges = [`under ${low}`, wide ? null : `${low} – ${high}`, `over ${high}`]
+  // The outer ranges show both middle boundaries and leave space for the floating section picker.
+  const ranges = [`under ${low}`, null, `over ${high}`]
   const last = scale.segments.length - 1
   return (
     <div
@@ -174,7 +169,7 @@ function CostScaleBar({
       data-position={scale.position.toFixed(3)}
       aria-hidden
     >
-      <div className={cn("relative flex", wide ? "h-6" : "h-3")}>
+      <div className="relative flex h-6">
         {scale.segments.map((band, index) => (
           <span
             key={band}
@@ -201,7 +196,7 @@ function CostScaleBar({
             data-current={band === metric.band || undefined}
             className={cn(
               "flex flex-1 flex-col text-label-tertiary tabular-nums",
-              wide ? "type-body" : "type-caption",
+              "type-body",
               index === 0 && "items-start",
               index === last && "items-end",
               index > 0 && index < last && "items-center",
@@ -218,29 +213,14 @@ function CostScaleBar({
   )
 }
 
-/**
- * The three shares as one composition. They are parts of a single whole, so
- * they draw as one track: each run takes its slice of the width, in that
- * slice's own color. Three separate meters hid the only fact that matters,
- * which is how the session divided its cost. The popover draws a hairline;
- * the wide pane draws a bar.
- */
-function CompositionTrack({
-  segments,
-  height,
-}: {
-  segments: ShareSegment[]
-  height: "hairline" | "bar"
-}) {
+/** The track shows each share as part of the total cost. */
+function CompositionTrack({ segments }: { segments: ShareSegment[] }) {
   return (
     <div
       data-testid="efficiency-composition"
-      data-height={height}
+      data-height="bar"
       aria-hidden
-      className={cn(
-        "flex gap-px overflow-hidden bg-surface-secondary",
-        height === "bar" ? "h-6 rounded-control" : "h-1 rounded-full",
-      )}
+      className="flex gap-px overflow-hidden bg-surface-secondary h-6 rounded-control"
     >
       {segments.map((segment) => (
         <span
@@ -255,37 +235,18 @@ function CompositionTrack({
   )
 }
 
-/**
- * The guidance for one reading, as the body of its tooltip. It names what the
- * reading measures, states the band it should sit in, and says what to change.
- *
- * The composition rows keep their guidance in a tooltip so the block stays
- * the height of its readings. A panel that grows and shrinks under the rows
- * moves everything below it every time the pointer crosses a row. The wide
- * cost reading does the same from its hero figure. The popover's cost row
- * prints the guidance inline, as one quiet paragraph that wraps at the width
- * of its pane.
- */
+/** The tooltip explains the reading, its expected band, and the suggested changes. */
 function MetricGuidance({
   metricKey,
   profile,
-  inline = false,
 }: {
   metricKey: MetricKey
   profile: EfficiencyProfile
-  inline?: boolean
 }) {
   const advice = [
     ...efficiencyThresholdGuidance(metricKey, profile),
     ...METRIC_GUIDANCE[metricKey],
   ]
-  if (inline) {
-    return (
-      <p className="type-callout text-pretty text-label-tertiary">
-        {[...METRIC_SUMMARY[metricKey], ...advice].join(" ")}
-      </p>
-    )
-  }
   return (
     <div className="space-y-1 text-pretty">
       {METRIC_SUMMARY[metricKey].map((sentence) => (
@@ -305,63 +266,43 @@ function MetricGuidance({
 const ROW_CLASS =
   "-mx-1.5 rounded-control px-1.5 py-1 type-body transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover focus-visible:bg-surface-hover"
 
-/**
- * The $/MTok reading: label and figure on one baseline, and its scale
- * underneath. This metric is not part of the composition, so it keeps the
- * scale the other readings gave up. The wide pane keeps the guidance in a
- * tooltip on the hero figure, so the scale and its labels are the whole
- * reading at rest. The popover prints the guidance under the scale.
- */
+/** The hero figure opens guidance in a tooltip. The scale shows the bands below it. */
 function CostRowLine({
   metric,
   profile,
-  wide,
 }: {
   metric: EfficiencyMetric
   profile: EfficiencyProfile
-  wide: boolean
 }) {
   return (
     <div className="type-body" data-testid="cost-row">
-      {wide ? (
-        <Tooltip
-          label={<MetricGuidance metricKey="costPerMTok" profile={profile} />}
-          side="bottom"
-          delayMs={150}
+      <Tooltip
+        label={<MetricGuidance metricKey="costPerMTok" profile={profile} />}
+        side="bottom"
+        delayMs={150}
+      >
+        <div
+          data-testid="cost-hero"
+          tabIndex={0}
+          className={cn(ROW_CLASS, "my-2 flex flex-wrap items-center gap-x-4 gap-y-1 pb-3")}
         >
-          <div
-            data-testid="cost-hero"
-            tabIndex={0}
-            className={cn(ROW_CLASS, "my-2 flex flex-wrap items-center gap-x-4 gap-y-1 pb-3")}
+          <span
+            className={cn(
+              "type-display font-semibold! tabular-nums",
+              metric.band === "bad" ? "text-brand" : "text-label",
+            )}
           >
-            <span
-              className={cn(
-                "type-display font-semibold! tabular-nums",
-                metric.band === "bad" ? "text-brand" : "text-label",
-              )}
-            >
-              {formatCostPerMTok(metric.value)}
-            </span>
-            <span className="flex flex-col type-callout">
-              <span className="font-semibold text-label">per million tokens</span>
-              <span className="text-label-secondary">of context growth and output</span>
-            </span>
-          </div>
-        </Tooltip>
-      ) : (
-        <span className="flex items-baseline justify-between gap-3 pb-3">
-          <span className="truncate text-label-secondary">$/MTok</span>
-          <span className="shrink-0 text-label tabular-nums">
             {formatCostPerMTok(metric.value)}
           </span>
-        </span>
-      )}
-      <CostScaleBar metric={metric} profile={profile} wide={wide} />
-      {!wide && (
-        <div className="mt-3" data-testid="cost-guidance">
-          <MetricGuidance metricKey="costPerMTok" profile={profile} inline />
+          <span className="flex flex-col type-callout">
+            <span className="font-semibold text-label">$/MTOK</span>
+            <span className="text-label-secondary">
+              per million tokens of work: context growth and output only
+            </span>
+          </span>
         </div>
-      )}
+      </Tooltip>
+      <CostScaleBar metric={metric} profile={profile} />
     </div>
   )
 }
@@ -405,7 +346,7 @@ function ShareRowPlaceholder({ row }: { row: ShareRow }) {
     <div className={cn(ROW_CLASS, "flex items-baseline gap-2")}>
       <span
         aria-hidden
-        className={cn("size-2 shrink-0 self-center rounded-full bg-surface-tertiary")}
+        className="size-2 shrink-0 self-center rounded-full bg-surface-tertiary"
       />
       <span className="min-w-0 flex-1 truncate text-label-secondary">{row.label}</span>
       <span className="shrink-0 text-label tabular-nums">—</span>
@@ -414,15 +355,10 @@ function ShareRowPlaceholder({ row }: { row: ShareRow }) {
   )
 }
 
-export function EfficiencyBreakdown({
-  metrics,
-  section,
-  layout = "popover",
-}: EfficiencyBreakdownProps) {
+export function EfficiencyBreakdown({ metrics, section }: EfficiencyBreakdownProps) {
   const segments = shareSegments(metrics)
   const showCost = section !== "composition"
   const showComposition = section !== "cost"
-  const wide = layout === "wide"
 
   if (!metrics.costPerMTok) {
     return null
@@ -430,19 +366,14 @@ export function EfficiencyBreakdown({
 
   return (
     <div className="flex flex-col" data-testid="efficiency-block">
-      {showCost && (
-        <CostRowLine metric={metrics.costPerMTok} profile={metrics.profile} wide={wide} />
-      )}
+      {showCost && <CostRowLine metric={metrics.costPerMTok} profile={metrics.profile} />}
       {showCost && showComposition && (
         <div className="my-3 border-b border-dashed border-separator" />
       )}
       {!showComposition ? null : segments.length > 0 ? (
         <>
-          <CompositionTrack segments={segments} height={wide ? "bar" : "hairline"} />
-          <div
-            data-testid="composition-legend"
-            className={cn("flex flex-col", wide ? "mt-3" : "mt-2")}
-          >
+          <CompositionTrack segments={segments} />
+          <div data-testid="composition-legend" className="flex flex-col mt-3">
             {segments.map((segment) => (
               <ShareRowLine key={segment.key} segment={segment} profile={metrics.profile} />
             ))}

--- a/apps/desktop/src/styles/session-detail.css
+++ b/apps/desktop/src/styles/session-detail.css
@@ -40,6 +40,7 @@
   height: var(--space-lg);
 }
 .session-detail-key {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 8rem), 1fr));
   margin-inline: 0;
 }
 .session-detail-wide .chart-key-stat {

--- a/apps/desktop/src/views/main-window/MainActivityView.tsx
+++ b/apps/desktop/src/views/main-window/MainActivityView.tsx
@@ -123,7 +123,6 @@ export function MainActivityView({
               </div>
             )}
             <SessionPane
-              layout="wide"
               embedded
               active={state.active}
               subject={item.subject}

--- a/apps/desktop/src/views/popover/SessionPane.tsx
+++ b/apps/desktop/src/views/popover/SessionPane.tsx
@@ -1,10 +1,7 @@
 import { confirm } from "@tauri-apps/plugin-dialog"
 import { useCallback } from "react"
 
-import {
-  SessionDetailPresentation,
-  type SessionDetailLayout,
-} from "../../components/session/SessionDetailPresentation"
+import { SessionDetailPresentation } from "../../components/session/SessionDetailPresentation"
 import type { TokensCostSplit } from "../../components/session/tokensCard"
 import { renderAgentIcon } from "../../lib/agentIcon"
 import {
@@ -48,8 +45,6 @@ export interface SessionPaneProps {
   refreshing: boolean
   /** Whether the load for this subject failed. */
   error: boolean
-  /** Which layout the detail draws. Defaults to the popover layout. */
-  layout?: SessionDetailLayout | undefined
   /** Leave the pane; omitted when the host owns navigation. */
   onBack?: (() => void) | undefined
   /** Newer adjacent session; omitted when there is none. */
@@ -192,7 +187,6 @@ export function SessionPane({
   loading,
   refreshing,
   error,
-  layout,
   onBack,
   onPrev,
   onNext,
@@ -324,7 +318,6 @@ export function SessionPane({
       subagentCount={payload?.orchestration?.subagentCount ?? 0}
       modelRuns={payload?.modelRuns ?? []}
       relations={relations}
-      {...(layout ? { layout } : {})}
       {...(onBack ? { onBack } : {})}
       {...(onPrev ? { onPrev } : {})}
       {...(onNext ? { onNext } : {})}

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -38,8 +38,9 @@ grants for `ai.antiburn.desktop.debug`, not `ai.antiburn.desktop`.
 
 ## Use developer tools and logs
 
-Debug webviews keep reload and developer tools available. Focus the webview,
-then use the normal platform shortcuts:
+Debug webviews keep the context menu, reload, and developer tools available.
+Right-click the webview and select **Inspect Element**, or focus the webview
+and use the normal platform shortcuts:
 
 - macOS: `Command+Option+I` for developer tools and `Command+R` to reload.
 - Windows and Linux: `Ctrl+Shift+I` for developer tools and `Ctrl+R` to reload.


### PR DESCRIPTION
## User impact

Session detail now has one presentation: remove the unused popover layout and its branches from the detail, cost, and efficiency components. The chart key uses flexible columns, the cost total has more space beside its table, and the final chart-key, sub-agent row, and efficiency-label tweaks are retained.

Debug builds allow the native context menu, and the main window grants Tauri's inspector-toggle permission so Inspect Element and the developer-tools shortcut are available after restarting the app. Release builds keep developer tools blocked.

Update publication test fixtures to serialize valid session evidence instead of placeholder JSON, fixing 42 failures when model attribution reads the payload. Ignore local `/worktrees` directories.

## Validation

- Desktop: formatting, ESLint, TypeScript, all 1,287 tests, and production frontend build pass.
- Rust shell: formatting, Clippy with warnings denied, and all 1,107 tests pass.
- Design-contract drift, changed-file and repository-wide slop checks, secret scan, and diff whitespace checks pass.
- Session-detail appearance reviewed during development at multiple window widths.

## Analytics

Measurement is unchanged. Existing session-detail navigation and use events retain their triggers; this change simplifies presentation and restores development-only debugging access. No new product action or event properties are introduced.

## Privacy and performance

No change to session data access, network access, retained data, or background work. Developer inspector access remains limited to debug builds with the current Tauri features. The evidence fixture helper is test-only.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
