### PR TITLE
chore(desktop): Add subtle pace markers to usage limit dials

### DIFF
--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import type {
@@ -108,9 +108,97 @@ function filledSegments(): number {
 }
 
 describe("UsageLimitsBar — the ring row", () => {
+  const shortWindow = liveWindow({
+    usedPercent: 42,
+    startsAt: "2027-01-15T09:00:00Z",
+    resetsAt: "2027-01-15T14:00:00Z",
+  })
+  const longWindow = liveWindow({
+    id: "weekly",
+    role: "primaryLong",
+    usedPercent: 75,
+    startsAt: "2027-01-12T00:00:00Z",
+    resetsAt: "2027-01-19T00:00:00Z",
+  })
+
+  it("marks the highest-usage window for each account independently", () => {
+    bar({
+      live: liveSummary({
+        providers: [
+          liveProvider({ accountKey: "first", windows: [shortWindow, longWindow] }),
+          liveProvider({ accountKey: "second", windows: [shortWindow] }),
+        ],
+      }),
+    })
+    const first = screen.getByRole("img", {
+      name: "Claude account 1 at 75 percent. Long-term limit. Pace marker at 50 percent",
+    })
+    const second = screen.getByRole("img", {
+      name: "Claude account 2 at 42 percent. 5-hour limit. Pace marker at 60 percent",
+    })
+    expect(within(first).getByTestId("usage-ring-notch")).toHaveAttribute(
+      "transform",
+      "rotate(180 16 16)",
+    )
+    expect(within(second).getByTestId("usage-ring-notch")).toHaveAttribute(
+      "transform",
+      "rotate(216 16 16)",
+    )
+  })
+
+  it("breaks equal-usage ties in display order", () => {
+    bar({
+      live: liveSummary({
+        providers: [
+          liveProvider({ windows: [longWindow, { ...shortWindow, usedPercent: 75 }] }),
+        ],
+      }),
+    })
+    expect(screen.getByTestId("usage-ring-notch")).toHaveAttribute(
+      "transform",
+      "rotate(216 16 16)",
+    )
+  })
+
+  it("does not borrow timing when the displayed window has no reset", () => {
+    bar({
+      live: liveSummary({
+        providers: [
+          liveProvider({ windows: [shortWindow, { ...longWindow, resetsAt: null }] }),
+        ],
+      }),
+    })
+    expect(screen.queryByTestId("usage-ring-notch")).not.toBeInTheDocument()
+    expect(screen.getByRole("img")).not.toHaveAttribute("title")
+    expect(screen.getByRole("img")).toHaveAccessibleName(
+      "Claude at 75 percent. Long-term limit",
+    )
+  })
+
+  it("uses the same snapshot time for collapsed and expanded markers", () => {
+    const live = liveSummary({ providers: [liveProvider({ windows: [shortWindow] })] })
+    const { rerender } = bar({ live })
+    const dial = screen.getByRole("img", {
+      name: "Claude at 42 percent. 5-hour limit. Pace marker at 60 percent",
+    })
+    fireEvent.focus(dial)
+    const tooltip = screen.getByRole("tooltip")
+    expect(tooltip).toHaveTextContent("Claude · 5-hour limit")
+    expect(tooltip).toHaveTextContent("42% used")
+    expect(tooltip).toHaveTextContent("60% would be on pace by now")
+    expect(screen.getByTestId("usage-ring-notch")).toHaveAttribute(
+      "transform",
+      "rotate(216 16 16)",
+    )
+    rerender(
+      <UsageLimitsBar live={live} expanded onToggleExpanded={vi.fn()} refreshing={false} />,
+    )
+    expect(screen.getByTestId("segmented-meter-notch")).toHaveStyle({ left: "60%" })
+  })
+
   it("states each provider's worst window as an accessible percentage", () => {
     bar()
-    const dial = screen.getByRole("img", { name: "Claude at 42 percent" })
+    const dial = screen.getByRole("img", { name: "Claude at 42 percent. 5-hour limit" })
     expect(dial).toBeInTheDocument()
     expect(dial).toHaveAttribute("tabindex", "0")
     expect(dial).toHaveClass("transition-[background-color]")
@@ -118,7 +206,7 @@ describe("UsageLimitsBar — the ring row", () => {
     dial.focus()
     expect(dial).toHaveFocus()
     expect(
-      screen.queryByRole("button", { name: "Claude at 42 percent" }),
+      screen.queryByRole("button", { name: "Claude at 42 percent. 5-hour limit" }),
     ).not.toBeInTheDocument()
   })
 
@@ -127,7 +215,7 @@ describe("UsageLimitsBar — the ring row", () => {
       activeProvider: { provider: "anthropic", activation: "hovered" },
     })
 
-    const trigger = screen.getByRole("img", { name: "Claude at 42 percent" })
+    const trigger = screen.getByRole("img", { name: "Claude at 42 percent. 5-hour limit" })
     expect(trigger).toHaveAttribute("data-state", "hovered")
     expect(trigger).toHaveClass("data-[state=hovered]:bg-surface-secondary/50")
   })
@@ -144,14 +232,18 @@ describe("UsageLimitsBar — the ring row", () => {
   it("reports a refresh in flight without hiding the readings it already has", () => {
     bar({ refreshing: true })
     expect(screen.getByRole("status")).toHaveTextContent("Refreshing usage limits")
-    expect(screen.getByRole("img", { name: "Claude at 42 percent" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("img", { name: "Claude at 42 percent. 5-hour limit" }),
+    ).toBeInTheDocument()
   })
 
   it("shows the percentage beside the ring", () => {
     bar()
-    const seat = screen.getByRole("img", { name: "Claude at 42 percent" })
+    const seat = screen.getByRole("img", { name: "Claude at 42 percent. 5-hour limit" })
     expect(within(seat).getByText("42%")).toBeInTheDocument()
-    expect(seat).toHaveAttribute("title", "Claude — 42%")
+    expect(seat).not.toHaveAttribute("title")
+    fireEvent.focus(seat)
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Claude · 5-hour limit42% used")
   })
 
   it("shows a dash beside the ring when the provider states no figure", () => {
@@ -206,7 +298,9 @@ describe("UsageLimitsBar — the disclosure", () => {
 
   it("drops the ring row and moves the disclosure beside the first provider", () => {
     bar({ expanded: true })
-    expect(screen.queryByRole("img", { name: "Claude at 42 percent" })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("img", { name: "Claude at 42 percent. 5-hour limit" }),
+    ).not.toBeInTheDocument()
     const region = screen.getByRole("region", { name: "Usage limits" })
     const group = within(region).getByRole("group", { name: "Claude" })
     const providerRow = within(group).getByRole("heading").parentElement
@@ -504,8 +598,11 @@ describe("UsageLimitsBar — grace period", () => {
         errors: [sourceError()],
       }),
     })
-    const seat = screen.getByRole("img", { name: `Claude at 42 percent. ${GRACE_NOTE}` })
-    expect(seat).toHaveAttribute("title", `Claude — 42% — ${GRACE_NOTE}`)
+    const seat = screen.getByRole("img", {
+      name: `Claude at 42 percent. 5-hour limit. ${GRACE_NOTE}`,
+    })
+    fireEvent.focus(seat)
+    expect(screen.getByRole("tooltip")).toHaveTextContent(GRACE_NOTE)
     const figureWrapper = within(seat).getByText("42%").closest('span[aria-hidden="true"]')
     expect(figureWrapper).toHaveClass("text-label-tertiary")
   })

--- a/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageLimitsBar.tsx
@@ -32,6 +32,7 @@ import {
 import { providerInitial } from "../../lib/presentation/providerUsage"
 import { SegmentedMeter } from "../ui/SegmentedMeter"
 import { SegmentFigure } from "../ui/SegmentFigure"
+import { Tooltip } from "../presentation/Tooltip"
 import { providerMark } from "./ProviderUsagePrimitives"
 import { UsageRing } from "./UsageRing"
 import { useStableAccountNumbers } from "./useStableAccountNumbers"
@@ -126,6 +127,7 @@ export function UsageLimitsBar({
                 provider={reading}
                 displayName={accountDisplayName(reading, key, accountNumbers, providerCounts)}
                 status={liveProviderStatus(live, reading)}
+                now={at}
                 onHover={onHoverProvider}
                 activation={
                   activeProvider?.provider === reading.provider
@@ -317,58 +319,94 @@ function ProviderRadial({
   provider,
   displayName,
   status,
+  now,
   onHover,
   activation,
 }: {
   provider: LiveProviderUsagePayload
   displayName: string
   status: LiveProviderStatus
+  now: number
   onHover?: ((provider: string | null, anchor: AnchorRegion | null) => void) | undefined
   activation: Exclude<AnchoredTriggerActivation, "idle"> | null
 }) {
   const percent = maxLiveUsedPercent(provider)
-  const figure = percent != null ? `${Math.round(percent)}%` : "no stated figure"
+  const window =
+    percent == null
+      ? undefined
+      : liveWindows(provider).find((window) => window.usedPercent === percent)
+  const expectedFraction = window ? liveWindowElapsed(window, now) : null
+  const windowLabel = window ? liveWindowLabel(window) : null
+  const elapsedPercent = expectedFraction == null ? null : Math.round(expectedFraction * 100)
+  const roundedPercent = percent == null ? null : Math.round(percent)
+  const figure = roundedPercent == null ? "no stated figure" : `${roundedPercent}% used`
   const graceNote =
     status.kind === "grace"
       ? liveGraceNote(status.category, provider.provider, status.ageMs)
       : null
-  const title = graceNote
-    ? `${displayName} — ${figure} — ${graceNote}`
-    : `${displayName} — ${figure}`
   const baseLabel = `${displayName}${
-    percent != null ? ` at ${Math.round(percent)} percent` : ", no stated figure"
+    roundedPercent != null ? ` at ${roundedPercent} percent` : ", no stated figure"
   }`
-  const ariaLabel = graceNote ? `${baseLabel}. ${graceNote}` : baseLabel
-  return (
-    <div
-      role="img"
-      tabIndex={0}
-      onMouseEnter={(event) =>
-        onHover?.(provider.provider, measureAnchorRegion(event.currentTarget))
-      }
-      onMouseLeave={() => onHover?.(null, null)}
-      data-state={activation ?? "idle"}
-      title={title}
-      className="flex shrink-0 items-center gap-1.5 rounded-full px-[var(--space-xs)] py-1 transition-[background-color] duration-[var(--duration-fast)] hover:bg-surface-secondary/50 data-[state=hovered]:bg-surface-secondary/50 data-[state=selected]:bg-surface-selected"
-      aria-label={ariaLabel}
-    >
-      <UsageRing
-        percent={percent}
-        mark={providerMark(provider.provider)}
-        glyph={providerInitial(displayName)}
-        size={RING_SIZE}
-        className="block text-label-secondary"
-      />
-      <span
-        aria-hidden="true"
-        className={cn(
-          "type-footnote leading-none",
-          graceNote ? "text-label-tertiary" : "text-label",
-        )}
-      >
-        <SegmentFigure>{percent != null ? `${Math.round(percent)}%` : "—"}</SegmentFigure>
-      </span>
+  const ariaLabel = [
+    baseLabel,
+    windowLabel,
+    elapsedPercent == null ? null : `Pace marker at ${elapsedPercent} percent`,
+    graceNote,
+  ]
+    .filter(Boolean)
+    .join(". ")
+  const tooltip = (
+    <div className="space-y-0.5">
+      <p className="font-medium text-label">
+        {displayName}
+        {windowLabel && ` · ${windowLabel}`}
+      </p>
+      <p className="text-label">
+        <SegmentFigure>{figure}</SegmentFigure>
+      </p>
+      {elapsedPercent != null && (
+        <p className="text-label-secondary">
+          <SegmentFigure>{`${elapsedPercent}% would be on pace by now`}</SegmentFigure>
+        </p>
+      )}
+      {graceNote && <p className="text-label-secondary">{graceNote}</p>}
     </div>
+  )
+  return (
+    <Tooltip label={tooltip} side="bottom" delayMs={1000}>
+      <div
+        role="img"
+        tabIndex={0}
+        onMouseEnter={(event) =>
+          onHover?.(provider.provider, measureAnchorRegion(event.currentTarget))
+        }
+        onMouseLeave={() => onHover?.(null, null)}
+        data-state={activation ?? "idle"}
+        className="flex shrink-0 items-center gap-1.5 rounded-full px-[var(--space-xs)] py-1 transition-[background-color] duration-[var(--duration-fast)] hover:bg-surface-secondary/50 data-[state=hovered]:bg-surface-secondary/50 data-[state=selected]:bg-surface-selected"
+        aria-label={ariaLabel}
+      >
+        <UsageRing
+          percent={percent}
+          expectedFraction={expectedFraction}
+          mark={providerMark(provider.provider)}
+          glyph={providerInitial(displayName)}
+          size={RING_SIZE}
+          className="block text-label-secondary"
+        />
+        <span
+          aria-hidden="true"
+          className={cn(
+            "inline-grid type-footnote leading-none",
+            graceNote ? "text-label-tertiary" : "text-label",
+          )}
+        >
+          <SegmentFigure className="invisible col-start-1 row-start-1">100%</SegmentFigure>
+          <SegmentFigure className="col-start-1 row-start-1">
+            {roundedPercent != null ? `${roundedPercent}%` : "—"}
+          </SegmentFigure>
+        </span>
+      </div>
+    </Tooltip>
   )
 }
 

--- a/apps/desktop/src/components/providerUsage/UsageRing.test.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageRing.test.tsx
@@ -23,6 +23,45 @@ const SQUARE = {
 }
 
 describe("UsageRing", () => {
+  it.each([
+    [0, 0],
+    [0.25, 90],
+    [0.5, 180],
+    [0.75, 270],
+    [1, 360],
+    [-0.5, 0],
+    [1.5, 360],
+  ])("places elapsed fraction %s clockwise at %s degrees", (fraction, degrees) => {
+    const { getByTestId } = render(<UsageRing percent={42} expectedFraction={fraction} />)
+    expect(getByTestId("usage-ring-notch")).toHaveAttribute(
+      "transform",
+      `rotate(${degrees} 16 16)`,
+    )
+  })
+
+  it.each([undefined, null])(
+    "omits the tick for unknown elapsed time (%s)",
+    (expectedFraction) => {
+      const { queryByTestId } = render(
+        <UsageRing
+          percent={42}
+          {...(expectedFraction === undefined ? {} : { expectedFraction })}
+        />,
+      )
+      expect(queryByTestId("usage-ring-notch")).not.toBeInTheDocument()
+    },
+  )
+
+  it("omits the tick when usage is unavailable even if timing is known", () => {
+    const { queryByTestId } = render(<UsageRing percent={null} expectedFraction={0.5} />)
+    expect(queryByTestId("usage-ring-notch")).not.toBeInTheDocument()
+  })
+
+  it("keeps the tick on a stated zero usage reading", () => {
+    const { getByTestId } = render(<UsageRing percent={0} expectedFraction={0.5} />)
+    expect(getByTestId("usage-ring-notch")).toBeInTheDocument()
+  })
+
   it("fills the arc in proportion to what is consumed", () => {
     const { container } = render(<UsageRing percent={75} />)
     // Three quarters gone leaves a quarter of the circumference hidden.

--- a/apps/desktop/src/components/providerUsage/UsageRing.tsx
+++ b/apps/desktop/src/components/providerUsage/UsageRing.tsx
@@ -42,6 +42,7 @@ function markTransform(mark: BrandMark): string {
  */
 export function UsageRing({
   percent,
+  expectedFraction = null,
   glyph,
   mark,
   size = 16,
@@ -49,6 +50,8 @@ export function UsageRing({
 }: {
   /** Consumed capacity, 0–100. `null` renders the indeterminate ring. */
   percent: number | null
+  /** The elapsed share of the displayed window, or null when its timing is unknown. */
+  expectedFraction?: number | null
   /**
    * What sits inside the ring — the provider's brand mark where one exists,
    * otherwise its initial.
@@ -121,6 +124,21 @@ export function UsageRing({
             transform="rotate(-90 16 16)"
             data-testid="usage-ring-arc"
           />
+          {expectedFraction != null && Number.isFinite(expectedFraction) && (
+            // The tick crosses the track and stays outside the provider mark in the 32-unit box.
+            <line
+              x1="16"
+              y1="1.75"
+              x2="16"
+              y2="3.25"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              className="text-label"
+              transform={`rotate(${Math.min(1, Math.max(0, expectedFraction)) * 360} 16 16)`}
+              data-testid="usage-ring-notch"
+            />
+          )}
         </>
       )}
       {mark && (

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -755,7 +755,7 @@ describe("PopoverView", () => {
     expect(invoke).toHaveBeenCalledWith("get_provider_usage", {
       utcOffsetMinutes: -new Date().getTimezoneOffset(),
     })
-    expect(screen.getByRole("img", { name: "Codex at 40 percent" })).toBeInTheDocument()
+    expect(screen.getByRole("img", { name: /^Codex at 40 percent\b/ })).toBeInTheDocument()
   })
 
   it("shows Checks in one passive anchored preview", async () => {
@@ -826,7 +826,7 @@ describe("PopoverView", () => {
   it("keeps an anchored preview open when Checks refreshes in the background", async () => {
     render(<PopoverView />)
     await screen.findByText("1 failed")
-    const trigger = await screen.findByRole("img", { name: "Codex at 40 percent" })
+    const trigger = await screen.findByRole("img", { name: /^Codex at 40 percent\b/ })
     fireEvent.mouseEnter(trigger)
     await waitFor(() =>
       expect(invoke).toHaveBeenCalledWith("show_popover_peek", expect.anything()),
@@ -965,7 +965,7 @@ describe("PopoverView", () => {
   it("requests a provider preview after the pointer rests on its trigger", async () => {
     render(<PopoverView />)
 
-    const trigger = await screen.findByRole("img", { name: "Codex at 40 percent" })
+    const trigger = await screen.findByRole("img", { name: /^Codex at 40 percent\b/ })
     vi.useFakeTimers()
     try {
       fireEvent.mouseEnter(trigger)
@@ -995,7 +995,7 @@ describe("PopoverView", () => {
   it("does not navigate when a provider dial is clicked", async () => {
     render(<PopoverView />)
 
-    const trigger = await screen.findByRole("img", { name: "Codex at 40 percent" })
+    const trigger = await screen.findByRole("img", { name: /^Codex at 40 percent\b/ })
     fireEvent.click(trigger)
 
     expect(screen.queryByRole("heading", { name: "Usage" })).not.toBeInTheDocument()
@@ -1005,7 +1005,7 @@ describe("PopoverView", () => {
   it("conceals an active provider preview before expanding the limits bar", async () => {
     render(<PopoverView />)
 
-    const trigger = await screen.findByRole("img", { name: "Codex at 40 percent" })
+    const trigger = await screen.findByRole("img", { name: /^Codex at 40 percent\b/ })
     fireEvent.mouseEnter(trigger)
     fireEvent.click(screen.getByRole("button", { name: "Expand usage limits" }))
 
@@ -1056,7 +1056,7 @@ describe("PopoverView", () => {
 
     await screen.findByText("Wire the tray popover")
     expect(screen.getByTestId("usage-limits-bar")).toBeInTheDocument()
-    expect(screen.getByRole("img", { name: "Codex at 40 percent" })).toBeInTheDocument()
+    expect(screen.getByRole("img", { name: /^Codex at 40 percent\b/ })).toBeInTheDocument()
     expect(screen.queryByText("No live limits")).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## User impact

Collapsed provider usage dials now show a pace marker for the limit window driving the displayed percentage. The marker compares usage with elapsed time so readers can see whether they are above, below, or on pace.

Hovering or focusing a dial opens a styled tooltip with the provider, limit window, current usage, pace difference, and marker meaning. Providers without sufficient timing data continue to show no marker.

Dials
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d34812ad-5431-4498-a283-f032728c182a" /><img width="300"  alt="image" src="https://github.com/user-attachments/assets/dca64f9c-baec-4469-a5f6-d5d905045102" />

Tooltip
<img width="200" height="81" alt="image" src="https://github.com/user-attachments/assets/af6f083e-262a-4ac7-9f10-1114b6ddb5d5" />



## Validation

- `pnpm --filter @antiburn/desktop exec vitest run src/components/providerUsage/UsageLimitsBar.test.tsx src/components/providerUsage/UsageRing.test.tsx src/components/presentation/Tooltip.test.tsx`
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop build`
- Prettier checks for the four changed files
- `node scripts/check-design-drift.mjs`
- Visual verification at 26px in light and dark themes

## Analytics

No analytics changes. This is a passive presentation improvement with no new user action or outcome to measure.

## Privacy and performance

No changes to data access, network access, retained data, or background work. The tooltip uses the existing shared presentation primitive.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
