### PR TITLE
Fix macOS popover focus stealing and fullscreen placement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,10 @@ jobs:
         working-directory: apps/desktop/src-tauri/crates/main-window
         run: cargo fmt --check
 
+      - name: Check anchored-window crate formatting
+        working-directory: apps/desktop/src-tauri/crates/anchored-window
+        run: cargo fmt --check
+
   desktop-backend-checks:
     name: desktop app (backend, ${{ matrix.check.name }}, ${{ matrix.workspace.name }}, ${{ matrix.platform.name }})
     needs: classify
@@ -238,6 +242,9 @@ jobs:
             tauri: true
           - name: main-window
             directory: apps/desktop/src-tauri/crates/main-window
+            tauri: true
+          - name: anchored-window
+            directory: apps/desktop/src-tauri/crates/anchored-window
             tauri: true
     runs-on: ${{ matrix.platform.os }}
     steps:

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -102,6 +102,10 @@ native lifecycle checks, opening latency, and hidden-window resource use. Run
 Rust formatting, Clippy, and tests from `src-tauri/crates/main-window` as well
 as the shell when changing the main-window mechanism.
 
+For companion-window changes, run the same Rust checks from
+`src-tauri/crates/anchored-window`. CI runs its Clippy checks and tests on macOS,
+Windows, and Linux.
+
 `rusqlite` is compiled from bundled sources, so neither CI nor a checkout needs
 a system SQLite.
 
@@ -151,10 +155,15 @@ Settings teardown, and the memory rules behind those policies.
 - **Popover.** 380pt wide, frameless, always on top, hidden from the taskbar.
   It is created on demand and anchored under its menu-bar item on each
   open, flipping above the item and clamping to the display when there is no
-  room below. It hides when it loses focus, when Escape is pressed, on a
-  second click of the menu-bar item, and — on macOS — on a click anywhere
-  outside the app, which catches the Finder desktop: clicking it makes no
-  window key, so no focus change is reported at all.
+  room below. On macOS it follows the reader to every Space, including a
+  full-screen Space. Hover previews use a passive companion panel with the same
+  Space behavior. Their native `NSPanel` and `WKWebView` are created directly,
+  without Wry or window-class conversion. Preview creation and presentation
+  preserve the active application and keyboard recipient. The popover hides
+  when it loses focus, when Escape is pressed, on a second click of the menu-bar
+  item, and — on macOS —
+  on a click anywhere outside the app, which catches the Finder desktop:
+  clicking it makes no window key, so no focus change is reported at all.
 - **Pin.** The tray menu's first item suspends all four of those dismissals,
   and reads Unpin Window while it does. The state is in memory only: a pin
   means "keep this on screen while I work", and a relaunch ends that work.
@@ -218,14 +227,19 @@ Settings teardown, and the memory rules behind those policies.
   makes the bundled app an agent; the shell applies the equivalent accessory
   activation policy at runtime so unbundled development runs match.
 
-Settings and onboarding have dedicated HTML and TypeScript entries. The
-resident shell uses URL fragments for the nudge and overlay, with the popover
+Settings, onboarding, and native macOS hover previews have dedicated HTML and
+TypeScript entries. The resident shell uses URL fragments for the nudge and overlay, with the popover
 as its default. Each window owns one surface until the shell releases it.
 
 ## Known gaps
 
 These build-level limits affect desktop development:
 
+- On macOS, Wry 0.55.1 activates the application during webview creation even
+  when the window requests `focused(false)`. Other Tauri-created surfaces,
+  including a cold popover, retain this upstream limitation. macOS hover
+  previews bypass Wry and create their nonactivating panel and WebKit view
+  directly. Wry remains an official crates.io transitive dependency.
 - The popover is opaque and square-cornered. Rounded, translucent chrome needs
   `macOSPrivateApi` plus transparent-window support, and arrives with the
   design system.

--- a/apps/desktop/knip.json
+++ b/apps/desktop/knip.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["src/main-window.tsx", "src/settings.tsx", "src/onboarding.tsx", "src/styles.css"],
+  "entry": [
+    "src/main-window.tsx",
+    "src/native-peek.tsx",
+    "src/settings.tsx",
+    "src/onboarding.tsx",
+    "src/styles.css"
+  ],
   "project": ["src/**/*.{ts,tsx,css}"],
   "ignoreDependencies": ["@tauri-apps/cli"]
 }

