### PR TITLE
Open main directly from the menu bar

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -149,49 +149,24 @@ Settings teardown, and the memory rules behind those policies.
   default section. Sessions shows the session list and selected detail. The sidebar Settings action and
   Command+, (Control+, on Windows and Linux) open the existing Settings window; see the
   [main-window validation runbook](../../docs/runbooks/main-window.md).
-- **Tray item.** Primary click toggles the popover. Secondary click opens a
-  menu with Open antiburn, Pin Window, Settings, and Quit. Native application
-  menus also provide Quit. Explicit Quit stops the
-  application; closing the main window does not. On macOS the
-  item stays highlighted for as long as the popover is open: the system's own
-  highlight is momentary and lets go on mouse-up, so the shell drives it, and
-  clears it again on every path that puts the popover away.
+- **Tray item.** Primary click opens or focuses the main window. Secondary click
+  opens a menu with Open antiburn, Settings, and Quit. Linux uses Open antiburn
+  from this menu because AppIndicator does not report primary click events.
+  Explicit Quit stops the application; closing the main window does not.
   The dot mark also shows the lowest remaining displayable provider allowance:
   bright dots remain and depleted dots stay dim. It starts full on launch,
   then moves to the cached reading without opening a provider connection.
   Unknown or disabled live usage keeps the ordinary full mark.
-- **Popover.** 380pt wide, frameless, always on top, hidden from the taskbar.
-  It is created on demand and anchored under its menu-bar item on each
-  open, flipping above the item and clamping to the display when there is no
-  room below. On macOS it follows the reader to every Space, including a
-  full-screen Space. Hover previews use a passive companion panel with the same
-  Space behavior. Their native `NSPanel` and `WKWebView` are created directly,
-  without Wry or window-class conversion. Preview creation and presentation
-  preserve the active application and keyboard recipient. The popover hides
-  when it loses focus, when Escape is pressed, on a second click of the menu-bar
-  item, and — on macOS —
-  on a click anywhere outside the app, which catches the Finder desktop:
-  clicking it makes no window key, so no focus change is reported at all.
-- **Pin.** The tray menu's first item suspends all four of those dismissals,
-  and reads Unpin Window while it does. The state is in memory only: a pin
-  means "keep this on screen while I work", and a relaunch ends that work.
-  Pinning also re-shows the popover, because opening the tray menu is what
-  took focus away from it in the first place.
 - **First run.** A 680×480 decorated window of its own, opened at launch while
   onboarding is unfinished — a fresh install should not have to discover the
   menu-bar glyph before it is told anything. While
-  it is unfinished the tray click goes here rather than to the popover, which
-  has nothing to show yet, and antiburn is an ordinary Dock application so the
+  it is unfinished the tray click opens onboarding, and antiburn is an ordinary Dock application so the
   window can be reached again once something else takes focus. Finishing it
   puts the onboarding window away, opens the main window, and retains the Dock
   icon. The existing notification still identifies the menu-bar companion.
 - **Settings.** An ordinary decorated window, created on demand and destroyed
   on close. A source list on the left, one pane on the right; every control
   writes through immediately, so there is no Save button and no dirty state.
-- **Popover lifetime.** Finishing onboarding starts one hidden renderer before
-  the onboarding window retires. After it becomes ready, the handoff renderer
-  stays warm for up to 60 seconds. The first reveal consumes that lease; later
-  dismissals use the normal 15-second grace period before renderer destruction.
 - **Local store.** One SQLite database under the app data directory
   (`ai.antiburn.desktop`, or `ai.antiburn.desktop.debug` for a development
   build — see above) holds preferences, scan roots, and the local session data

--- a/apps/desktop/src-tauri/src/nudges.rs
+++ b/apps/desktop/src-tauri/src/nudges.rs
@@ -166,17 +166,8 @@ fn on_action(app: &AppHandle, event: NudgeActionEvent) {
     // Every other CTA opens or focuses a different window. The key release
     // from the CTA's dismissal must not pull focus back to the popover.
     crate::popover::clear_nudge_yield(app);
-    // "Show me" opens the popover under the glyph the notification is already
-    // pointing at, so the reader's first sight of it is the thing the icon
-    // does rather than a settings pane about it.
     if event.kind == NudgeKind::MenuBarLocation {
-        match app
-            .tray_by_id("antiburn")
-            .and_then(|tray| tray.rect().ok().flatten())
-        {
-            Some(rect) => crate::popover::toggle(app, rect),
-            None => open_without_a_tray_rect(app),
-        }
+        crate::tray::open_main_window(app);
         return;
     }
     if event.kind == NudgeKind::UpdateAvailable {
@@ -257,21 +248,6 @@ fn classify_update_action(event: &NudgeActionEvent) -> UpdateAction<'_> {
     }
     UpdateAction::Install(expected_version)
 }
