### PR TITLE
chore: release app 0.5.2 and engine 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [0.5.2] - 2026-09-10
 
-This release supersedes 0.5.1, which was withdrawn before publication.
-
 ### Changed
 
 - Session Details has a simpler layout and clearer Burn Check cards that adapt
@@ -42,32 +40,6 @@ This release supersedes 0.5.1, which was withdrawn before publication.
   for agents without a dedicated guidance profile.
 - Session-detail metric pickers keep a consistent width, percentage labels have
   clear spacing, and the status bar keeps a consistent height.
-
-- Expanded sub-agent rows stay aligned with the cost table columns.
-- Expired Pi credentials can refresh through Pi before antiburn retries live
-  usage, including installations managed by nvm.
-- Cache churn now uses the correct Claude or OpenAI accounting policy in mixed
-  model sessions. Token-burn estimates stay unknown when prices or total-token
-  evidence is unavailable.
-- Session changes are detected more reliably for bounded inline sources and
-  OpenCode databases, including edits that do not change row counts or saved
-  timestamps.
-
-## [0.5.1] - 2026-09-10
-
-Withdrawn before publication; superseded by 0.5.2.
-
-### Changed
-
-- Session Details has a simpler layout and clearer Burn Check cards that adapt
-  to the window width.
-- Burn Checks now use stronger evidence contracts for supported Claude Code,
-  Codex, OpenCode, Pi, and Antigravity sessions. Findings keep exact provider
-  routes and supported checks decline clean results when required evidence is
-  incomplete.
-
-### Fixed
-
 - Expanded sub-agent rows stay aligned with the cost table columns.
 - Expired Pi credentials can refresh through Pi before antiburn retries live
   usage, including installations managed by nvm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,42 @@ CI changes, and documentation that no user acts on stay out — see
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-09-10
+
+This release supersedes 0.5.1, which was withdrawn before publication.
+
+### Changed
+
+- Session Details has a simpler layout and clearer Burn Check cards that adapt
+  to the window width.
+- Burn Checks now use stronger evidence contracts for supported Claude Code,
+  Codex, OpenCode, Pi, and Antigravity sessions. Findings keep exact provider
+  routes and supported checks decline clean results when required evidence is
+  incomplete.
+
+### Fixed
+
+- Long sessions retain complete thread evidence up to 16,384 identities, so
+  crossing 512 identities no longer prevents otherwise eligible clean Burn Check
+  results. Previously analyzed sessions are reprocessed.
+- Efficiency guidance no longer gives Claude or Codex threshold recommendations
+  for agents without a dedicated guidance profile.
+- Session-detail metric pickers keep a consistent width, percentage labels have
+  clear spacing, and the status bar keeps a consistent height.
+
+- Expanded sub-agent rows stay aligned with the cost table columns.
+- Expired Pi credentials can refresh through Pi before antiburn retries live
+  usage, including installations managed by nvm.
+- Cache churn now uses the correct Claude or OpenAI accounting policy in mixed
+  model sessions. Token-burn estimates stay unknown when prices or total-token
+  evidence is unavailable.
+- Session changes are detected more reliably for bounded inline sources and
+  OpenCode databases, including edits that do not change row counts or saved
+  timestamps.
+
 ## [0.5.1] - 2026-09-10
+
+Withdrawn before publication; superseded by 0.5.2.
 
 ### Changed
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antiburn/desktop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "antiburn-anchored-window",
  "antiburn-hud",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "antiburn-local"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["crates/anchored-window", "crates/hud", "crates/main-window", "crates
 
 [package]
 name = "antiburn"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.97"
 description = "antiburn desktop application: a tray/menu-bar shell over the local antiburn engine."

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "antiburn",
   "mainBinaryName": "antiburn",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "ai.antiburn.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/crates/antiburn-local/CHANGELOG.md
+++ b/crates/antiburn-local/CHANGELOG.md
@@ -17,6 +17,15 @@ version and refuses the release if there is none.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-09-10
+
+### Fixed
+
+- Raise the retained thread identity cap from 512 to 16,384 for long sessions.
+  Overflow still marks attribution partial and blocks affected clean results.
+- Advance analyzer revision to 22 so prior evidence is reprocessed with the
+  larger identity cap.
+
 ## [0.7.0] - 2026-09-10
 
 ### Added

--- a/crates/antiburn-local/Cargo.lock
+++ b/crates/antiburn-local/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "antiburn-local"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/antiburn-local/Cargo.toml
+++ b/crates/antiburn-local/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "antiburn-local"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Self-contained, network-free local engine for antiburn: discovery, session analysis, repository identity, pricing, and versioned local persistence/export contracts."
 license = "MIT"


### PR DESCRIPTION
## User impact

Prepare app 0.5.2 from main at `66d45c0b`, including the long-session thread evidence fix, corrected efficiency guidance, and session-detail layout fixes. Combine all changes since 0.5.0 under the 0.5.2 changelog entry.

Bump the engine to 0.7.1 for the increased thread identity cap and analyzer revision. Only release versions, lockfile package entries, and changelogs change. After merge, tag engine 0.7.1 first, verify app-engine provenance, then tag app 0.5.2 to build the draft releases.

## Validation

- App and engine release-version checks pass.
- Frontend lint, type checks, all 1,301 tests, and production build pass.
- Engine and desktop Rust formatting, Clippy, and full test suites pass.
- Changed JSON formatting, repository slop checks, secret scan, and diff whitespace checks pass.
- App-engine provenance requires the new annotated engine tag after merge.
- Signed installers and manual install/update acceptance follow the release workflows.

## Analytics

Measurement is unchanged by this release metadata change; existing instrumentation ships with the release.

## Privacy and performance

None from this release metadata change.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

