### PR TITLE
chore: refresh tray vendor to latest Tauri-compatible upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,10 +298,10 @@ jobs:
         working-directory: ${{ matrix.workspace.directory }}
         run: cargo ${{ matrix.check.command }}
 
-      - name: Check vendored tray library and tests
+      - name: Check vendored tray library, tests, and examples
         if: matrix.workspace.name == 'shell' && matrix.check.name == 'Clippy'
         working-directory: apps/desktop/src-tauri/vendor/tray-icon
-        run: cargo clippy --locked --lib --tests -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Test vendored tray library and native harness
         if: matrix.workspace.name == 'shell' && matrix.check.name == 'Tests'

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -705,7 +705,7 @@ tracing-serde@0.2.0 | MIT | https://github.com/tokio-rs/tracing
 tracing-subscriber@0.3.23 | MIT | https://github.com/tokio-rs/tracing
 tracing@0.1.44 | MIT | https://github.com/tokio-rs/tracing
 transpose@0.2.3 | MIT OR Apache-2.0 | https://github.com/ejmahler/transpose
-tray-icon@0.24.1 | MIT OR Apache-2.0 | https://github.com/tauri-apps/tray-icon
+tray-icon@0.24.2 | MIT OR Apache-2.0 | https://github.com/tauri-apps/tray-icon
 try-lock@0.2.5 | MIT | https://github.com/seanmonstar/try-lock
 typeid@1.0.3 | MIT OR Apache-2.0 | https://github.com/dtolnay/typeid
 typenum@1.20.1 | MIT OR Apache-2.0 | https://github.com/paholg/typenum
@@ -6546,7 +6546,7 @@ Apache License
 
 Used by:
   muda@0.19.3
-  tray-icon@0.24.1
+  tray-icon@0.24.2
 
 MIT License
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "crossbeam-channel",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -213,9 +213,9 @@ strip = true
 
 # Temporary vendoring for two macOS behavior fixes.
 #
-# The upstream revision moves `NSMenu` attachment into menu tracking so macOS 27
-# continues to deliver primary clicks. The local delta adds an opt-in highlight
-# override so popover visibility owns the status item's persistent highlight.
+# The vendor uses the latest upstream baseline compatible with Tauri.
+# The local patches attach `NSMenu` only during tracking for macOS 27 clicks.
+# They also let popover visibility control the status item's persistent highlight.
 # Native menu tracking still highlights the item and restores the latest
 # override afterward.
 #

--- a/apps/desktop/src-tauri/vendor/tray-icon/.cargo/audit.toml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+    # quick-xml, pulled in by dev-dependency wayland-scanner > winit
+    "RUSTSEC-2026-0194",
+    # quick-xml, pulled in by dev-dependency wayland-scanner > winit
+    "RUSTSEC-2026-0195",
+]

--- a/apps/desktop/src-tauri/vendor/tray-icon/.changes/nis-hidden.md
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.changes/nis-hidden.md
@@ -1,5 +1,0 @@
----
-tray-icon: patch
----
-
-Migrated to use `NIS_HIDDEN` to change visible states on Windows

--- a/apps/desktop/src-tauri/vendor/tray-icon/.changes/objc2-0.3.2.md
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.changes/objc2-0.3.2.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+On macOS, updated `objc2-*` dependencies to 0.3.2

--- a/apps/desktop/src-tauri/vendor/tray-icon/.changes/perf-macos-avoid-allocating.md
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.changes/perf-macos-avoid-allocating.md
@@ -1,5 +1,0 @@
----
-"tray-icon": patch
----
-
-Avoid unnecessary cloning when applying tray icons, titles, and tooltips on macOS.

--- a/apps/desktop/src-tauri/vendor/tray-icon/.changes/set-cb-size.md
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.changes/set-cb-size.md
@@ -1,5 +1,0 @@
----
-tray-icon: patch
----
-
-Set `NOTIFYICONDATAW.cbSize` to `size_of::<NOTIFYICONDATAW>()`, this increased the max tooltip length from 64 to 128 characters.

--- a/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/audit.yml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/audit.yml
@@ -23,11 +23,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+  checks: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v1
+      - uses: actions/checkout@v7
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/clippy-fmt.yml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/clippy-fmt.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     strategy:
@@ -24,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install system deps
         if: matrix.platform == 'ubuntu-latest'
         run: |
