### PR TITLE
Make tray Burn Checks click-only with clearer hover feedback

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -858,3 +858,8 @@ state in the same slot. Sample-session disclosure labels use semibold callout
 text and the count first, such as “3 Sample sessions”, with no chevron. Hover
 uses `surface-secondary/50` and `label` text with the standard fast transition. Preserve their
 expanded state, keyboard interaction, and accessible disclosure attributes.
+
+The menu-bar Burn Checks summary uses `surface-card/50` at rest and
+`surface-secondary/70` on hover or focus within, with a `duration-fast` colour
+transition. Its summary button uses a pointer cursor. Hover does not open the
+checks companion; clicking opens Burn Checks in the main window.

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -758,36 +758,36 @@ describe("PopoverView", () => {
     expect(screen.getByRole("img", { name: "Codex at 40 percent" })).toBeInTheDocument()
   })
 
-  it("shows Checks in one passive anchored preview", async () => {
+  it("keeps Checks click-only when hovered or focused", async () => {
     render(<PopoverView />)
-
     await screen.findByText("1 failed")
     const trigger = (await screen.findByTestId("burn-check-headline")).closest("button")!
-    fireEvent.mouseEnter(trigger)
 
-    expect(screen.queryByRole("heading", { name: "Checks" })).not.toBeInTheDocument()
-    await waitFor(() => {
-      expect(trigger.parentElement).toHaveAttribute("data-state", "active")
-      const requests = invoke.mock.calls.filter(([command]) => command === "show_popover_peek")
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.[1]).toMatchObject({
-        target: { kind: "checks" },
-        initialPresentation: {
-          kind: "checks",
-          presentation: {
-            failures: [expect.objectContaining({ id: "cacheChurn" })],
-            wins: [expect.objectContaining({ id: "sessionsOverDepth" })],
-            refreshUnavailable: false,
-          },
-        },
+    vi.useFakeTimers()
+    try {
+      fireEvent.mouseEnter(trigger)
+      fireEvent.focus(trigger)
+      await act(async () => vi.advanceTimersByTimeAsync(300))
+      expect(trigger.parentElement).toHaveAttribute("data-state", "idle")
+      expect(
+        invoke.mock.calls.filter(([command]) => command === "show_popover_peek"),
+      ).toHaveLength(0)
+      fireEvent.click(trigger)
+      expect(invoke).toHaveBeenCalledWith("open_main_window_section", {
+        section: "burnChecks",
       })
-    })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it("conceals the Checks preview when the Activity list scrolls", async () => {
+  it("conceals the provider preview when the Activity list scrolls", async () => {
     render(<PopoverView />)
     await screen.findByText("1 failed")
-    fireEvent.mouseEnter((await screen.findByTestId("burn-check-headline")).closest("button")!)
+    fireEvent.mouseEnter(await screen.findByRole("img", { name: "Codex at 40 percent" }))
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("show_popover_peek", expect.anything()),
+    )
 
     const viewport = screen
       .getByRole("region", { name: "Sessions" })

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -84,7 +84,7 @@ function selectedProviderPresentation(
  * The tray popover.
  *
  * The window shows activity. Session cards open the retained main window.
- * Usage and Checks use the anchored companion window.
+ * Usage uses the anchored companion window. Checks opens the main window.
  * `PopoverSession` owns Escape handling and temporary attention-banner dismissal.
  */
 
@@ -204,19 +204,10 @@ export function PopoverView() {
               className="shrink-0 px-[var(--space-sm)] pt-[var(--space-md)]"
             >
               <ChecksSummary
-                active={
-                  peekTrigger.target?.kind === "checks" && peekTrigger.activation !== "idle"
-                }
+                active={false}
                 presentation={checks}
                 reportUnavailable={state.checksUnavailable}
-                onPreview={(anchor) => {
-                  if (!checks) return
-                  void peekTriggers.hover({ kind: "checks" }, anchor, {
-                    kind: "checks",
-                    presentation: checks,
-                    pendingEvidence: state.checksReport?.pendingEvidence ?? 0,
-                  })
-                }}
+                onPreview={() => void peekTriggers.leave()}
                 onLeave={() => void peekTriggers.leave()}
                 onOpen={() => {
                   void peekTriggers.leave()

--- a/apps/desktop/src/views/popover/ChecksView.tsx
+++ b/apps/desktop/src/views/popover/ChecksView.tsx
@@ -65,7 +65,7 @@ export function ChecksSummary({
         hovered.current = false
         if (!focused.current) onLeave()
       }}
-      className="burn-check-summary-surface group flex items-center rounded-control bg-surface-card/50 hover:bg-surface-hover/35 data-[state=active]:bg-surface-selected/40"
+      className="burn-check-summary-surface group flex items-center rounded-control bg-surface-card/50 transition-colors duration-fast hover:bg-surface-secondary/70 focus-within:bg-surface-secondary/70 data-[state=active]:bg-surface-selected/40"
     >
       <button
         type="button"
@@ -82,7 +82,7 @@ export function ChecksSummary({
           focused.current = false
           if (!hovered.current) onLeave()
         }}
-        className="min-w-0 flex-1 rounded-control text-left disabled:opacity-100 active:transform-none active:opacity-100"
+        className="min-w-0 flex-1 cursor-pointer rounded-control text-left disabled:opacity-100 active:transform-none active:opacity-100"
       >
         <BurnCheckSummary presentation={burnChecks} />
       </button>

--- a/docs/plans/tray-opens-main.md
+++ b/docs/plans/tray-opens-main.md
@@ -1,0 +1,20 @@
+# Burn Checks summary without an anchored preview
+
+## Corrected scope
+
+Keep the normal menu-bar popover, tray controls, provider usage previews, and
+onboarding behaviour. Hovering or focusing the Burn Checks summary must not
+open the additional anchored checks window. Clicking the summary still opens
+Burn Checks in the main window.
+
+Preserve the native tray behaviour from PR #493. Keith reviewed the corrected
+build and explicitly requested publishing a PR and assigning it to Zack.
+
+| Step | Status |
+| --- | --- |
+| Restore the normal menu-bar behaviour | Complete |
+| Remove only the checks hover/focus preview trigger | Complete |
+| Verify provider previews and checks click navigation | 73 tests, lint, types, and formatting passed |
+| Build and launch for Keith to test | Complete; awaiting Keith’s review |
+| Add a clearer checks-card hover and focus treatment | Complete; 73 tests, lint, types, design drift, and build passed; launched for review |
+| PR | Publishing authorized; assign to Zack; results tracked in the PR |


### PR DESCRIPTION
## User impact
Stacked on #493. The Burn Checks summary in the menu-bar popover now has a clearer hover/focus fill and a pointer cursor. Clicking it still opens Burn Checks in the main window; hovering or focusing it no longer opens the additional anchored checks preview.

The normal tray popover, native tray controls, and provider usage previews retain their behaviour.

**Screenshot:** Keith to attach the menu-bar Burn Checks summary in its hover state.

## Validation
- 73 focused tests passed, covering checks navigation, absence of the checks hover/focus preview, and provider previews.
- ESLint, TypeScript, formatting, and design-contract drift passed.
- macOS debug bundle built and launched for review.
- Source changes transferred unchanged from the tested review worktree to this clean branch.

## Analytics
Existing click navigation and interaction instrumentation are unchanged. No new events or properties.

## Privacy and performance
No new data collection or network activity. Hovering checks no longer requests the companion preview.

## Checklist
- [x] Tests use synthetic data.
- [x] No credentials or private session content added.
- [x] Commit includes DCO sign-off.
- [x] Tests and design documentation updated.