--- a/apps/desktop/native-peek.html
+++ b/apps/desktop/native-peek.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>antiburn Preview</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/native-peek.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -131,12 +131,20 @@ dependencies = [
 name = "antiburn-anchored-window"
 version = "0.1.0"
 dependencies = [
+ "block2",
+ "dispatch2",
  "gtk",
+ "objc2",
  "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-web-kit",
  "serde",
+ "serde_json",
  "tauri",
  "tokio",
  "tracing",
+ "url",
  "windows 0.62.2",
 ]
 

--- a/apps/desktop/src-tauri/crates/anchored-window/Cargo.lock
+++ b/apps/desktop/src-tauri/crates/anchored-window/Cargo.lock
@@ -45,12 +45,20 @@ dependencies = [
 name = "antiburn-anchored-window"
 version = "0.1.0"
 dependencies = [
+ "block2",
+ "dispatch2",
  "gtk",
+ "objc2",
  "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-web-kit",
  "serde",
+ "serde_json",
  "tauri",
  "tokio",
  "tracing",
+ "url",
  "windows 0.62.2",
 ]
 
@@ -2052,6 +2060,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]

--- a/apps/desktop/src-tauri/crates/anchored-window/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/anchored-window/Cargo.toml
@@ -21,7 +21,15 @@ tokio = { version = "1", features = ["sync", "time"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+serde_json = "1"
+url = "2"
 objc2-app-kit = { version = "0.3", features = ["NSEvent", "NSScreen", "NSWindow"] }
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSURLRequest", "NSURLResponse", "NSData", "NSDictionary", "NSString"] }
+objc2-web-kit = { version = "0.3", default-features = false, features = ["std", "objc2-app-kit", "objc2-core-foundation", "block2", "WKWebView", "WKWebViewConfiguration", "WKUserContentController", "WKUserScript", "WKScriptMessage", "WKScriptMessageHandler", "WKFrameInfo", "WKNavigation", "WKNavigationAction", "WKNavigationResponse", "WKNavigationDelegate", "WKURLSchemeHandler", "WKURLSchemeTask"] }
+objc2-quartz-core = { version = "0.3", default-features = false, features = ["std", "CALayer", "objc2-core-foundation"] }
+dispatch2 = "0.3"
+block2 = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/apps/desktop/src-tauri/crates/anchored-window/src/companion.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/companion.rs
@@ -1,0 +1,4 @@
+#[cfg(target_os = "macos")]
+pub(crate) use crate::macos::NativeWindow as CompanionWindow;
+#[cfg(not(target_os = "macos"))]
+pub(crate) use tauri::WebviewWindow as CompanionWindow;

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lib.rs
@@ -4,6 +4,7 @@
 //! cancellable task. The host owns the target type, IPC authorization, and
 //! data policy.
 
+mod companion;
 mod geometry;
 mod lifecycle;
 #[cfg(target_os = "linux")]
@@ -27,3 +28,6 @@ pub const REQUEST_EVENT: &str = "anchored-window-request";
 
 /// The event that reports companion lifecycle changes to the anchor window.
 pub const STATE_EVENT: &str = "anchored-window-state";
+
+#[cfg(target_os = "macos")]
+pub use macos::NativeRequestHandler;

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle.rs
@@ -175,6 +175,16 @@ impl<T: Clone + PartialEq, P: Clone> Lifecycle<T, P> {
         Some(reveal_now)
     }
 
+    #[cfg(target_os = "macos")]
+    pub(crate) fn renderer_failed(&mut self, renderer_generation: u64) -> bool {
+        if self.renderer_generation != renderer_generation {
+            return false;
+        }
+        self.conceal();
+        self.renderer_destroyed();
+        true
+    }
+
     pub(crate) fn renderer_destroyed(&mut self) {
         self.cancel_task();
         self.renderer_generation = self.renderer_generation.wrapping_add(1).max(1);

--- a/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/presentation.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/lifecycle/tests/presentation.rs
@@ -194,3 +194,37 @@ fn same_target_reentry_does_not_bypass_a_pending_retarget_commit() {
     assert!(!lifecycle.awaiting_retarget_commit);
     assert!(!lifecycle.retarget_committed(second.generation));
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn renderer_failure_clears_the_target_and_rejects_late_failures() {
+    let mut lifecycle = crate::lifecycle::Lifecycle::<&str, ()>::new(100.0);
+    lifecycle.renderer_generation = 2;
+    lifecycle.request(
+        "preview",
+        crate::AnchorRegion {
+            top: 0.0,
+            height: 20.0,
+        },
+        100.0,
+        None,
+    );
+    assert!(!lifecycle.renderer_failed(1));
+    assert_eq!(lifecycle.target, Some("preview"));
+    assert!(lifecycle.renderer_failed(2));
+    assert_eq!(lifecycle.target, None);
+    assert!(!lifecycle.visible);
+    assert!(!lifecycle.renderer_ready);
+    assert_eq!(lifecycle.renderer_generation, 3);
+    lifecycle.request(
+        "replacement",
+        crate::AnchorRegion {
+            top: 0.0,
+            height: 20.0,
+        },
+        100.0,
+        None,
+    );
+    assert!(!lifecycle.renderer_failed(2));
+    assert_eq!(lifecycle.target, Some("replacement"));
+}

--- a/apps/desktop/src-tauri/crates/anchored-window/src/macos.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/macos.rs
@@ -1,11 +1,13 @@
-use std::sync::{Arc, Mutex};
-
-use objc2_app_kit::{NSEvent, NSWindow};
-use tauri::window::{Effect, EffectState, EffectsBuilder};
-use tauri::{Manager, Runtime, WebviewWindow, WebviewWindowBuilder};
+mod bridge;
+mod native;
+pub use native::NativeRequestHandler;
+pub(crate) use native::NativeWindow;
 
 use crate::AnchorRegion;
 use crate::geometry::{CursorProximity, Point, Rect, classify_cursor, place_left_preferred};
+use objc2_app_kit::{NSEvent, NSWindow};
+use std::sync::{Arc, Mutex};
+use tauri::WebviewWindow;
 
 pub(crate) struct FrameRequest {
     pub width: f64,
@@ -15,66 +17,22 @@ pub(crate) struct FrameRequest {
     pub screen_margin: f64,
 }
 
-pub(crate) fn configure<'a, R: Runtime, M: Manager<R>>(
-    builder: WebviewWindowBuilder<'a, R, M>,
-    corner_radius: f64,
-) -> WebviewWindowBuilder<'a, R, M> {
-    builder.accept_first_mouse(true).effects(
-        EffectsBuilder::new()
-            .effect(Effect::Popover)
-            .state(EffectState::Active)
-            .radius(corner_radius)
-            .build(),
-    )
-}
-
-pub(crate) fn show_without_activation(window: &WebviewWindow) -> tauri::Result<()> {
-    let window = window.clone();
-    window.clone().run_on_main_thread(move || {
-        if let Ok(pointer) = window.ns_window() {
-            // SAFETY: The pointer is the live NSWindow, and this code runs on the main thread.
-            unsafe {
-                (&*pointer.cast::<NSWindow>()).orderFrontRegardless();
-            }
-        } else {
-            tracing::warn!("failed to access the anchored NSWindow");
-        }
-    })
-}
-
 pub(crate) fn apply_frame(
     anchor: &WebviewWindow,
-    companion: &WebviewWindow,
+    companion: &NativeWindow,
     request: FrameRequest,
     native_frame: Arc<Mutex<Option<Rect>>>,
 ) -> tauri::Result<()> {
     let anchor = anchor.clone();
-    let companion = companion.clone();
-    companion.clone().run_on_main_thread(move || {
-        apply_frame_on_main_thread(&anchor, &companion, request, &native_frame);
+    companion.with_objects(move |objects| {
+        let Ok(pointer) = anchor.ns_window() else {
+            return;
+        };
+        // SAFETY: The anchor owns this window, and this callback runs on the main thread.
+        let anchor = unsafe { &*pointer.cast::<NSWindow>() };
+        objects.panel.setLevel(anchor.level());
+        update_frame(anchor, &objects.panel, request, &native_frame);
     })
-}
-
-fn apply_frame_on_main_thread(
-    anchor: &WebviewWindow,
-    companion: &WebviewWindow,
-    request: FrameRequest,
-    native_frame: &Mutex<Option<Rect>>,
-) {
-    let (Ok(anchor_pointer), Ok(companion_pointer)) = (anchor.ns_window(), companion.ns_window())
-    else {
-        tracing::warn!("failed to access anchored NSWindow values");
-        return;
-    };
-    // SAFETY: The pointers are live NSWindow values, and this code runs on the main thread.
-    unsafe {
-        update_frame(
-            &*anchor_pointer.cast::<NSWindow>(),
-            &*companion_pointer.cast::<NSWindow>(),
-            request,
-            native_frame,
-        );
-    }
 }
 
 fn update_frame(
@@ -209,10 +167,6 @@ fn clamp_origin(value: f64, minimum: f64, maximum: f64) -> f64 {
         return maximum;
     }
     value.clamp(minimum, maximum)
-}
-
-pub(crate) fn hide(window: &WebviewWindow) -> tauri::Result<()> {
-    window.hide()
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/anchored-window/src/macos/bridge.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/macos/bridge.rs
@@ -1,0 +1,400 @@
+use super::native::{NativeRequestHandler, NativeState, NativeWindow};
+use objc2::{
+    AnyThread, DeclaredClass, MainThreadMarker, MainThreadOnly, define_class, msg_send,
+    rc::Retained, runtime::ProtocolObject,
+};
+use objc2_foundation::{
+    NSData, NSDictionary, NSError, NSHTTPURLResponse, NSObject, NSObjectProtocol, NSString,
+};
+use objc2_web_kit::{
+    WKNavigation, WKNavigationAction, WKNavigationActionPolicy, WKNavigationDelegate,
+    WKNavigationResponse, WKNavigationResponsePolicy, WKScriptMessage, WKScriptMessageHandler,
+    WKURLSchemeHandler, WKURLSchemeTask, WKUserContentController, WKWebView,
+};
+use serde::Deserialize;
+use std::{
+    cell::Cell,
+    sync::{Weak, atomic::Ordering},
+};
+
+pub(super) const SCHEME: &str = "antiburn-anchored";
+
+#[derive(Clone)]
+pub(super) struct BridgePolicy {
+    pub entry: url::Url,
+}
+impl BridgePolicy {
+    pub fn new(app: &tauri::AppHandle, route: &str) -> tauri::Result<Self> {
+        let base = if tauri::is_dev() {
+            app.config().build.dev_url.clone()
+        } else {
+            None
+        };
+        let base = base.unwrap_or_else(|| {
+            url::Url::parse("antiburn-anchored://localhost/")
+                .expect("the built-in preview URL is valid")
+        });
+        let entry = base
+            .join(route)
+            .map_err(|error| tauri::Error::Io(std::io::Error::other(error)))?;
+        Ok(Self { entry })
+    }
+    fn allows_document(&self, value: &str) -> bool {
+        let Ok(url) = url::Url::parse(value) else {
+            return false;
+        };
+        url.scheme() == self.entry.scheme()
+            && url.host_str() == self.entry.host_str()
+            && url.port_or_known_default() == self.entry.port_or_known_default()
+            && url.username().is_empty()
+            && url.password().is_none()
+            && url.path() == self.entry.path()
+            && url.query() == self.entry.query()
+    }
+}
+
+fn asset_path(raw: &str) -> Option<&str> {
+    let raw = raw.strip_prefix("antiburn-anchored://localhost/")?;
+    if raw.contains(['%', '?', '#', '\\'])
+        || raw
+            .split('/')
+            .any(|part| part == ".." || part == "." || part.is_empty())
+    {
+        return None;
+    }
+    (raw == "native-peek.html" || raw.starts_with("assets/")).then_some(raw)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Request {
+    id: u64,
+    renderer_generation: u64,
+    command: String,
+    args: serde_json::Value,
+}
+impl Request {
+    fn parse(body: &str, generation: u64) -> Option<Self> {
+        if body.len() > 16_384 {
+            return None;
+        }
+        let request: Self = serde_json::from_str(body).ok()?;
+        (request.id > 0
+            && request.id <= 9_007_199_254_740_991
+            && request.renderer_generation == generation
+            && request.args.is_object()
+            && matches!(
+                request.command.as_str(),
+                "get_popover_peek_state"
+                    | "get_popover_peek_data"
+                    | "popover_peek_ready"
+                    | "popover_peek_presented"
+                    | "popover_peek_retarget_ready"
+                    | "popover_peek_concealed"
+                    | "note_interaction"
+            ))
+        .then_some(request)
+    }
+}
+
+pub(super) struct DelegateState {
+    owner: Weak<NativeState>,
+    policy: BridgePolicy,
+    generation: u64,
+    handler: NativeRequestHandler,
+    webview: Cell<*const WKWebView>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = DelegateState]
+    pub(super) struct Delegate;
+    unsafe impl NSObjectProtocol for Delegate {}
+    unsafe impl WKScriptMessageHandler for Delegate {
+        #[unsafe(method(userContentController:didReceiveScriptMessage:))]
+        fn receive(&self, _controller: &WKUserContentController, message: &WKScriptMessage) {
+            // SAFETY: WebKit delivers these objects on the main thread.
+            unsafe {
+                let state = self.ivars();
+                let Some(owner) = state.owner.upgrade() else {
+                    return;
+                };
+                if !owner.alive.load(Ordering::Acquire) {
+                    return;
+                }
+                let Some(webview) = message.webView() else {
+                    return;
+                };
+                if !std::ptr::eq(&*webview, state.webview.get()) {
+                    return;
+                }
+                let frame = message.frameInfo();
+                if !frame.isMainFrame() {
+                    return;
+                }
+                let Some(url) = frame.request().URL().and_then(|url| url.absoluteString()) else {
+                    return;
+                };
+                if !state.policy.allows_document(&url.to_string()) {
+                    return;
+                }
+                let Ok(body) = message.body().downcast::<NSString>() else {
+                    return;
+                };
+                let Some(request) = Request::parse(&body.to_string(), state.generation) else {
+                    return;
+                };
+                let handler = state.handler;
+                let weak = state.owner.clone();
+                tauri::async_runtime::spawn_blocking(move || {
+                    let Some(owner) = weak.upgrade() else {
+                        return;
+                    };
+                    if !owner.alive.load(Ordering::Acquire) {
+                        return;
+                    }
+                    let result = handler(&owner.app, &request.command, request.args);
+                    let response = match result {
+                        Ok(value) => serde_json::json!({"id":request.id,"value":value}),
+                        Err(error) => serde_json::json!({"id":request.id,"error":error}),
+                    };
+                    let _ = NativeWindow(owner)
+                        .eval(format!("window.__ANTIBURN_NATIVE_DELIVER__?.({response})"));
+                });
+            }
+        }
+    }
+    unsafe impl WKNavigationDelegate for Delegate {
+        #[unsafe(method(webView:decidePolicyForNavigationAction:decisionHandler:))]
+        fn navigation(
+            &self,
+            _view: &WKWebView,
+            action: &WKNavigationAction,
+            decision: &block2::Block<dyn Fn(WKNavigationActionPolicy)>,
+        ) {
+            // SAFETY: The action and decision block are valid for this delegate callback.
+            unsafe {
+                let allowed = action
+                    .targetFrame()
+                    .is_some_and(|frame| frame.isMainFrame())
+                    && action
+                        .request()
+                        .URL()
+                        .and_then(|url| url.absoluteString())
+                        .is_some_and(|url| self.ivars().policy.allows_document(&url.to_string()));
+                decision.call((if allowed {
+                    WKNavigationActionPolicy::Allow
+                } else {
+                    WKNavigationActionPolicy::Cancel
+                },));
+            }
+        }
+        #[unsafe(method(webView:decidePolicyForNavigationResponse:decisionHandler:))]
+        fn response(
+            &self,
+            _view: &WKWebView,
+            response: &WKNavigationResponse,
+            decision: &block2::Block<dyn Fn(WKNavigationResponsePolicy)>,
+        ) {
+            // SAFETY: WebKit owns this response and decision block during the callback.
+            unsafe {
+                decision.call((if response.canShowMIMEType() {
+                    WKNavigationResponsePolicy::Allow
+                } else {
+                    WKNavigationResponsePolicy::Cancel
+                },));
+            }
+        }
+        #[unsafe(method(webViewWebContentProcessDidTerminate:))]
+        fn terminated(&self, _view: &WKWebView) {
+            self.fail();
+        }
+        #[unsafe(method(webView:didFailProvisionalNavigation:withError:))]
+        fn load_failed(
+            &self,
+            _view: &WKWebView,
+            _navigation: Option<&WKNavigation>,
+            error: &NSError,
+        ) {
+            tracing::warn!(error = %error, "native companion navigation failed");
+            self.fail();
+        }
+    }
+    unsafe impl WKURLSchemeHandler for Delegate {
+        #[unsafe(method(webView:startURLSchemeTask:))]
+        fn start_task(&self, _view: &WKWebView, task: &ProtocolObject<dyn WKURLSchemeTask>) {
+            // SAFETY: The scheme task remains active throughout this synchronous callback.
+            unsafe {
+                let Some(owner) = self.ivars().owner.upgrade() else {
+                    return;
+                };
+                let Some(url) = task.request().URL() else {
+                    return;
+                };
+                let raw = url
+                    .absoluteString()
+                    .map(|value| value.to_string())
+                    .unwrap_or_default();
+                let asset = asset_path(&raw)
+                    .and_then(|path| owner.app.asset_resolver().get(path.to_string()));
+                let (status, bytes, mime) = match asset {
+                    Some(asset) => (200, asset.bytes, asset.mime_type),
+                    None => (404, Vec::new(), "text/plain".into()),
+                };
+                let names = [
+                    NSString::from_str("Content-Type"),
+                    NSString::from_str("Content-Security-Policy"),
+                    NSString::from_str("Cache-Control"),
+                ];
+                let values = [
+                    NSString::from_str(&mime),
+                    NSString::from_str(
+                        "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'",
+                    ),
+                    NSString::from_str("no-store"),
+                ];
+                let headers = NSDictionary::from_slices(
+                    &[&*names[0], &*names[1], &*names[2]],
+                    &[&*values[0], &*values[1], &*values[2]],
+                );
+                if let Some(response) =
+                    NSHTTPURLResponse::initWithURL_statusCode_HTTPVersion_headerFields(
+                        NSHTTPURLResponse::alloc(),
+                        &url,
+                        status,
+                        None,
+                        Some(&headers),
+                    )
+                {
+                    task.didReceiveResponse(&response);
+                    task.didReceiveData(&NSData::with_bytes(&bytes));
+                    task.didFinish();
+                }
+            }
+        }
+        #[unsafe(method(webView:stopURLSchemeTask:))]
+        fn stop_task(&self, _view: &WKWebView, _task: &ProtocolObject<dyn WKURLSchemeTask>) {}
+    }
+);
+
+impl Delegate {
+    pub fn new(
+        mtm: MainThreadMarker,
+        owner: Weak<NativeState>,
+        policy: BridgePolicy,
+        generation: u64,
+        handler: NativeRequestHandler,
+    ) -> Retained<Self> {
+        let allocated = Self::alloc(mtm).set_ivars(DelegateState {
+            owner,
+            policy,
+            generation,
+            handler,
+            webview: Cell::new(std::ptr::null()),
+        });
+        // SAFETY: The NSObject subclass initializes its ivars before calling its superclass initializer.
+        unsafe { msg_send![super(allocated), init] }
+    }
+    pub fn set_webview(&self, view: &WKWebView) {
+        self.ivars().webview.set(view);
+    }
+    pub fn invalidate(&self) {
+        self.ivars().webview.set(std::ptr::null());
+    }
+    fn fail(&self) {
+        if let Some(owner) = self.ivars().owner.upgrade() {
+            NativeWindow(owner).fail();
+        }
+    }
+}
+
+pub(super) fn initialization_script(generation: u64, policy: &BridgePolicy) -> String {
+    let entry =
+        serde_json::to_string(policy.entry.as_str()).expect("a URL string is JSON serializable");
+    format!(
+        r#"(() => {{
+      const expected = new URL({entry});
+      if (window !== window.top || location.protocol !== expected.protocol || location.host !== expected.host || location.pathname !== expected.pathname) return;
+      const pending = new Map(), listeners = new Map(); let sequence = 0, closed = false;
+      Object.defineProperty(window, '__ANTIBURN_WINDOW_GENERATION__', {{value:{generation}}});
+      Object.defineProperty(window, '__ANTIBURN_NATIVE_DELIVER__', {{value:(message) => {{
+        if (closed) return;
+        if (message.event) {{ for (const callback of listeners.get(message.event) ?? []) callback(message.payload); return; }}
+        const call = pending.get(message.id); if (!call) return;
+        clearTimeout(call.timer); pending.delete(message.id);
+        if (message.error !== undefined) call.reject(new Error(message.error)); else call.resolve(message.value);
+      }}}});
+      Object.defineProperty(window, '__ANTIBURN_NATIVE_PEEK__', {{value:Object.freeze({{
+        invoke(command, args = {{}}) {{ return new Promise((resolve, reject) => {{
+          if (closed || pending.size >= 128) {{ reject(new Error('Native preview is unavailable')); return; }}
+          const id = ++sequence;
+          const timer = setTimeout(() => {{ pending.delete(id); reject(new Error('Native preview request timed out')); }}, 10000);
+          pending.set(id, {{resolve,reject,timer}});
+          try {{ window.webkit.messageHandlers.anchored.postMessage(JSON.stringify({{id,rendererGeneration:{generation},command,args}})); }}
+          catch (error) {{ clearTimeout(timer); pending.delete(id); reject(error); }}
+        }}); }},
+        async listen(event, callback) {{
+          if (closed) throw new Error('Native preview is unavailable');
+          if (!listeners.has(event)) listeners.set(event,new Set());
+          listeners.get(event).add(callback);
+          return () => listeners.get(event)?.delete(callback);
+        }}
+      }})}});
+      addEventListener('pagehide', () => {{ closed = true; for (const call of pending.values()) {{clearTimeout(call.timer);call.reject(new Error('Native preview closed'));}} pending.clear(); listeners.clear(); }}, {{once:true}});
+    }})();"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn document_policy_rejects_other_origins_and_documents() {
+        let policy = BridgePolicy {
+            entry: url::Url::parse("antiburn-anchored://localhost/native-peek.html").unwrap(),
+        };
+        assert!(policy.allows_document("antiburn-anchored://localhost/native-peek.html"));
+        for url in [
+            "antiburn-anchored://other/native-peek.html",
+            "antiburn-anchored://localhost/index.html",
+            "https://localhost/native-peek.html",
+            "antiburn-anchored://user@localhost/native-peek.html",
+        ] {
+            assert!(!policy.allows_document(url));
+        }
+        let dev = BridgePolicy {
+            entry: url::Url::parse("http://127.0.0.1:1420/native-peek.html").unwrap(),
+        };
+        assert!(dev.allows_document("http://127.0.0.1:1420/native-peek.html"));
+        assert!(!dev.allows_document("http://127.0.0.1:1421/native-peek.html"));
+    }
+    #[test]
+    fn asset_paths_are_confined_to_the_preview_and_built_assets() {
+        assert_eq!(
+            asset_path("antiburn-anchored://localhost/assets/example.js"),
+            Some("assets/example.js")
+        );
+        for path in [
+            "assets/../secret",
+            "assets/%2e%2e/secret",
+            "index.html",
+            "assets//secret",
+            "assets/a\\b",
+            "assets/file.js?other",
+        ] {
+            assert!(asset_path(&format!("antiburn-anchored://localhost/{path}")).is_none());
+        }
+    }
+    #[test]
+    fn requests_require_current_renderer_and_allowlisted_operations() {
+        let body = |generation, command| {
+            serde_json::json!({"id":1,"rendererGeneration":generation,"command":command,"args":{}})
+                .to_string()
+        };
+        assert!(Request::parse(&body(4, "get_popover_peek_state"), 4).is_some());
+        assert!(Request::parse(&body(3, "popover_peek_ready"), 4).is_none());
+        assert!(Request::parse(&body(4, "open_main"), 4).is_none());
+        assert!(Request::parse(&"x".repeat(16_385), 4).is_none());
+    }
+}

--- a/apps/desktop/src-tauri/crates/anchored-window/src/macos/native.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/macos/native.rs
@@ -1,0 +1,309 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use super::bridge::{BridgePolicy, Delegate};
+use crate::AnchoredWindowConfig;
+use dispatch2::MainThreadBound;
+use objc2::{
+    MainThreadMarker, MainThreadOnly, define_class, msg_send, rc::Retained, runtime::ProtocolObject,
+};
+use objc2_app_kit::{
+    NSAutoresizingMaskOptions, NSBackingStoreType, NSColor, NSPanel, NSVisualEffectBlendingMode,
+    NSVisualEffectMaterial, NSVisualEffectState, NSVisualEffectView, NSWindow,
+    NSWindowAnimationBehavior, NSWindowCollectionBehavior, NSWindowStyleMask,
+};
+use objc2_foundation::{NSObjectProtocol, NSPoint, NSRect, NSSize, NSString, NSURL, NSURLRequest};
+use objc2_web_kit::{WKUserScript, WKUserScriptInjectionTime, WKWebView, WKWebViewConfiguration};
+use serde::Serialize;
+
+pub type NativeRequestHandler =
+    fn(&tauri::AppHandle, &str, serde_json::Value) -> Result<serde_json::Value, String>;
+
+define_class!(
+    #[unsafe(super(NSPanel, NSWindow))]
+    #[thread_kind = MainThreadOnly]
+    pub(crate) struct PassivePanel;
+    unsafe impl NSObjectProtocol for PassivePanel {}
+    impl PassivePanel {
+        #[unsafe(method(canBecomeKeyWindow))]
+        fn can_become_key(&self) -> bool { false }
+        #[unsafe(method(canBecomeMainWindow))]
+        fn can_become_main(&self) -> bool { false }
+    }
+);
+
+struct NativeConfiguration {
+    policy: BridgePolicy,
+    frame: NSRect,
+    radius: f64,
+    generation: u64,
+    title: String,
+}
+
+pub(super) struct NativeObjects {
+    pub panel: Retained<PassivePanel>,
+    pub webview: Retained<WKWebView>,
+    delegate: Retained<Delegate>,
+}
+
+pub(super) struct NativeState {
+    pub app: tauri::AppHandle,
+    objects: Mutex<Option<MainThreadBound<NativeObjects>>>,
+    pub alive: AtomicBool,
+    visible: AtomicBool,
+    pub failed: Arc<dyn Fn() + Send + Sync>,
+}
+
+#[derive(Clone)]
+pub(crate) struct NativeWindow(pub(super) Arc<NativeState>);
+
+fn native_error(message: impl Into<String>) -> tauri::Error {
+    tauri::Error::Io(std::io::Error::other(message.into()))
+}
+
+impl NativeWindow {
+    pub(crate) fn create(
+        app: &tauri::AppHandle,
+        config: &AnchoredWindowConfig,
+        generation: u64,
+        height: f64,
+        handler: NativeRequestHandler,
+        failed: impl Fn() + Send + Sync + 'static,
+    ) -> tauri::Result<Self> {
+        let policy = BridgePolicy::new(app, &config.route)?;
+        let state = Arc::new(NativeState {
+            app: app.clone(),
+            objects: Mutex::new(None),
+            alive: AtomicBool::new(true),
+            visible: AtomicBool::new(false),
+            failed: Arc::new(failed),
+        });
+        let window = Self(state);
+        let pending = window.clone();
+        let configuration = NativeConfiguration {
+            policy,
+            frame: NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(config.width, height)),
+            radius: config.corner_radius,
+            generation,
+            title: config.title.clone(),
+        };
+        app.run_on_main_thread(move || {
+            if !pending.0.alive.load(Ordering::Acquire) {
+                return;
+            }
+            let mtm = MainThreadMarker::new()
+                .expect("native companion creation requires the main thread");
+            match NativeObjects::new(mtm, &pending, configuration, handler) {
+                Ok(objects) => {
+                    *pending
+                        .0
+                        .objects
+                        .lock()
+                        .expect("native WebKit objects mutex must not be poisoned") =
+                        Some(MainThreadBound::new(objects, mtm));
+                }
+                Err(error) => {
+                    tracing::error!(%error, "native companion creation failed");
+                    pending.fail();
+                }
+            }
+        })?;
+        Ok(window)
+    }
+
+    pub(super) fn fail(&self) {
+        if !self.0.alive.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        let failed = self.0.failed.clone();
+        tauri::async_runtime::spawn_blocking(move || failed());
+    }
+
+    pub(super) fn with_objects(
+        &self,
+        action: impl FnOnce(&NativeObjects) + Send + 'static,
+    ) -> tauri::Result<()> {
+        let window = self.clone();
+        self.0.app.run_on_main_thread(move || {
+            if !window.0.alive.load(Ordering::Acquire) {
+                return;
+            }
+            let mtm =
+                MainThreadMarker::new().expect("native companion access requires the main thread");
+            let objects = window
+                .0
+                .objects
+                .lock()
+                .expect("native WebKit objects mutex must not be poisoned");
+            if let Some(objects) = objects.as_ref() {
+                action(objects.get(mtm));
+            }
+        })
+    }
+
+    pub(crate) fn show(&self) -> tauri::Result<()> {
+        let state = self.0.clone();
+        self.with_objects(move |objects| {
+            objects.panel.orderFrontRegardless();
+            state.visible.store(true, Ordering::Release);
+        })
+    }
+
+    pub(crate) fn hide(&self) -> tauri::Result<()> {
+        self.0.visible.store(false, Ordering::Release);
+        self.with_objects(|objects| objects.panel.orderOut(None))
+    }
+
+    pub(crate) fn is_visible(&self) -> tauri::Result<bool> {
+        Ok(self.0.alive.load(Ordering::Acquire) && self.0.visible.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn emit<S: Serialize + Clone>(&self, event: &str, payload: S) -> tauri::Result<()> {
+        let event = serde_json::to_string(event)?;
+        let payload = serde_json::to_string(&payload)?;
+        self.eval(format!(
+            "window.__ANTIBURN_NATIVE_DELIVER__?.({{event:{event},payload:{payload}}})"
+        ))
+    }
+
+    pub(super) fn eval(&self, script: String) -> tauri::Result<()> {
+        self.with_objects(move |objects| {
+            // SAFETY: The webview is live, and this callback runs on the main thread.
+            unsafe {
+                objects
+                    .webview
+                    .evaluateJavaScript_completionHandler(&NSString::from_str(&script), None);
+            }
+        })
+    }
+
+    pub(crate) fn destroy(&self) -> tauri::Result<()> {
+        self.0.alive.store(false, Ordering::Release);
+        let window = self.clone();
+        self.0
+            .app
+            .run_on_main_thread(move || window.destroy_on_main_thread())
+    }
+
+    pub(crate) fn destroy_on_main_thread(&self) {
+        let mtm =
+            MainThreadMarker::new().expect("native companion destruction requires the main thread");
+        self.0.alive.store(false, Ordering::Release);
+        self.0.visible.store(false, Ordering::Release);
+        let objects = self
+            .0
+            .objects
+            .lock()
+            .expect("native WebKit objects mutex must not be poisoned")
+            .take();
+        if let Some(objects) = objects {
+            let objects = objects.into_inner(mtm);
+            // SAFETY: All WebKit objects belong to the current main thread.
+            unsafe {
+                objects.webview.stopLoading();
+                objects.webview.setNavigationDelegate(None);
+                let controller = objects.webview.configuration().userContentController();
+                controller.removeAllScriptMessageHandlers();
+                controller.removeAllUserScripts();
+            }
+            objects.delegate.invalidate();
+            objects.panel.orderOut(None);
+            objects.panel.setContentView(None);
+            objects.panel.close();
+        }
+    }
+}
+
+impl NativeObjects {
+    fn new(
+        mtm: MainThreadMarker,
+        owner: &NativeWindow,
+        configuration: NativeConfiguration,
+        handler: NativeRequestHandler,
+    ) -> tauri::Result<Self> {
+        let NativeConfiguration {
+            policy,
+            frame,
+            radius,
+            generation,
+            title,
+        } = configuration;
+        // SAFETY: The panel subclass has no ivars, and all objects are created on the main thread.
+        unsafe {
+            let panel: Retained<PassivePanel> = msg_send![PassivePanel::alloc(mtm), initWithContentRect: frame, styleMask: NSWindowStyleMask::NonactivatingPanel, backing: NSBackingStoreType::Buffered, defer: false];
+            panel.setReleasedWhenClosed(false);
+            panel.setTitle(&NSString::from_str(&title));
+            panel.setHidesOnDeactivate(false);
+            panel.setFloatingPanel(true);
+            panel.setAnimationBehavior(NSWindowAnimationBehavior::None);
+            panel.setCollectionBehavior(
+                NSWindowCollectionBehavior::CanJoinAllSpaces
+                    | NSWindowCollectionBehavior::FullScreenAuxiliary,
+            );
+            panel.setOpaque(false);
+            panel.setBackgroundColor(Some(&NSColor::clearColor()));
+            panel.setHasShadow(true);
+            let content = NSVisualEffectView::initWithFrame(NSVisualEffectView::alloc(mtm), frame);
+            content.setMaterial(NSVisualEffectMaterial::Popover);
+            content.setState(NSVisualEffectState::Active);
+            content.setBlendingMode(NSVisualEffectBlendingMode::BehindWindow);
+            content.setWantsLayer(true);
+            if let Some(layer) = content.layer() {
+                layer.setCornerRadius(radius);
+                layer.setMasksToBounds(true);
+            }
+            panel.setContentView(Some(&content));
+
+            let configuration = WKWebViewConfiguration::new(mtm);
+            let delegate = Delegate::new(
+                mtm,
+                Arc::downgrade(&owner.0),
+                policy.clone(),
+                generation,
+                handler,
+            );
+            configuration.setURLSchemeHandler_forURLScheme(
+                Some(ProtocolObject::from_ref(&*delegate)),
+                &NSString::from_str(super::bridge::SCHEME),
+            );
+            let controller = configuration.userContentController();
+            controller.addScriptMessageHandler_name(
+                ProtocolObject::from_ref(&*delegate),
+                &NSString::from_str("anchored"),
+            );
+            let script = super::bridge::initialization_script(generation, &policy);
+            let script = WKUserScript::initWithSource_injectionTime_forMainFrameOnly(
+                WKUserScript::alloc(mtm),
+                &NSString::from_str(&script),
+                WKUserScriptInjectionTime::AtDocumentStart,
+                true,
+            );
+            controller.addUserScript(&script);
+            let webview = WKWebView::initWithFrame_configuration(
+                WKWebView::alloc(mtm),
+                frame,
+                &configuration,
+            );
+            delegate.set_webview(&webview);
+            webview.setNavigationDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+            webview.setAutoresizingMask(
+                NSAutoresizingMaskOptions::ViewWidthSizable
+                    | NSAutoresizingMaskOptions::ViewHeightSizable,
+            );
+            webview.setUnderPageBackgroundColor(Some(&NSColor::clearColor()));
+            // WebKit exposes this background setting through its Objective-C property.
+            let _: () = msg_send![&webview, setValue: &*objc2_foundation::NSNumber::numberWithBool(false), forKey: &*NSString::from_str("drawsBackground")];
+            content.addSubview(&webview);
+            let url = NSURL::URLWithString(&NSString::from_str(policy.entry.as_str()))
+                .ok_or_else(|| native_error("invalid native companion URL"))?;
+            webview.loadRequest(&NSURLRequest::requestWithURL(&url));
+            Ok(Self {
+                panel,
+                webview,
+                delegate,
+            })
+        }
+    }
+}

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/mod.rs
@@ -1,9 +1,10 @@
 mod tasks;
 mod window;
 
+use crate::companion::CompanionWindow;
 use serde::Serialize;
 use std::sync::{Arc, Mutex};
-use tauri::{Emitter, Manager, WebviewWindow};
+use tauri::{Emitter, Manager};
 
 #[cfg(target_os = "macos")]
 use crate::geometry::Rect;
@@ -20,6 +21,10 @@ struct Inner<T, P> {
     frame_update: Mutex<()>,
     #[cfg(target_os = "macos")]
     native_frame: Arc<Mutex<Option<Rect>>>,
+    #[cfg(target_os = "macos")]
+    native_window: Mutex<Option<CompanionWindow>>,
+    #[cfg(target_os = "macos")]
+    native_handler: Option<crate::macos::NativeRequestHandler>,
     #[cfg(target_os = "linux")]
     pointer_tracker: Arc<crate::linux::PointerTracker>,
 }
@@ -46,10 +51,55 @@ where
                 frame_update: Mutex::new(()),
                 #[cfg(target_os = "macos")]
                 native_frame: Arc::new(Mutex::new(None)),
+                #[cfg(target_os = "macos")]
+                native_window: Mutex::new(None),
+                #[cfg(target_os = "macos")]
+                native_handler: None,
                 #[cfg(target_os = "linux")]
                 pointer_tracker: Arc::new(crate::linux::PointerTracker::new()),
             }),
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn with_native_handler(mut self, handler: crate::macos::NativeRequestHandler) -> Self {
+        Arc::get_mut(&mut self.inner)
+            .expect("configure the manager before sharing")
+            .native_handler = Some(handler);
+        self
+    }
+
+    fn companion(&self, _app: &tauri::AppHandle) -> Option<CompanionWindow> {
+        #[cfg(target_os = "macos")]
+        {
+            self.inner
+                .native_window
+                .lock()
+                .expect("native companion slot mutex must not be poisoned")
+                .clone()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            _app.get_webview_window(&self.inner.config.label)
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn native_renderer_failed(&self, app: &tauri::AppHandle, renderer_generation: u64) {
+        let _frame_update = self.lock_frame_update();
+        if !self.lock_lifecycle().renderer_failed(renderer_generation) {
+            return;
+        }
+        if let Some(window) = self
+            .inner
+            .native_window
+            .lock()
+            .expect("native companion slot mutex must not be poisoned")
+            .take()
+        {
+            let _ = window.destroy();
+        }
+        let _ = self.emit_state(app);
     }
 
     fn normalized_heights(&self) -> (f64, f64, f64) {
@@ -110,7 +160,7 @@ where
     fn apply_request_transition(
         &self,
         app: &tauri::AppHandle,
-        window: &WebviewWindow,
+        window: &CompanionWindow,
         transition: RequestTransition<T>,
         delivery_pending: bool,
     ) -> tauri::Result<AnchoredWindowRequest<T>> {
@@ -143,7 +193,7 @@ where
     fn retry_pending_native_transition(
         &self,
         app: &tauri::AppHandle,
-        window: &WebviewWindow,
+        window: &CompanionWindow,
     ) -> tauri::Result<()> {
         let should_reveal = {
             let lifecycle = self.lock_lifecycle();
@@ -159,7 +209,7 @@ where
 
     fn deliver_render_request(
         &self,
-        window: &WebviewWindow,
+        window: &CompanionWindow,
         request: Option<AnchoredWindowRenderRequest<T, P>>,
     ) -> tauri::Result<()> {
         let Some(request) = request else {
@@ -181,7 +231,7 @@ where
         content_height: Option<f64>,
     ) -> tauri::Result<bool> {
         let _frame_update = self.lock_frame_update();
-        let Some(window) = app.get_webview_window(&self.inner.config.label) else {
+        let Some(window) = self.companion(app) else {
             return Ok(false);
         };
         let presented = {
@@ -231,7 +281,7 @@ where
             (request, lifecycle.renderer_ready)
         };
         let render_request = self.lock_lifecycle().render_request();
-        if let Some(window) = app.get_webview_window(&self.inner.config.label) {
+        if let Some(window) = self.companion(app) {
             platform::hide(&window)?;
         }
         {
@@ -247,10 +297,13 @@ where
     /// Mark the current renderer load ready and deliver the latest request.
     pub fn renderer_ready(
         &self,
-        window: &WebviewWindow,
+        app: &tauri::AppHandle,
         renderer_generation: u64,
     ) -> tauri::Result<bool> {
         let _frame_update = self.lock_frame_update();
+        let Some(window) = self.companion(app) else {
+            return Ok(false);
+        };
         let Some(reveal_now) = ({
             let mut lifecycle = self.lock_lifecycle();
             lifecycle.renderer_ready(renderer_generation)
@@ -259,10 +312,10 @@ where
         };
         let request = self.lock_lifecycle().pending_render_request();
         if reveal_now {
-            self.reveal_placeholder(window.app_handle(), window)?;
+            self.reveal_placeholder(app, &window)?;
         }
-        self.deliver_render_request(window, request)?;
-        if let Err(error) = self.emit_state(window.app_handle()) {
+        self.deliver_render_request(&window, request)?;
+        if let Err(error) = self.emit_state(app) {
             tracing::warn!(%error, "failed to emit anchored-window renderer state");
         }
         Ok(true)
@@ -276,7 +329,7 @@ where
         content_height: Option<f64>,
     ) -> tauri::Result<bool> {
         let _frame_update = self.lock_frame_update();
-        let Some(window) = app.get_webview_window(&self.inner.config.label) else {
+        let Some(window) = self.companion(app) else {
             return Ok(false);
         };
         let (presentation_pending, reveal_pending, should_apply_frame) = {
@@ -319,7 +372,7 @@ where
         if !self.lock_lifecycle().concealment_is_current(generation) {
             return false;
         }
-        if let Some(window) = app.get_webview_window(&self.inner.config.label)
+        if let Some(window) = self.companion(app)
             && let Err(error) = platform::hide(&window)
         {
             tracing::warn!(%error, "failed to hide the concealed anchored window");
@@ -353,9 +406,7 @@ where
                 if !self.lock_lifecycle().can_reposition() {
                     return;
                 }
-                if let Some(companion) = window
-                    .app_handle()
-                    .get_webview_window(&self.inner.config.label)
+                if let Some(companion) = self.companion(window.app_handle())
                     && let Err(error) =
                         self.apply_size_and_position(window.app_handle(), &companion)
                 {
@@ -391,6 +442,20 @@ where
         });
     }
 
+    #[cfg(target_os = "macos")]
+    fn retire_renderer_if_current(&self, app: &tauri::AppHandle, generation: u64) {
+        let manager = Self {
+            inner: Arc::clone(&self.inner),
+        };
+        let retirement_app = app.clone();
+        if let Err(error) = app.run_on_main_thread(move || {
+            manager.retire_renderer_on_main_thread(&retirement_app, generation);
+        }) {
+            tracing::warn!(%error, "failed to schedule anchored panel retirement");
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
     fn retire_renderer_if_current(&self, app: &tauri::AppHandle, generation: u64) {
         let _frame_update = self.lock_frame_update();
         if !self
@@ -399,10 +464,45 @@ where
         {
             return;
         }
-        if let Some(window) = app.get_webview_window(&self.inner.config.label)
+        if let Some(window) = self.companion(app)
             && let Err(error) = window.destroy()
         {
             tracing::warn!(%error, "failed to destroy the concealed anchored window");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn retire_renderer_on_main_thread(&self, app: &tauri::AppHandle, generation: u64) {
+        let _frame_update = self.lock_frame_update();
+        if !self
+            .lock_lifecycle()
+            .renderer_retirement_is_current(generation)
+        {
+            return;
+        }
+        let Some(window) = self.companion(app) else {
+            return;
+        };
+        self.inner
+            .native_window
+            .lock()
+            .expect("native companion slot mutex must not be poisoned")
+            .take();
+        window.destroy_on_main_thread();
+        self.lock_lifecycle().renderer_destroyed();
+    }
+
+    /// Release the native companion before the application event loop stops.
+    #[cfg(target_os = "macos")]
+    pub fn shutdown(&self) {
+        if let Some(window) = self
+            .inner
+            .native_window
+            .lock()
+            .expect("native companion slot mutex must not be poisoned")
+            .take()
+        {
+            window.destroy_on_main_thread();
         }
     }
 

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/tasks.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/tasks.rs
@@ -2,7 +2,8 @@ use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
-use tauri::{Emitter, Manager};
+#[cfg(not(target_os = "macos"))]
+use tauri::Emitter;
 
 use crate::REQUEST_EVENT;
 use crate::geometry::CursorProximity;
@@ -197,7 +198,7 @@ where
         request: &AnchoredWindowRenderRequest<T, P>,
         renderer_ready: bool,
     ) -> tauri::Result<()> {
-        let Some(window) = app.get_webview_window(&self.inner.config.label) else {
+        let Some(window) = self.companion(app) else {
             if self.lock_lifecycle().concealed(request.generation) {
                 self.emit_state(app)?;
             }
@@ -231,7 +232,7 @@ where
         {
             return;
         }
-        if let Some(window) = app.get_webview_window(&self.inner.config.label)
+        if let Some(window) = self.companion(app)
             && let Err(error) = platform::hide(&window)
         {
             tracing::warn!(%error, "failed to hide anchored window after fallback");

--- a/apps/desktop/src-tauri/crates/anchored-window/src/manager/window.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/manager/window.rs
@@ -1,10 +1,13 @@
 #[cfg(target_os = "linux")]
 use std::sync::Arc;
 
+use crate::companion::CompanionWindow;
 use serde::Serialize;
-use tauri::{Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use tauri::{Manager, WebviewWindow};
 #[cfg(not(target_os = "macos"))]
 use tauri::{PhysicalPosition, PhysicalSize};
+#[cfg(not(target_os = "macos"))]
+use tauri::{WebviewUrl, WebviewWindowBuilder};
 
 use crate::geometry::CursorProximity;
 #[cfg(not(target_os = "macos"))]
@@ -18,8 +21,8 @@ where
     T: Clone + PartialEq + Send + Sync + Serialize + 'static,
     P: Clone + Send + Sync + Serialize + 'static,
 {
-    pub(super) fn ensure_window(&self, app: &tauri::AppHandle) -> tauri::Result<WebviewWindow> {
-        if let Some(window) = app.get_webview_window(&self.inner.config.label) {
+    pub(super) fn ensure_window(&self, app: &tauri::AppHandle) -> tauri::Result<CompanionWindow> {
+        if let Some(window) = self.companion(app) {
             #[cfg(target_os = "linux")]
             crate::linux::install_pointer_tracking(
                 &window,
@@ -33,38 +36,70 @@ where
             lifecycle.renderer_ready = false;
             (lifecycle.renderer_generation, lifecycle.height)
         };
-        let script = format!(
-            "Object.defineProperty(globalThis, \"__ANTIBURN_WINDOW_GENERATION__\", {{ value: {renderer_generation}, writable: false, configurable: false }});"
-        );
-        let builder = WebviewWindowBuilder::new(
-            app,
-            &self.inner.config.label,
-            WebviewUrl::App(self.inner.config.route.clone().into()),
-        )
-        .initialization_script(script)
-        .title(&self.inner.config.title)
-        .inner_size(self.inner.config.width, initial_height)
-        .resizable(false)
-        .maximizable(false)
-        .minimizable(false)
-        .decorations(false)
-        .shadow(true)
-        .always_on_top(true)
-        .skip_taskbar(true)
-        .visible(false)
-        .focused(false)
-        .transparent(cfg!(target_os = "macos"))
-        .focusable(false);
-        let window = platform::configure(builder, self.inner.config.corner_radius).build()?;
-        #[cfg(target_os = "linux")]
-        crate::linux::install_pointer_tracking(&window, Arc::clone(&self.inner.pointer_tracker))?;
+        #[cfg(target_os = "macos")]
+        let window = {
+            let manager = std::sync::Arc::downgrade(&self.inner);
+            let failure_app = app.clone();
+            let handler = self.inner.native_handler.ok_or_else(|| {
+                tauri::Error::Io(std::io::Error::other("native companion handler is missing"))
+            })?;
+            let window = crate::macos::NativeWindow::create(
+                app,
+                &self.inner.config,
+                renderer_generation,
+                initial_height,
+                handler,
+                move || {
+                    if let Some(inner) = manager.upgrade() {
+                        Self { inner }.native_renderer_failed(&failure_app, renderer_generation);
+                    }
+                },
+            )?;
+            *self
+                .inner
+                .native_window
+                .lock()
+                .expect("native companion slot mutex must not be poisoned") = Some(window.clone());
+            window
+        };
+        #[cfg(not(target_os = "macos"))]
+        let window = {
+            let script = format!(
+                "Object.defineProperty(globalThis, \"__ANTIBURN_WINDOW_GENERATION__\", {{ value: {renderer_generation}, writable: false, configurable: false }});"
+            );
+            let builder = WebviewWindowBuilder::new(
+                app,
+                &self.inner.config.label,
+                WebviewUrl::App(self.inner.config.route.clone().into()),
+            )
+            .initialization_script(script)
+            .title(&self.inner.config.title)
+            .inner_size(self.inner.config.width, initial_height)
+            .resizable(false)
+            .maximizable(false)
+            .minimizable(false)
+            .decorations(false)
+            .shadow(true)
+            .always_on_top(true)
+            .skip_taskbar(true)
+            .visible(false)
+            .focused(false)
+            .focusable(false);
+            let window = platform::configure(builder).build()?;
+            #[cfg(target_os = "linux")]
+            crate::linux::install_pointer_tracking(
+                &window,
+                Arc::clone(&self.inner.pointer_tracker),
+            )?;
+            window
+        };
         Ok(window)
     }
 
     pub(super) fn apply_size_and_position(
         &self,
         app: &tauri::AppHandle,
-        companion: &WebviewWindow,
+        companion: &CompanionWindow,
     ) -> tauri::Result<()> {
         let Some(anchor) = app.get_webview_window(&self.inner.config.anchor_label) else {
             return Ok(());
@@ -81,7 +116,7 @@ where
     fn apply_platform_frame(
         &self,
         anchor: &WebviewWindow,
-        companion: &WebviewWindow,
+        companion: &CompanionWindow,
         gap: f64,
         screen_margin: f64,
     ) -> tauri::Result<()> {
@@ -108,7 +143,7 @@ where
     fn apply_platform_frame(
         &self,
         anchor: &WebviewWindow,
-        companion: &WebviewWindow,
+        companion: &CompanionWindow,
         gap: f64,
         screen_margin: f64,
     ) -> tauri::Result<()> {
@@ -175,7 +210,7 @@ where
         app: &tauri::AppHandle,
         edge_tolerance: f64,
     ) -> Option<CursorProximity> {
-        let Some(window) = app.get_webview_window(&self.inner.config.label) else {
+        let Some(window) = self.companion(app) else {
             return Some(CursorProximity::Outside);
         };
         match window.is_visible() {
@@ -231,7 +266,7 @@ where
     pub(super) fn reveal_placeholder(
         &self,
         app: &tauri::AppHandle,
-        window: &WebviewWindow,
+        window: &CompanionWindow,
     ) -> tauri::Result<()> {
         if let Err(error) = self.apply_size_and_position(app, window) {
             self.lock_lifecycle().force_hidden();

--- a/apps/desktop/src-tauri/crates/anchored-window/src/platform.rs
+++ b/apps/desktop/src-tauri/crates/anchored-window/src/platform.rs
@@ -1,17 +1,10 @@
-use tauri::{Manager, WebviewWindow, WebviewWindowBuilder};
-
-#[cfg(target_os = "macos")]
-pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
-    builder: WebviewWindowBuilder<'a, tauri::Wry, M>,
-    corner_radius: f64,
-) -> WebviewWindowBuilder<'a, tauri::Wry, M> {
-    crate::macos::configure(builder, corner_radius)
-}
+use crate::companion::CompanionWindow;
+#[cfg(not(target_os = "macos"))]
+use tauri::{Manager, WebviewWindowBuilder};
 
 #[cfg(target_os = "linux")]
 pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
     builder: WebviewWindowBuilder<'a, tauri::Wry, M>,
-    _corner_radius: f64,
 ) -> WebviewWindowBuilder<'a, tauri::Wry, M> {
     crate::linux::configure(builder)
 }
@@ -19,23 +12,22 @@ pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
 #[cfg(target_os = "windows")]
 pub(crate) fn configure<'a, M: Manager<tauri::Wry>>(
     builder: WebviewWindowBuilder<'a, tauri::Wry, M>,
-    _corner_radius: f64,
 ) -> WebviewWindowBuilder<'a, tauri::Wry, M> {
     crate::windows::configure(builder)
 }
 
-pub(crate) fn show(window: &WebviewWindow) -> tauri::Result<()> {
+pub(crate) fn show(window: &CompanionWindow) -> tauri::Result<()> {
     #[cfg(target_os = "macos")]
-    return crate::macos::show_without_activation(window);
+    return window.show();
     #[cfg(target_os = "linux")]
     return crate::linux::show_without_activation(window);
     #[cfg(target_os = "windows")]
     return crate::windows::show_without_activation(window);
 }
 
-pub(crate) fn hide(window: &WebviewWindow) -> tauri::Result<()> {
+pub(crate) fn hide(window: &CompanionWindow) -> tauri::Result<()> {
     #[cfg(target_os = "macos")]
-    return crate::macos::hide(window);
+    return window.hide();
     #[cfg(target_os = "linux")]
     return crate::linux::hide(window);
     #[cfg(target_os = "windows")]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -365,6 +365,10 @@ pub fn run() {
         // A deliberate quit: stop the background tasks before the store
         // they write to is dropped.
         RunEvent::Exit => {
+            #[cfg(target_os = "macos")]
+            if let Some(manager) = app.try_state::<popover_peek::PopoverPeekManager>() {
+                manager.shutdown();
+            }
             main_window::flush_placement(app);
             // Ask a running report reduction to stop at its next probe.
             // The reduction is read-only, so even a task that never sees
@@ -523,6 +527,7 @@ fn on_window_event(window: &tauri::Window, event: &WindowEvent) {
         .try_state::<popover_peek::PopoverPeekManager>()
     {
         manager.handle_anchor_event(window, event);
+        #[cfg(not(target_os = "macos"))]
         if window.label() == popover_peek::LABEL && matches!(event, WindowEvent::Destroyed) {
             manager.handle_companion_destroyed();
             if manager.state().target.is_some() {

--- a/apps/desktop/src-tauri/src/popover/panel.rs
+++ b/apps/desktop/src-tauri/src/popover/panel.rs
@@ -8,11 +8,11 @@
 //! input, while the previous application stays active.
 //!
 //! Window operations must run on the main thread. Each public function here
-//! marshals its work through [`tauri::WebviewWindow::run_on_main_thread`],
-//! except [`prepare_for_destroy`], which its callers already run there.
+//! marshals its work through Tauri's main-thread callbacks, except
+//! [`prepare_for_destroy`], which its callers already run there.
 
 use tauri::{Manager, WebviewWindow};
-use tauri_nspanel::objc2_app_kit::NSWindowStyleMask;
+use tauri_nspanel::objc2_app_kit::{NSResponder, NSWindowCollectionBehavior, NSWindowStyleMask};
 use tauri_nspanel::objc2_foundation::NSThread;
 use tauri_nspanel::{ManagerExt, WebviewPanelManager, WebviewWindowExt};
 
@@ -30,9 +30,8 @@ tauri_nspanel::tauri_panel! {
 /// isn't present. Safe to call from any thread — the work is marshaled onto
 /// the main thread.
 ///
-/// Only the style mask changes. The window keeps the level that
-/// `always_on_top` set and the default collection behavior, so the popover
-/// stays a surface of the current Space.
+/// The window keeps the level that `always_on_top` set. It joins every Space,
+/// including a full-screen Space owned by another application.
 pub(super) fn to_nonactivating_panel(window: &WebviewWindow) {
     if window
         .try_state::<WebviewPanelManager<tauri::Wry>>()
@@ -47,17 +46,17 @@ pub(super) fn to_nonactivating_panel(window: &WebviewWindow) {
         };
         // Borderless + never activate the application on key.
         panel.set_style_mask(NSWindowStyleMask::NonactivatingPanel);
+        panel.set_collection_behavior(
+            NSWindowCollectionBehavior::CanJoinAllSpaces
+                | NSWindowCollectionBehavior::FullScreenAuxiliary,
+        );
     });
 }
 
 /// Give the popover key-window status without activating the application.
 ///
-/// Orders the panel front, makes the content view first responder, then makes
-/// the panel key. `makeKeyWindow` alone does not hand keyboard events to the
-/// embedded WKWebView: without an explicit first responder the window itself
-/// absorbs them, and typing and Escape stop reaching the views even though
-/// mouse clicks (hit-testing, independent of first-responder state) keep
-/// working.
+/// Orders the panel front and makes it key, then gives its webview keyboard
+/// focus. The direct webview handle avoids the wrapper and its material views.
 ///
 /// Returns `false` when the nspanel plugin is not registered or the closure
 /// cannot be marshaled; the caller falls back to a plain `set_focus`. Inside
@@ -73,17 +72,22 @@ pub(super) fn focus_without_activation(window: &WebviewWindow) -> bool {
     let window = window.clone();
     window
         .clone()
-        .run_on_main_thread(move || match window.get_webview_panel(super::LABEL) {
-            Ok(panel) => {
-                panel.order_front_regardless();
-                let content_view = panel.content_view();
-                panel.make_first_responder(Some(&content_view));
-                panel.make_key_window();
-            }
-            Err(_) => {
-                let _ = window.set_focus();
-            }
-        })
+        .with_webview(
+            move |webview| match window.get_webview_panel(super::LABEL) {
+                Ok(panel) => {
+                    panel.order_front_regardless();
+                    panel.make_key_window();
+                    // SAFETY: The handle is the live WKWebView, and this callback runs on the main thread.
+                    let responder = unsafe { &*webview.inner().cast::<NSResponder>() };
+                    if !panel.make_first_responder(Some(responder)) {
+                        tracing::warn!("failed to give the popover webview keyboard focus");
+                    }
+                }
+                Err(_) => {
+                    let _ = window.set_focus();
+                }
+            },
+        )
         .is_ok()
 }
 

--- a/apps/desktop/src-tauri/src/popover_peek.rs
+++ b/apps/desktop/src-tauri/src/popover_peek.rs
@@ -78,10 +78,15 @@ pub type PopoverPeekManager = AnchoredWindowManager<PopoverPeekTarget, PopoverPe
 const MAX_CONTENT_HEIGHT: f64 = 780.0;
 
 pub fn manager() -> PopoverPeekManager {
-    AnchoredWindowManager::new(AnchoredWindowConfig {
+    let manager = AnchoredWindowManager::new(AnchoredWindowConfig {
         label: LABEL.to_string(),
         anchor_label: crate::popover::LABEL.to_string(),
-        route: "index.html#/popover-peek".to_string(),
+        route: if cfg!(target_os = "macos") {
+            "native-peek.html"
+        } else {
+            "index.html#/popover-peek"
+        }
+        .to_string(),
         title: "antiburn".to_string(),
         width: 380.0,
         corner_radius: crate::popover::CORNER_RADIUS,
@@ -95,7 +100,10 @@ pub fn manager() -> PopoverPeekManager {
             edge_tolerance: 12.0,
             outside_delay: Duration::from_millis(180),
         }),
-    })
+    });
+    #[cfg(target_os = "macos")]
+    let manager = manager.with_native_handler(native_request);
+    manager
 }
 
 fn validate_popover_caller(actual: &str) -> Result<(), String> {
@@ -232,18 +240,23 @@ pub fn get_popover_peek_data(
     manager: tauri::State<'_, PopoverPeekManager>,
 ) -> Result<PopoverPeekData, String> {
     validate_peek_caller(window.label())?;
-    let target = current_target(&manager, generation)?;
+    peek_data(window.app_handle(), &manager, generation)
+}
+
+fn peek_data(
+    app: &tauri::AppHandle,
+    manager: &PopoverPeekManager,
+    generation: u64,
+) -> Result<PopoverPeekData, String> {
+    let target = current_target(manager, generation)?;
     match target {
         PopoverPeekTarget::Provider {
             provider,
             utc_offset_minutes,
         } => {
-            let local = crate::commands::provider_usage_summary(
-                window.app_handle(),
-                Some(utc_offset_minutes),
-            )?;
-            let live = crate::commands::cached_live_usage(window.app_handle());
-            current_target(&manager, generation)?;
+            let local = crate::commands::provider_usage_summary(app, Some(utc_offset_minutes))?;
+            let live = crate::commands::cached_live_usage(app);
+            current_target(manager, generation)?;
             Ok(selected_provider_data(&provider, local, live))
         }
         PopoverPeekTarget::Checks => {
@@ -297,7 +310,7 @@ pub fn popover_peek_ready(
 ) -> Result<bool, String> {
     validate_peek_caller(window.label())?;
     manager
-        .renderer_ready(&window, generation)
+        .renderer_ready(window.app_handle(), generation)
         .map_err(|error| error.to_string())
 }
 
@@ -351,6 +364,97 @@ pub fn popover_peek_concealed(
     Ok(manager.concealed(window.app_handle(), generation))
 }
 
+#[cfg(target_os = "macos")]
+fn native_request(
+    app: &tauri::AppHandle,
+    command: &str,
+    args: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct Generation {
+        generation: u64,
+    }
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct Presentation {
+        generation: u64,
+        content_height: Option<f64>,
+    }
+    let manager = app.state::<PopoverPeekManager>();
+    let result = match command {
+        "get_popover_peek_state" => {
+            if args != serde_json::json!({}) {
+                return Err("unexpected state arguments".into());
+            }
+            serde_json::to_value(manager.state())
+        }
+        "get_popover_peek_data" => {
+            let args: Generation =
+                serde_json::from_value(args).map_err(|error| error.to_string())?;
+            serde_json::to_value(peek_data(app, &manager, args.generation)?)
+        }
+        "popover_peek_ready" | "popover_peek_concealed" => {
+            let args: Generation =
+                serde_json::from_value(args).map_err(|error| error.to_string())?;
+            let accepted = if command == "popover_peek_ready" {
+                manager
+                    .renderer_ready(app, args.generation)
+                    .map_err(|error| error.to_string())?
+            } else {
+                manager.concealed(app, args.generation)
+            };
+            serde_json::to_value(accepted)
+        }
+        "popover_peek_presented" | "popover_peek_retarget_ready" => {
+            let args: Presentation =
+                serde_json::from_value(args).map_err(|error| error.to_string())?;
+            let accepted = if command == "popover_peek_presented" {
+                current_target(&manager, args.generation)?;
+                manager.presented(app, args.generation, args.content_height)
+            } else {
+                manager.retarget_committed_with_height(app, args.generation, args.content_height)
+            };
+            serde_json::to_value(accepted.map_err(|error| error.to_string())?)
+        }
+        "note_interaction" => {
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Note {
+                interaction: crate::analytics::event::Interaction,
+            }
+            let note: Note = serde_json::from_value(args).map_err(|error| error.to_string())?;
+            validate_native_interaction(&note.interaction)?;
+            if manager.state().visible {
+                crate::analytics::record_interaction(app, note.interaction);
+            }
+            Ok(serde_json::Value::Null)
+        }
+        _ => return Err("unsupported native preview command".into()),
+    };
+    result.map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn validate_native_interaction(
+    interaction: &crate::analytics::event::Interaction,
+) -> Result<(), String> {
+    use crate::analytics::event::{Interaction, StateSurface, Surface};
+    match interaction {
+        Interaction::SurfaceViewed {
+            surface: Surface::ProviderPreview | Surface::ChecksPreview,
+            ..
+        }
+        | Interaction::SurfaceStateObserved {
+            surface: StateSurface::ProviderPreview | StateSurface::ChecksPreview,
+            ..
+        }
+        | Interaction::LiveUsageStateObserved { .. } => Ok(()),
+        _ => Err("the native preview cannot report this interaction".into()),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
 pub fn rebuild_if_targeted(app: &tauri::AppHandle) {
     if let Some(manager) = app.try_state::<PopoverPeekManager>()
         && let Err(error) = manager.rebuild_if_targeted(app)
@@ -426,6 +530,26 @@ mod tests {
         assert!(validate_state_caller(LABEL).is_ok());
         assert!(validate_state_caller("popover").is_ok());
         assert!(validate_state_caller("settings").is_err());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn native_analytics_cannot_report_unrelated_surfaces() {
+        use crate::analytics::event::{Interaction, Origin, Surface};
+        assert!(
+            validate_native_interaction(&Interaction::SurfaceViewed {
+                surface: Surface::ProviderPreview,
+                origin: Origin::User
+            })
+            .is_ok()
+        );
+        assert!(
+            validate_native_interaction(&Interaction::SurfaceViewed {
+                surface: Surface::Settings,
+                origin: Origin::User
+            })
+            .is_err()
+        );
     }
 
     #[test]

--- a/apps/desktop/src/lib/ipc.nativePeek.test.ts
+++ b/apps/desktop/src/lib/ipc.nativePeek.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { noteInteraction, type Interaction } from "./ipc"
+
+const tauriInvoke = vi.hoisted(() => vi.fn())
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriInvoke,
+  isTauri: () => false,
+}))
+
+const nativeInvoke = vi.fn()
+
+describe("native peek analytics", () => {
+  beforeEach(() => {
+    tauriInvoke.mockReset()
+    nativeInvoke.mockReset()
+    nativeInvoke.mockResolvedValue(undefined)
+    Object.defineProperty(window, "__ANTIBURN_NATIVE_PEEK__", {
+      configurable: true,
+      value: { invoke: nativeInvoke, listen: vi.fn() },
+    })
+  })
+
+  it("sends preview exposure events through the restricted native command", () => {
+    const interactions: Interaction[] = [
+      { kind: "surfaceViewed", surface: "provider_preview", origin: "user" },
+      {
+        kind: "surfaceStateObserved",
+        surface: "provider_preview",
+        state: "ready",
+        origin: "user",
+      },
+      { kind: "liveUsageStateObserved", provider: "openai", state: "fresh", origin: "user" },
+    ]
+    interactions.forEach(noteInteraction)
+
+    expect(nativeInvoke.mock.calls).toEqual(
+      interactions.map((interaction) => ["note_interaction", { interaction }]),
+    )
+    expect(tauriInvoke).not.toHaveBeenCalled()
+  })
+
+  it("does not widen the native command beyond preview observations", () => {
+    noteInteraction({ kind: "sessionOpened", agent: "codex", environment: "native" })
+    noteInteraction({ kind: "surfaceViewed", surface: "activity", origin: "user" })
+
+    expect(nativeInvoke).not.toHaveBeenCalled()
+    expect(tauriInvoke).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -17,6 +17,7 @@
 import { invoke, isTauri } from "@tauri-apps/api/core"
 import { listen, type UnlistenFn } from "@tauri-apps/api/event"
 
+import { nativePeekBridge } from "./nativePeekBridge"
 import type { SettingsPane } from "./settingsPanes"
 import type { FolderAccessOutcome, FolderPermissions, ProbeRecord } from "./types/repository"
 import type {
@@ -802,6 +803,20 @@ export type LiveUsageProvider = "anthropic" | "openai" | "google"
 export type LiveUsageState =
   "fresh" | "stale" | "authentication" | "rate_limited" | "unavailable" | "no_credentials"
 
+function isNativePeekInteraction(interaction: Interaction): boolean {
+  switch (interaction.kind) {
+    case "surfaceViewed":
+    case "surfaceStateObserved":
+      return (
+        interaction.surface === "provider_preview" || interaction.surface === "checks_preview"
+      )
+    case "liveUsageStateObserved":
+      return true
+    default:
+      return false
+  }
+}
+
 /**
  * Report one interaction. Fire-and-forget, and silent on failure.
  *
@@ -811,6 +826,14 @@ export type LiveUsageState =
  * one gate rather than two that can drift apart.
  */
 export function noteInteraction(interaction: Interaction): void {
+  const native = nativePeekBridge()
+  if (native) {
+    if (!isNativePeekInteraction(interaction)) return
+    void native.invoke("note_interaction", { interaction }).catch(() => {
+      // Analytics errors must not interrupt the preview.
+    })
+    return
+  }
   if (!hasShell()) return
   void invoke("note_interaction", { interaction }).catch(() => {
     // Analytics must never surface an error into something the reader asked

--- a/apps/desktop/src/lib/nativePeekBridge.ts
+++ b/apps/desktop/src/lib/nativePeekBridge.ts
@@ -1,0 +1,16 @@
+/** The restricted transport injected into the native macOS preview webview. */
+export interface NativePeekBridge {
+  invoke(command: string, args?: object): Promise<unknown>
+  listen(event: string, callback: (payload: unknown) => void): Promise<() => void>
+}
+
+declare global {
+  interface Window {
+    readonly __ANTIBURN_NATIVE_PEEK__?: NativePeekBridge
+  }
+}
+
+/** Return the native preview transport when this page runs in its WKWebView. */
+export function nativePeekBridge(): NativePeekBridge | null {
+  return window.__ANTIBURN_NATIVE_PEEK__ ?? null
+}

--- a/apps/desktop/src/lib/popoverPeekIpc.test.ts
+++ b/apps/desktop/src/lib/popoverPeekIpc.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  getPopoverPeekAnchorState,
+  getPopoverPeekData,
+  getPopoverPeekState,
+  hidePopoverPeek,
+  onPopoverPeekLifecycle,
+  onPopoverPeekRequest,
+  popoverPeekConcealed,
+  popoverPeekPresented,
+  popoverPeekReady,
+  popoverPeekRetargetReady,
+  showPopoverPeek,
+  type PopoverPeekRequest,
+} from "./popoverPeekIpc"
+
+const shell = vi.hoisted(() => ({ present: false }))
+const tauriInvoke = vi.hoisted(() => vi.fn())
+const tauriListen = vi.hoisted(() => vi.fn())
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriInvoke,
+  isTauri: () => shell.present,
+}))
+vi.mock("@tauri-apps/api/event", () => ({ listen: tauriListen }))
+
+const nativeInvoke = vi.fn()
+const nativeListen = vi.fn()
+
+function installNativeBridge(): void {
+  Object.defineProperty(window, "__ANTIBURN_NATIVE_PEEK__", {
+    configurable: true,
+    value: { invoke: nativeInvoke, listen: nativeListen },
+  })
+}
+
+describe("popover peek IPC", () => {
+  beforeEach(() => {
+    shell.present = false
+    tauriInvoke.mockReset()
+    tauriListen.mockReset()
+    nativeInvoke.mockReset()
+    nativeListen.mockReset()
+    Reflect.deleteProperty(window, "__ANTIBURN_NATIVE_PEEK__")
+  })
+
+  it("uses the native bridge for companion commands before checking for Tauri", async () => {
+    installNativeBridge()
+    nativeInvoke.mockResolvedValue(true)
+
+    await getPopoverPeekState()
+    await getPopoverPeekData(17)
+    await popoverPeekReady(5)
+    await popoverPeekPresented(17, 196)
+    await popoverPeekRetargetReady(18, null)
+    await popoverPeekConcealed(19)
+
+    expect(nativeInvoke.mock.calls).toEqual([
+      ["get_popover_peek_state", undefined],
+      ["get_popover_peek_data", { generation: 17 }],
+      ["popover_peek_ready", { generation: 5 }],
+      ["popover_peek_presented", { generation: 17, contentHeight: 196 }],
+      ["popover_peek_retarget_ready", { generation: 18, contentHeight: null }],
+      ["popover_peek_concealed", { generation: 19 }],
+    ])
+    expect(tauriInvoke).not.toHaveBeenCalled()
+  })
+
+  it("delivers the native request payload and returns its unlisten function", async () => {
+    installNativeBridge()
+    const unlisten = vi.fn()
+    const delivery: { callback: ((payload: unknown) => void) | null } = { callback: null }
+    nativeListen.mockImplementation(async (_event, callback) => {
+      delivery.callback = callback
+      return unlisten
+    })
+    const handler = vi.fn()
+    const request: PopoverPeekRequest = {
+      generation: 23,
+      target: { kind: "checks" },
+      retargetCommitRequired: false,
+      initialPresentation: null,
+    }
+
+    const stop = await onPopoverPeekRequest(handler)
+    delivery.callback?.(request)
+    stop()
+
+    expect(nativeListen).toHaveBeenCalledWith("anchored-window-request", expect.any(Function))
+    expect(handler).toHaveBeenCalledWith(request)
+    expect(unlisten).toHaveBeenCalledOnce()
+    expect(tauriListen).not.toHaveBeenCalled()
+  })
+
+  it("keeps anchor operations on the Tauri transport", async () => {
+    shell.present = true
+    installNativeBridge()
+    tauriInvoke.mockResolvedValue({
+      generation: 3,
+      target: null,
+      rendererReady: true,
+      visible: false,
+      awaitingRetargetCommit: false,
+      awaitingPresentation: false,
+      awaitingConcealment: false,
+    })
+    tauriListen.mockResolvedValue(() => undefined)
+
+    await showPopoverPeek({ kind: "checks" }, { top: 12, height: 30 })
+    await hidePopoverPeek()
+    await getPopoverPeekAnchorState()
+    await onPopoverPeekLifecycle(() => undefined)
+
+    expect(tauriInvoke).toHaveBeenNthCalledWith(1, "show_popover_peek", {
+      target: { kind: "checks" },
+      anchor: { top: 12, height: 30 },
+      initialPresentation: null,
+    })
+    expect(tauriInvoke).toHaveBeenNthCalledWith(2, "hide_popover_peek")
+    expect(tauriInvoke).toHaveBeenNthCalledWith(3, "get_popover_peek_state")
+    expect(tauriListen).toHaveBeenCalledWith("anchored-window-state", expect.any(Function))
+    expect(nativeInvoke).not.toHaveBeenCalled()
+    expect(nativeListen).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/popoverPeekIpc.ts
+++ b/apps/desktop/src/lib/popoverPeekIpc.ts
@@ -9,6 +9,7 @@ import type {
   AnchoredWindowState,
 } from "./anchoredTrigger"
 import { hasShell, type LiveUsageSummaryPayload, type ProviderUsageSummaryPayload } from "./ipc"
+import { nativePeekBridge, type NativePeekBridge } from "./nativePeekBridge"
 import type { ChecksPresentation } from "./presentation/checks"
 
 export const POPOVER_PEEK_LABEL = "popover-peek"
@@ -42,6 +43,22 @@ export type PopoverPeekData =
     }
   | { kind: "checks"; presentation: ChecksPresentation }
 
+function browserState(): PopoverPeekState {
+  return {
+    generation: 0,
+    target: null,
+    rendererReady: true,
+    visible: false,
+    awaitingRetargetCommit: false,
+    awaitingPresentation: false,
+    awaitingConcealment: false,
+  }
+}
+
+function nativeInvoke<T>(bridge: NativePeekBridge, command: string, args?: object): Promise<T> {
+  return bridge.invoke(command, args) as Promise<T>
+}
+
 /** Retarget the companion beside the popover. */
 export async function showPopoverPeek(
   target: PopoverPeekTarget,
@@ -64,33 +81,31 @@ export async function hidePopoverPeek(): Promise<void> {
 
 /** Read the latest preview request after the resident renderer mounts. */
 export async function getPopoverPeekState(): Promise<PopoverPeekState> {
-  if (!hasShell()) {
-    return {
-      generation: 0,
-      target: null,
-      rendererReady: true,
-      visible: false,
-      awaitingRetargetCommit: false,
-      awaitingPresentation: false,
-      awaitingConcealment: false,
-    }
-  }
+  const native = nativePeekBridge()
+  if (native) return nativeInvoke<PopoverPeekState>(native, "get_popover_peek_state")
+  if (!hasShell()) return browserState()
   return invoke<PopoverPeekState>("get_popover_peek_state")
 }
 
 /** Read the latest preview lifecycle from the popover that owns the anchor. */
 export async function getPopoverPeekAnchorState(): Promise<PopoverPeekState> {
-  return getPopoverPeekState()
+  if (!hasShell()) return browserState()
+  return invoke<PopoverPeekState>("get_popover_peek_state")
 }
 
 /** Load the current target through the companion's restricted shell command. */
 export async function getPopoverPeekData(generation: number): Promise<PopoverPeekData> {
+  const native = nativePeekBridge()
+  if (native)
+    return nativeInvoke<PopoverPeekData>(native, "get_popover_peek_data", { generation })
   if (!hasShell()) throw new Error("popover peek data requires the desktop shell")
   return invoke<PopoverPeekData>("get_popover_peek_data", { generation })
 }
 
 /** Mark the companion ready after its resident standby skeleton commits. */
 export async function popoverPeekReady(generation: number): Promise<boolean> {
+  const native = nativePeekBridge()
+  if (native) return nativeInvoke<boolean>(native, "popover_peek_ready", { generation })
   if (!hasShell()) return true
   return invoke<boolean>("popover_peek_ready", { generation })
 }
@@ -100,6 +115,13 @@ export async function popoverPeekPresented(
   generation: number,
   contentHeight: number | null,
 ): Promise<boolean> {
+  const native = nativePeekBridge()
+  if (native) {
+    return nativeInvoke<boolean>(native, "popover_peek_presented", {
+      generation,
+      contentHeight,
+    })
+  }
   if (!hasShell()) return true
   return invoke<boolean>("popover_peek_presented", { generation, contentHeight })
 }
@@ -109,12 +131,21 @@ export async function popoverPeekRetargetReady(
   generation: number,
   contentHeight: number | null,
 ): Promise<boolean> {
+  const native = nativePeekBridge()
+  if (native) {
+    return nativeInvoke<boolean>(native, "popover_peek_retarget_ready", {
+      generation,
+      contentHeight,
+    })
+  }
   if (!hasShell()) return true
   return invoke<boolean>("popover_peek_retarget_ready", { generation, contentHeight })
 }
 
 /** Confirm that React committed the cleared generation before native hiding. */
 export async function popoverPeekConcealed(generation: number): Promise<boolean> {
+  const native = nativePeekBridge()
+  if (native) return nativeInvoke<boolean>(native, "popover_peek_concealed", { generation })
   if (!hasShell()) return true
   return invoke<boolean>("popover_peek_concealed", { generation })
 }
@@ -127,6 +158,12 @@ const POPOVER_PEEK_STATE_EVENT = "anchored-window-state"
 export async function onPopoverPeekRequest(
   handler: (request: PopoverPeekRequest) => void,
 ): Promise<UnlistenFn> {
+  const native = nativePeekBridge()
+  if (native) {
+    return native.listen(POPOVER_PEEK_REQUEST_EVENT, (payload) =>
+      handler(payload as PopoverPeekRequest),
+    )
+  }
   if (!hasShell()) return () => undefined
   return listen<PopoverPeekRequest>(POPOVER_PEEK_REQUEST_EVENT, (event) =>
     handler(event.payload),

--- a/apps/desktop/src/native-peek.tsx
+++ b/apps/desktop/src/native-peek.tsx
@@ -1,0 +1,4 @@
+import { mountWindow } from "./bootstrap"
+import { PopoverPeekView } from "./views/PopoverPeekView"
+
+mountWindow(<PopoverPeekView />, "popover-peek")

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -46,6 +46,7 @@ export default defineConfig(({ command, mode }) => ({
       input: {
         main: fileURLToPath(new URL("./index.html", import.meta.url)),
         mainWindow: fileURLToPath(new URL("./main.html", import.meta.url)),
+        nativePeek: fileURLToPath(new URL("./native-peek.html", import.meta.url)),
         onboarding: fileURLToPath(new URL("./onboarding.html", import.meta.url)),
         settings: fileURLToPath(new URL("./settings.html", import.meta.url)),
       },


### PR DESCRIPTION
## Summary

Fixes #470
Fixes #473

Prevent hover previews from activating antiburn, and allow the menu-bar popover and its previews to appear over fullscreen applications. Deliberately opening the main window continues to activate antiburn normally.

## Problems and solutions

### #470 — Hovering the popover changes app-switcher order

Creating a hover preview through Wry could activate antiburn before the window was configured as nonactivating. The baseline live test reproduced this behavior.

On macOS, hover previews now use directly created `NSPanel`s and `WKWebView`s. The panels are nonactivating from initialization, cannot become key or main windows, and are presented without activation or keyboard-focus requests.

The implementation reuses the existing preview components, positioning, and hover lifecycle. A restricted native bridge handles renderer messages and assets, validates requests and generations, and preserves analytics consent handling. Failed renderers are retired and can be recreated on the next hover.

### #473 — Popover opens outside the active fullscreen Space

The popover’s default macOS collection behavior prevented it from appearing over another application’s fullscreen Space.

The popover and hover previews now use `CanJoinAllSpaces` and `FullScreenAuxiliary`. The interactive popover also gives keyboard focus to its embedded webview correctly.

## Scope and compatibility

- Native WebKit replaces Wry only for macOS hover previews.
- The interactive popover and other app windows retain their existing Tauri implementations.
- Windows/Linux previews retain their existing backend.
- Wry remains an official crates.io dependency; no Wry fork or vendored source is introduced.
- Superseded implementation code and redundant tests are removed.
- CI now covers the anchored-window crate on macOS, Windows, and Linux.

## Live tests

Application activation and keyboard focus were checked separately.

| Test | Result |
|---|---|
| Baseline cold hover preview | Reproduced antiburn activation |
| Native provider/check previews, pointer transfer, and scrolling | No preview-triggered activation observed |
| Repeated dismissal and recreation | Ten cycles completed without observed activation |
| Key window and keyboard responder during preview creation | Remained unchanged |
| TextEdit typing with an IPC-triggered native preview | Typing continued in the same TextEdit field |
| Preview WebKit process termination | Preview retired and recreated successfully |
| Fullscreen application | Popover and preview appeared over the fullscreen Space |
| Deliberate main-window opening | Activated antiburn and focused its main window |
| User test after a fresh launch | Opening and hovering the popover left app-switcher order unchanged |

## Automated validation

- macOS shell and anchored-window Clippy/tests passed.
- Linux shell and anchored-window Clippy/tests passed.
- Windows anchored-window compilation passed.
- Analytics-enabled shell checks passed.
- Frontend formatting, lint, typecheck, build, and tests passed, with focused checks repeated after cleanup.

Full Windows shell compilation and exhaustive display/appearance testing remain outstanding.
