### PR TITLE
Refine Burn checks and session presentation

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -16,6 +16,7 @@ sources:
   - src/styles/session-rows.css
   - src/styles/session-detail.css
   - src/components/ui/text-roll.css
+  - src/components/burn-checks/burn-check-summary.css
 colors:
   # Concrete token colors use modern HSL function syntax.
   # Use the shortest value that keeps the same 8-bit RGB channels.
@@ -38,6 +39,12 @@ colors:
   surface-card:
     light: "hsl(0 0% 0% / 0.04)"
     dark: "hsl(0 0% 100% / 0.08)"
+  stats-edge:
+    light: "hsl(0 0% 0% / 0.04)"
+    dark: "hsl(0 0% 100% / 0.05)"
+  session-card: # quiet session-list rest fill; dark mode needs less lift than generic cards
+    light: "hsl(0 0% 0% / 0.02)"
+    dark: "hsl(0 0% 100% / 0.03)"
   surface-header: # the quiet band at the head of the menu-bar popover; fainter than a card
     light: "hsl(0 0% 0% / 0.025)"
     dark: "hsl(0 0% 100% / 0.03)"
@@ -146,6 +153,18 @@ colors:
   agent-mark: # vendor brand-mark ink; see the Vendor brand marks note below
     light: "hsl(52 11% 13.3%)"
     dark: "hsl(60 15% 96.2%)"
+  burn-check-failure-fill: # failure arcs and terminal marks
+    light: "hsl(17.6 100% 58.6%)"
+    dark: "hsl(17.6 100% 58.6%)"
+  burn-check-failure-text: # failure wording on session and summary surfaces
+    light: "hsl(18 100% 36.4%)"
+    dark: "hsl(18 100% 68%)"
+  burn-check-pass-fill: # pass arcs and terminal marks
+    light: "hsl(191.5 83% 36.8%)"
+    dark: "hsl(192 63% 47.6%)"
+  burn-check-neutral: # unassessed arcs and neutral lifecycle marks
+    light: "hsl(209 6% 73.7%)"
+    dark: "hsl(210 3% 50.5%)"
   # Floating-HUD sub-palette only (src/styles/hud.css)
   burn:
     light: "hsl(18 100% 50%)"
