### PR TITLE
chore(desktop): add Settings menu and shortcut parity

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -146,12 +146,14 @@ Settings teardown, and the memory rules behind those policies.
   frame is capped at 85% of each usable display dimension. Saved user sizes
   retain their dimensions within the available work area. The navigation shell
   uses a persistent 220px sidebar with dense desktop rows. Burn checks is the
-  default section. Sessions shows the session list and selected detail. The sidebar Settings action and
-  Command+, (Control+, on Windows and Linux) open the existing Settings window; see the
-  [main-window validation runbook](../../docs/runbooks/main-window.md).
+  default section. Sessions shows the session list and selected detail. The
+  sidebar Settings action opens the existing Settings window. Command+,
+  (Control+, on Windows and Linux) opens it from the main window, onboarding,
+  and popover; see the [main-window validation runbook](../../docs/runbooks/main-window.md).
 - **Tray item.** Primary click toggles the popover. Secondary click opens a
   menu with Open antiburn, Pin Window, Settings, and Quit. Native application
-  menus also provide Quit. Explicit Quit stops the
+  menus also provide Quit. On macOS, the antiburn application menu provides
+  Settings... with Command+,. Explicit Quit stops the
   application; closing the main window does not. On macOS the
   item stays highlighted for as long as the popover is open: the system's own
   highlight is momentary and lets go on mouse-up, so the shell drives it, and

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -1,10 +1,8 @@
 //! The menu-bar / system-tray item.
 //!
 //! Left click toggles the popover; right click opens a short menu. The menu
-//! carries Quit because an agent application has no Dock icon and no
-//! application menu — without it there would be no way to exit antiburn. It
-//! also carries the popover's pin, which needs a surface that survives the
-//! popover being dismissed — and the menu bar is the only one there is.
+//! keeps Quit available when no window is open. It also carries the popover's
+//! pin, which needs a surface that survives the popover being dismissed.
 //!
 //! Linux is different. The AppIndicator backend reports no click events, and
 //! every click opens the menu. So the menu's first item, Open antiburn, is what
