### PR TITLE
Fix duplicate Codex token counts

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -28,7 +28,7 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 32,
+            parser_revision: 33,
             analyzer_revision: 23,
             metrics_schema_revision: 8,
             evidence_schema_revision: 18,

--- a/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
@@ -415,8 +415,8 @@ fn a_vanished_source_has_its_rows_and_resume_dropped_on_the_next_publish() {
 #[test]
 fn current_resume_revisions_reject_each_prior_batch_revision() {
     let current = crate::analysis::resume_revisions();
-    assert_eq!(current.snapshot_revision, 6);
-    assert_eq!(current.parser_revision, 32);
+    assert_eq!(current.snapshot_revision, 7);
+    assert_eq!(current.parser_revision, 33);
     assert_eq!(current.analyzer_revision, 23);
     assert_eq!(current.metrics_schema_revision, 8);
     assert_eq!(current.evidence_schema_revision, 18);
@@ -432,8 +432,8 @@ fn current_resume_revisions_reject_each_prior_batch_revision() {
     for field in 0..6 {
         let mut stale = stored.clone();
         match field {
-            0 => stale.snapshot_revision = 5,
-            1 => stale.parser_revision = 30,
+            0 => stale.snapshot_revision = 6,
+            1 => stale.parser_revision = 32,
             2 => stale.analyzer_revision = 20,
             3 => stale.metrics_schema_revision = 7,
             4 => stale.evidence_schema_revision = 16,

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -1157,7 +1157,7 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 32,
+                "parserRevision": 33,
                 "analyzerRevision": 23,
                 "evidenceSchemaRevision": 18,
                 "sourceKind": "file",

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -161,6 +161,7 @@ pub use vendors::{has_dedicated_reader, reader_for};
 // instead of double-counting it (`vendors::claude::visit_reader`).
 // Codex `token_usage_record` support requires a parser revision bump.
 // Stored sessions must re-ingest to restore complete coverage and deduplicate paired usage rows.
+// +1 for bounded mismatched-total pairing and preserving distinct response identities.
 // +1 for the Claude context-window rule: the catalogue now covers `opus-5`
 // and `mythos-5`, splits `opus-4` so 4.0 and 4.1 resolve to 200k while 4.6
 // to 4.9 stay 1M, and an explicit `[1m]`/`[200k]` tag beats the catalogue
@@ -172,7 +173,7 @@ pub use vendors::{has_dedicated_reader, reader_for};
 // This batch also reparses nested resources and paired subagent observations.
 // +1 for Pi assistant request-start timestamps: token and context buckets now
 // use `message.timestamp` while event ordering keeps the outer row timestamp.
-pub const PARSER_REVISION: i64 = 32;
+pub const PARSER_REVISION: i64 = 33;
 // +1 for turn row chart signals: `has_thinking`, `last_tool`, and
 // `subagent_launches` are now ingest-derived row columns
 // (`rows::turn_row_from_event`), so every session must reparse to
@@ -272,7 +273,8 @@ pub const COVERAGE_SCHEMA_REVISION: i64 = 4;
 // +1 because `ClaudeStreamState` gained a `context_window_source` field.
 // +1 because parent evidence now includes delegated model control observations.
 // This batch also changes retained nested resource and paired subagent state.
-pub const RESUME_SNAPSHOT_REVISION: i64 = 6;
+// +1 for the bounded Codex cross-format usage matcher in adapter snapshots.
+pub const RESUME_SNAPSHOT_REVISION: i64 = 7;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -384,7 +384,10 @@ struct CodexStreamState {
     fork_attribution_incomplete: bool,
     /// See [`json_text_codec`].
     #[serde(with = "json_text_codec")]
-    previous_usage_key: Option<(UsageRecordKey, bool)>,
+    previous_usage_key: Option<UsageRecordSeen>,
+    /// See [`json_text_codec`].
+    #[serde(with = "json_text_codec")]
+    recent_cross_format_usage: Option<UsageRecordSeen>,
     previous_event_was_boundary: bool,
     previous_boundary_ts: Option<i64>,
     context_window: Option<u64>,
@@ -404,7 +407,7 @@ struct CodexStreamState {
 
 /// Snapshot codec for a `CodexStreamState` field whose type carries
 /// `serde_json::Value` data at any depth (`pending_rows`,
-/// `previous_usage_key`).
+/// `previous_usage_key`, `recent_cross_format_usage`).
 ///
 /// `serde_json::Value`'s `Deserialize` impl calls `deserialize_any`, a
 /// self-describing lookahead `postcard` explicitly does not implement (its
@@ -569,13 +572,13 @@ impl CodexStreamState {
         }
 
         if is_usage_record {
-            if let Some(key) = usage_record_key(&value) {
-                let key_with_ownership = (key, usage_is_owned);
-                let duplicate = self.previous_usage_key.as_ref() == Some(&key_with_ownership);
-                self.previous_usage_key = Some(key_with_ownership);
-                if duplicate {
-                    return;
-                }
+            if usage_record_is_duplicate(
+                &mut self.previous_usage_key,
+                &mut self.recent_cross_format_usage,
+                &value,
+                usage_is_owned,
+            ) {
+                return;
             }
             if !usage_is_owned {
                 return;
@@ -639,6 +642,7 @@ impl CodexStreamState {
         if settings || matches!(record_type, Some("session_meta" | "turn_context")) {
             // A new request context separates equal usage totals from different requests.
             self.previous_usage_key = None;
+            self.recent_cross_format_usage = None;
         }
         let provider = if record_type == Some("session_meta") {
             value.pointer("/payload/model_provider")
@@ -1212,14 +1216,13 @@ fn parse_codex(content: &str) -> (Vec<NormalizedEvent>, Option<u64>, Option<Stri
             let is_usage_record = is_token_count_record(record_type, payload_type)
                 || record_type == Some("token_usage_record");
             let inherited_usage = !usage_is_owned && is_usage_record;
-            if let Some(key) = usage_record_key(&value) {
-                let key_with_ownership = (key, usage_is_owned);
-                let duplicate_usage =
-                    controls.previous_usage_key.as_ref() == Some(&key_with_ownership);
-                controls.previous_usage_key = Some(key_with_ownership);
-                if duplicate_usage {
-                    continue;
-                }
+            if usage_record_is_duplicate(
+                &mut controls.previous_usage_key,
+                &mut controls.recent_cross_format_usage,
+                &value,
+                usage_is_owned,
+            ) {
+                continue;
             }
             if !inherited_usage && let Some(mut ev) = record_to_event(&value) {
                 ev.provider = controls.current_provider.clone();
@@ -1927,6 +1930,22 @@ fn is_usage_free_record(value: &Value) -> bool {
 
 /// The per-response and cumulative usage that identify one usage row.
 type UsageRecordKey = (Value, Value);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum UsageRecordFormat {
+    LegacyTokenCount,
+    TokenUsageRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct UsageRecordSeen {
+    key: UsageRecordKey,
+    format: UsageRecordFormat,
+    identity: Option<Value>,
+    owned: bool,
+    ts_ms: Option<i64>,
+}
+
 type TokenUsageObjects<'a> = (
     &'a Map<String, Value>,
     &'a Map<String, Value>,
@@ -1950,8 +1969,8 @@ fn token_usage_record_objects(payload: &Map<String, Value>) -> Option<TokenUsage
 /// Returns a common deduplication key for both Codex usage formats.
 ///
 /// Codex can write equivalent `token_usage_record` and `token_count` rows.
-/// It can also repeat the last usage row after a rollout resumes. Both parsing
-/// paths drop a row when this pair matches the prior row with the same owner.
+/// The first value is per-response usage; the second is cumulative usage.
+/// The dedupe policy compares these values with format and request identity.
 fn usage_record_key(value: &Value) -> Option<UsageRecordKey> {
     let record_type = value.get("type").and_then(Value::as_str);
     let payload_type = value.pointer("/payload/type").and_then(Value::as_str);
@@ -1973,6 +1992,107 @@ fn usage_record_key(value: &Value) -> Option<UsageRecordKey> {
             .cloned()
             .unwrap_or(Value::Null),
     ))
+}
+
+fn usage_record_format(value: &Value) -> Option<UsageRecordFormat> {
+    let record_type = value.get("type").and_then(Value::as_str);
+    let payload_type = value.pointer("/payload/type").and_then(Value::as_str);
+    if record_type == Some("token_usage_record") {
+        Some(UsageRecordFormat::TokenUsageRecord)
+    } else if is_token_count_record(record_type, payload_type) {
+        Some(UsageRecordFormat::LegacyTokenCount)
+    } else {
+        None
+    }
+}
+
+/// A cross-format match needs a timestamp because equal per-response usage
+/// can belong to distinct requests. Keep the window short and retain one candidate.
+const CROSS_FORMAT_USAGE_DEDUPE_WINDOW_MS: u64 = 5_000;
+
+fn usage_record_is_duplicate(
+    previous: &mut Option<UsageRecordSeen>,
+    recent: &mut Option<UsageRecordSeen>,
+    value: &Value,
+    owned: bool,
+) -> bool {
+    let Some(key) = usage_record_key(value) else {
+        return false;
+    };
+    let Some(format) = usage_record_format(value) else {
+        return false;
+    };
+    let current = UsageRecordSeen {
+        key,
+        format,
+        identity: usage_record_identity(value),
+        owned,
+        ts_ms: value.get("timestamp").and_then(parse_ts),
+    };
+
+    let same_format_repeat = previous.as_ref().is_some_and(|prior| {
+        prior.owned == current.owned
+            && prior.format == current.format
+            && prior.key == current.key
+            && prior.identity == current.identity
+    });
+    let exact_cross_format_repeat = previous.as_ref().is_some_and(|prior| {
+        prior.owned == current.owned
+            && prior.format != current.format
+            && prior.key == current.key
+            && prior
+                .ts_ms
+                .zip(current.ts_ms)
+                .is_some_and(|(prior, current)| {
+                    prior.abs_diff(current) <= CROSS_FORMAT_USAGE_DEDUPE_WINDOW_MS
+                })
+    });
+
+    let mismatched_cross_format_repeat = !same_format_repeat
+        && !exact_cross_format_repeat
+        && recent.as_ref().is_some_and(|prior| {
+            prior.owned == current.owned
+                && prior.format != current.format
+                && prior.key.0 == current.key.0
+                && prior.key.1 != current.key.1
+                && prior
+                    .ts_ms
+                    .zip(current.ts_ms)
+                    .is_some_and(|(prior, current)| {
+                        prior.abs_diff(current) <= CROSS_FORMAT_USAGE_DEDUPE_WINDOW_MS
+                    })
+        });
+
+    let duplicate =
+        same_format_repeat || exact_cross_format_repeat || mismatched_cross_format_repeat;
+    if exact_cross_format_repeat || mismatched_cross_format_repeat {
+        *recent = None;
+    }
+    *previous = Some(current.clone());
+    if !duplicate {
+        *recent = Some(current);
+    }
+    duplicate
+}
+
+fn usage_record_identity(value: &Value) -> Option<Value> {
+    if usage_record_format(value) != Some(UsageRecordFormat::TokenUsageRecord) {
+        return None;
+    }
+    let payload = value.get("payload")?.as_object()?;
+    let mut identity = Map::new();
+    for key in [
+        "thread_id",
+        "turn_id",
+        "session_id",
+        "root_turn_id",
+        "response_id",
+    ] {
+        if let Some(value) = payload.get(key) {
+            identity.insert(key.to_owned(), value.clone());
+        }
+    }
+    (!identity.is_empty()).then_some(Value::Object(identity))
 }
 
 fn is_token_count_record(record_type: Option<&str>, payload_type: Option<&str>) -> bool {
@@ -2237,7 +2357,7 @@ mod tests {
 
     #[test]
     fn record_to_event_changes_require_an_inertness_review() {
-        const EXPECTED_FINGERPRINT: u64 = 6_996_697_630_133_459_451;
+        const EXPECTED_FINGERPRINT: u64 = 18_370_784_376_499_888_089;
         let source = include_str!("codex.rs").replace("\r\n", "\n");
         let start = source.find("fn observe_model_and_effort").unwrap();
         let end = source.find("\n#[cfg(test)]\nmod tests").unwrap();
@@ -2501,6 +2621,188 @@ mod tests {
             streamed.events[0].ts_ms,
             parse_ts(&serde_json::json!("2026-09-01T00:00:01Z"))
         );
+    }
+
+    #[test]
+    fn mismatched_cumulative_usage_rows_deduplicate_by_per_response_usage() {
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-09-01T00:00:00Z","type":"session_meta","payload":{"model":"gpt-test","effort":"high"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:00:01Z","type":"token_usage_record","payload":{"usage":{"input_tokens":60863,"cached_input_tokens":0,"output_tokens":107},"turn_token_usage":{"input_tokens":60863,"cached_input_tokens":0,"output_tokens":107},"thread_token_usage":{"input_tokens":60863,"cached_input_tokens":0,"output_tokens":107}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"model_context_window":200000,"last_token_usage":{"input_tokens":60863,"cached_input_tokens":0,"output_tokens":107},"total_token_usage":{"input_tokens":70000,"cached_input_tokens":50000,"output_tokens":200}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:00:03Z","type":"token_usage_record","payload":{"usage":{"input_tokens":67617,"cached_input_tokens":60800,"output_tokens":126},"turn_token_usage":{"input_tokens":67617,"cached_input_tokens":60800,"output_tokens":126},"thread_token_usage":{"input_tokens":128480,"cached_input_tokens":60800,"output_tokens":233}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:00:04Z","type":"event_msg","payload":{"type":"token_count","info":{"model_context_window":200000,"last_token_usage":{"input_tokens":67617,"cached_input_tokens":60800,"output_tokens":126},"total_token_usage":{"input_tokens":130000,"cached_input_tokens":110000,"output_tokens":350}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:00:05Z","type":"token_usage_record","payload":{"usage":{"input_tokens":67756,"cached_input_tokens":67584,"output_tokens":185},"turn_token_usage":{"input_tokens":67756,"cached_input_tokens":67584,"output_tokens":185},"thread_token_usage":{"input_tokens":196236,"cached_input_tokens":128384,"output_tokens":418}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:00:06Z","type":"event_msg","payload":{"type":"token_count","info":{"model_context_window":200000,"last_token_usage":{"input_tokens":67756,"cached_input_tokens":67584,"output_tokens":185},"total_token_usage":{"input_tokens":200000,"cached_input_tokens":180000,"output_tokens":500}}}}"#,
+            "\n",
+        );
+
+        let (coverage, streamed) = collect_synthetic_codex(jsonl);
+        let (legacy_events, context_window, model, _) = parse_codex(jsonl);
+
+        assert_eq!(coverage, crate::analysis::RecordCoverage::Complete);
+        assert_eq!(streamed.events, legacy_events);
+        assert_eq!(streamed.events.len(), 3);
+        let usage = streamed
+            .events
+            .iter()
+            .fold(Usage::default(), |total, event| {
+                total.saturating_add(event.usage)
+            });
+        assert_eq!(usage.input_tokens, 67_852);
+        assert_eq!(usage.cache_read_tokens, 128_384);
+        assert_eq!(usage.output_tokens, 418);
+        assert_eq!(
+            streamed
+                .events
+                .iter()
+                .map(|event| event.usage.context_tokens())
+                .max(),
+            Some(67_756)
+        );
+        assert_eq!(streamed.context_window, Some(200_000));
+        assert_eq!(context_window, Some(200_000));
+        assert_eq!(streamed.model.as_deref(), Some("gpt-test"));
+        assert_eq!(model.as_deref(), Some("gpt-test"));
+    }
+
+    #[test]
+    fn equal_usage_requests_with_distinct_response_ids_are_preserved() {
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-09-01T00:10:00Z","type":"session_meta","payload":{"effort":"high"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:10:01Z","type":"token_usage_record","payload":{"response_id":"response-a","usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:10:02Z","type":"token_usage_record","payload":{"response_id":"response-b","usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5}}}"#,
+            "\n",
+        );
+
+        let (_, streamed) = collect_synthetic_codex(jsonl);
+        let (legacy_events, _, _, _) = parse_codex(jsonl);
+
+        assert_eq!(streamed.events, legacy_events);
+        assert_eq!(streamed.events.len(), 2);
+        assert_eq!(streamed.events[0].usage, streamed.events[1].usage);
+    }
+
+    #[test]
+    fn mismatched_cross_format_usage_outside_window_is_preserved() {
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-09-01T00:20:00Z","type":"session_meta","payload":{"effort":"high"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:20:01Z","type":"token_usage_record","payload":{"usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:20:07Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"total_token_usage":{"input_tokens":300,"cached_input_tokens":200,"output_tokens":15}}}}"#,
+            "\n",
+        );
+
+        let (_, streamed) = collect_synthetic_codex(jsonl);
+        let (legacy_events, _, _, _) = parse_codex(jsonl);
+
+        assert_eq!(streamed.events, legacy_events);
+        assert_eq!(streamed.events.len(), 2);
+    }
+
+    #[test]
+    fn adjacent_equal_usage_pairs_are_consumed_independently() {
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-09-01T00:30:00Z","type":"session_meta","payload":{"effort":"high"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:30:01Z","type":"token_usage_record","payload":{"usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:30:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"total_token_usage":{"input_tokens":110,"cached_input_tokens":20,"output_tokens":6}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:30:03Z","type":"token_usage_record","payload":{"usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":200,"cached_input_tokens":40,"output_tokens":10}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:30:04Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"total_token_usage":{"input_tokens":210,"cached_input_tokens":40,"output_tokens":11}}}}"#,
+            "\n",
+        );
+
+        let (_, streamed) = collect_synthetic_codex(jsonl);
+        let (legacy_events, _, _, _) = parse_codex(jsonl);
+
+        assert_eq!(streamed.events, legacy_events);
+        assert_eq!(streamed.events.len(), 2);
+    }
+
+    #[test]
+    fn a_distinct_usage_row_blocks_an_older_cross_format_match() {
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-09-01T00:40:00Z","type":"session_meta","payload":{"effort":"high"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:40:01Z","type":"token_usage_record","payload":{"usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:40:02Z","type":"token_usage_record","payload":{"usage":{"input_tokens":200,"cached_input_tokens":30,"output_tokens":6},"turn_token_usage":{"input_tokens":200,"cached_input_tokens":30,"output_tokens":6},"thread_token_usage":{"input_tokens":300,"cached_input_tokens":50,"output_tokens":11}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:40:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"total_token_usage":{"input_tokens":400,"cached_input_tokens":80,"output_tokens":16}}}}"#,
+            "\n",
+        );
+
+        let (_, streamed) = collect_synthetic_codex(jsonl);
+        let (legacy_events, _, _, _) = parse_codex(jsonl);
+
+        assert_eq!(streamed.events, legacy_events);
+        assert_eq!(streamed.events.len(), 3);
+    }
+
+    #[test]
+    fn reversed_cross_format_usage_rows_deduplicate() {
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-09-01T00:50:00Z","type":"session_meta","payload":{"effort":"high"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:50:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"total_token_usage":{"input_tokens":300,"cached_input_tokens":200,"output_tokens":15}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-09-01T00:50:02Z","type":"token_usage_record","payload":{"usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5}}}"#,
+            "\n",
+        );
+
+        let (_, streamed) = collect_synthetic_codex(jsonl);
+        let (legacy_events, _, _, _) = parse_codex(jsonl);
+
+        assert_eq!(streamed.events, legacy_events);
+        assert_eq!(streamed.events.len(), 1);
+    }
+
+    #[test]
+    fn mismatched_cross_format_usage_without_timestamps_is_preserved() {
+        let new_record = serde_json::json!({
+            "type": "token_usage_record",
+            "payload": {
+                "usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 5},
+                "turn_token_usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 5},
+                "thread_token_usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 5}
+            }
+        });
+        let legacy_record = serde_json::json!({
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 5},
+                    "total_token_usage": {"input_tokens": 300, "cached_input_tokens": 200, "output_tokens": 15}
+                }
+            }
+        });
+        let mut previous = None;
+        let mut recent = None;
+
+        assert!(!usage_record_is_duplicate(
+            &mut previous,
+            &mut recent,
+            &new_record,
+            true
+        ));
+        assert!(!usage_record_is_duplicate(
+            &mut previous,
+            &mut recent,
+            &legacy_record,
+            true
+        ));
     }
 
     #[test]
@@ -3303,6 +3605,61 @@ mod tests {
             assert_eq!(second_visit.outcome, VisitOutcome::AcceptedFull);
             assert!(second_session.events.is_empty());
             assert_eq!(second_session.context_window, Some(96_000));
+        }
+
+        #[test]
+        fn a_resumed_mismatched_cumulative_usage_record_deduplicates() {
+            let first_records = concat!(
+                r#"{"timestamp":"2026-09-02T01:00:00Z","type":"turn_context","payload":{"effort":"high"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-09-02T01:00:01Z","type":"token_usage_record","payload":{"usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"turn_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"thread_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5}}}"#,
+                "\n",
+            );
+            let legacy_record = concat!(
+                r#"{"timestamp":"2026-09-02T01:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":5},"total_token_usage":{"input_tokens":300,"cached_input_tokens":200,"output_tokens":15}}}}"#,
+                "\n",
+            );
+            let directory = TempDir::new().expect("tempdir");
+            let path = write_source(&directory, first_records.as_bytes());
+            let input = file_input(&path);
+            let first_claim = claim_for_path(&path);
+            let mut first_pass = SessionCollector::new("codex", "claimed-session");
+            let first_visit = CodexSessionReader
+                .visit_claimed_resumed(
+                    &input,
+                    &first_claim,
+                    &fresh_snapshot(),
+                    &|| false,
+                    &mut first_pass,
+                )
+                .expect("first resumed visit");
+            assert_eq!(first_pass.into_session().unwrap().events.len(), 1);
+            let snapshot = snapshot_from(first_visit.resume.expect("first pass resumes"));
+
+            OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .expect("open source for append")
+                .write_all(legacy_record.as_bytes())
+                .expect("append legacy usage record");
+            let second_claim = claim_for_path(&path);
+            let mut second_pass = SessionCollector::new("codex", "claimed-session");
+            let second_visit = CodexSessionReader
+                .visit_claimed_resumed(
+                    &input,
+                    &second_claim,
+                    &snapshot,
+                    &|| false,
+                    &mut second_pass,
+                )
+                .expect("second resumed visit");
+            let resumed_session = second_pass.into_session().unwrap();
+
+            assert_eq!(second_visit.outcome, VisitOutcome::AcceptedFull);
+            assert!(resumed_session.events.is_empty());
+            let mut full = SessionCollector::new("codex", "claimed-session");
+            CodexSessionReader.visit(&input, &mut full).unwrap();
+            assert_eq!(full.into_session().unwrap().events.len(), 1);
         }
 
         #[test]

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -194,7 +194,7 @@
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -192,7 +192,7 @@
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -194,7 +194,7 @@
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -208,7 +208,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -184,7 +184,7 @@
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -208,7 +208,7 @@
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -184,7 +184,7 @@
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -192,7 +192,7 @@
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -142,7 +142,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -132,7 +132,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -158,7 +158,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -170,7 +170,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -138,7 +138,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -164,7 +164,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -146,7 +146,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -143,7 +143,7 @@
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 32,
+      "parserRevision": 33,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/docs/check-coverage.md
+++ b/docs/check-coverage.md
@@ -1,6 +1,6 @@
 # Burn Check Source Coverage
 
-Audit date: 2026-09-10.
+Audit date: 2026-09-11.
 
 This document covers local passive evidence only. Coverage must not use hooks,
 new extensions, runtime subscriptions, or agent calls to fill evidence gaps. Existing
@@ -126,6 +126,16 @@ An overflow or oversized UUID records `CapExceeded`, makes attribution
 incomplete, and blocks every clean result that needs complete affected evidence.
 An oversized resume identity set is rejected instead of being trusted.
 
+Codex cache and token checks use one observation for a matching
+`token_usage_record.payload.usage` and `event_msg`/`token_count.info.last_token_usage`
+pair within five seconds. Available request identities separate same-format
+requests with equal usage. The reader retains one recent observation.
+Their cumulative `thread_token_usage`
+and `total_token_usage` values are cross checks only because the two producer
+paths can report different bases. Repeated legacy rows and cross-format copies
+remain deduplicated across resume boundaries. An unmatched valid per-response
+record remains evidence; malformed usage remains partial.
+
 Maintainer confirmation (2026-09-10): raise the identity cap to 16,384 as an
 interim measure for longer sessions. Reviewed passive alternatives include
 indexed local relationship queries and bounded batch processing. Those
@@ -152,7 +162,7 @@ identity is retained without copying private document bodies into evidence.
 | Pi                          | T                   | `EffortSemantics::AgentSelectedPolicy` evaluates the saved agent-selected thinking level, not translated provider effort. Reviewed native routes and branch/fork policy state are retained. Missing levels/routes and unknown models fail closed; provider overrides are not guessed.                                                   |
 | Pi                          | S                   | Existing output from the official subagent example extension supplies nested `toolResult` messages, exact native call/worker identity, and actual models. This is finding-only. Arbitrary extensions, fork ancestry, requested aliases, and a nonpremium observed worker cannot establish clean.                                        |
 | Pi                          | M, B, K, F          | Confirmed unsupported for the reviewed sources. Tool calls and bounded skill invocation identity do not establish historical resource exposure or speed. No alternative local proof was identified.                                                                                                                                     |
-| Claude, Codex, OpenCode, Pi | C                   | Durable request provider/API fields and the compatible-request query select reviewed cache-write or uncached-input accounting. Main-thread identity, order, token classes, model, route, and compaction boundaries constrain pairs. Unknown or incompatible segments remain partial, not clean. Google cache policy remains unreviewed. |
+| Claude, Codex, OpenCode, Pi | C                   | Durable request provider/API fields and the compatible-request query select reviewed cache-write or uncached-input accounting. Main-thread identity, order, token classes, model, route, and compaction boundaries constrain pairs. Codex pairs `token_usage_record` with equivalent `token_count` usage by per-response fields; cumulative fields do not decide equivalence. Unknown or incompatible segments remain partial, not clean. Google cache policy remains unreviewed. |
 | OpenCode                    | C                   | Both accepted export and SQLite shapes use validated ordered history. `parentID` identifies the user being answered, not the predecessor. Missing wrappers/timestamps, duplicate or out-of-order messages, and unresolved forks prevent complete history. CoreV2 `session_message` is not the existing SQLite table contract.           |
 | Cursor                      | D, O                | O retains direct timed-model findings; the source gate denies clean on every surface. D remains unavailable because the current reader does not emit request-usage evidence. Synthetic source-gate tests do not establish native parsing support.                                                                                       |
 | Cursor                      | T, S, M, B, K, F, C | Broader surface characterization is deferred. Current settings, relations, inventories, and cache evidence remain partial, unknown, or unsupported as listed; no new parity claim is made.                                                                                                                                              |

--- a/docs/session-coverage.md
+++ b/docs/session-coverage.md
@@ -1,6 +1,6 @@
 # Session Parsing Coverage
 
-Audit date: 2026-09-10.
+Audit date: 2026-09-11.
 
 This document records how Antiburn discovers and parses local session sources.
 It covers source identity, framing, companion data, normalized facts, and
@@ -37,6 +37,17 @@ release range: an accepted schema, header, or pinned producer commit with
 synthetic fixtures can define its contract. This does not prove all historical
 versions. Full and resumed reads must agree where resume is supported.
 
+Codex can emit one response's usage in both `token_usage_record` and
+`event_msg`/`token_count`. Per-response usage fields identify cross-format pairs
+within five seconds, while available request identities separate same-format
+requests with equal usage. The reader retains one recent observation.
+Cumulative `thread_token_usage` and
+`total_token_usage` fields can use different producer bases, so they do not
+decide whether a cross-format pair is a duplicate. Repeated legacy rows and
+cross-format pairs are deduplicated within the active request segment, and the
+bounded dedupe state crosses a resume boundary. Missing or malformed
+per-response usage remains partial.
+
 Inline materialized sources use a fingerprint of the full bounded content, not
 only a head region. The content is already materialized and size-bounded before
 this fingerprint is calculated. OpenCode SQLite fingerprints stream every
@@ -66,7 +77,7 @@ Newly discovered repositories remain enabled by default.
 | `SourceFormat`                 | Agent         | Native source                                                              | Discovery and framing                                                                                                                                          | Parsed facts                                                                                                                                                                  | State                                                                                             |
 | ------------------------------ | ------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `ClaudeJsonl`                  | Claude Code   | `~/.claude/projects/<workspace>/*.jsonl`                                   | Native discovery; bounded JSONL with source claims; resume supported                                                                                           | Usage, token classes, time, models, request controls/routes, calls, observed resource injection, thread links, compactions, exact Task/Agent child pairing                    | Characterized accepted core; observed resources are not full inventories                          |
-| `CodexRolloutJsonl`            | Codex         | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`                             | Native discovery with child rollouts; bounded JSONL; resume supported                                                                                          | Usage, time, models, provider/control inheritance, service tier, tools, harness version, spawn records, selected skill documents, exact tool-search MCP exposure, compactions | Characterized accepted core; resource subsets only                                                |
+| `CodexRolloutJsonl`            | Codex         | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`                             | Native discovery with child rollouts; bounded JSONL; resume supported; paired `token_usage_record`/`token_count` usage dedupe                                                       | Per-response usage and context window, time, models, provider/control inheritance, service tier, tools, harness version, spawn records, selected skill documents, exact tool-search MCP exposure, compactions | Characterized accepted core; resource subsets only                                                |
 | `OpenCodeJsonl`                | OpenCode      | Legacy exported session JSONL                                              | Native or WSL export discovery; bounded JSONL with validated history wrappers/order                                                                            | Usage, time, models, provider/API fields where saved, raw variants, task proof, selected skills, tools, compactions, session/message identities                               | Characterized accepted export; no historical effort map or resource inventory                     |
 | `OpenCodeSqliteV2`             | OpenCode      | `~/.local/share/opencode/opencode.db` or platform equivalent               | Read-only snapshot of the root and descendant `session`, `message`, `part` cluster; row-streamed content fingerprint; validated creation-time/message-ID order | Native messages and parts, task metadata joined to child models, selected skills, usage, provider/API fields, compactions, identities                                         | Characterized table contract; not CoreV2 `session_message`                                        |
 | `PiV3Jsonl`                    | Pi            | `~/.pi/agent/sessions/**/*.jsonl` or `PI_AGENT_DIR`                        | Native discovery; version 3 header; bounded JSONL; resume supported                                                                                            | Usage at the nested request-start timestamp, top-level event time, provider/API/model, agent-selected thinking policy, branch/fork state, tools, links, compactions, official example-extension nested worker results | Characterized core; extension delegation is finding-only, not arbitrary extension support         |
@@ -122,7 +133,7 @@ compactions, or incomplete history prevent clean. OpenCode uses validated
 ordered history, not `parentID` as a fabricated predecessor link.
 
 The route columns use engine turn migration 7 and desktop migration 39. Current
-parser/analyzer/evidence/coverage/resume revisions are 32/23/18/4/6. Existing
+parser/analyzer/evidence/coverage/resume revisions are 33/23/18/4/7. Existing
 revision gates invalidate old projections and snapshots; JSON and binary
 evidence round trips and full/resumed replay are covered by tests.
 


### PR DESCRIPTION
Codex can record one response in both `token_usage_record` and `event_msg`/`token_count`.
Different cumulative totals made the old key count both rows.
This inflated usage, cache reads, output, and rewrite markers.

This change pairs records when per-response usage matches within five seconds.
It retains one bounded candidate.
It supports either record order.
It consumes each pair once.
Resumed snapshots carry the candidate.
Same-format dedupe still uses cumulative usage.
It also includes available request identities.
Distinct responses with equal usage stay separate.
Parser and resume revisions refresh existing analyses.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- Shell Cargo checks, formatter, clippy, and tests
- `slop:all` and `secrets`

The regression fixture contains three paired requests.
It verifies uncached input `67,852`, cache reads `128,384`, output `418`, and peak context `67,756`.
No new analytics events are needed.
This change corrects existing accounting.
