### PR TITLE
chore: release app 0.5.1 and engine 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,12 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-09-10
+
 ### Changed
 
+- Session Details has a simpler layout and clearer Burn Check cards that adapt
+  to the window width.
 - Burn Checks now use stronger evidence contracts for supported Claude Code,
   Codex, OpenCode, Pi, and Antigravity sessions. Findings keep exact provider
   routes and supported checks decline clean results when required evidence is
@@ -29,6 +33,9 @@ CI changes, and documentation that no user acts on stay out — see
 
 ### Fixed
 
+- Expanded sub-agent rows stay aligned with the cost table columns.
+- Expired Pi credentials can refresh through Pi before antiburn retries live
+  usage, including installations managed by nvm.
 - Cache churn now uses the correct Claude or OpenAI accounting policy in mixed
   model sessions. Token-burn estimates stay unknown when prices or total-token
   evidence is unavailable.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "antiburn-anchored-window",
  "antiburn-hud",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/anchored-window", "crates/hud", "crates/main-window", "crates
 
 [package]
 name = "antiburn"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -17,6 +17,8 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-09-10
+
 ### Added
 
 - Typed per-detector finding causes now support exact target grouping and

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "antiburn-local"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MIT"


### PR DESCRIPTION
## User impact

Prepare desktop 0.5.1 with session-detail layout fixes, Pi credential refresh, and more reliable Burn Check evidence and session-change detection. Finalize the existing engine notes as 0.7.0 because its session-reader API changes are breaking.

Update both components' manifests and lockfiles without changing dependencies. After review and merge, tag the merged commit with `antiburn-local-v0.7.0`, verify the app's engine provenance, then tag `antiburn-v0.5.1`. Both workflows produce drafts for release review.

## Validation

- App and engine release-version verification passes.
- Desktop lint, type-check, 1,287 frontend tests, and production frontend build pass.
- Engine and desktop Rust formatting, Clippy with warnings denied, and full test suites pass, including 1,107 desktop Rust tests.
- Changed JSON files pass Prettier; `git diff --check`, `pnpm run slop:all`, and `pnpm run secrets` pass.
- App-engine provenance verification requires the new annotated engine tag after merge; the existing 0.6.1 tag correctly rejects the changed engine tree.
- Signed installers and platform smoke tests remain for the release workflows and draft review.

## Analytics

Measurement is unchanged by this version-and-changelog change. Existing instrumentation ships with the release.

## Privacy and performance

None from this release metadata change.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