@@ -162,6 +160,9 @@ fn pin_label(pinned: bool) -> &'static str {
 
 /// Builds the menu-bar item and wires up its click and menu handling.
 pub fn create(app: &AppHandle) -> tauri::Result<TrayIcon> {
+    #[cfg(target_os = "macos")]
+    install_app_menu(app)?;
+
     let menu = build_menu(app)?;
     app.manage(TrayMenu {
         pin: menu.pin,
@@ -192,6 +193,21 @@ pub fn create(app: &AppHandle) -> tauri::Result<TrayIcon> {
     tray.with_inner_tray_icon(|inner| inner.set_highlight_override(Some(false)))?;
 
     Ok(tray)
+}
+
+#[cfg(target_os = "macos")]
+fn install_app_menu(app: &AppHandle) -> tauri::Result<()> {
+    let menu = Menu::default(app)?;
+    let items = menu.items()?;
+    let app_menu = items
+        .first()
+        .and_then(|item| item.as_submenu())
+        .ok_or_else(|| anyhow::anyhow!("the default macOS menu has no application submenu"))?;
+    let settings_item = MenuItem::with_id(app, MENU_SETTINGS, "Settings...", true, Some("Cmd+,"))?;
+    // The tray handler receives application menu events with the same ID.
+    app_menu.insert_items(&[&settings_item, &PredefinedMenuItem::separator(app)?], 2)?;
+    app.set_menu(menu)?;
+    Ok(())
 }
 
 /// Register the tray meter after the initial full icon is visible.
@@ -660,8 +676,8 @@ fn on_menu_event(app: &AppHandle, event: MenuEvent) {
             }
         }
         MENU_SETTINGS => {
-            // No pane in particular: the tray's Settings item is a general
-            // entry point, so it leaves the window wherever it was last.
+            // The general Settings menu actions do not select a pane. They
+            // leave the window wherever it was last.
             if let Err(error) = settings::open(app, None) {
                 ::tracing::error!(event = "settings_window_open_failed", error = %error);
             }

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -580,9 +580,9 @@ export async function takeSettingsPane(): Promise<string | null> {
  * `core:window:allow-close` in `capabilities/default.json` — the ACL's
  * `core:window:default` set is read-only.
  *
- * Used by the two windows that own a ⌘W: settings, and the first-run flow.
- * Both are accessory-app windows with no application menu, so the standard
- * shortcut has no owner unless the view handles it.
+ * Used by the two windows that own Command-W: Settings and the first-run flow.
+ * Their view handlers keep Command-W and Control-W available across platform
+ * menu configurations.
  */
 export async function closeCurrentWindow(): Promise<void> {
   if (!hasShell()) return

--- a/apps/desktop/src/views/OnboardingView.test.tsx
+++ b/apps/desktop/src/views/OnboardingView.test.tsx
@@ -163,6 +163,8 @@ describe("OnboardingView", () => {
     expect(
       screen.queryByRole("heading", { name: "Stop hitting your token limits." }),
     ).not.toBeInTheDocument()
+    fireEvent.keyDown(document, { key: ",", ctrlKey: true })
+    expect(invoke).toHaveBeenCalledWith("open_settings_window", { pane: null })
 
     resolveSettings(SETTINGS)
     expect(
@@ -599,4 +601,23 @@ describe("OnboardingView", () => {
       screen.getByRole("heading", { name: "Stop hitting your token limits." }),
     ).toBeInTheDocument()
   })
+
+  it.each(["metaKey", "ctrlKey"])(
+    "opens Settings with %s+comma during onboarding",
+    async (modifier) => {
+      render(<OnboardingView />)
+      await screen.findByRole("heading", {
+        name: "Stop hitting your token limits.",
+      })
+
+      fireEvent.keyDown(document, { key: ",", [modifier]: true })
+
+      await waitFor(() =>
+        expect(invoke).toHaveBeenCalledWith("open_settings_window", { pane: null }),
+      )
+      expect(
+        invoke.mock.calls.filter(([command]) => command === "open_settings_window"),
+      ).toHaveLength(1)
+    },
+  )
 })

--- a/apps/desktop/src/views/OnboardingView.tsx
+++ b/apps/desktop/src/views/OnboardingView.tsx
@@ -1,7 +1,8 @@
-import { useState, useSyncExternalStore, type KeyboardEvent as ReactKeyboardEvent } from "react"
+import { useState, useSyncExternalStore } from "react"
 
 import { PushButton } from "../components/ui/PushButton"
-import { closeCurrentWindow } from "../lib/ipc"
+import { closeCurrentWindow, openSettingsWindow } from "../lib/ipc"
+import { useGlobalKeydown } from "../lib/useGlobalKeydown"
 import { OnboardingFlow } from "./onboarding/OnboardingFlow"
 import { OnboardingSession } from "./onboarding/OnboardingSession"
 
@@ -19,6 +20,7 @@ export function OnboardingView() {
     session.getSnapshot,
     session.getSnapshot,
   )
+  useGlobalKeydown(true, handleWindowKeyDown)
 
   if (state.loadState === "loading") {
     return (
@@ -50,7 +52,7 @@ export function OnboardingView() {
   )
 
   return (
-    <div className="h-full" onKeyDownCapture={handleWindowKeyDown}>
+    <div className="h-full">
       <OnboardingFlow
         defaultRoots={state.defaultRoots}
         blockedRoots={blockedRoots}
@@ -83,7 +85,12 @@ export function OnboardingView() {
   )
 }
 
-function handleWindowKeyDown(event: ReactKeyboardEvent<HTMLDivElement>): void {
+function handleWindowKeyDown(event: KeyboardEvent): void {
+  if ((event.metaKey || event.ctrlKey) && !event.altKey && event.key === ",") {
+    event.preventDefault()
+    void openSettingsWindow()
+    return
+  }
   if ((event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === "w") {
     event.preventDefault()
     void closeCurrentWindow()

--- a/apps/desktop/src/views/PopoverView.test.tsx
+++ b/apps/desktop/src/views/PopoverView.test.tsx
@@ -1350,16 +1350,19 @@ describe("PopoverView — window behaviour", () => {
     await waitFor(() => expect(invoke).toHaveBeenCalledWith("hide_popover"))
   })
 
-  it("opens Settings on the platform preferences shortcut", async () => {
-    render(<PopoverView />)
-    await screen.findByText("Wire the tray popover")
+  it.each(["metaKey", "ctrlKey"])(
+    "opens Settings with %s+comma from the popover",
+    async (modifier) => {
+      render(<PopoverView />)
+      await screen.findByText("Wire the tray popover")
 
-    fireEvent.keyDown(document, { key: ",", metaKey: true })
+      fireEvent.keyDown(document, { key: ",", [modifier]: true })
 
-    await waitFor(() =>
-      expect(invoke).toHaveBeenCalledWith("open_settings_window", { pane: null }),
-    )
-  })
+      await waitFor(() =>
+        expect(invoke).toHaveBeenCalledWith("open_settings_window", { pane: null }),
+      )
+    },
+  )
 })
 
 describe("PopoverView — floating HUD restore", () => {

--- a/apps/desktop/src/views/SettingsView.tsx
+++ b/apps/desktop/src/views/SettingsView.tsx
@@ -69,10 +69,9 @@ export function SettingsView() {
   )
   const controller = useAppSettings()
 
-  // ⌘W closes the window. The shell runs as an accessory app with no
-  // application menu, so the standard shortcut has no owner unless it is
-  // handled here. The close request takes the same path as the title-bar
-  // button, and the shell releases this renderer.
+  // Command-W closes the window. This handler supports platforms without an
+  // application menu. The close request uses the title-bar button path, and
+  // the shell releases this renderer.
   // Esc must NOT close: dismiss-on-Escape is modal behavior and a settings
   // window is not a modal. Do not "fix" this by adding Escape.
   useGlobalKeydown(true, (event) => {

--- a/apps/desktop/src/views/popover/PopoverSession.ts
+++ b/apps/desktop/src/views/popover/PopoverSession.ts
@@ -318,9 +318,9 @@ export class PopoverSession {
     void this.startPopoverVisibility(generation)
     void this.listenLiveUsage(generation)
 
-    // ⌘, opens Settings — the platform's standard preferences shortcut, which
-    // an accessory app with no application menu has to own itself. Bound
-    // alongside Escape on `window`, deliberately: it is the last object in an
+    // The preferences shortcut opens Settings. The window listener supports
+    // the nonactivating popover and platforms without an application menu.
+    // It is bound alongside Escape on `window`: this is the last object in an
     // event's propagation path, so every surface listening on `document` has
     // already had its chance to claim the key first.
     window.addEventListener("keydown", this.onWindowKeyDown)

--- a/docs/runbooks/main-window.md
+++ b/docs/runbooks/main-window.md
@@ -96,7 +96,7 @@ Check the 1100×600 default and 1000×560 minimum with light and dark themes.
 
 - The sidebar remains visible throughout resizing; no compact navigation mode appears.
 - Sessions is the main section. Settings appears at the bottom; no Quit action appears.
-- The Settings sidebar action and Command+, (Control+, on Windows/Linux) open the existing Settings window.
+- The Settings sidebar action opens the existing Settings window. Command+, (Control+, on Windows/Linux) opens it from the main window, onboarding, and popover.
 - Check readable 28px rows and independent vertical content scrolling without horizontal overflow.
 - Restore an older saved 560×420 window; it expands to at least 1000×560 when the display allows.
 - Close and reopen the main window; the selected section persists.


### PR DESCRIPTION
## User impact

Adds Settings... with Command+, to the macOS antiburn application menu, between About and Services.

The shortcut opens, focuses, or restores the existing Settings window without changing its selected pane. Command+, and Control+, remain available from the main window, onboarding, and popover. Windows and Linux retain their existing tray menu and Control+, behavior without gaining unwanted native menu bars.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`: 1,220 tests passed in the sandbox; the two filesystem-watcher cases passed in a targeted run with native macOS filesystem-event access
- `pnpm --filter @antiburn/desktop lint`
- `pnpm --filter @antiburn/desktop type-check`
- `pnpm --filter @antiburn/desktop test`: 1,462 tests passed
- Manually verified the macOS menu placement and displayed Command+, shortcut
- Manually verified menu opening, shortcut opening, refocusing, minimized restoration, and single-window behavior
- Reviewed the final diff for macOS, Windows, and Linux behavior with no remaining findings
- Local cross-target checks reached platform dependencies but could not complete without the Linux GTK/ATK sysroot and Windows MinGW headers; the repository CI matrix provides native coverage

## Analytics

Product question: are users successfully reaching Settings through the platform-standard entry points?

The existing Settings surface-view event records a successful visible opening, and existing pane-view events continue to measure Settings use. This change does not add or alter analytics events, properties, triggers, duplicate limits, or rate limits. Entry-point attribution remains intentionally unchanged because every route opens the same Settings surface.

## Privacy and performance

None.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.
