### PR TITLE
fix(desktop): avoid unsupported efficiency tooltip guidance

### DIFF
--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
@@ -21,15 +21,17 @@ function totals(over: Partial<SessionEfficiency> = {}): SessionEfficiency {
   }
 }
 
-function expectNoBenchmarkLanguage() {
-  expect(document.body).not.toHaveTextContent(/For (Claude|Codex)/i)
-  expect(document.body).not.toHaveTextContent(/aim for/i)
-  expect(document.body).not.toHaveTextContent(/too (high|low)/i)
-  expect(document.body).not.toHaveTextContent(/out of band/i)
-  expect(screen.queryByText(/^(good|ok|bad|high|low)$/i)).toBeNull()
+function expectNoProfileGuidance(content: HTMLElement) {
+  expect(content).not.toHaveTextContent(/Claude|Codex/i)
+  expect(content).not.toHaveTextContent(/aim for/i)
+  expect(content).not.toHaveTextContent(/too (high|low)/i)
+  expect(content).not.toHaveTextContent(/out of band/i)
+  expect(content).not.toHaveTextContent(
+    /\$(20|33|46|80)|\b(8|10|14|17|18|25|33|36|54|57|59|69)%/,
+  )
 }
 
-const NEUTRAL_CASES = ["pi", "cursor", "opencode", "antigravity", "future-agent"].flatMap(
+const NEUTRAL_CASES = ["pi", "cursor", "opencode", "antigravity", "unknown", ""].flatMap(
   (agent) => [
     { agent, layout: "popover" as const },
     { agent, layout: "wide" as const },
@@ -72,11 +74,18 @@ describe("EfficiencyBreakdown", () => {
   })
 
   it.each(NEUTRAL_CASES)(
-    "shows neutral $agent metrics and all guidance in the $layout layout",
+    "keeps the legacy visuals but uses neutral guidance for '$agent' in $layout",
     ({ agent, layout }) => {
-      render(
-        <EfficiencyBreakdown metrics={efficiencyMetrics(totals(), agent)} layout={layout} />,
-      )
+      const metrics = efficiencyMetrics(totals(), agent)
+      const baseline = efficiencyMetrics(totals(), "claude-code")
+      expect(metrics.costPerMTok).toEqual(baseline.costPerMTok)
+      expect(metrics.realWorkShare).toEqual(baseline.realWorkShare)
+      expect(metrics.rewriteShare).toEqual(baseline.rewriteShare)
+      expect(metrics.carryShare).toEqual(baseline.carryShare)
+      expect(metrics.profile).toBe(baseline.profile)
+      expect(metrics.guidanceProfile).toBeNull()
+
+      render(<EfficiencyBreakdown metrics={metrics} layout={layout} />)
 
       expect(screen.getByText("$40.00")).toHaveClass("text-label")
       expect(screen.getByText("$40.00")).not.toHaveClass("text-brand")
@@ -84,30 +93,41 @@ describe("EfficiencyBreakdown", () => {
       expect(screen.getByText("12%")).toBeTruthy()
       expect(screen.getByText("54%")).toBeTruthy()
       expect(screen.getByTestId("efficiency-composition")).toBeTruthy()
-      expect(screen.queryByTestId("thermometer-costPerMTok")).toBeNull()
+      expect(screen.getAllByText("ok")).toHaveLength(4)
+
+      const cost = screen.getByTestId("thermometer-costPerMTok")
+      expect(cost.dataset.position).toBe("0.383")
+      expect(within(cost).getByTestId("cost-band-word-good")).toHaveTextContent("under $33")
+      expect(within(cost).getByTestId("cost-band-word-bad")).toHaveTextContent("over $80")
+      if (layout === "wide") {
+        expect(within(cost).getByTestId("cost-band-word-ok")).not.toHaveTextContent("$33 – $80")
+      } else {
+        expect(within(cost).getByTestId("cost-band-word-ok")).toHaveTextContent("$33 – $80")
+      }
 
       if (layout === "wide") {
         const hero = screen.getByTestId("cost-hero")
         fireEvent.focus(hero)
-        expect(
-          screen.getAllByText(
-            "The Context tab shows how spend splits across work, rewrite, and carry.",
-          ).length,
-        ).toBeGreaterThan(0)
-        expectNoBenchmarkLanguage()
-        fireEvent.blur(hero)
-      } else {
-        expect(screen.getByTestId("cost-guidance")).toHaveTextContent(
+        const tooltip = screen.getByRole("tooltip")
+        expect(tooltip).toHaveTextContent(
           "The Context tab shows how spend splits across work, rewrite, and carry.",
         )
-        expectNoBenchmarkLanguage()
+        expectNoProfileGuidance(tooltip)
+        fireEvent.blur(hero)
+      } else {
+        const guidance = screen.getByTestId("cost-guidance")
+        expect(guidance).toHaveTextContent(
+          "The Context tab shows how spend splits across work, rewrite, and carry.",
+        )
+        expectNoProfileGuidance(guidance)
       }
 
       for (const { key, summary } of SHARE_GUIDANCE) {
         const row = screen.getByTestId(`share-row-${key}`)
         fireEvent.focus(row)
-        expect(screen.getAllByText(summary).length).toBeGreaterThan(0)
-        expectNoBenchmarkLanguage()
+        const tooltip = screen.getByRole("tooltip")
+        expect(within(tooltip).getByText(summary)).toBeTruthy()
+        expectNoProfileGuidance(tooltip)
         fireEvent.blur(row)
       }
     },

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
@@ -21,6 +21,27 @@ function totals(over: Partial<SessionEfficiency> = {}): SessionEfficiency {
   }
 }
 
+function expectNoBenchmarkLanguage() {
+  expect(document.body).not.toHaveTextContent(/For (Claude|Codex)/i)
+  expect(document.body).not.toHaveTextContent(/aim for/i)
+  expect(document.body).not.toHaveTextContent(/too (high|low)/i)
+  expect(document.body).not.toHaveTextContent(/out of band/i)
+  expect(screen.queryByText(/^(good|ok|bad|high|low)$/i)).toBeNull()
+}
+
+const NEUTRAL_CASES = ["pi", "cursor", "opencode", "antigravity", "future-agent"].flatMap(
+  (agent) => [
+    { agent, layout: "popover" as const },
+    { agent, layout: "wide" as const },
+  ],
+)
+
+const SHARE_GUIDANCE = [
+  { key: "realWorkShare", summary: /share of the session's cost spent on fresh input/ },
+  { key: "rewriteShare", summary: /share of the session's cost spent rehydrating/ },
+  { key: "carryShare", summary: /share of the session's cost spent resending/ },
+]
+
 describe("EfficiencyBreakdown", () => {
   it.each([
     { totalUsd: 5, figure: "$20.00", band: "good", ink: "text-label" },
@@ -49,6 +70,48 @@ describe("EfficiencyBreakdown", () => {
     // The scale names its middle band once; each share row names its own.
     expect(screen.getAllByText("ok")).toHaveLength(4)
   })
+
+  it.each(NEUTRAL_CASES)(
+    "shows neutral $agent metrics and all guidance in the $layout layout",
+    ({ agent, layout }) => {
+      render(
+        <EfficiencyBreakdown metrics={efficiencyMetrics(totals(), agent)} layout={layout} />,
+      )
+
+      expect(screen.getByText("$40.00")).toHaveClass("text-label")
+      expect(screen.getByText("$40.00")).not.toHaveClass("text-brand")
+      expect(screen.getByText("34%")).toBeTruthy()
+      expect(screen.getByText("12%")).toBeTruthy()
+      expect(screen.getByText("54%")).toBeTruthy()
+      expect(screen.getByTestId("efficiency-composition")).toBeTruthy()
+      expect(screen.queryByTestId("thermometer-costPerMTok")).toBeNull()
+
+      if (layout === "wide") {
+        const hero = screen.getByTestId("cost-hero")
+        fireEvent.focus(hero)
+        expect(
+          screen.getAllByText(
+            "The Context tab shows how spend splits across work, rewrite, and carry.",
+          ).length,
+        ).toBeGreaterThan(0)
+        expectNoBenchmarkLanguage()
+        fireEvent.blur(hero)
+      } else {
+        expect(screen.getByTestId("cost-guidance")).toHaveTextContent(
+          "The Context tab shows how spend splits across work, rewrite, and carry.",
+        )
+        expectNoBenchmarkLanguage()
+      }
+
+      for (const { key, summary } of SHARE_GUIDANCE) {
+        const row = screen.getByTestId(`share-row-${key}`)
+        fireEvent.focus(row)
+        expect(screen.getAllByText(summary).length).toBeGreaterThan(0)
+        expectNoBenchmarkLanguage()
+        fireEvent.blur(row)
+      }
+    },
+  )
 
   it("draws the cost reading as a bullet graph that labels its own scale", () => {
     render(<EfficiencyBreakdown metrics={efficiencyMetrics(totals(), "claude-code")} />)
@@ -194,7 +257,9 @@ describe("EfficiencyBreakdown", () => {
     expect(paragraph).toHaveTextContent(
       "For Claude, aim for below $33. Above $80 is too high. Craft tight workflows",
     )
-    expect(paragraph).toHaveTextContent(/Context tab shows/)
+    expect(paragraph).toHaveTextContent(
+      "The Context tab shows which of work, rewrite, and carry is out of band.",
+    )
     expect(guidance).not.toHaveClass("max-w-prose")
     // The cost row is plain text now, not a tooltip trigger.
     expect(screen.getByTestId("cost-row")).not.toHaveAttribute("tabindex")
@@ -235,6 +300,11 @@ describe("EfficiencyBreakdown", () => {
     )
     expect(
       screen.getAllByText("For Claude, aim for below $33. Above $80 is too high.").length,
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getAllByText(
+        "The Context tab shows which of work, rewrite, and carry is out of band.",
+      ).length,
     ).toBeGreaterThan(0)
     fireEvent.blur(hero)
     expect(screen.queryByText(/average cost for each million tokens/)).toBeNull()

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
@@ -273,18 +273,18 @@ function CompositionTrack({
  */
 function MetricGuidance({
   metricKey,
-  profile,
+  guidanceProfile,
   inline = false,
 }: {
   metricKey: MetricKey
-  profile: EfficiencyProfile | null
+  guidanceProfile: EfficiencyProfile | null
   inline?: boolean
 }) {
   const metricGuidance =
-    profile === null
+    guidanceProfile === null
       ? (NEUTRAL_GUIDANCE_OVERRIDES[metricKey] ?? METRIC_GUIDANCE[metricKey])
       : METRIC_GUIDANCE[metricKey]
-  const advice = [...efficiencyThresholdGuidance(metricKey, profile), ...metricGuidance]
+  const advice = [...efficiencyThresholdGuidance(metricKey, guidanceProfile), ...metricGuidance]
   if (inline) {
     return (
       <p className="type-callout text-pretty text-label-tertiary">
@@ -312,25 +312,26 @@ const ROW_CLASS =
   "-mx-1.5 rounded-control px-1.5 py-1 type-body transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover focus-visible:bg-surface-hover"
 
 /**
- * The $/MTok reading shows the label and figure on one baseline.
- * It shows a scale only when a benchmark applies.
+ * The $/MTok reading shows the label, figure, and legacy scale.
  * The wide pane opens guidance from the hero figure.
  * The popover prints guidance below the reading.
  */
 function CostRowLine({
   metric,
   profile,
+  guidanceProfile,
   wide,
 }: {
   metric: EfficiencyMetric
-  profile: EfficiencyProfile | null
+  profile: EfficiencyProfile
+  guidanceProfile: EfficiencyProfile | null
   wide: boolean
 }) {
   return (
     <div className="type-body" data-testid="cost-row">
       {wide ? (
         <Tooltip
-          label={<MetricGuidance metricKey="costPerMTok" profile={profile} />}
+          label={<MetricGuidance metricKey="costPerMTok" guidanceProfile={guidanceProfile} />}
           side="bottom"
           delayMs={150}
         >
@@ -361,10 +362,10 @@ function CostRowLine({
           </span>
         </span>
       )}
-      {profile !== null && <CostScaleBar metric={metric} profile={profile} wide={wide} />}
+      <CostScaleBar metric={metric} profile={profile} wide={wide} />
       {!wide && (
         <div className="mt-3" data-testid="cost-guidance">
-          <MetricGuidance metricKey="costPerMTok" profile={profile} inline />
+          <MetricGuidance metricKey="costPerMTok" guidanceProfile={guidanceProfile} inline />
         </div>
       )}
     </div>
@@ -372,18 +373,21 @@ function CostRowLine({
 }
 
 /**
- * One composition line shows the slice color, name, share, and optional band word.
+ * One composition line shows the slice color, name, share, and band word.
  * The track shows the size, so the row has no bar.
  */
 function ShareRowLine({
   segment,
-  profile,
+  guidanceProfile,
 }: {
   segment: ShareSegment
-  profile: EfficiencyProfile | null
+  guidanceProfile: EfficiencyProfile | null
 }) {
   return (
-    <Tooltip label={<MetricGuidance metricKey={segment.key} profile={profile} />} delayMs={150}>
+    <Tooltip
+      label={<MetricGuidance metricKey={segment.key} guidanceProfile={guidanceProfile} />}
+      delayMs={150}
+    >
       <div
         data-testid={`share-row-${segment.key}`}
         className={cn(ROW_CLASS, "flex items-baseline gap-2")}
@@ -395,13 +399,9 @@ function ShareRowLine({
         />
         <span className="min-w-0 flex-1 truncate text-label-secondary">{segment.label}</span>
         <span className="shrink-0 text-label tabular-nums">{segment.displayPercent}</span>
-        {segment.metric.band === null ? (
-          <span className="w-12 shrink-0" />
-        ) : (
-          <span className={cn("w-12 shrink-0 text-end", BAND_WORD_CLASS)}>
-            {efficiencyBandWord(segment.metric.band, segment.key)}
-          </span>
-        )}
+        <span className={cn("w-12 shrink-0 text-end", BAND_WORD_CLASS)}>
+          {efficiencyBandWord(segment.metric.band, segment.key)}
+        </span>
       </div>
     </Tooltip>
   )
@@ -439,7 +439,12 @@ export function EfficiencyBreakdown({
   return (
     <div className="flex flex-col" data-testid="efficiency-block">
       {showCost && (
-        <CostRowLine metric={metrics.costPerMTok} profile={metrics.profile} wide={wide} />
+        <CostRowLine
+          metric={metrics.costPerMTok}
+          profile={metrics.profile}
+          guidanceProfile={metrics.guidanceProfile}
+          wide={wide}
+        />
       )}
       {showCost && showComposition && (
         <div className="my-3 border-b border-dashed border-separator" />
@@ -452,7 +457,11 @@ export function EfficiencyBreakdown({
             className={cn("flex flex-col", wide ? "mt-3" : "mt-2")}
           >
             {segments.map((segment) => (
-              <ShareRowLine key={segment.key} segment={segment} profile={metrics.profile} />
+              <ShareRowLine
+                key={segment.key}
+                segment={segment}
+                guidanceProfile={metrics.guidanceProfile}
+              />
             ))}
           </div>
         </>

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
@@ -69,6 +69,14 @@ const METRIC_GUIDANCE: Record<MetricKey, string[]> = {
   ],
 }
 
+/** Neutral advice replaces text that requires a benchmark. */
+const NEUTRAL_GUIDANCE_OVERRIDES: Partial<Record<MetricKey, string[]>> = {
+  costPerMTok: [
+    "Craft tight workflows, and use cheaper models when they're good enough.",
+    "The Context tab shows how spend splits across work, rewrite, and carry.",
+  ],
+}
+
 interface ShareRow {
   key: ShareMetricKey
   label: string
@@ -256,15 +264,12 @@ function CompositionTrack({
 }
 
 /**
- * The guidance for one reading, as the body of its tooltip. It names what the
- * reading measures, states the band it should sit in, and says what to change.
+ * The guidance names the measurement and says what to change.
+ * Supported benchmark profiles also state the target band.
  *
- * The composition rows keep their guidance in a tooltip so the block stays
- * the height of its readings. A panel that grows and shrinks under the rows
- * moves everything below it every time the pointer crosses a row. The wide
- * cost reading does the same from its hero figure. The popover's cost row
- * prints the guidance inline, as one quiet paragraph that wraps at the width
- * of its pane.
+ * Composition rows keep guidance in a tooltip, so the block keeps a stable height.
+ * The wide cost reading opens guidance from its hero figure.
+ * The popover prints cost guidance inline as one paragraph.
  */
 function MetricGuidance({
   metricKey,
@@ -272,13 +277,14 @@ function MetricGuidance({
   inline = false,
 }: {
   metricKey: MetricKey
-  profile: EfficiencyProfile
+  profile: EfficiencyProfile | null
   inline?: boolean
 }) {
-  const advice = [
-    ...efficiencyThresholdGuidance(metricKey, profile),
-    ...METRIC_GUIDANCE[metricKey],
-  ]
+  const metricGuidance =
+    profile === null
+      ? (NEUTRAL_GUIDANCE_OVERRIDES[metricKey] ?? METRIC_GUIDANCE[metricKey])
+      : METRIC_GUIDANCE[metricKey]
+  const advice = [...efficiencyThresholdGuidance(metricKey, profile), ...metricGuidance]
   if (inline) {
     return (
       <p className="type-callout text-pretty text-label-tertiary">
@@ -306,11 +312,10 @@ const ROW_CLASS =
   "-mx-1.5 rounded-control px-1.5 py-1 type-body transition-colors duration-[var(--duration-fast)] ease-out hover:bg-surface-hover focus-visible:bg-surface-hover"
 
 /**
- * The $/MTok reading: label and figure on one baseline, and its scale
- * underneath. This metric is not part of the composition, so it keeps the
- * scale the other readings gave up. The wide pane keeps the guidance in a
- * tooltip on the hero figure, so the scale and its labels are the whole
- * reading at rest. The popover prints the guidance under the scale.
+ * The $/MTok reading shows the label and figure on one baseline.
+ * It shows a scale only when a benchmark applies.
+ * The wide pane opens guidance from the hero figure.
+ * The popover prints guidance below the reading.
  */
 function CostRowLine({
   metric,
@@ -318,7 +323,7 @@ function CostRowLine({
   wide,
 }: {
   metric: EfficiencyMetric
-  profile: EfficiencyProfile
+  profile: EfficiencyProfile | null
   wide: boolean
 }) {
   return (
@@ -356,7 +361,7 @@ function CostRowLine({
           </span>
         </span>
       )}
-      <CostScaleBar metric={metric} profile={profile} wide={wide} />
+      {profile !== null && <CostScaleBar metric={metric} profile={profile} wide={wide} />}
       {!wide && (
         <div className="mt-3" data-testid="cost-guidance">
           <MetricGuidance metricKey="costPerMTok" profile={profile} inline />
@@ -367,16 +372,15 @@ function CostRowLine({
 }
 
 /**
- * One line of the composition legend: the slice's color, its name, its share,
- * and the band word. The run in the track above carries the size, so the row
- * carries no bar of its own.
+ * One composition line shows the slice color, name, share, and optional band word.
+ * The track shows the size, so the row has no bar.
  */
 function ShareRowLine({
   segment,
   profile,
 }: {
   segment: ShareSegment
-  profile: EfficiencyProfile
+  profile: EfficiencyProfile | null
 }) {
   return (
     <Tooltip label={<MetricGuidance metricKey={segment.key} profile={profile} />} delayMs={150}>
@@ -391,9 +395,13 @@ function ShareRowLine({
         />
         <span className="min-w-0 flex-1 truncate text-label-secondary">{segment.label}</span>
         <span className="shrink-0 text-label tabular-nums">{segment.displayPercent}</span>
-        <span className={cn("w-12 shrink-0 text-end", BAND_WORD_CLASS)}>
-          {efficiencyBandWord(segment.metric.band, segment.key)}
-        </span>
+        {segment.metric.band === null ? (
+          <span className="w-12 shrink-0" />
+        ) : (
+          <span className={cn("w-12 shrink-0 text-end", BAND_WORD_CLASS)}>
+            {efficiencyBandWord(segment.metric.band, segment.key)}
+          </span>
+        )}
       </div>
     </Tooltip>
   )

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
@@ -33,6 +33,7 @@ describe("efficiencyMetrics", () => {
     expect(m.carryShare?.value).toBeCloseTo(0.54)
     expect(m.unpricedTurns).toBe(0)
     expect(m.profile).toBe("claude")
+    expect(m.guidanceProfile).toBe("claude")
   })
 
   it("bands an ok Claude session as ok on every metric", () => {
@@ -81,6 +82,7 @@ describe("efficiencyMetrics", () => {
     // $40/MTok is ok for Claude and high for Codex.
     const m = efficiencyMetrics(totals(), "codex")
     expect(m.profile).toBe("codex")
+    expect(m.guidanceProfile).toBe("codex")
     expect(m.costPerMTok?.band).toBe("ok")
     const dear = efficiencyMetrics(totals({ totalUsd: 12, rewriteUsd: 0.6 }), "codex")
     expect(dear.costPerMTok?.band).toBe("bad")
@@ -107,20 +109,22 @@ describe("efficiencyMetrics", () => {
     expect(m.realWorkShare).not.toBeNull()
   })
 
-  it("preserves Pi values without applying benchmark bands", () => {
-    const m = efficiencyMetrics(totals({ unpricedTurns: 3 }), "pi")
+  it.each(["pi", "cursor", "opencode", "antigravity", "unknown", "", "__proto__"])(
+    "preserves the legacy visualization for %s without agent-specific guidance",
+    (agent) => {
+      const subjectTotals = totals({ unpricedTurns: 3 })
+      const baseline = efficiencyMetrics(subjectTotals, "claude-code")
+      const metrics = efficiencyMetrics(subjectTotals, agent)
 
-    expect(m.costPerMTok?.value).toBeCloseTo(40)
-    expect(m.realWorkShare?.value).toBeCloseTo(0.34)
-    expect(m.rewriteShare?.value).toBeCloseTo(0.12)
-    expect(m.carryShare?.value).toBeCloseTo(0.54)
-    expect(m.costPerMTok?.band).toBeNull()
-    expect(m.realWorkShare?.band).toBeNull()
-    expect(m.rewriteShare?.band).toBeNull()
-    expect(m.carryShare?.band).toBeNull()
-    expect(m.unpricedTurns).toBe(3)
-    expect(m.profile).toBeNull()
-  })
+      expect(metrics.costPerMTok).toEqual(baseline.costPerMTok)
+      expect(metrics.realWorkShare).toEqual(baseline.realWorkShare)
+      expect(metrics.rewriteShare).toEqual(baseline.rewriteShare)
+      expect(metrics.carryShare).toEqual(baseline.carryShare)
+      expect(metrics.unpricedTurns).toBe(3)
+      expect(metrics.profile).toBe("claude")
+      expect(metrics.guidanceProfile).toBeNull()
+    },
+  )
 
   it("carries the unpriced turn count through", () => {
     expect(efficiencyMetrics(totals({ unpricedTurns: 3 }), "claude-code").unpricedTurns).toBe(3)
@@ -128,14 +132,16 @@ describe("efficiencyMetrics", () => {
 })
 
 describe("efficiencyProfile", () => {
-  it("maps only exact supported agents to benchmark profiles", () => {
+  it("maps only exact supported agents to guidance profiles", () => {
     expect(efficiencyProfile("claude-code")).toBe("claude")
     expect(efficiencyProfile("codex")).toBe("codex")
     expect(efficiencyProfile("cursor")).toBeNull()
     expect(efficiencyProfile("pi")).toBeNull()
     expect(efficiencyProfile("opencode")).toBeNull()
     expect(efficiencyProfile("antigravity")).toBeNull()
-    expect(efficiencyProfile("future-agent")).toBeNull()
+    expect(efficiencyProfile("unknown")).toBeNull()
+    expect(efficiencyProfile("")).toBeNull()
+    expect(efficiencyProfile("__proto__")).toBeNull()
   })
 })
 

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.test.ts
@@ -107,16 +107,35 @@ describe("efficiencyMetrics", () => {
     expect(m.realWorkShare).not.toBeNull()
   })
 
+  it("preserves Pi values without applying benchmark bands", () => {
+    const m = efficiencyMetrics(totals({ unpricedTurns: 3 }), "pi")
+
+    expect(m.costPerMTok?.value).toBeCloseTo(40)
+    expect(m.realWorkShare?.value).toBeCloseTo(0.34)
+    expect(m.rewriteShare?.value).toBeCloseTo(0.12)
+    expect(m.carryShare?.value).toBeCloseTo(0.54)
+    expect(m.costPerMTok?.band).toBeNull()
+    expect(m.realWorkShare?.band).toBeNull()
+    expect(m.rewriteShare?.band).toBeNull()
+    expect(m.carryShare?.band).toBeNull()
+    expect(m.unpricedTurns).toBe(3)
+    expect(m.profile).toBeNull()
+  })
+
   it("carries the unpriced turn count through", () => {
     expect(efficiencyMetrics(totals({ unpricedTurns: 3 }), "claude-code").unpricedTurns).toBe(3)
   })
 })
 
 describe("efficiencyProfile", () => {
-  it("uses the Claude bands for every agent but Codex", () => {
-    expect(efficiencyProfile("codex")).toBe("codex")
+  it("maps only exact supported agents to benchmark profiles", () => {
     expect(efficiencyProfile("claude-code")).toBe("claude")
-    expect(efficiencyProfile("cursor")).toBe("claude")
+    expect(efficiencyProfile("codex")).toBe("codex")
+    expect(efficiencyProfile("cursor")).toBeNull()
+    expect(efficiencyProfile("pi")).toBeNull()
+    expect(efficiencyProfile("opencode")).toBeNull()
+    expect(efficiencyProfile("antigravity")).toBeNull()
+    expect(efficiencyProfile("future-agent")).toBeNull()
   })
 })
 
@@ -153,5 +172,6 @@ describe("formatting", () => {
     expect(efficiencyThresholdGuidance("carryShare", "codex")).toEqual([
       "For Codex, aim for below 59%. Above 69% is too high.",
     ])
+    expect(efficiencyThresholdGuidance("carryShare", null)).toEqual([])
   })
 })

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.ts
@@ -1,7 +1,8 @@
 /**
  * The headline efficiency metric and the three spend shares the card shows.
  *
- * Bands apply only to Claude Code and Codex because their harness behavior differs.
+ * Every session keeps the legacy visualization scale.
+ * Agent-specific threshold guidance appears only for explicitly supported agents.
  */
 
 import type { SessionEfficiency } from "../types/session"
@@ -9,13 +10,13 @@ import type { SessionEfficiency } from "../types/session"
 /** How a metric reads against its band thresholds. */
 export type EfficiencyBand = "good" | "ok" | "bad"
 
-/** The agent family whose thresholds a session reads against. */
+/** A reference family used for visualization or agent-specific guidance. */
 export type EfficiencyProfile = "claude" | "codex"
 
-/** One metric with its reading and an optional benchmark band. */
+/** One metric with its reading against the visualization scale. */
 export interface EfficiencyMetric {
   value: number
-  band: EfficiencyBand | null
+  band: EfficiencyBand
 }
 
 export interface EfficiencyMetrics {
@@ -28,13 +29,17 @@ export interface EfficiencyMetrics {
   /** Share of the spend that was carry, in the range 0 to 1. */
   carryShare: EfficiencyMetric | null
   unpricedTurns: number
-  profile: EfficiencyProfile | null
+  /** The non-null profile preserves the legacy scale and verdict visualization. */
+  profile: EfficiencyProfile
+  /** The nullable profile controls agent-specific tooltip and inline guidance. */
+  guidanceProfile: EfficiencyProfile | null
 }
 
-/** The good and bad edges for one metric. */
+/** Band edges and direction for one metric. */
 interface BandEdges {
   good: number
   bad: number
+  higherIsBetter: boolean
 }
 
 interface ProfileEdges {
@@ -44,47 +49,37 @@ interface ProfileEdges {
   carryShare: BandEdges
 }
 
-const HIGHER_IS_BETTER: Record<keyof ProfileEdges, boolean> = {
-  costPerMTok: false,
-  rewriteShare: false,
-  realWorkShare: true,
-  carryShare: false,
-}
-
 const EDGES: Record<EfficiencyProfile, ProfileEdges> = {
   claude: {
-    costPerMTok: { good: 33, bad: 80 },
-    rewriteShare: { good: 0.1, bad: 0.25 },
-    realWorkShare: { good: 0.36, bad: 0.18 },
+    costPerMTok: { good: 33, bad: 80, higherIsBetter: false },
+    rewriteShare: { good: 0.1, bad: 0.25, higherIsBetter: false },
+    realWorkShare: { good: 0.36, bad: 0.18, higherIsBetter: true },
     // Carry uses the overhead left when Real Work and Rewrite reach the same band.
-    carryShare: { good: 0.54, bad: 0.57 },
+    carryShare: { good: 0.54, bad: 0.57, higherIsBetter: false },
   },
   codex: {
-    costPerMTok: { good: 20, bad: 46 },
-    rewriteShare: { good: 0.08, bad: 0.14 },
-    realWorkShare: { good: 0.33, bad: 0.17 },
+    costPerMTok: { good: 20, bad: 46, higherIsBetter: false },
+    rewriteShare: { good: 0.08, bad: 0.14, higherIsBetter: false },
+    realWorkShare: { good: 0.33, bad: 0.17, higherIsBetter: true },
     // Carry uses the overhead left when Real Work and Rewrite reach the same band.
-    carryShare: { good: 0.59, bad: 0.69 },
+    carryShare: { good: 0.59, bad: 0.69, higherIsBetter: false },
   },
 }
 
-const PROFILE_BY_AGENT: Partial<Record<string, EfficiencyProfile>> = {
-  "claude-code": "claude",
-  codex: "codex",
-}
-
-/** The optional threshold family for an agent slug. */
+/** Return the guidance profile only for an exact supported agent slug. */
 export function efficiencyProfile(agent: string): EfficiencyProfile | null {
-  if (!Object.prototype.hasOwnProperty.call(PROFILE_BY_AGENT, agent)) return null
-  return PROFILE_BY_AGENT[agent] ?? null
+  if (agent === "claude-code") return "claude"
+  if (agent === "codex") return "codex"
+  return null
 }
 
-function bandFor(
-  value: number,
-  edges: BandEdges,
-  metricKey: keyof ProfileEdges,
-): EfficiencyBand {
-  if (HIGHER_IS_BETTER[metricKey]) {
+/** Preserve the pre-existing reference scale. This fallback does not validate agent-specific guidance. */
+function visualizationProfile(agent: string): EfficiencyProfile {
+  return agent === "codex" ? "codex" : "claude"
+}
+
+function bandFor(value: number, edges: BandEdges): EfficiencyBand {
+  if (edges.higherIsBetter) {
     if (value > edges.good) return "good"
     if (value < edges.bad) return "bad"
     return "ok"
@@ -122,7 +117,7 @@ function thermometerFor(
     position = (2 + Math.min(1, (value - high) / (top - high))) / 3
   }
   return {
-    segments: HIGHER_IS_BETTER[metricKey] ? ["bad", "ok", "good"] : ["good", "ok", "bad"],
+    segments: edges.higherIsBetter ? ["bad", "ok", "good"] : ["good", "ok", "bad"],
     position,
     ticks: [
       formatEdge(metricKey, 0),
@@ -142,38 +137,32 @@ export function efficiencyThermometer(
   return thermometerFor(value, EDGES[profile][metricKey], metricKey)
 }
 
-function metric(
-  value: number,
-  metricKey: keyof ProfileEdges,
-  profile: EfficiencyProfile | null,
-): EfficiencyMetric {
-  return {
-    value,
-    band: profile === null ? null : bandFor(value, EDGES[profile][metricKey], metricKey),
-  }
+function metric(value: number, edges: BandEdges): EfficiencyMetric {
+  return { value, band: bandFor(value, edges) }
 }
 
-/** The three metrics for one subject's totals, with applicable benchmark bands. */
+/** Build metrics with the legacy scale and separate agent-specific guidance applicability. */
 export function efficiencyMetrics(totals: SessionEfficiency, agent: string): EfficiencyMetrics {
-  const profile = efficiencyProfile(agent)
+  const profile = visualizationProfile(agent)
+  const guidanceProfile = efficiencyProfile(agent)
+  const edges = EDGES[profile]
   const denominatorTokens = totals.growthTokens + totals.outputTokens
   const hasSpend = totals.totalUsd > 0
   return {
     costPerMTok:
       hasSpend && denominatorTokens > 0
-        ? metric((totals.totalUsd / denominatorTokens) * 1e6, "costPerMTok", profile)
+        ? metric((totals.totalUsd / denominatorTokens) * 1e6, edges.costPerMTok)
         : null,
     realWorkShare: hasSpend
-      ? metric(totals.newWorkUsd / totals.totalUsd, "realWorkShare", profile)
+      ? metric(totals.newWorkUsd / totals.totalUsd, edges.realWorkShare)
       : null,
     rewriteShare: hasSpend
-      ? metric(totals.rewriteUsd / totals.totalUsd, "rewriteShare", profile)
+      ? metric(totals.rewriteUsd / totals.totalUsd, edges.rewriteShare)
       : null,
-    carryShare: hasSpend
-      ? metric(totals.carryUsd / totals.totalUsd, "carryShare", profile)
-      : null,
+    carryShare: hasSpend ? metric(totals.carryUsd / totals.totalUsd, edges.carryShare) : null,
     unpricedTurns: totals.unpricedTurns,
     profile,
+    guidanceProfile,
   }
 }
 
@@ -208,7 +197,7 @@ export function efficiencyBandWord(
   metricKey: keyof ProfileEdges,
 ): string {
   if (band !== "bad") return band
-  return HIGHER_IS_BETTER[metricKey] ? "low" : "high"
+  return EDGES.claude[metricKey].higherIsBetter ? "low" : "high"
 }
 
 /** Describe the good, bad, and neutral ranges for one metric. */
@@ -220,7 +209,7 @@ export function efficiencyThresholdGuidance(
 
   const edges = EDGES[profile][metricKey]
   const fmt = (value: number) => formatEdge(metricKey, value)
-  if (HIGHER_IS_BETTER[metricKey]) {
+  if (edges.higherIsBetter) {
     return [
       `For ${readableProfile[profile]}, aim for above ${fmt(edges.good)}. Below ${fmt(edges.bad)} is too low.`,
     ]

--- a/apps/desktop/src/lib/presentation/sessionEfficiency.ts
+++ b/apps/desktop/src/lib/presentation/sessionEfficiency.ts
@@ -1,8 +1,7 @@
 /**
  * The headline efficiency metric and the three spend shares the card shows.
  *
- * The bands differ by agent family because pricing and harness behavior differ.
- * Any agent other than Codex uses the Claude Code bands.
+ * Bands apply only to Claude Code and Codex because their harness behavior differs.
  */
 
 import type { SessionEfficiency } from "../types/session"
@@ -13,10 +12,10 @@ export type EfficiencyBand = "good" | "ok" | "bad"
 /** The agent family whose thresholds a session reads against. */
 export type EfficiencyProfile = "claude" | "codex"
 
-/** One metric with its reading, or null when the ratio is undefined. */
+/** One metric with its reading and an optional benchmark band. */
 export interface EfficiencyMetric {
   value: number
-  band: EfficiencyBand
+  band: EfficiencyBand | null
 }
 
 export interface EfficiencyMetrics {
@@ -29,18 +28,13 @@ export interface EfficiencyMetrics {
   /** Share of the spend that was carry, in the range 0 to 1. */
   carryShare: EfficiencyMetric | null
   unpricedTurns: number
-  profile: EfficiencyProfile
+  profile: EfficiencyProfile | null
 }
 
-/**
- * Band edges for one metric. A reading below `good` is good and one above
- * `bad` is bad; anything between reads as ok. A "higher is better"
- * metric flips the comparison.
- */
+/** The good and bad edges for one metric. */
 interface BandEdges {
   good: number
   bad: number
-  higherIsBetter: boolean
 }
 
 interface ProfileEdges {
@@ -50,30 +44,47 @@ interface ProfileEdges {
   carryShare: BandEdges
 }
 
+const HIGHER_IS_BETTER: Record<keyof ProfileEdges, boolean> = {
+  costPerMTok: false,
+  rewriteShare: false,
+  realWorkShare: true,
+  carryShare: false,
+}
+
 const EDGES: Record<EfficiencyProfile, ProfileEdges> = {
   claude: {
-    costPerMTok: { good: 33, bad: 80, higherIsBetter: false },
-    rewriteShare: { good: 0.1, bad: 0.25, higherIsBetter: false },
-    realWorkShare: { good: 0.36, bad: 0.18, higherIsBetter: true },
+    costPerMTok: { good: 33, bad: 80 },
+    rewriteShare: { good: 0.1, bad: 0.25 },
+    realWorkShare: { good: 0.36, bad: 0.18 },
     // Carry uses the overhead left when Real Work and Rewrite reach the same band.
-    carryShare: { good: 0.54, bad: 0.57, higherIsBetter: false },
+    carryShare: { good: 0.54, bad: 0.57 },
   },
   codex: {
-    costPerMTok: { good: 20, bad: 46, higherIsBetter: false },
-    rewriteShare: { good: 0.08, bad: 0.14, higherIsBetter: false },
-    realWorkShare: { good: 0.33, bad: 0.17, higherIsBetter: true },
+    costPerMTok: { good: 20, bad: 46 },
+    rewriteShare: { good: 0.08, bad: 0.14 },
+    realWorkShare: { good: 0.33, bad: 0.17 },
     // Carry uses the overhead left when Real Work and Rewrite reach the same band.
-    carryShare: { good: 0.59, bad: 0.69, higherIsBetter: false },
+    carryShare: { good: 0.59, bad: 0.69 },
   },
 }
 
-/** The threshold family for an agent slug. */
-export function efficiencyProfile(agent: string): EfficiencyProfile {
-  return agent === "codex" ? "codex" : "claude"
+const PROFILE_BY_AGENT: Partial<Record<string, EfficiencyProfile>> = {
+  "claude-code": "claude",
+  codex: "codex",
 }
 
-function bandFor(value: number, edges: BandEdges): EfficiencyBand {
-  if (edges.higherIsBetter) {
+/** The optional threshold family for an agent slug. */
+export function efficiencyProfile(agent: string): EfficiencyProfile | null {
+  if (!Object.prototype.hasOwnProperty.call(PROFILE_BY_AGENT, agent)) return null
+  return PROFILE_BY_AGENT[agent] ?? null
+}
+
+function bandFor(
+  value: number,
+  edges: BandEdges,
+  metricKey: keyof ProfileEdges,
+): EfficiencyBand {
+  if (HIGHER_IS_BETTER[metricKey]) {
     if (value > edges.good) return "good"
     if (value < edges.bad) return "bad"
     return "ok"
@@ -111,7 +122,7 @@ function thermometerFor(
     position = (2 + Math.min(1, (value - high) / (top - high))) / 3
   }
   return {
-    segments: edges.higherIsBetter ? ["bad", "ok", "good"] : ["good", "ok", "bad"],
+    segments: HIGHER_IS_BETTER[metricKey] ? ["bad", "ok", "good"] : ["good", "ok", "bad"],
     position,
     ticks: [
       formatEdge(metricKey, 0),
@@ -131,28 +142,36 @@ export function efficiencyThermometer(
   return thermometerFor(value, EDGES[profile][metricKey], metricKey)
 }
 
-function metric(value: number, edges: BandEdges): EfficiencyMetric {
-  return { value, band: bandFor(value, edges) }
+function metric(
+  value: number,
+  metricKey: keyof ProfileEdges,
+  profile: EfficiencyProfile | null,
+): EfficiencyMetric {
+  return {
+    value,
+    band: profile === null ? null : bandFor(value, EDGES[profile][metricKey], metricKey),
+  }
 }
 
-/** The three metrics for one subject's totals, read against `agent`'s bands. */
+/** The three metrics for one subject's totals, with applicable benchmark bands. */
 export function efficiencyMetrics(totals: SessionEfficiency, agent: string): EfficiencyMetrics {
   const profile = efficiencyProfile(agent)
-  const edges = EDGES[profile]
   const denominatorTokens = totals.growthTokens + totals.outputTokens
   const hasSpend = totals.totalUsd > 0
   return {
     costPerMTok:
       hasSpend && denominatorTokens > 0
-        ? metric((totals.totalUsd / denominatorTokens) * 1e6, edges.costPerMTok)
+        ? metric((totals.totalUsd / denominatorTokens) * 1e6, "costPerMTok", profile)
         : null,
     realWorkShare: hasSpend
-      ? metric(totals.newWorkUsd / totals.totalUsd, edges.realWorkShare)
+      ? metric(totals.newWorkUsd / totals.totalUsd, "realWorkShare", profile)
       : null,
     rewriteShare: hasSpend
-      ? metric(totals.rewriteUsd / totals.totalUsd, edges.rewriteShare)
+      ? metric(totals.rewriteUsd / totals.totalUsd, "rewriteShare", profile)
       : null,
-    carryShare: hasSpend ? metric(totals.carryUsd / totals.totalUsd, edges.carryShare) : null,
+    carryShare: hasSpend
+      ? metric(totals.carryUsd / totals.totalUsd, "carryShare", profile)
+      : null,
     unpricedTurns: totals.unpricedTurns,
     profile,
   }
@@ -175,9 +194,9 @@ function formatEdge(metricKey: keyof ProfileEdges, value: number): string {
   return metricKey === "costPerMTok" ? `$${value}` : `${Math.round(value * 100)}%`
 }
 
-function readableProfile(profile: EfficiencyProfile) {
-  if (profile === "claude") return "Claude"
-  if (profile === "codex") return "Codex"
+const readableProfile: Record<EfficiencyProfile, string> = {
+  claude: "Claude",
+  codex: "Codex",
 }
 
 /**
@@ -189,22 +208,24 @@ export function efficiencyBandWord(
   metricKey: keyof ProfileEdges,
 ): string {
   if (band !== "bad") return band
-  return EDGES.claude[metricKey].higherIsBetter ? "low" : "high"
+  return HIGHER_IS_BETTER[metricKey] ? "low" : "high"
 }
 
 /** Describe the good, bad, and neutral ranges for one metric. */
 export function efficiencyThresholdGuidance(
   metricKey: keyof ProfileEdges,
-  profile: EfficiencyProfile,
+  profile: EfficiencyProfile | null,
 ): string[] {
+  if (profile === null) return []
+
   const edges = EDGES[profile][metricKey]
   const fmt = (value: number) => formatEdge(metricKey, value)
-  if (edges.higherIsBetter) {
+  if (HIGHER_IS_BETTER[metricKey]) {
     return [
-      `For ${readableProfile(profile)}, aim for above ${fmt(edges.good)}. Below ${fmt(edges.bad)} is too low.`,
+      `For ${readableProfile[profile]}, aim for above ${fmt(edges.good)}. Below ${fmt(edges.bad)} is too low.`,
     ]
   }
   return [
-    `For ${readableProfile(profile)}, aim for below ${fmt(edges.good)}. Above ${fmt(edges.bad)} is too high.`,
+    `For ${readableProfile[profile]}, aim for below ${fmt(edges.good)}. Above ${fmt(edges.bad)} is too high.`,
   ]
 }


### PR DESCRIPTION
## User impact

Fixes #475.

Preserve all existing efficiency figures, scales, verdicts, colors, and layout for every agent. Only the tooltip/inline guidance changes when an agent has no dedicated threshold profile.

- Separate the existing visualization profile from nullable `guidanceProfile`.
- Keep Claude Code and Codex guidance unchanged.
- For Pi, Cursor, OpenCode, Antigravity, unknown, and empty slugs, omit Claude/Codex identity and numeric threshold recommendations from guidance.
- Keep metric explanations and general advice. Replace the neutral cost guidance’s "out of band" statement with a description of the cost composition.

The existing reference scales remain unchanged for compatibility; this change does not claim they are validated provider-specific benchmarks. No provider/model inference is added.

Updated following review: the original removal of scales/verdicts has been reversed. Nothing is hidden because the session is Pi.

## Validation

- Desktop formatting, lint, type-check: passed.
- Focused efficiency tests: 45 passed.
- Full desktop suite: 100 files, 1,313 tests passed.
- Production build: passed; existing chunk-size advisory remains.
- Design-drift contract: passed.
- `pnpm run slop:all`: passed, score 100, zero issues.
- `pnpm run secrets`: passed.
- `git diff --check`: passed.

Synthetic regressions cover both layouts, all four metric guidance surfaces, known and unknown agents, empty slugs, preserved visual details, and unchanged known-profile copy. Actual changes were compared with the pre-PR baseline.

## Analytics

Product question: does efficiency guidance avoid incorrect agent identity and unsupported numeric recommendations? Measurement is unchanged: this fixes copy on existing metric surfaces without adding an interaction. No new events, properties, triggers, or rate limits. Deterministic regression tests validate the corrected result; no instrumentation or catalog changes are needed.

## Privacy and performance

None. No changes to parsing, provider routes, data access, network access, retained data, or background work. No coverage-document or design-token changes are required.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.