### PR TITLE
chore: show remaining usage in menubar tooltip

### DIFF
--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -72,7 +72,7 @@ struct UsageMeterState {
     columns: usize,
     generation: u64,
     #[cfg(debug_assertions)]
-    debug_columns: Option<usize>,
+    debug_used_percent: Option<f64>,
 }
 
 impl Default for UsageMeter {
@@ -82,7 +82,7 @@ impl Default for UsageMeter {
                 columns: COLUMN_COUNT,
                 generation: 0,
                 #[cfg(debug_assertions)]
-                debug_columns: None,
+                debug_used_percent: None,
             }),
         }
     }
@@ -205,12 +205,12 @@ pub fn sync_usage(
     launch: bool,
 ) {
     #[cfg(debug_assertions)]
-    if let Some(columns) = debug_columns(app) {
-        set_columns(app, columns, Some(UPDATE_TRANSITION));
+    if let Some(used) = debug_used_percent(app) {
+        set_usage(app, Some(used), true, Some(UPDATE_TRANSITION));
         return;
     }
-    let columns = active.then(|| usage_columns(summary)).flatten();
-    let transition = if columns.is_some() {
+    let used = active.then(|| usage_used_percent(summary)).flatten();
+    let transition = if used.is_some() {
         Some(if launch {
             LAUNCH_TRANSITION
         } else {
@@ -219,12 +219,12 @@ pub fn sync_usage(
     } else {
         None
     };
-    set_columns(app, columns.unwrap_or(COLUMN_COUNT), transition);
+    set_usage(app, used, false, transition);
 }
 
 /// Restore the neutral tray mark immediately when usage monitoring is inactive.
 pub fn clear_usage(app: &AppHandle) {
-    set_columns(app, COLUMN_COUNT, None);
+    set_usage(app, None, false, None);
 }
 
 /// Toggle a debug-only random usage value without changing persisted usage.
@@ -233,22 +233,22 @@ fn toggle_random_usage(app: &AppHandle) -> bool {
     let Some(meter) = app.try_state::<UsageMeter>() else {
         return false;
     };
-    let columns = {
+    let used = {
         let mut state = meter
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if state.debug_columns.is_some() {
-            state.debug_columns = None;
+        if state.debug_used_percent.is_some() {
+            state.debug_used_percent = None;
             None
         } else {
-            let columns = random_debug_columns(random_seed());
-            state.debug_columns = Some(columns);
-            Some(columns)
+            let used = random_debug_used_percent(random_seed());
+            state.debug_used_percent = Some(used);
+            Some(used)
         }
     };
-    if let Some(columns) = columns {
-        set_columns(app, columns, Some(UPDATE_TRANSITION));
+    if let Some(used) = used {
+        set_usage(app, Some(used), true, Some(UPDATE_TRANSITION));
         return true;
     }
 
@@ -307,13 +307,13 @@ pub(crate) fn simulate_burn_checks(app: &AppHandle, report: &mut crate::dto::Che
 }
 
 #[cfg(debug_assertions)]
-fn debug_columns(app: &AppHandle) -> Option<usize> {
+fn debug_used_percent(app: &AppHandle) -> Option<f64> {
     app.try_state::<UsageMeter>().and_then(|meter| {
         meter
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .debug_columns
+            .debug_used_percent
     })
 }
 
@@ -326,9 +326,35 @@ fn random_seed() -> u128 {
 }
 
 #[cfg(debug_assertions)]
-fn random_debug_columns(seed: u128) -> usize {
-    let used = (seed % 101) as f64;
-    columns_for_used_percent(used)
+fn random_debug_used_percent(seed: u128) -> f64 {
+    (seed % 101) as f64
+}
+
+fn usage_tooltip(used: Option<f64>, simulated: bool) -> String {
+    let Some(used) = used else {
+        return "antiburn".to_string();
+    };
+    let remaining = (100.0 - used).round();
+    let suffix = if simulated { " (simulated)" } else { "" };
+    format!("antiburn — {remaining:.0}% remaining{suffix}")
+}
+
+fn set_usage(app: &AppHandle, used: Option<f64>, simulated: bool, transition: Option<Duration>) {
+    let main_thread_app = app.clone();
+    if let Err(error) = app.run_on_main_thread(move || {
+        if let Some(tray) = main_thread_app.tray_by_id(TRAY_ID)
+            && let Err(error) = tray.set_tooltip(Some(usage_tooltip(used, simulated)))
+        {
+            ::tracing::warn!(event = "tray_usage_tooltip_update_failed", error = %error);
+        }
+        set_columns(
+            &main_thread_app,
+            used.map(columns_for_used_percent).unwrap_or(COLUMN_COUNT),
+            transition,
+        );
+    }) {
+        ::tracing::warn!(event = "tray_usage_update_schedule_failed", error = %error);
+    }
 }
 
 fn set_columns(app: &AppHandle, target: usize, transition: Option<Duration>) {
@@ -460,16 +486,15 @@ fn tray_dot_alpha_indices(rgba: &[u8], width: u32, height: u32) -> Vec<Vec<usize
     dots
 }
 
-fn usage_columns(summary: &crate::dto::LiveUsageSummary) -> Option<usize> {
-    let used = summary
+fn usage_used_percent(summary: &crate::dto::LiveUsageSummary) -> Option<f64> {
+    summary
         .providers
         .iter()
         .filter(|provider| provider_is_displayable(summary, provider))
         .flat_map(visible_windows)
         .filter_map(|window| window.used_percent)
         .filter(|percent| percent.is_finite() && (0.0..=100.0).contains(percent))
-        .max_by(f64::total_cmp)?;
-    Some(columns_for_used_percent(used))
+        .max_by(f64::total_cmp)
 }
 
 fn columns_for_used_percent(used: f64) -> usize {
@@ -787,12 +812,76 @@ mod tests {
         assert_eq!(columns_for_used_percent(100.0), 0);
     }
 
+    #[test]
+    fn the_tooltip_reports_rounded_remaining_allowance() {
+        for (used, expected) in [
+            (0.0, "antiburn — 100% remaining"),
+            (100.0, "antiburn — 0% remaining"),
+            (79.4, "antiburn — 21% remaining"),
+            (79.5, "antiburn — 21% remaining"),
+            (79.6, "antiburn — 20% remaining"),
+        ] {
+            assert_eq!(usage_tooltip(Some(used), false), expected);
+        }
+        assert_eq!(usage_tooltip(None, false), "antiburn");
+    }
+
+    #[test]
+    fn usage_changes_within_one_column_bucket_have_distinct_tooltips() {
+        assert_eq!(
+            columns_for_used_percent(71.0),
+            columns_for_used_percent(79.0)
+        );
+        assert_eq!(usage_tooltip(Some(71.0), false), "antiburn — 29% remaining");
+        assert_eq!(usage_tooltip(Some(79.0), false), "antiburn — 21% remaining");
+    }
+
+    #[test]
+    fn invalid_percentages_do_not_drive_the_icon_or_tooltip() {
+        let mut summary = crate::dto::LiveUsageSummary {
+            providers: vec![provider(
+                "openai",
+                "Read from Codex",
+                [
+                    None,
+                    Some(f64::NAN),
+                    Some(f64::INFINITY),
+                    Some(-1.0),
+                    Some(101.0),
+                ]
+                .into_iter()
+                .map(|used| window("five-hour", "primaryShort", None, used))
+                .collect(),
+            )],
+            ..Default::default()
+        };
+        assert_eq!(usage_used_percent(&summary), None);
+        assert_eq!(
+            usage_tooltip(usage_used_percent(&summary), false),
+            "antiburn"
+        );
+
+        summary.providers[0]
+            .windows
+            .push(window("weekly", "primaryLong", None, Some(25.0)));
+        let used = usage_used_percent(&summary);
+        assert_eq!(used, Some(25.0));
+        assert_eq!(used.map(columns_for_used_percent), Some(4));
+        assert_eq!(usage_tooltip(used, false), "antiburn — 75% remaining");
+    }
+
     #[cfg(debug_assertions)]
     #[test]
     fn debug_random_usage_stays_within_the_column_range() {
-        assert_eq!(random_debug_columns(0), COLUMN_COUNT);
-        assert_eq!(random_debug_columns(100), 0);
-        assert!(random_debug_columns(57) <= COLUMN_COUNT);
+        assert_eq!(random_debug_used_percent(0), 0.0);
+        assert_eq!(random_debug_used_percent(100), 100.0);
+        let used = random_debug_used_percent(57);
+        assert_eq!(used, 57.0);
+        assert_eq!(columns_for_used_percent(used), 2);
+        assert_eq!(
+            usage_tooltip(Some(used), true),
+            "antiburn — 43% remaining (simulated)"
+        );
     }
 
     #[test]
@@ -801,7 +890,7 @@ mod tests {
             columns: 3,
             generation: 4,
             #[cfg(debug_assertions)]
-            debug_columns: None,
+            debug_used_percent: None,
         };
         assert!(frame_is_current(&state, 3, 4));
 
@@ -863,7 +952,10 @@ mod tests {
             generated_at: "2026-09-04T12:00:00Z".to_string(),
             ..Default::default()
         };
-        assert_eq!(usage_columns(&summary), Some(1));
+        let used = usage_used_percent(&summary);
+        assert_eq!(used, Some(80.0));
+        assert_eq!(used.map(columns_for_used_percent), Some(1));
+        assert_eq!(usage_tooltip(used, false), "antiburn — 20% remaining");
     }
 
     #[test]
@@ -879,7 +971,9 @@ mod tests {
             )],
             ..Default::default()
         };
-        assert_eq!(usage_columns(&summary), Some(4));
+        let used = usage_used_percent(&summary);
+        assert_eq!(used, Some(30.0));
+        assert_eq!(used.map(columns_for_used_percent), Some(4));
     }
 
     #[test]
@@ -912,7 +1006,7 @@ mod tests {
             ..Default::default()
         };
         summary.providers[1].observed_at = "2026-09-04T12:10:00Z".to_string();
-        assert_eq!(usage_columns(&summary), None);
+        assert_eq!(usage_used_percent(&summary), None);
     }
 
     fn provider(


### PR DESCRIPTION
## User impact

The menubar tooltip shows “antiburn — 20% remaining” using the same allowance that drives the dots. It updates within a dot bucket, resets when usage is unavailable, and labels simulated values.

Tooltip and icon updates are serialized to prevent mismatched readings.

**Known limitation:** Menubar tooltips do not appear in fullscreen mode.

<img width="175" height="67" alt="image" src="https://github.com/user-attachments/assets/96fd24bd-54f0-48ab-9c6f-7682d19286cb" />


## Validation

- Formatting and Clippy passed.
- All 1,225 shell tests passed; two watcher tests required rerunning outside the sandbox.
- Debug build launched; native neutral tooltip verified.
- Live and simulated hover checks remain unverified because automation could not open the simulation menu.

## Analytics

This change helps users interpret the dots. No new events: the tooltip passively describes existing usage, and hover tracking is unnecessary.

## Privacy and performance

No new data or network access. Tooltip updates use the existing usage-refresh flow.

## Checklist

- [x] Synthetic test data used.
- [x] No credentials, private session content, or private paths included.
- [x] Single commit includes a DCO sign-off.
- [x] Tests updated; no documentation changes needed.