@@ -40,7 +43,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/covector-status.yml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/covector-status.yml
@@ -5,12 +5,15 @@
 name: covector status
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   covector:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: covector status
         uses: jbolda/covector/packages/action@covector-v0
         id: covector

--- a/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/covector-version-or-publish.yml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/covector-version-or-publish.yml
@@ -9,6 +9,12 @@ on:
     branches:
       - dev
 
+permissions:
+  # required to create the GitHub Release
+  contents: write
+  # required for creating the Version Packages Release
+  pull-requests: write
+
 jobs:
   version-or-publish:
     runs-on: ubuntu-latest
@@ -19,7 +25,7 @@ jobs:
       successfulPublish: ${{ steps.covector.outputs.successfulPublish }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: cargo login
@@ -33,8 +39,6 @@ jobs:
       - name: covector version or publish (publish when no change files present)
         uses: jbolda/covector/packages/action@covector-v0
         id: covector
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.ORG_NPM_TOKEN }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           command: 'version-or-publish'
@@ -47,7 +51,7 @@ jobs:
 
       - name: Create Pull Request With Versions Bumped
         if: steps.covector.outputs.commandRan == 'version'
-        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 7.0.6
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: Apply Version Updates From Current Changes

--- a/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/test.yml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/.github/workflows/test.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -27,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: install system deps
         if: matrix.platform == 'ubuntu-latest'