-
-/// The same CTA where the tray backend reports no rectangle.
-///
-/// On Linux that is every time: the AppIndicator backend has no item geometry
-/// to give, so the button would do nothing at all. The tray menu's own open
-/// path already knows how to make an anchor, so send the reader through it.
-#[cfg(target_os = "linux")]
-fn open_without_a_tray_rect(app: &AppHandle) {
-    crate::popover::open_from_tray_menu(app);
-}
-
-/// macOS and Windows do report a rectangle, so a missing one means the tray
-/// item is not there yet. Doing nothing is what this CTA already did.
-#[cfg(not(target_os = "linux"))]
-fn open_without_a_tray_rect(_app: &AppHandle) {}
 
 #[cfg(test)]
 mod tests {

--- a/apps/desktop/src-tauri/src/onboarding.rs
+++ b/apps/desktop/src-tauri/src/onboarding.rs
@@ -1,28 +1,7 @@
 //! The standalone first-run window.
 //!
-//! Onboarding used to be a surface of the popover, sized at 380×520. Two things
-//! were wrong with that and both are why this module exists.
-//!
-//! The popover is created hidden and shown only by a click on the menu-bar
-//! item, so a fresh install booted into the menu bar and waited — silently —
-//! for the reader to find a 16pt template glyph. The flow whose job is to
-//! establish trust sat behind the discovery problem it should have been
-//! solving. This window opens itself at launch instead (see
-//! [`crate::run`]'s setup).
-//!
-//! And 380pt is the wrong room for the work. The Repositories step stacks a
-//! folder-permission notice — whose three buttons wrap to two rows at that
-//! width — above a list of ~60pt repository rows, which left two or three of
-//! them visible at the one moment the reader is deciding what antiburn may
-//! read. 680×480 gives the same step about 130pt of list under a notice that no
-//! longer wraps, and every other step more room than it had.
-//!
-//! The first-run flow uses a window instead of a bounded-height popover surface.
-//!
-//! Chrome follows [`crate::settings`] rather than inventing a second pattern:
-//! fixed size, non-resizable, and on macOS an overlay title bar with the
-//! floating title hidden, so the frontend paints its own
-//! `data-tauri-drag-region` strip (`src/views/onboarding/OnboardingFlow.tsx`).
+//! First launch opens this window until setup is complete.
+//! Menu-bar clicks restore unfinished setup. Completing setup opens the main window.
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -53,14 +32,12 @@ const FINISH_TEARDOWN_DELAY: Duration = Duration::from_secs(1);
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FinishHandoffAction {
     OpenMain,
-    PrewarmPopover,
     DestroyOnboarding,
 }
 
-fn finish_handoff_schedule() -> [(Duration, FinishHandoffAction); 3] {
+fn finish_handoff_schedule() -> [(Duration, FinishHandoffAction); 2] {
     [
         (Duration::ZERO, FinishHandoffAction::OpenMain),
-        (Duration::ZERO, FinishHandoffAction::PrewarmPopover),
         (
             FINISH_TEARDOWN_DELAY,
             FinishHandoffAction::DestroyOnboarding,
@@ -124,7 +101,7 @@ pub fn restart(app: &AppHandle) -> tauri::Result<()> {
 ///
 /// Called twice over a first run's life: once from setup, and again if the
 /// reader closes the window before finishing and then clicks the menu-bar item
-/// ([`crate::popover::toggle`]). The second path is why this reuses an existing
+/// ([`crate::open_launch_surface`]). The second path is why this reuses an existing
 /// window rather than assuming it is the only caller — a close hides rather
 /// than destroys (see `crate::on_window_event`), so the flow comes back with
 /// the steps the reader already walked still behind it.
@@ -297,9 +274,6 @@ pub fn finish(app: &AppHandle) {
                             );
                         }
                     }
-                    FinishHandoffAction::PrewarmPopover => {
-                        crate::popover::prewarm(&check_app);
-                    }
                     FinishHandoffAction::DestroyOnboarding => {
                         if let Some(window) = check_app.get_webview_window(LABEL) {
                             let _ = window.destroy();
@@ -315,8 +289,7 @@ pub fn finish(app: &AppHandle) {
 ///
 /// An unreadable store answers `false`: the flow's whole job is the *first*
 /// run, and re-running it because a read failed would be worse than skipping
-/// it. Every caller has a working fallback for that answer — the popover opens
-/// normally, and setup simply shows no window.
+/// it. The normal launch path opens the main window when setup is complete.
 pub fn is_pending(app: &AppHandle) -> bool {
     app.try_state::<crate::store::Store>()
         .and_then(|store| store.settings().ok())
@@ -338,12 +311,11 @@ mod tests {
     }
 
     #[test]
-    fn the_finish_handoff_schedules_main_and_prewarm_before_teardown() {
+    fn the_finish_handoff_opens_only_main_before_teardown() {
         assert_eq!(
             finish_handoff_schedule(),
             [
                 (Duration::ZERO, FinishHandoffAction::OpenMain),
-                (Duration::ZERO, FinishHandoffAction::PrewarmPopover),
                 (
                     FINISH_TEARDOWN_DELAY,
                     FinishHandoffAction::DestroyOnboarding

--- a/apps/desktop/src-tauri/src/popover.rs
+++ b/apps/desktop/src-tauri/src/popover.rs
@@ -1,41 +1,6 @@
-//! The tray-anchored popover window.
+//! Legacy popover lifecycle and IPC support.
 //!
-//! The popover is created lazily on the first tray click. After its first
-//! reveal, dismissal hides the renderer but keeps it ready for the process
-//! lifetime. Each later open reuses the same renderer and its loaded state.
-//!
-//! # Geometry
-//!
-//! The width is fixed at [`WIDTH`]; the height is **per view**, bounded by
-//! [`MIN_HEIGHT`] and [`MAX_HEIGHT`], and animated between the two ends of a
-//! change so a surface swap reads as one surface growing rather than two
-//! windows replacing each other. The webview asks for a height when its view
-//! changes ([`crate::commands::set_popover_height`]) and passes `animate: false`
-//! when the reader has asked the system for reduced motion — the preference
-//! lives in the webview, so the decision is made there and honored here.
-//!
-//! Every height change re-runs the anchoring maths against the menu-bar item's
-//! last known rectangle, because a taller popover on a bottom-anchored panel
-//! (Windows, most Linux panels) has to move as well as grow.
-//!
-//! On Linux the tray backend reports no item rectangle. The tray menu's "Open
-//! antiburn" item makes an anchor from the panel instead: the work area shows
-//! where the panel is, and the popover opens against the end of it that holds
-//! the tray. That placement needs the X11 backend `main.rs` selects.
-//!
-//! # Dismissal
-//!
-//! Three things put the popover away everywhere: looking at something else
-//! ([`hide_on_focus_loss`]), Escape ([`hide`], reached from the webview), and a
-//! second click on the menu-bar item ([`toggle`]). On macOS a fourth joins
-//! them — a click anywhere outside the application (`hide_on_outside_click`,
-//! driven by [`crate::global_click`]), which is the one case that reports no
-//! focus change at all, because clicking the Finder desktop makes no window
-//! key. All of them answer to [`set_pinned`]: while the popover is pinned none
-//! fire, and the tray menu's Unpin item is what gives them back.
-//!
-//! Whichever way it goes, it leaves through [`note_hidden`], which is also
-//! where the menu-bar item is unlit; [`note_shown`] is the other half.
+//! User entry points open the main window. No startup or tray path creates this renderer.
 
 #[cfg(target_os = "macos")]
 mod panel;
@@ -49,14 +14,12 @@ use std::time::{Duration, Instant};
 #[cfg(target_os = "macos")]
 use tauri::window::{Effect, EffectState, EffectsBuilder};
 use tauri::{
-    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Rect, WebviewUrl, WebviewWindow,
+    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder, Window,
 };
 
 use crate::window_lifecycle::{self, ManagedWindowReadiness};
-use crate::window_readiness::{
-    OpenAction, PrewarmAction, ToggleAction, WindowReadiness, renderer_generation_script,
-};
+use crate::window_readiness::{WindowReadiness, renderer_generation_script};
 
 use self::retention::{DueEviction, EvictionMode, EvictionSchedule, EvictionToken, Retention};
 
@@ -160,14 +123,6 @@ const ANCHOR_GAP: f64 = 6.0;
 /// Minimum logical gap between the popover and the edge of its display.
 const SCREEN_MARGIN: f64 = 8.0;
 
-/// How long after an automatic dismissal a tray click is treated as part of
-/// that dismissal rather than a fresh open.
-///
-/// Clicking the menu-bar item while the popover is open fires focus loss
-/// *before* the tray click arrives, so a naive toggle would hide the popover
-/// and immediately reopen it. This window swallows that second half.
-const REOPEN_SUPPRESSION: Duration = Duration::from_millis(250);
-
 /// The menu-bar item's rectangle, in physical pixels on the display it lives
 /// on. Kept as plain numbers rather than a [`Rect`] so a height change can
 /// re-anchor without the tray handing the rectangle over a second time.
@@ -177,184 +132,6 @@ struct AnchorRect {
     y: f64,
     width: f64,
     height: f64,
-}
-
-/// A rectangle on a display, in physical pixels. Used for both a monitor and
-/// the usable region inside it.
-#[cfg(any(target_os = "linux", test))]
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct ScreenRect {
-    x: f64,
-    y: f64,
-    width: f64,
-    height: f64,
-}
-
-/// Makes an anchor for a popover that has no menu-bar rectangle to hang off.
-///
-/// The tray backend on Linux reports no item rectangle, so the popover needs
-/// another point to open against. That point is the outer corner of the panel
-/// that holds the tray, which the work area describes: the space a panel takes
-/// is exactly the space the work area gives up.
-///
-/// The panel with the larger inset is the one the tray sits in. Its far edge
-/// gives the anchor, because every mainstream desktop keeps the tray at the end
-/// of the panel: the right end of a horizontal bar.
-///
-/// The cursor is deliberately **not** used, although it names the very item the
-/// reader just chose. The tray menu belongs to the desktop shell, not to this
-/// application, so on a Wayland session the pointer is over a surface the X
-/// server cannot see, and the reading is a stale position somewhere else
-/// entirely. A wrong point is worse than no point, and the panel geometry
-/// answers the same question without asking the pointer.
-///
-/// The rectangle has no width and no height. [`compute_position`] then centers
-/// the popover on the point and drops it [`ANCHOR_GAP`] below. A bottom panel
-/// flips it above and the display edges clamp it, through the same code every
-/// platform already uses.
-///
-/// The placement needs the X11 backend `main.rs` selects. A session with no X
-/// server leaves the position to the compositor.
-#[cfg(any(target_os = "linux", test))]
-fn synthesized_anchor(
-    work_area: Option<ScreenRect>,
-    monitor: Option<ScreenRect>,
-) -> Option<AnchorRect> {
-    let area = work_area?;
-    let monitor = monitor?;
-
-    let top_inset = area.y - monitor.y;
-    let bottom_inset = (monitor.y + monitor.height) - (area.y + area.height);
-
-    // The tray hangs at the right end of the panel, so the anchor takes the
-    // work area's right edge either way. Only the vertical edge changes.
-    let x = area.x + area.width;
-    let y = if bottom_inset > top_inset {
-        // A bottom panel. The anchor is its top edge, so the flip in
-        // `compute_position` lifts the popover clear of it.
-        area.y + area.height
-    } else {
-        // A top panel, or no panel at all. The anchor is its bottom edge.
-        area.y
-    };
-
-    Some(AnchorRect {
-        x,
-        y,
-        width: 0.0,
-        height: 0.0,
-    })
-}
-
-/// The anchor the Linux popover opens against.
-///
-/// Every reading stays in **physical** pixels, which is what
-/// [`compute_position`] expects: it divides by the containing monitor's own
-/// scale, so logical values here would be scaled a second time.
-///
-/// The **primary** monitor answers first, and that is the point of the order.
-/// A desktop puts its panel on the primary display, so the tray is there, and
-/// the popover belongs beside the tray rather than beside whatever display the
-/// window was last on.
-#[cfg(target_os = "linux")]
-fn linux_anchor(window: &WebviewWindow) -> Option<AnchorRect> {
-    let monitor = window
-        .primary_monitor()
-        .ok()
-        .flatten()
-        .or_else(|| window.current_monitor().ok().flatten())?;
-
-    let area = monitor.work_area();
-    let work = ScreenRect {
-        x: f64::from(area.position.x),
-        y: f64::from(area.position.y),
-        width: f64::from(area.size.width),
-        height: f64::from(area.size.height),
-    };
-    let bounds = ScreenRect {
-        x: f64::from(monitor.position().x),
-        y: f64::from(monitor.position().y),
-        width: f64::from(monitor.size().width),
-        height: f64::from(monitor.size().height),
-    };
-    synthesized_anchor(Some(work), Some(bounds))
-}
-
-/// Opens the popover from the tray menu's Open item.
-///
-/// This is the only route into the popover on Linux. The AppIndicator backend
-/// reports no click events, so [`toggle`] never runs there.
-///
-/// The item shows the popover; it never toggles it. A toggle is unreachable
-/// through a menu: where opening the menu takes focus, the popover is already
-/// hidden by the time the reader chooses the item, and an item that reads "Open
-/// antiburn" but hides the window reads as broken. Escape, focus loss, and the
-/// pin stay the ways to put it away.
-#[cfg(target_os = "linux")]
-pub fn open_from_tray_menu(app: &AppHandle) {
-    let requested_at = Instant::now();
-    // The same gate [`toggle`] applies: before the first run is finished the
-    // popover has nothing to show, so send the reader to the flow they are owed.
-    if crate::onboarding::is_pending(app) {
-        if let Err(error) = crate::onboarding::open(app) {
-            ::tracing::warn!(
-                event = "onboarding_window_open_failed",
-                trigger = "tray",
-                error = %error
-            );
-        }
-        return;
-    }
-
-    let Some(state) = app.try_state::<PopoverState>() else {
-        return;
-    };
-
-    // Opening the AppIndicator menu takes focus from an unpinned popover, which
-    // dismisses it and arms the reopen suppression. A menu item is an explicit
-    // command, not the second half of that gesture, so clear the latch rather
-    // than read it. `set_pinned` clears it for the same reason. If this read the
-    // latch, the item would do nothing right after the menu opens.
-    state.clear_auto_hide();
-
-    let request = match request_open_window(app, Some(requested_at)) {
-        Ok(request) => request,
-        Err(error) => {
-            ::tracing::error!(event = "popover_create_failed", error = %error);
-            return;
-        }
-    };
-    let (window, ready) = match request {
-        WindowRequest::Ready(window) => (window, true),
-        WindowRequest::Loading(window) => (window, false),
-        WindowRequest::AwaitingBuild | WindowRequest::Cancelled => return,
-    };
-
-    // Record the anchor as well as use it: `apply_height` places the window
-    // against the recorded one on every view height change.
-    //
-    // With no anchor, skip placement. The window manager decides, which is what
-    // it does today; invented coordinates would be worse.
-    if let Some(anchor) = linux_anchor(&window) {
-        state.record_anchor(anchor);
-        if let Err(error) = place(&window, anchor, WIDTH, state.height()) {
-            // Positioning is best-effort here as everywhere else.
-            ::tracing::warn!(event = "popover_anchor_failed", error = %error);
-        }
-    }
-
-    if !ready {
-        return;
-    }
-
-    if window.is_visible().unwrap_or(false) {
-        // Already on screen, and now re-placed. The scan gate is open, so
-        // `note_shown` has nothing left to do.
-        let _ = window.set_focus();
-        return;
-    }
-
-    reveal(&window);
 }
 
 /// Shared show/hide bookkeeping, registered as Tauri managed state.
@@ -426,31 +203,6 @@ impl PopoverState {
         }
     }
 
-    /// Forget any automatic dismissal, so the next open is treated as a fresh
-    /// one. Used when pinning: the tray right-click that opened the menu is
-    /// what hid the popover, and the pin must not be swallowed as the second
-    /// half of that gesture.
-    fn clear_auto_hide(&self) {
-        if let Ok(mut slot) = self.auto_hidden_at.lock() {
-            *slot = None;
-        }
-    }
-
-    /// True when an automatic dismissal just happened, meaning the tray click
-    /// being handled is the same user gesture that caused it.
-    fn suppresses_reopen(&self) -> bool {
-        let Ok(mut slot) = self.auto_hidden_at.lock() else {
-            return false;
-        };
-        match *slot {
-            Some(at) if at.elapsed() < REOPEN_SUPPRESSION => {
-                *slot = None;
-                true
-            }
-            _ => false,
-        }
-    }
-
     fn begin_focus_hold(&self) {
         self.focus_hold.fetch_add(1, Ordering::SeqCst);
     }
@@ -471,10 +223,6 @@ impl PopoverState {
 
     fn is_pinned(&self) -> bool {
         self.pinned.load(Ordering::SeqCst)
-    }
-
-    fn set_pinned(&self, pinned: bool) {
-        self.pinned.store(pinned, Ordering::SeqCst);
     }
 
     fn begin_nudge_key_handoff(&self, popover_focused: bool) {
@@ -549,24 +297,12 @@ impl PopoverState {
             .take_due(token, renderer_generation, visible)
     }
 
-    fn mark_prewarm(&self, generation: u64, now: Instant) {
-        self.retention().begin_prewarm(generation, now);
-    }
-
     fn is_prewarm(&self, generation: u64) -> bool {
         self.retention().is_prewarm(generation)
     }
 
     fn clear_prewarm(&self) {
         self.retention().take_prewarm();
-    }
-
-    fn prewarm_generation(&self) -> Option<u64> {
-        self.retention().prewarm_generation()
-    }
-
-    fn transfer_prewarm(&self, from: u64, to: u64) -> bool {
-        self.retention().transfer_prewarm(from, to)
     }
 
     fn mark_prewarm_ready(&self, generation: u64, now: Instant) -> bool {
@@ -587,12 +323,6 @@ impl PopoverState {
 
     fn take_prewarm(&self) -> Option<u64> {
         self.retention().take_prewarm()
-    }
-
-    fn record_anchor(&self, anchor: AnchorRect) {
-        if let Ok(mut slot) = self.anchor.lock() {
-            *slot = Some(anchor);
-        }
     }
 
     fn anchor(&self) -> Option<AnchorRect> {
@@ -753,278 +483,6 @@ fn destroy_window(window: &WebviewWindow) -> tauri::Result<()> {
     window.destroy()
 }
 
-enum WindowRequest {
-    Ready(WebviewWindow),
-    Loading(WebviewWindow),
-    AwaitingBuild,
-    Cancelled,
-}
-
-fn begin_open_timing(
-    state: &PopoverState,
-    requested_at: Option<Instant>,
-    generation: u64,
-    renderer_state: &'static str,
-) {
-    let Some(requested_at) = requested_at else {
-        return;
-    };
-    state.timing.begin_open(
-        generation,
-        requested_at,
-        state.is_prewarm(generation),
-        renderer_state,
-    );
-}
-
-fn transfer_prewarm_for_replacement(
-    state: &PopoverState,
-    previous_generation: Option<u64>,
-    replacement_generation: u64,
-) -> bool {
-    let Some(previous_generation) = previous_generation else {
-        return false;
-    };
-    if previous_generation != replacement_generation {
-        state.transfer_prewarm(previous_generation, replacement_generation);
-        state.cancel_eviction();
-    }
-    state.is_prewarm(replacement_generation)
-}
-
-fn replace_expired_prewarm(
-    app: &AppHandle,
-    requested_at: Option<Instant>,
-) -> tauri::Result<Option<WindowRequest>> {
-    let state = app.state::<PopoverState>();
-    let Some(expired) = state.expired_prewarm(Instant::now()) else {
-        return Ok(None);
-    };
-    let expired_generation = expired.renderer_generation();
-
-    state.cancel_eviction();
-    state.readiness().reset();
-    state.timing.cancel_open();
-    let generation = {
-        let mut readiness = state.readiness();
-        match readiness.request_open(Instant::now()) {
-            OpenAction::StartLoading { generation } => generation,
-            _ => unreachable!("a reset lifecycle starts loading"),
-        }
-    };
-    begin_open_timing(&state, requested_at, generation, "expired");
-
-    let Some(existing) = app.get_webview_window(LABEL) else {
-        state.clear_prewarm_generation(expired_generation);
-        return build_window(app, generation)
-            .map(WindowRequest::Loading)
-            .map(Some);
-    };
-
-    state.readiness().defer_build_until_destroyed(generation);
-    if let Err(error) = destroy_window(&existing) {
-        window_lifecycle::cancel_load::<PopoverState>(app, generation);
-        let retry = state.arm_eviction_retry(expired_generation, expired.mode());
-        arm_prewarm_eviction(app, retry);
-        return Err(error);
-    }
-    state.clear_prewarm_generation(expired_generation);
-    Ok(Some(WindowRequest::AwaitingBuild))
-}
-
-fn request_open_window(
-    app: &AppHandle,
-    requested_at: Option<Instant>,
-) -> tauri::Result<WindowRequest> {
-    if let Some(request) = replace_expired_prewarm(app, requested_at)? {
-        return Ok(request);
-    }
-    let state = app.state::<PopoverState>();
-    let prewarm_generation = state.prewarm_generation();
-    let prewarm_loading = prewarm_generation
-        .is_some_and(|generation| state.readiness().loading_generation() == Some(generation));
-    if !prewarm_loading {
-        state.cancel_eviction();
-    }
-    let Some(existing) = app.get_webview_window(LABEL) else {
-        let mut readiness = state.readiness();
-        let action = readiness.request_open(Instant::now());
-        let generation = match action {
-            OpenAction::StartLoading { generation } | OpenAction::Rebuild { generation } => {
-                generation
-            }
-            OpenAction::AwaitReady => {
-                let generation = readiness
-                    .loading_generation()
-                    .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
-                drop(readiness);
-                begin_open_timing(&state, requested_at, generation, "loading");
-                return Ok(WindowRequest::AwaitingBuild);
-            }
-            OpenAction::Reveal => {
-                readiness.reset();
-                match readiness.request_open(Instant::now()) {
-                    OpenAction::StartLoading { generation } => generation,
-                    _ => unreachable!("an idle lifecycle starts loading"),
-                }
-            }
-        };
-        drop(readiness);
-        transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
-        begin_open_timing(&state, requested_at, generation, "build");
-        return build_window(app, generation).map(WindowRequest::Loading);
-    };
-
-    let action = {
-        let mut readiness = state.readiness();
-        readiness.request_open(Instant::now())
-    };
-    match action {
-        OpenAction::Reveal => {
-            let generation = state.renderer_generation.load(Ordering::SeqCst);
-            begin_open_timing(&state, requested_at, generation, "ready");
-            Ok(WindowRequest::Ready(existing))
-        }
-        OpenAction::AwaitReady => {
-            let generation = state
-                .readiness()
-                .loading_generation()
-                .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
-            begin_open_timing(&state, requested_at, generation, "loading");
-            Ok(WindowRequest::Loading(existing))
-        }
-        OpenAction::StartLoading { generation } | OpenAction::Rebuild { generation } => {
-            let prewarmed =
-                transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
-            begin_open_timing(&state, requested_at, generation, "replacement");
-            if !state.readiness().defer_build_until_destroyed(generation) {
-                return Ok(WindowRequest::AwaitingBuild);
-            }
-            if let Err(error) = destroy_window(&existing) {
-                window_lifecycle::cancel_load::<PopoverState>(app, generation);
-                if prewarmed && let Some(prewarm_generation) = prewarm_generation {
-                    state.transfer_prewarm(generation, prewarm_generation);
-                    schedule_prewarm_eviction(app);
-                }
-                return Err(error);
-            }
-            Ok(WindowRequest::AwaitingBuild)
-        }
-    }
-}
-
-fn request_toggle_window(app: &AppHandle, requested_at: Instant) -> tauri::Result<WindowRequest> {
-    if let Some(request) = replace_expired_prewarm(app, Some(requested_at))? {
-        return Ok(request);
-    }
-    let state = app.state::<PopoverState>();
-    let prewarm_generation = state.prewarm_generation();
-    let prewarm_loading = prewarm_generation
-        .is_some_and(|generation| state.readiness().loading_generation() == Some(generation));
-    if !prewarm_loading {
-        state.cancel_eviction();
-    }
-    let Some(existing) = app.get_webview_window(LABEL) else {
-        let mut readiness = state.readiness();
-        let action = readiness.toggle_open(Instant::now());
-        let generation = match action {
-            ToggleAction::StartLoading { generation } | ToggleAction::Rebuild { generation } => {
-                generation
-            }
-            ToggleAction::AwaitReady => {
-                let generation = readiness
-                    .loading_generation()
-                    .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
-                drop(readiness);
-                state.timing.begin_open(
-                    generation,
-                    requested_at,
-                    prewarm_generation == Some(generation),
-                    "loading",
-                );
-                return Ok(WindowRequest::AwaitingBuild);
-            }
-            ToggleAction::CancelPendingReveal => {
-                drop(readiness);
-                state.timing.cancel_open();
-                return Ok(WindowRequest::Cancelled);
-            }
-            ToggleAction::UseWindowVisibility => {
-                readiness.reset();
-                match readiness.toggle_open(Instant::now()) {
-                    ToggleAction::StartLoading { generation } => generation,
-                    _ => unreachable!("an idle lifecycle starts loading"),
-                }
-            }
-        };
-        drop(readiness);
-        transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
-        state.timing.begin_open(
-            generation,
-            requested_at,
-            state.is_prewarm(generation),
-            "build",
-        );
-        return build_window(app, generation).map(WindowRequest::Loading);
-    };
-
-    let action = {
-        let mut readiness = state.readiness();
-        readiness.toggle_open(Instant::now())
-    };
-    match action {
-        ToggleAction::UseWindowVisibility => {
-            let generation = state.renderer_generation.load(Ordering::SeqCst);
-            state.timing.begin_open(
-                generation,
-                requested_at,
-                prewarm_generation == Some(generation),
-                "ready",
-            );
-            Ok(WindowRequest::Ready(existing))
-        }
-        ToggleAction::AwaitReady => {
-            let generation = state
-                .readiness()
-                .loading_generation()
-                .unwrap_or_else(|| state.renderer_generation.load(Ordering::SeqCst));
-            state.timing.begin_open(
-                generation,
-                requested_at,
-                prewarm_generation == Some(generation),
-                "loading",
-            );
-            Ok(WindowRequest::Loading(existing))
-        }
-        ToggleAction::CancelPendingReveal => {
-            state.timing.cancel_open();
-            Ok(WindowRequest::Cancelled)
-        }
-        ToggleAction::StartLoading { generation } | ToggleAction::Rebuild { generation } => {
-            let prewarmed =
-                transfer_prewarm_for_replacement(&state, prewarm_generation, generation);
-            state.timing.begin_open(
-                generation,
-                requested_at,
-                state.is_prewarm(generation),
-                "replacement",
-            );
-            if !state.readiness().defer_build_until_destroyed(generation) {
-                return Ok(WindowRequest::AwaitingBuild);
-            }
-            if let Err(error) = destroy_window(&existing) {
-                window_lifecycle::cancel_load::<PopoverState>(app, generation);
-                if prewarmed && let Some(prewarm_generation) = prewarm_generation {
-                    state.transfer_prewarm(generation, prewarm_generation);
-                    schedule_prewarm_eviction(app);
-                }
-                return Err(error);
-            }
-            Ok(WindowRequest::AwaitingBuild)
-        }
-    }
-}
-
 /// Build a deferred replacement after Tauri removes the old window label.
 pub fn rebuild_after_destroy(app: &AppHandle) {
     let state = app.state::<PopoverState>();
@@ -1045,103 +503,6 @@ pub fn rebuild_after_destroy(app: &AppHandle) {
             ::tracing::error!(event = "window_rebuild_failed", window = LABEL, error = %error);
         }
     }
-}
-
-/// Build one hidden renderer for the handoff from onboarding to the menu bar.
-pub fn prewarm(app: &AppHandle) {
-    if crate::onboarding::is_pending(app) || app.get_webview_window(LABEL).is_some() {
-        return;
-    }
-    let Some(state) = app.try_state::<PopoverState>() else {
-        return;
-    };
-    let generation = {
-        let mut readiness = state.readiness();
-        match readiness.request_prewarm(Instant::now()) {
-            PrewarmAction::StartLoading { generation } => generation,
-            PrewarmAction::KeepExisting => return,
-        }
-    };
-    state.mark_prewarm(generation, Instant::now());
-    if let Err(error) = build_window(app, generation) {
-        state.clear_prewarm();
-        ::tracing::warn!(event = "popover_prewarm_failed", error = %error);
-    }
-}
-
-/// Handles a click on the menu-bar item.
-///
-/// `anchor` is the item's screen rectangle as reported by the tray backend.
-pub fn toggle(app: &AppHandle, anchor: Rect) {
-    let requested_at = Instant::now();
-    // Before the first run is finished the popover has nothing to show — the
-    // activity list is empty by construction, because the scan scheduler is
-    // gated on the same flag (see [`crate::scan`]). Send the click to the flow
-    // that is actually owed the reader, which also gets the window back for
-    // anyone who closed it partway through.
-    if crate::onboarding::is_pending(app) {
-        if let Err(error) = crate::onboarding::open(app) {
-            ::tracing::warn!(
-                event = "onboarding_window_open_failed",
-                trigger = "tray",
-                error = %error
-            );
-        }
-        return;
-    }
-
-    if let Some(window) = app.get_webview_window(LABEL)
-        && window.is_visible().unwrap_or(false)
-    {
-        // A pinned popover has no hide half to its toggle. Raise it instead of
-        // doing nothing: a menu-bar item that swallows a click reads as broken,
-        // and re-anchoring picks up a menu bar that has since moved display.
-        if is_pinned(app) {
-            if let Err(error) = anchor_to(&window, anchor) {
-                ::tracing::warn!(event = "popover_anchor_failed", error = %error);
-            }
-            focus_popover(&window);
-            return;
-        }
-        hide_window(app);
-        return;
-    }
-
-    if let Some(state) = app.try_state::<PopoverState>()
-        && state.suppresses_reopen()
-    {
-        return;
-    }
-
-    let request = match request_toggle_window(app, requested_at) {
-        Ok(request) => request,
-        Err(error) => {
-            ::tracing::error!(event = "popover_create_failed", error = %error);
-            return;
-        }
-    };
-    let (window, ready) = match request {
-        WindowRequest::Ready(window) => (window, true),
-        WindowRequest::Loading(window) => (window, false),
-        WindowRequest::AwaitingBuild => return,
-        WindowRequest::Cancelled => {
-            note_hidden(app);
-            schedule_prewarm_eviction(app);
-            return;
-        }
-    };
-
-    if let Err(error) = anchor_to(&window, anchor) {
-        // Positioning is best-effort: a popover in the wrong place still beats
-        // no popover at all.
-        ::tracing::warn!(event = "popover_anchor_failed", error = %error);
-    }
-
-    if !ready {
-        return;
-    }
-
-    reveal(&window);
 }
 
 /// Dismisses the popover from the webview — the Escape key, and anything else
@@ -1527,97 +888,6 @@ pub fn is_pinned(app: &AppHandle) -> bool {
         .is_some_and(|state| state.is_pinned())
 }
 
-/// Sets the pin, and either way hands focus back to the popover.
-///
-/// Pinning has to re-show the window, not just set a flag: the tray right-click
-/// that opened the menu took focus, so by the time this runs the popover has
-/// already hidden itself.
-///
-/// Unpinning does not hide anything — it restores ordinary dismissal rather
-/// than performing one — but it *must* refocus, for the same reason
-/// [`end_focus_hold`] does. The window sat there unfocused for as long as the
-/// menu was up, so without this there is no focus left to lose and the next
-/// click on another application would dismiss nothing.
-///
-/// Pinning is refused while the first run is unfinished. Re-showing is the
-/// point of a pin, and the popover must stay hidden during this period.
-/// Unpinning remains available so the tray action always does what it says.
-pub fn set_pinned(app: &AppHandle, pinned: bool) {
-    if pinned && crate::onboarding::is_pending(app) {
-        return;
-    }
-    let Some(state) = app.try_state::<PopoverState>() else {
-        return;
-    };
-    if !pinned {
-        state.set_pinned(false);
-        state.readiness().cancel_pending_reveal();
-        if let Some(window) = app.get_webview_window(LABEL)
-            && window.is_visible().unwrap_or(false)
-        {
-            focus_popover(&window);
-        } else {
-            schedule_prewarm_eviction(app);
-        }
-        return;
-    }
-
-    let request = match request_open_window(app, None) {
-        Ok(request) => request,
-        Err(error) => {
-            ::tracing::error!(event = "popover_create_failed", error = %error);
-            return;
-        }
-    };
-    let (window, ready) = match request {
-        WindowRequest::Ready(window) => (window, true),
-        WindowRequest::Loading(window) => (window, false),
-        WindowRequest::AwaitingBuild => {
-            state.set_pinned(true);
-            return;
-        }
-        WindowRequest::Cancelled => return,
-    };
-    state.set_pinned(true);
-
-    // Only a pin re-opens, and only from hidden: re-anchoring a window already
-    // on screen would move it for no reason the reader asked for.
-    if pinned && !window.is_visible().unwrap_or(false) {
-        // The dismissal this pin is undoing armed the reopen suppression;
-        // leaving it armed would let the next tray click be swallowed.
-        state.clear_auto_hide();
-
-        // The menu-bar item's live rectangle is the truth, and the only source
-        // that works on a cold start where the popover has never been opened.
-        // The remembered anchor covers a tray backend that reports none.
-        let placed = match app
-            .tray_by_id(crate::tray::TRAY_ID)
-            .and_then(|tray| tray.rect().ok().flatten())
-        {
-            Some(rect) => anchor_to(&window, rect),
-            None => match state.anchor() {
-                Some(anchor) => place(&window, anchor, WIDTH, state.height()),
-                None => fallback_place(&window, &state),
-            },
-        };
-        if let Err(error) = placed {
-            // Best-effort, as everywhere else: a popover in the wrong place
-            // still beats a pin that appears to do nothing.
-            ::tracing::warn!(event = "popover_anchor_failed", error = %error);
-        }
-
-        if ready {
-            reveal(&window);
-        }
-    }
-
-    // Guarded exactly as `end_focus_hold` is: focusing a hidden window would
-    // order it front, and an unpin is not a request to open anything.
-    if window.is_visible().unwrap_or(false) {
-        focus_popover(&window);
-    }
-}
-
 /// Reveal the popover after React commits its shell.
 pub fn renderer_ready(window: &WebviewWindow, generation: u64) {
     let app = window.app_handle();
@@ -1755,54 +1025,6 @@ pub fn note_hidden(app: &AppHandle) {
     crate::tray::set_highlight(app, false);
 }
 
-/// Records the menu-bar item's rectangle and places the popover against it.
-fn anchor_to(window: &WebviewWindow, anchor: Rect) -> tauri::Result<()> {
-    // Tray backends hand over *physical* coordinates on macOS and Windows, so
-    // the `to_physical(1.0)` is a no-op cast, not a conversion. Notably the
-    // popover window's own scale factor must NOT be used here: on a
-    // multi-display desktop the popover may last have been shown on a
-    // different-DPI screen than the one the menu-bar item lives on, and
-    // converting with the wrong scale lands the window on the wrong display.
-    let position = anchor.position.to_physical::<f64>(1.0);
-    let size = anchor.size.to_physical::<f64>(1.0);
-    let anchor = AnchorRect {
-        x: position.x,
-        y: position.y,
-        width: size.width,
-        height: size.height,
-    };
-    let state = window.app_handle().state::<PopoverState>();
-    state.record_anchor(anchor);
-
-    // The window's own logical geometry: the width is a constant and the
-    // height is the shell's bookkeeping, so no physical size read (whose scale
-    // depends on where the window last was) is involved.
-    place(window, anchor, WIDTH, state.height())
-}
-
-/// The last placement a pinned show can try: the tray backend reports no
-/// rectangle, and no earlier open left an anchor behind.
-///
-/// Linux only, because it is the only platform that reaches here. A pin on a
-/// cold start would otherwise leave the window wherever the window manager put
-/// it, which is the middle of the screen.
-///
-/// Records the anchor as well as using it, so the next height change places the
-/// window against the same point.
-#[cfg(target_os = "linux")]
-fn fallback_place(window: &WebviewWindow, state: &PopoverState) -> tauri::Result<()> {
-    let Some(anchor) = linux_anchor(window) else {
-        return Ok(());
-    };
-    state.record_anchor(anchor);
-    place(window, anchor, WIDTH, state.height())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn fallback_place(_window: &WebviewWindow, _state: &PopoverState) -> tauri::Result<()> {
-    Ok(())
-}
-
 /// The display's usable frame in logical coordinates, plus the scale that maps
 /// the anchor's physical rectangle into the same space.
 struct MonitorFrame {
@@ -1916,6 +1138,7 @@ fn clamp(value: f64, min: f64, max: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::window_readiness::OpenAction;
 
     #[test]
     fn clamp_prefers_the_low_edge_on_undersized_displays() {
@@ -2058,20 +1281,6 @@ mod tests {
     }
 
     #[test]
-    fn a_fresh_state_does_not_suppress_reopening() {
-        let state = PopoverState::default();
-        assert!(!state.suppresses_reopen());
-    }
-
-    #[test]
-    fn an_automatic_dismissal_suppresses_exactly_one_reopen() {
-        let state = PopoverState::default();
-        state.record_auto_hide();
-        assert!(state.suppresses_reopen());
-        assert!(!state.suppresses_reopen());
-    }
-
-    #[test]
     fn onboarding_restart_cancels_a_pending_cold_reveal() {
         let state = PopoverState::default();
         let started_at = Instant::now();
@@ -2087,43 +1296,6 @@ mod tests {
                 .renderer_ready(generation, started_at + Duration::from_millis(1)),
             crate::window_readiness::ReadyAction::StayHidden { .. }
         ));
-    }
-
-    #[test]
-    fn repeated_expired_readiness_keeps_the_deferred_replacement() {
-        let state = PopoverState::default();
-        let started_at = Instant::now();
-        assert!(matches!(
-            state.readiness().request_prewarm(started_at),
-            PrewarmAction::StartLoading { .. }
-        ));
-        let expired_generation = match state
-            .readiness()
-            .request_open(started_at + Duration::from_secs(64))
-        {
-            OpenAction::Rebuild { generation } => generation,
-            _ => unreachable!("the stale prewarm starts a replacement"),
-        };
-        state.timing.begin_open(
-            expired_generation,
-            started_at + Duration::from_secs(64),
-            true,
-            "loading",
-        );
-
-        let expired_at = started_at + Duration::from_secs(65);
-        prepare_expired_renderer_retirement(&state, expired_generation, expired_at);
-        let replacement = state
-            .readiness()
-            .loading_generation()
-            .expect("the pending click owns a replacement");
-        prepare_expired_renderer_retirement(&state, expired_generation, expired_at);
-
-        assert_eq!(state.readiness().loading_generation(), Some(replacement));
-        assert_eq!(
-            state.readiness().begin_deferred_build(expired_at),
-            Some(replacement)
-        );
     }
 
     #[test]
@@ -2200,63 +1372,6 @@ mod tests {
     }
 
     #[test]
-    fn a_pinned_unfocused_popover_is_never_pulled_forward() {
-        let state = PopoverState::default();
-        state.set_pinned(true);
-        state.begin_nudge_key_handoff(false);
-        assert!(state.is_pinned());
-        assert!(!state.release_nudge_key_handoff());
-    }
-
-    #[test]
-    fn a_prewarm_marker_belongs_to_one_renderer_generation() {
-        let state = PopoverState::default();
-
-        state.mark_prewarm(4, Instant::now());
-        assert!(state.is_prewarm(4));
-        assert!(!state.is_prewarm(5));
-
-        state.clear_prewarm();
-        assert!(!state.is_prewarm(4));
-    }
-
-    #[test]
-    fn the_pin_is_a_latch_the_reader_can_take_back() {
-        let state = PopoverState::default();
-        state.set_pinned(true);
-        assert!(state.is_pinned());
-        state.set_pinned(false);
-        assert!(!state.is_pinned());
-    }
-
-    #[test]
-    fn every_replacement_path_transfers_the_active_prewarm_deadline() {
-        let state = PopoverState::default();
-        let started_at = Instant::now();
-        state.mark_prewarm(4, started_at);
-
-        assert!(transfer_prewarm_for_replacement(&state, Some(4), 5));
-        assert!(!state.is_prewarm(4));
-        assert!(state.is_prewarm(5));
-        let schedule = state
-            .arm_prewarm_retention(5, started_at + Duration::from_secs(10))
-            .expect("the transferred prewarm remains retained");
-        assert_eq!(schedule.delay(), Duration::from_secs(55));
-        assert_eq!(schedule.mode(), EvictionMode::PrewarmLoading);
-    }
-
-    /// The tray right-click that opens the menu hides the popover, arming the
-    /// reopen suppression. Pinning clears it, or the next tray click would be
-    /// swallowed as the second half of a dismissal that no longer stands.
-    #[test]
-    fn clearing_a_dismissal_leaves_no_suppression_behind() {
-        let state = PopoverState::default();
-        state.record_auto_hide();
-        state.clear_auto_hide();
-        assert!(!state.suppresses_reopen());
-    }
-
-    #[test]
     fn a_view_can_only_ask_for_a_height_the_window_can_actually_be() {
         assert_eq!(clamp_height(MAX_HEIGHT), MAX_HEIGHT);
         assert_eq!(clamp_height(MIN_HEIGHT), MIN_HEIGHT);
@@ -2297,127 +1412,6 @@ mod tests {
         // Ease-out: more than half the distance is covered by the halfway point.
         assert!(ease_out(0.5) > 0.5);
         assert!(ease_out(0.25) < ease_out(0.75));
-    }
-
-    /// The GNOME shape, measured from a running session: a 32px top bar and a
-    /// 67px dock on the left. The tray is at the right end of the top bar, so
-    /// the anchor is the work area's top-right corner.
-    #[test]
-    fn a_top_panel_anchors_at_the_right_end_of_that_panel() {
-        let work = ScreenRect {
-            x: 67.0,
-            y: 32.0,
-            width: 2493.0,
-            height: 1338.0,
-        };
-        let monitor = ScreenRect {
-            x: 0.0,
-            y: 0.0,
-            width: 2560.0,
-            height: 1370.0,
-        };
-        assert_eq!(
-            synthesized_anchor(Some(work), Some(monitor)),
-            Some(AnchorRect {
-                x: 2560.0,
-                y: 32.0,
-                width: 0.0,
-                height: 0.0,
-            })
-        );
-    }
-
-    /// The KDE and Windows-like shape: one panel along the bottom. The anchor
-    /// is that panel's *top* edge, so the popover has something to sit above.
-    #[test]
-    fn a_bottom_panel_anchors_at_the_top_edge_of_that_panel() {
-        let work = ScreenRect {
-            x: 0.0,
-            y: 0.0,
-            width: 1920.0,
-            height: 1036.0,
-        };
-        let monitor = ScreenRect {
-            x: 0.0,
-            y: 0.0,
-            width: 1920.0,
-            height: 1080.0,
-        };
-        assert_eq!(
-            synthesized_anchor(Some(work), Some(monitor)),
-            Some(AnchorRect {
-                x: 1920.0,
-                y: 1036.0,
-                width: 0.0,
-                height: 0.0,
-            })
-        );
-    }
-
-    /// A display whose work area fills it has no panel to read. The top edge is
-    /// the right answer, because a tray that is not in a reserved strip is in a
-    /// bar the desktop draws over its own windows.
-    #[test]
-    fn a_display_with_no_reserved_panel_anchors_at_its_top_right() {
-        let full = ScreenRect {
-            x: 0.0,
-            y: 0.0,
-            width: 1920.0,
-            height: 1080.0,
-        };
-        assert_eq!(
-            synthesized_anchor(Some(full), Some(full)),
-            Some(AnchorRect {
-                x: 1920.0,
-                y: 0.0,
-                width: 0.0,
-                height: 0.0,
-            })
-        );
-    }
-
-    /// Nothing to place against is not an excuse to invent coordinates: the
-    /// window manager keeps the decision.
-    #[test]
-    fn no_monitor_at_all_leaves_the_placement_to_the_window_manager() {
-        assert_eq!(synthesized_anchor(None, None), None);
-    }
-
-    /// The whole Linux path, end to end, on the session this was measured from:
-    /// the popover opens under the top bar and tucks against the right edge,
-    /// which is where the tray item it belongs to sits.
-    #[test]
-    fn the_gnome_anchor_places_the_popover_beside_the_tray() {
-        let work = ScreenRect {
-            x: 67.0,
-            y: 32.0,
-            width: 2493.0,
-            height: 1338.0,
-        };
-        let monitor = ScreenRect {
-            x: 0.0,
-            y: 0.0,
-            width: 2560.0,
-            height: 1370.0,
-        };
-        let frame = MonitorFrame {
-            left: 0.0,
-            top: 0.0,
-            right: 2560.0,
-            bottom: 1370.0,
-            scale: 1.0,
-        };
-        let anchor = synthesized_anchor(Some(work), Some(monitor)).expect("the monitor answered");
-        let (x, y) = compute_position(anchor, Some(&frame), WIDTH, DEFAULT_HEIGHT);
-
-        // Clamped to the display's right margin rather than centered on the
-        // corner, which is what keeps it under the tray instead of half off
-        // the screen.
-        assert!(
-            (x - (2560.0 - WIDTH - SCREEN_MARGIN)).abs() < 0.5,
-            "x was {x}"
-        );
-        assert!((y - (32.0 + ANCHOR_GAP)).abs() < 0.5, "y was {y}");
     }
 
     /// The contract the Linux glue depends on: the anchor goes in physical, the

--- a/apps/desktop/src-tauri/src/popover/retention.rs
+++ b/apps/desktop/src-tauri/src/popover/retention.rs
@@ -9,9 +9,6 @@ use std::time::{Duration, Instant};
 /// How long onboarding keeps a hidden renderer after it becomes ready.
 pub(super) const PREWARM_READY_EVICTION_DELAY: Duration = Duration::from_secs(60);
 
-/// How long onboarding keeps a renderer that does not become ready.
-pub(super) const PREWARM_LOADING_EVICTION_DELAY: Duration = Duration::from_secs(65);
-
 /// How long the shell waits before it retries a failed destruction.
 pub(super) const EVICTION_RETRY_DELAY: Duration = Duration::from_secs(1);
 
@@ -74,22 +71,8 @@ struct PrewarmLease {
 }
 
 impl PrewarmLease {
-    fn begin(&mut self, generation: u64, now: Instant) {
-        self.generation = Some(generation);
-        self.loading_deadline = Some(now + PREWARM_LOADING_EVICTION_DELAY);
-        self.ready_deadline = None;
-    }
-
     fn contains(&self, generation: u64) -> bool {
         self.generation == Some(generation)
-    }
-
-    fn transfer(&mut self, from: u64, to: u64) -> bool {
-        if !self.contains(from) {
-            return false;
-        }
-        self.generation = Some(to);
-        true
     }
 
     fn mark_ready(&mut self, generation: u64, now: Instant) -> bool {
@@ -167,20 +150,8 @@ pub(super) struct Retention {
 }
 
 impl Retention {
-    pub(super) fn begin_prewarm(&mut self, generation: u64, now: Instant) {
-        self.prewarm.begin(generation, now);
-    }
-
     pub(super) fn is_prewarm(&self, generation: u64) -> bool {
         self.prewarm.contains(generation)
-    }
-
-    pub(super) fn prewarm_generation(&self) -> Option<u64> {
-        self.prewarm.generation
-    }
-
-    pub(super) fn transfer_prewarm(&mut self, from: u64, to: u64) -> bool {
-        self.prewarm.transfer(from, to)
     }
 
     pub(super) fn mark_prewarm_ready(&mut self, generation: u64, now: Instant) -> bool {
@@ -304,174 +275,5 @@ mod tests {
         let mut retention = Retention::default();
 
         assert_eq!(retention.arm_hidden(4, now), None);
-    }
-
-    #[test]
-    fn onboarding_prewarm_changes_from_a_loading_to_a_ready_lease() {
-        let started_at = Instant::now();
-        let mut retention = Retention::default();
-        retention.begin_prewarm(4, started_at);
-
-        let loading = retention
-            .arm_hidden(4, started_at)
-            .expect("a loading prewarm must get a fail-safe schedule");
-        assert_eq!(loading.delay(), Duration::from_secs(65));
-        assert_eq!(loading.mode(), EvictionMode::PrewarmLoading);
-
-        let ready_at = started_at + Duration::from_secs(2);
-        assert!(retention.mark_prewarm_ready(4, ready_at));
-        let ready = retention
-            .arm_hidden(4, ready_at)
-            .expect("a ready prewarm must keep its renderer");
-        assert_eq!(ready.delay(), Duration::from_secs(60));
-        assert_eq!(ready.mode(), EvictionMode::PrewarmReady);
-    }
-
-    #[test]
-    fn a_generation_transfer_preserves_the_original_loading_deadline() {
-        let started_at = Instant::now();
-        let mut retention = Retention::default();
-        retention.begin_prewarm(4, started_at);
-
-        assert!(retention.transfer_prewarm(4, 5));
-        assert!(!retention.is_prewarm(4));
-        assert!(retention.is_prewarm(5));
-
-        let schedule = retention
-            .arm_hidden(5, started_at + Duration::from_secs(10))
-            .expect("the replacement must inherit the lease");
-        assert_eq!(schedule.delay(), Duration::from_secs(55));
-        assert_eq!(schedule.mode(), EvictionMode::PrewarmLoading);
-    }
-
-    #[test]
-    fn a_ready_generation_transfer_preserves_the_absolute_deadline() {
-        let started_at = Instant::now();
-        let ready_at = started_at + Duration::from_secs(2);
-        let mut retention = Retention::default();
-        retention.begin_prewarm(4, started_at);
-        assert!(retention.mark_prewarm_ready(4, ready_at));
-
-        assert!(retention.transfer_prewarm(4, 5));
-        let first = retention
-            .arm_hidden(5, ready_at + Duration::from_secs(10))
-            .expect("the transferred ready lease remains active");
-        assert_eq!(first.delay(), Duration::from_secs(50));
-
-        let rearmed = retention
-            .arm_hidden(5, ready_at + Duration::from_secs(20))
-            .expect("rearming keeps the original ready deadline");
-        assert_eq!(rearmed.delay(), Duration::from_secs(40));
-        assert_eq!(rearmed.mode(), EvictionMode::PrewarmReady);
-    }
-
-    #[test]
-    fn the_first_reveal_consumes_the_prewarm_lease_once() {
-        let mut retention = Retention::default();
-        let now = Instant::now();
-        retention.begin_prewarm(4, now);
-
-        assert!(retention.consume_prewarm_on_reveal(4));
-        assert!(!retention.consume_prewarm_on_reveal(4));
-        assert_eq!(retention.prewarm_generation(), None);
-        assert_eq!(retention.arm_hidden(4, now), None);
-    }
-
-    #[test]
-    fn an_expired_loading_lease_cannot_become_a_ready_lease() {
-        let started_at = Instant::now();
-        let mut retention = Retention::default();
-        retention.begin_prewarm(4, started_at);
-        let expired_at = started_at + PREWARM_LOADING_EVICTION_DELAY;
-
-        assert_eq!(
-            retention.expired_prewarm(expired_at),
-            Some(DueEviction {
-                renderer_generation: 4,
-                mode: EvictionMode::PrewarmLoading,
-            })
-        );
-        assert!(!retention.mark_prewarm_ready(4, expired_at));
-        assert!(retention.is_prewarm(4));
-    }
-
-    #[test]
-    fn a_replacement_schedule_invalidates_the_old_eviction_token() {
-        let now = Instant::now();
-        let mut retention = Retention::default();
-        retention.begin_prewarm(4, now);
-        let first = retention
-            .arm_hidden(4, now)
-            .expect("the first prewarm schedule must arm eviction");
-        let replacement = retention
-            .arm_hidden(4, now)
-            .expect("the repeated prewarm schedule must replace eviction");
-
-        assert_eq!(retention.take_due(first.token(), 4, false), None);
-        assert_eq!(
-            retention.take_due(replacement.token(), 4, false),
-            Some(DueEviction {
-                renderer_generation: 4,
-                mode: EvictionMode::PrewarmLoading,
-            })
-        );
-    }
-
-    #[test]
-    fn visibility_and_renderer_replacement_protect_a_prewarm_renderer() {
-        let now = Instant::now();
-        let mut visible = Retention::default();
-        visible.begin_prewarm(4, now);
-        let visible_schedule = visible
-            .arm_hidden(4, now)
-            .expect("the prewarm must arm eviction");
-        assert_eq!(visible.take_due(visible_schedule.token(), 4, true), None);
-
-        let mut replaced = Retention::default();
-        replaced.begin_prewarm(4, now);
-        let replaced_schedule = replaced
-            .arm_hidden(4, now)
-            .expect("the prewarm must arm eviction");
-        assert_eq!(replaced.take_due(replaced_schedule.token(), 5, false), None);
-    }
-
-    #[test]
-    fn a_failed_destruction_retries_without_releasing_the_prewarm_lease() {
-        let now = Instant::now();
-        let mut retention = Retention::default();
-        retention.begin_prewarm(4, now);
-        let first = retention
-            .arm_hidden(4, now)
-            .expect("the loading prewarm must arm eviction");
-
-        let due = retention
-            .take_due(first.token(), 4, false)
-            .expect("the deadline callback must own the matching renderer");
-        let retry = retention.arm_retry(due.renderer_generation(), due.mode());
-
-        assert_eq!(retry.delay(), Duration::from_secs(1));
-        assert_eq!(retry.mode(), EvictionMode::PrewarmLoading);
-        assert!(retention.is_prewarm(4));
-        assert_eq!(
-            retention.take_due(retry.token(), 4, false),
-            Some(DueEviction {
-                renderer_generation: 4,
-                mode: EvictionMode::PrewarmLoading,
-            })
-        );
-    }
-
-    #[test]
-    fn onboarding_restart_takes_the_active_lease_and_invalidates_eviction() {
-        let now = Instant::now();
-        let mut retention = Retention::default();
-        retention.begin_prewarm(4, now);
-        let schedule = retention
-            .arm_hidden(4, now)
-            .expect("the loading prewarm must arm eviction");
-
-        assert_eq!(retention.take_prewarm(), Some(4));
-        retention.cancel_eviction();
-        assert_eq!(retention.take_due(schedule.token(), 4, false), None);
     }
 }

--- a/apps/desktop/src-tauri/src/popover/timing.rs
+++ b/apps/desktop/src-tauri/src/popover/timing.rs
@@ -122,37 +122,6 @@ impl PopoverTiming {
         }
     }
 
-    pub(super) fn begin_open(
-        &self,
-        generation: u64,
-        requested_at: Instant,
-        prewarmed: bool,
-        renderer_state: &'static str,
-    ) {
-        let milestones = self
-            .milestones
-            .lock()
-            .map(|milestones| *milestones)
-            .unwrap_or_default();
-        if let Ok(mut open) = self.open.lock() {
-            *open = Some(OpenTiming::new(
-                generation,
-                requested_at,
-                prewarmed,
-                renderer_state,
-                milestones,
-            ));
-        }
-        ::tracing::info!(
-            event = "popover_open_timing",
-            phase = "requested",
-            generation,
-            prewarmed,
-            renderer_state,
-            elapsed_ms = 0_u64
-        );
-    }
-
     pub(super) fn cancel_open(&self) {
         if let Ok(mut open) = self.open.lock() {
             *open = None;
@@ -387,20 +356,5 @@ mod tests {
             timing.mark_revealed(7, requested_at + Duration::from_millis(70)),
             None
         );
-    }
-
-    #[test]
-    fn an_expired_replacement_keeps_the_original_click_boundary() {
-        let requested_at = Instant::now();
-        let timing = PopoverTiming::default();
-        timing.begin_open(7, requested_at, true, "loading");
-
-        assert!(timing.replace_open_generation(7, 8));
-        let open = timing.open.lock().expect("the timing lock stays available");
-        let open = open.as_ref().expect("the click remains active");
-        assert_eq!(open.generation, 8);
-        assert_eq!(open.requested_at, requested_at);
-        assert!(!open.prewarmed);
-        assert_eq!(open.renderer_state, "expired_replacement");
     }
 }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -1,14 +1,7 @@
 //! The menu-bar / system-tray item.
 //!
-//! Left click toggles the popover; right click opens a short menu. The menu
-//! carries Quit because an agent application has no Dock icon and no
-//! application menu — without it there would be no way to exit antiburn. It
-//! also carries the popover's pin, which needs a surface that survives the
-//! popover being dismissed — and the menu bar is the only one there is.
-//!
-//! Linux is different. The AppIndicator backend reports no click events, and
-//! every click opens the menu. So the menu's first item, Open antiburn, is what
-//! opens the popover there.
+//! Left click opens the main window. Right click opens the application menu.
+//! Linux uses the menu's Open antiburn item because AppIndicator reports no clicks.
 
 use std::sync::Mutex;
 use std::time::Duration;
@@ -23,7 +16,7 @@ use tauri::{Emitter, Manager, Wry};
 
 #[cfg(debug_assertions)]
 use crate::commands;
-use crate::{nudges, popover, settings};
+use crate::{nudges, settings};
 
 const DOT_COUNT: usize = 13;
 const COLUMN_COUNT: usize = 5;
@@ -89,9 +82,6 @@ impl Default for UsageMeter {
 }
 
 const MENU_MAIN: &str = "open-main";
-#[cfg(target_os = "linux")]
-const MENU_OPEN_POPOVER: &str = "open-popover";
-const MENU_PIN: &str = "pin";
 const MENU_SETTINGS: &str = "settings";
 #[cfg(debug_assertions)]
 const MENU_RESET_ONBOARDING: &str = "reset-onboarding";
@@ -101,13 +91,7 @@ const MENU_RANDOM_USAGE: &str = "random-usage";
 const MENU_BURN_CHECKS: &str = "burn-checks";
 const MENU_QUIT: &str = "quit";
 
-/// Title case, matching "Quit antiburn" and the platform's own menus.
-const PIN_LABEL: &str = "Pin Window";
-const UNPIN_LABEL: &str = "Unpin Window";
-
 const OPEN_LABEL: &str = "Open antiburn";
-#[cfg(target_os = "linux")]
-const OPEN_POPOVER_LABEL: &str = "Open Usage Popover";
 #[cfg(debug_assertions)]
 const RESET_ONBOARDING_LABEL: &str = "Reset Onboarding";
 #[cfg(debug_assertions)]
@@ -138,7 +122,6 @@ impl Default for DebugBurnChecks {
 /// marshals through `run_main_thread!`, which runs its closure inline when the
 /// caller is already on the main thread — as [`on_menu_event`] is.
 pub struct TrayMenu {
-    pin: MenuItem<Wry>,
     #[cfg(debug_assertions)]
     random_usage: CheckMenuItem<Wry>,
     #[cfg(debug_assertions)]
@@ -147,24 +130,16 @@ pub struct TrayMenu {
 
 struct BuiltMenu {
     menu: Menu<Wry>,
-    pin: MenuItem<Wry>,
     #[cfg(debug_assertions)]
     random_usage: CheckMenuItem<Wry>,
     #[cfg(debug_assertions)]
     burn_checks: CheckMenuItem<Wry>,
 }
 
-/// The label the pin item carries for a given state — it names the action, not
-/// the condition, so a pinned window offers "Unpin Window".
-fn pin_label(pinned: bool) -> &'static str {
-    if pinned { UNPIN_LABEL } else { PIN_LABEL }
-}
-
 /// Builds the menu-bar item and wires up its click and menu handling.
 pub fn create(app: &AppHandle) -> tauri::Result<TrayIcon> {
     let menu = build_menu(app)?;
     app.manage(TrayMenu {
-        pin: menu.pin,
         #[cfg(debug_assertions)]
         random_usage: menu.random_usage,
         #[cfg(debug_assertions)]
@@ -180,9 +155,7 @@ pub fn create(app: &AppHandle) -> tauri::Result<TrayIcon> {
         .icon_as_template(true)
         .tooltip("antiburn")
         .menu(&menu.menu)
-        // The menu belongs to the secondary button; the primary button is the
-        // popover toggle. Linux ignores this option, because the AppIndicator
-        // menu opens on every click.
+        // The primary button opens the main window. Linux opens the menu on every click.
         .show_menu_on_left_click(false)
         .on_tray_icon_event(on_tray_event)
         .on_menu_event(on_menu_event)
@@ -532,22 +505,8 @@ fn visible_windows(provider: &crate::dto::LiveProviderUsage) -> Vec<&crate::dto:
         .collect()
 }
 
-/// Returns the menu and a handle to the one item that changes after the build.
-///
-/// The pin sits above Settings: it acts on the window the reader just had in
-/// front of them, where the other two act on the application.
-///
-/// On Linux the menu is the only route into the popover, so Open goes first as
-/// the default action. It needs no separator of its own, because it acts on the
-/// same window the pin does.
+/// Build the application menu and its debug controls.
 fn build_menu(app: &AppHandle) -> tauri::Result<BuiltMenu> {
-    let pin_item = MenuItem::with_id(
-        app,
-        MENU_PIN,
-        pin_label(popover::is_pinned(app)),
-        true,
-        None::<&str>,
-    )?;
     let settings_item = MenuItem::with_id(app, MENU_SETTINGS, "Settings…", true, None::<&str>)?;
     #[cfg(debug_assertions)]
     let reset_onboarding_item = MenuItem::with_id(
@@ -578,20 +537,8 @@ fn build_menu(app: &AppHandle) -> tauri::Result<BuiltMenu> {
     let separator = PredefinedMenuItem::separator(app)?;
     let quit_item = MenuItem::with_id(app, MENU_QUIT, "Quit antiburn", true, None::<&str>)?;
     let main_item = MenuItem::with_id(app, MENU_MAIN, OPEN_LABEL, true, None::<&str>)?;
-    #[cfg(target_os = "linux")]
-    let open_popover_item = MenuItem::with_id(
-        app,
-        MENU_OPEN_POPOVER,
-        OPEN_POPOVER_LABEL,
-        true,
-        None::<&str>,
-    )?;
-
     let items: Vec<&dyn IsMenuItem<Wry>> = vec![
         &main_item,
-        #[cfg(target_os = "linux")]
-        &open_popover_item,
-        &pin_item,
         &settings_item,
         #[cfg(debug_assertions)]
         &reset_onboarding_item,
@@ -605,7 +552,6 @@ fn build_menu(app: &AppHandle) -> tauri::Result<BuiltMenu> {
     let menu = Menu::with_items(app, &items)?;
     Ok(BuiltMenu {
         menu,
-        pin: pin_item,
         #[cfg(debug_assertions)]
         random_usage: random_usage_item,
         #[cfg(debug_assertions)]
@@ -613,52 +559,35 @@ fn build_menu(app: &AppHandle) -> tauri::Result<BuiltMenu> {
     })
 }
 
+fn opens_main_window(event: &TrayIconEvent) -> bool {
+    matches!(
+        event,
+        TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            ..
+        }
+    )
+}
+
 fn on_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
-    // Act on release, not press: pressing and dragging away should not toggle.
-    if let TrayIconEvent::Click {
-        button: MouseButton::Left,
-        button_state: MouseButtonState::Up,
-        rect,
-        ..
-    } = event
-    {
-        // The tray click acknowledges the nudge, even when it closes the popover.
+    if opens_main_window(&event) {
         nudges::dismiss(tray.app_handle());
-        popover::toggle(tray.app_handle(), rect);
+        open_main_window(tray.app_handle());
+    }
+}
+
+pub(crate) fn open_main_window(app: &AppHandle) {
+    if let Err(error) =
+        crate::open_launch_surface(app, crate::main_window::OpenTrigger::Interaction)
+    {
+        ::tracing::error!(event = "main_window_open_failed", trigger = "tray", error = %error);
     }
 }
 
 fn on_menu_event(app: &AppHandle, event: MenuEvent) {
     match event.id().as_ref() {
-        MENU_MAIN => {
-            if let Err(error) =
-                crate::open_launch_surface(app, crate::main_window::OpenTrigger::Interaction)
-            {
-                ::tracing::error!(event = "main_window_open_failed", trigger = "tray", error = %error);
-            }
-        }
-        #[cfg(target_os = "linux")]
-        MENU_OPEN_POPOVER => popover::open_from_tray_menu(app),
-        MENU_PIN => {
-            // The item names the action, so choosing it always means "do the
-            // other thing"; the popover is re-shown by `set_pinned`, because
-            // opening this menu is what dismissed it.
-            popover::set_pinned(app, !popover::is_pinned(app));
-            // Read the state back rather than trusting what was asked for, so
-            // the label can never claim a pin that did not take.
-            let pinned = popover::is_pinned(app);
-            if let Some(menu) = app.try_state::<TrayMenu>()
-                && let Err(error) = menu.pin.set_text(pin_label(pinned))
-            {
-                // The pin itself took effect; only the label is stale, and the
-                // next state change relabels it.
-                ::tracing::warn!(
-                    event = "tray_pin_relabel_failed",
-                    pinned,
-                    error = %error
-                );
-            }
-        }
+        MENU_MAIN => open_main_window(app),
         MENU_SETTINGS => {
             // No pane in particular: the tray's Settings item is a general
             // entry point, so it leaves the window wherever it was last.
@@ -744,13 +673,35 @@ mod tests {
         LiveUsageSupport, LiveUsageWindow,
     };
 
-    /// A pinned window offers the way out, not a restatement of where it is.
-    /// This is the whole contract of the item, so it is worth a test that does
-    /// not need a menu to run.
     #[test]
-    fn the_pin_item_always_names_the_action_it_would_take() {
-        assert_eq!(pin_label(false), "Pin Window");
-        assert_eq!(pin_label(true), "Unpin Window");
+    fn only_primary_button_release_opens_main() {
+        for button in [MouseButton::Left, MouseButton::Right, MouseButton::Middle] {
+            for button_state in [MouseButtonState::Down, MouseButtonState::Up] {
+                let event = TrayIconEvent::Click {
+                    id: TRAY_ID.into(),
+                    position: tauri::PhysicalPosition::new(0.0, 0.0),
+                    rect: tauri::Rect {
+                        position: tauri::PhysicalPosition::new(0, 0).into(),
+                        size: tauri::PhysicalSize::new(20, 20).into(),
+                    },
+                    button,
+                    button_state,
+                };
+                assert_eq!(
+                    opens_main_window(&event),
+                    button == MouseButton::Left && button_state == MouseButtonState::Up,
+                );
+            }
+        }
+        let hover = TrayIconEvent::Enter {
+            id: TRAY_ID.into(),
+            position: tauri::PhysicalPosition::new(0.0, 0.0),
+            rect: tauri::Rect {
+                position: tauri::PhysicalPosition::new(0, 0).into(),
+                size: tauri::PhysicalSize::new(20, 20).into(),
+            },
+        };
+        assert!(!opens_main_window(&hover));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/window_readiness.rs
+++ b/apps/desktop/src-tauri/src/window_readiness.rs
@@ -37,30 +37,6 @@ pub enum RetainedOpenAction {
     AttendTerminal,
 }
 
-/// The action for a request that toggles a window.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ToggleAction {
-    /// Build the first renderer for this window.
-    StartLoading { generation: u64 },
-    /// Keep waiting and reveal the window when the renderer becomes ready.
-    AwaitReady,
-    /// Cancel the reveal that was waiting for renderer readiness.
-    CancelPendingReveal,
-    /// Use the current native visibility to show or hide the ready window.
-    UseWindowVisibility,
-    /// Replace the stale renderer once for this load cycle.
-    Rebuild { generation: u64 },
-}
-
-/// The action for a request that warms a hidden window.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PrewarmAction {
-    /// Build the first renderer without a pending reveal.
-    StartLoading { generation: u64 },
-    /// Keep the renderer or load that already exists.
-    KeepExisting,
-}
-
 /// The action to take after the renderer reports readiness.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReadyAction {
@@ -130,17 +106,6 @@ pub struct WindowReadiness {
 }
 
 impl WindowReadiness {
-    /// Request a hidden renderer without changing an existing reveal request.
-    pub fn request_prewarm(&mut self, now: Instant) -> PrewarmAction {
-        match &self.phase {
-            Phase::Idle => {
-                let generation = self.replace_loading(now, false, false);
-                PrewarmAction::StartLoading { generation }
-            }
-            Phase::Loading(_) | Phase::Ready(_) | Phase::Terminal(_) => PrewarmAction::KeepExisting,
-        }
-    }
-
     /// Request a visible window without duplicating an active renderer load.
     pub fn request_open(&mut self, now: Instant) -> OpenAction {
         match &mut self.phase {
@@ -198,31 +163,6 @@ impl WindowReadiness {
                 }
             }
             Phase::Terminal(_) => RetainedOpenAction::AttendTerminal,
-        }
-    }
-
-    /// Request a toggle without showing a renderer that still loads.
-    pub fn toggle_open(&mut self, now: Instant) -> ToggleAction {
-        match &mut self.phase {
-            Phase::Idle => {
-                let generation = self.replace_loading(now, true, false);
-                ToggleAction::StartLoading { generation }
-            }
-            Phase::Ready(_) => ToggleAction::UseWindowVisibility,
-            Phase::Terminal(_) => ToggleAction::AwaitReady,
-            Phase::Loading(load) if load.reveal_pending => {
-                load.reveal_pending = false;
-                ToggleAction::CancelPendingReveal
-            }
-            Phase::Loading(load) => {
-                load.reveal_pending = true;
-                if load_is_stale(load, now) && !load.rebuild_used {
-                    let generation = self.replace_loading(now, true, true);
-                    ToggleAction::Rebuild { generation }
-                } else {
-                    ToggleAction::AwaitReady
-                }
-            }
         }
     }
 
@@ -569,33 +509,13 @@ mod tests {
     }
 
     fn ready_hidden(readiness: &mut WindowReadiness, now: Instant) -> u64 {
-        let PrewarmAction::StartLoading { generation } = readiness.request_prewarm(now) else {
-            panic!("an idle lifecycle must start prewarming")
-        };
+        let generation = start_loading(readiness, now);
+        readiness.cancel_pending_reveal();
         assert!(matches!(
             readiness.renderer_ready(generation, now),
             ReadyAction::StayHidden { .. }
         ));
         generation
-    }
-
-    #[test]
-    fn existing_open_and_prewarm_behavior_remains_available() {
-        let started_at = Instant::now();
-        let mut readiness = WindowReadiness::default();
-        let generation = start_loading(&mut readiness, started_at);
-        assert_eq!(readiness.request_open(started_at), OpenAction::AwaitReady);
-        assert_eq!(
-            readiness.renderer_ready(generation, started_at + Duration::from_secs(1)),
-            ReadyAction::Reveal {
-                loading_for: Duration::from_secs(1)
-            }
-        );
-        assert_eq!(readiness.request_open(started_at), OpenAction::Reveal);
-        assert_eq!(
-            readiness.request_prewarm(started_at),
-            PrewarmAction::KeepExisting
-        );
     }
 
     #[test]

--- a/docs/plans/tray-opens-main.md
+++ b/docs/plans/tray-opens-main.md
@@ -1,0 +1,32 @@
+# Menu-bar clicks open the main window
+
+Keith approved this plan. Stack the change on PR #493.
+
+## Scope
+
+Replace the anchored report window with direct access to the main window.
+Menu-bar clicks open or focus the main window. Remove popover pin controls
+and redirect other user-facing paths that can open the anchored report.
+Preserve the tray context menu and unrelated notification behaviour.
+
+## Steps
+
+| Step | Status |
+| --- | --- |
+| Trace window entry points and tray controls | Complete |
+| Implement direct main-window opening and regression coverage | Complete |
+| Run relevant checks and build | Native tests and Clippy passed; bundle and doctest verification in progress |
+| Open stacked PR and verify CI | Next; results tracked in the PR |
+
+## Validation
+
+- All 1,198 native unit tests passed.
+- Native Clippy, Rust formatting, frontend formatting/build, design drift,
+  full-tree slop, and secret checks passed.
+- The initial doctest run could not resolve compiled Tauri dependencies while
+  other Cargo jobs used the shared target. Recheck after bundling completes.
+- Confirm manually: repeated primary clicks focus main; secondary click keeps
+  the application menu; setup and the menu-bar notification open the right window.
+
+The diff removes obsolete opening APIs and their dedicated tests. Legacy IPC
+and lifecycle support remain for a separate removal of the old renderer.

--- a/docs/plans/tray-opens-main.md
+++ b/docs/plans/tray-opens-main.md
@@ -15,16 +15,17 @@ Preserve the tray context menu and unrelated notification behaviour.
 | --- | --- |
 | Trace window entry points and tray controls | Complete |
 | Implement direct main-window opening and regression coverage | Complete |
-| Run relevant checks and build | Native tests and Clippy passed; bundle and doctest verification in progress |
-| Open stacked PR and verify CI | Next; results tracked in the PR |
+| Run relevant checks and build | Complete |
+| Open stacked PR and verify CI | [PR #496 and live checks](https://github.com/antiburn/antiburn/pull/496/checks) |
 
 ## Validation
 
 - All 1,198 native unit tests passed.
 - Native Clippy, Rust formatting, frontend formatting/build, design drift,
   full-tree slop, and secret checks passed.
-- The initial doctest run could not resolve compiled Tauri dependencies while
-  other Cargo jobs used the shared target. Recheck after bundling completes.
+- Native debug bundling and the separate doctest run passed.
+- The review build was launched. Automated visual verification was unavailable
+  because Computer Use permissions were not granted.
 - Confirm manually: repeated primary clicks focus main; secondary click keeps
   the application menu; setup and the menu-bar notification open the right window.
 


### PR DESCRIPTION
## User impact
Stacked on #493. Clicking the menu-bar icon now opens or focuses the main window instead of showing the anchored popover. Repeated clicks keep the main window open. Unfinished setup still opens onboarding.

Remove Pin Window and Linux's Open Usage Popover menu item. The menu-bar notification's Show me action also opens main. Completing onboarding no longer prewarms the popover. Right-click Open antiburn, Settings, and Quit remain available; Linux uses the Open antiburn menu item.

Most of this diff deletes the obsolete opening, toggling, pinning, and prewarm APIs and their dedicated tests. Legacy renderer IPC/lifecycle support remains for separate cleanup.

**Screenshot:** Keith to attach the main window with the tray context menu visible.

## Validation
- All selected [CI checks](https://github.com/antiburn/antiburn/actions/runs/34564170531) passed, including macOS/Linux/Windows native checks and ci-required.
- 1,198 native unit tests passed; native Clippy and formatting passed.
- Frontend formatting/build, design drift, full-tree slop, and secret scan passed.
- Regression tests cover primary-button release versus other buttons/hover, and onboarding handoff without prewarming.
- macOS debug bundling and the separate doctest recheck passed. The review build is running.
- Manual menu-bar interaction review remains: Computer Use permissions were not granted.

## Analytics
Existing main-window and onboarding paths are reused. No new events or properties are introduced. This change does not separately measure the source of a main-window opening; that remains an intentional measurement gap.

## Privacy and performance
No new data collection or network activity. Onboarding no longer creates a hidden popover renderer.

## Checklist
- [x] Tests use synthetic events.
- [x] No credentials or private session content added.
- [x] Commits include DCO sign-off.
- [x] Tests and desktop behaviour documentation updated.
