### PR TITLE
fix(desktop): recolor the session detail readings and unify the view pickers

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -77,6 +77,12 @@ colors:
   accent-fill: # concrete fill; use bg-accent-fill for backgrounds
     light: "hsl(210 100% 44.5%)"
     dark: "hsl(213.3 92% 48%)"
+  selected-fill: # the solid chip of a view picker; the neutral furthest from the track
+    light: "hsl(240 6% 26%)"
+    dark: "hsl(240 6% 84%)"
+  selected-ink: # the ink on that chip
+    light: "hsl(0 0% 100%)"
+    dark: "hsl(240 4% 12%)"
   brand: # antiburn orange for text and small glyphs
     light: "hsl(18 92% 39%)"
     dark: "hsl(17.6 100% 58.6%)"
@@ -220,6 +226,9 @@ colors:
   mark-compaction: # a compaction mark, lit; the brand tint in both themes
     light: "hsl(17.6 100% 58.6%)"
     dark: "hsl(17.6 100% 58.6%)"
+  measure: # the reading itself: the real-work run and the cost-scale measure; a calm blue
+    light: "hsl(191.5 83% 36.8%)"
+    dark: "hsl(192 63% 47.6%)"
   share-work: # efficiency composition, real work; teal, for fills
     light: "hsl(173.4 80% 40%)"
     dark: "hsl(173.5 78% 46.4%)"
@@ -235,6 +244,9 @@ colors:
   share-carry: # efficiency composition, carry; the mid neutral
     light: "hsl(240 5% 52%)"
     dark: "hsl(240 6% 62%)"
+  waste-warn: # a wasted-token figure that is bad, below the red for a severe one
+    light: "hsl(24 100% 45%)"
+    dark: "hsl(17.6 100% 58.6%)"
   context-warning:
     light: "hsl(32 95% 43.72%)"
     dark: "hsl(36.4 100% 52%)"
@@ -470,8 +482,15 @@ Notes for what isn't expressible as a token:
   session-row fork-glyph pattern. Every horizontal bar uses the usage meter (`SegmentedMeter`)
   silhouette; judgment is carried by the band word's ink, never by a multi-color bar. Color only
   where it means a category: blue for context, the token series colors for in/out, yellow and
-  pink for cache marks, brand orange for a compaction, teal for real work, red for waste.
-  Everything else stays greyscale until the pointer names a layer. The wide Cost tab is a query
+  pink for cache marks, brand orange for a compaction, and the `measure` blue wherever the view
+  draws a reading — the real-work run of the efficiency composition and the measure on the cost
+  scale. In that composition rewrite waste takes the mid neutral and carry takes the brand
+  orange, so the same orange means a compaction in the chart and carry in the bar below it; the
+  two never share a shape, and the legend beside each names it. The Tools tab reports its wasted
+  tokens in `waste-warn`, and in `system-red-text` when the waste is both a large share of the
+  startup context and large in absolute terms. `waste-warn` is its own token because `brand` is
+  too dark on the light surface to read as orange beside that red. Everything else stays greyscale
+  until the pointer names a layer. The wide Cost tab is a query
   container, and its burn checks answer their own pane width. Each check is a card, which is what
   groups its name with its verdict; the verdict is the mark alone, with the word kept for a screen
   reader, and the card itself is the affordance that opens the explanation. Two cards to a row, and

--- a/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.test.tsx
@@ -678,6 +678,52 @@ describe("SessionDetailPresentation — session facts", () => {
       screen.getByText("No startup context has been recorded for this session."),
     ).toBeTruthy()
   })