--- a/apps/desktop/src-tauri/vendor/tray-icon/CHANGELOG.md
+++ b/apps/desktop/src-tauri/vendor/tray-icon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[0.24.2]
+
+- [`962c9be`](https://www.github.com/tauri-apps/tray-icon/commit/962c9be6fcc6f82782abe86e9a3a86427ba7bbb8) ([#337](https://www.github.com/tauri-apps/tray-icon/pull/337) by [@Legend-Master](https://www.github.com/tauri-apps/tray-icon/../../Legend-Master)) Migrated to use `NIS_HIDDEN` to change visible states on Windows
+- [`9826ff4`](https://www.github.com/tauri-apps/tray-icon/commit/9826ff42e52be0ac92e0803eed16d517299ec7c0) ([#327](https://www.github.com/tauri-apps/tray-icon/pull/327) by [@Tunglies](https://www.github.com/tauri-apps/tray-icon/../../Tunglies)) Avoid unnecessary cloning when applying tray icons, titles, and tooltips on macOS.
+- [`962c9be`](https://www.github.com/tauri-apps/tray-icon/commit/962c9be6fcc6f82782abe86e9a3a86427ba7bbb8) ([#337](https://www.github.com/tauri-apps/tray-icon/pull/337) by [@Legend-Master](https://www.github.com/tauri-apps/tray-icon/../../Legend-Master)) Set `NOTIFYICONDATAW.cbSize` to `size_of::<NOTIFYICONDATAW>()`, this increased the max tooltip length from 64 to 128 characters.
+
 ## \[0.24.1]
 
 - [`7adc007`](https://www.github.com/tauri-apps/tray-icon/commit/7adc007bb54a91e7e6de4baac87ae534e1aa0550) ([#325](https://www.github.com/tauri-apps/tray-icon/pull/325) by [@Y-ASLant](https://www.github.com/tauri-apps/tray-icon/../../Y-ASLant)) On Windows, preserve tray icon visibility on Explorer restart so a hidden tray icon won't become visible.

--- a/apps/desktop/src-tauri/vendor/tray-icon/Cargo.lock
+++ b/apps/desktop/src-tauri/vendor/tray-icon/Cargo.lock
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.8.0",
  "core-foundation 0.10.0",
@@ -820,6 +820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +874,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.8.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -1137,11 +1150,10 @@ checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2005,12 +2017,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,6 +2045,15 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2141,9 +2156,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2358,10 +2373,10 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -2385,8 +2400,19 @@ dependencies = [
  "bitflags 2.8.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2413,6 +2439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,7 +2466,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.8.0",
+ "dispatch2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2446,6 +2485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,6 +2504,28 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2484,6 +2555,17 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.8.0",
  "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.8.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2526,6 +2608,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,16 +2638,37 @@ dependencies = [
  "bitflags 2.8.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.8.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
 ]
 
 [[package]]
@@ -2576,8 +2691,18 @@ dependencies = [
  "bitflags 2.8.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3289,23 +3414,23 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.4"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6121216ff67fe4bcfe64508ea1700bc15f74937d835a07b4a209cc00a8926a84"
+checksum = "e9fa4618f999c4249db1681cba0a19b890718f274de7fa93c445d46bd3a8a999"
 dependencies = [
  "bitflags 2.8.0",
  "block2 0.6.2",
  "core-foundation 0.10.0",
- "core-graphics 0.24.0",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
- "dispatch",
+ "dbus",
+ "dispatch2",
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk",
@@ -3314,10 +3439,11 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
@@ -3329,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "tao-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+checksum = "5f7eeb6d99155545da6150a1795945f16ac9c178deb2a5f2e74d776107bd5849"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3542,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -4248,6 +4374,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4525,7 +4660,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/apps/desktop/src-tauri/vendor/tray-icon/Cargo.lock
+++ b/apps/desktop/src-tauri/vendor/tray-icon/Cargo.lock
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.4",
 ]
@@ -855,6 +855,16 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2 0.6.4",
+]
 
 [[package]]
 name = "displaydoc"
@@ -2184,9 +2194,9 @@ dependencies = [
  "keyboard-types",
  "libxdo",
  "objc2 0.6.4",
- "objc2-app-kit 0.3.0",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.0",
  "serde",
@@ -2356,14 +2366,14 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.8.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2404,19 +2414,20 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.8.0",
+ "dispatch2",
  "objc2 0.6.4",
 ]
 
 [[package]]
 name = "objc2-core-graphics"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.8.0",
  "objc2-core-foundation",
@@ -2467,12 +2478,12 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.8.0",
- "block2 0.6.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3283,7 +3294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6121216ff67fe4bcfe64508ea1700bc15f74937d835a07b4a209cc00a8926a84"
 dependencies = [
  "bitflags 2.8.0",
- "block2 0.6.0",
+ "block2 0.6.2",
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
  "crossbeam-channel",
@@ -3301,8 +3312,8 @@ dependencies = [
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "objc2 0.6.4",
- "objc2-app-kit 0.3.0",
- "objc2-foundation 0.3.0",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
@@ -3541,10 +3552,10 @@ dependencies = [
  "libappindicator",
  "muda",
  "objc2 0.6.4",
- "objc2-app-kit 0.3.0",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.0",
  "serde",

--- a/apps/desktop/src-tauri/vendor/tray-icon/Cargo.toml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tray-icon"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 description = "Create tray icons for desktop applications"
 homepage = "https://github.com/tauri-apps/tray-icon"
@@ -59,12 +59,12 @@ objc2-core-graphics = { version = "0.3.2", default-features = false, features = 
   "std",
   "CGDirectDisplay",
 ] }
-objc2-core-foundation = { version = "0.3", default-features = false, features = [
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
   "std",
   "CFCGTypes",
   "CFRunLoop",
 ] }
-objc2-foundation = { version = "0.3", default-features = false, features = [
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
   "std",
   "block2",
   "objc2-core-foundation",
@@ -82,11 +82,8 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "NSCell",
   "NSControl",
   "NSEvent",
-  "NSApplication",
-  "NSGraphicsContext",
   "NSImage",
   "NSMenu",
-  "NSMenuItem",
   "NSResponder",
   "NSStatusBar",
   "NSStatusBarButton",
@@ -101,7 +98,10 @@ png = "0.18"
 
 [dev-dependencies]
 winit = "0.30"
-tao = "0.34"
+tao = "0.36"
 eframe = "0.31"
 image = { version = "0.25", default-features = false, features = ["png"] }
 serde_json = "1"
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSGraphicsContext"] }

--- a/apps/desktop/src-tauri/vendor/tray-icon/Cargo.toml
+++ b/apps/desktop/src-tauri/vendor/tray-icon/Cargo.toml
@@ -55,7 +55,7 @@ gtk = "0.18"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 objc2 = "0.6"
-objc2-core-graphics = { version = "0.3", default-features = false, features = [
+objc2-core-graphics = { version = "0.3.2", default-features = false, features = [
   "std",
   "CGDirectDisplay",
 ] }
@@ -75,7 +75,7 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
   "NSString",
   "NSThread",
 ] }
-objc2-app-kit = { version = "0.3", default-features = false, features = [
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "std",
   "objc2-core-foundation",
   "NSButton",

--- a/apps/desktop/src-tauri/vendor/tray-icon/README.antiburn.md
+++ b/apps/desktop/src-tauri/vendor/tray-icon/README.antiburn.md
@@ -11,6 +11,11 @@ after native menu tracking, and survives status-item recreation. The
 `macos_highlight_override` test exercises the public API and native mouse event
 target when `TRAY_ICON_RUN_NATIVE_TEST=1` is set.
 
+The local patch also requires `objc2-app-kit` and `objc2-core-graphics` 0.3.2
+or later, matching the safe bindings used by the desktop shell. Redundant
+`unsafe` blocks are removed from the macOS implementation and native harness.
+The standalone lockfile uses the same binding versions as the shell.
+
 Remove this vendor copy when a compatible upstream release provides equivalent
 highlight control and retains the macOS 27 menu attachment fix.
 

--- a/apps/desktop/src-tauri/vendor/tray-icon/README.antiburn.md
+++ b/apps/desktop/src-tauri/vendor/tray-icon/README.antiburn.md
@@ -1,20 +1,30 @@
 # antiburn vendoring notes
 
-This directory vendors `tray-icon` 0.24.1 from upstream revision
-`0ada43072646fe4454b1f969f4f446dc401fa1aa`. That revision includes the macOS 27
-menu attachment fix from [upstream PR 341](https://github.com/tauri-apps/tray-icon/pull/341).
+This directory vendors `tray-icon` 0.24.2 from upstream revision
+`77c96c432cf2785679affc117389104a6e850528`. This is the last upstream revision
+before the 0.25 backend and menu dependency changes. It includes the complete
+macOS bindings update from [upstream PR 352](https://github.com/tauri-apps/tray-icon/pull/352),
+including the dependency lockfile and example API updates.
 
-The local patch adds an opt-in macOS highlight override. The override preserves
-AppKit's default pressed behavior when unset. When set, it keeps primary mouse
-events from changing the requested state, restores the latest requested state
-after native menu tracking, and survives status-item recreation. The
-`macos_highlight_override` test exercises the public API and native mouse event
-target when `TRAY_ICON_RUN_NATIVE_TEST=1` is set.
+Tauri 2.11.5 requires `tray-icon` 0.24, `muda` 0.19, and the legacy tray feature
+names. Upstream 0.25 changes these interfaces and requires `muda` 0.20. Refresh
+past this revision when Tauri supports those interfaces. The Windows GUID API
+and the GTK-free Linux/BSD backend are not included in this baseline.
 
-The local patch also requires `objc2-app-kit` and `objc2-core-graphics` 0.3.2
-or later, matching the safe bindings used by the desktop shell. Redundant
-`unsafe` blocks are removed from the macOS implementation and native harness.
-The standalone lockfile uses the same binding versions as the shell.
+The local patch retains the macOS 27 menu attachment fix from
+[upstream PR 341](https://github.com/tauri-apps/tray-icon/pull/341), originally
+pinned at `0ada43072646fe4454b1f969f4f446dc401fa1aa`. It attaches the native menu
+only during menu tracking so primary clicks continue to reach the tray target.
+
+The local patch also adds an opt-in macOS highlight override. The override
+preserves AppKit's default pressed behavior when unset. When set, it keeps
+primary mouse events from changing the requested state, restores the latest
+requested state after native menu tracking, and survives status-item recreation.
+The `macos_highlight_override` test exercises the public API and native mouse
+event target when `TRAY_ICON_RUN_NATIVE_TEST=1` is set. The patch uses the safe
+bindings from the new baseline in both the implementation and test harness.
+The macOS test dependency explicitly enables `NSApplication` and
+`NSGraphicsContext` for synthetic mouse events; it does not rely on example dependencies enabling that feature.
 
 Remove this vendor copy when a compatible upstream release provides equivalent
 highlight control and retains the macOS 27 menu attachment fix.

--- a/apps/desktop/src-tauri/vendor/tray-icon/examples/tao.rs
+++ b/apps/desktop/src-tauri/vendor/tray-icon/examples/tao.rs
@@ -78,10 +78,10 @@ fn main() {
                 // Tao only exposes a redraw method on the Window so we use core-foundation directly.
                 #[cfg(target_os = "macos")]
                 unsafe {
-                    use objc2_core_foundation::{CFRunLoopGetMain, CFRunLoopWakeUp};
+                    use objc2_core_foundation::CFRunLoop;
 
-                    let rl = CFRunLoopGetMain().unwrap();
-                    CFRunLoopWakeUp(&rl);
+                    let rl = CFRunLoop::main().unwrap();
+                    CFRunLoop::wake_up(&rl);
                 }
             }
 

--- a/apps/desktop/src-tauri/vendor/tray-icon/examples/winit.rs
+++ b/apps/desktop/src-tauri/vendor/tray-icon/examples/winit.rs
@@ -86,10 +86,10 @@ impl ApplicationHandler<UserEvent> for Application {
             // Winit only exposes a redraw method on the Window so we use core-foundation directly.
             #[cfg(target_os = "macos")]
             unsafe {
-                use objc2_core_foundation::{CFRunLoopGetMain, CFRunLoopWakeUp};
+                use objc2_core_foundation::CFRunLoop;
 
-                let rl = CFRunLoopGetMain().unwrap();
-                CFRunLoopWakeUp(&rl);
+                let rl = CFRunLoop::main().unwrap();
+                CFRunLoop::wake_up(&rl);
             }
         }
     }

--- a/apps/desktop/src-tauri/vendor/tray-icon/src/platform_impl/macos/mod.rs
+++ b/apps/desktop/src-tauri/vendor/tray-icon/src/platform_impl/macos/mod.rs
@@ -58,9 +58,8 @@ impl TrayIcon {
         mtm: MainThreadMarker,
     ) -> crate::Result<(Retained<NSStatusItem>, Retained<TrayTarget>)> {
         let forced_highlight = highlight_state.highlight_override.get();
-        let ns_status_item = unsafe {
-            NSStatusBar::systemStatusBar().statusItemWithLength(NSVariableStatusItemLength)
-        };
+        let ns_status_item =
+            NSStatusBar::systemStatusBar().statusItemWithLength(NSVariableStatusItemLength);
 
         set_icon_for_ns_status_item_button(
             &ns_status_item,
@@ -108,10 +107,8 @@ impl TrayIcon {
     fn remove(&mut self) {
         if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
         {
-            unsafe {
-                NSStatusBar::systemStatusBar().removeStatusItem(ns_status_item);
-                tray_target.removeFromSuperview();
-            }
+            NSStatusBar::systemStatusBar().removeStatusItem(ns_status_item);
+            tray_target.removeFromSuperview();
         }
 
         self.ns_status_item = None;
@@ -158,11 +155,9 @@ impl TrayIcon {
         tooltip: Option<S>,
         mtm: MainThreadMarker,
     ) -> crate::Result<()> {
-        unsafe {
-            let tooltip = tooltip.map(|tooltip| NSString::from_str(tooltip.as_ref()));
-            if let Some(button) = ns_status_item.button(mtm) {
-                button.setToolTip(tooltip.as_deref());
-            }
+        let tooltip = tooltip.map(|tooltip| NSString::from_str(tooltip.as_ref()));
+        if let Some(button) = ns_status_item.button(mtm) {
+            button.setToolTip(tooltip.as_deref());
         }
         Ok(())
     }
@@ -183,10 +178,8 @@ impl TrayIcon {
         mtm: MainThreadMarker,
     ) {
         if let Some(title) = title {
-            unsafe {
-                if let Some(button) = ns_status_item.button(mtm) {
-                    button.setTitle(&NSString::from_str(title.as_ref()));
-                }
+            if let Some(button) = ns_status_item.button(mtm) {
+                button.setTitle(&NSString::from_str(title.as_ref()));
             }
         }
     }
@@ -223,22 +216,17 @@ impl TrayIcon {
                 .highlight_override
                 .get()
                 .unwrap_or(false);
-            // SAFETY: The marker requires the main thread. The retained status item keeps its button alive.
-            unsafe {
-                let button = ns_status_item.button(self.mtm).unwrap();
-                button.highlight(highlight);
-            }
+            let button = ns_status_item.button(self.mtm).unwrap();
+            button.highlight(highlight);
         }
     }
 
     pub fn set_icon_as_template(&mut self, is_template: bool) {
         if let Some(ns_status_item) = &self.ns_status_item {
-            unsafe {
-                let button = ns_status_item.button(self.mtm).unwrap();
-                if let Some(nsimage) = button.image() {
-                    nsimage.setTemplate(is_template);
-                    button.setImage(Some(&nsimage));
-                }
+            let button = ns_status_item.button(self.mtm).unwrap();
+            if let Some(nsimage) = button.image() {
+                nsimage.setTemplate(is_template);
+                button.setImage(Some(&nsimage));
             }
         }
         self.attrs.icon_is_template = is_template;
@@ -286,11 +274,9 @@ impl TrayIcon {
 
     pub fn rect(&self) -> Option<Rect> {
         let ns_status_item = self.ns_status_item.as_deref()?;
-        unsafe {
-            let button = ns_status_item.button(self.mtm).unwrap();
-            let window = button.window();
-            window.map(|window| get_tray_rect(&window))
-        }
+        let button = ns_status_item.button(self.mtm).unwrap();
+        let window = button.window();
+        window.map(|window| get_tray_rect(&window))
     }
 
     pub fn ns_status_item(&self) -> Option<&Retained<NSStatusItem>> {
@@ -310,7 +296,7 @@ fn set_icon_for_ns_status_item_button(
     icon_is_template: bool,
     mtm: MainThreadMarker,
 ) -> crate::Result<()> {
-    let button = unsafe { ns_status_item.button(mtm).unwrap() };
+    let button = ns_status_item.button(mtm).unwrap();
 
     if let Some(icon) = icon {
         let png_icon = icon.inner.to_png()?;
@@ -320,21 +306,19 @@ fn set_icon_for_ns_status_item_button(
         let icon_height: f64 = 18.0;
         let icon_width: f64 = (width as f64) / (height as f64 / icon_height);
 
-        unsafe {
-            // build our icon
-            let nsdata = NSData::from_vec(png_icon);
+        // build our icon
+        let nsdata = NSData::from_vec(png_icon);
 
-            let nsimage = NSImage::initWithData(NSImage::alloc(), &nsdata).unwrap();
-            let new_size = NSSize::new(icon_width, icon_height);
+        let nsimage = NSImage::initWithData(NSImage::alloc(), &nsdata).unwrap();
+        let new_size = NSSize::new(icon_width, icon_height);
 
-            button.setImage(Some(&nsimage));
-            nsimage.setSize(new_size);
-            // The image is to the right of the title
-            button.setImagePosition(NSCellImagePosition::ImageLeft);
-            nsimage.setTemplate(icon_is_template);
-        }
+        button.setImage(Some(&nsimage));
+        nsimage.setSize(new_size);
+        // The image is to the right of the title
+        button.setImagePosition(NSCellImagePosition::ImageLeft);
+        nsimage.setTemplate(icon_is_template);
     } else {
-        unsafe { button.setImage(None) };
+        button.setImage(None);
     }
 
     Ok(())
@@ -421,7 +405,7 @@ define_class!(
 
         #[unsafe(method(otherMouseDown:))]
         fn on_other_mouse_down(&self, event: &NSEvent) {
-            let button_number = unsafe { event.buttonNumber() };
+            let button_number = event.buttonNumber();
             if button_number == 2 {
                 send_mouse_event(
                     self,
@@ -437,7 +421,7 @@ define_class!(
 
         #[unsafe(method(otherMouseUp:))]
         fn on_other_mouse_up(&self, event: &NSEvent) {
-            let button_number = unsafe { event.buttonNumber() };
+            let button_number = event.buttonNumber();
             if button_number == 2 {
                 send_mouse_event(
                     self,
@@ -506,28 +490,24 @@ define_class!(
 impl TrayTarget {
     fn update_dimensions(&self) {
         let mtm = MainThreadMarker::from(self);
-        unsafe {
-            let button = self.ivars().status_item.button(mtm).unwrap();
-            self.setFrame(button.frame());
-        }
+        let button = self.ivars().status_item.button(mtm).unwrap();
+        self.setFrame(button.frame());
     }
 }
 
 fn on_tray_click(this: &TrayTarget, button: MouseButton) {
     let mtm = MainThreadMarker::from(this);
-    unsafe {
-        let ns_button = this.ivars().status_item.button(mtm).unwrap();
-        let menu_on_left_click = this.ivars().menu_on_left_click.get();
-        let menu_on_right_click = this.ivars().menu_on_right_click.get();
-        if (menu_on_right_click && button == MouseButton::Right)
-            || (menu_on_left_click && button == MouseButton::Left)
-        {
-            if !show_menu(this) {
-                apply_click_highlight(this, button, &ns_button);
-            }
-        } else {
+    let ns_button = this.ivars().status_item.button(mtm).unwrap();
+    let menu_on_left_click = this.ivars().menu_on_left_click.get();
+    let menu_on_right_click = this.ivars().menu_on_right_click.get();
+    if (menu_on_right_click && button == MouseButton::Right)
+        || (menu_on_left_click && button == MouseButton::Left)
+    {
+        if !show_menu(this) {
             apply_click_highlight(this, button, &ns_button);
         }
+    } else {
+        apply_click_highlight(this, button, &ns_button);
     }
 }
 
@@ -559,8 +539,7 @@ fn apply_click_highlight(this: &TrayTarget, mouse_button: MouseButton, button: &
         mouse_button,
         this.ivars().highlight_state.highlight_override.get(),
     ) {
-        // SAFETY: TrayTarget runs on the main thread. Its retained status item owns this button.
-        unsafe { button.highlight(highlight) };
+        button.highlight(highlight);
     }
 }
 
@@ -570,11 +549,8 @@ fn apply_primary_highlight(this: &TrayTarget, highlight: bool) {
         this.ivars().highlight_state.highlight_override.get(),
     ) {
         let mtm = MainThreadMarker::from(this);
-        // SAFETY: The marker requires the main thread. The target retains the status item and its button.
-        unsafe {
-            let button = this.ivars().status_item.button(mtm).unwrap();
-            button.highlight(highlight);
-        }
+        let button = this.ivars().status_item.button(mtm).unwrap();
+        button.highlight(highlight);
     }
 }
 
@@ -626,52 +602,50 @@ fn send_mouse_event(
     click_event: Option<MouseClickEvent>,
 ) {
     let mtm = MainThreadMarker::from(this);
-    unsafe {
-        let tray_id = TrayIconId(this.ivars().id.to_string());
+    let tray_id = TrayIconId(this.ivars().id.to_string());
 
-        // icon position & size
-        let window = event.window(mtm).unwrap();
-        let icon_rect = get_tray_rect(&window);
+    // icon position & size
+    let window = event.window(mtm).unwrap();
+    let icon_rect = get_tray_rect(&window);
 
-        // cursor position
-        let mouse_location = NSEvent::mouseLocation();
-        let scale_factor = window.backingScaleFactor();
-        let cursor_position = crate::dpi::LogicalPosition::new(
-            mouse_location.x,
-            flip_window_screen_coordinates(mouse_location.y),
-        )
-        .to_physical(scale_factor);
+    // cursor position
+    let mouse_location = NSEvent::mouseLocation();
+    let scale_factor = window.backingScaleFactor();
+    let cursor_position = crate::dpi::LogicalPosition::new(
+        mouse_location.x,
+        flip_window_screen_coordinates(mouse_location.y),
+    )
+    .to_physical(scale_factor);
 
-        let event = match mouse_event_type {
-            MouseEventType::Click => {
-                let click_event = click_event.unwrap();
-                TrayIconEvent::Click {
-                    id: tray_id,
-                    position: cursor_position,
-                    rect: icon_rect,
-                    button: click_event.button,
-                    button_state: click_event.state,
-                }
+    let event = match mouse_event_type {
+        MouseEventType::Click => {
+            let click_event = click_event.unwrap();
+            TrayIconEvent::Click {
+                id: tray_id,
+                position: cursor_position,
+                rect: icon_rect,
+                button: click_event.button,
+                button_state: click_event.state,
             }
-            MouseEventType::Enter => TrayIconEvent::Enter {
-                id: tray_id,
-                position: cursor_position,
-                rect: icon_rect,
-            },
-            MouseEventType::Leave => TrayIconEvent::Leave {
-                id: tray_id,
-                position: cursor_position,
-                rect: icon_rect,
-            },
-            MouseEventType::Move => TrayIconEvent::Move {
-                id: tray_id,
-                position: cursor_position,
-                rect: icon_rect,
-            },
-        };
+        }
+        MouseEventType::Enter => TrayIconEvent::Enter {
+            id: tray_id,
+            position: cursor_position,
+            rect: icon_rect,
+        },
+        MouseEventType::Leave => TrayIconEvent::Leave {
+            id: tray_id,
+            position: cursor_position,
+            rect: icon_rect,
+        },
+        MouseEventType::Move => TrayIconEvent::Move {
+            id: tray_id,
+            position: cursor_position,
+            rect: icon_rect,
+        },
+    };
 
-        TrayIconEvent::send(event);
-    }
+    TrayIconEvent::send(event);
 }
 
 #[derive(Debug)]
@@ -700,7 +674,7 @@ struct MouseClickEvent {
 /// This conversion happens to be symmetric, so we only need this one function
 /// to convert between the two coordinate systems.
 fn flip_window_screen_coordinates(y: f64) -> f64 {
-    unsafe { CGDisplayPixelsHigh(CGMainDisplayID()) as f64 - y }
+    CGDisplayPixelsHigh(CGMainDisplayID()) as f64 - y
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/vendor/tray-icon/tests/macos_highlight_override.rs
+++ b/apps/desktop/src-tauri/vendor/tray-icon/tests/macos_highlight_override.rs
@@ -53,18 +53,14 @@ fn main() {
         tray: &tray_icon::TrayIcon,
         mtm: MainThreadMarker,
     ) -> objc2::rc::Retained<objc2_app_kit::NSStatusBarButton> {
-        // SAFETY: The marker requires the main thread. The tray retains the status item and returns a retained button.
-        unsafe {
-            tray.ns_status_item()
-                .expect("the status item is visible")
-                .button(mtm)
-                .expect("the status item has a button")
-        }
+        tray.ns_status_item()
+            .expect("the status item is visible")
+            .button(mtm)
+            .expect("the status item has a button")
     }
 
     fn is_highlighted(tray: &tray_icon::TrayIcon, mtm: MainThreadMarker) -> bool {
-        // SAFETY: The marker requires the main thread, and the retained button remains alive during this call.
-        unsafe { button(tray, mtm).isHighlighted() }
+        button(tray, mtm).isHighlighted()
     }
 
     fn dispatch_primary_event(
@@ -73,10 +69,9 @@ fn main() {
         event_type: NSEventType,
     ) {
         let button = button(tray, mtm);
-        // SAFETY: The marker requires the main thread. Retained objects keep the window, event, and target alive.
-        unsafe {
-            let window = button.window().expect("the status button has a window");
-            let event = NSEvent::mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure(
+
+        let window = button.window().expect("the status button has a window");
+        let event = NSEvent::mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure(
                 event_type,
                 NSPoint::new(0.0, 0.0),
                 NSEventModifierFlags::empty(),
@@ -88,16 +83,15 @@ fn main() {
                 1.0,
             )
             .expect("create a native mouse event");
-            let target = button
-                .subviews()
-                .lastObject()
-                .expect("the status button has the tray event target");
+        let target = button
+            .subviews()
+            .lastObject()
+            .expect("the status button has the tray event target");
 
-            match event_type {
-                NSEventType::LeftMouseDown => target.mouseDown(&event),
-                NSEventType::LeftMouseUp => target.mouseUp(&event),
-                _ => panic!("only primary mouse events are supported"),
-            }
+        match event_type {
+            NSEventType::LeftMouseDown => target.mouseDown(&event),
+            NSEventType::LeftMouseUp => target.mouseUp(&event),
+            _ => panic!("only primary mouse events are supported"),
         }
     }
 


### PR DESCRIPTION
Refresh the vendored tray library to upstream revision `77c96c432cf2785679affc117389104a6e850528` (0.24.2), the latest revision compatible with Tauri 2.11.5. This incorporates upstream's complete macOS bindings update and removes the 18 redundant unsafe warnings from desktop development builds.

Import the upstream dependency lockfile, example API fixes, changelog, and repository metadata. Preserve the macOS 27 click-delivery patch from upstream PR #341 and antiburn's persistent highlight override, including its native regression harness. Explicitly enable the harness's AppKit features and extend vendor Clippy coverage to examples on all CI platforms. Update the shell lockfile, third-party notices, and vendor provenance documentation.

Tauri still requires tray-icon 0.24, muda 0.19, and the legacy feature names. The 0.25 Windows GUID API and Linux/BSD KSNI backend remain deferred until Tauri supports that dependency boundary.

Validation: shell and vendor formatting; shell Clippy and vendor all-target Clippy with warnings denied; six vendor unit tests and the native AppKit highlight harness; third-party notice regeneration and verification; repository slop and secret checks. All 1,227 shell tests passed locally. Cross-platform PR CI passed all 45 checks, including vendor library, test, and example Clippy checks on macOS, Windows, and Linux.

The refresh preserves application tray behavior and adds no analytics or application network calls.
