### PR TITLE
Make Burn Checks draggable from the top on macOS

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -863,3 +863,9 @@ The menu-bar Burn Checks summary uses `surface-card/50` at rest and
 `surface-secondary/70` on hover or focus within, with a `duration-fast` colour
 transition. Its summary button uses a pointer cursor. Hover does not open the
 checks companion; clicking opens Burn Checks in the main window.
+
+On macOS, Burn Checks reserves a fixed 40px drag strip above its scroll area,
+using `--main-window-titlebar-height` and `data-tauri-drag-region`. The strip
+remains available in loading and error states. Sidebar dragging remains
+available; report controls scroll below the strip and stay interactive.
+Windows and Linux use their native title bars without this added strip.

--- a/apps/desktop/src/views/main-window/BurnChecksView.test.tsx
+++ b/apps/desktop/src/views/main-window/BurnChecksView.test.tsx
@@ -458,6 +458,36 @@ describe("BurnChecksView", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("keeps the macOS drag strip outside the report while loading and after load", async () => {
+    const userAgent = vi.spyOn(navigator, "userAgent", "get").mockReturnValue("Macintosh")
+    try {
+      const pending = deferred<ChecksReportPayload>()
+      const { view } = setup(target, false, aggregate, pending.promise)
+      const strip = view.container.querySelector("[data-tauri-drag-region]")!
+      expect(strip).toHaveAttribute("aria-hidden", "true")
+      expect(strip).toHaveClass("shrink-0")
+      expect(strip.contains(screen.getByRole("region", { name: "Loading Burn checks" }))).toBe(
+        false,
+      )
+      await act(async () => pending.resolve(report))
+      await screen.findByRole("button", { name: /Old model usage.*8% burn/ })
+      expect(view.container.querySelectorAll("[data-tauri-drag-region]")).toHaveLength(1)
+      expect(view.container.querySelector("[data-tauri-drag-region] button")).toBeNull()
+    } finally {
+      userAgent.mockRestore()
+    }
+  })
+
+  it("uses native title bars without adding a drag strip on Windows", () => {
+    const userAgent = vi.spyOn(navigator, "userAgent", "get").mockReturnValue("Windows")
+    try {
+      const { view } = setup()
+      expect(view.container.querySelector("[data-tauri-drag-region]")).toBeNull()
+    } finally {
+      userAgent.mockRestore()
+    }
+  })
+
   it("uses one busy region and one announcement for the shaped loading skeleton", () => {
     const pending = deferred<ChecksReportPayload>()
     const { view } = setup(target, false, aggregate, pending.promise)

--- a/apps/desktop/src/views/main-window/BurnChecksView.tsx
+++ b/apps/desktop/src/views/main-window/BurnChecksView.tsx
@@ -1,5 +1,7 @@
 import { useSyncExternalStore } from "react"
 
+import { isMacOS } from "../../lib/platform"
+
 import { ScrollPane } from "../../components/ui/ScrollPane"
 import { Skeleton } from "../../components/ui/Skeleton"
 import { type BurnChecksSession } from "./BurnChecksSession"
@@ -21,6 +23,13 @@ export function BurnChecksView({
   if (!report)
     return (
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-surface-window">
+        {isMacOS() && (
+          <div
+            className="h-[var(--main-window-titlebar-height)] shrink-0"
+            data-tauri-drag-region
+            aria-hidden="true"
+          />
+        )}
         <h1 className="sr-only">Burn checks</h1>
         {state.error ? (
           <div className="flex flex-1 items-center justify-center text-center">
@@ -91,6 +100,13 @@ export function BurnChecksView({
     )
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-surface-window">
+      {isMacOS() && (
+        <div
+          className="h-[var(--main-window-titlebar-height)] shrink-0"
+          data-tauri-drag-region
+          aria-hidden="true"
+        />
+      )}
       <ScrollPane className="min-h-0" topEdgeFade>
         <div className="w-full px-8 py-6">
           <h1 className="sr-only">Burn checks</h1>

--- a/docs/plans/burn-checks-drag-strip.md
+++ b/docs/plans/burn-checks-drag-strip.md
@@ -1,0 +1,15 @@
+# Burn Checks window dragging
+
+Add a macOS-only, fixed 40px drag strip above the Burn Checks scroll area.
+Use the existing main-window titlebar height and Tauri drag-region behavior.
+Preserve sidebar dragging and keep report controls outside the drag region.
+The review build was provided to Keith. Keith explicitly requested publishing
+the PR, assigning Zack, and replying to Marty’s Slack thread.
+
+| Step | Status |
+| --- | --- |
+| Add drag strip for loaded, loading, and unavailable states | Complete |
+| Verify macOS-only chrome and run checks | 55 tests, lint, types, formatting, and design drift passed |
+| Build and launch for review | Complete; awaiting manual drag verification |
+
+| Publish and assign PR | Authorized; results tracked in the PR |


### PR DESCRIPTION
## User impact
Stacked on #493. Burn Checks now has a fixed macOS drag strip across the top of the report pane, alongside the existing sidebar drag region. It remains available after scrolling and during loading or errors. Report buttons stay below it and remain interactive.

The strip uses the existing 40px main-window titlebar height and Tauri drag handling. Windows and Linux keep their native title bars.

**Screenshot:** Keith to attach the Burn Checks window showing the top drag area.

## Validation
- All 55 BurnChecksView tests passed, including macOS loading/loaded drag-region coverage and no added strip on Windows.
- ESLint, TypeScript, formatting, and design-contract drift passed.
- macOS debug bundle built and launched for review.
- Manual native dragging requires user verification; Computer Use permission was unavailable.

## Analytics
Native window dragging does not introduce product events or properties. Existing report interaction tracking is unchanged.

## Privacy and performance
No new data collection, network activity, or background work.

## Checklist
- [x] Synthetic test data.
- [x] No credentials or private session content added.
- [x] DCO sign-off included.
- [x] Tests and design documentation updated.