@@ -269,6 +288,7 @@ typography:
   callout: { fontSize: 12px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0" }
   footnote: { fontSize: 11px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.12px" }
   caption: { fontSize: 11px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.06px" }
+  metadata: { fontSize: 10.5px, fontWeight: 400, lineHeight: 1.4, letterSpacing: "0.08px" } # transient metadata in a constrained list row
 spacing:
   1: 4px
   2: 8px
@@ -299,6 +319,7 @@ rounded:
   popover: 10px # outer corner for macOS floating popover and notification surfaces
   full: 9999px
 shadow:
+  stats-card: "inset 0 0 0 1px var(--color-stats-edge)"
   popover: "0 4px 12px rgb(0 0 0 / 0.15), 0 1px 3px rgb(0 0 0 / 0.08)"
   tooltip: "0 2px 8px rgb(0 0 0 / 0.12), 0 0.5px 2px rgb(0 0 0 / 0.06)"
   raised: "0 1px 2px rgb(0 0 0 / 0.15), 0 0 0 0.5px rgb(0 0 0 / 0.04)" # @theme-registered; consume as the `shadow-raised` utility
@@ -309,6 +330,7 @@ motion:
   # the `ease-out-quart` utility. Plain `ease-out` is the default elsewhere.
   --duration-quick: 100ms # a crossfade that leads the movement it accompanies
   --duration-fast: 120ms # the default control, hover, and disclosure transition
+  --duration-medium: 180ms # a paired visibility crossfade
   --duration-slow: 300ms # a meter or bar that fills
   --ease-out-quart: cubic-bezier(0.23, 1, 0.32, 1)
   # Recipes, for the timings the tokens above do not carry. Animation timings
@@ -367,7 +389,8 @@ components:
     backgroundColor: { light: "rgb(235 235 235 / 0.92)", dark: "rgb(50 50 50 / 0.96)" }
     backdropFilter: "blur(20px) saturate(180%)"
     textColor: "{colors.label}"
-    rounded: 3px
+    rounded: "{rounded.control}"
+    padding: 8px
     shadow: "{shadow.tooltip}"
     maxWidth: 250px
   switch:
@@ -399,6 +422,14 @@ components:
     rounded: "7px track, {rounded.control} segment"
     shadow: "{shadow.raised}"
     separator: "{colors.separator} hairline between two unselected neighbours"
+  list-display-toolbar:
+    className: "ListDisplayToolbar + SegmentedControl variant=text-tabs"
+    selectedInk: "{colors.accent}"
+    indicatorColor: "{colors.label}"
+    typography: "{typography.footnote}"
+    height: 32px
+    padding: "0 12px"
+    motion: "100ms color and underline opacity crossfade; no moving indicator"
   scroll:
     className: "ui-scrollbar + ui-scrollbar-thumb"
     width: 6px
@@ -410,6 +441,27 @@ components:
 The token reference is the YAML front matter above. Light and Dark live in one file:
 every `colors` entry carries both values, and only those values differ between themes.
 Notes for what isn't expressible as a token:
+
+- **Popover spend summary** — one shared `surface-card` card uses `rounded-control`,
+  a 12px top inset, 8px side insets, 12px horizontal and 8px vertical internal padding, and three equal columns with 8px gaps.
+  The following component owns the gap below the card; the summary adds no bottom padding.
+  Every cost uses system sans with `type-title-3 font-semibold!`; each secondary line
+  uses `type-footnote text-label-secondary` without an added top gap. `SegmentFigure` supplies
+  tabular numerals. The secondary line keeps the token count in `label-secondary`, then
+  renders the middle dot and period in `label-tertiary` with 4px side margins around the dot:
+  `1.35B · 7 days`. Periods read Today, 7 days, and 30 days,
+  while accessible labels retain Last 7 days and Last 30 days.
+  Token units remain accessible but visually implicit. If cost is unavailable, the
+  token count becomes the primary figure and only the period appears below it.
+  The summary has no column dividers, individual card shadows, or entrance animation.
+  The shared card uses `shadow-stats-card`: a uniform 1px inset outline that follows
+  its rounded corners. `stats-edge` uses pure black at 4% in light mode and pure white
+  at 5% in dark mode, so no single edge reads as a divider.
+  The collapsed provider row uses a 16px leading inset, 10px top padding, 6px bottom padding,
+  and 4px horizontal radial padding, so the first ring aligns with the summary's 20px content
+  inset. The expanded row uses 4px bottom padding. The disclosure keeps its visual size and
+  has a centered 40px square hit area in both states. A 12px gap separates its slot from the
+  provider group.
 
 - **Utilities** — every `colors` key is a Tailwind utility via `bg-/text-/border-<name>` (e.g.
   `bg-surface`, `text-label`, `text-system-green`). Use `bg-accent-fill` for accent backgrounds; the
@@ -438,6 +490,88 @@ Notes for what isn't expressible as a token:
   published brand value is made for a filled mark at 18px, and a row of 6px dots on an uncontrolled
   desktop needs more chroma to read as the same colour. The lift is a factor applied to the package
   value, so the source stays the package.
+  Session cards omit the mark from the model line. Instead, each card places a decorative 40px neutral
+  mark at 5% opacity in light mode and 6% in dark mode, cropped 6px beyond the lower-right edge. The
+  denser Antigravity mark scales to 90% inside the same box for equal optical weight. The card clips
+  overflow, and the mark ignores pointer input and assistive technology. The model tooltip keeps the
+  vendor mark and source name for explicit identification. It does not repeat repository metadata,
+  which remains in the card's trailing context row.
+- **Burn Checks** — `BurnCheckIndicator` owns the feature palette and iconography. Failure uses
+  `burn-check-failure-fill` for arcs or marks and `burn-check-failure-text` for wording. Pass arcs
+  and terminal ticks use `burn-check-pass-fill`. A passing session-card verdict uses the same cyan
+  with semibold sentence-case `All X passed` wording. Passed counts in mixed results use the same cyan at regular
+  weight, so the color maps to the dial segment while failure retains weight priority. Unassessed arcs and
+  lifecycle marks use `burn-check-neutral`. A compact session-list verdict uses system monospace with
+  `type-footnote tabular-nums text-label-secondary`, aligns its text to the card's 8px content
+  gap, and renders each outcome and middle dot as separate elements. The dot uses 2px CSS margins on
+  each side instead of monospace space characters. The verdict omits unassessed counts and the repeated “Burn Checks” noun
+  from assessed counts. Failure wording uses semibold weight. Compact Lucide indicators use a
+  15px visual size. Compact segmented dials remain 14px with a 1.5px optical stroke and 14-degree requested
+  gaps. A text-bearing indicator shifts down 1px for optical alignment with the monospace verdict.
+  Session-card rows use a 2px interline gap inside unchanged 12px vertical card padding. A zero-failure result with at least one assessed check uses an outlined ring and tick, even
+  when some checks are not assessed. Session cards keep the passing verdict visible above the title.
+  Failed and non-result states keep their explicit verdict wording. Session cards use
+  fill alone in the default state, without inset top or bottom edges; their existing hover, tooltip-open, and selected fills
+  remain unchanged. Their interaction transitions only the background fill and opts out of the generic
+  role-button scale and opacity feedback, so thin Burn Check icons remain raster-stable. Cards within one date group use a 12px gap; date headings retain their existing
+  8px separation from the next group. Hover-only repository and time metadata and the decorative
+  vendor watermark form a paired opacity crossfade. Both wait for `--duration-fast`, then transition
+  linearly over `--duration-medium`; metadata fades in while the watermark fades out. Pointer exit
+  reverses the transition without a delay. The same state persists while a card tooltip is open.
+  The Burn Check tooltip uses system sans and groups details as Failed, Passed, then Not assessed.
+  Its `type-callout` title uses semibold weight; group labels remain medium.
+  It reuses the circular Burn Check alert, pass, and neutral icons in a leading 14px column. The
+  Failed heading uses the same tertiary ink as other group labels; failed row text uses
+  `burn-check-failure-text`, and the failed icon uses `burn-check-failure-fill`. Not-assessed rows omit their repeated “not assessed” suffix. The group
+  heading remains the visible and accessible status, so row icons stay decorative. The tooltip has
+  no repeated result summary or “Open the session” footer.
+  Session-detail check cards and expandable rows share the tooltip's individual-check marks:
+  a 14px `CircleAlert` with a 2.5px stroke and `burn-check-failure-fill` for failures,
+  and a 14px `CircleCheck` with a 2px stroke and `burn-check-pass-fill` for passes.
+  Failure wording and evidence use `burn-check-failure-text`, including card tooltips
+  and expanded guidance. Passing row wording stays neutral. Unassessed checks remain
+  omitted from the detail cards and rows.
+  The popover summary uses a stable “All burn checks” heading without a dial, reserving circular indicators
+  for provider usage and individual sessions. It uses `--space-md` (12px) horizontal padding and a 12px text-to-meter gap.
+  The text block uses `--space-sm` (8px) top and bottom padding, matching the spend card.
+  Failed and passed counts use `font-mono type-footnote tabular-nums`, matching session verdicts.
+  Failed counts use semibold failure ink; passed counts use regular cyan `burn-check-pass-fill`.
+  The headline uses system sans with `type-headline font-semibold! text-label`. A regular
+  `type-footnote text-label-tertiary` “30 days” label shares its baseline with an 8px gap.
+  Counts carry the visible verdict;
+  the accessible description and companion retain the full result and evidence status.
+  When no counts exist, the second line shows the loading or unavailable status.
+  Remaining context stays in system sans. The summary omits visible “Evidence incomplete” wording;
+  its accessible description retains the evidence status.
+  The summary is the first card in the collapsing overview header, above spend and provider limits.
+  Its wrapper uses twelve pixels of top padding and `--space-sm` (8px) horizontal padding.
+  The wrapper and inner padding use the same tokens as the spend card, so their text starts on the same line.
+  Provider rings retain their existing optical indent.
+  A single separator after
+  the provider limits is inset twelve pixels from both popover edges. The session toolbar starts eight
+  pixels below that rule.
+  The session list uses the remaining popover height without a persistent footer.
+  A static one-pixel edge sits one pixel inside the card. Its state color starts at 40% opacity and fades
+  to 10% at the 45% stop, then into a faint separator at the right. Findings use
+  `burn-check-failure-fill`; results with passes and no findings use `burn-check-pass-fill`;
+  loading, unavailable, and unassessed states use `burn-check-neutral`. Failure takes precedence over pass.
+  The fill stays neutral at 50% of `surface-card`, so the semantic state remains in the edge and content.
+  The surface uses `rounded-control` (5px), matching the spend summary card. The twelve-pixel gap between these cards matches the top inset. Hover uses 35% of `surface-hover`, and the active preview uses 40% of
+  `surface-selected`, while the keyboard-focus treatment remains unchanged.
+  Increased contrast uses a solid edge in the resolved state color.
+  The trailing estimate uses four filled Lucide flame silhouettes, masked over a neutral track.
+  Each full flame represents 25% token burn and fills from the bottom, in order from left to right.
+  The 78 × 18px meter uses local SVG geometry. Values below five percent use a yellow-to-brand
+  gradient; higher values use brand-to-red, matching the existing token-burn threshold.
+  The exact estimate stays in the accessible summary, meter value, app tooltip, and companion
+  panel. The flame tooltip opens on hover or keyboard focus and explains the estimate and scale.
+  The summary button opens Burn checks in the main window. The meter is a separate focus target
+  beside the button, so inspecting it does not open the main window.
+  Its estimate uses semibold `font-mono type-callout tabular-nums` in `burn-check-failure-text`,
+  or cyan `burn-check-pass-fill` for zero burn. The explanation uses secondary callout text,
+  followed by the scale in tertiary footnote text. Color identifies the result, not the explanatory prose.
+  Its target is at least 40px high. Inspecting the flames dismisses the companion, so only one
+  explanation opens at a time. Unknown estimates omit the meter. Flames remain static when reports update.
 - **Themes** — three sources, in cascade order. The system light/dark preference is the default. A
   platform whose webview exposes live system label/separator/accent tokens picks those up through
   `@supports`, so text and chrome track the OS exactly. A platform without them takes an explicit
@@ -540,10 +674,33 @@ hover and tooltip states retain that fill. This yields a 5.4% black tint in ligh
 an 8.4% white tint in dark mode, without reducing text or badge opacity. Sidebar and generic
 collection selections keep their full-strength token;
 row density, grouping, badges, and tooltips match the menu-bar list. The 340px collection uses
-existing title truncation rather than a responsive layout change. The detail toolbar shows the
-session title; Back appears only for related-session history. Embedded shortcuts stay inside
-the detail pane. Hidden panes pause hygiene reads, relative-time clocks, and active-row motion.
-The menu-bar list keeps its existing navigation and presentation defaults.
+existing title truncation rather than a responsive layout change. Session cards lead structurally with the
+token-burn verdict, while the unique title uses `type-body font-medium! text-label` as the primary row identifier.
+Titles stay on one line, truncate at rest, and reveal their overflow at about 45px per second with an
+interruptible horizontal transition after a deliberate card hover. Reduced motion keeps the truncated resting
+title and disables the reveal.
+Routine verdict text uses secondary ink; failure wording retains its status colour. One context row
+shows the complete first model in semibold secondary ink, keeps its same-size thinking suffix tertiary, adds a separator-free
+`+N` count as a 16px-high, borderless muted pill with `surface-tertiary/40`, tertiary ink, and
+`font-mono type-metadata tabular-nums`, and exposes the complete source and model context
+in a tooltip. The tooltip leads with the vendor icon and name without a redundant Source label,
+groups full model identifiers under one Models label, and gives model values primary contrast.
+The first model never truncates. Repository moves to the trailing metadata zone
+beside the hover timestamp, appears only while the card is hovered, and exists only when the list spans multiple
+repositories or it is the row's only context. The trailing repository does not open a second tooltip. On hover,
+repository and timestamp anchor to the card's right edge on the model baseline. An 8px inter-group gap
+protects the model cluster, including its `+N` pill, from a long truncated repository. Repository and time form one
+`font-mono type-metadata tabular-nums` group with a compact 2px gap around their middle
+dot; the timestamp never wraps. When the repository name exceeds
+18 monospace characters, the visible timestamp drops “ago”; its accessible label remains complete. The model line does
+not reserve inline space for the vendor mark. Group labels use sentence case. A
+shared `ListDisplayToolbar` places the pinned activity label and the right-aligned `text-tabs` badge metric control on one row with the labels Cost,
+Week %, and 5h %. Its accessible group name replaces redundant visible labels. The selected choice uses accent ink and a
+primary-label hairline underline. The control crossfades only color and underline opacity over `--duration-quick`; it never slides a moving indicator.
+The detail toolbar shows the session title; Back appears
+only for related-session history. Embedded shortcuts stay inside the detail pane. Hidden panes pause
+hygiene reads, relative-time clocks, and active-row motion. The menu-bar list shares this card presentation
+while keeping its existing navigation behavior.
 
 Burn checks uses the workspace as one flexible pane instead of adding a collection pane. It has no
 visual page header. The scroll viewport starts with the report summary and keeps a screen-reader-only
@@ -581,12 +738,12 @@ The main-window collection slot owns this presentation; menu-bar empty states re
 
 #### Session card state treatment
 
-| State                 | Fill                             | Behavior                                                        |
-| --------------------- | -------------------------------- | --------------------------------------------------------------- |
-| Rest                  | `surface-card/50`                | Quiet background; text and badges retain their normal contrast. |
-| Hover or open tooltip | `surface-secondary/50`           | Applies only to an unselected card.                             |
-| Selected              | `surface-selected/60`            | Persists through hover and open tooltips.                       |
-| Keyboard focus        | Existing focus-visible treatment | Remains independent of the selected fill.                       |
+| State                 | Fill                             | Behavior                                                    |
+| --------------------- | -------------------------------- | ----------------------------------------------------------- |
+| Rest                  | `session-card`                   | Dark mode is quieter; light mode retains the existing fill. |
+| Hover or open tooltip | `surface-secondary/50`           | Applies only to an unselected card.                         |
+| Selected              | `surface-selected/60`            | Persists through hover and open tooltips.                   |
+| Keyboard focus        | Existing focus-visible treatment | Remains independent of the selected fill.                   |
 
 Apply this treatment to main-window session selection. Do not change the shared color
 tokens or the menu-bar list's default appearance to achieve it.
@@ -597,8 +754,8 @@ tokens or the menu-bar list's default appearance to achieve it.
   solid surface-window with no blur. Rounded controls have no outline; the active
   tab uses surface and the raised shadow. Tab labels use regular weight.
   The section picker and action group are both 32px tall, with 24px inner controls.
-  Typography matches the session list: row names use body-large (13.5px), figures and
-  table rows use body (13px), and descriptions use callout (12px). Section headings
+  Within the detail, check row names use body-large (13.5px), figures and table rows use
+  body (13px), and descriptions use callout (12px). Section headings
   are screen-reader-only; caption is reserved for compact toolbar metadata.
   There are no inherited size overrides. Content has 40px side padding.
   Cost composition closes the Context tab, below the plot and its key.

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -76,7 +76,7 @@ describe("App", () => {
     render(<App />)
 
     expect(screen.queryByTestId("route-loading")).not.toBeInTheDocument()
-    await screen.findByRole("button", { name: "antiburn v0.1.0" })
+    await screen.findByRole("heading", { name: "Activity" })
     expect(
       screen.queryByRole("heading", { name: "Stop hitting your token limits." }),
     ).not.toBeInTheDocument()

--- a/apps/desktop/src/components/burn-checks/BurnCheckFlames.test.tsx
+++ b/apps/desktop/src/components/burn-checks/BurnCheckFlames.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { BurnCheckFlames } from "./BurnCheckFlames"
+
+describe("BurnCheckFlames", () => {
+  it.each([
+    [0, [0, 0, 0, 0]],
+    [300, [2.76, 0, 0, 0]],
+    [2_500, [23, 0, 0, 0]],
+    [3_750, [23, 11.5, 0, 0]],
+    [10_000, [23, 23, 23, 23]],
+  ])("fills four equal portions for %i basis points", (basisPoints, heights) => {
+    const { container } = render(<BurnCheckFlames basisPoints={basisPoints} />)
+    const fills = container.querySelectorAll("g > rect[fill^='url']")
+    expect(fills).toHaveLength(4)
+    fills.forEach((fill, index) => {
+      expect(Number(fill.getAttribute("height"))).toBeCloseTo(heights[index]!)
+    })
+    expect(screen.getByRole("meter", { name: "Estimated token burn" })).toHaveAttribute(
+      "aria-valuenow",
+      String(basisPoints / 100),
+    )
+  })
+
+  it("keeps mask and gradient references unique across summaries", () => {
+    const { container } = render(
+      <>
+        <BurnCheckFlames basisPoints={300} />
+        <BurnCheckFlames basisPoints={1_600} />
+      </>,
+    )
+    const ids = Array.from(container.querySelectorAll("[id]"), (node) => node.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const svg of container.querySelectorAll("[role='meter'] > svg")) {
+      expect(svg.querySelector("g")).toHaveAttribute(
+        "mask",
+        `url(#${svg.querySelector("mask")!.id})`,
+      )
+    }
+  })
+})

--- a/apps/desktop/src/components/burn-checks/BurnCheckFlames.tsx
+++ b/apps/desktop/src/components/burn-checks/BurnCheckFlames.tsx
@@ -1,0 +1,105 @@
+import { Flame } from "lucide-react"
+import { useId } from "react"
+
+import { formatTokenBurnPercent } from "../../lib/presentation/checks"
+import { Tooltip } from "../presentation/Tooltip"
+
+const FLAMES = [0, 1, 2, 3] as const
+
+export function BurnCheckFlames({ basisPoints }: { basisPoints: number }) {
+  const id = useId()
+  const value = Math.max(0, Math.min(10_000, basisPoints))
+  const label = `${formatTokenBurnPercent(value)} token burn`
+  const lowBurn = value < 500
+
+  return (
+    <Tooltip
+      label={
+        <span className="block space-y-1">
+          <span
+            className={`block font-mono type-callout font-semibold! tabular-nums ${value === 0 ? "text-burn-check-pass-fill" : "text-burn-check-failure-text"}`}
+          >
+            {label}
+          </span>
+          <span className="block type-callout text-label-secondary">
+            Estimated share of tokens spent on avoidable work.
+          </span>
+          <span className="block type-footnote text-label-tertiary">
+            Each full flame represents 25% token burn.
+          </span>
+        </span>
+      }
+    >
+      <span
+        tabIndex={0}
+        role="meter"
+        aria-label="Estimated token burn"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={value / 100}
+        aria-valuetext={label}
+        className="inline-flex min-h-10 items-center rounded-control"
+      >
+        <svg
+          aria-hidden="true"
+          width={78}
+          height={18}
+          viewBox="0 0 104 24"
+          className="block shrink-0"
+        >
+          <defs>
+            <linearGradient id={`${id}-gradient`} x1="0" y1="1" x2="0" y2="0">
+              <stop
+                offset="0%"
+                stopColor={
+                  lowBurn
+                    ? "var(--color-system-yellow-tint-val)"
+                    : "var(--color-brand-tint-val)"
+                }
+              />
+              <stop
+                offset="100%"
+                stopColor={
+                  lowBurn ? "var(--color-brand-tint-val)" : "var(--color-system-red-tint-val)"
+                }
+              />
+            </linearGradient>
+            <mask
+              id={`${id}-mask`}
+              maskUnits="userSpaceOnUse"
+              x={0}
+              y={0}
+              width={104}
+              height={24}
+            >
+              {FLAMES.map((index) => (
+                <Flame key={index} x={index * 27} size={23} fill="white" stroke="white" />
+              ))}
+            </mask>
+          </defs>
+          <g mask={`url(#${id}-mask)`}>
+            <rect
+              width={104}
+              height={24}
+              fill="var(--color-burn-check-neutral-val)"
+              opacity={0.3}
+            />
+            {FLAMES.map((index) => {
+              const fraction = Math.max(0, Math.min(1, value / 2_500 - index))
+              return (
+                <rect
+                  key={index}
+                  x={index * 27}
+                  y={23 * (1 - fraction)}
+                  width={23}
+                  height={23 * fraction}
+                  fill={`url(#${id}-gradient)`}
+                />
+              )
+            })}
+          </g>
+        </svg>
+      </span>
+    </Tooltip>
+  )
+}

--- a/apps/desktop/src/components/burn-checks/BurnCheckIndicator.tsx
+++ b/apps/desktop/src/components/burn-checks/BurnCheckIndicator.tsx
@@ -1,0 +1,75 @@
+import { CircleDashed } from "lucide-react"
+
+import type { BurnCheckPresentation } from "../../lib/presentation/burnChecks"
+import { SegmentedRadialDial } from "../ui/SegmentedRadialDial"
+import { BURN_CHECK_MARKS } from "./burnCheckMarks"
+
+const SEGMENT_CLASS = {
+  failed: BURN_CHECK_MARKS.finding.iconClass,
+  passed: BURN_CHECK_MARKS.clean.iconClass,
+  unassessed: BURN_CHECK_MARKS.notAssessed.iconClass,
+} as const
+
+export function BurnCheckIndicator({
+  presentation,
+  size,
+  labelled = false,
+}: {
+  presentation: BurnCheckPresentation
+  size: number
+  labelled?: boolean
+}) {
+  const label = labelled ? presentation.accessibleDescription : undefined
+  const common = {
+    role: labelled ? ("img" as const) : undefined,
+    "aria-label": label,
+    "aria-hidden": labelled ? undefined : (true as const),
+  }
+
+  if (presentation.indicator.kind === "segments") {
+    const dialSize = size <= 16 ? size - 2 : size
+    return (
+      <SegmentedRadialDial
+        size={dialSize}
+        strokeWidth={size <= 16 ? 1.5 : 3}
+        gapAngle={size <= 16 ? 14 : 5}
+        {...(label ? { label } : {})}
+        segments={presentation.indicator.segments.map((segment) => ({
+          id: segment.outcome,
+          value: segment.value,
+          className: SEGMENT_CLASS[segment.outcome],
+        }))}
+      />
+    )
+  }
+
+  if (presentation.indicator.kind === "pass") {
+    const mark = BURN_CHECK_MARKS.clean
+    const markSize = size <= 16 ? size - 1 : size - 4
+    return (
+      <mark.Icon
+        {...common}
+        data-burn-check-indicator="pass"
+        size={markSize}
+        strokeWidth={mark.strokeWidth}
+        className={`shrink-0 ${mark.iconClass}`}
+      />
+    )
+  }
+
+  const mark =
+    presentation.indicator.kind === "fail"
+      ? BURN_CHECK_MARKS.finding
+      : BURN_CHECK_MARKS.notAssessed
+  const Icon = presentation.indicator.kind === "running" ? CircleDashed : mark.Icon
+  const markSize = size <= 16 ? size - 1 : size
+  return (
+    <Icon
+      {...common}
+      data-burn-check-indicator={presentation.indicator.kind}
+      size={markSize}
+      strokeWidth={mark.strokeWidth}
+      className={`shrink-0 ${mark.iconClass}`}
+    />
+  )
+}

--- a/apps/desktop/src/components/burn-checks/BurnCheckStatus.tsx
+++ b/apps/desktop/src/components/burn-checks/BurnCheckStatus.tsx
@@ -1,0 +1,77 @@
+import { Fragment, type ComponentPropsWithoutRef, type Ref } from "react"
+
+import type { BurnCheckPresentation } from "../../lib/presentation/burnChecks"
+import { BurnCheckIndicator } from "./BurnCheckIndicator"
+
+type BurnCheckStatusProps = {
+  presentation: BurnCheckPresentation
+  hideText?: boolean
+  omitUnassessed?: boolean
+  ref?: Ref<HTMLSpanElement>
+} & Omit<ComponentPropsWithoutRef<"span">, "children" | "aria-label">
+
+export function BurnCheckStatus({
+  presentation,
+  hideText = false,
+  omitUnassessed = false,
+  ref,
+  ...triggerProps
+}: BurnCheckStatusProps) {
+  const isPassingVerdict =
+    presentation.state === "allPassed" || presentation.state === "assessedPassed"
+  const compactPhrases = (
+    omitUnassessed
+      ? presentation.compactPhrases.filter((phrase) => phrase.outcome !== "unassessed")
+      : presentation.compactPhrases
+  ).map((phrase) =>
+    omitUnassessed && isPassingVerdict && phrase.outcome === "passed"
+      ? { ...phrase, text: `All ${presentation.counts.passed} passed` }
+      : phrase,
+  )
+
+  return (
+    <span
+      {...triggerProps}
+      ref={ref}
+      className="flex min-w-0 items-center gap-x-2 font-mono type-footnote tabular-nums text-label-secondary"
+      aria-label={presentation.accessibleDescription}
+    >
+      <span
+        className={hideText ? "inline-flex shrink-0" : "inline-flex shrink-0 translate-y-px"}
+        data-burn-check-indicator-wrap=""
+      >
+        <BurnCheckIndicator presentation={presentation} size={16} />
+      </span>
+      {!hideText && (
+        <span className="min-w-0 truncate">
+          {compactPhrases.map((phrase, index) => (
+            <Fragment key={`${phrase.outcome}-${phrase.text}`}>
+              {index > 0 && (
+                <span
+                  className="mx-0.5 inline-block"
+                  aria-hidden="true"
+                  data-burn-check-separator=""
+                >
+                  ·
+                </span>
+              )}
+              <span
+                className={
+                  phrase.outcome === "failed"
+                    ? "font-semibold! text-burn-check-failure-text"
+                    : phrase.outcome === "passed"
+                      ? isPassingVerdict
+                        ? "font-semibold! text-burn-check-pass-fill"
+                        : "text-burn-check-pass-fill"
+                      : undefined
+                }
+              >
+                {phrase.text}
+              </span>
+            </Fragment>
+          ))}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/apps/desktop/src/components/burn-checks/BurnCheckSummary.tsx
+++ b/apps/desktop/src/components/burn-checks/BurnCheckSummary.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react"
+
+import type { BurnCheckPresentation } from "../../lib/presentation/burnChecks"
+
+export function BurnCheckSummary({
+  presentation,
+  trailing,
+}: {
+  presentation: BurnCheckPresentation
+  trailing?: ReactNode
+}) {
+  const secondary = [
+    ...presentation.breakdownPhrases.map((phrase) => ({
+      key: `${phrase.outcome}-${phrase.text}`,
+      text: phrase.text,
+      failure: phrase.outcome === "failed",
+      passed: phrase.outcome === "passed",
+    })),
+    ...presentation.contextPhrases
+      .filter((text) => text !== "Evidence incomplete")
+      .map((text) => ({
+        key: `context-${text}`,
+        text,
+        failure: false,
+        passed: false,
+      })),
+  ]
+  return (
+    <span
+      className="grid min-h-10 min-w-0 flex-1 grid-cols-[minmax(0,1fr)_max-content] items-center gap-x-3 px-[var(--space-md)] py-[var(--space-sm)] text-left"
+      aria-label={presentation.accessibleDescription}
+    >
+      <span className="min-w-0">
+        <span className="flex min-w-0 items-baseline gap-2">
+          <span
+            data-testid="burn-check-headline"
+            className="truncate type-headline font-semibold! text-label"
+          >
+            All burn checks
+          </span>
+          <span className="shrink-0 type-footnote font-normal! text-label-tertiary">
+            30 days
+          </span>
+        </span>
+        {secondary.length > 0 ? (
+          <span className="block truncate type-footnote tabular-nums text-label-secondary">
+            {secondary.map((phrase, index) => (
+              <span key={phrase.key}>
+                {index > 0 && <span aria-hidden="true"> · </span>}
+                <span
+                  className={
+                    phrase.failure
+                      ? "font-mono font-semibold! text-burn-check-failure-text"
+                      : phrase.passed
+                        ? "font-mono text-burn-check-pass-fill"
+                        : undefined
+                  }
+                >
+                  {phrase.text}
+                </span>
+              </span>
+            ))}
+          </span>
+        ) : (
+          <span className="block truncate type-footnote text-label-secondary">
+            {presentation.headline}
+          </span>
+        )}
+      </span>
+      {trailing && <span className="shrink-0">{trailing}</span>}
+    </span>
+  )
+}

--- a/apps/desktop/src/components/burn-checks/BurnChecks.test.tsx
+++ b/apps/desktop/src/components/burn-checks/BurnChecks.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { sessionBurnCheckPresentation } from "../../lib/presentation/burnChecks"
+import { BurnCheckIndicator } from "./BurnCheckIndicator"
+import { BurnCheckStatus } from "./BurnCheckStatus"
+import { BurnCheckSummary } from "./BurnCheckSummary"
+
+function presentation(...statuses: Array<"finding" | "clean" | "notAssessed">) {
+  return sessionBurnCheckPresentation(
+    statuses.map((status) => ({ status })),
+    "ready",
+  )
+}
+
+describe("Burn Check components", () => {
+  it("renders matching dial segments and count phrases", () => {
+    const value = presentation("finding", "clean", "clean", "notAssessed")
+    const { container } = render(<BurnCheckStatus presentation={value} />)
+    expect(screen.getByLabelText(value.accessibleDescription)).toHaveClass(
+      "gap-x-2",
+      "font-mono",
+      "type-footnote",
+      "tabular-nums",
+      "text-label-secondary",
+    )
+    expect(screen.getByLabelText(value.accessibleDescription)).not.toHaveClass("type-callout")
+    expect(screen.getByLabelText(value.accessibleDescription)).not.toHaveClass(
+      "tracking-tight!",
+    )
+    expect(screen.getByLabelText(value.accessibleDescription)).not.toHaveClass("gap-x-1.5")
+    expect(screen.getByLabelText(value.accessibleDescription)).not.toHaveClass("text-label")
+    expect(container.querySelectorAll("circle")).toHaveLength(3)
+    const failedAngle = Number(
+      container.querySelector('[data-segment-id="failed"]')?.getAttribute("data-arc-angle"),
+    )
+    const passedAngle = Number(
+      container.querySelector('[data-segment-id="passed"]')?.getAttribute("data-arc-angle"),
+    )
+    const unassessedAngle = Number(
+      container.querySelector('[data-segment-id="unassessed"]')?.getAttribute("data-arc-angle"),
+    )
+    expect(passedAngle).toBeCloseTo(failedAngle * 2, 5)
+    expect(unassessedAngle).toBeCloseTo(failedAngle, 5)
+    expect(screen.getByText("1 failed")).toHaveClass(
+      "font-semibold!",
+      "text-burn-check-failure-text",
+    )
+    expect(screen.getByText("2 passed")).toHaveClass("text-burn-check-pass-fill")
+    expect(screen.getByText("2 passed")).not.toHaveClass("font-semibold!")
+    expect(screen.getByText("1 not assessed")).toBeInTheDocument()
+    const separators = container.querySelectorAll("[data-burn-check-separator]")
+    expect(separators).toHaveLength(2)
+    expect(separators[0]).toHaveTextContent("·")
+    expect(separators[0]?.textContent).toBe("·")
+    expect(separators[0]).toHaveClass("mx-0.5", "inline-block")
+    expect(container.querySelector("[data-burn-check-indicator-wrap]")).toHaveClass(
+      "translate-y-px",
+    )
+  })
+
+  it("uses terminal marks only for complete all-pass and all-fail states", () => {
+    const passed = render(<BurnCheckIndicator presentation={presentation("clean")} size={16} />)
+    const passMark = passed.container.querySelector('[data-burn-check-indicator="pass"]')
+    expect(passMark).not.toBeNull()
+    expect(passMark).toHaveAttribute("width", "15")
+    passed.unmount()
+
+    const failed = render(
+      <BurnCheckIndicator presentation={presentation("finding")} size={16} />,
+    )
+    expect(
+      failed.container.querySelector('[data-burn-check-indicator="fail"]'),
+    ).toHaveAttribute("width", "15")
+  })
+
+  it("uses a lighter compact segmented dial", () => {
+    const { container } = render(
+      <BurnCheckIndicator presentation={presentation("finding", "clean")} size={16} />,
+    )
+    const dial = container.querySelector("[data-segmented-radial-dial]")
+    expect(dial).toHaveAttribute("width", "14")
+    expect(dial?.querySelector("circle")).toHaveAttribute("stroke-width", "1.5")
+    const [failed, passed] = dial?.querySelectorAll("circle") ?? []
+    const renderedGap =
+      Number(passed?.getAttribute("data-start-angle")) -
+      Number(failed?.getAttribute("data-arc-angle"))
+    expect(renderedGap).toBeGreaterThan(26)
+  })
+
+  it("renders summary hierarchy and a trailing slot without a second status dial", () => {
+    const value = presentation("finding", "clean", "notAssessed")
+    const { container } = render(
+      <BurnCheckSummary presentation={value} trailing={<span>12% token burn</span>} />,
+    )
+    expect(container.querySelector("svg")).toBeNull()
+    const headline = screen.getByTestId("burn-check-headline")
+    expect(headline).toHaveClass("font-semibold!", "text-label")
+    expect(headline).toHaveTextContent("All burn checks")
+    expect(screen.getByText("30 days")).toHaveClass("type-footnote", "text-label-tertiary")
+    expect(screen.queryByText("incomplete")).not.toBeInTheDocument()
+    expect(screen.getByText("1 failed")).toHaveClass("text-burn-check-failure-text")
+    expect(screen.getByText("1 passed")).toHaveClass("font-mono", "text-burn-check-pass-fill")
+    expect(screen.getByText("1 failed")).toHaveClass("font-mono", "font-semibold!")
+    expect(screen.getByText("1 not assessed")).toBeInTheDocument()
+    expect(screen.queryByText("Evidence incomplete")).not.toBeInTheDocument()
+    expect(screen.getByLabelText(value.accessibleDescription)).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Evidence incomplete"),
+    )
+    expect(screen.getByText("12% token burn")).toBeInTheDocument()
+    expect(screen.getByLabelText(value.accessibleDescription)).toHaveClass(
+      "min-h-10",
+      "px-[var(--space-md)]",
+      "py-[var(--space-sm)]",
+    )
+  })
+
+  it("can label a standalone indicator", () => {
+    const value = presentation("clean", "notAssessed")
+    render(<BurnCheckIndicator presentation={value} size={24} labelled />)
+    expect(screen.getByRole("img", { name: value.accessibleDescription })).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/components/burn-checks/burn-check-summary.css
+++ b/apps/desktop/src/components/burn-checks/burn-check-summary.css
@@ -1,0 +1,43 @@
+.burn-check-summary-surface {
+  --burn-check-summary-edge-width: 1px;
+  --burn-check-summary-tone: var(--color-burn-check-neutral-val);
+
+  position: relative;
+}
+
+.burn-check-summary-surface[data-tone="failure"] {
+  --burn-check-summary-tone: var(--color-burn-check-failure-fill-val);
+}
+
+.burn-check-summary-surface[data-tone="pass"] {
+  --burn-check-summary-tone: var(--color-burn-check-pass-fill-val);
+}
+
+.burn-check-summary-surface::before {
+  position: absolute;
+  inset: var(--burn-check-summary-edge-width);
+  padding: var(--burn-check-summary-edge-width);
+  border-radius: calc(var(--radius-control) - var(--burn-check-summary-edge-width));
+  background: linear-gradient(
+    105deg,
+    color-mix(in srgb, var(--burn-check-summary-tone) 40%, transparent),
+    color-mix(in srgb, var(--burn-check-summary-tone) 10%, transparent) 45%,
+    color-mix(in srgb, var(--color-border) 35%, transparent) 85%
+  );
+  content: "";
+  pointer-events: none;
+  mask:
+    linear-gradient(white 0 0) content-box,
+    linear-gradient(white 0 0);
+  mask-composite: exclude;
+}
+
+:where(html[data-keyboard]) [data-burn-check-summary-trigger]:focus-visible {
+  border-radius: var(--radius-control);
+}
+
+@media (prefers-contrast: more) {
+  .burn-check-summary-surface::before {
+    background: var(--burn-check-summary-tone);
+  }
+}

--- a/apps/desktop/src/components/burn-checks/burnCheckMarks.ts
+++ b/apps/desktop/src/components/burn-checks/burnCheckMarks.ts
@@ -1,0 +1,25 @@
+import { CircleAlert, CircleCheck, CircleMinus, type LucideIcon } from "lucide-react"
+
+export interface BurnCheckMark {
+  Icon: LucideIcon
+  strokeWidth: number
+  iconClass: string
+}
+
+export const BURN_CHECK_MARKS = {
+  finding: {
+    Icon: CircleAlert,
+    strokeWidth: 2.5,
+    iconClass: "text-burn-check-failure-fill",
+  },
+  clean: {
+    Icon: CircleCheck,
+    strokeWidth: 2,
+    iconClass: "text-burn-check-pass-fill",
+  },
+  notAssessed: {
+    Icon: CircleMinus,
+    strokeWidth: 2,
+    iconClass: "text-burn-check-neutral",
+  },
+} satisfies Record<"finding" | "clean" | "notAssessed", BurnCheckMark>

--- a/apps/desktop/src/components/presentation/TruncatedText.test.tsx
+++ b/apps/desktop/src/components/presentation/TruncatedText.test.tsx
@@ -42,4 +42,18 @@ describe("TruncatedText", () => {
     expect(element.getAttribute("title")).toBe("A title that needs more than two lines")
     vi.restoreAllMocks()
   })
+
+  it("prepares a truncated single line for an interruptible hover reveal", () => {
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(300)
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(120)
+    render(<TruncatedText text="A long scrolling title" scrollOnHover />)
+
+    const text = screen.getByText("A long scrolling title")
+    const container = text.closest("[data-scroll-on-hover]")
+    expect(text).toHaveClass("truncate")
+    expect(container).toHaveAttribute("data-truncated", "true")
+    expect(container?.getAttribute("style")).toContain("--truncated-text-offset: -180px")
+    expect(container?.getAttribute("style")).toContain("--truncated-text-duration: 3960ms")
+    vi.restoreAllMocks()
+  })
 })

--- a/apps/desktop/src/components/presentation/TruncatedText.tsx
+++ b/apps/desktop/src/components/presentation/TruncatedText.tsx
@@ -14,11 +14,7 @@ import { cn } from "../../lib/cn"
  * `ResizeObserver` reports later box size changes.
  * A text or line change starts a new subscription and checks the content again.
  */
-function useTruncated(
-  ref: RefObject<HTMLElement | null>,
-  text: string,
-  lines: number,
-): boolean {
+function useOverflow(ref: RefObject<HTMLElement | null>, text: string, lines: number): number {
   const subscribe = useCallback(
     (onChange: () => void) => {
       const element = ref.current
@@ -32,20 +28,19 @@ function useTruncated(
     [ref, text, lines],
   )
 
-  const getSnapshot = useCallback(
-    () =>
-      ref.current
-        ? ref.current.scrollWidth > ref.current.clientWidth ||
-          (lines > 1 && ref.current.scrollHeight > ref.current.clientHeight)
-        : false,
-    [lines, ref],
-  )
+  const getSnapshot = useCallback(() => {
+    if (!ref.current) return 0
+    const horizontal = Math.max(0, ref.current.scrollWidth - ref.current.clientWidth)
+    const vertical =
+      lines > 1 ? Math.max(0, ref.current.scrollHeight - ref.current.clientHeight) : 0
+    return Math.max(horizontal, vertical)
+  }, [lines, ref])
 
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
-function getServerSnapshot(): boolean {
-  return false
+function getServerSnapshot(): number {
+  return 0
 }
 
 export interface TruncatedTextProps {
@@ -58,6 +53,8 @@ export interface TruncatedTextProps {
    * The text is duplicated into `data-text` for the CSS overlay to paint.
    */
   shimmer?: boolean
+  /** Reveal a truncated single line by moving it horizontally on parent hover. */
+  scrollOnHover?: boolean
 }
 
 /**
@@ -69,12 +66,44 @@ export function TruncatedText({
   text,
   lines = 1,
   shimmer = false,
+  scrollOnHover = false,
 }: TruncatedTextProps) {
   const lineLimit = Number.isFinite(lines) ? Math.max(1, Math.floor(lines)) : 1
   const ref = useRef<HTMLDivElement | null>(null)
-  const truncated = useTruncated(ref, text, lineLimit)
+  const overflow = useOverflow(ref, text, lineLimit)
+  const truncated = overflow > 0
   const lineStyle =
     lineLimit > 1 ? ({ "--truncated-text-lines": lineLimit } as CSSProperties) : undefined
+
+  if (scrollOnHover && lineLimit === 1) {
+    const scrollStyle = {
+      "--truncated-text-offset": `${-overflow}px`,
+      "--truncated-text-duration": `${Math.max(900, overflow * 22)}ms`,
+    } as CSSProperties
+
+    return (
+      <div
+        className={cn(className, "session-title-scroll")}
+        style={scrollStyle}
+        title={truncated ? text : undefined}
+        data-scroll-on-hover=""
+        data-truncated={truncated ? "true" : undefined}
+        aria-label={shimmer ? text : undefined}
+      >
+        <div
+          ref={ref}
+          className={cn(
+            "session-title-scroll-rest truncate",
+            shimmer && "activity-row-title-shimmer",
+          )}
+          data-text={shimmer ? text : undefined}
+        >
+          {text}
+        </div>
+        <span className="session-title-scroll-copy" data-text={text} aria-hidden="true" />
+      </div>
+    )
+  }
 
   return (
     <div

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
@@ -166,6 +166,24 @@ describe("UsageLimitsBar — the ring row", () => {
 })
 
 describe("UsageLimitsBar — the disclosure", () => {
+  it("keeps the compact spacing above the Burn Checks summary", () => {
+    const { rerender } = bar()
+    expect(screen.getByTestId("usage-limits-bar").firstElementChild).toHaveClass(
+      "pt-2.5",
+      "pb-1.5",
+    )
+
+    rerender(
+      <UsageLimitsBar
+        live={liveSummary()}
+        expanded
+        onToggleExpanded={vi.fn()}
+        refreshing={false}
+      />,
+    )
+    expect(screen.getByRole("region", { name: "Usage limits" })).toHaveClass("pt-3", "pb-1")
+  })
+
   it("marks itself pressed only while the meters are open", () => {
     const { rerender } = bar()
     const collapsed = screen.getByRole("button", { name: "Expand usage limits" })

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
@@ -118,7 +118,7 @@ export function UsageLimitsBar({
   return (
     <div data-testid="usage-limits-bar" className="relative shrink-0">
       {!expanded && (
-        <div className="flex min-w-0 items-center gap-2 px-3 py-2.5">
+        <div className="flex min-w-0 items-center gap-[var(--space-md)] pt-2.5 pr-3 pb-1.5 pl-[var(--space-lg)]">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             {limited.map(({ reading, key }) => (
               <ProviderRadial
@@ -149,7 +149,7 @@ export function UsageLimitsBar({
           aria-label="Usage limits"
           // The top space keeps the disclosure near its closed position.
           // The group padding gives each hover highlight clear space.
-          className="space-y-1 px-2 pt-3 pb-2"
+          className="space-y-1 px-2 pt-3 pb-1"
         >
           {limited.map(({ reading, key }, index) => (
             <ProviderGroup
@@ -193,8 +193,7 @@ function accountDisplayName(
 /**
  * The chart-icon disclosure, and the refresh spinner that sits beside it.
  *
- * The same size, weight, and grey as the settings gear in the popover footer
- * (`PopoverView.tsx`), and the same in both states. The control marks itself
+ * The control keeps the same size, weight, and grey in both states. It marks itself
  * pressed for assistive technology, but the meters under it are the sighted
  * answer to "is it open", and an orange glyph competed with the orange arcs
  * and segments it sits among.
@@ -234,10 +233,9 @@ function LimitsDisclosure({
         aria-pressed={expanded}
         aria-controls={expanded ? regionId : undefined}
         aria-label={expanded ? "Collapse usage limits" : "Expand usage limits"}
-        // The pseudo-element extends the hit area past the glyph box. It
-        // stops at the gap before the last ring, so the two do not overlap.
+        // The centered hit area measures 40px without changing the visible button.
         className={cn(
-          "relative flex h-7 w-7 shrink-0 items-center justify-center rounded-control text-label-secondary transition-colors duration-[var(--duration-fast)] before:absolute before:-inset-x-2 before:-inset-y-2.5 before:content-[''] hover:bg-surface-hover",
+          "relative flex h-7 w-7 shrink-0 items-center justify-center rounded-control text-label-secondary transition-colors duration-[var(--duration-fast)] before:absolute before:top-1/2 before:left-1/2 before:size-[calc(var(--space-xl)*2)] before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] hover:bg-surface-hover",
           compact && "-my-1.5",
         )}
       >
@@ -351,7 +349,7 @@ function ProviderRadial({
       onMouseLeave={() => onHover?.(null, null)}
       data-state={activation ?? "idle"}
       title={title}
-      className="flex shrink-0 items-center gap-1.5 rounded-full p-1 transition-[background-color] duration-[var(--duration-fast)] hover:bg-surface-secondary/50 data-[state=hovered]:bg-surface-secondary/50 data-[state=selected]:bg-surface-selected"
+      className="flex shrink-0 items-center gap-1.5 rounded-full px-[var(--space-xs)] py-1 transition-[background-color] duration-[var(--duration-fast)] hover:bg-surface-secondary/50 data-[state=hovered]:bg-surface-secondary/50 data-[state=selected]:bg-surface-selected"
       aria-label={ariaLabel}
     >
       <UsageRing
@@ -391,7 +389,7 @@ function UnavailableRadial({ entry }: { entry: UnavailableLiveProvider }) {
   return (
     <div
       data-testid="usage-limits-unavailable"
-      className="shrink-0 p-1"
+      className="shrink-0 px-[var(--space-xs)] py-1"
       title={`${entry.displayName} — ${reason}`}
       aria-label={`${entry.displayName}, usage unavailable (${reason})`}
     >

--- a/apps/desktop/src/components/providerUsage/UsageSpendSummary.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageSpendSummary.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
 import type { ProviderUsageWindowsPayload } from "../../lib/ipc"
@@ -24,13 +24,42 @@ describe("UsageSpendSummary", () => {
     )
 
     expect(screen.getAllByText("$1.25")).toHaveLength(3)
-    expect(screen.getByText("1.25k tokens")).toBeInTheDocument()
-    expect(screen.getAllByText("1.25k")).toHaveLength(2)
-    expect(screen.getByText("Today")).toBeInTheDocument()
-    expect(screen.getByText("Last 7 days")).toBeInTheDocument()
-    expect(screen.getByText("Last 30 days")).toBeInTheDocument()
+    expect(screen.getAllByText("1.25k")).toHaveLength(3)
+    for (const [label, accessibleLabel] of [
+      ["Today", "Today"],
+      ["7 days", "Last 7 days"],
+      ["30 days", "Last 30 days"],
+    ]) {
+      const column = screen
+        .getAllByRole("term")
+        .find((term) => term.textContent === accessibleLabel)
+      expect(column).toBeDefined()
+      const reading = within(column!.parentElement!)
+      expect(reading.getByText("$1.25")).toBeInTheDocument()
+      expect(reading.getByText("$1.25").parentElement).toHaveClass(
+        "type-title-3",
+        "font-semibold!",
+      )
+      expect(reading.getByText("1.25k").parentElement).toHaveTextContent(
+        `1.25k tokens·${label}`,
+      )
+      expect(reading.getByText("·")).toHaveClass("text-label-tertiary")
+      expect(reading.getByText("1.25k").parentElement).not.toHaveClass(
+        "mt-[calc(var(--space-xs)/2)]",
+      )
+    }
+    expect(screen.getByText("Last 7 days")).toHaveClass("sr-only")
+    expect(screen.getByText("Last 30 days")).toHaveClass("sr-only")
+    expect(screen.getByText("7 days")).toHaveClass("text-label-tertiary")
+    expect(screen.getByText("30 days")).toHaveClass("text-label-tertiary")
     expect(screen.queryByRole("heading")).not.toBeInTheDocument()
     expect(screen.getByRole("region", { name: "Usage and spend" })).not.toHaveAttribute("title")
+    expect(screen.getByRole("region", { name: "Usage and spend" })).toHaveClass(
+      "pt-[var(--space-md)]",
+    )
+    expect(
+      screen.getByRole("region", { name: "Usage and spend" }).firstElementChild,
+    ).toHaveClass("px-[var(--space-md)]", "py-[var(--space-sm)]", "shadow-stats-card")
   })
 
   it("shows the API pricing caveat for subscription usage", () => {
@@ -69,6 +98,12 @@ describe("UsageSpendSummary", () => {
     )
 
     expect(screen.getAllByText("1.25k")).toHaveLength(3)
-    expect(screen.getAllByText("tokens")).toHaveLength(3)
+    expect(screen.getAllByText("Today")).toHaveLength(2)
+    expect(screen.getByText("7 days")).toBeInTheDocument()
+    expect(screen.getByText("30 days")).toBeInTheDocument()
+    expect(screen.getByText("Last 7 days")).toHaveClass("sr-only")
+    expect(screen.getByText("Last 30 days")).toHaveClass("sr-only")
+    expect(screen.queryByText("·")).not.toBeInTheDocument()
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/components/providerUsage/UsageSpendSummary.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageSpendSummary.tsx
@@ -1,5 +1,4 @@
 import type { ProviderUsageWindowsPayload } from "../../lib/ipc"
-import { cn } from "../../lib/cn"
 import {
   formatSpendFigure,
   formatTokenFigure,
@@ -25,7 +24,7 @@ export const EMPTY_USAGE_WINDOWS: ProviderUsageWindowsPayload = {
   last30Days: { ...EMPTY_USAGE_WINDOW },
 }
 
-/** The large figure: the cost when the models could be priced, else the tokens. */
+/** The primary figure shows the cost when pricing is available, or the token count otherwise. */
 function figure(window: UsageWindow): string {
   if (window.estimatedUsd != null) {
     return formatSpendFigure(window.estimatedUsd)
@@ -33,34 +32,12 @@ function figure(window: UsageWindow): string {
   return formatTokenFigure(windowTokens(window))
 }
 
-/**
- * The line under the figure: the token count behind a cost, or the unit alone
- * when the tokens are the figure. The first column includes the token unit.
- */
-function caption(window: UsageWindow, first: boolean): string {
-  if (window.estimatedUsd == null) return "tokens"
-  const tokens = formatTokenFigure(windowTokens(window))
-  return first ? `${tokens} tokens` : tokens
-}
-
-/**
- * The spend summary at the top of the popover: three windows, each a label
- * over a figure over a caption. The card has no heading. The figures are the
- * first ink, in the mono face the session cost badges use for a price. A
- * full-width band in the header surface carries the summary, so it reads as
- * the popover's header and not as one of the session cards. The band ends at
- * the ring row.
- *
- * Every column has the same three fixed-height lines, so the rows align
- * across columns without a shared grid row.
- */
+/** The shared card shows each cost above its token count and period. */
 export function UsageSpendSummary({
   totals,
-  compact = false,
   showApiPricingCaveat = false,
 }: {
   totals: ProviderUsageWindowsPayload
-  compact?: boolean
   showApiPricingCaveat?: boolean
 }) {
   return (
@@ -71,12 +48,16 @@ export function UsageSpendSummary({
           ? "You're on subscription, so these are just estimated dollar values."
           : undefined
       }
-      className={cn("bg-surface-header", compact ? "px-4 pt-3 pb-2.5" : "px-3 pt-3 pb-2.5")}
+      className="px-[var(--space-sm)] pt-[var(--space-md)]"
     >
-      <dl className="grid grid-cols-[1.35fr_1fr_1fr] gap-x-3">
-        <SpendColumn label="Today" window={totals.today} first />
-        <SpendColumn label="Last 7 days" window={totals.week} />
-        <SpendColumn label="Last 30 days" window={totals.last30Days} />
+      <dl className="grid grid-cols-3 gap-x-[var(--space-sm)] rounded-control bg-surface-card px-[var(--space-md)] py-[var(--space-sm)] shadow-stats-card">
+        <SpendColumn label="Today" accessibleLabel="Today" window={totals.today} />
+        <SpendColumn label="7 days" accessibleLabel="Last 7 days" window={totals.week} />
+        <SpendColumn
+          label="30 days"
+          accessibleLabel="Last 30 days"
+          window={totals.last30Days}
+        />
       </dl>
     </section>
   )
@@ -84,31 +65,34 @@ export function UsageSpendSummary({
 
 function SpendColumn({
   label,
+  accessibleLabel,
   window,
-  first = false,
 }: {
   label: string
+  accessibleLabel: string
   window: UsageWindow
-  first?: boolean
 }) {
+  const hasCost = window.estimatedUsd != null
   return (
-    // The column holds its text off its own left edge, so the three readings
-    // sit nearer the middle of their columns. The text stays left-aligned.
-    <div className="min-w-0 pl-2">
-      <dt className="type-caption text-label-secondary">{label}</dt>
-      {/* The important modifiers are necessary because the type-* classes
-          are unlayered CSS. The 17 px line is tighter than the type scale,
-          the way the status bar sets its own figure line. */}
-      <dd
-        className={cn(
-          first ? "type-title-3" : "type-body-large",
-          "font-mono tracking-tight! leading-[17px] whitespace-nowrap text-label",
-        )}
-      >
+    <div className="min-w-0">
+      <dt className="sr-only">{accessibleLabel}</dt>
+      <dd className="type-title-3 font-semibold! whitespace-nowrap text-label">
         <SegmentFigure>{figure(window)}</SegmentFigure>
+        {!hasCost && <span className="sr-only"> tokens</span>}
       </dd>
-      <dd className="type-caption whitespace-nowrap text-label-tertiary">
-        <SegmentFigure>{caption(window, first)}</SegmentFigure>
+      <dd className="type-footnote whitespace-nowrap text-label-secondary">
+        {hasCost && (
+          <>
+            <SegmentFigure>{formatTokenFigure(windowTokens(window))}</SegmentFigure>
+            <span className="sr-only"> tokens</span>
+            <span aria-hidden="true" className="mx-[var(--space-xs)] text-label-tertiary">
+              ·
+            </span>
+          </>
+        )}
+        <span aria-hidden="true" className="text-label-tertiary">
+          {label}
+        </span>
       </dd>
     </div>
   )

--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -264,8 +264,8 @@ describe("SessionList — rows", () => {
       onBadgeMetricChange: vi.fn(),
     })
 
-    expect(screen.getByRole("radio", { name: "$" })).toHaveAttribute("aria-checked", "false")
-    expect(screen.getByRole("radio", { name: "5h" })).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByRole("radio", { name: "Cost" })).toHaveAttribute("aria-checked", "false")
+    expect(screen.getByRole("radio", { name: "5h %" })).toHaveAttribute("aria-checked", "true")
     expect(screen.queryByLabelText("Estimated cost $1.00")).toBeNull()
     expect(
       screen.getByLabelText("Share of your 5-hour limit is not known for this session."),
@@ -352,7 +352,7 @@ describe("SessionList — rows", () => {
       },
     })
 
-    expect(screen.queryByRole("radio", { name: "5h" })).toBeNull()
+    expect(screen.queryByRole("radio", { name: "5h %" })).toBeNull()
   })
 
   it("offers five-hour mode when the usage panel shows an empty five-hour window", () => {
@@ -402,7 +402,7 @@ describe("SessionList — rows", () => {
       },
     })
 
-    expect(screen.getByRole("radio", { name: "5h" })).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "5h %" })).toBeInTheDocument()
   })
 
   it("keeps a five-hour allocation badge as time passes, since the factor never expires", () => {
@@ -432,12 +432,12 @@ describe("SessionList — rows", () => {
     }
     const { rerender } = render(<SessionList {...props} />)
 
-    expect(screen.getByRole("radio", { name: "5h" })).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByRole("radio", { name: "5h %" })).toHaveAttribute("aria-checked", "true")
     expect(screen.getByText("6.3%")).toBeInTheDocument()
 
     rerender(<SessionList {...props} now={new Date(NOW.getTime() + 3_600_001)} />)
-    expect(screen.getByRole("radio", { name: "5h" })).toHaveAttribute("aria-checked", "true")
-    expect(screen.getByRole("radio", { name: "$" })).toHaveAttribute("aria-checked", "false")
+    expect(screen.getByRole("radio", { name: "5h %" })).toHaveAttribute("aria-checked", "true")
+    expect(screen.getByRole("radio", { name: "Cost" })).toHaveAttribute("aria-checked", "false")
     expect(screen.getByText("6.3%")).toBeInTheDocument()
   })
 
@@ -454,9 +454,11 @@ describe("SessionList — rows", () => {
     expect(screen.getByText("Amp")).toBeTruthy()
   })
 
-  it("shows up to two lines of the primary text", () => {
+  it("keeps the primary text on one line and prepares overflow for hover reveal", () => {
     list({ entries: [entry({ title: "A long session title" })] })
-    expect(screen.getByText("A long session title").className).toContain("truncated-text-lines")
+    const title = screen.getByText("A long session title")
+    expect(title).toHaveClass("truncate")
+    expect(title.closest("[data-scroll-on-hover]")).not.toBeNull()
   })
 
   it("marks a hot spend with the brand pill, and a usual cost without one", () => {
@@ -529,6 +531,7 @@ describe("SessionList — rows", () => {
   })
 
   it("shows short model names in the supplied parent-first order", () => {
+    const renderAgentIcon = vi.fn(() => <span data-testid="agent-icon" />)
     list({
       entries: [
         entry({
@@ -538,23 +541,207 @@ describe("SessionList — rows", () => {
           ],
         }),
       ],
+      renderAgentIcon,
     })
-    const models = screen.getByText("5.6-sol").closest("[title]")
-    expect(models?.getAttribute("title")).toBe("gpt-5.6-sol/xhigh\nclaude-fable-5/high")
-    expect(models?.textContent).toBe("5.6-sol xhigh · fable-5 high")
+    const context = screen.getByLabelText(
+      "Session source: Claude Code. Models: gpt-5.6-sol/xhigh, claude-fable-5/high.",
+    )
+    expect(context).toHaveTextContent(/5\.6-sol xhigh\s*\+1/)
+    expect(context).not.toHaveTextContent("· +1")
+    expect(context.querySelector("[data-additional-model-count]")).toHaveClass(
+      "h-4",
+      "min-w-4",
+      "rounded-full",
+      "bg-surface-tertiary/40",
+      "font-mono",
+      "type-metadata",
+      "font-medium!",
+      "tabular-nums",
+      "text-label-tertiary",
+    )
+    expect(screen.getByText("5.6-sol").parentElement).toHaveClass(
+      "shrink-0",
+      "whitespace-nowrap",
+    )
+    expect(context).not.toHaveTextContent("fable-5 high")
+    expect(context).not.toHaveTextContent("avery/widgets")
+    expect(context).toHaveAttribute("data-shared-tooltip-trigger")
+
+    fireEvent.focus(context)
+    const tooltip = screen.getByRole("tooltip")
+    const tooltipContent = tooltip.querySelector<HTMLElement>("[data-session-context-tooltip]")!
+    expect(within(tooltipContent).getByText("Claude Code")).toHaveClass(
+      "type-callout",
+      "font-medium!",
+      "text-label",
+    )
+    expect(within(tooltipContent).getByText("Models")).toHaveClass(
+      "type-caption",
+      "text-label-tertiary",
+    )
+    expect(within(tooltipContent).getByText("gpt-5.6-sol/xhigh")).toHaveClass(
+      "font-mono",
+      "type-footnote",
+      "text-label",
+    )
+    expect(within(tooltipContent).queryByText("Repository")).toBeNull()
+    expect(within(tooltipContent).queryByText("avery/widgets")).toBeNull()
+    expect(within(tooltipContent).queryByText("Source")).toBeNull()
+    expect(tooltipContent.querySelector('[data-testid="agent-icon"]')).toBeTruthy()
+    expect(renderAgentIcon).toHaveBeenCalledWith("claude-code", 16, undefined, "neutral")
+    expect(renderAgentIcon).toHaveBeenCalledWith("claude-code", 40, undefined, "neutral")
+    expect(renderAgentIcon).not.toHaveBeenCalledWith("claude-code", 12, undefined, "neutral")
+  })
+
+  it("makes the title primary and moves vendor identity into a subtle watermark", () => {
+    const renderAgentIcon = vi.fn(() => <span data-testid="agent-icon" />)
+    list({
+      entries: [entry({ title: "Supporting identity", modelRuns: [{ model: "gpt-5" }] })],
+      renderAgentIcon,
+    })
+
+    const title = screen.getByText("Supporting identity")
+    const titleContainer = title.closest("[data-scroll-on-hover]")
+    const card = title.closest(".session-card")
+    expect(titleContainer).toHaveClass("type-body", "font-medium!", "text-label")
+    expect(card).toHaveClass(
+      "gap-y-0.5",
+      "py-3",
+      "isolate",
+      "overflow-hidden",
+      "bg-session-card",
+    )
+    expect(card).not.toHaveClass("bg-surface-card/50")
+    expect(card).not.toHaveClass("gap-y-1")
+    expect(titleContainer).not.toHaveClass("type-body-large", "text-label-secondary")
+    expect(screen.getByLabelText(/Burn Checks/)).toHaveClass("text-label-secondary")
+    const watermark = screen
+      .getByTestId("agent-icon")
+      .closest("[data-session-vendor-watermark]")
+    expect(watermark).toHaveClass(
+      "pointer-events-none",
+      "absolute",
+      "-right-1.5",
+      "-bottom-1.5",
+      "h-10",
+      "w-10",
+      "session-vendor-watermark",
+    )
+    expect(watermark).toHaveAttribute("aria-hidden", "true")
+    expect(
+      screen
+        .getByLabelText("Session source: Claude Code. Models: gpt-5.")
+        .querySelector('[data-testid="agent-icon"]'),
+    ).toBeNull()
+    expect(screen.getByText("5")).toHaveClass("font-semibold!", "text-label-secondary")
+    expect(screen.getByText("5")).not.toHaveClass("font-medium!")
+    expect(screen.getByText("5")).not.toHaveClass("text-label")
+    expect(
+      screen.getByLabelText("Session source: Claude Code. Models: gpt-5."),
+    ).toBeInTheDocument()
+  })
+
+  it("shows repositories only when they distinguish visible sessions", () => {
+    const renderAgentIcon = () => <span data-testid="agent-icon" />
+    const { rerender } = list({
+      entries: [
+        entry({ sessionId: "one", repo: "antiburn" }),
+        entry({ sessionId: "two", repo: "antiburn" }),
+      ],
+      renderAgentIcon,
+    })
+    expect(screen.queryByText("antiburn")).toBeNull()
+
+    rerender(
+      <SessionList
+        entries={[
+          entry({
+            sessionId: "one",
+            repo: "antiburn",
+            modelRuns: [{ model: "gpt-5.6-sol", thinkingMode: "medium" }],
+          }),
+          entry({
+            sessionId: "two",
+            repo: "another-repo",
+            modelRuns: [{ model: "gpt-5.6-sol", thinkingMode: "medium" }],
+          }),
+        ]}
+        days={7}
+        now={NOW}
+        renderAgentIcon={renderAgentIcon}
+      />,
+    )
+    const firstRepository = screen.getByText("antiburn")
+    const secondRepository = screen.getByText("another-repo")
+    expect(firstRepository).toBeInTheDocument()
+    expect(secondRepository).toBeInTheDocument()
+    const firstMetadata = firstRepository.closest("[data-session-trailing-metadata]")
+    const secondMetadata = secondRepository.closest("[data-session-trailing-metadata]")
+    const firstContext = firstRepository.closest("[data-session-context-row]")
+    expect(firstMetadata).toHaveClass(
+      "font-mono",
+      "type-metadata",
+      "tabular-nums",
+      "items-baseline",
+      "gap-x-0.5",
+      "ml-auto",
+      "justify-end",
+      "session-trailing-metadata",
+    )
+    expect(firstContext).toHaveClass("items-baseline", "gap-x-2")
+    expect(secondMetadata).toHaveClass("font-mono", "type-metadata", "tabular-nums")
+    expect(screen.getAllByText("medium")[0]).not.toHaveClass("type-caption")
+    expect(within(firstMetadata as HTMLElement).getByText("·")).toBeInTheDocument()
+    expect(firstContext?.textContent?.indexOf("5.6-sol")).toBeLessThan(
+      firstContext?.textContent?.indexOf("antiburn") ?? -1,
+    )
   })
 
   it("includes the relative-time suffix", () => {
     list({ entries: [entry({ timestamp: at(0, 9) })] })
-    expect(screen.getByText(/ ago$/)).toBeTruthy()
+    const time = screen.getByText(/ ago$/)
+    expect(time).toHaveClass("shrink-0", "whitespace-nowrap")
+    expect(time.closest("[data-session-trailing-metadata]")).toHaveClass(
+      "font-mono",
+      "type-metadata",
+      "tabular-nums",
+    )
+  })
+
+  it("compacts the timestamp beside a long repository name", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    list({
+      entries: [
+        entry({
+          sessionId: "long-repo",
+          repo: "what-does-this-do-basics",
+          timestamp: at(0, 9),
+        }),
+        entry({ sessionId: "short-repo", repo: "antiburn", timestamp: at(0, 10) }),
+      ],
+    })
+
+    const longMetadata = screen
+      .getByText("what-does-this-do-basics")
+      .closest("[data-session-trailing-metadata]") as HTMLElement
+    const shortMetadata = screen
+      .getByText("antiburn")
+      .closest("[data-session-trailing-metadata]") as HTMLElement
+    expect(within(longMetadata).getByText("3h")).toBeInTheDocument()
+    expect(within(longMetadata).queryByText("3h ago")).toBeNull()
+    expect(within(longMetadata).getByText("3h")).toHaveAttribute(
+      "aria-label",
+      "Last activity 3h ago",
+    )
+    expect(within(shortMetadata).getByText("2h ago")).toBeInTheDocument()
   })
 
   it("shows evidence computation instead of a synthetic hygiene verdict", () => {
     list({ entries: [entry({ sessionId: "session-pending" })] })
-    const verdict = screen.getByLabelText("Computing session hygiene checks")
-    expect(verdict.textContent).toBe("Computing checks…")
-    expect(verdict.style.color).toBe("var(--color-label-tertiary)")
-    expect(screen.queryByLabelText("All checks passed")).toBeNull()
+    const verdict = screen.getByLabelText(/Running Burn Checks/)
+    expect(verdict).toHaveTextContent("Running Burn Checks…")
+    expect(screen.queryByLabelText(/All Burn Checks passed/)).toBeNull()
   })
 
   it("renders finding and clean statuses returned by the batched IPC path", async () => {
@@ -598,8 +785,8 @@ describe("SessionList — rows", () => {
     list({ entries: [entry({ sessionId: "synthetic-hygiene-result" })] })
 
     await waitFor(() => {
-      expect(screen.getByLabelText("5 of 6 burn checks passed").textContent).toBe(
-        "5/6 burn checks",
+      expect(screen.getByLabelText(/Some Burn Checks failed/)).toHaveTextContent(
+        "1 failed·5 passed",
       )
     })
     expect(getSessionHygiene).toHaveBeenCalledWith([
@@ -609,6 +796,30 @@ describe("SessionList — rows", () => {
         wslDistro: null,
       },
     ])
+  })
+
+  it("keeps a cyan all-passed verdict above the session title", async () => {
+    getSessionHygiene.mockResolvedValueOnce([
+      {
+        evidenceState: "ready",
+        badges: [
+          "sessionOverdepth",
+          "modelOverthinking",
+          "overpoweredSubagents",
+          "obsoleteModel",
+          "fastModeOveruse",
+          "excessCacheRehydration",
+        ].map((id) => ({ id, status: "clean", notAssessedReason: null })),
+      },
+    ])
+    list({ entries: [entry({ sessionId: "clean-session", title: "Primary clean title" })] })
+
+    const verdict = await screen.findByLabelText(/All Burn Checks passed/)
+    expect(verdict).toHaveTextContent("All 6 passed")
+    expect(screen.getByText("All 6 passed")).toHaveClass("text-burn-check-pass-fill")
+    expect(
+      screen.getByText("Primary clean title").closest("[data-session-status-bar]"),
+    ).toBeNull()
   })
 
   it("keeps the last verdict on screen, marked stale, while a live session recomputes", async () => {
@@ -628,11 +839,9 @@ describe("SessionList — rows", () => {
     list({ entries: [entry({ sessionId: "synthetic-hygiene-stale" })] })
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Refreshing — 5 of 6 burn checks passed").textContent).toBe(
-        "5/6 burn checks",
-      )
+      expect(screen.getByLabelText(/Refreshing/)).toHaveTextContent("1 failed·5 passed")
     })
-    expect(screen.queryByLabelText("Refreshing session hygiene checks")).toBeNull()
+    expect(screen.queryByText("Refreshing Burn Checks…")).toBeNull()
   })
 
   it("states the last-activity time", () => {
@@ -669,10 +878,10 @@ describe("SessionList — navigation", () => {
     expect(screen.queryByRole("button", { name: /Untracked/ })).toBeNull()
   })
 
-  it("renders an agent icon only from the injected renderer", () => {
+  it("renders a vendor watermark only from the injected renderer", () => {
     const renderAgentIcon = vi.fn(() => <span data-testid="agent-icon" />)
     list({ entries: [entry({ surface: "cli" })], renderAgentIcon })
-    expect(renderAgentIcon).toHaveBeenCalledWith("claude-code", 14, "cli")
+    expect(renderAgentIcon).toHaveBeenCalledWith("claude-code", 40, "cli", "neutral")
     expect(screen.getByTestId("agent-icon")).toBeTruthy()
   })
 })
@@ -687,9 +896,29 @@ describe("SessionList — grouping", () => {
       ],
     })
     expect(screen.getByTestId("activity-pinned-group-label").textContent).toBe("Today")
+    expect(screen.getByTestId("activity-pinned-group-label")).not.toHaveClass(
+      "uppercase",
+      "tracking-wide",
+    )
     // The first heading is announced but not painted twice.
     expect(screen.getByText("Yesterday")).toBeTruthy()
     expect(screen.getByText("3 days ago")).toBeTruthy()
+  })
+
+  it("keeps the badge metric control inline with the pinned date label", () => {
+    list({ entries: [entry()], onBadgeMetricChange: vi.fn() })
+    const toolbar = document.querySelector<HTMLElement>("[data-list-display-toolbar]")!
+    const control = screen.getByRole("radiogroup", { name: "Session metric" })
+
+    expect(toolbar).toContainElement(control)
+    expect(toolbar).toHaveTextContent("Today")
+    expect(screen.queryByTestId("activity-pinned-group-label")).not.toBeInTheDocument()
+    expect(screen.queryByRole("heading", { name: "Sessions" })).not.toBeInTheDocument()
+    expect(control).toHaveAttribute("data-variant", "text-tabs")
+    expect(control).toHaveClass("inline-flex")
+    expect(control).not.toHaveClass("bg-surface-secondary")
+    expect(screen.getByRole("radio", { name: "Week %" })).toBeInTheDocument()
+    expect(toolbar).not.toHaveTextContent("Show")
   })
 
   it("orders the newest session first within a day", () => {
@@ -717,6 +946,22 @@ describe("SessionList — grouping", () => {
 })
 
 describe("SessionList — virtualization", () => {
+  it("uses a 12px gap between cards in the same date group", async () => {
+    const { container } = list({
+      entries: [
+        entry({ sessionId: "first", title: "First fixture", timestamp: at(0, 11) }),
+        entry({ sessionId: "second", title: "Second fixture", timestamp: at(0, 10) }),
+      ],
+    })
+
+    await waitFor(() => {
+      const rows = [...container.querySelectorAll<HTMLElement>('[data-virtual-kind="row"]')]
+      expect(rows).toHaveLength(2)
+      expect(rows[0]).not.toHaveClass("pt-3")
+      expect(rows[1]).toHaveClass("pt-3")
+    })
+  })
+
   it.each([225, 500])("bounds mounted rows for %i sessions", async (count) => {
     list({ entries: entries(count), onOpenSession: vi.fn() })
 
@@ -903,7 +1148,7 @@ describe("SessionList — shared tooltips", () => {
         }),
       ],
     })
-    const status = await screen.findByLabelText("5 of 6 burn checks passed")
+    const status = await screen.findByLabelText(/Some Burn Checks failed/)
     const cost = screen.getByLabelText("Estimated cost $2.40")
     const fork = screen.getByLabelText("Forked from another session")
     const repository = screen.getByText("avery/widgets +1")
@@ -916,9 +1161,7 @@ describe("SessionList — shared tooltips", () => {
     act(() => vi.advanceTimersByTime(149))
     expect(document.querySelector(".ui-tooltip")).toBeNull()
     act(() => vi.advanceTimersByTime(1))
-    expect(document.querySelector(".ui-tooltip")?.textContent).toContain(
-      "Open the session for details",
-    )
+    expect(document.querySelector(".ui-tooltip")?.textContent).toContain("Burn Checks")
     expect(status.dataset.state).toBe("delayed-open")
     expect(status.getAttribute("aria-describedby")).toBe(
       document.querySelector(".ui-tooltip")?.id,
@@ -943,9 +1186,9 @@ describe("SessionList — shared tooltips", () => {
     fireEvent.pointerOut(fork)
     fireEvent.pointerOver(repository)
     act(() => vi.advanceTimersByTime(600))
-    expect(document.querySelector(".ui-tooltip")?.textContent).toBe("Also observed: avery/docs")
+    expect(document.querySelector(".ui-tooltip")).toBeNull()
+    expect(repository).not.toHaveAttribute("data-shared-tooltip-trigger")
 
-    fireEvent.pointerOut(repository)
     fireEvent.pointerOver(wsl)
     act(() => vi.advanceTimersByTime(600))
     expect(document.querySelector(".ui-tooltip")?.textContent).toBe(
@@ -958,7 +1201,7 @@ describe("SessionList — shared tooltips", () => {
     const { container, unmount } = list({
       entries: [entry({ hasForkParent: true, repo: "avery/widgets", wslDistro: "Ubuntu" })],
     })
-    const status = screen.getByLabelText("Computing session hygiene checks")
+    const status = screen.getByLabelText(/Running Burn Checks/)
     const fork = screen.getByLabelText("Forked from another session")
     const repository = screen.getByText("avery/widgets")
     const wsl = screen.getByLabelText("Found in Ubuntu on Windows Subsystem for Linux")
@@ -976,18 +1219,13 @@ describe("SessionList — shared tooltips", () => {
     act(() => vi.advanceTimersByTime(499))
     expect(document.querySelector(".ui-tooltip")).toBeNull()
 
-    fireEvent.pointerOver(repository)
-    act(() => vi.advanceTimersByTime(600))
-    expect(document.querySelector(".ui-tooltip")?.textContent).toBe("avery/widgets")
-
     fireEvent.scroll(viewport)
     expect(document.querySelector(".ui-tooltip")).toBeNull()
-    expect(repository.dataset.state).toBe("closed")
+    expect(repository).not.toHaveAttribute("data-state")
 
     fireEvent.focus(status)
-    expect(document.querySelector(".ui-tooltip")?.textContent).toBe(
-      "Computing session hygiene checks",
-    )
+    expect(document.querySelector(".ui-tooltip")?.textContent).toContain("Not assessed · 6")
+    expect(document.querySelector(".ui-tooltip")?.textContent).toContain("Session depth")
     fireEvent.blur(status)
     expect(document.querySelector(".ui-tooltip")).toBeNull()
 
@@ -1140,7 +1378,7 @@ describe("SessionList — native drag header", () => {
     const { container, rerender } = render(<SessionList {...props} />)
     expect(container.querySelector("[data-tauri-drag-region]")).toBeNull()
     rerender(<SessionList {...props} draggableHeader />)
-    expect(screen.getByTestId("activity-pinned-group-label")).toHaveAttribute(
+    expect(container.querySelector("[data-list-display-toolbar]")).toHaveAttribute(
       "data-tauri-drag-region",
       "deep",
     )

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -11,6 +11,7 @@ import type { SessionHygienePayload } from "../../lib/insightsIpc"
 import {
   agentDisplayName,
   agentProvider,
+  type AgentIconAppearance,
   type AgentSurface,
 } from "../../lib/presentation/agents"
 import { liveDisplayableProviders, liveWindows } from "../../lib/presentation/liveUsage"
@@ -33,7 +34,7 @@ import { SessionStatusBar } from "./SessionStatusBar"
 import { SessionTooltipOwner } from "./SessionTooltipOwner"
 import { type SessionCostBadgeProps } from "./metrics/SessionCostBadge"
 import { ScrollPane } from "../ui/ScrollPane"
-import { SegmentedControl } from "../ui/SegmentedControl"
+import { ListDisplayToolbar } from "../ui/ListDisplayToolbar"
 import { countGroupedItems, groupActivityByDay } from "../activity/activityFeedGrouping"
 import { useActivityGroupPinning, type ViewportRef } from "../activity/useActivityGroupPinning"
 import type {
@@ -50,6 +51,7 @@ type SessionAgentIconRenderer = (
   slug: string,
   size: number,
   surface?: AgentSurface,
+  appearance?: AgentIconAppearance,
 ) => ReactNode
 
 /** One coding session in the list. */
@@ -270,6 +272,7 @@ interface SessionRowProps {
   active?: boolean
   renderAgentIcon?: SessionAgentIconRenderer | undefined
   wslIcon?: ReactNode | undefined
+  showRepository?: boolean | undefined
   showCost?: boolean
   limitBadge?:
     | {
@@ -300,26 +303,108 @@ function SessionRow({
   active = true,
   renderAgentIcon,
   wslIcon,
+  showRepository = false,
   limitBadge,
   showCost = true,
 }: SessionRowProps) {
   const selectionMode = !!entry.sessionId && !!onSelect
   const clickable = !!entry.sessionId && (!!onOpen || selectionMode)
   const primary = primaryLine(entry)
-  const hasRepo = entry.repo !== ""
   const modelRuns = entry.modelRuns ?? []
   const modelPairs = modelRunShortPairs(modelRuns)
+  const modelNames = modelRunNames(modelRuns)
+  const firstModel = modelPairs[0]
+  const additionalModelCount = Math.max(0, modelPairs.length - 1)
+  const hasContextAnchor = modelPairs.length > 0
+  const hasRepo =
+    entry.repo !== "" && (showRepository || (!hasContextAnchor && !renderAgentIcon))
+  const repositoryLabel = entry.repo
+    ? `${entry.repo}${entry.additionalRepos?.length ? ` +${entry.additionalRepos.length}` : ""}`
+    : ""
+  const compactTrailingTime = hasRepo && repositoryLabel.length > 18
   const hygieneChecks = sessionHygieneChecks(hygiene)
+  const hasContextDetails = !!entry.branch || !!entry.wslDistro
+  const hasContextIdentity = hasContextAnchor || hasRepo || hasContextDetails
+  const contextDescription = [
+    `Session source: ${agentDisplayName(entry.agent)}.`,
+    modelNames.length > 0 ? `Models: ${modelNames.join(", ")}.` : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+  const contextTooltip = (
+    <div className="flex min-w-[180px] flex-col gap-y-2" data-session-context-tooltip="">
+      <div className="flex items-center gap-x-2">
+        {renderAgentIcon && (
+          <span
+            className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
+            aria-hidden="true"
+          >
+            {renderAgentIcon(entry.agent, 16, entry.surface, "neutral")}
+          </span>
+        )}
+        <span className="min-w-0 truncate type-callout font-medium! text-label">
+          {agentDisplayName(entry.agent)}
+        </span>
+      </div>
+
+      {modelNames.length > 0 && (
+        <div className="flex flex-col gap-y-0.5">
+          <span className="type-caption text-label-tertiary">Models</span>
+          {modelNames.map((name) => (
+            <span key={name} className="font-mono type-footnote text-label">
+              {name}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+  const titleContent = (
+    <div className="relative z-10 flex min-w-0 flex-1 items-center gap-x-1">
+      <TruncatedText
+        // One ink for every title. The shimmer overlay is the only
+        // difference an active session shows.
+        className="min-w-0 type-body font-medium! text-label"
+        text={primary}
+        lines={1}
+        shimmer={entry.isActive && active}
+        scrollOnHover
+      />
+
+      {entry.hasForkParent && (
+        <Tooltip label="Forked from another session" delayMs={500}>
+          <span
+            className="inline-flex shrink-0 text-label-tertiary"
+            aria-label="Forked from another session"
+          >
+            <GitFork size={12} strokeWidth={2} aria-hidden="true" />
+          </span>
+        </Tooltip>
+      )}
+      {!!entry.forkChildCount && (
+        <Tooltip
+          label={`${entry.forkChildCount} direct ${entry.forkChildCount === 1 ? "fork" : "forks"}`}
+          delayMs={500}
+        >
+          <span
+            className="inline-flex shrink-0 text-label-tertiary"
+            aria-label={`${entry.forkChildCount} direct ${entry.forkChildCount === 1 ? "fork" : "forks"}`}
+          >
+            <GitBranchPlus size={12} strokeWidth={2} aria-hidden="true" />
+          </span>
+        </Tooltip>
+      )}
+    </div>
+  )
 
   return (
     <div
       className={cn(
-        "group relative",
-        "w-full grid grid-cols-[14px_minmax(0,1fr)] gap-x-2 gap-y-1",
+        "session-card group relative isolate overflow-hidden",
+        "w-full grid grid-cols-[14px_minmax(0,1fr)] gap-x-2 gap-y-0.5",
         "items-center",
         "rounded-[var(--radius-popover)] px-3 py-3",
-        selected ? "bg-surface-selected/60" : "bg-surface-card/50",
-        "transition-colors duration-[var(--duration-fast)] ease-out",
+        selected ? "bg-surface-selected/60" : "bg-session-card",
         entry.isActive && active && "activity-row-active",
         clickable && "cursor-pointer",
         clickable &&
@@ -364,7 +449,17 @@ function SessionRow({
     >
       {entry.isActive && <span className="sr-only">Active session</span>}
 
-      <div className="row-1 col-2">
+      {renderAgentIcon && (
+        <span
+          className="session-vendor-watermark pointer-events-none absolute -right-1.5 -bottom-1.5 z-0 inline-flex h-10 w-10 items-center justify-center"
+          aria-hidden="true"
+          data-session-vendor-watermark=""
+        >
+          {renderAgentIcon(entry.agent, 40, entry.surface, "neutral")}
+        </span>
+      )}
+
+      <div className="relative z-10 col-span-full">
         <SessionStatusBar
           checks={hygieneChecks}
           evidenceState={hygiene.evidenceState}
@@ -373,83 +468,42 @@ function SessionRow({
         />
       </div>
 
-      <span className="row-2 col-1 h-full pt-[3px]">
-        {renderAgentIcon?.(entry.agent, 14, entry.surface)}
-      </span>
+      <div className="col-2 min-w-0">{titleContent}</div>
 
-      <div className="col-2 flex min-w-0 items-center gap-x-1">
-        <TruncatedText
-          // One ink for every title. The shimmer overlay is the only
-          // difference an active session shows.
-          className="min-w-0 mt-px mb-0.5 type-body-large text-label"
-          text={primary}
-          lines={2}
-          shimmer={entry.isActive && active}
-        />
-
-        {entry.hasForkParent && (
-          <Tooltip label="Forked from another session" delayMs={500}>
-            <span
-              className="inline-flex shrink-0 text-label-tertiary"
-              aria-label="Forked from another session"
-            >
-              <GitFork size={12} strokeWidth={2} aria-hidden="true" />
-            </span>
-          </Tooltip>
-        )}
-        {!!entry.forkChildCount && (
-          <Tooltip
-            label={`${entry.forkChildCount} direct ${entry.forkChildCount === 1 ? "fork" : "forks"}`}
-            delayMs={500}
-          >
-            <span
-              className="inline-flex shrink-0 text-label-tertiary"
-              aria-label={`${entry.forkChildCount} direct ${entry.forkChildCount === 1 ? "fork" : "forks"}`}
-            >
-              <GitBranchPlus size={12} strokeWidth={2} aria-hidden="true" />
-            </span>
-          </Tooltip>
-        )}
-      </div>
-
-      {modelPairs.length > 0 && (
-        <div className="col-2 min-w-0 space-y-px">
-          <div
-            className="min-w-0 max-w-full truncate type-callout text-label-tertiary"
-            title={modelRunNames(modelRuns).join("\n")}
-          >
-            {modelPairs.map((pair, index) => (
-              <span key={`${pair.model}/${pair.thinkingMode ?? ""}`}>
-                {index > 0 && " · "}
-                <span className="font-medium">{pair.model}</span>
-                {pair.thinkingMode && (
-                  <span className="type-caption"> {pair.thinkingMode}</span>
-                )}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {(entry.timestamp || hasRepo || entry.branch || entry.wslDistro) && (
-        <div className="col-2 w-full flex justify-between">
-          {(hasRepo || entry.branch || entry.wslDistro) && (
-            <div className="flex min-w-0 items-baseline gap-x-2">
-              {hasRepo && (
-                <Tooltip
-                  label={
-                    entry.additionalRepos?.length
-                      ? `Also observed: ${entry.additionalRepos.join(", ")}`
-                      : entry.repo
-                  }
-                >
-                  <span className="min-w-0 truncate type-callout text-label-tertiary">
-                    {entry.repo}
-                    {entry.additionalRepos?.length ? ` +${entry.additionalRepos.length}` : ""}
+      {(hasContextIdentity || entry.timestamp) && (
+        <div
+          className="relative z-10 col-2 flex w-full min-w-0 items-baseline gap-x-2"
+          data-session-context-row=""
+        >
+          {hasContextAnchor && (
+            <Tooltip label={contextTooltip}>
+              <div
+                aria-label={contextDescription}
+                className="flex shrink-0 items-baseline gap-x-1.5 type-callout text-label-tertiary"
+              >
+                {firstModel && (
+                  <span className="shrink-0 whitespace-nowrap">
+                    <span className="font-semibold! text-label-secondary">
+                      {firstModel.model}
+                    </span>
+                    {firstModel.thinkingMode && <span> {firstModel.thinkingMode}</span>}
                   </span>
-                </Tooltip>
-              )}
+                )}
 
+                {additionalModelCount > 0 && (
+                  <span
+                    className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-surface-tertiary/40 px-1 font-mono type-metadata font-medium! tabular-nums text-label-tertiary"
+                    data-additional-model-count=""
+                  >
+                    +{additionalModelCount}
+                  </span>
+                )}
+              </div>
+            </Tooltip>
+          )}
+
+          {hasContextDetails && (
+            <div className="flex min-w-0 items-center gap-x-1.5 overflow-hidden">
               <WslOriginBadge
                 distro={entry.wslDistro}
                 {...(wslIcon ? { icon: wslIcon } : {})}
@@ -464,15 +518,33 @@ function SessionRow({
             </div>
           )}
 
-          {entry.timestamp && (
-            <time
-              dateTime={entry.timestamp}
-              aria-label={`Last activity ${relativeTime(entry.timestamp)}`}
-              // The host row reveals the timestamp on hover.
-              className="tabular-nums type-footnote font-mono text-label-tertiary opacity-0 transition-opacity duration-[var(--duration-fast)] group-hover:opacity-100"
+          {(hasRepo || entry.timestamp) && (
+            <div
+              className="session-trailing-metadata ml-auto flex min-w-0 flex-1 items-baseline justify-end gap-x-0.5 font-mono type-metadata tabular-nums text-label-tertiary"
+              data-session-trailing-metadata=""
             >
-              {relativeTime(entry.timestamp)}
-            </time>
+              {hasRepo && <span className="min-w-0 truncate">{repositoryLabel}</span>}
+
+              {hasRepo && entry.timestamp && (
+                <span className="shrink-0" aria-hidden="true">
+                  ·
+                </span>
+              )}
+
+              {entry.timestamp && (
+                <time
+                  dateTime={entry.timestamp}
+                  aria-label={`Last activity ${relativeTime(entry.timestamp)}`}
+                  // The host row reveals the timestamp on hover.
+                  className="shrink-0 whitespace-nowrap"
+                >
+                  {relativeTime(
+                    entry.timestamp,
+                    compactTrailingTime ? { compact: true } : undefined,
+                  )}
+                </time>
+              )}
+            </div>
           )}
         </div>
       )}
@@ -533,6 +605,14 @@ export function SessionList({
   }))
 
   const groups = groupActivityByDay(items, { days, ...(now ? { now } : {}) })
+  const visibleRepositories = new Set<string>()
+  for (const group of groups) {
+    for (const { entry } of group.items) {
+      if (entry.repo) visibleRepositories.add(entry.repo)
+      for (const repo of entry.additionalRepos ?? []) visibleRepositories.add(repo)
+    }
+  }
+  const showRepositories = visibleRepositories.size > 1
   const visibleCount = countGroupedItems(groups)
   let rowPosition = 0
   const virtualItems: VirtualSessionItem[] = groups.flatMap((group, groupIndex) => [
@@ -732,34 +812,32 @@ export function SessionList({
         {visibleCount === 0 ? resolvedEmptyTitle : ""}
       </span>
 
-      {topLabel && (
+      {onBadgeMetricChange && (
+        <ListDisplayToolbar
+          {...(topLabel ? { label: topLabel } : {})}
+          options={[
+            { value: "cost", label: "Cost" },
+            { value: "weeklyPercent", label: "Week %" },
+            ...(fiveHourAvailable
+              ? [{ value: "fiveHourPercent" as const, label: "5h %" }]
+              : []),
+          ]}
+          value={selectedMetric}
+          onChange={onBadgeMetricChange}
+          ariaLabel="Session metric"
+          dragRegion={draggableHeader}
+        />
+      )}
+
+      {topLabel && !onBadgeMetricChange && (
         <div
           data-testid="activity-pinned-group-label"
           data-tauri-drag-region={draggableHeader ? "deep" : undefined}
           // The inset matches the cards, so the label sits on their left
           // edge. The type matches the usage view's group labels.
-          className="mb-1 flex h-7 shrink-0 items-center justify-between gap-2 px-3 type-caption font-medium tracking-wide uppercase text-label-tertiary"
+          className="mb-1 flex h-7 shrink-0 items-center px-3 type-caption font-medium text-label-tertiary"
         >
           <span>{topLabel}</span>
-          {onBadgeMetricChange && (
-            <SegmentedControl
-              options={[
-                { value: "cost", label: "$" },
-                { value: "weeklyPercent", label: "week" },
-                ...(fiveHourAvailable
-                  ? [{ value: "fiveHourPercent" as const, label: "5h" }]
-                  : []),
-              ]}
-              value={selectedMetric}
-              onChange={onBadgeMetricChange}
-              ariaLabel="Session badge metric"
-              /* The same picker treatment as the section picker over the
-                 session detail: a pill track with no outline, and a solid
-                 neutral chip for the selected metric. */
-              variant="native-tabs"
-              className="ui-segmented-solid normal-case rounded-full! bg-surface-secondary! [&_button]:rounded-full! [&_button]:px-2.5!"
-            />
-          )}
         </div>
       )}
 
@@ -805,9 +883,10 @@ export function SessionList({
                               : {})}
                             className={cn(
                               "absolute top-0 left-0 w-full",
-                              ((virtualItem.type === "heading" && virtualItem.groupIndex > 0) ||
-                                (virtualItem.type === "row" && virtualItem.itemIndex > 0)) &&
+                              virtualItem.type === "heading" &&
+                                virtualItem.groupIndex > 0 &&
                                 "pt-2",
+                              virtualItem.type === "row" && virtualItem.itemIndex > 0 && "pt-3",
                             )}
                             style={{ transform: `translateY(${measuredItem.start}px)` }}
                           >
@@ -818,7 +897,7 @@ export function SessionList({
                                 className={
                                   virtualItem.groupIndex === 0
                                     ? "sr-only"
-                                    : "py-1 type-caption font-medium tracking-wide uppercase text-label-tertiary"
+                                    : "py-1 type-caption font-medium text-label-tertiary"
                                 }
                               >
                                 {group.label}
@@ -860,6 +939,7 @@ export function SessionList({
                                   : {})}
                                 {...(renderAgentIcon ? { renderAgentIcon } : {})}
                                 {...(wslIcon ? { wslIcon } : {})}
+                                showRepository={showRepositories}
                                 {...(selectedMetric !== "cost"
                                   ? {
                                       limitBadge: sessionLimitBadge(

--- a/apps/desktop/src/components/session/SessionStatusBar.test.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.test.tsx
@@ -85,55 +85,60 @@ const WITH_NOT_ASSESSED: SessionHygieneCheck[] = [
 afterEach(cleanup)
 
 describe("SessionStatusBar", () => {
-  it("inks a fill-free line green with the full pass count when every check passes", () => {
+  it("shows the complete pass wording with a cyan terminal tick", () => {
     render(<SessionStatusBar checks={ALL_PASSED} />)
-    const verdict = screen.getByLabelText("All checks passed")
-    expect(verdict.textContent).toBe("6/6 burn checks")
-    expect(verdict.style.color).toBe("var(--color-system-green)")
-    expect(verdict.className).not.toContain("bg-")
-    expect(verdict.parentElement?.className).not.toContain("bg-")
+    const verdict = screen.getByLabelText(/All Burn Checks passed/)
+    expect(verdict).toHaveTextContent("All 6 passed")
+    expect(screen.getByText("All 6 passed")).toHaveClass(
+      "font-semibold!",
+      "text-burn-check-pass-fill",
+    )
+    expect(verdict).toHaveClass("font-mono", "type-footnote", "tabular-nums")
+    expect(verdict).not.toHaveClass("type-callout")
+    expect(verdict).not.toHaveClass("tracking-tight!")
+    expect(verdict.querySelector('[data-burn-check-indicator="pass"]')).not.toBeNull()
   })
 
-  it("inks a minority failure toward the orange end of the ramp", () => {
+  it("uses result-first mixed wording and failure ink", () => {
     render(<SessionStatusBar checks={CHECKS} />)
-    const verdict = screen.getByLabelText("5 of 6 burn checks passed")
-    expect(verdict.textContent).toBe("5/6 burn checks")
-    expect(verdict.className).not.toContain("rounded-full")
-    expect(verdict.style.backgroundColor).toBe("")
-    expect(verdict.style.color).toContain("--color-system-red-tint) 17%")
-    expect(verdict.style.color).toContain("--color-system-orange")
-    expect(verdict.parentElement?.className).not.toContain("bg-")
+    const verdict = screen.getByLabelText(/Some Burn Checks failed/)
+    expect(verdict).toHaveTextContent("1 failed·5 passed")
+    expect(screen.getByText("1 failed")).toHaveClass("text-burn-check-failure-text")
+    expect(screen.getByText("5 passed")).toHaveClass("text-burn-check-pass-fill")
+    expect(screen.getByText("5 passed")).not.toHaveClass("font-semibold!")
+    expect(verdict.querySelectorAll("circle")).toHaveLength(2)
   })
 
-  it("excludes unavailable checks from the result", () => {
+  it("omits unavailable checks from compact wording", () => {
     render(<SessionStatusBar checks={WITH_NOT_ASSESSED} />)
-    const verdict = screen.getByLabelText("4 of 5 burn checks passed")
-    expect(verdict.textContent).toBe("4/5 burn checks")
-    expect(verdict.style.color).toContain("--color-system-red-tint) 20%")
-    expect(verdict.style.color).toContain("--color-system-orange")
+    const verdict = screen.getByLabelText(/6 session checks/)
+    expect(verdict).toHaveTextContent("1 failed·4 passed")
+    expect(verdict).not.toHaveTextContent("not assessed")
   })
 
-  it("qualifies an all-pass result when unavailable checks are hidden", () => {
+  it("uses a pass mark while disclosing partial all-pass coverage", () => {
     const checks = WITH_NOT_ASSESSED.map((check) =>
       check.status === "finding"
         ? { ...check, status: "clean" as const, ink: "system-green" as const }
         : check,
     )
     render(<SessionStatusBar checks={checks} />)
-    const verdict = screen.getByLabelText("All assessed checks passed")
-    expect(verdict.textContent).toBe("5/5 burn checks")
-    expect(screen.queryByLabelText("All checks passed")).toBeNull()
+    const verdict = screen.getByLabelText(/All assessed Burn Checks passed/)
+    expect(verdict).toHaveTextContent("All 5 passed")
+    expect(screen.getByText("All 5 passed")).toHaveClass("text-burn-check-pass-fill")
+    expect(verdict.querySelector('[data-burn-check-indicator="pass"]')).not.toBeNull()
   })
 
-  it("reaches full red ink only when every check fails", () => {
+  it("uses the terminal failure mark only when every check fails", () => {
     const allFailed = CHECKS.map((check) => ({
       ...check,
       status: "finding" as const,
       ink: "system-red-text" as const,
     }))
     render(<SessionStatusBar checks={allFailed} />)
-    const verdict = screen.getByLabelText("0 of 6 burn checks passed")
-    expect(verdict.style.color).toContain("--color-system-red-tint) 100%")
+    const verdict = screen.getByLabelText(/All Burn Checks failed/)
+    expect(verdict).toHaveTextContent("6 failed")
+    expect(verdict.querySelector('[data-burn-check-indicator="fail"]')).not.toBeNull()
   })
 
   it("shows a computing state instead of claiming a clean result", () => {
@@ -144,28 +149,27 @@ describe("SessionStatusBar", () => {
       ink: "label-tertiary" as const,
     }))
     render(<SessionStatusBar checks={notAssessed} evidenceState="processing" />)
-    const verdict = screen.getByLabelText("Computing session hygiene checks")
-    expect(verdict.textContent).toBe("Computing checks…")
-    expect(verdict.style.color).toBe("var(--color-label-tertiary)")
+    const verdict = screen.getByLabelText(/Running Burn Checks/)
+    expect(verdict).toHaveTextContent("Running Burn Checks…")
+    expect(verdict.querySelector('[data-burn-check-indicator="running"]')).not.toBeNull()
   })
 
   it("keeps the ellipsis off settled evidence states", () => {
     render(<SessionStatusBar checks={[]} evidenceState="unsupported" />)
-    const verdict = screen.getByLabelText("Unsupported session hygiene checks")
-    expect(verdict.textContent).toBe("Unsupported checks")
+    const verdict = screen.getByLabelText("Burn Checks not supported")
+    expect(verdict).toHaveTextContent("Burn Checks not supported")
   })
 
   it("shows the verdict, not the state text, once at least one check is assessed", () => {
     render(<SessionStatusBar checks={CHECKS} evidenceState="processing" />)
-    const verdict = screen.getByLabelText("Computing — 5 of 6 burn checks passed")
-    expect(verdict.textContent).toBe("5/6 burn checks")
+    const verdict = screen.getByLabelText(/Burn Checks incomplete/)
+    expect(verdict).toHaveTextContent("1 failed·5 passed")
   })
 
   it("prefixes the transient state onto an assessed but stale verdict", () => {
     render(<SessionStatusBar checks={CHECKS} evidenceState="stale" />)
-    const verdict = screen.getByLabelText("Refreshing — 5 of 6 burn checks passed")
-    expect(verdict.textContent).toBe("5/6 burn checks")
-    expect(verdict.style.color).toContain("--color-system-orange")
+    const verdict = screen.getByLabelText(/Refreshing/)
+    expect(verdict).toHaveTextContent("1 failed·5 passed")
   })
 
   it("uses only the assessed checks for a singular result", () => {
@@ -181,12 +185,11 @@ describe("SessionStatusBar", () => {
       },
     ]
     render(<SessionStatusBar checks={oneAssessed} />)
-    const verdict = screen.getByLabelText("0 of 1 burn check passed")
-    expect(verdict.textContent).toBe("0/1 burn check")
-    expect(verdict.style.color).toContain("--color-system-red-tint) 100%")
+    const verdict = screen.getByLabelText(/3 session checks/)
+    expect(verdict).toHaveTextContent("1 failed")
   })
 
-  it("omits a settled result when no checks were assessed", () => {
+  it("names a settled result when no checks were assessed", () => {
     const noneAssessed = CHECKS.map((check) => ({
       ...check,
       status: "notAssessed" as const,
@@ -194,9 +197,8 @@ describe("SessionStatusBar", () => {
       ink: "label-tertiary" as const,
     }))
     render(<SessionStatusBar checks={noneAssessed} evidenceState="ready" />)
-    expect(screen.queryByText(/burn check/i)).toBeNull()
-    expect(screen.queryByText("0/0")).toBeNull()
-    expect(screen.queryByLabelText(/assessed/i)).toBeNull()
+    expect(screen.getByText("Burn Checks not assessed")).toBeInTheDocument()
+    expect(screen.getByLabelText(/6 not assessed/)).toBeInTheDocument()
   })
 
   it("keeps the cost at the right edge when no checks were assessed", () => {
@@ -248,24 +250,71 @@ describe("SessionStatusBar", () => {
     ).toHaveTextContent("unknown")
   })
 
-  it("omits unavailable checks from the tooltip", async () => {
+  it("keeps unavailable checks in the tooltip detail", async () => {
     render(<SessionStatusBar checks={WITH_NOT_ASSESSED} />)
-    fireEvent.focus(screen.getByLabelText("4 of 5 burn checks passed"))
+    fireEvent.focus(screen.getByLabelText(/6 session checks/))
 
+    expect(await screen.findByText("Burn Checks")).toHaveClass(
+      "type-callout",
+      "font-semibold!",
+      "text-label",
+    )
     expect(await screen.findByText("Session overdepth detected")).toBeTruthy()
-    expect(screen.queryByText("Overpowered subagents detected")).toBeNull()
-    expect(screen.queryByText("couldn't read the whole session log")).toBeNull()
+    expect(screen.getByText("Overpowered subagents")).toBeInTheDocument()
+    expect(screen.queryByText("Overpowered subagents not assessed")).toBeNull()
+    expect(screen.getByText("Failed · 1")).toHaveClass("text-label-tertiary")
+    expect(screen.getByText("Failed · 1")).not.toHaveClass("text-burn-check-failure-text")
+    expect(screen.getByText("Session overdepth detected")).toHaveClass(
+      "text-burn-check-failure-text",
+    )
+    const groups = screen
+      .getByText("Burn Checks")
+      .closest("[data-burn-check-tooltip]")!
+      .querySelectorAll("[data-burn-check-tooltip-group]")
+    expect([...groups].map((group) => group.textContent)).toEqual([
+      "Failed · 1",
+      "Passed · 4",
+      "Not assessed · 1",
+    ])
+    expect(screen.queryByText("Open the session for details")).toBeNull()
   })
 
-  it("marks each assessed status with a named icon, not a text glyph", async () => {
+  it("uses the Burn Check status icons without repeating their labels", async () => {
     render(<SessionStatusBar checks={WITH_NOT_ASSESSED} />)
-    fireEvent.focus(screen.getByLabelText("4 of 5 burn checks passed"))
+    fireEvent.focus(screen.getByLabelText(/6 session checks/))
 
-    for (const label of ["Finding", "Passed"]) {
-      const marks = await screen.findAllByLabelText(label)
-      expect(marks.every((mark) => mark.tagName.toLowerCase() === "svg")).toBe(true)
+    await screen.findByText("Burn Checks")
+    const marks = document.querySelectorAll("[data-burn-check-tooltip-mark]")
+    expect(marks).toHaveLength(6)
+    for (const mark of marks) {
+      expect(mark.tagName.toLowerCase()).toBe("svg")
+      expect(mark).toHaveAttribute("aria-hidden", "true")
+      expect(mark).toHaveAttribute("width", "14")
+      expect(mark).toHaveAttribute("height", "14")
+      expect(mark).toHaveAttribute(
+        "stroke-width",
+        mark.getAttribute("data-burn-check-tooltip-mark") === "finding" ? "2.5" : "2",
+      )
     }
-    expect(screen.queryByLabelText("Not assessed")).toBeNull()
+    expect(document.querySelectorAll('[data-burn-check-tooltip-mark="finding"]')).toHaveLength(
+      1,
+    )
+    expect(document.querySelectorAll('[data-burn-check-tooltip-mark="clean"]')).toHaveLength(4)
+    expect(
+      document.querySelectorAll('[data-burn-check-tooltip-mark="notAssessed"]'),
+    ).toHaveLength(1)
+    expect(document.querySelector('[data-burn-check-tooltip-mark="finding"]')).toHaveClass(
+      "lucide-circle-alert",
+      "text-burn-check-failure-fill",
+    )
+    expect(document.querySelector('[data-burn-check-tooltip-mark="clean"]')).toHaveClass(
+      "lucide-circle-check",
+      "text-burn-check-pass-fill",
+    )
+    expect(document.querySelector('[data-burn-check-tooltip-mark="notAssessed"]')).toHaveClass(
+      "lucide-circle-minus",
+      "text-burn-check-neutral",
+    )
   })
 
   it("shows a usual cost figure without pill chrome", () => {

--- a/apps/desktop/src/components/session/SessionStatusBar.tsx
+++ b/apps/desktop/src/components/session/SessionStatusBar.tsx
@@ -1,12 +1,10 @@
-import { Check, Flame, X, type LucideIcon } from "lucide-react"
-import { Fragment } from "react"
+import { Flame } from "lucide-react"
 
 import type { SessionHygieneEvidenceState } from "../../lib/insightsIpc"
-import {
-  sessionHygieneStateIsTransient,
-  sessionHygieneStateLabel,
-  type SessionHygieneCheck,
-} from "../../lib/presentation/sessionHygiene"
+import { sessionBurnCheckPresentation } from "../../lib/presentation/burnChecks"
+import type { SessionHygieneCheck } from "../../lib/presentation/sessionHygiene"
+import { BurnCheckStatus } from "../burn-checks/BurnCheckStatus"
+import { BURN_CHECK_MARKS, type BurnCheckMark } from "../burn-checks/burnCheckMarks"
 import { Tooltip } from "../presentation/Tooltip"
 import { SessionCostBadge, type SessionCostBadgeProps } from "./metrics/SessionCostBadge"
 
@@ -33,29 +31,6 @@ export interface SessionStatusBarProps {
 }
 
 /**
- * The verdict line shows the pass count and the session cost.
- *
- * The verdict uses plain monospace text without badge chrome. Severity lives
- * in the ink. The ink moves from green through orange to red as findings rise.
- * The tooltip lists each check with its result.
- */
-
-/**
- * Return the ink for the assessed finding share. A clean result is green.
- * Findings mix orange with red in proportion to their share.
- *
- * The mix runs between the vivid fill tones, not the darkened text ones. The
- * text tones are tuned for contrast on a light surface, and a mostly-orange
- * mix of them reads as brown, which states nothing.
- */
-function verdictInk(failedShare: number, assessedCount: number): string {
-  if (assessedCount === 0) return "var(--color-label-tertiary)"
-  if (failedShare === 0) return "var(--color-system-green)"
-  const pct = Math.round(failedShare * 100)
-  return `color-mix(in oklch, var(--color-system-red-tint) ${pct}%, var(--color-system-orange-tint))`
-}
-
-/**
  * Show the share as a figure and a percent sign.
  *
  * English style puts no space before the percent sign, so the two stay one
@@ -77,58 +52,80 @@ function roundedLimitPercent(percent: number): number {
   return Number(percent.toFixed(1))
 }
 
-interface StatusMark {
-  Icon: LucideIcon
-  /** Box size in px. The tooltip surface sets 12px text. */
-  size: number
-  strokeWidth: number
+interface StatusMark extends BurnCheckMark {
   label: string
+  headingClass: string
+  textClass: string
 }
 
-type AssessedHygieneCheck = SessionHygieneCheck & { status: "finding" | "clean" }
-
-function isAssessed(check: SessionHygieneCheck): check is AssessedHygieneCheck {
-  return check.status !== "notAssessed"
+const STATUS_MARK: Record<SessionHygieneCheck["status"], StatusMark> = {
+  finding: {
+    ...BURN_CHECK_MARKS.finding,
+    label: "Failed",
+    headingClass: "text-label-tertiary",
+    textClass: "text-burn-check-failure-text",
+  },
+  clean: {
+    ...BURN_CHECK_MARKS.clean,
+    label: "Passed",
+    headingClass: "text-label-tertiary",
+    textClass: "text-label",
+  },
+  notAssessed: {
+    ...BURN_CHECK_MARKS.notAssessed,
+    label: "Not assessed",
+    headingClass: "text-label-tertiary",
+    textClass: "text-label-secondary",
+  },
 }
 
-const STATUS_MARK: Record<AssessedHygieneCheck["status"], StatusMark> = {
-  finding: { Icon: X, size: 12, strokeWidth: 2.5, label: "Finding" },
-  clean: { Icon: Check, size: 12, strokeWidth: 2.5, label: "Passed" },
+function tooltipCheckTitle(check: SessionHygieneCheck): string {
+  return check.status === "notAssessed"
+    ? check.title.replace(/ not assessed$/i, "")
+    : check.title
 }
 
-const INK_CLASS: Record<SessionHygieneCheck["ink"], string> = {
-  "system-red-text": "text-system-red-text",
-  "system-green": "text-system-green",
-  "label-tertiary": "text-label-tertiary",
-}
-
-function renderTooltip(failed: AssessedHygieneCheck[], passed: AssessedHygieneCheck[]) {
-  const groups = [failed, passed].filter((group) => group.length > 0)
+function renderTooltip(checks: SessionHygieneCheck[]) {
+  const groups = (["finding", "clean", "notAssessed"] as const)
+    .map((status) => checks.filter((check) => check.status === status))
+    .filter((group) => group.length > 0)
   return (
-    <div className="grid grid-cols-[1fr_max-content] gap-x-2.5 gap-y-0 items-center font-mono [word-spacing:-2px]">
-      {groups.map((group, index) => (
-        <Fragment key={group[0]!.status}>
-          {index > 0 && <div className="col-span-full border-b border-separator" />}
-          {group.map((check) => {
-            const mark = STATUS_MARK[check.status]
-            return (
-              <Fragment key={check.id}>
-                <span className={INK_CLASS[check.ink]}>{check.title}</span>
-                <mark.Icon
-                  size={mark.size}
-                  strokeWidth={mark.strokeWidth}
-                  role="img"
-                  aria-label={mark.label}
-                  className={`justify-self-center ${INK_CLASS[check.ink]}`}
-                />
-              </Fragment>
-            )
-          })}
-        </Fragment>
-      ))}
-      <span className="col-span-full mt-2.5 text-label-secondary">
-        Open the session for details
-      </span>
+    <div className="flex min-w-[200px] flex-col" data-burn-check-tooltip="">
+      <span className="type-callout font-semibold! text-label">Burn Checks</span>
+      <div className="mt-2 flex flex-col gap-y-2.5">
+        {groups.map((group) => {
+          const mark = STATUS_MARK[group[0]!.status]
+          return (
+            <section key={group[0]!.status} aria-label={`${mark.label}, ${group.length}`}>
+              <div
+                className={`type-caption font-medium! tabular-nums ${mark.headingClass}`}
+                data-burn-check-tooltip-group={group[0]!.status}
+              >
+                {mark.label} · {group.length}
+              </div>
+              <ul className="mt-1 flex flex-col gap-y-1">
+                {group.map((check) => (
+                  <li
+                    key={check.id}
+                    className="grid grid-cols-[14px_minmax(0,1fr)] items-start gap-x-1.5"
+                  >
+                    <mark.Icon
+                      size={14}
+                      strokeWidth={mark.strokeWidth}
+                      aria-hidden="true"
+                      className={`mt-px shrink-0 ${mark.iconClass}`}
+                      data-burn-check-tooltip-mark={check.status}
+                    />
+                    <span className={`type-callout text-pretty ${mark.textClass}`}>
+                      {tooltipCheckTitle(check)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -139,61 +136,21 @@ export function SessionStatusBar({
   cost,
   limitBadge,
 }: SessionStatusBarProps) {
-  const assessedChecks = checks.filter(isAssessed)
-  const failed = assessedChecks.filter((check) => check.status === "finding")
-  const passed = assessedChecks.filter((check) => check.status === "clean")
-  const assessedCount = passed.length + failed.length
-  const failedShare = assessedCount === 0 ? 0 : failed.length / assessedCount
-  const allPassed = passed.length === assessedCount && assessedCount > 0
-  const hasUnavailableChecks = assessedCount < checks.length
-  const stateLabel = sessionHygieneStateLabel(evidenceState)
-  // A transient state ends on its own, so its label carries an ellipsis.
-  const stateText = stateLabel
-    ? `${stateLabel} checks${sessionHygieneStateIsTransient(evidenceState) ? "…" : ""}`
-    : null
-  // Once at least one check is assessed, the verdict is worth more than the
-  // state label — a stale or refreshing session still has a last result. Only
-  // the never-assessed case keeps the plain state text in the count's place.
-  const showStateText = stateLabel !== null && assessedCount === 0
-  const checkNoun = assessedCount === 1 ? "burn check" : "burn checks"
-  const countText = `${passed.length}/${assessedCount} ${checkNoun}`
-  // A transient state next to an assessed verdict still names itself, as a
-  // prefix on the aria label and the tooltip text.
-  const verdictPrefix = stateLabel && !showStateText ? `${stateLabel} — ` : ""
-  const verdictLabel = showStateText
-    ? `${stateLabel} session hygiene checks`
-    : `${verdictPrefix}${
-        allPassed
-          ? hasUnavailableChecks
-            ? "All assessed checks passed"
-            : "All checks passed"
-          : `${passed.length} of ${assessedCount} ${checkNoun} passed`
-      }`
-  const tooltip = showStateText ? verdictLabel : renderTooltip(failed, passed)
-  const showVerdict = showStateText || assessedCount > 0
+  const presentation = sessionBurnCheckPresentation(checks, evidenceState)
+  const hasCheckDetails = checks.length > 0
+  const tooltip = hasCheckDetails ? renderTooltip(checks) : presentation.accessibleDescription
   const isHighLimitShare = roundedLimitPercent(limitBadge?.percent ?? 0) >= 5
 
   return (
-    // One height for every state. A pill badge adds a pixel of padding above
-    // and below its 13px line box, so a row that shows one would otherwise
-    // stand taller than a row that shows plain text.
-    <div className="flex h-[15px] w-full items-center justify-between gap-x-1.5 text-label-secondary">
-      {showVerdict && (
-        <Tooltip label={tooltip} delayMs={150}>
-          <span
-            // The modifiers remove the wider sans spacing from type-footnote.
-            // Monospace text already adds enough space between characters.
-            // Negative word spacing keeps the count together.
-            aria-label={verdictLabel}
-            className="font-mono type-footnote font-medium! tracking-tight! [word-spacing:-2px] leading-[13px] tabular-nums"
-            style={{ color: verdictInk(failedShare, assessedCount) }}
-          >
-            {showStateText ? stateText : countText}
-          </span>
-        </Tooltip>
-      )}
+    <div
+      className="flex w-full min-w-0 items-center justify-between gap-x-2 text-label-secondary"
+      data-session-status-bar=""
+    >
+      <Tooltip label={tooltip} delayMs={150}>
+        <BurnCheckStatus presentation={presentation} omitUnassessed />
+      </Tooltip>
 
-      <div className="ml-auto">
+      <div className="ml-auto shrink-0">
         {limitBadge && limitBadge.percent !== null ? (
           <Tooltip label={limitBadge.label} delayMs={150}>
             <span

--- a/apps/desktop/src/components/session/analysis/HygieneBreakdown.test.tsx
+++ b/apps/desktop/src/components/session/analysis/HygieneBreakdown.test.tsx
@@ -41,6 +41,48 @@ function view() {
 }
 
 describe("HygieneBreakdown", () => {
+  it.each([true, false])("uses Burn Check marks with inlineGuidance=%s", (inlineGuidance) => {
+    render(
+      <HygieneBreakdown
+        checks={sessionHygieneChecks(PAYLOAD)}
+        inlineGuidance={inlineGuidance}
+        collapsePassing={false}
+      />,
+    )
+
+    for (const { name, iconClass, colorClass, strokeWidth } of [
+      {
+        name: "Session overdepth",
+        iconClass: "lucide-circle-alert",
+        colorClass: "text-burn-check-failure-fill",
+        strokeWidth: "2.5",
+      },
+      {
+        name: "Model overthinking",
+        iconClass: "lucide-circle-check",
+        colorClass: "text-burn-check-pass-fill",
+        strokeWidth: "2",
+      },
+    ]) {
+      const row = inlineGuidance
+        ? screen.getByRole("group", { name })
+        : screen.getByRole("button", { name: `${name} details` }).parentElement!
+      const icon = row.querySelector(`.${iconClass}`)
+      expect(icon).toHaveClass(colorClass)
+      expect(icon).toHaveAttribute("stroke-width", strokeWidth)
+      expect(icon).toHaveAttribute("width", "14")
+      expect(icon).toHaveAttribute("height", "14")
+      expect(icon).toHaveAttribute("aria-hidden", "true")
+    }
+
+    if (!inlineGuidance) {
+      expect(screen.getByText("Failed")).toHaveClass("text-burn-check-failure-text")
+      for (const word of screen.getAllByText("Passed")) {
+        expect(word).toHaveClass("text-label-secondary")
+      }
+    }
+  })
+
   it("carries each check at three densities and opens its advice in a tooltip", () => {
     const checks = sessionHygieneChecks(PAYLOAD)
     render(<HygieneBreakdown checks={checks} inlineGuidance />)
@@ -82,6 +124,9 @@ describe("HygieneBreakdown", () => {
     const finding = screen.getByRole("group", { name: "Session overdepth" })
     fireEvent.focus(finding)
     expect(screen.getAllByText(/475,000 tokens/).length).toBeGreaterThan(0)
+    for (const evidence of screen.getAllByText(/475,000 tokens/)) {
+      expect(evidence).toHaveClass("text-burn-check-failure-text")
+    }
     fireEvent.blur(finding)
   })
 
@@ -135,6 +180,9 @@ describe("HygieneBreakdown", () => {
     )
     expect(guidanceRegion.firstElementChild).not.toHaveClass("px-3", "pb-3")
     expect(guidanceRegion.querySelector('[class*="text-sm"]')).toBeNull()
+    expect(screen.getByText(/475,000 tokens/).parentElement).toHaveClass(
+      "text-burn-check-failure-text",
+    )
 
     fireEvent.click(screen.getByRole("button", { name: "4/5 passed" }))
     fireEvent.click(screen.getByRole("button", { name: "Model overthinking details" }))

--- a/apps/desktop/src/components/session/analysis/HygieneBreakdown.tsx
+++ b/apps/desktop/src/components/session/analysis/HygieneBreakdown.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, CircleCheck, CircleX, type LucideIcon } from "lucide-react"
+import { ChevronRight } from "lucide-react"
 import { useId, useState } from "react"
 
 import { cn } from "../../../lib/cn"
@@ -8,6 +8,7 @@ import {
   type SessionHygieneCheck,
 } from "../../../lib/presentation/sessionHygiene"
 import { Tooltip } from "../../presentation/Tooltip"
+import { BURN_CHECK_MARKS, type BurnCheckMark } from "../../burn-checks/burnCheckMarks"
 import { RowInfo } from "./RowInfo"
 
 export interface HygieneBreakdownProps {
@@ -22,10 +23,8 @@ export interface HygieneBreakdownProps {
   inlineGuidance?: boolean
 }
 
-interface HygieneStatusPresentation {
-  Icon: LucideIcon
+interface HygieneStatusPresentation extends BurnCheckMark {
   label: string
-  textClass: string
   /** The ink of the status word. A passing word stays neutral. */
   wordClass: string
 }
@@ -41,15 +40,13 @@ const STATUS_ICON_SIZE = 14
 
 const STATUS_PRESENTATION: Record<AssessedHygieneCheck["status"], HygieneStatusPresentation> = {
   finding: {
-    Icon: CircleX,
+    ...BURN_CHECK_MARKS.finding,
     label: "Failed",
-    textClass: "text-share-waste-text",
-    wordClass: "text-share-waste-text",
+    wordClass: "text-burn-check-failure-text",
   },
   clean: {
-    Icon: CircleCheck,
+    ...BURN_CHECK_MARKS.clean,
     label: "Passed",
-    textClass: "text-share-work-text",
     wordClass: "text-label-secondary",
   },
 }
@@ -60,7 +57,7 @@ function HygieneGuidance({ check }: { check: AssessedHygieneCheck }) {
   return (
     <div className="mt-1 flex flex-col gap-2 rounded-control border border-separator p-3 text-pretty type-callout text-label-secondary">
       {documentation.findingDetails.length > 0 && (
-        <div className="flex flex-col gap-1 text-share-waste-text">
+        <div className="flex flex-col gap-1 text-burn-check-failure-text">
           {documentation.findingDetails.map((sentence) => (
             <p key={sentence}>{sentence}</p>
           ))}
@@ -119,9 +116,9 @@ function HygieneRow({
         <span className={cn("pointer-events-none", status.wordClass)}>{status.label}</span>
         <status.Icon
           size={STATUS_ICON_SIZE}
-          strokeWidth={2}
+          strokeWidth={status.strokeWidth}
           aria-hidden="true"
-          className={cn("pointer-events-none shrink-0", status.textClass)}
+          className={cn("pointer-events-none shrink-0", status.iconClass)}
         />
       </div>
 
@@ -145,7 +142,7 @@ function InlineHygieneTooltip({ check }: { check: AssessedHygieneCheck }) {
   return (
     <div className="space-y-1 text-pretty">
       {documentation.findingDetails.map((sentence) => (
-        <p key={sentence} className="text-share-waste-text">
+        <p key={sentence} className="text-burn-check-failure-text">
           {sentence}
         </p>
       ))}
@@ -189,8 +186,9 @@ function InlineHygieneRow({ check }: { check: AssessedHygieneCheck }) {
           <span className="min-w-0 text-pretty text-label">{check.name}</span>
           <status.Icon
             size={STATUS_ICON_SIZE}
+            strokeWidth={status.strokeWidth}
             aria-hidden="true"
-            className={cn("shrink-0 self-center", status.textClass)}
+            className={cn("shrink-0 self-center", status.iconClass)}
           />
           <span className="session-check-word">{status.label}</span>
         </div>

--- a/apps/desktop/src/components/ui/ListDisplayToolbar.test.tsx
+++ b/apps/desktop/src/components/ui/ListDisplayToolbar.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ListDisplayToolbar } from "./ListDisplayToolbar"
+
+const OPTIONS = [
+  { value: "cost", label: "Cost" },
+  { value: "weeklyPercent", label: "Week %" },
+] as const
+
+describe("ListDisplayToolbar", () => {
+  it("renders a low-chrome display choice without a redundant visible label", () => {
+    const onChange = vi.fn()
+    render(
+      <ListDisplayToolbar
+        label="Today"
+        options={OPTIONS}
+        value="cost"
+        onChange={onChange}
+        ariaLabel="Session metric"
+      />,
+    )
+
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument()
+    expect(screen.getByText("Today")).toHaveClass("text-label-tertiary")
+    const control = screen.getByRole("radiogroup", { name: "Session metric" })
+    expect(control).toHaveAttribute("data-variant", "text-tabs")
+    expect(control).not.toHaveTextContent("Show")
+
+    fireEvent.click(screen.getByRole("radio", { name: "Week %" }))
+    expect(onChange).toHaveBeenCalledWith("weeklyPercent")
+  })
+
+  it("lets a window host opt the toolbar into its drag region", () => {
+    const { container } = render(
+      <ListDisplayToolbar
+        options={OPTIONS}
+        value="cost"
+        onChange={() => {}}
+        ariaLabel="Session metric"
+        dragRegion
+      />,
+    )
+
+    expect(container.firstElementChild).toHaveAttribute("data-tauri-drag-region", "deep")
+    for (const button of screen.getAllByRole("radio")) {
+      expect(button).not.toHaveAttribute("data-tauri-drag-region")
+    }
+  })
+})

--- a/apps/desktop/src/components/ui/ListDisplayToolbar.tsx
+++ b/apps/desktop/src/components/ui/ListDisplayToolbar.tsx
@@ -1,0 +1,42 @@
+import { cn } from "../../lib/cn"
+import { SegmentedControl, type SegmentedOption } from "./SegmentedControl"
+
+export function ListDisplayToolbar<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  dragRegion = false,
+  className,
+}: {
+  label?: string
+  options: ReadonlyArray<SegmentedOption<T>>
+  value: T
+  onChange: (next: T) => void
+  ariaLabel: string
+  dragRegion?: boolean
+  className?: string
+}) {
+  return (
+    <div
+      data-list-display-toolbar=""
+      data-tauri-drag-region={dragRegion ? "deep" : undefined}
+      className={cn(
+        "mb-1 flex h-8 shrink-0 items-center px-3",
+        label ? "justify-between" : "justify-end",
+        className,
+      )}
+    >
+      {label && <span className="type-caption font-medium text-label-tertiary">{label}</span>}
+      <SegmentedControl
+        options={options}
+        value={value}
+        onChange={onChange}
+        ariaLabel={ariaLabel}
+        className="normal-case"
+        variant="text-tabs"
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/components/ui/SegmentedControl.test.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.test.tsx
@@ -164,7 +164,7 @@ describe("SegmentedControl", () => {
       expect(tablist.className).not.toContain(chrome)
     }
     expect(tablist.getAttribute("style")).toBeNull()
-    expect(document.querySelector(".bg-accent-fill")).toBeNull()
+    expect(document.querySelector(".segmented-control-text-indicator.bg-label")).not.toBeNull()
     expect(document.querySelector(".duration-\\[var\\(--duration-fast\\)\\]")).toBeNull()
 
     const selected = screen.getByRole("tab", { name: "B" })

--- a/apps/desktop/src/components/ui/SegmentedControl.tsx
+++ b/apps/desktop/src/components/ui/SegmentedControl.tsx
@@ -197,7 +197,7 @@ export function SegmentedControl<T extends string>({
               <span
                 aria-hidden="true"
                 className={cn(
-                  "segmented-control-text-indicator pointer-events-none absolute inset-x-0 bottom-0 h-px rounded-full bg-accent transition-opacity duration-[var(--duration-quick)] ease-out-quart",
+                  "segmented-control-text-indicator pointer-events-none absolute inset-x-0 bottom-0 h-px rounded-full bg-label transition-opacity duration-[var(--duration-quick)] ease-out-quart",
                   selected ? "opacity-100" : "opacity-0",
                 )}
               />

--- a/apps/desktop/src/components/ui/SegmentedRadialDial.test.tsx
+++ b/apps/desktop/src/components/ui/SegmentedRadialDial.test.tsx
@@ -1,0 +1,120 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { SegmentedRadialDial } from "./SegmentedRadialDial"
+
+function circles(container: HTMLElement): SVGCircleElement[] {
+  return [...container.querySelectorAll<SVGCircleElement>("circle")]
+}
+
+function visibleGap(circle: SVGCircleElement, nextCircle: SVGCircleElement): number {
+  const radius = Number(circle.getAttribute("r"))
+  const strokeWidth = Number(circle.getAttribute("stroke-width"))
+  const endAngle = Number(circle.dataset.startAngle) + Number(circle.dataset.arcAngle)
+  const centerlineGap = Number(nextCircle.dataset.startAngle) - endAngle
+  const endpointDistance = 2 * radius * Math.sin((centerlineGap * Math.PI) / 360)
+  return endpointDistance - strokeWidth
+}
+
+describe("SegmentedRadialDial", () => {
+  it("renders no arcs for an empty set", () => {
+    const { container } = render(<SegmentedRadialDial segments={[]} size={16} />)
+    expect(circles(container)).toEqual([])
+  })
+
+  it("omits zero, negative, and nonfinite values without changing order", () => {
+    const { container } = render(
+      <SegmentedRadialDial
+        size={24}
+        segments={[
+          { id: "zero", value: 0, className: "zero" },
+          { id: "passed", value: 3, className: "passed" },
+          { id: "negative", value: -1, className: "negative" },
+          { id: "failed", value: 1, className: "failed" },
+          { id: "infinite", value: Number.POSITIVE_INFINITY, className: "infinite" },
+        ]}
+      />,
+    )
+
+    expect(circles(container).map((circle) => circle.dataset.segmentId)).toEqual([
+      "passed",
+      "failed",
+    ])
+  })
+
+  it("renders one positive segment as a complete circle", () => {
+    const { container } = render(
+      <SegmentedRadialDial
+        size={32}
+        gapAngle={200}
+        segments={[{ id: "only", value: 2, className: "only" }]}
+      />,
+    )
+    const circle = circles(container)[0]!
+    expect(circle.dataset.arcAngle).toBe("360")
+    expect(circle).not.toHaveAttribute("stroke-dasharray")
+  })
+
+  it("normalizes highly uneven values without overflowing", () => {
+    const { container } = render(
+      <SegmentedRadialDial
+        size={48}
+        gapAngle={4}
+        segments={[
+          { id: "large", value: Number.MAX_VALUE, className: "large" },
+          { id: "small", value: 1, className: "small" },
+        ]}
+      />,
+    )
+    const angles = circles(container).map((circle) => Number(circle.dataset.arcAngle))
+    expect(angles.every(Number.isFinite)).toBe(true)
+    expect(angles[1]).toBeGreaterThan(0)
+    expect(angles[0]! / (angles[0]! + angles[1]!)).toBeGreaterThan(0.999_999)
+  })
+
+  it("bounds excessive gaps and keeps every arc finite", () => {
+    const { container } = render(
+      <SegmentedRadialDial
+        size={24}
+        gapAngle={1_000}
+        segments={[
+          { id: "one", value: 1, className: "one" },
+          { id: "two", value: 1, className: "two" },
+          { id: "three", value: 1, className: "three" },
+        ]}
+      />,
+    )
+    const angles = circles(container).map((circle) => Number(circle.dataset.arcAngle))
+    expect(angles).toHaveLength(3)
+    expect(angles.every((angle) => Number.isFinite(angle) && angle > 0)).toBe(true)
+    expect(angles.reduce((total, angle) => total + angle, 0)).toBeCloseTo(0.001, 5)
+  })
+
+  it.each([16, 24])("keeps rounded endpoints visually separate at %spx", (size) => {
+    const { container } = render(
+      <SegmentedRadialDial
+        size={size}
+        gapAngle={5}
+        segments={[
+          { id: "failed", value: 1, className: "failed" },
+          { id: "passed", value: 5, className: "passed" },
+        ]}
+      />,
+    )
+    const [failed, passed] = circles(container)
+    expect(visibleGap(failed!, passed!)).toBeGreaterThan(0)
+  })
+
+  it("supports labelled and decorative rendering", () => {
+    const segment = [{ id: "one", value: 1, className: "one" }]
+    const labelled = render(
+      <SegmentedRadialDial segments={segment} size={16} label="Three of six checks passed" />,
+    )
+    expect(labelled.getByRole("img", { name: "Three of six checks passed" })).toBeTruthy()
+    labelled.unmount()
+
+    const decorative = render(<SegmentedRadialDial segments={segment} size={16} />)
+    expect(decorative.container.querySelector("svg")).toHaveAttribute("aria-hidden", "true")
+    expect(decorative.queryByRole("img")).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/ui/SegmentedRadialDial.tsx
+++ b/apps/desktop/src/components/ui/SegmentedRadialDial.tsx
@@ -1,0 +1,138 @@
+interface SegmentedRadialDialSegment {
+  id: string
+  value: number
+  className: string
+}
+
+interface SegmentedRadialDialProps {
+  segments: readonly SegmentedRadialDialSegment[]
+  size: number
+  strokeWidth?: number
+  gapAngle?: number
+  startAngle?: number
+  label?: string
+}
+
+const FULL_CIRCLE = 360
+const MIN_DRAWABLE_ANGLE = 0.001
+
+function finiteOr(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) ? value : fallback
+}
+
+function stableNumber(value: number): number {
+  return Number(value.toFixed(6))
+}
+
+function stablePositiveNumber(value: number): number {
+  const rounded = stableNumber(value)
+  if (rounded > 0) return rounded
+  return value > 0 ? value : Number.MIN_VALUE
+}
+
+function roundCapClearanceAngle(strokeWidth: number, radius: number): number {
+  const chordRatio = Math.min(1, strokeWidth / (2 * radius))
+  return (2 * Math.asin(chordRatio) * FULL_CIRCLE) / (2 * Math.PI)
+}
+
+export function SegmentedRadialDial({
+  segments,
+  size,
+  strokeWidth = 2.5,
+  gapAngle = 5,
+  startAngle = -90,
+  label,
+}: SegmentedRadialDialProps) {
+  const renderedSize = Math.max(1, finiteOr(size, 16))
+  const renderedStroke = Math.min(
+    renderedSize - MIN_DRAWABLE_ANGLE,
+    Math.max(MIN_DRAWABLE_ANGLE, finiteOr(strokeWidth, 2.5)),
+  )
+  const radius = (renderedSize - renderedStroke) / 2
+  const center = renderedSize / 2
+  const validSegments = segments.filter(
+    (segment) => Number.isFinite(segment.value) && segment.value > 0,
+  )
+  const maximum = validSegments.reduce(
+    (currentMaximum, segment) => Math.max(currentMaximum, segment.value),
+    0,
+  )
+  const normalizedTotal = validSegments.reduce(
+    (total, segment) => total + segment.value / maximum,
+    0,
+  )
+  const capClearanceAngle = roundCapClearanceAngle(renderedStroke, radius)
+  const maximumGap =
+    validSegments.length > 1 ? (FULL_CIRCLE - MIN_DRAWABLE_ANGLE) / validSegments.length : 0
+  const requestedGap = Math.max(0, finiteOr(gapAngle, 0))
+  const renderedGap = Math.min(
+    maximumGap,
+    validSegments.length > 1 ? requestedGap + capClearanceAngle : 0,
+  )
+  const drawableAngle = FULL_CIRCLE - renderedGap * validSegments.length
+  const arcAngles = validSegments.map((segment) =>
+    stablePositiveNumber(drawableAngle * (segment.value / maximum / normalizedTotal)),
+  )
+  const segmentStarts = arcAngles.map((_, index) =>
+    stableNumber(
+      arcAngles.slice(0, index).reduce((total, arcAngle) => total + arcAngle, 0) +
+        renderedGap * index,
+    ),
+  )
+
+  return (
+    <svg
+      data-segmented-radial-dial=""
+      viewBox={`0 0 ${renderedSize} ${renderedSize}`}
+      width={renderedSize}
+      height={renderedSize}
+      role={label ? "img" : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+      focusable="false"
+    >
+      <g transform={`rotate(${finiteOr(startAngle, -90)} ${center} ${center})`}>
+        {validSegments.map((segment, index) => {
+          if (validSegments.length === 1) {
+            return (
+              <circle
+                key={segment.id}
+                data-segment-id={segment.id}
+                data-arc-angle={FULL_CIRCLE}
+                cx={center}
+                cy={center}
+                r={radius}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={renderedStroke}
+                className={segment.className}
+              />
+            )
+          }
+
+          const arcAngle = arcAngles[index] ?? 0
+          const segmentStart = segmentStarts[index] ?? 0
+          return (
+            <circle
+              key={segment.id}
+              data-segment-id={segment.id}
+              data-arc-angle={arcAngle}
+              data-start-angle={segmentStart}
+              cx={center}
+              cy={center}
+              r={radius}
+              pathLength={FULL_CIRCLE}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={renderedStroke}
+              strokeLinecap="round"
+              strokeDasharray={`${arcAngle} ${stableNumber(FULL_CIRCLE - arcAngle)}`}
+              strokeDashoffset={-segmentStart}
+              className={segment.className}
+            />
+          )
+        })}
+      </g>
+    </svg>
+  )
+}

--- a/apps/desktop/src/lib/agentIcon.test.tsx
+++ b/apps/desktop/src/lib/agentIcon.test.tsx
@@ -50,6 +50,14 @@ describe("renderAgentIcon", () => {
     expect(svg?.querySelector("path")?.getAttribute("d")).toBe(markOf("antigravity").path)
   })
 
+  it("keeps vendor identity while presenting a neutral mark", () => {
+    render(<div data-testid="host">{renderAgentIcon("claude-code", 12, "cli", "neutral")}</div>)
+    const wrapper = screen.getByTestId("host").firstElementChild
+    expect(wrapper).toHaveAttribute("aria-label", "Claude Code")
+    expect(wrapper).toHaveClass("text-label-tertiary")
+    expect(wrapper?.querySelector("svg")?.style.color).toBe("")
+  })
+
   it.each(["cli", "ide_desktop", "unknown"] as const)(
     "draws a surface glyph for an unknown slug on %s",
     (surface) => {

--- a/apps/desktop/src/lib/agentIcon.tsx
+++ b/apps/desktop/src/lib/agentIcon.tsx
@@ -41,7 +41,12 @@ import {
 } from "simple-icons"
 
 import { ANTIGRAVITY_MARK, fromSimpleIcons, OPENAI_MARK, type BrandMark } from "./brandMarks"
-import { agentDisplayName, agentIconName, type AgentSurface } from "./presentation/agents"
+import {
+  agentDisplayName,
+  agentIconName,
+  type AgentIconAppearance,
+  type AgentSurface,
+} from "./presentation/agents"
 
 /**
  * Registry icon name → brand mark. Keyed by the registry's icon names (not
@@ -80,7 +85,17 @@ function glyphFor(surface: AgentSurface | undefined): LucideIcon {
   return Bot
 }
 
-function Mark({ name, mark, size }: { name: string; mark: BrandMark; size: number }) {
+function Mark({
+  name,
+  mark,
+  size,
+  appearance,
+}: {
+  name: string
+  mark: BrandMark
+  size: number
+  appearance: AgentIconAppearance
+}) {
   return (
     <svg
       viewBox={mark.viewBox}
@@ -88,7 +103,11 @@ function Mark({ name, mark, size }: { name: string; mark: BrandMark; size: numbe
       height={size}
       fill="currentColor"
       // Brand-coloured marks override the inherited ink; the rest inherit it.
-      style={BRAND_COLORED.has(name) ? { color: `#${mark.hex}` } : undefined}
+      style={
+        appearance === "default" && BRAND_COLORED.has(name)
+          ? { color: `#${mark.hex}` }
+          : undefined
+      }
       aria-hidden="true"
     >
       <path d={mark.path} />
@@ -115,19 +134,24 @@ function LetterTile({ name, size }: { name: string; size: number }) {
  * Matches the `SessionAgentIconRenderer` / `AgentIconRenderer` signatures the
  * presentation components declare, so it can be passed straight into either.
  */
-export function renderAgentIcon(slug: string, size: number, surface?: AgentSurface): ReactNode {
+export function renderAgentIcon(
+  slug: string,
+  size: number,
+  surface?: AgentSurface,
+  appearance: AgentIconAppearance = "default",
+): ReactNode {
   const iconName = agentIconName(slug)
   const mark = BRAND_MARKS[iconName]
   const Glyph = glyphFor(surface)
   return (
     <span
       data-agent-icon={iconName}
-      className="text-agent-mark"
+      className={appearance === "neutral" ? "text-label-tertiary" : "text-agent-mark"}
       role="img"
       aria-label={agentDisplayName(slug)}
     >
       {mark ? (
-        <Mark name={iconName} mark={mark} size={size} />
+        <Mark name={iconName} mark={mark} size={size} appearance={appearance} />
       ) : iconName === "generic-agent" ? (
         <Glyph size={size} strokeWidth={1.75} aria-hidden="true" />
       ) : (

--- a/apps/desktop/src/lib/presentation/agents.ts
+++ b/apps/desktop/src/lib/presentation/agents.ts
@@ -12,6 +12,9 @@
 /** Where a session was discovered from. */
 export type AgentSurface = "cli" | "ide_desktop" | "unknown"
 
+/** A call site can mute vendor colour without changing the vendor artwork. */
+export type AgentIconAppearance = "default" | "neutral"
+
 /** Everything the presentation layer knows about one agent. */
 interface AgentInfo {
   displayName: string

--- a/apps/desktop/src/lib/presentation/burnChecks.test.ts
+++ b/apps/desktop/src/lib/presentation/burnChecks.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest"
+
+import type { ChecksReportPayload } from "../insightsIpc"
+import {
+  aggregateBurnCheckPresentation,
+  emptyBurnCheckPresentation,
+  sessionBurnCheckPresentation,
+} from "./burnChecks"
+
+function sessionStatuses(...statuses: Array<"finding" | "clean" | "notAssessed">) {
+  return statuses.map((status) => ({ status }))
+}
+
+function report(
+  categories: ChecksReportPayload["categories"],
+  evidenceSettled = true,
+): ChecksReportPayload {
+  return {
+    pendingEvidence: 0,
+    evidenceSettled,
+    estimatedTokenBurnBasisPoints: null,
+    categories,
+  }
+}
+
+function category(
+  finding: number,
+  clean: number,
+  unavailable = 0,
+): ChecksReportPayload["categories"][number] {
+  return {
+    id: "cacheChurn",
+    finding,
+    clean,
+    unavailable,
+    estimatedTokenBurnBasisPoints: null,
+  }
+}
+
+describe("sessionBurnCheckPresentation", () => {
+  it("uses terminal language only for complete nonempty results", () => {
+    const passed = sessionBurnCheckPresentation(sessionStatuses("clean", "clean"), "ready")
+    expect(passed.state).toBe("allPassed")
+    expect(passed.headline).toBe("All Burn Checks passed")
+    expect(passed.compactPhrases.map((phrase) => phrase.text)).toEqual(["2 passed"])
+    expect(passed.indicator.kind).toBe("pass")
+
+    const failed = sessionBurnCheckPresentation(sessionStatuses("finding", "finding"), "ready")
+    expect(failed.state).toBe("allFailed")
+    expect(failed.headline).toBe("All Burn Checks failed")
+    expect(failed.indicator.kind).toBe("fail")
+  })
+
+  it("pluralizes mixed compact phrases without repeating the noun", () => {
+    const value = sessionBurnCheckPresentation(
+      sessionStatuses("finding", "clean", "clean", "clean"),
+      "ready",
+    )
+    expect(value.headline).toBe("Some Burn Checks failed")
+    expect(value.compactPhrases.map((phrase) => phrase.text)).toEqual(["1 failed", "3 passed"])
+    expect(value.breakdownPhrases.map((phrase) => phrase.text)).toEqual([
+      "1 failed",
+      "3 passed",
+    ])
+  })
+
+  it("uses a pass verdict while keeping unassessed coverage visible", () => {
+    const value = sessionBurnCheckPresentation(
+      sessionStatuses("clean", "clean", "notAssessed"),
+      "ready",
+    )
+    expect(value.state).toBe("assessedPassed")
+    expect(value.headline).toBe("All assessed Burn Checks passed")
+    expect(value.compactPhrases.map((phrase) => phrase.text)).toEqual([
+      "2 passed",
+      "1 not assessed",
+    ])
+    expect(value.breakdownPhrases.map((phrase) => phrase.text)).toEqual([
+      "2 passed",
+      "1 not assessed",
+    ])
+    expect(value.indicator.kind).toBe("pass")
+    expect(value.accessibleDescription).toContain("3 session checks")
+  })
+
+  it.each([
+    ["pending", "Running Burn Checks…"],
+    ["processing", "Running Burn Checks…"],
+    ["stale", "Refreshing Burn Checks…"],
+    ["activelyGrowing", "Burn Checks awaiting session data"],
+    ["unsupported", "Burn Checks not supported"],
+    ["failed", "Burn Checks unavailable"],
+    ["ready", "Burn Checks not assessed"],
+  ] as const)("maps %s evidence with no result to %s", (lifecycle, expected) => {
+    const value = sessionBurnCheckPresentation([], lifecycle)
+    expect(value.headline).toBe(expected)
+    expect(value.compactPhrases).toEqual([{ outcome: "status", text: expected }])
+  })
+
+  it("preserves results and discloses stale, growing, and failed refreshes", () => {
+    const checks = sessionStatuses("finding", "clean")
+    expect(sessionBurnCheckPresentation(checks, "stale").contextPhrases).toEqual([
+      "Refreshing",
+      "Evidence incomplete",
+    ])
+    expect(sessionBurnCheckPresentation(checks, "activelyGrowing").contextPhrases).toEqual([
+      "Session still growing",
+      "Evidence incomplete",
+    ])
+    expect(sessionBurnCheckPresentation(checks, "failed").contextPhrases).toEqual([
+      "Refresh unavailable",
+      "Evidence incomplete",
+    ])
+  })
+
+  it("keeps processing separate from unavailable and unassessed counts", () => {
+    const value = sessionBurnCheckPresentation(sessionStatuses("clean"), "processing")
+    expect(value.compactPhrases.map((phrase) => phrase.text)).toEqual(["1 passed"])
+    expect(value.counts.unassessed).toBe(0)
+    expect(value.contextPhrases).toEqual(["Running", "Evidence incomplete"])
+  })
+})
+
+describe("aggregateBurnCheckPresentation", () => {
+  it("counts every report category once and preserves mixed classification", () => {
+    const value = aggregateBurnCheckPresentation(
+      report([category(2, 3, 4), category(0, 3, 2), category(0, 0, 5)]),
+    )
+    expect(value.counts).toEqual({ failed: 1, passed: 1, unassessed: 1 })
+    expect(value.breakdownPhrases.map((phrase) => phrase.text)).toEqual([
+      "1 failed",
+      "1 passed",
+      "1 not assessed",
+    ])
+    expect(value.contextPhrases).toContain("Evidence incomplete")
+    expect(value.accessibleDescription).toContain("3 report categories")
+  })
+
+  it("uses evidenceSettled to keep otherwise complete results nonterminal", () => {
+    const value = aggregateBurnCheckPresentation(
+      report([category(0, 4), category(0, 9)], false),
+    )
+    expect(value.state).toBe("assessedPassed")
+    expect(value.headline).toBe("All assessed Burn Checks passed")
+    expect(value.indicator.kind).toBe("pass")
+  })
+
+  it("retains results when a refresh fails", () => {
+    const value = aggregateBurnCheckPresentation(report([category(2, 3)]), true)
+    expect(value.counts.failed).toBe(1)
+    expect(value.compactPhrases[0]?.text).toBe("1 failed")
+    expect(value.contextPhrases).toContain("Refresh unavailable")
+  })
+
+  it("never turns an empty report into a pass", () => {
+    const value = aggregateBurnCheckPresentation(report([]))
+    expect(value.state).toBe("notAssessed")
+    expect(value.indicator.kind).toBe("neutral")
+  })
+})
+
+describe("emptyBurnCheckPresentation", () => {
+  it("distinguishes report loading from unavailability", () => {
+    expect(emptyBurnCheckPresentation("pending").headline).toBe("Running Burn Checks…")
+    expect(emptyBurnCheckPresentation("unavailable").headline).toBe("Burn Checks unavailable")
+  })
+})

--- a/apps/desktop/src/lib/presentation/burnChecks.ts
+++ b/apps/desktop/src/lib/presentation/burnChecks.ts
@@ -1,0 +1,277 @@
+import type { ChecksReportPayload, SessionHygieneEvidenceState } from "../insightsIpc"
+import type { SessionHygieneCheck } from "./sessionHygiene"
+
+type BurnCheckLifecycle =
+  | "pending"
+  | "processing"
+  | "ready"
+  | "stale"
+  | "activelyGrowing"
+  | "unsupported"
+  | "unavailable"
+
+type BurnCheckScope = "sessionChecks" | "reportCategories"
+type BurnCheckOutcome = "failed" | "passed" | "unassessed"
+type BurnCheckState =
+  | "allPassed"
+  | "assessedPassed"
+  | "allFailed"
+  | "mixed"
+  | "incomplete"
+  | "running"
+  | "refreshing"
+  | "awaitingSessionData"
+  | "unsupported"
+  | "unavailable"
+  | "notAssessed"
+
+interface BurnCheckCounts {
+  failed: number
+  passed: number
+  unassessed: number
+}
+
+interface BurnCheckPhrase {
+  outcome: BurnCheckOutcome | "status"
+  text: string
+}
+
+type BurnCheckIndicatorSpec =
+  | { kind: "pass" }
+  | { kind: "fail" }
+  | { kind: "segments"; segments: Array<{ outcome: BurnCheckOutcome; value: number }> }
+  | { kind: "running" }
+  | { kind: "neutral" }
+
+export interface BurnCheckPresentation {
+  state: BurnCheckState
+  scope: BurnCheckScope
+  counts: BurnCheckCounts
+  evidenceComplete: boolean
+  lifecycle: BurnCheckLifecycle
+  refreshFailed: boolean
+  headline: string
+  headlineTone: "failure" | "neutral"
+  compactPhrases: BurnCheckPhrase[]
+  breakdownPhrases: BurnCheckPhrase[]
+  contextPhrases: string[]
+  accessibleDescription: string
+  indicator: BurnCheckIndicatorSpec
+}
+
+interface PresentationFacts {
+  scope: BurnCheckScope
+  counts: BurnCheckCounts
+  evidenceComplete: boolean
+  lifecycle: BurnCheckLifecycle
+  refreshFailed: boolean
+}
+
+function compactPhrases(counts: BurnCheckCounts): BurnCheckPhrase[] {
+  const phrases: BurnCheckPhrase[] = []
+  if (counts.failed > 0) {
+    phrases.push({
+      outcome: "failed",
+      text: `${counts.failed} failed`,
+    })
+  }
+  if (counts.passed > 0) {
+    phrases.push({
+      outcome: "passed",
+      text: `${counts.passed} passed`,
+    })
+  }
+  if (counts.unassessed > 0) {
+    phrases.push({
+      outcome: "unassessed",
+      text: `${counts.unassessed} not assessed`,
+    })
+  }
+  return phrases
+}
+
+function breakdownPhrases(counts: BurnCheckCounts): BurnCheckPhrase[] {
+  const phrases: BurnCheckPhrase[] = []
+  if (counts.failed > 0) phrases.push({ outcome: "failed", text: `${counts.failed} failed` })
+  if (counts.passed > 0) phrases.push({ outcome: "passed", text: `${counts.passed} passed` })
+  if (counts.unassessed > 0) {
+    phrases.push({ outcome: "unassessed", text: `${counts.unassessed} not assessed` })
+  }
+  return phrases
+}
+
+function lifecycleState(lifecycle: BurnCheckLifecycle): {
+  state: BurnCheckState
+  headline: string
+} {
+  switch (lifecycle) {
+    case "pending":
+    case "processing":
+      return { state: "running", headline: "Running Burn Checks…" }
+    case "stale":
+      return { state: "refreshing", headline: "Refreshing Burn Checks…" }
+    case "activelyGrowing":
+      return {
+        state: "awaitingSessionData",
+        headline: "Burn Checks awaiting session data",
+      }
+    case "unsupported":
+      return { state: "unsupported", headline: "Burn Checks not supported" }
+    case "unavailable":
+      return { state: "unavailable", headline: "Burn Checks unavailable" }
+    case "ready":
+      return { state: "notAssessed", headline: "Burn Checks not assessed" }
+  }
+}
+
+function indicatorFor(state: BurnCheckState, counts: BurnCheckCounts): BurnCheckIndicatorSpec {
+  if (state === "allPassed" || state === "assessedPassed") return { kind: "pass" }
+  if (state === "allFailed") return { kind: "fail" }
+  if (state === "running" || state === "refreshing") return { kind: "running" }
+  if (counts.failed + counts.passed > 0) {
+    const segments = (["failed", "passed", "unassessed"] as const).flatMap((outcome) =>
+      counts[outcome] > 0 ? [{ outcome, value: counts[outcome] }] : [],
+    )
+    return { kind: "segments", segments }
+  }
+  return { kind: "neutral" }
+}
+
+function contextPhrases(facts: PresentationFacts, hasResults: boolean): string[] {
+  if (!hasResults) return []
+  const phrases: string[] = []
+  if (facts.lifecycle === "pending" || facts.lifecycle === "processing") {
+    phrases.push("Running")
+  }
+  if (facts.lifecycle === "stale") phrases.push("Refreshing")
+  if (facts.lifecycle === "activelyGrowing") phrases.push("Session still growing")
+  if (facts.lifecycle === "unavailable" || facts.refreshFailed) {
+    phrases.push("Refresh unavailable")
+  }
+  if (!facts.evidenceComplete) phrases.push("Evidence incomplete")
+  return [...new Set(phrases)]
+}
+
+function presentation(facts: PresentationFacts): BurnCheckPresentation {
+  const resultCount = facts.counts.failed + facts.counts.passed
+  const hasResults = resultCount > 0
+  const terminal = facts.lifecycle === "ready" && facts.evidenceComplete && hasResults
+  let state: BurnCheckState
+  let headline: string
+
+  if (terminal && facts.counts.failed === 0) {
+    state = "allPassed"
+    headline = "All Burn Checks passed"
+  } else if (terminal && facts.counts.passed === 0) {
+    state = "allFailed"
+    headline = "All Burn Checks failed"
+  } else if (terminal) {
+    state = "mixed"
+    headline = "Some Burn Checks failed"
+  } else if (hasResults && facts.counts.failed === 0) {
+    state = "assessedPassed"
+    headline = "All assessed Burn Checks passed"
+  } else if (hasResults) {
+    state = "incomplete"
+    headline = "Burn Checks incomplete"
+  } else {
+    ;({ state, headline } = lifecycleState(facts.lifecycle))
+  }
+
+  const compact = hasResults
+    ? compactPhrases(facts.counts)
+    : [{ outcome: "status" as const, text: headline }]
+  const breakdown = breakdownPhrases(facts.counts)
+  const context = contextPhrases(facts, hasResults)
+  const total = facts.counts.failed + facts.counts.passed + facts.counts.unassessed
+  const scopeDescription =
+    total === 0
+      ? null
+      : facts.scope === "sessionChecks"
+        ? `${total} session ${total === 1 ? "check" : "checks"}`
+        : `${total} report ${total === 1 ? "category" : "categories"}`
+  const details = [
+    scopeDescription,
+    breakdown.length > 0 ? breakdown.map((phrase) => phrase.text).join(", ") : null,
+    ...context,
+  ].filter((detail): detail is string => detail !== null)
+  const accessibleDescription =
+    details.length === 0 ? headline : `${headline}. ${details.join(". ")}.`
+
+  return {
+    ...facts,
+    state,
+    headline,
+    headlineTone:
+      state === "allFailed" || state === "mixed" || facts.counts.failed > 0
+        ? "failure"
+        : "neutral",
+    compactPhrases: compact,
+    breakdownPhrases: breakdown,
+    contextPhrases: context,
+    accessibleDescription,
+    indicator: indicatorFor(state, facts.counts),
+  }
+}
+
+function sessionLifecycle(state: SessionHygieneEvidenceState): BurnCheckLifecycle {
+  return state === "failed" ? "unavailable" : state
+}
+
+export function sessionBurnCheckPresentation(
+  checks: readonly Pick<SessionHygieneCheck, "status">[],
+  evidenceState: SessionHygieneEvidenceState,
+): BurnCheckPresentation {
+  const counts = checks.reduce<BurnCheckCounts>(
+    (result, check) => {
+      if (check.status === "finding") result.failed += 1
+      else if (check.status === "clean") result.passed += 1
+      else result.unassessed += 1
+      return result
+    },
+    { failed: 0, passed: 0, unassessed: 0 },
+  )
+  return presentation({
+    scope: "sessionChecks",
+    counts,
+    evidenceComplete: evidenceState === "ready" && counts.unassessed === 0,
+    lifecycle: sessionLifecycle(evidenceState),
+    refreshFailed: evidenceState === "failed" && counts.failed + counts.passed > 0,
+  })
+}
+
+export function aggregateBurnCheckPresentation(
+  report: ChecksReportPayload,
+  refreshFailed = false,
+): BurnCheckPresentation {
+  const counts = report.categories.reduce<BurnCheckCounts>(
+    (result, category) => {
+      if (category.finding > 0) result.failed += 1
+      else if (category.clean > 0) result.passed += 1
+      else result.unassessed += 1
+      return result
+    },
+    { failed: 0, passed: 0, unassessed: 0 },
+  )
+  const evidenceComplete =
+    report.evidenceSettled && report.categories.every((category) => category.unavailable === 0)
+  return presentation({
+    scope: "reportCategories",
+    counts,
+    evidenceComplete,
+    lifecycle: report.evidenceSettled ? "ready" : "processing",
+    refreshFailed,
+  })
+}
+
+export function emptyBurnCheckPresentation(
+  lifecycle: "pending" | "unavailable",
+): BurnCheckPresentation {
+  return presentation({
+    scope: "reportCategories",
+    counts: { failed: 0, passed: 0, unassessed: 0 },
+    evidenceComplete: false,
+    lifecycle,
+    refreshFailed: false,
+  })
+}

--- a/apps/desktop/src/lib/presentation/checks.ts
+++ b/apps/desktop/src/lib/presentation/checks.ts
@@ -3,6 +3,7 @@ import type {
   ChecksCategoryPayload,
   ChecksReportPayload,
 } from "../insightsIpc"
+import { aggregateBurnCheckPresentation, type BurnCheckPresentation } from "./burnChecks"
 
 export const CHECK_LABELS: Record<BurnCheckDetectorId, string> = {
   sessionsOverDepth: "Session overdepth",
@@ -25,6 +26,7 @@ export interface ChecksPresentation {
   wins: ChecksCategoryPayload[]
   unavailable: ChecksCategoryPayload[]
   refreshUnavailable: boolean
+  burnChecks: BurnCheckPresentation
   estimate: ChecksEstimate
 }
 
@@ -52,6 +54,7 @@ export function checksPresentation(
       (category) => category.finding === 0 && category.clean === 0,
     ),
     refreshUnavailable,
+    burnChecks: aggregateBurnCheckPresentation(report, refreshUnavailable),
     estimate: {
       tokenBurnBasisPoints: report.estimatedTokenBurnBasisPoints,
     },

--- a/apps/desktop/src/lib/presentation/sessionHygiene.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.ts
@@ -295,21 +295,6 @@ export function sessionHygieneStateLabel(state: SessionHygieneEvidenceState): st
   }
 }
 
-/** True while the engine still works and the verdict can change on its own. */
-export function sessionHygieneStateIsTransient(state: SessionHygieneEvidenceState): boolean {
-  switch (state) {
-    case "pending":
-    case "processing":
-    case "stale":
-    case "activelyGrowing":
-      return true
-    case "unsupported":
-    case "failed":
-    case "ready":
-      return false
-  }
-}
-
 /** Reader wording for why one check was not assessed. */
 export function notAssessedReasonLabel(reason: InsightsNotAssessedReason): string {
   switch (reason) {

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -12,6 +12,8 @@ body,
   line-height: 1.4;
   font-optical-sizing: auto;
   text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   /* Transparent by default so a window that opts into translucent material
      shows it. A window that wants an opaque surface paints one itself. */
   background: transparent;

--- a/apps/desktop/src/styles/platform-controls.css
+++ b/apps/desktop/src/styles/platform-controls.css
@@ -133,7 +133,7 @@
 
 /* --- Tooltip --- */
 .ui-tooltip {
-  padding: 3px 7px;
+  padding: 8px;
   font-size: 12px;
   line-height: 1.4;
   max-width: 250px;
@@ -146,7 +146,7 @@
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 0.5px solid var(--color-border);
-  border-radius: 3px;
+  border-radius: var(--radius-control);
   box-shadow:
     0 2px 8px rgb(0 0 0 / 0.12),
     0 0.5px 2px rgb(0 0 0 / 0.06);

--- a/apps/desktop/src/styles/session-rows.css
+++ b/apps/desktop/src/styles/session-rows.css
@@ -1,4 +1,104 @@
-/* These styles show active sessions with a title shimmer. */
+/* Session rows change fill without scaling the thin Burn Check geometry. */
+.session-card {
+  transition-property: background-color;
+  transition-duration: var(--duration-fast);
+  transition-timing-function: ease-out;
+}
+
+.session-card:active {
+  opacity: 1;
+  transform: none;
+}
+
+/* Crossfade context without changing the card geometry. */
+.session-vendor-watermark,
+.session-trailing-metadata {
+  transition-property: opacity;
+  transition-duration: var(--duration-medium);
+  transition-timing-function: linear;
+}
+
+/* Keep repeated vendor identity behind the card content in both themes. */
+.session-vendor-watermark {
+  opacity: 0.05;
+}
+
+.session-trailing-metadata {
+  opacity: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .session-vendor-watermark {
+    opacity: 0.06;
+  }
+}
+
+:root[data-theme="light"] .session-vendor-watermark {
+  opacity: 0.05;
+}
+
+:root[data-theme="dark"] .session-vendor-watermark {
+  opacity: 0.06;
+}
+
+.session-card:hover .session-vendor-watermark,
+.session-card:has([data-state*="open"]) .session-vendor-watermark {
+  opacity: 0;
+  transition-delay: var(--duration-fast);
+}
+
+.session-card:hover .session-trailing-metadata,
+.session-card:has([data-state*="open"]) .session-trailing-metadata {
+  opacity: 1;
+  transition-delay: var(--duration-fast);
+}
+
+/* The radial Antigravity mark has more optical weight than the other marks. */
+.session-vendor-watermark [data-agent-icon="antigravity"] {
+  scale: 0.9;
+}
+
+/* A long title stays compact until the pointer rests on its session card. */
+.session-title-scroll {
+  position: relative;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.session-title-scroll-rest {
+  transition-property: opacity;
+  transition-duration: var(--duration-fast);
+  transition-timing-function: ease-out;
+}
+
+.session-title-scroll-copy {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: max-content;
+  opacity: 0;
+  pointer-events: none;
+  transition-property: transform, opacity;
+  transition-duration: var(--duration-slow), var(--duration-fast);
+  transition-timing-function: ease-out, ease-out;
+}
+
+.session-title-scroll-copy::before {
+  content: attr(data-text);
+}
+
+.session-card:hover .session-title-scroll[data-truncated="true"] .session-title-scroll-rest {
+  opacity: 0;
+}
+
+.session-card:hover .session-title-scroll[data-truncated="true"] .session-title-scroll-copy {
+  opacity: 1;
+  transform: translateX(var(--truncated-text-offset));
+  transition-duration: var(--truncated-text-duration), var(--duration-fast);
+  transition-delay: var(--duration-slow), 0ms;
+  transition-timing-function: linear, ease-out;
+}
 
 .activity-row-active {
   --activity-row-shimmer-cycle: 4000ms;
@@ -97,6 +197,14 @@
    It keeps its resting meaning: the title drops the overlay and paints as
    plain primary text rather than staying at the dimmed shimmer base. */
 @media (prefers-reduced-motion: reduce) {
+  .session-title-scroll-rest {
+    opacity: 1 !important;
+  }
+
+  .session-title-scroll-copy {
+    display: none;
+  }
+
   .activity-row-title-shimmer {
     color: var(--color-text-primary);
   }

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -25,6 +25,8 @@
   --color-surface-secondary: var(--color-bg-secondary);
   --color-surface-tertiary: var(--color-bg-tertiary);
   --color-surface-card: var(--color-bg-card);
+  --color-stats-edge: var(--color-stats-edge-val);
+  --color-session-card: var(--color-bg-session-card);
   /* The quiet band at the head of the menu-bar popover. Fainter than a
      card, so the spend summary reads as the header and not as a row. */
   --color-surface-header: var(--color-bg-header);
@@ -104,6 +106,13 @@
      see lib/agentIcon.tsx. */
   --color-agent-mark: var(--color-agent-mark-val);
 
+  /* Burn Check outcomes use a feature-specific palette. They do not replace
+     native accents or the broader status palette. */
+  --color-burn-check-failure-fill: var(--color-burn-check-failure-fill-val);
+  --color-burn-check-failure-text: var(--color-burn-check-failure-text-val);
+  --color-burn-check-pass-fill: var(--color-burn-check-pass-fill-val);
+  --color-burn-check-neutral: var(--color-burn-check-neutral-val);
+
   /* Session-analysis chart tokens are theme-adaptive too and live in
    * ./session-analysis-colors.css. */
 
@@ -115,6 +124,7 @@
   /* The design contract's shadow.raised, for a segment or thumb that sits on
      a recessed track. Consume as `shadow-raised`. */
   --shadow-raised: 0 1px 2px rgb(0 0 0 / 0.15), 0 0 0 0.5px rgb(0 0 0 / 0.04);
+  --shadow-stats-card: inset 0 0 0 1px var(--color-stats-edge);
 
   /* A strong ease-out for a control that must feel like it settles rather than
      stops. Tailwind registers `--ease-*`, so this becomes `ease-out-quart`.
@@ -133,6 +143,8 @@
   --color-bg-row-hover: hsl(0 0% 0% / 0.04);
 
   --color-bg-card: hsl(0 0% 0% / 0.04);
+  --color-stats-edge-val: hsl(0 0% 0% / 0.04);
+  --color-bg-session-card: hsl(0 0% 0% / 0.02);
 
   --color-bg-header: hsl(0 0% 0% / 0.025);
   /* Raised fill for text inputs/textareas. Light mode = whiter than surface;
@@ -192,6 +204,12 @@
   /* Brand-mark ink */
   --color-agent-mark-val: hsl(52 11% 13.3%);
 
+  /* Burn Checks */
+  --color-burn-check-failure-fill-val: hsl(17.6 100% 58.6%);
+  --color-burn-check-failure-text-val: hsl(18 100% 36.4%);
+  --color-burn-check-pass-fill-val: hsl(191.5 83% 36.8%);
+  --color-burn-check-neutral-val: hsl(209 6% 73.7%);
+
   /* Spacing rhythm (multiples of 4) */
   --space-xs: 4px;
   --space-sm: 8px;
@@ -213,6 +231,7 @@
      Animation timings stay with the keyframes that own them in motion.css. */
   --duration-quick: 100ms;
   --duration-fast: 120ms;
+  --duration-medium: 180ms;
   --duration-slow: 300ms;
 
   /* Source-list / sidebar width for multi-pane windows. Geometry vars are not
@@ -257,6 +276,8 @@
     --color-bg-tertiary: hsl(0 0% 100% / 0.18);
     --color-bg-row-hover: hsl(0 0% 100% / 0.07);
     --color-bg-card: hsl(0 0% 100% / 0.08);
+    --color-stats-edge-val: hsl(0 0% 100% / 0.05);
+    --color-bg-session-card: hsl(0 0% 100% / 0.03);
     --color-bg-header: hsl(0 0% 100% / 0.03);
     --color-bg-input: hsl(0 0% 100% / 0.08);
     --color-bg-window: hsl(0 0% 15.6% / 0.8);
@@ -291,6 +312,10 @@
     --color-shimmer-val: hsl(0 0% 100%);
     --color-system-gold-text-val: hsl(43.5 88% 66%);
     --color-agent-mark-val: hsl(60 15% 96.2%);
+    --color-burn-check-failure-fill-val: hsl(17.6 100% 58.6%);
+    --color-burn-check-failure-text-val: hsl(18 100% 68%);
+    --color-burn-check-pass-fill-val: hsl(192 63% 47.6%);
+    --color-burn-check-neutral-val: hsl(210 3% 50.5%);
     /* The system tertiary label is ~25% opacity in dark mode; bump to 62%,
        where small text reaches 4.5:1 on a card (same rationale as light
        mode). The hard case is again the popover: the surface is translucent,
@@ -312,6 +337,7 @@
 
 /* --- Explicit theme override, for platforms with no live system tokens --- */
 :root[data-theme="light"] {
+  --color-stats-edge-val: hsl(0 0% 0% / 0.04);
   --color-bg-primary: hsl(0 0% 100% / 0.85);
   --color-bg-secondary: hsl(0 0% 0% / 0.08);
   --color-bg-tertiary: hsl(0 0% 0% / 0.12);
@@ -319,6 +345,7 @@
      bg-selected at 0.09, so the two states looked the same. */
   --color-bg-row-hover: hsl(0 0% 0% / 0.04);
   --color-bg-card: hsl(0 0% 0% / 0.04);
+  --color-bg-session-card: hsl(0 0% 0% / 0.02);
   --color-bg-header: hsl(0 0% 0% / 0.025);
   --color-bg-input: hsl(0 0% 100%);
   --color-bg-window: hsl(0 0% 96.4%);
@@ -353,6 +380,10 @@
   --color-shimmer-val: hsl(0 0% 100%);
   --color-system-gold-text-val: hsl(41 100% 28.6%);
   --color-agent-mark-val: hsl(52 11% 13.3%);
+  --color-burn-check-failure-fill-val: hsl(17.6 100% 58.6%);
+  --color-burn-check-failure-text-val: hsl(18 100% 36.4%);
+  --color-burn-check-pass-fill-val: hsl(191.5 83% 36.8%);
+  --color-burn-check-neutral-val: hsl(209 6% 73.7%);
 }
 
 @media (prefers-reduced-transparency: reduce) and (prefers-color-scheme: light) {
@@ -376,11 +407,13 @@
 }
 
 :root[data-theme="dark"] {
+  --color-stats-edge-val: hsl(0 0% 100% / 0.05);
   --color-bg-primary: hsl(0 0% 11.7% / 0.92);
   --color-bg-secondary: hsl(0 0% 100% / 0.12);
   --color-bg-tertiary: hsl(0 0% 100% / 0.18);
   --color-bg-row-hover: hsl(0 0% 100% / 0.04);
   --color-bg-card: hsl(0 0% 100% / 0.08);
+  --color-bg-session-card: hsl(0 0% 100% / 0.03);
   --color-bg-header: hsl(0 0% 100% / 0.03);
   --color-bg-input: hsl(240 1.6% 23%);
   --color-bg-window: hsl(0 0% 12.5%);
@@ -415,6 +448,10 @@
   --color-shimmer-val: hsl(0 0% 100%);
   --color-system-gold-text-val: hsl(43.5 88% 66%);
   --color-agent-mark-val: hsl(60 15% 96.2%);
+  --color-burn-check-failure-fill-val: hsl(17.6 100% 58.6%);
+  --color-burn-check-failure-text-val: hsl(18 100% 68%);
+  --color-burn-check-pass-fill-val: hsl(192 63% 47.6%);
+  --color-burn-check-neutral-val: hsl(210 3% 50.5%);
 }
 
 /* Must follow the :root[data-theme="dark"] block above — media queries add no

--- a/apps/desktop/src/styles/typography.css
+++ b/apps/desktop/src/styles/typography.css
@@ -77,6 +77,13 @@
   letter-spacing: 0.06px;
 }
 
+/* Use this step only for transient metadata in a constrained list row. */
+.type-metadata {
+  font-size: 10.5px;
+  font-weight: 400;
+  letter-spacing: 0.08px;
+}
+
 /* Limit the text to the selected number of lines. */
 .truncated-text-lines {
   display: -webkit-box;

--- a/apps/desktop/src/views/PopoverPeekView.test.tsx
+++ b/apps/desktop/src/views/PopoverPeekView.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { PopoverPeekData } from "../lib/popoverPeekIpc"
+import { aggregateBurnCheckPresentation } from "../lib/presentation/burnChecks"
 import { PopoverPeekView } from "./PopoverPeekView"
 
 const harness = vi.hoisted(() => ({
@@ -95,6 +96,27 @@ const CHECKS_DATA: PopoverPeekData = {
     ],
     unavailable: [],
     refreshUnavailable: false,
+    burnChecks: aggregateBurnCheckPresentation({
+      pendingEvidence: 0,
+      evidenceSettled: true,
+      estimatedTokenBurnBasisPoints: 1_625,
+      categories: [
+        {
+          id: "cacheChurn",
+          finding: 7,
+          clean: 7,
+          unavailable: 0,
+          estimatedTokenBurnBasisPoints: 1_250,
+        },
+        {
+          id: "sessionsOverDepth",
+          finding: 0,
+          clean: 12,
+          unavailable: 0,
+          estimatedTokenBurnBasisPoints: 0,
+        },
+      ],
+    }),
     estimate: { tokenBurnBasisPoints: 1_625 },
   },
 }

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { PopoverView } from "./PopoverView"
@@ -529,7 +529,7 @@ describe("PopoverView", () => {
   it("opens Burn checks in the main window from the checks summary", async () => {
     render(<PopoverView />)
 
-    fireEvent.click(await screen.findByRole("button", { name: /Burn checks/ }))
+    fireEvent.click(await screen.findByRole("button", { name: /Burn Checks/i }))
 
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("open_main_window_section", {
@@ -573,7 +573,7 @@ describe("PopoverView", () => {
       modelRuns: [{ model: "claude-fable-5", thinkingMode: "high" }],
     })
 
-    expect(await screen.findByTitle("claude-fable-5/high")).toBeInTheDocument()
+    expect(await screen.findByLabelText(/Models: claude-fable-5\/high\./)).toBeInTheDocument()
     expect(
       invoke.mock.calls.filter(([command]) => command === "list_recent_sessions"),
     ).toHaveLength(listCallsBefore)
@@ -611,7 +611,7 @@ describe("PopoverView", () => {
       modelRuns: [{ model: "claude-fable-5", thinkingMode: "high" }],
     })
 
-    expect(await screen.findByTitle("claude-fable-5/high")).toBeInTheDocument()
+    expect(await screen.findByLabelText(/Models: claude-fable-5\/high\./)).toBeInTheDocument()
     // The row is rebuilt from the pushed payload alone, so its high-cost flag
     // must be recomputed against the cohort rather than defaulting to false.
     expect(screen.getByLabelText(/higher than usual/i)).toBeInTheDocument()
@@ -630,15 +630,79 @@ describe("PopoverView", () => {
     expect(screen.getByText("Wire the tray popover")).toBeInTheDocument()
   })
 
-  it("folds Usage and Checks as one measured Activity header", async () => {
+  it("folds Checks, Usage, and limits together above the session viewport", async () => {
     render(<PopoverView />)
 
     const summary = await screen.findByRole("region", { name: "Usage and spend" })
     expect(summary).not.toHaveAttribute("title")
     const foldTarget = summary.parentElement
     expect(foldTarget).toContainElement(screen.getByTestId("usage-limits-bar"))
-    expect(foldTarget).toContainElement(screen.getByRole("button", { name: /Burn checks/ }))
+    const checksTrigger = screen
+      .getByTestId("burn-check-headline")
+      .closest<HTMLElement>("button")
+    const checksOverview = screen.getByTestId("checks-summary-overview")
+    expect(foldTarget).toContainElement(checksTrigger)
+    expect(checksOverview).toContainElement(checksTrigger)
+    expect(checksOverview).toHaveClass(
+      "shrink-0",
+      "px-[var(--space-sm)]",
+      "pt-[var(--space-md)]",
+    )
+    expect(checksOverview).not.toHaveClass("pb-3")
+    expect(checksOverview.nextElementSibling).toBe(summary)
+    expect(checksOverview.compareDocumentPosition(summary)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+    expect(foldTarget?.lastElementChild).toHaveClass("mx-3", "border-b", "border-separator")
+    const sessionViewport = foldTarget?.parentElement?.nextElementSibling
+    expect(sessionViewport).not.toHaveClass("[&>section]:pt-1")
+    expect(checksOverview.compareDocumentPosition(sessionViewport!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
     expect(foldTarget?.parentElement?.children).toHaveLength(1)
+  })
+
+  it("keeps Checks first when the provider row is absent", async () => {
+    const emptyLiveUsage = {
+      ...LIVE_USAGE,
+      providers: [],
+      errors: [],
+      meters: [],
+    }
+    mockCommands({
+      get_live_usage: emptyLiveUsage,
+      refresh_live_usage: emptyLiveUsage,
+    })
+    render(<PopoverView />)
+
+    await screen.findByTestId("burn-check-headline")
+    const checksOverview = screen.getByTestId("checks-summary-overview")
+    expect(checksOverview).toHaveClass("pt-[var(--space-md)]")
+    expect(checksOverview.nextElementSibling).toHaveAccessibleName("Usage and spend")
+  })
+
+  it("keeps loading and unavailable Checks states in the overview", async () => {
+    let resolveReport: ((report: typeof CHECKS_REPORT) => void) | null = null
+    const report = new Promise<typeof CHECKS_REPORT>((resolve) => {
+      resolveReport = resolve
+    })
+    mockCommands({ get_checks_report: report })
+    const view = render(<PopoverView />)
+
+    const loadingOverview = screen.getByTestId("checks-summary-overview")
+    expect(
+      await within(loadingOverview).findAllByText("Running Burn Checks…"),
+    ).not.toHaveLength(0)
+
+    view.unmount()
+    mockCommands({ get_checks_report: new Error("report unavailable") })
+    render(<PopoverView />)
+
+    const unavailableOverview = screen.getByTestId("checks-summary-overview")
+    expect(
+      await within(unavailableOverview).findAllByText("Burn Checks unavailable"),
+    ).not.toHaveLength(0)
+    resolveReport!(CHECKS_REPORT)
   })
 
   it("shows the API pricing caveat when a live account reports a subscription", async () => {
@@ -697,8 +761,8 @@ describe("PopoverView", () => {
   it("shows Checks in one passive anchored preview", async () => {
     render(<PopoverView />)
 
-    await screen.findByText("1 check failed")
-    const trigger = await screen.findByRole("button", { name: /Burn checks/ })
+    await screen.findByText("1 failed")
+    const trigger = (await screen.findByTestId("burn-check-headline")).closest("button")!
     fireEvent.mouseEnter(trigger)
 
     expect(screen.queryByRole("heading", { name: "Checks" })).not.toBeInTheDocument()
@@ -722,8 +786,8 @@ describe("PopoverView", () => {
 
   it("conceals the Checks preview when the Activity list scrolls", async () => {
     render(<PopoverView />)
-    await screen.findByText("1 check failed")
-    fireEvent.mouseEnter(await screen.findByRole("button", { name: /Burn checks/ }))
+    await screen.findByText("1 failed")
+    fireEvent.mouseEnter((await screen.findByTestId("burn-check-headline")).closest("button")!)
 
     const viewport = screen
       .getByRole("region", { name: "Sessions" })
@@ -756,12 +820,12 @@ describe("PopoverView", () => {
     resolveFirst!(CHECKS_REPORT)
 
     await waitFor(() => expect(checksCalls).toBe(2))
-    expect(await screen.findByText("1 check failed")).toBeInTheDocument()
+    expect(await screen.findByText("1 failed")).toBeInTheDocument()
   })
 
   it("keeps an anchored preview open when Checks refreshes in the background", async () => {
     render(<PopoverView />)
-    await screen.findByText("1 check failed")
+    await screen.findByText("1 failed")
     const trigger = await screen.findByRole("img", { name: "Codex at 40 percent" })
     fireEvent.mouseEnter(trigger)
     await waitFor(() =>
@@ -802,14 +866,14 @@ describe("PopoverView", () => {
     await waitFor(() =>
       expect(invoke.mock.calls.some(([command]) => command === "get_checks_report")).toBe(true),
     )
-    expect(await screen.findByText("1 check failed")).toBeInTheDocument()
+    expect(await screen.findByText("1 failed")).toBeInTheDocument()
 
     emit("scan:finished", SCAN_STATUS)
-    await waitFor(() => expect(screen.getByText("1 check failed")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("1 failed")).toBeInTheDocument())
 
     settled = true
     emit("checks:report-changed", null)
-    expect(await screen.findByText("1 check failed")).toBeInTheDocument()
+    expect(await screen.findByText("1 failed")).toBeInTheDocument()
   })
 
   it("keeps the verdict stable while new evidence is still processing", async () => {
@@ -822,13 +886,13 @@ describe("PopoverView", () => {
       return original(command, args)
     })
     render(<PopoverView />)
-    await screen.findByText("1 check failed")
+    await screen.findByText("1 failed")
 
     settled = false
     emit("scan:finished", SCAN_STATUS)
 
-    expect(await screen.findByText("1 check failed")).toBeInTheDocument()
-    expect(screen.queryByText("Checking local sessions…")).not.toBeInTheDocument()
+    expect(await screen.findByText("1 failed")).toBeInTheDocument()
+    expect(screen.getByText("Running")).toBeInTheDocument()
   })
 
   it("marks a retained verdict when a later Checks request fails", async () => {
@@ -843,18 +907,18 @@ describe("PopoverView", () => {
       return original(command, args)
     })
     render(<PopoverView />)
-    expect(await screen.findByText("1 check failed")).toBeInTheDocument()
+    expect(await screen.findByText("1 failed")).toBeInTheDocument()
 
     fail = true
     emit("checks:report-changed", null)
 
-    expect(await screen.findByText(/1 check failed · refresh unavailable/)).toBeInTheDocument()
+    expect(await screen.findByText("Refresh unavailable")).toBeInTheDocument()
     expect(screen.queryByText(/refreshing/i)).not.toBeInTheDocument()
   })
 
   it("refreshes after a settled scan that queues no evidence work", async () => {
     render(<PopoverView />)
-    await screen.findByText("1 check failed")
+    await screen.findByText("1 failed")
     const callsBefore = invoke.mock.calls.filter(
       ([command]) => command === "get_checks_report",
     ).length
@@ -871,7 +935,7 @@ describe("PopoverView", () => {
 
   it("cancels Checks work when the popover session stops", async () => {
     const view = render(<PopoverView />)
-    await screen.findByText("1 check failed")
+    await screen.findByText("1 failed")
 
     view.unmount()
 
@@ -882,13 +946,13 @@ describe("PopoverView", () => {
 
   it("uses a new Checks consumer ID when the popover session restarts", async () => {
     const firstView = render(<PopoverView />)
-    await screen.findByText("1 check failed")
+    await screen.findByText("1 failed")
     const firstId = invoke.mock.calls.find(([command]) => command === "get_checks_report")?.[1]
       ?.consumerId
     firstView.unmount()
 
     const secondView = render(<PopoverView />)
-    await screen.findByText("1 check failed")
+    await screen.findByText("1 failed")
     const ids = invoke.mock.calls
       .filter(([command]) => command === "get_checks_report")
       .map(([, args]) => args.consumerId)
@@ -971,41 +1035,15 @@ describe("PopoverView", () => {
     })
   })
 
-  it("shows the app version beside the title", async () => {
-    render(<PopoverView />)
-    await screen.findByTestId("usage-limits-bar")
-
-    const footer = screen.getByRole("button", { name: "Open settings" }).parentElement
-    expect(footer).not.toBeNull()
-    expect(footer).toHaveTextContent("antiburn")
-    expect(footer?.querySelector('[data-testid="usage-limits-bar"]')).toBeNull()
-    const nameAndVersion = screen.getByRole("button", { name: "antiburn v0.1.0 debug" })
-    expect(nameAndVersion).toHaveClass("type-caption", "text-label-secondary")
-  })
-
-  it("opens the GitHub repo when the name and version are clicked", async () => {
-    render(<PopoverView />)
-    await screen.findByTestId("usage-limits-bar")
-
-    fireEvent.click(screen.getByRole("button", { name: "antiburn v0.1.0 debug" }))
-
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith("open_github_repo"))
-  })
-
-  it("omits the debug label from a release build", async () => {
-    mockCommands({ app_info: { appVersion: "0.1.0", debugBuild: false } })
+  it("omits the legacy footer and keeps a programmatic activity heading", async () => {
     render(<PopoverView />)
 
-    expect(await screen.findByRole("button", { name: "antiburn v0.1.0" })).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "antiburn v0.1.0 debug" })).toBeNull()
-  })
-
-  it("omits the version when app info cannot load", async () => {
-    mockCommands({ app_info: new Error("unavailable") })
-    render(<PopoverView />)
-
-    await screen.findByTestId("usage-limits-bar")
-    expect(screen.queryByText(/^v\d/)).toBeNull()
+    const heading = await screen.findByRole("heading", { name: "Activity" })
+    expect(heading).toHaveClass("sr-only")
+    expect(heading).toHaveFocus()
+    expect(screen.queryByRole("button", { name: "Open settings" })).not.toBeInTheDocument()
+    expect(screen.queryByText(/antiburn v0\.1\.0/)).not.toBeInTheDocument()
+    expect(invoke).not.toHaveBeenCalledWith("app_info")
   })
 
   it("still shows a live-only pill on a fresh day with zero local spend anywhere", async () => {
@@ -1029,8 +1067,7 @@ describe("PopoverView", () => {
 
     await screen.findByText("Wire the tray popover")
     expect(screen.queryByTestId("usage-limits-bar")).not.toBeInTheDocument()
-    // The plain footer is unaffected — it never depended on usage at all.
-    expect(screen.getByRole("button", { name: "antiburn v0.1.0 debug" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Open settings" })).not.toBeInTheDocument()
   })
 
   it("persists the usage-limits toggle through set_settings, and opens the meters", async () => {

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState, useSyncExternalStore } from "react"
 
-import { AlertTriangle, Settings } from "lucide-react"
+import { AlertTriangle } from "lucide-react"
 import type { VirtualItem } from "@tanstack/react-virtual"
 
 import { SessionList } from "../components/session/SessionList"
@@ -19,7 +19,6 @@ import {
   noteInteraction,
   openMainWindowSection,
   openMainWindowSession,
-  openGithubRepo,
   openSettingsWindow,
 } from "../lib/ipc"
 import {
@@ -100,47 +99,6 @@ function ActivitySkeleton() {
           <Skeleton className="h-3 w-28" />
         </div>
       ))}
-    </div>
-  )
-}
-
-/**
- * The activity surface's bottom bar shows the app name and version.
- * The name also carries the surface's focus heading, and opens the
- * project's GitHub repository when clicked.
- * The settings control opens the standalone Settings window.
- */
-function PopoverFooter({
-  appVersion,
-  debugBuild,
-  onOpenSettings,
-}: {
-  appVersion: string | null
-  debugBuild: boolean
-  onOpenSettings: () => void
-}) {
-  const versionLabel = appVersion ? ` v${appVersion}${debugBuild ? " debug" : ""}` : ""
-
-  return (
-    <div className="flex h-11 shrink-0 items-center gap-2 border-t border-separator px-4">
-      {/* Focused by the popover when this surface takes over, so a keyboard
-          or screen-reader user lands in the view rather than on <body>. */}
-      <button
-        type="button"
-        data-view-heading
-        onClick={() => void openGithubRepo()}
-        className="type-caption whitespace-nowrap text-label-secondary outline-none hover:underline"
-      >
-        antiburn{versionLabel}
-      </button>
-      <button
-        type="button"
-        onClick={onOpenSettings}
-        aria-label="Open settings"
-        className="-mr-0.5 ml-auto inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-control text-label-secondary hover:bg-surface-hover"
-      >
-        <Settings size={14} strokeWidth={1.75} aria-hidden="true" />
-      </button>
     </div>
   )
 }
@@ -241,16 +199,40 @@ export function PopoverView() {
             step with the list scroll. */}
         <div ref={activityHeaderWrap} className="shrink-0 overflow-hidden">
           <div>
+            <div
+              data-testid="checks-summary-overview"
+              className="shrink-0 px-[var(--space-sm)] pt-[var(--space-md)]"
+            >
+              <ChecksSummary
+                active={
+                  peekTrigger.target?.kind === "checks" && peekTrigger.activation !== "idle"
+                }
+                presentation={checks}
+                reportUnavailable={state.checksUnavailable}
+                onPreview={(anchor) => {
+                  if (!checks) return
+                  void peekTriggers.hover({ kind: "checks" }, anchor, {
+                    kind: "checks",
+                    presentation: checks,
+                    pendingEvidence: state.checksReport?.pendingEvidence ?? 0,
+                  })
+                }}
+                onLeave={() => void peekTriggers.leave()}
+                onOpen={() => {
+                  void peekTriggers.leave()
+                  void openMainWindowSection("burnChecks")
+                }}
+              />
+            </div>
             {state.usage && (
               <UsageSpendSummary
                 totals={state.usage.totals ?? EMPTY_USAGE_WINDOWS}
-                compact
                 showApiPricingCaveat={state.liveUsage.providers.some(
                   ({ plan }) => plan !== null,
                 )}
               />
             )}
-            <div className="divide-y divide-separator border-b border-separator">
+            <div>
               <UsageLimitsBar
                 live={state.liveUsage}
                 expanded={limitsExpanded}
@@ -283,29 +265,8 @@ export function PopoverView() {
                     : null
                 }
               />
-              <div className="px-2 py-1">
-                <ChecksSummary
-                  active={
-                    peekTrigger.target?.kind === "checks" && peekTrigger.activation !== "idle"
-                  }
-                  presentation={checks}
-                  reportUnavailable={state.checksUnavailable}
-                  onPreview={(anchor) => {
-                    if (!checks) return
-                    void peekTriggers.hover({ kind: "checks" }, anchor, {
-                      kind: "checks",
-                      presentation: checks,
-                      pendingEvidence: state.checksReport?.pendingEvidence ?? 0,
-                    })
-                  }}
-                  onLeave={() => void peekTriggers.leave()}
-                  onOpen={() => {
-                    void peekTriggers.leave()
-                    void openMainWindowSection("burnChecks")
-                  }}
-                />
-              </div>
             </div>
+            <div className="mx-3 border-b border-separator" aria-hidden="true" />
           </div>
         </div>
 
@@ -349,18 +310,15 @@ export function PopoverView() {
             />
           )}
         </div>
-
-        <PopoverFooter
-          appVersion={state.appVersion}
-          debugBuild={state.debugBuild}
-          onOpenSettings={() => void openSettingsWindow()}
-        />
       </div>
     )
   }
 
   return (
     <div ref={focusHeading} className="h-full">
+      <h1 data-view-heading tabIndex={-1} className="sr-only outline-none">
+        Activity
+      </h1>
       {body()}
     </div>
   )

--- a/apps/desktop/src/views/main-window/BurnChecksView.test.tsx
+++ b/apps/desktop/src/views/main-window/BurnChecksView.test.tsx
@@ -1032,10 +1032,15 @@ describe("BurnChecksView", () => {
   })
 
   it("does not use a fallback prompt when exact targets are unavailable", async () => {
-    setup({
-      ...target,
-      promptFix: { status: "unavailable", reason: "unsupportedSourceFormat" },
-    }, false, aggregate, report)
+    setup(
+      {
+        ...target,
+        promptFix: { status: "unavailable", reason: "unsupportedSourceFormat" },
+      },
+      false,
+      aggregate,
+      report,
+    )
 
     await screen.findByText("Some sessions used an older model when a newer one was available.")
     expect(screen.queryByRole("button", { name: "Copy fix prompt" })).not.toBeInTheDocument()

--- a/apps/desktop/src/views/popover/ChecksView.test.tsx
+++ b/apps/desktop/src/views/popover/ChecksView.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import type { BurnCheckDetectorId, ChecksCategoryPayload } from "../../lib/insightsIpc"
 import type { ChecksPresentation } from "../../lib/presentation/checks"
+import { aggregateBurnCheckPresentation } from "../../lib/presentation/burnChecks"
 import { ChecksPeek, ChecksSummary } from "./ChecksView"
 
 function category(
@@ -38,6 +39,12 @@ const presentation: ChecksPresentation = {
   wins,
   unavailable: [],
   refreshUnavailable: false,
+  burnChecks: aggregateBurnCheckPresentation({
+    pendingEvidence: 0,
+    evidenceSettled: true,
+    estimatedTokenBurnBasisPoints: 1_625,
+    categories: [failure, ...wins],
+  }),
   estimate: { tokenBurnBasisPoints: 1_625 },
 }
 
@@ -54,16 +61,40 @@ describe("Checks", () => {
       />,
     )
 
-    expect(screen.getByText("16% token burn").closest(".text-system-red-text")).not.toBeNull()
+    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuetext", "16% token burn")
     expect(screen.queryByText("Last 30 days")).not.toBeInTheDocument()
-    const trigger = screen.getByRole("button", { name: /Burn checks/ })
+    const trigger = screen.getByTestId("burn-check-headline").closest("button")!
+    expect(trigger).toHaveAccessibleName(
+      `All burn checks. Last 30 days. ${presentation.burnChecks.accessibleDescription} 16% token burn.`,
+    )
     fireEvent.mouseEnter(trigger)
     fireEvent.focus(trigger)
     expect(onPreview).toHaveBeenCalledTimes(2)
     expect(onPreview).toHaveBeenLastCalledWith({ top: 0, height: 0 })
   })
 
-  it("shows the aggregate token burn estimate in the main popover", () => {
+  it("opens the main view from the summary without capturing flame interactions", () => {
+    const onOpen = vi.fn()
+    render(
+      <ChecksSummary
+        active={false}
+        presentation={presentation}
+        reportUnavailable={false}
+        onPreview={vi.fn()}
+        onLeave={vi.fn()}
+        onOpen={onOpen}
+      />,
+    )
+    const trigger = screen.getByRole("button", { name: /Burn Checks/i })
+    const meter = screen.getByRole("meter")
+    expect(trigger).not.toContainElement(meter)
+    fireEvent.click(meter)
+    expect(onOpen).not.toHaveBeenCalled()
+    fireEvent.click(trigger)
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+
+  it("shows the aggregate token burn as four flames in the main popover", () => {
     const { container } = render(
       <ChecksSummary
         active={false}
@@ -74,8 +105,119 @@ describe("Checks", () => {
       />,
     )
 
-    expect(screen.getByText("16% token burn")).toBeInTheDocument()
-    expect(container.querySelectorAll(".text-roll")).toHaveLength(1)
+    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuenow", "16.25")
+    expect(container.querySelectorAll("mask .lucide-flame")).toHaveLength(4)
+    expect(container.querySelectorAll(".text-roll")).toHaveLength(0)
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "failure")
+    expect(container.firstElementChild).toHaveClass("rounded-control", "bg-surface-card/50")
+  })
+
+  it("uses failure, pass, and neutral border tones from assessed outcomes", () => {
+    const passedCategory = category("sessionsOverDepth")
+    const passedPresentation: ChecksPresentation = {
+      failures: [],
+      wins: [passedCategory],
+      unavailable: [],
+      refreshUnavailable: false,
+      burnChecks: aggregateBurnCheckPresentation({
+        pendingEvidence: 0,
+        evidenceSettled: true,
+        estimatedTokenBurnBasisPoints: 0,
+        categories: [passedCategory],
+      }),
+      estimate: { tokenBurnBasisPoints: 0 },
+    }
+    const partialCategory = category("sessionsOverDepth", { clean: 8, unavailable: 4 })
+    const partialPresentation: ChecksPresentation = {
+      ...passedPresentation,
+      wins: [partialCategory],
+      burnChecks: aggregateBurnCheckPresentation({
+        pendingEvidence: 0,
+        evidenceSettled: true,
+        estimatedTokenBurnBasisPoints: 0,
+        categories: [partialCategory],
+      }),
+    }
+    const unassessedCategory = category("sessionsOverDepth", {
+      clean: 0,
+      unavailable: 12,
+      estimatedTokenBurnBasisPoints: null,
+    })
+    const unassessedPresentation: ChecksPresentation = {
+      failures: [],
+      wins: [],
+      unavailable: [unassessedCategory],
+      refreshUnavailable: false,
+      burnChecks: aggregateBurnCheckPresentation({
+        pendingEvidence: 0,
+        evidenceSettled: true,
+        estimatedTokenBurnBasisPoints: null,
+        categories: [unassessedCategory],
+      }),
+      estimate: { tokenBurnBasisPoints: null },
+    }
+    const props = {
+      active: false,
+      reportUnavailable: false,
+      onPreview: vi.fn(),
+      onLeave: vi.fn(),
+    }
+    const { container, rerender } = render(
+      <ChecksSummary {...props} presentation={presentation} />,
+    )
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "failure")
+
+    rerender(<ChecksSummary {...props} presentation={passedPresentation} />)
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "pass")
+
+    rerender(<ChecksSummary {...props} presentation={partialPresentation} />)
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "pass")
+
+    rerender(<ChecksSummary {...props} presentation={unassessedPresentation} />)
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "neutral")
+
+    rerender(<ChecksSummary {...props} presentation={null} />)
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "neutral")
+
+    rerender(<ChecksSummary {...props} presentation={null} reportUnavailable />)
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "neutral")
+
+    rerender(
+      <ChecksSummary
+        {...props}
+        presentation={{
+          ...presentation,
+          refreshUnavailable: true,
+          burnChecks: aggregateBurnCheckPresentation(
+            {
+              pendingEvidence: 0,
+              evidenceSettled: false,
+              estimatedTokenBurnBasisPoints: 1_625,
+              categories: [failure, ...wins],
+            },
+            true,
+          ),
+        }}
+      />,
+    )
+    expect(container.firstElementChild).toHaveAttribute("data-tone", "failure")
+  })
+
+  it("omits the flame meter when the estimate is unavailable", () => {
+    render(
+      <ChecksSummary
+        active={false}
+        presentation={{ ...presentation, estimate: { tokenBurnBasisPoints: null } }}
+        reportUnavailable={false}
+        onPreview={vi.fn()}
+        onLeave={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole("meter")).not.toBeInTheDocument()
+    expect(screen.getByTestId("burn-check-headline").closest("button")).toHaveAccessibleName(
+      `All burn checks. Last 30 days. ${presentation.burnChecks.accessibleDescription}`,
+    )
   })
 
   it("shows a positive sub-percent fallback without rounding it to zero", () => {
@@ -89,7 +231,43 @@ describe("Checks", () => {
       />,
     )
 
-    expect(screen.getByText("<1% token burn").closest(".text-system-yellow")).not.toBeNull()
+    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuetext", "<1% token burn")
+    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuenow", "0.01")
+  })
+
+  it("inspects flames without opening a competing companion", async () => {
+    const onPreview = vi.fn()
+    const onLeave = vi.fn()
+    render(
+      <ChecksSummary
+        active={false}
+        presentation={presentation}
+        reportUnavailable={false}
+        onPreview={onPreview}
+        onLeave={onLeave}
+      />,
+    )
+    const meter = screen.getByRole("meter")
+    fireEvent.mouseEnter(meter)
+    expect(onPreview).not.toHaveBeenCalled()
+    expect(onLeave).toHaveBeenCalledOnce()
+
+    fireEvent.mouseLeave(meter, {
+      relatedTarget: screen.getByTestId("burn-check-headline"),
+    })
+    expect(onPreview).toHaveBeenCalledOnce()
+
+    fireEvent.focus(meter)
+    expect(onPreview).toHaveBeenCalledOnce()
+    expect(onLeave).toHaveBeenCalledTimes(2)
+    const tooltip = await screen.findByRole("tooltip")
+    expect(within(tooltip).getByText("16% token burn")).toHaveClass(
+      "text-burn-check-failure-text",
+      "font-mono",
+      "type-callout",
+    )
+    expect(tooltip).toHaveTextContent("Estimated share of tokens spent on avoidable work.")
+    expect(tooltip).toHaveTextContent("Each full flame represents 25% token burn.")
   })
 
   it("conceals only after both hover and focus leave", () => {
@@ -104,7 +282,7 @@ describe("Checks", () => {
       />,
     )
     const summary = container.firstElementChild!
-    const trigger = screen.getByRole("button", { name: /Burn checks/ })
+    const trigger = screen.getByTestId("burn-check-headline").closest("button")!
     fireEvent.mouseEnter(summary)
     fireEvent.focus(trigger)
     fireEvent.mouseLeave(summary)
@@ -137,8 +315,9 @@ describe("Checks", () => {
         onLeave={vi.fn()}
       />,
     )
-    const summary = screen.getByRole("button", { name: /Burn checks/ })
+    const summary = screen.getByText("Running Burn Checks…").closest("[aria-busy]")
     expect(summary).toBeDisabled()
+    expect(screen.queryByRole("meter")).not.toBeInTheDocument()
   })
 
   it("ends the loading state when the report is unavailable", () => {
@@ -151,8 +330,10 @@ describe("Checks", () => {
         onLeave={vi.fn()}
       />,
     )
-    expect(screen.getByText("Checks unavailable")).toBeInTheDocument()
-    expect(screen.queryByText("Checking local sessions…")).not.toBeInTheDocument()
+    const headline = screen.getByText("Burn Checks unavailable")
+    expect(headline).toBeInTheDocument()
+    expect(headline.closest("button")).toBeDisabled()
+    expect(screen.queryByText("Running Burn Checks…")).not.toBeInTheDocument()
   })
 
   it("shows floored token burn estimates and every confirmed pass in preview mode", () => {
@@ -255,7 +436,7 @@ describe("Checks", () => {
     }
   })
 
-  it("animates changing summary and anchored token estimates", () => {
+  it("updates the flame value and retains animated estimates in the companion", () => {
     const { container, rerender } = render(
       <ChecksSummary
         active={false}
@@ -265,7 +446,7 @@ describe("Checks", () => {
         onLeave={vi.fn()}
       />,
     )
-    expect(container.querySelector(".text-roll-sr")).toHaveTextContent("16% token burn")
+    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuetext", "16% token burn")
 
     rerender(
       <ChecksSummary
@@ -276,8 +457,8 @@ describe("Checks", () => {
         onLeave={vi.fn()}
       />,
     )
-    expect(container.querySelector(".text-roll-sr")).toHaveTextContent("15% token burn")
-    expect(container.querySelectorAll(".text-roll-in").length).toBeGreaterThan(0)
+    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuetext", "15% token burn")
+    expect(container.querySelectorAll(".text-roll-in")).toHaveLength(0)
 
     rerender(
       <ChecksPeek
@@ -317,6 +498,12 @@ describe("Checks", () => {
           wins,
           unavailable: [],
           refreshUnavailable: false,
+          burnChecks: aggregateBurnCheckPresentation({
+            pendingEvidence: 0,
+            evidenceSettled: true,
+            estimatedTokenBurnBasisPoints: 0,
+            categories: wins,
+          }),
           estimate: { tokenBurnBasisPoints: 0 },
         }}
       />,
@@ -335,6 +522,12 @@ describe("Checks", () => {
           wins: [category("sessionsOverDepth", { clean: 8, unavailable: 4 })],
           unavailable: [],
           refreshUnavailable: false,
+          burnChecks: aggregateBurnCheckPresentation({
+            pendingEvidence: 0,
+            evidenceSettled: true,
+            estimatedTokenBurnBasisPoints: 0,
+            categories: [category("sessionsOverDepth", { clean: 8, unavailable: 4 })],
+          }),
           estimate: { tokenBurnBasisPoints: 0 },
         }}
       />,

--- a/apps/desktop/src/views/popover/ChecksView.tsx
+++ b/apps/desktop/src/views/popover/ChecksView.tsx
@@ -1,26 +1,25 @@
-import { CheckCircle2, CircleDashed, CircleX, Flame, LoaderCircle } from "lucide-react"
+import { CheckCircle2, CircleDashed, Flame, LoaderCircle } from "lucide-react"
 import { useRef } from "react"
 
 import { TextRoll } from "../../components/ui/TextRoll"
+import { BurnCheckSummary } from "../../components/burn-checks/BurnCheckSummary"
+import { BurnCheckFlames } from "../../components/burn-checks/BurnCheckFlames"
+import "../../components/burn-checks/burn-check-summary.css"
 import { measureAnchorRegion } from "../../lib/anchorRegion"
 import type { ChecksCategoryPayload } from "../../lib/insightsIpc"
 import {
   checksHeroPresentation,
   formatTokenBurnPercent,
-  tokenBurnTone,
   type ChecksPresentation,
 } from "../../lib/presentation/checks"
 import { checkRowPresentation } from "../checks/checkUi"
+import { emptyBurnCheckPresentation } from "../../lib/presentation/burnChecks"
 
 function summaryEstimate(presentation: ChecksPresentation): string | null {
   const basisPoints = presentation.estimate.tokenBurnBasisPoints
   return basisPoints == null || presentation.failures.length === 0
     ? null
     : `${formatTokenBurnPercent(basisPoints)} token burn`
-}
-
-function refreshFailureSuffix(presentation: ChecksPresentation): string {
-  return presentation.refreshUnavailable ? " · refresh unavailable" : ""
 }
 
 export function ChecksSummary({
@@ -38,45 +37,41 @@ export function ChecksSummary({
   onLeave: () => void
   onOpen?: () => void
 }) {
-  const failures = presentation?.failures.length ?? 0
-  const wins = presentation?.wins.length ?? 0
-  const hasFindings = failures > 0
-  const hasWins = wins > 0
-  const checksNeedingEvidence = presentation
-    ? [...presentation.failures, ...presentation.wins, ...presentation.unavailable].filter(
-        (category) => category.unavailable > 0,
-      ).length
-    : 0
-  const completePass =
-    hasWins && presentation?.unavailable.length === 0 && checksNeedingEvidence === 0
-  const StatusIcon =
-    presentation == null
-      ? CircleDashed
-      : hasFindings
-        ? CircleX
-        : completePass
-          ? CheckCircle2
-          : CircleDashed
   const estimate = presentation ? summaryEstimate(presentation) : null
+  const burnChecks =
+    presentation?.burnChecks ??
+    emptyBurnCheckPresentation(reportUnavailable ? "unavailable" : "pending")
+  const accessibleLabel = estimate
+    ? `${burnChecks.accessibleDescription} ${estimate}.`
+    : burnChecks.accessibleDescription
+  const tone =
+    burnChecks.counts.failed > 0 ? "failure" : burnChecks.counts.passed > 0 ? "pass" : "neutral"
   const hovered = useRef(false)
   const focused = useRef(false)
+  const summary = useRef<HTMLDivElement>(null)
 
   return (
     <div
+      ref={summary}
       data-state={active ? "active" : "idle"}
+      data-tone={tone}
       onMouseEnter={(event) => {
         hovered.current = true
+        if (event.target instanceof Element && event.target.closest("[data-burn-check-flames]"))
+          return
         if (presentation) onPreview(measureAnchorRegion(event.currentTarget))
       }}
       onMouseLeave={() => {
         hovered.current = false
         if (!focused.current) onLeave()
       }}
-      className="group flex items-center rounded-control hover:bg-surface-hover data-[state=active]:bg-surface-selected"
+      className="burn-check-summary-surface group flex items-center rounded-control bg-surface-card/50 hover:bg-surface-hover/35 data-[state=active]:bg-surface-selected/40"
     >
       <button
         type="button"
         disabled={!presentation}
+        data-burn-check-summary-trigger
+        aria-label={`All burn checks. Last 30 days. ${accessibleLabel}`}
         aria-busy={!presentation && !reportUnavailable}
         onClick={onOpen}
         onFocus={(event) => {
@@ -87,34 +82,32 @@ export function ChecksSummary({
           focused.current = false
           if (!hovered.current) onLeave()
         }}
-        className="grid min-w-0 flex-1 grid-cols-[16px_minmax(0,1fr)_max-content] items-center gap-x-2 rounded-control px-2 py-2 text-left disabled:opacity-100 active:transform-none active:opacity-100"
+        className="min-w-0 flex-1 rounded-control text-left disabled:opacity-100 active:transform-none active:opacity-100"
       >
-        <StatusIcon
-          size={14}
-          strokeWidth={presentation == null ? 2 : 2.5}
-          className={`shrink-0 ${hasFindings ? "text-system-red-text" : completePass ? "text-system-green" : "text-label-tertiary"}`}
-          aria-hidden="true"
-        />
-        <span className="min-w-0">
-          <span className="block type-body font-medium! text-label">Burn checks</span>
-          <span className="block truncate type-footnote text-label-secondary">
-            {presentation &&
-              (hasFindings
-                ? `${failures} check${failures === 1 ? "" : "s"} failed`
-                : hasWins
-                  ? `${wins} check${wins === 1 ? "" : "s"} passed${checksNeedingEvidence > 0 ? ` · ${checksNeedingEvidence} need evidence` : ""}`
-                  : "More evidence needed")}
-            {presentation && refreshFailureSuffix(presentation)}
-            {!presentation &&
-              (reportUnavailable ? "Checks unavailable" : "Checking local sessions…")}
-          </span>
-        </span>
-        <span
-          className={`type-footnote font-medium! tabular-nums ${presentation?.estimate.tokenBurnBasisPoints == null ? "text-label-secondary" : tokenBurnTone(presentation.estimate.tokenBurnBasisPoints)}`}
-        >
-          {presentation && estimate ? <TextRoll text={estimate} /> : null}
-        </span>
+        <BurnCheckSummary presentation={burnChecks} />
       </button>
+      {presentation && estimate && presentation.estimate.tokenBurnBasisPoints != null && (
+        <span
+          className="pr-[var(--space-md)]"
+          data-burn-check-flames
+          onMouseEnter={onLeave}
+          onMouseLeave={(event) => {
+            if (
+              summary.current &&
+              event.relatedTarget instanceof Node &&
+              summary.current.contains(event.relatedTarget) &&
+              !event.currentTarget.contains(document.activeElement)
+            )
+              onPreview(measureAnchorRegion(summary.current))
+          }}
+          onFocus={(event) => {
+            event.stopPropagation()
+            onLeave()
+          }}
+        >
+          <BurnCheckFlames basisPoints={presentation.estimate.tokenBurnBasisPoints} />
+        </span>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/views/popover/PopoverPeekController.test.ts
+++ b/apps/desktop/src/views/popover/PopoverPeekController.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { PopoverPeekData } from "../../lib/popoverPeekIpc"
+import { emptyBurnCheckPresentation } from "../../lib/presentation/burnChecks"
 import { PopoverPeekController } from "./PopoverPeekController"
 
 const analytics = vi.hoisted(() => ({
@@ -67,6 +68,7 @@ function checksData(): PopoverPeekData {
       unavailable: [],
       refreshUnavailable: false,
       estimate: { tokenBurnBasisPoints: null },
+      burnChecks: emptyBurnCheckPresentation("pending"),
     },
   }
 }

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -7,7 +7,6 @@ import {
   EMPTY_LIVE_USAGE,
   EMPTY_PROVIDER_USAGE,
   EMPTY_SESSION_LIMIT_ALLOCATIONS,
-  appInfo,
   getLiveUsage,
   getProviderUsage,
   getSessionLimitAllocations,
@@ -66,8 +65,6 @@ import type { LocalRepositoryItem, LocalRepositoryStatus } from "../../lib/types
  */
 
 export interface PopoverSnapshot {
-  appVersion: string | null
-  debugBuild: boolean
   settings: AppSettings | null
   entries: SessionListEntry[] | null
   /** True when the initial activity-list read failed. */
@@ -237,8 +234,6 @@ export class PopoverSession {
   private stopLiveUsageListening: (() => void) | null = null
 
   private snapshot: PopoverSnapshot = {
-    appVersion: null,
-    debugBuild: false,
     settings: null,
     entries: null,
     entriesUnavailable: false,
@@ -377,16 +372,13 @@ export class PopoverSession {
   // the stored time window. The cached limits do not wait for either read.
   private loadInitial = async (generation: number): Promise<void> => {
     const usage = this.loadCachedUsage(generation)
-    const [stored, health, info] = await Promise.all([
+    const [stored, health] = await Promise.all([
       getSettings().catch(() => DEFAULT_SETTINGS),
       getStorageHealth().catch(() => HEALTHY_STORAGE),
-      appInfo().catch(() => null),
     ])
     if (generation !== this.generation) return
     applyTheme(stored.theme)
     this.update({
-      appVersion: info?.appVersion ?? null,
-      debugBuild: info?.debugBuild ?? false,
       settings: stored,
       storage: health,
     })

--- a/apps/desktop/src/views/settings/GeneralPane.tsx
+++ b/apps/desktop/src/views/settings/GeneralPane.tsx
@@ -63,10 +63,7 @@ export interface GeneralPaneProps extends AppSettingsController {
  * General preferences: how much history the popover shows, whether antiburn
  * keeps looking on its own, and how much it has accumulated.
  *
- * The monitoring toggle here and the pause control in the popover footer are
- * the same preference. That is deliberate: the footer is where a reader notices
- * background work happening, and Settings is where they go looking for the
- * switch that stops it.
+ * The monitoring toggle controls whether antiburn continues to scan in the background.
  */
 export function GeneralPane({ settings, update, info }: GeneralPaneProps) {
   const [restartingSetup, setRestartingSetup] = useState(false)

--- a/apps/desktop/tests/burn-check-boundaries.test.ts
+++ b/apps/desktop/tests/burn-check-boundaries.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { describe, expect, it } from "vitest"
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "src")
+const IMPORT_SOURCE = /from\s+["']([^"']+)["']/g
+
+function imports(relativePath: string): string[] {
+  const source = readFileSync(path.join(ROOT, relativePath), "utf8")
+  return [...source.matchAll(IMPORT_SOURCE)].map((match) => match[1]!)
+}
+
+describe("Burn Check import boundaries", () => {
+  it("keeps the generic dial independent of Burn Check and domain modules", () => {
+    expect(imports("components/ui/SegmentedRadialDial.tsx")).toEqual([])
+  })
+
+  it("keeps the presentation adapter independent of UI", () => {
+    const sources = imports("lib/presentation/burnChecks.ts")
+    expect(
+      sources.some((source) => source.includes("components") || source.includes("views")),
+    ).toBe(false)
+  })
+
+  it("keeps Burn Check components independent of IPC and window controllers", () => {
+    const directory = path.join(ROOT, "components", "burn-checks")
+    const sources = readdirSync(directory)
+      .filter((file) => /\.tsx?$/.test(file) && !/\.test\.tsx?$/.test(file))
+      .flatMap((file) => imports(path.join("components", "burn-checks", file)))
+    expect(
+      sources.filter(
+        (source) =>
+          source.toLowerCase().includes("ipc") ||
+          source.includes("/views/") ||
+          source.toLowerCase().includes("controller"),
+      ),
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
# Refine Burn checks and session presentation

## User impact

Make the desktop overview and session list easier to scan. The overview leads with an “All burn checks” summary for the last 30 days, followed by aligned spend figures and provider limits. Session cards show consistent check outcomes, a compact model context row, and a clearer metric picker. Tooltips use more comfortable spacing and organize supporting detail into readable groups.

Reorganize the popover around an overview-to-session reading flow and remove its persistent footer, giving session activity more room.

## High-level design decisions

- **Separate identity from result.** Keep “All burn checks” stable, put outcomes on the second line, and show the recent scope as tertiary text. Preserve loading, unavailable, and incomplete-evidence details where appropriate.
- **Use shared presentation rules.** Compute check wording, counts, and indicators in a pure adapter. Keep the generic segmented dial independent of domain logic and the visual components independent of IPC and window controllers.
- **Align the overview surfaces.** Give the checks and spend cards consistent outer insets and inner padding. Use semantic tokens, a subdued state-colored edge, and a semibold summary heading.
- **Distinguish count from magnitude.** Use segmented indicators for check outcomes and a flame meter for estimated token burn, with each full flame representing an equal share. Keep the exact estimate accessible and available in a tooltip. The meter is a separate focus target from the summary navigation button.
- **Keep session cards compact.** Separate the verdict, session identity, and supporting context so each can be scanned independently.
- **Simplify navigation and chrome.** Share a Cost / weekly percentage / short-window percentage toolbar, preserve main-window opening and anchored previews, and remove the persistent popover footer to give the list more space. Keep an accessible Activity heading for focus restoration.

## Popover information architecture

- **Lead with the overall result.** Move Burn checks above spend and provider limits so the popover first answers how the checks look, then provides usage context, before showing the sessions behind that activity.
- **Separate overview from activity.** Group checks, spend, and provider limits in the collapsing overview area. Use a shared divider to introduce the session list, keeping the overview visually distinct from individual session cards.
- **Put comparison controls with the list.** Place the metric selector beside the current activity-group label. Its position communicates that changing the metric changes how session figures are compared, rather than changing the aggregate overview.
- **Remove the persistent footer.** Remove the app-name/version link and Settings shortcut from the bottom of the popover. Let the session list use that space and remove the need to load version metadata for this surface.
- **Preserve navigation and focus.** Keep the checks summary as the route into the main Burn checks view and retain session opening behavior. Replace the removed footer's focus target with an accessible Activity heading so focus restoration still has a meaningful destination.

## Session-card design decisions

- **Make the session recognizable.** Keep the title as the primary identifier, with the check verdict above it and model context beneath it. Use distinct typographic treatments to separate names, outcomes, and measurements.
- **Make outcomes consistent.** Reuse the same status language, marks, and semantic colors across cards and check details. Keep compact verdicts focused on assessed results while retaining evidence limitations in accessible descriptions and tooltips.
- **Reveal detail progressively.** Show the leading model and a compact indication of additional models. Group the full model identities and session source in a shared tooltip rather than expanding every card.
- **Keep secondary metadata quiet.** Reveal repository and activity details on hover, showing repository context when it helps distinguish sessions. Use subdued vendor artwork at rest and fade it as the metadata appears.
- **Preserve a stable reading layout.** Truncate long titles at rest and reveal their overflow after a deliberate hover. Keep the resting text available when reduced motion is enabled, and avoid changing card geometry during interaction.
- **Make selection distinct from hover.** Retain the selected surface while hovering or opening a tooltip. Use surface and color feedback instead of scaling the card, keeping text and fine status geometry steady.
- **Keep measurements comparable.** Align the selected cost or limit metric consistently and use tabular figures for changing values. Keep the metric selector at the list level so every card follows the same comparison mode.

## Burn checks design decisions

- **Give each outcome a recognizable mark.** Use a circled check for a pass, a circled alert for a finding, and a neutral circled minus for an unassessed check. Mixed summaries use a segmented ring to show the composition of outcomes; running states use a dashed mark. Share these marks across the session-card verdict, its tooltip, and individual check details.
- **Make color semantic and consistent.** Use warm orange for findings, cyan for passes, and neutral gray for unassessed evidence. Separate text and icon color tokens where readability requires it, with theme-specific values. Pair color with wording and shape so it is never the only explanation of a result.
- **Keep the surface quieter than the result.** Retain neutral card fills and primary heading text. Apply state color to the compact marks, outcome counts, and a restrained summary edge, with a stronger edge in increased-contrast mode.
- **Separate outcomes from evidence availability.** Use “passed” and “failed” for assessed outcomes. Use “not assessed,” “running,” “refreshing,” “awaiting session data,” “not supported,” and “unavailable” for their respective evidence states. Reserve unqualified aggregate verdicts for complete, settled results; preserve existing results with a refresh or evidence qualifier when appropriate.
- **Keep compact wording honest about its scope.** Session-card counts summarize assessed checks, while the overview counts report categories. Keep the full scope and evidence limitations in accessible descriptions and detailed explanations. The stable “All burn checks” heading names the destination rather than asserting that everything passed or finished.
- **Use flames for estimated waste, not failed-check counts.** The flame meter represents estimated token burn, while the status marks and counts represent check outcomes. A session or report can have findings with little estimated burn. Provide the exact estimate and its meaning in the tooltip and accessible value; omit the meter when the estimate is unknown.
- **Give each interaction a clear purpose.** Hover or focus on the summary reveals its companion; activating the summary opens the main Burn checks view. Inspecting the separate flame meter reveals the estimate explanation and dismisses the competing companion. Keep the meter static when its value changes.

## Tooltip design decisions

- **Give supporting detail room to breathe.** Increase the shared tooltip padding and use the standard control corner radius. Apply this treatment across the shared tooltip surface so short hints and richer explanations feel consistent.
- **Group check details by outcome.** Present failures, passes, and unassessed checks in distinct groups, with group counts and the same outcome marks used on cards. Emphasize findings while keeping passing descriptions neutral.
- **Clarify the session context.** Lead the model tooltip with the vendor mark and source name, then group complete model identifiers under a quiet label. Preserve readable model values without repeating source labels or expanding the resting card.
- **Explain the flame meter.** Lead its tooltip with the exact token-burn estimate, followed by a plain-language definition and an explanation of the scale. Keep explanatory prose secondary so the result remains easy to find.
- **Keep explanations coordinated.** Preserve the existing tooltip interaction system and keep the flame explanation separate from the anchored checks companion, avoiding competing overlays for the same pointer or focus interaction.

## Validation

- Desktop lint and TypeScript checks passed.
- All 1,444 tests across 116 test files passed.
- Production frontend build passed; the existing large-chunk advisory remains.
- Formatting for every changed desktop file and the design-drift contract passed.
- `pnpm run slop:all` and `pnpm run secrets` passed.
- Native debug build and launch succeeded earlier in the session; subsequent changes are frontend-only.
- Reviewed user-supplied light and dark screenshots. This was not a fresh native end-to-end test of every interaction.

## Analytics

This change refines existing presentation and controls. Existing metric-selection and window-navigation behavior remains in place; no analytics events, properties, or collection triggers are added. Measurement definitions are unchanged.

## Privacy and performance

No new data access, network access, persisted user data, or background polling is introduced. The removed footer no longer requests app-version metadata. Title overflow uses the existing ResizeObserver subscription, and reveal motion uses CSS transitions. The new dial and flame meter are static SVGs.

## Review

A quick local code review found no blocking issue in the reviewed diff. It covered presentation boundaries, outcome handling, tooltip/focus behavior, reduced-motion handling, and the rebase integration. Broader hierarchy refinements remain separate design proposals.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

## Screenshots
Menubar App - popover
<img width="300" alt="image" src="https://github.com/user-attachments/assets/cdad9d6a-0130-474c-9481-30df77d02035" /><img width="300" alt="image" src="https://github.com/user-attachments/assets/8fb8ec1e-b589-41aa-bd8c-2b50709bceaf" />

Desktop - Main window
<img width="1492" height="929" alt="Screenshot 2026-09-11 at 2 16 19 pm" src="https://github.com/user-attachments/assets/5a9f4bcd-616c-4670-9669-da0a44903b6d" />

<img width="1492" height="929" alt="Screenshot 2026-09-11 at 2 16 26 pm" src="https://github.com/user-attachments/assets/babf97aa-965f-4923-bd2b-e00e328e5221" />