+
+  it("reddens the wasted-token figure only for a large share of a large context", () => {
+    function wastedContext(unusedTokens: number, usedTokens: number) {
+      return summary({
+        sessions: [
+          metrics({
+            initialContext: {
+              sources: [
+                {
+                  source: "skill_instructions",
+                  sourceName: "idle",
+                  tokenCount: unusedTokens,
+                  useCount: 0,
+                },
+                {
+                  source: "skill_instructions",
+                  sourceName: "busy",
+                  tokenCount: usedTokens,
+                  useCount: 1,
+                },
+              ],
+            },
+          }),
+        ],
+      })
+    }
+
+    function figureClass() {
+      fireEvent.click(screen.getByRole("tab", { name: /^Tools/ }))
+      return screen.getByTestId("tools-wasted-figure").className
+    }
+
+    // Three quarters of the startup context, and far past the floor.
+    const severe = view({ summary: wastedContext(30_000, 10_000) })
+    expect(figureClass()).toContain("text-system-red-text")
+    severe.unmount()
+
+    // The same share of a context too small for the waste to matter.
+    const small = view({ summary: wastedContext(3_000, 1_000) })
+    expect(figureClass()).toContain("text-waste-warn")
+    small.unmount()
+
+    // Past the floor, but a small share of a large context.
+    view({ summary: wastedContext(12_000, 200_000) })
+    expect(figureClass()).toContain("text-waste-warn")
+  })
 })
 
 describe("SessionDetailPresentation — presentation", () => {

--- a/apps/desktop/src/components/session/SessionDetailPresentation.tsx
+++ b/apps/desktop/src/components/session/SessionDetailPresentation.tsx
@@ -35,6 +35,7 @@ import {
   formatDuration,
   isEmptySummary,
   skillMcpUsage,
+  type SkillMcpUsage,
 } from "../../lib/presentation/sessionAnalysis"
 import { resultComponentCost, type LocalSessionCost } from "../../lib/presentation/sessionCosts"
 import { efficiencyMetrics } from "../../lib/presentation/sessionEfficiency"
@@ -338,6 +339,20 @@ const SERIES_SWATCH_CLASS: Record<ChartSeries, string> = {
 /** A shorter caption for a stat whose full name does not fit one cell. */
 const KEY_CAPTIONS: Record<string, string> = {
   "Provider cache misses": "Cache misses",
+}
+
+/* The wasted-token figure turns red only when the waste is a large share of
+   the startup context and large in absolute terms. Each test alone reports
+   the wrong sessions: a big context wastes a small share of a large number,
+   and a small context wastes a large share of a small one. */
+const WASTED_RED_SHARE = 0.5
+const WASTED_RED_TOKENS = 10_000
+
+/** The ink for the wasted-token figure: a warning orange, or red when it is worse. */
+function wastedTokensInk({ wastedTokens, totalTokens }: SkillMcpUsage): string {
+  const share = totalTokens > 0 ? wastedTokens / totalTokens : 0
+  const severe = share >= WASTED_RED_SHARE && wastedTokens >= WASTED_RED_TOKENS
+  return severe ? "text-system-red-text" : "text-waste-warn"
 }
 
 /**
@@ -897,7 +912,7 @@ export function SessionDetailPresentation({
               )}
 
               {tab === "cost" && (
-                <div className="session-detail-cost flex min-h-full flex-col gap-x-6">
+                <div className="session-detail-cost flex min-h-full flex-col gap-6">
                   {costSection}
                   {hasAssessedHygieneChecks && (
                     <section className="shrink-0">
@@ -922,7 +937,13 @@ export function SessionDetailPresentation({
                         ceiling, so it is a headline and not a meter. */}
                     {toolsUsage != null && toolsUsage.wastedTokens > 0 && (
                       <p className="flex items-center gap-x-4 my-2 py-3">
-                        <span className="font-semibold! text-brand tabular-nums type-display">
+                        <span
+                          data-testid="tools-wasted-figure"
+                          className={cn(
+                            "font-semibold! tabular-nums type-display",
+                            wastedTokensInk(toolsUsage),
+                          )}
+                        >
                           {formatCompact(toolsUsage.wastedTokens)}
                         </span>
                         <span className="flex flex-col type-callout leading-tight">
@@ -948,7 +969,7 @@ export function SessionDetailPresentation({
                 through to the content on either side of the pill. */}
             <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-6">
               <SegmentedControl
-                className="session-detail-tabs session-detail-floating-tabs pointer-events-auto type-callout shrink-0 rounded-full! bg-surface/80! shadow-raised [&_button]:rounded-full!"
+                className="ui-segmented-solid session-detail-tabs session-detail-floating-tabs pointer-events-auto type-callout shrink-0 rounded-full! bg-surface/80! shadow-raised [&_button]:rounded-full!"
                 options={DETAIL_TABS}
                 value={tab}
                 onChange={setTab}

--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -265,7 +265,7 @@ describe("SessionList — rows", () => {
     })
 
     expect(screen.getByRole("radio", { name: "$" })).toHaveAttribute("aria-checked", "false")
-    expect(screen.getByRole("radio", { name: "% 5h" })).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByRole("radio", { name: "5h" })).toHaveAttribute("aria-checked", "true")
     expect(screen.queryByLabelText("Estimated cost $1.00")).toBeNull()
     expect(
       screen.getByLabelText("Share of your 5-hour limit is not known for this session."),
@@ -352,7 +352,7 @@ describe("SessionList — rows", () => {
       },
     })
 
-    expect(screen.queryByRole("radio", { name: "% 5h" })).toBeNull()
+    expect(screen.queryByRole("radio", { name: "5h" })).toBeNull()
   })
 
   it("offers five-hour mode when the usage panel shows an empty five-hour window", () => {
@@ -402,7 +402,7 @@ describe("SessionList — rows", () => {
       },
     })
 
-    expect(screen.getByRole("radio", { name: "% 5h" })).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "5h" })).toBeInTheDocument()
   })
 
   it("keeps a five-hour allocation badge as time passes, since the factor never expires", () => {
@@ -432,11 +432,11 @@ describe("SessionList — rows", () => {
     }
     const { rerender } = render(<SessionList {...props} />)
 
-    expect(screen.getByRole("radio", { name: "% 5h" })).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByRole("radio", { name: "5h" })).toHaveAttribute("aria-checked", "true")
     expect(screen.getByText("6.3%")).toBeInTheDocument()
 
     rerender(<SessionList {...props} now={new Date(NOW.getTime() + 3_600_001)} />)
-    expect(screen.getByRole("radio", { name: "% 5h" })).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByRole("radio", { name: "5h" })).toHaveAttribute("aria-checked", "true")
     expect(screen.getByRole("radio", { name: "$" })).toHaveAttribute("aria-checked", "false")
     expect(screen.getByText("6.3%")).toBeInTheDocument()
   })

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -745,9 +745,9 @@ export function SessionList({
             <SegmentedControl
               options={[
                 { value: "cost", label: "$" },
-                { value: "weeklyPercent", label: "% week" },
+                { value: "weeklyPercent", label: "week" },
                 ...(fiveHourAvailable
-                  ? [{ value: "fiveHourPercent" as const, label: "% 5h" }]
+                  ? [{ value: "fiveHourPercent" as const, label: "5h" }]
                   : []),
               ]}
               value={selectedMetric}

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -753,7 +753,11 @@ export function SessionList({
               value={selectedMetric}
               onChange={onBadgeMetricChange}
               ariaLabel="Session badge metric"
-              className="normal-case"
+              /* The same picker treatment as the section picker over the
+                 session detail: a pill track with no outline, and a solid
+                 neutral chip for the selected metric. */
+              variant="native-tabs"
+              className="ui-segmented-solid normal-case rounded-full! bg-surface-secondary! [&_button]:rounded-full! [&_button]:px-2.5!"
             />
           )}
         </div>

--- a/apps/desktop/src/components/session/SessionStatusBar.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.tsx
@@ -55,8 +55,22 @@ function verdictInk(failedShare: number, assessedCount: number): string {
   return `color-mix(in oklch, var(--color-system-red-tint) ${pct}%, var(--color-system-orange-tint))`
 }
 
-function formatLimitPercent(percent: number): string {
-  return `${roundedLimitPercent(percent)}%`
+/**
+ * Show the share as a figure and a percent sign.
+ *
+ * English style puts no space before the percent sign, so the two stay one
+ * text run: the figure and the sign are sibling text nodes, and the value
+ * copies as "17.2%". The empty element between them is a hair space. The
+ * monospace percent sign fills its cell with ink, and without that space it
+ * looks joined to the last digit.
+ */
+function LimitPercent({ percent }: { percent: number }) {
+  return (
+    <>
+      {roundedLimitPercent(percent)}
+      <span aria-hidden="true" className="inline-block w-px" />%
+    </>
+  )
 }
 
 function roundedLimitPercent(percent: number): number {
@@ -182,7 +196,10 @@ export function SessionStatusBar({
             <span
               className={
                 isHighLimitShare
-                  ? "flex shrink-0 items-center gap-0.5 rounded-full bg-brand-tint px-1.5 py-px font-mono type-footnote font-medium! leading-[13px] tracking-tight! text-white tabular-nums"
+                  ? // The pill keeps the tracking of type-footnote. Tighter
+                    // tracking moves the wide percent sign into the last digit,
+                    // because the monospace cell is already full.
+                    "flex shrink-0 items-center gap-0.5 rounded-full bg-brand-tint px-1.5 py-px font-mono type-footnote font-medium! leading-[13px] text-white tabular-nums"
                   : "font-mono type-footnote tabular-nums text-label-secondary"
               }
               data-session-limit-provider={limitBadge.provider}
@@ -196,7 +213,7 @@ export function SessionStatusBar({
               tabIndex={0}
             >
               {isHighLimitShare && <Flame size={11} className="shrink-0" aria-hidden="true" />}
-              {formatLimitPercent(limitBadge.percent)}
+              <LimitPercent percent={limitBadge.percent} />
             </span>
           </Tooltip>
         ) : limitBadge ? (

--- a/apps/desktop/src/components/session/SessionStatusBar.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.tsx
@@ -174,7 +174,10 @@ export function SessionStatusBar({
   const isHighLimitShare = roundedLimitPercent(limitBadge?.percent ?? 0) >= 5
 
   return (
-    <div className="flex w-full items-center justify-between gap-x-1.5 text-label-secondary">
+    // One height for every state. A pill badge adds a pixel of padding above
+    // and below its 13px line box, so a row that shows one would otherwise
+    // stand taller than a row that shows plain text.
+    <div className="flex h-[15px] w-full items-center justify-between gap-x-1.5 text-label-secondary">
       {showVerdict && (
         <Tooltip label={tooltip} delayMs={150}>
           <span
@@ -200,7 +203,9 @@ export function SessionStatusBar({
                     // tracking moves the wide percent sign into the last digit,
                     // because the monospace cell is already full.
                     "flex shrink-0 items-center gap-0.5 rounded-full bg-brand-tint px-1.5 py-px font-mono type-footnote font-medium! leading-[13px] text-white tabular-nums"
-                  : "font-mono type-footnote tabular-nums text-label-secondary"
+                  : // The same 13px line box as the pill, so the two states of
+                    // the badge occupy one box.
+                    "font-mono type-footnote leading-[13px] tabular-nums text-label-secondary"
               }
               data-session-limit-provider={limitBadge.provider}
               data-session-limit-window={limitBadge.windowId}
@@ -219,7 +224,7 @@ export function SessionStatusBar({
         ) : limitBadge ? (
           <Tooltip label={limitBadge.label} delayMs={150}>
             <span
-              className="font-mono type-footnote text-label-secondary opacity-50"
+              className="font-mono type-footnote leading-[13px] text-label-secondary opacity-50"
               aria-label={limitBadge.label}
               tabIndex={0}
             >

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.test.tsx
@@ -63,6 +63,9 @@ describe("EfficiencyBreakdown", () => {
 
     const measure = cost.querySelector<HTMLElement>('[data-testid="cost-measure"]')
     expect(Number.parseFloat(measure!.style.width)).toBeCloseTo(38.3, 1)
+    // The measure is the reading, not a verdict, so it draws in the same
+    // blue as the real-work run and leaves the judgment to the band word.
+    expect(measure!.className).toContain("bg-measure")
     // The band steps and the ranges mark every edge, so no target line draws.
     expect(cost.querySelector('[data-testid="cost-target"]')).toBeNull()
 
@@ -104,11 +107,11 @@ describe("EfficiencyBreakdown", () => {
     expect(widths.reduce((sum, width) => sum + width, 0)).toBeCloseTo(1, 5)
 
     // Each slice keeps its own color so it stays recognisable between
-    // sessions: label ink for real work, brand orange for waste, neutral
-    // for carry. No slice takes a verdict colour.
-    expect(runs[0]!.className).toContain("bg-label")
-    expect(runs[1]!.className).toContain("bg-brand-tint")
-    expect(runs[2]!.className).toContain("bg-share-carry")
+    // sessions: the measure blue for real work, neutral for waste, brand
+    // orange for carry. No slice takes a verdict colour.
+    expect(runs[0]!.className).toContain("bg-measure")
+    expect(runs[1]!.className).toContain("bg-share-carry")
+    expect(runs[2]!.className).toContain("bg-brand-tint")
 
     // No share draws a meter of its own any more.
     expect(screen.queryByTestId("share-segment-realWorkShare")).toBeNull()

--- a/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/EfficiencyBreakdown.tsx
@@ -71,9 +71,9 @@ interface ShareRow {
   key: ShareMetricKey
   label: string
   /* The slice keeps one color for the life of the feature, so a reader
-     recognizes it between sessions. Real work is the label ink, rewrite
-     waste is the brand orange, because waste is the burn antiburn is named
-     for, and carry stays the mid neutral. */
+     recognizes it between sessions. Real work takes the measure blue, the
+     same blue the cost scale draws its reading in. Rewrite waste takes the
+     mid neutral and carry the brand orange. */
   inkClassName: string
 }
 
@@ -81,17 +81,17 @@ const SHARE_ROWS: ShareRow[] = [
   {
     key: "realWorkShare",
     label: "Real Work %",
-    inkClassName: "bg-label",
+    inkClassName: "bg-measure",
   },
   {
     key: "rewriteShare",
     label: "Rewrite Waste %",
-    inkClassName: "bg-brand-tint",
+    inkClassName: "bg-share-carry",
   },
   {
     key: "carryShare",
     label: "Carry %",
-    inkClassName: "bg-share-carry",
+    inkClassName: "bg-brand-tint",
   },
 ]
 
@@ -141,7 +141,7 @@ function shareSegments(metrics: EfficiencyMetrics): ShareSegment[] {
 
 /**
  * The $/MTok scale as a bullet graph. Three grey bands mark good, middle,
- * and bad at fixed thirds, and a thin brand measure runs from zero to this
+ * and bad at fixed thirds, and a thin blue measure runs from zero to this
  * session's reading. Under each band sit its word and its dollar range, so
  * the scale labels itself and the reading needs no tag. The band steps and
  * the ranges already mark every edge, so no separate target line is drawn.
@@ -184,7 +184,7 @@ function CostScaleBar({
         ))}
         <span
           data-testid="cost-measure"
-          className="absolute inset-y-1 left-0 rounded-e-sm bg-brand-tint"
+          className="absolute inset-y-1 left-0 rounded-e-sm bg-measure"
           style={{ width: `${scale.position * 100}%` }}
         />
       </div>

--- a/apps/desktop/src/components/ui/SegmentedControl.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.tsx
@@ -160,9 +160,15 @@ export function SegmentedControl<T extends string>({
                   ? cn(
                       "ui-segmented-native-segment relative min-w-0 rounded-control py-0.5 type-caption transition-colors duration-[var(--duration-quick)] ease-out-quart disabled:opacity-50",
                       !stretchNativeTabs && "px-4",
+                      // One weight for every segment. The track sizes its
+                      // columns to their content, so a heavier selected
+                      // segment changes the width of the whole control each
+                      // time the selection moves. The chip names the
+                      // selection instead.
+                      "font-medium!",
                       selected
-                        ? "font-semibold! text-label shadow-raised"
-                        : "font-medium! text-label-secondary hover:text-label",
+                        ? "text-label shadow-raised"
+                        : "text-label-secondary hover:text-label",
                     )
                   : raisedTabs
                     ? cn(

--- a/apps/desktop/src/styles/controls.css
+++ b/apps/desktop/src/styles/controls.css
@@ -63,7 +63,9 @@ button:active,
 }
 
 .ui-segmented-native-segment:not([aria-selected="true"]):not([aria-checked="true"])
-  + .ui-segmented-native-segment:not([aria-selected="true"]):not([aria-checked="true"])::before {
+  + .ui-segmented-native-segment:not([aria-selected="true"]):not(
+    [aria-checked="true"]
+  )::before {
   content: "";
   position: absolute;
   inset-block: 5px;

--- a/apps/desktop/src/styles/controls.css
+++ b/apps/desktop/src/styles/controls.css
@@ -48,17 +48,22 @@ button:active,
    The macOS segmented control. The track is recessed and the selected
    segment is raised on the surface: white on the light theme and a lighter
    grey on the dark one, where the surface is darker than the track. A
-   hairline separates two unselected neighbours. */
+   hairline separates two unselected neighbours.
+
+   Each rule reads both selected states. The control writes `aria-selected`
+   when it is a set of tabs and `aria-checked` when it is a radio group, and
+   the variant looks the same in both roles. */
 .ui-segmented-native {
   border-radius: calc(var(--radius-control) + 2px);
 }
 
-.ui-segmented-native-segment[aria-selected="true"] {
+.ui-segmented-native-segment[aria-selected="true"],
+.ui-segmented-native-segment[aria-checked="true"] {
   background-color: var(--color-surface);
 }
 
-.ui-segmented-native-segment:not([aria-selected="true"])
-  + .ui-segmented-native-segment:not([aria-selected="true"])::before {
+.ui-segmented-native-segment:not([aria-selected="true"]):not([aria-checked="true"])
+  + .ui-segmented-native-segment:not([aria-selected="true"]):not([aria-checked="true"])::before {
   content: "";
   position: absolute;
   inset-block: 5px;
@@ -68,11 +73,26 @@ button:active,
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .ui-segmented-native-segment[aria-selected="true"] {
+  :root:not([data-theme="light"]) .ui-segmented-native-segment[aria-selected="true"],
+  :root:not([data-theme="light"]) .ui-segmented-native-segment[aria-checked="true"] {
     background-color: var(--color-surface-tertiary);
   }
 }
 
-:root[data-theme="dark"] .ui-segmented-native-segment[aria-selected="true"] {
+:root[data-theme="dark"] .ui-segmented-native-segment[aria-selected="true"],
+:root[data-theme="dark"] .ui-segmented-native-segment[aria-checked="true"] {
   background-color: var(--color-surface-tertiary);
+}
+
+/* A view picker whose selected segment is a solid neutral chip, not the
+   raised surface above. The two pickers in the main window use it: the
+   metric picker over the session list, and the section picker that floats
+   over the session detail. The selector carries `:root` to reach the
+   specificity of the theme branches above, and comes after them, so it wins
+   the tie in every theme. */
+:root .ui-segmented-solid .ui-segmented-native-segment[aria-selected="true"],
+:root .ui-segmented-solid .ui-segmented-native-segment[aria-checked="true"] {
+  background-color: var(--color-selected-fill);
+  color: var(--color-selected-ink);
+  box-shadow: var(--shadow-raised);
 }

--- a/apps/desktop/src/styles/session-analysis-colors.css
+++ b/apps/desktop/src/styles/session-analysis-colors.css
@@ -71,16 +71,27 @@
   --color-mark-routing-miss: var(--color-mark-routing-miss-val);
   --color-mark-compaction: var(--color-mark-compaction-val);
 
-  /* The three parts of the efficiency composition: real work, rewrite waste,
-     and carry. Real work takes a teal and rewrite waste a hot red, so the
-     composition reads good to bad. Carry takes a mid grey, because carry is
-     neither good nor bad. The `-text` pair is the same hue as ink for words:
-     a fill color is too light to read on the light surface. */
+  /* The reading itself, wherever the session analysis draws one: the real-work
+     run of the efficiency composition, and the measure on the cost scale. A
+     calm blue, because a reading is not a verdict. The words beside it carry
+     the judgment. */
+  --color-measure: var(--color-measure-val);
+
+  /* The words for the two verdict-bearing shares. The composition runs take
+     their fills elsewhere; these `-text` values are the same hues as ink,
+     because a fill color is too light to read on the light surface. */
   --color-share-work: var(--color-share-work-val);
   --color-share-work-text: var(--color-share-work-text-val);
   --color-share-waste: var(--color-share-waste-val);
   --color-share-waste-text: var(--color-share-waste-text-val);
   --color-share-carry: var(--color-share-carry-val);
+
+  /* The ink for a wasted-token figure that is bad, below the red that marks a
+     severe one. The light value turns the hue away from the brand orange and
+     keeps enough contrast to read on white. `--color-brand` is too dark on the
+     light surface and looks like rust, not orange. The dark value is the brand
+     orange, which needs no change against the dark surface. */
+  --color-waste-warn: var(--color-waste-warn-val);
 
   /* The one alert hue in this palette, shared by every surface that needs an
      attention step between neutral and critical states. Its own
@@ -115,11 +126,13 @@
   --color-mark-rehydration-val: hsl(45.5 96% 56.2%); /* yellow */
   --color-mark-routing-miss-val: hsl(330.3 81% 60.3%); /* pink */
   --color-mark-compaction-val: hsl(17.6 100% 58.6%); /* brand-tint */
+  --color-measure-val: hsl(191.5 83% 36.8%); /* cyan-blue */
   --color-share-work-val: hsl(173.4 80% 40%); /* teal */
   --color-share-work-text-val: hsl(174 80% 25.4%);
   --color-share-waste-val: hsl(347.9 100% 56%); /* hot red */
   --color-share-waste-text-val: hsl(348 100% 34.5%);
   --color-share-carry-val: hsl(240 5% 52%);
+  --color-waste-warn-val: hsl(24 100% 45%); /* orange, dark enough to read on white */
   --color-context-warning-val: hsl(32 95% 43.72%); /* amber-600 */
   --color-context-critical-val: hsl(0 72% 50.5%); /* red-600 */
 }
@@ -147,11 +160,13 @@
     --color-mark-rehydration-val: hsl(45.2 96% 60.1%); /* yellow */
     --color-mark-routing-miss-val: hsl(330.6 82% 64.5%); /* pink */
     --color-mark-compaction-val: hsl(17.6 100% 58.6%); /* brand-tint */
+    --color-measure-val: hsl(192 63% 47.6%); /* cyan-blue, lifted for the dark surface */
     --color-share-work-val: hsl(173.5 78% 46.4%); /* teal */
     --color-share-work-text-val: hsl(173.5 78% 46.4%);
     --color-share-waste-val: hsl(348 100% 60.5%); /* hot red */
     --color-share-waste-text-val: hsl(348 100% 60.5%);
     --color-share-carry-val: hsl(240 6% 62%);
+    --color-waste-warn-val: hsl(17.6 100% 58.6%); /* brand-tint */
     --color-context-warning-val: hsl(36.4 100% 52%); /* vivid amber */
     --color-context-critical-val: hsl(0 90% 70.7%); /* red-400 */
   }
@@ -175,11 +190,13 @@
   --color-mark-rehydration-val: hsl(45.2 96% 60.1%);
   --color-mark-routing-miss-val: hsl(330.6 82% 64.5%);
   --color-mark-compaction-val: hsl(17.6 100% 58.6%);
+  --color-measure-val: hsl(192 63% 47.6%);
   --color-share-work-val: hsl(173.5 78% 46.4%);
   --color-share-work-text-val: hsl(173.5 78% 46.4%);
   --color-share-waste-val: hsl(348 100% 60.5%);
   --color-share-waste-text-val: hsl(348 100% 60.5%);
   --color-share-carry-val: hsl(240 6% 62%);
+  --color-waste-warn-val: hsl(17.6 100% 58.6%);
   --color-context-warning-val: hsl(36.4 100% 52%);
   --color-context-critical-val: hsl(0 90% 70.7%);
 }

--- a/apps/desktop/src/styles/session-detail.css
+++ b/apps/desktop/src/styles/session-detail.css
@@ -61,13 +61,9 @@
 .session-detail-wide .session-detail-tabs button::before {
   display: none;
 }
-/* The selected view takes the accent fill and white ink, the same as the
-   session list's metric picker, so both pickers in the window read alike. */
-.session-detail-wide .session-detail-tabs button[aria-selected="true"] {
-  background-color: var(--color-accent-fill);
-  color: white;
-  box-shadow: var(--shadow-raised);
-}
+/* The selected view takes the solid neutral chip of `.ui-segmented-solid`,
+   the same as the session list's metric picker, so both pickers in the
+   window read alike. */
 .session-detail-wide .session-detail-tabs button {
   font-weight: 400 !important;
   font-size: inherit;

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -49,6 +49,12 @@
   /* accent-fill is the concrete value; the live system accent token breaks when
      used as a background-color, so backgrounds must use this one. */
   --color-accent-fill: var(--color-accent-fill-val);
+  /* The solid chip of a view picker, and the ink on it. The fill is the
+     neutral furthest from the track: the darkest one on the light theme and
+     the lightest one on the dark theme. A dark chip on a dark track has too
+     little separation to name the selected view. */
+  --color-selected-fill: var(--color-selected-fill-val);
+  --color-selected-ink: var(--color-selected-ink-val);
   /* The antiburn brand orange, in the two-token shape system-orange uses.
      brand-tint fills a large shape — a meter segment, a ring arc, a hover
      wash — and carries the mark unchanged in both themes. brand inks text and
@@ -154,6 +160,8 @@
   --color-accent-val: hsl(211.2 100% 50%);
   --color-accent-fill-val: hsl(210 100% 44.5%);
   --color-accent-hover-val: hsl(210.4 100% 39%);
+  --color-selected-fill-val: hsl(240 6% 26%);
+  --color-selected-ink-val: hsl(0 0% 100%);
 
   /* Brand — the antiburn orange. The mark itself fills large shapes in both
      themes. On a light surface it measures 2.9:1, so text and small glyphs
@@ -260,6 +268,8 @@
     --color-accent-val: hsl(210 100% 51.9%);
     --color-accent-fill-val: hsl(213.3 92% 48%);
     --color-accent-hover-val: hsl(213.5 91% 42%);
+    --color-selected-fill-val: hsl(240 6% 84%);
+    --color-selected-ink-val: hsl(240 4% 12%);
     /* The mark measures 7.4:1 on a dark surface, so text keeps it too. */
     --color-brand-tint-val: hsl(17.6 100% 58.6%);
     --color-brand-unlit-val: hsl(17.7 75% 58.6%);
@@ -321,6 +331,8 @@
   --color-accent-val: hsl(211.2 100% 50%);
   --color-accent-fill-val: hsl(210 100% 44.5%);
   --color-accent-hover-val: hsl(210.4 100% 39%);
+  --color-selected-fill-val: hsl(240 6% 26%);
+  --color-selected-ink-val: hsl(0 0% 100%);
   --color-brand-tint-val: hsl(17.6 100% 58.6%);
   --color-brand-unlit-val: hsl(17.7 75% 58.6%);
   --color-brand-val: hsl(18 92% 39%);
@@ -381,6 +393,8 @@
   --color-accent-val: hsl(210 100% 51.9%);
   --color-accent-fill-val: hsl(213.3 92% 48%);
   --color-accent-hover-val: hsl(213.5 91% 42%);
+  --color-selected-fill-val: hsl(240 6% 84%);
+  --color-selected-ink-val: hsl(240 4% 12%);
   --color-brand-tint-val: hsl(17.6 100% 58.6%);
   --color-brand-unlit-val: hsl(17.7 75% 58.6%);
   --color-brand-val: hsl(17.6 100% 58.6%);

--- a/docs/plans/session-detail-blue.md
+++ b/docs/plans/session-detail-blue.md
@@ -118,3 +118,23 @@ clearer split.
 Options if the light case matters: use `system-red` (`hsl(354 100% 42.1%)`) instead of
 `system-red-text` for more saturation, or carry the severity in a word beside the figure
 rather than in the ink alone.
+
+## Follow-up polish
+
+Three items came from a look at the built branch.
+
+| Item | State |
+|---|---|
+| Picker changed width with the selection | done — every `native-tabs` segment now takes `font-medium`, so the track columns keep one size |
+| Metric labels shortened to `$ / week / 5h` | done — the `%` added nothing that the values do not already show |
+| Percent sign looked joined to the figure | done — see below |
+
+The limit badge sets its figures in a tabular monospace face. The percent sign fills its cell
+with ink where a digit does not, so the gap in front of it looks smaller than the gaps between
+the digits. Two changes fix it. The pill no longer takes `tracking-tight`, which had pulled the
+sign a further 0.28px into the last digit and which its own plain sibling never used. A 1px
+inline spacer then adds the hair space that the face cannot give. The spacer is an empty
+element between two text nodes, so the value still reads and copies as one run: `17.2%`.
+
+English style puts no space before a percent sign, so a real space was not an option. A space
+would also cost a full monospace cell in every row of the list.

--- a/docs/plans/session-detail-blue.md
+++ b/docs/plans/session-detail-blue.md
@@ -1,0 +1,120 @@
+# Session detail: a blue for the reading, orange for carry
+
+Four tweaks to the Sessions detail view, from three Notate captures on 2026-09-10.
+Branch `feat/sessions-detail-view-blue`, off `main` at 28822df9.
+
+## What changes
+
+| # | Where | Now | After |
+|---|---|---|---|
+| 1 | Context tab, composition bar + legend dots | Real Work black, Rewrite Waste orange, Carry grey | Real Work **blue**, Rewrite Waste **grey**, Carry **orange** |
+| 2 | Cost tab, `$/MTOK` measure bar | brand orange | the same **blue** |
+| 3 | Tools tab, "N tokens burned" figure | always brand orange | orange, or **red** when the wasted share is high |
+| 4 | Cost tab layout | `gap-x-6` (no vertical gap) | `gap-6` |
+
+Item 4 is the missing padding between the hero and Checks, spotted earlier and still
+unfixed on `main`.
+
+## Decisions already taken
+
+- **Recolour in place, no reorder.** The row order stays Real Work / Rewrite Waste / Carry.
+- **A new token,** rather than retuning `share-work`. `share-work` stays teal, so the pass
+  wording in Checks is untouched.
+- **Severity by share of startup context wasted,** not by absolute tokens.
+- **The gap fix rides along** in this branch.
+
+## The blue
+
+`hsl(191.5 83% 36.8%)` light, `hsl(192 63% 47.6%)` dark — the value Marty defined as
+`burn-check-pass-fill` on `feat/desktop-pr4-burn-check-design`. That branch's PR (#441) is
+closed unmerged, so the token does not exist on `main` and we add our own.
+
+Proposed name: **`measure`**, in the session-analysis sub-palette. It covers both uses — the
+Real Work slice and the cost measure bar are each "the reading", drawn calmly, with the verdict
+left to the words beside them. Alternative if `measure` reads too abstract: `share-work-blue`,
+though that invites confusion with the teal `share-work`.
+
+## File by file
+
+**`src/styles/session-analysis-colors.css`** — a token needs all four blocks: the `@theme`
+declaration, the light `:root`, the `@media (prefers-color-scheme: dark)` branch, and the
+explicit `:root[data-theme="dark"]` branch.
+
+**`design.md`** — add the `measure:` entry, and amend the Session Detail colour sentence at
+line 473. See the risk below.
+
+**`src/components/session/analysis/EfficiencyBreakdown.tsx`**
+
+- `SHARE_ROWS` (line 80): `bg-label` → `bg-measure`, `bg-brand-tint` → `bg-share-carry`,
+  `bg-share-carry` → `bg-brand-tint`. One `inkClassName` drives both the bar run and the
+  legend dot, so each row changes once.
+- The comment above `SHARE_ROWS` explains the current colour reasoning and needs rewriting.
+- `CostScaleBar` (line 187): the `cost-measure` span goes `bg-brand-tint` → `bg-measure`.
+
+**`src/components/session/SessionDetailPresentation.tsx`**
+
+- Line 900: `gap-x-6` → `gap-6`.
+- Line 925: the figure's `text-brand` becomes conditional. `skillMcpUsage` already returns
+  both `wastedTokens` and `totalTokens`, so the share is a division, no new derivation.
+  Red uses `text-system-red-text`, the palette's red for words.
+
+**Tests** — `EfficiencyBreakdown.test.tsx` asserts the three run colours at lines 109-111 and
+needs updating. Worth adding: one case for the cost measure's colour, one for the Tools figure
+crossing the red threshold.
+
+## Where red starts
+
+Settled in review on 2026-09-10. The figure turns red when **both** hold:
+
+- at least **50%** of the startup context went unused, and
+- at least **10k tokens** were burned.
+
+Either one alone leaves it brand orange. The share stops a large context from going red on a
+small proportion; the floor stops a tiny context from going red on a handful of tokens. Both
+numbers live in named constants beside the Tools hero, so retuning is one edit.
+
+The 10k floor is my pick, not Keith's — he asked for a floor without naming a figure. It sits
+at roughly a third of the 23.5k in the capture that prompted this, so a session like that still
+reaches red on merit. Raise it if red turns out to be common.
+
+## The one risk
+
+`design.md` line 473 currently reads: "brand orange for a compaction, teal for real work, red
+for waste." After this change orange means both a compaction mark and the Carry slice, and
+waste is no longer the red end of the composition. The doc sentence has to change to match, and
+CI's `check-design-drift.mjs` enforces that it does. Worth a look before I build, since it
+loosens a rule the rest of the view leans on.
+
+## Verify
+
+Run the app, open a session with all three tabs populated, check light and dark. Then
+`pnpm --filter @antiburn/desktop lint`, `type-check`, and `test`.
+
+## Status
+
+| Step | State |
+|---|---|
+| Plan agreed | done |
+| Token added | done — `measure`, all four blocks, plus the `design.md` entry |
+| Composition + cost bar recoloured | done |
+| Tools severity | done — `WASTED_RED_SHARE` 0.5, `WASTED_RED_TOKENS` 10k |
+| Gap fix | done |
+| Tests updated | done — 1288 tests pass; lint, type-check, design-drift clean |
+| Checked in the running app | done — harness render, light and dark |
+
+## What the render showed
+
+The blue lands in both themes: `rgb(16 142 172)` light, `rgb(45 167 198)` dark, on the cost
+measure and the Real Work run alike. Rewrite Waste reads as a mid neutral, Carry as brand
+orange.
+
+One finding worth a decision. In **light** mode the two verdict inks are nearly the same
+colour: `text-system-red-text` is `rgb(190 0 20)` and `text-brand` resolves to `rgb(191 63 8)`,
+a dark rust. Identical lightness, 23° of hue apart. Side by side you can tell them apart; in
+the app you only ever see one figure, with nothing to compare it to, so "orange vs red" may not
+read as a signal at all. Dark mode is fine — `rgb(255 138 128)` against `rgb(255 106 44)` is a
+clearer split.
+
+Options if the light case matters: use `system-red` (`hsl(354 100% 42.1%)`) instead of
+`system-red-text` for more saturation, or carry the severity in a word beside the figure
+rather than in the ink alone.


### PR DESCRIPTION
## User impact

<img width="370" height="306" alt="Screenshot 2026-09-10 at 17-33-05" src="https://github.com/user-attachments/assets/ec1d4d58-09c8-4073-9194-89834d7d8d4a" />
<img width="1572" height="1501" alt="Screenshot 2026-09-10 at 17-16-29" src="https://github.com/user-attachments/assets/5f5db21b-d0a3-48f0-bcf6-dbbc2479e89c" />
<img width="1569" height="1504" alt="Screenshot 2026-09-10 at 17-16-24" src="https://github.com/user-attachments/assets/23c244c1-69e3-434f-a23d-0840a58a6c40" />
<img width="1559" height="1514" alt="Screenshot 2026-09-10 at 17-16-18" src="https://github.com/user-attachments/assets/982ec2aa-2981-4700-b012-62cfca686411" />

The session detail view and the session list read as one window.

**A calm blue for the readings.** The Real Work run in the efficiency breakdown and the
cost-scale measure now take a new `measure` token — `hsl(191.5 83% 36.8%)` light,
`hsl(192 63% 47.6%)` dark. They were competing with the brand orange beside them.

**A wasted-token figure that reads as orange.** The Tools tab shows its wasted tokens in a new
`waste-warn` token, and in `system-red-text` when the waste is both half or more of the startup
context and at least 10k tokens. `waste-warn` is its own token because `brand` renders as a
dark rust on the light surface: at `rgb(191 63 8)` it sits within 23° of hue of the red beside
it, at the same lightness, so the two verdicts were indistinguishable in a view where you only
ever see one of them.

**One treatment for both view pickers.** The metric picker over the session list and the
section picker over the session detail now share `.ui-segmented-solid`: a pill track with a
solid neutral chip for the selection. The Settings panes keep their blue.

**Three fixes found by using the built branch.**

- The picker changed width every time the selection moved, because the selected segment took a
  heavier weight and the track sizes its columns to their content. Every segment now takes one
  weight; the chip names the selection.
- The metric labels drop the percent sign: `$ / week / 5h`. The values already carry it.
- The percent sign in the limit badge looked joined to the last digit. In a tabular monospace
  face the sign fills its cell with ink where a digit does not, so the gap in front of it looks
  smaller than the gaps between the digits. The hot pill also carried `tracking-tight`, which
  pulled the sign a further 0.28px in and which its own plain sibling never used. That is gone,
  and a 1px inline spacer adds the hair space the face cannot give. English style puts no space
  before a percent sign, and a real space would cost a full monospace cell in every row, so the
  spacer sits between two text nodes: the value still reads and copies as one run, `17.2%`.

Known limits: `measure` and `waste-warn` are new tokens rather than retunes of `brand` or
`accent-fill`, so no other screen changes color.

<!-- Screenshot goes here: the main window with the session list and a session detail open. -->

## Validation

From `apps/desktop`:

- `pnpm test` — 1288 tests in 100 files pass. The percent-sign change needed no assertion
  updates, which is the point of keeping the two text nodes adjacent.
- `pnpm lint` — clean.
- `pnpm type-check` — clean.

From the repository root:

- `node scripts/check-design-drift.mjs` — "design contract is in sync with the stylesheets".

Rendered in a Vite harness in both themes. The blue resolves to `rgb(16 142 172)` light and
`rgb(45 167 198)` dark on both the cost measure and the Real Work run. The picker track
measures 136.12px on `$`, `week` and `5h` alike.

## Analytics

Unchanged. This is a color and spacing change to views that are already instrumented. It adds
no feature to discover, no new action to take, and no new outcome to report, so it raises no
product question that the existing session-view events do not already answer. No triggers,
properties, or limits change.

## Privacy and performance

None. No change to data access, network access, retained data, or background work.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
