### PR TITLE
Raise thread identity cap to 16,384 for long sessions

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -29,7 +29,7 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
             parser_revision: 31,
-            analyzer_revision: 21,
+            analyzer_revision: 22,
             metrics_schema_revision: 8,
             evidence_schema_revision: 18,
         }

--- a/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
@@ -417,7 +417,7 @@ fn current_resume_revisions_reject_each_prior_batch_revision() {
     let current = crate::analysis::resume_revisions();
     assert_eq!(current.snapshot_revision, 6);
     assert_eq!(current.parser_revision, 31);
-    assert_eq!(current.analyzer_revision, 21);
+    assert_eq!(current.analyzer_revision, 22);
     assert_eq!(current.metrics_schema_revision, 8);
     assert_eq!(current.evidence_schema_revision, 18);
     assert_eq!(current.coverage_schema_revision, 4);

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -1158,7 +1158,7 @@ mod tests {
             "coverage": coverage,
             "provenance": {
                 "parserRevision": 31,
-                "analyzerRevision": 21,
+                "analyzerRevision": 22,
                 "evidenceSchemaRevision": 18,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",

--- a/crates/antiburn-local/src/analysis/evidence_sink.rs
+++ b/crates/antiburn-local/src/analysis/evidence_sink.rs
@@ -47,16 +47,15 @@ fn resolved_model_id(facts: &TurnFacts) -> Option<&str> {
 }
 
 /// Tests enforce this ceiling for the accumulator's retained heap bytes.
-/// A saturated accumulator (every collection at its cap) measures about
-/// 29,900 bytes; this bound rounds that up generously (over 2x).
-pub const RETAINED_EVIDENCE_BYTES_BOUND: usize = 256 * 1_024;
+/// The bound includes 16,384 thread identities with up to 256 bytes each.
+pub const RETAINED_EVIDENCE_BYTES_BOUND: usize = 8 * 1_024 * 1_024;
 
 /// A `BTreeMap` or `BTreeSet` has no queryable capacity: each insert grows
 /// exactly one B-tree node. This estimates one entry's node overhead —
 /// pointers and per-node slack — on top of its own key or value bytes.
 const BTREE_ENTRY_OVERHEAD_BYTES: usize = 48;
 const MAX_MODEL_CONTROL_OBSERVATIONS: usize = 128;
-const MAX_TRACKED_THREAD_UUIDS: usize = 512;
+const MAX_TRACKED_THREAD_UUIDS: usize = 16_384;
 const THREAD_UUIDS_DIAGNOSTIC: &str = "thread_link.seen_uuids";
 
 /// The two fields [`SessionEvidenceAccumulator::coverage_record`] leaves
@@ -3140,6 +3139,34 @@ mod tests {
                 reason: CoverageReason::AttributionIncomplete,
             }
         );
+    }
+
+    #[test]
+    fn long_thread_identity_tracking_preserves_complete_coverage() {
+        let mut accumulator = accumulator(true);
+        for index in 0..MAX_TRACKED_THREAD_UUIDS {
+            accumulator.record(NormalizedRecord::Observation(Box::new(
+                EvidenceObservation::ThreadLink {
+                    uuid: Some(format!("{index:0256}")),
+                    parent_uuid: (index > 0).then(|| format!("{:0256}", index - 1)),
+                },
+            )));
+        }
+        let encoded = serde_json::to_vec(&accumulator.resume_state()).unwrap();
+        let resume = serde_json::from_slice(&encoded).unwrap();
+        let restored = SessionEvidenceAccumulator::from_coverage_record_with_resume(
+            accumulator.coverage_record(),
+            resume,
+        );
+        let evidence = restored.evidence(&TurnFacts::default());
+        assert_eq!(evidence.coverage, EvidenceCoverage::Complete);
+        assert!(
+            !evidence
+                .diagnostics
+                .capped_collections
+                .contains(THREAD_UUIDS_DIAGNOSTIC)
+        );
+        assert!(restored.retained_bytes() < RETAINED_EVIDENCE_BYTES_BOUND);
     }
 
     #[test]

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -213,7 +213,8 @@ pub const PARSER_REVISION: i64 = 31;
 // +1 for reviewed route resolution in effort and speed assessment.
 // Recompute repeated context within compatible request segments.
 // This batch also reassesses nested resource use and paired subagent models.
-pub const ANALYZER_REVISION: i64 = 21;
+// Reassess sessions with the larger thread identity limit.
+pub const ANALYZER_REVISION: i64 = 22;
 // +1 for seam R2: the worker path now derives `inclusive_model_breakdown`
 // and `model_runs` from published turn rows instead of the accumulator
 // (`query_model_breakdown`, `query_model_runs`), so every session in the

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -187,7 +187,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -185,7 +185,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -187,7 +187,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -202,7 +202,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -177,7 +177,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -201,7 +201,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -177,7 +177,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -185,7 +185,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -136,7 +136,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -126,7 +126,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -152,7 +152,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -164,7 +164,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -132,7 +132,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -158,7 +158,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -140,7 +140,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -137,7 +137,7 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 21,
+      "analyzerRevision": 22,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"

--- a/docs/check-coverage.md
+++ b/docs/check-coverage.md
@@ -116,10 +116,16 @@ deny session-wide `Clean`, even when a nested observed-resource map is complete.
 A scoped finding requires complete coverage of that observed subset, calls, and
 eligible activity. An unrelated partial resource group does not block it.
 
-Thread attribution retains at most 512 distinct UUIDs, each at most 256 bytes.
+Thread attribution retains at most 16,384 distinct UUIDs, each at most 256 bytes.
 An overflow or oversized UUID records `CapExceeded`, makes attribution
 incomplete, and blocks every clean result that needs complete affected evidence.
 An oversized resume identity set is rejected instead of being trusted.
+
+Maintainer confirmation (2026-09-10): raise the identity cap to 16,384 as an
+interim measure for longer sessions. Reviewed passive alternatives include
+indexed local relationship queries and bounded batch processing. Those
+alternatives remain outside this change; sessions above the cap still lose
+clean-result eligibility. Analyzer revision 22 reprocesses prior evidence.
 
 Skills mean full documents injected into model context. Listings, installed
 skills, and names in tool calls do not prove unused document overhead. Resource

--- a/docs/session-coverage.md
+++ b/docs/session-coverage.md
@@ -116,15 +116,18 @@ compactions, or incomplete history prevent clean. OpenCode uses validated
 ordered history, not `parentID` as a fabricated predecessor link.
 
 The route columns use engine turn migration 7 and desktop migration 39. Current
-parser/analyzer/evidence/coverage/resume revisions are 31/21/17/4/6. Existing
+parser/analyzer/evidence/coverage/resume revisions are 31/22/18/4/6. Existing
 revision gates invalidate old projections and snapshots; JSON and binary
 evidence round trips and full/resumed replay are covered by tests.
 
-The evidence accumulator retains at most 512 distinct thread UUIDs. Each UUID
+The evidence accumulator retains at most 16,384 distinct thread UUIDs. Each UUID
 must be at most 256 bytes. A new UUID after the set is full, or an oversized
 UUID, makes attribution incomplete and records `Partial(CapExceeded)`. Resume
 deserialization rejects an oversized set or UUID. Defensive reconstruction also
 caps invalid in-memory resume state and keeps the evidence partial.
+The retained evidence memory ceiling is 8 MiB per accumulator. A synthetic
+16,384-record linked chain with maximum-length identities verifies complete
+coverage and resume round trips within that ceiling.
 
 ## Companion Sources
 


### PR DESCRIPTION
## User impact

Long sessions can exhaust the 512-entry message identity set and lose clean burn-check results despite successful parsing. Raise the per-source cap to 16,384 as an interim fix. Bump the analyzer revision to 22 so existing evidence and resume snapshots are invalidated and reprocessed.

Overflow still produces partial evidence. This change does not replace the capped set with disk-backed relationship queries.

## Validation

- Engine and desktop shell: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
- `check_coverage_contract` (3 tests).
- New synthetic 16,384-ID linked-chain test verifies complete coverage, resume serialization/restoration, and the retained-memory bound using 256-byte IDs. Existing overflow tests exercise the new limit.
- Updated revision expectations and characterization goldens.
- `pnpm run slop:all`, `pnpm run secrets`, and `git diff --check`.

## Analytics

Measurement is unchanged. This corrects assessment coverage within existing session analysis; it introduces no user action or event trigger. No additional instrumentation is needed for this interim limit adjustment.

## Privacy and performance

The identity set remains bounded per source. Its maximum count increases 32-fold; the tested retained-evidence ceiling increases from 256 KiB to 8 MiB per accumulator to accommodate maximum-length IDs and collection overhead. This ceiling is not a total-process memory bound. Resume snapshots can grow accordingly. The analyzer revision triggers reanalysis of existing sessions. No new data sources or network access are introduced.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
