### PR TITLE
Fix false cache rehydration warnings and duplicate Codex usage

### DIFF
--- a/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/reconcile_tests.rs
@@ -28,8 +28,8 @@ fn reconciling_backfills_existing_pi_sessions_with_current_revisions() {
     assert_eq!(
         crate::analysis::projection_revisions(),
         ProjectionRevisions {
-            parser_revision: 33,
-            analyzer_revision: 23,
+            parser_revision: 34,
+            analyzer_revision: 24,
             metrics_schema_revision: 8,
             evidence_schema_revision: 18,
         }

--- a/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests/resume_tests.rs
@@ -415,9 +415,9 @@ fn a_vanished_source_has_its_rows_and_resume_dropped_on_the_next_publish() {
 #[test]
 fn current_resume_revisions_reject_each_prior_batch_revision() {
     let current = crate::analysis::resume_revisions();
-    assert_eq!(current.snapshot_revision, 7);
-    assert_eq!(current.parser_revision, 33);
-    assert_eq!(current.analyzer_revision, 23);
+    assert_eq!(current.snapshot_revision, 8);
+    assert_eq!(current.parser_revision, 34);
+    assert_eq!(current.analyzer_revision, 24);
     assert_eq!(current.metrics_schema_revision, 8);
     assert_eq!(current.evidence_schema_revision, 18);
     assert_eq!(current.coverage_schema_revision, 4);

--- a/apps/desktop/src/lib/presentation/sessionHygiene.ts
+++ b/apps/desktop/src/lib/presentation/sessionHygiene.ts
@@ -118,14 +118,14 @@ const CHECKS: readonly HygieneCheckDefinition[] = [
     cleanTitle: "Cache rehydration under control",
     findingTitle: "Cache rehydration out of control",
     notAssessedTitle: "Cache rehydration not assessed",
-    summary: "Spending tokens to refresh the server-side cache is a waste of money/quota.",
+    summary: "Repeated full-price context processing can increase cost and quota use.",
     guidance: [
       "Avoid long breaks in sessions.",
       "If you have a long break, compact before or even after it.",
       "Avoid switching models with a large context accumulated.",
     ],
     explainer:
-      "When the cache expires mid-session, the next turn rewrites the whole context at full price. Long idle gaps are the usual cause.",
+      "This estimates paid context beyond context growth. Cache expiry, context changes, and provider evictions can contribute; the estimate does not establish the cause.",
   },
 ]
 

--- a/crates/antiburn-local/src/analysis/evidence.rs
+++ b/crates/antiburn-local/src/analysis/evidence.rs
@@ -390,12 +390,8 @@ pub struct RepeatedContext {
     pub repeated_tokens: u64,
     pub pairs_considered: u64,
     pub pairs_skipped: u64,
-    /// Sum of `paid` (the accounting's billed bucket) over every
-    /// considered pair's current turn, same accounting as
-    /// `repeated_tokens`. `repeated_tokens <= paid_tokens` by
-    /// construction: a pair's overpay never exceeds what it paid.
-    /// Old persisted evidence has no field here, so it deserializes as
-    /// `0`.
+    /// Sum the accounting's paid bucket across all eligible requests, including each segment's first request.
+    /// Old persisted evidence uses zero until analysis refreshes it.
     #[serde(default)]
     pub paid_tokens: u64,
 }
@@ -1157,8 +1153,8 @@ mod tests {
             },
             "coverage": coverage,
             "provenance": {
-                "parserRevision": 33,
-                "analyzerRevision": 23,
+                "parserRevision": 34,
+                "analyzerRevision": 24,
                 "evidenceSchemaRevision": 18,
                 "sourceKind": "file",
                 "sourceAcceptance": "not_observed",

--- a/crates/antiburn-local/src/analysis/evidence_query.rs
+++ b/crates/antiburn-local/src/analysis/evidence_query.rs
@@ -67,9 +67,7 @@ pub struct TurnFacts {
     /// The same sum under uncached-input billing: paid context
     /// (`input_tokens`) beyond positive growth.
     pub repeated_context_uncached_input_tokens: u64,
-    /// Sum of the raw cache-write bucket over every considered pair's
-    /// current turn, before subtracting growth
-    /// (`RepeatedContext::paid_tokens` under cache-write accounting).
+    /// Sum the paid cache-write bucket across all eligible requests.
     pub repeated_context_cache_write_paid_tokens: u64,
     /// The same sum under uncached-input accounting.
     pub repeated_context_uncached_input_paid_tokens: u64,
@@ -1243,7 +1241,7 @@ fn query_duplicate_turn_identities(
 /// Scan all main rows so intervening links and compactions can break request pairs.
 const REPEATED_CONTEXT_SCAN_SQL: &str = "SELECT thread_id, ts_ms, input_tokens,
         cache_read_tokens, cache_write_tokens, is_compaction_boundary,
-        source_key, role, model, provider, api, uuid, parent_uuid, turn_index
+        source_key, role, model, provider, api, uuid, parent_uuid, turn_index, output_tokens
    FROM turn
   WHERE environment_key = ?1 AND agent = ?2 AND session_id = ?3 AND (claim_fence = ?4 OR (claim_fence = ?5 AND source_key IN (SELECT value FROM json_each(?6))))
     AND scope = 'main'
@@ -1254,9 +1252,7 @@ struct RepeatedContextTotals {
     incomplete: bool,
     cache_write_tokens: u64,
     uncached_input_tokens: u64,
-    /// Sum of the raw cache-write bucket (`RepeatedContext::paid_tokens`
-    /// under `CacheAccounting::CacheWrite`) over every considered pair's
-    /// current turn, before subtracting growth.
+    /// Sum the paid cache-write bucket across all eligible requests.
     cache_write_paid_tokens: u64,
     /// The same sum under uncached-input accounting.
     uncached_input_paid_tokens: u64,
@@ -1378,6 +1374,9 @@ fn query_repeated_context(
         let depth = as_u64(input_tokens)
             .saturating_add(as_u64(cache_read_tokens))
             .saturating_add(as_u64(cache_write));
+        if key.agent == "codex" && depth == 0 && row.get::<_, i64>(14)? == 0 {
+            continue;
+        }
         if mode.is_none()
             || mode != accounting
             || model.as_deref().is_none_or(|model| model.trim().is_empty())
@@ -1387,6 +1386,9 @@ fn query_repeated_context(
             pairs_skipped = pairs_skipped.saturating_add(u64::from(previous.take().is_some()));
             continue;
         }
+        cache_write_paid_tokens = cache_write_paid_tokens.saturating_add(as_u64(cache_write));
+        uncached_input_paid_tokens =
+            uncached_input_paid_tokens.saturating_add(as_u64(input_tokens));
         let route = (model, provider, api);
         if let Some((previous_ts, previous_depth, previous_route)) = previous {
             let in_order = matches!((previous_ts, ts_ms), (Some(previous_ts), Some(ts_ms)) if ts_ms >= previous_ts);
@@ -1399,9 +1401,6 @@ fn query_repeated_context(
                     cache_write_tokens.saturating_add(paid_cache_write.saturating_sub(growth));
                 uncached_input_tokens = uncached_input_tokens
                     .saturating_add(paid_uncached_input.saturating_sub(growth));
-                cache_write_paid_tokens = cache_write_paid_tokens.saturating_add(paid_cache_write);
-                uncached_input_paid_tokens =
-                    uncached_input_paid_tokens.saturating_add(paid_uncached_input);
             } else {
                 pairs_skipped = pairs_skipped.saturating_add(1);
                 incomplete = true;
@@ -2182,6 +2181,24 @@ mod tests {
     }
 
     #[test]
+    fn paid_totals_include_initial_requests_and_new_segments() {
+        for agent in ["claude", "codex"] {
+            let mut rows: Vec<_> = (0..3).map(|index| cache_row("s1", index)).collect();
+            for row in &mut rows {
+                row.input_tokens = 100;
+                row.cache_write_tokens = 100;
+            }
+            rows[2].model = Some("different-model".to_owned());
+            let facts = route_facts(agent, &rows);
+            assert_eq!(facts.repeated_context_cache_write_paid_tokens, 300);
+            assert_eq!(facts.repeated_context_uncached_input_paid_tokens, 300);
+            assert_eq!(facts.repeated_context_cache_write_tokens, 100);
+            assert_eq!(facts.repeated_context_pairs_considered, 1);
+            assert!(facts.repeated_context_incomplete);
+        }
+    }
+
+    #[test]
     fn known_request_contracts_use_disjoint_input_buckets() {
         use RepeatedContextAccounting::{CacheWrite, UncachedInput};
         for (agent, provider, api, expected) in [
@@ -2315,7 +2332,7 @@ mod tests {
         };
         assert_eq!(observed.accounting, RepeatedContextAccounting::CacheWrite);
         assert_eq!(observed.repeated_tokens, 200);
-        assert_eq!(observed.paid_tokens, 200);
+        assert_eq!(observed.paid_tokens, 400);
 
         let reversed: Vec<_> = rows
             .into_iter()

--- a/crates/antiburn-local/src/analysis/mod.rs
+++ b/crates/antiburn-local/src/analysis/mod.rs
@@ -173,7 +173,8 @@ pub use vendors::{has_dedicated_reader, reader_for};
 // This batch also reparses nested resources and paired subagent observations.
 // +1 for Pi assistant request-start timestamps: token and context buckets now
 // use `message.timestamp` while event ordering keeps the outer row timestamp.
-pub const PARSER_REVISION: i64 = 33;
+// Deduplicate delayed exact Codex usage copies.
+pub const PARSER_REVISION: i64 = 34;
 // +1 for turn row chart signals: `has_thinking`, `last_tool`, and
 // `subagent_launches` are now ingest-derived row columns
 // (`rows::turn_row_from_event`), so every session must reparse to
@@ -217,7 +218,8 @@ pub const PARSER_REVISION: i64 = 33;
 // Recompute repeated context within compatible request segments.
 // This batch also reassesses nested resource use and paired subagent models.
 // Reassess sessions with the larger thread identity limit.
-pub const ANALYZER_REVISION: i64 = 23;
+// Compare actual requests and include every eligible payment in cache ratios.
+pub const ANALYZER_REVISION: i64 = 24;
 // +1 for seam R2: the worker path now derives `inclusive_model_breakdown`
 // and `model_runs` from published turn rows instead of the accumulator
 // (`query_model_breakdown`, `query_model_runs`), so every session in the
@@ -274,7 +276,8 @@ pub const COVERAGE_SCHEMA_REVISION: i64 = 4;
 // +1 because parent evidence now includes delegated model control observations.
 // This batch also changes retained nested resource and paired subagent state.
 // +1 for the bounded Codex cross-format usage matcher in adapter snapshots.
-pub const RESUME_SNAPSHOT_REVISION: i64 = 7;
+// Reject snapshots that can retain duplicate usage totals.
+pub const RESUME_SNAPSHOT_REVISION: i64 = 8;
 
 /// Normalize and analyze a batch of live sessions into one averaged summary.
 ///

--- a/crates/antiburn-local/src/analysis/vendors/codex.rs
+++ b/crates/antiburn-local/src/analysis/vendors/codex.rs
@@ -2006,8 +2006,7 @@ fn usage_record_format(value: &Value) -> Option<UsageRecordFormat> {
     }
 }
 
-/// A cross-format match needs a timestamp because equal per-response usage
-/// can belong to distinct requests. Keep the window short and retain one candidate.
+/// A match with different cumulative totals requires timestamps within this window.
 const CROSS_FORMAT_USAGE_DEDUPE_WINDOW_MS: u64 = 5_000;
 
 fn usage_record_is_duplicate(
@@ -2040,12 +2039,17 @@ fn usage_record_is_duplicate(
         prior.owned == current.owned
             && prior.format != current.format
             && prior.key == current.key
-            && prior
-                .ts_ms
-                .zip(current.ts_ms)
-                .is_some_and(|(prior, current)| {
-                    prior.abs_diff(current) <= CROSS_FORMAT_USAGE_DEDUPE_WINDOW_MS
-                })
+            && (prior
+                .key
+                .1
+                .as_object()
+                .is_some_and(|usage| !usage.is_empty())
+                || prior
+                    .ts_ms
+                    .zip(current.ts_ms)
+                    .is_some_and(|(prior, current)| {
+                        prior.abs_diff(current) <= CROSS_FORMAT_USAGE_DEDUPE_WINDOW_MS
+                    }))
     });
 
     let mismatched_cross_format_repeat = !same_format_repeat
@@ -2357,7 +2361,7 @@ mod tests {
 
     #[test]
     fn record_to_event_changes_require_an_inertness_review() {
-        const EXPECTED_FINGERPRINT: u64 = 18_370_784_376_499_888_089;
+        const EXPECTED_FINGERPRINT: u64 = 17_590_009_681_109_556_840;
         let source = include_str!("codex.rs").replace("\r\n", "\n");
         let start = source.find("fn observe_model_and_effort").unwrap();
         let end = source.find("\n#[cfg(test)]\nmod tests").unwrap();
@@ -3554,7 +3558,7 @@ mod tests {
         }
 
         #[test]
-        fn a_resumed_legacy_usage_record_deduplicates_after_a_new_record() {
+        fn a_delayed_resumed_legacy_record_deduplicates_after_a_new_record() {
             let first_records = concat!(
                 r#"{"timestamp":"2026-09-02T00:00:00Z","type":"turn_context","payload":{"effort":"high"}}"#,
                 "\n",
@@ -3562,7 +3566,7 @@ mod tests {
                 "\n",
             );
             let legacy_record = concat!(
-                r#"{"timestamp":"2026-09-02T00:00:04Z","type":"event_msg","payload":{"type":"token_count","info":{"model_context_window":96000,"last_token_usage":{"input_tokens":30,"cached_input_tokens":10,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":1,"total_tokens":35},"total_token_usage":{"input_tokens":30,"cached_input_tokens":10,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":1,"total_tokens":35}}}}"#,
+                r#"{"timestamp":"2026-09-02T00:01:04Z","type":"event_msg","payload":{"type":"token_count","info":{"model_context_window":96000,"last_token_usage":{"input_tokens":30,"cached_input_tokens":10,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":1,"total_tokens":35},"total_token_usage":{"input_tokens":30,"cached_input_tokens":10,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":1,"total_tokens":35}}}}"#,
                 "\n",
             );
             let directory = TempDir::new().expect("tempdir");

--- a/crates/antiburn-local/src/insights/badges.rs
+++ b/crates/antiburn-local/src/insights/badges.rs
@@ -266,11 +266,15 @@ mod tests {
     }
 
     #[test]
-    fn each_badge_accepts_a_finding_from_partial_evidence() {
+    fn partial_evidence_follows_each_badges_finding_policy() {
         for id in BadgeId::ALL {
             assert_eq!(
                 badge(&finding_evidence(id, true), id).status,
-                BadgeStatus::Finding
+                if id == BadgeId::ExcessCacheRehydration {
+                    BadgeStatus::NotAssessed(super::super::NotAssessedReason::IncompleteEvidence)
+                } else {
+                    BadgeStatus::Finding
+                }
             );
         }
     }

--- a/crates/antiburn-local/src/insights/detectors/cache_churn.rs
+++ b/crates/antiburn-local/src/insights/detectors/cache_churn.rs
@@ -14,18 +14,12 @@
 //!
 //! The finding fires only when `repeated_tokens > 0` and the multiple
 //! reaches the bound.
-//! `unique_paid_tokens == 0` (every paid token in a considered pair was
+//! `unique_paid_tokens == 0` (every eligible paid token was
 //! a repeat) is treated as an infinite multiple, so it is always a
 //! finding.
 //!
-//! Partial-evidence rules:
-//! - Partial cache evidence still permits a finding: repeated and paid
-//!   tokens read from partial evidence prove presence.
-//! - Partial cache evidence prevents clean. A missed record may hide
-//!   repeated context or understate the paid total.
-//! - `repeated_context` `Unsupported` reports a contract gap: the
-//!   source supports neither cache-write nor uncached-input
-//!   accounting.
+//! Partial evidence cannot establish the session ratio or a clean result.
+//! Missing payments can change the denominator and the threshold outcome.
 
 use crate::analysis::{EvidenceValue, SessionEvidence};
 use crate::remediation::FindingCause;
@@ -33,12 +27,14 @@ use crate::remediation::FindingCause;
 use super::{ModelFamily, Observation, ReportCatalogs, model_family, observed};
 
 pub(crate) fn evaluate(evidence: &SessionEvidence, catalogs: &ReportCatalogs) -> Observation {
-    let Some(cache) = observed(&evidence.cache) else {
-        return Observation::ContractIncomplete;
+    let cache = match &evidence.cache {
+        EvidenceValue::Complete(cache) => cache,
+        EvidenceValue::Partial { .. } => return Observation::NoFinding,
+        EvidenceValue::Unsupported => return Observation::ContractIncomplete,
     };
     let repeated_context = match &cache.repeated_context {
+        EvidenceValue::Partial { .. } => return Observation::NoFinding,
         EvidenceValue::Unsupported => return Observation::ContractIncomplete,
-        EvidenceValue::Partial { observed, .. } => observed,
         EvidenceValue::Complete(observed) => observed,
     };
     if repeated_context.repeated_tokens == 0 {
@@ -165,9 +161,14 @@ mod tests {
             });
             set_dominant_main_model(&mut evidence, "claude-sonnet-4-6");
 
-            assert_eq!(evaluate(&evidence, &ReportCatalogs::default()), {
-                Observation::Finding
-            });
+            assert_eq!(
+                evaluate(&evidence, &ReportCatalogs::default()),
+                if partial {
+                    Observation::NoFinding
+                } else {
+                    Observation::Finding
+                }
+            );
         }
     }
 
@@ -353,6 +354,21 @@ mod tests {
         assert_eq!(
             evaluate(&evidence, &ReportCatalogs::default()),
             Observation::Finding
+        );
+    }
+
+    #[test]
+    fn partial_repeated_context_cannot_establish_a_ratio() {
+        let mut evidence = claude_evidence("partial-ratio");
+        edit_cache(&mut evidence, false, |cache| {
+            cache.repeated_context = EvidenceValue::Partial {
+                observed: repeated_context(RepeatedContextAccounting::CacheWrite, 100, 100),
+                reason: CoverageReason::MalformedRecord,
+            };
+        });
+        assert_eq!(
+            evaluate(&evidence, &ReportCatalogs::default()),
+            Observation::NoFinding
         );
     }
 

--- a/crates/antiburn-local/src/insights/report.rs
+++ b/crates/antiburn-local/src/insights/report.rs
@@ -3594,7 +3594,16 @@ mod tests {
             for fact in clean_only {
                 let mut row = trigger_finding(detector, &catalogs);
                 degrade_fact_to_partial(&mut row, fact);
+                let incomplete_ratio = detector == DetectorId::CacheChurn
+                    && !matches!(row.cache, EvidenceValue::Complete(_));
                 let status = status_for_with_catalogs(row, detector, catalogs.clone());
+                if incomplete_ratio {
+                    assert_eq!(
+                        status,
+                        DetectorStatus::NotAssessed(NotAssessedReason::IncompleteEvidence)
+                    );
+                    continue;
+                }
                 assert!(
                     matches!(status, DetectorStatus::Findings(_)),
                     "degrading clean-only fact {fact:?} for {detector:?} must still report a finding, got {status:?}"

--- a/crates/antiburn-local/tests/codex_characterization.rs
+++ b/crates/antiburn-local/tests/codex_characterization.rs
@@ -1116,15 +1116,9 @@ fn context_reread_reads_complete_uncached_input_repeated_context_and_a_finding_b
         repeated_context.accounting,
         antiburn_local::analysis::RepeatedContextAccounting::UncachedInput
     );
-    // Turn two grows the window from 2000 to 60000 (+58000), paying 2000
-    // fresh uncached-input tokens; turn three re-sends the same
-    // 60000-token window fully uncached after the idle gap, so growth is
-    // 0 and the whole 60000 it pays is repeated. paid_tokens sums both
-    // turns' paid buckets: 2000 + 60000 = 62000.
+    // The initial payment and both later payments contribute to the denominator.
     assert_eq!(repeated_context.repeated_tokens, 60_000);
-    assert_eq!(repeated_context.paid_tokens, 62_000);
-    // multiple = 62000 / (62000 - 60000) = 31, far above the OpenAI
-    // bound of 2.0.
+    assert_eq!(repeated_context.paid_tokens, 64_000);
     let unique_paid_tokens = repeated_context.paid_tokens - repeated_context.repeated_tokens;
     let multiple = repeated_context.paid_tokens as f64 / unique_paid_tokens as f64;
     assert!(multiple >= 2.0);
@@ -1190,14 +1184,9 @@ fn cache_write_tokens_reads_the_split_keeps_uncached_input_accounting() {
         repeated_context.accounting,
         antiburn_local::analysis::RepeatedContextAccounting::UncachedInput
     );
-    // Pair one (turn one -> turn two): occupancy grows 2000 -> 60000
-    // (+58000); turn two pays only 1000 fresh input, below growth, so
-    // nothing is repeated. Pair two (turn two -> turn three): occupancy
-    // stays at 60000 (growth 0); turn three pays 58000 fresh input, all of
-    // it repeated. repeated_tokens: 0 + 58000 = 58000. paid_tokens sums
-    // both pairs' paid buckets: 1000 + 58000 = 59000.
+    // The initial payment adds 1,500 uncached tokens to the denominator.
     assert_eq!(repeated_context.repeated_tokens, 58_000);
-    assert_eq!(repeated_context.paid_tokens, 59_000);
+    assert_eq!(repeated_context.paid_tokens, 60_500);
 }
 
 /// `records_all_kinds` carries no `cache_write_input_tokens` key anywhere,
@@ -1406,4 +1395,70 @@ fn usage_free_token_count_records_are_recognized_eventless() {
     // 300 `input_tokens`.
     assert_eq!(metrics.metrics().tokens_in, 200);
     assert_eq!(metrics.metrics().tokens_out, 40);
+}
+
+#[test]
+fn delayed_usage_copies_and_assistant_messages_preserve_cache_accounting() {
+    pricing::install();
+    for reversed in [false, true] {
+        let mut records = vec![
+            json!({"type":"session_meta","payload":{"model":"gpt-5.6","model_provider":"openai","effort":"medium"}}),
+        ];
+        let mut cumulative_input = 0;
+        let mut cumulative_cached = 0;
+        for (input, cached) in [(1000, 0), (1080, 980), (1160, 1060)] {
+            let usage =
+                json!({"input_tokens":input,"cached_input_tokens":cached,"output_tokens":10});
+            cumulative_input += input;
+            cumulative_cached += cached;
+            let total = json!({"input_tokens":cumulative_input,"cached_input_tokens":cumulative_cached,"output_tokens":10});
+            let mut pair = vec![
+                json!({"type":"token_usage_record","payload":{"usage":usage,"turn_token_usage":total,"thread_token_usage":total}}),
+                json!({"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":usage,"total_token_usage":total}}}),
+            ];
+            if reversed {
+                pair.reverse();
+            }
+            records.push(json!({"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Synthetic progress."}]}}));
+            records.push(pair.remove(0));
+            records.push(json!({"type":"response_item","payload":{"type":"function_call_output","call_id":"synthetic-tool","output":"done"}}));
+            records.push(pair.remove(0));
+        }
+        let source = records
+            .into_iter()
+            .enumerate()
+            .map(|(index, mut record)| {
+                record["timestamp"] = json!(format!("2026-08-05T10:{index:02}:00Z"));
+                record.to_string() + "\n"
+            })
+            .collect();
+        let input = SessionInput {
+            source: RawSource::Jsonl(source),
+            ..provider_input(vec![])
+        };
+        let (evidence, metrics) = composite(&input);
+        assert_eq!(metrics.metrics().tokens_in, 1200);
+        let EvidenceValue::Complete(cache) = &evidence.cache else {
+            panic!(
+                "complete cache: {:?}; {:?}",
+                evidence.cache, evidence.diagnostics
+            );
+        };
+        let EvidenceValue::Complete(repeated) = &cache.repeated_context else {
+            panic!("complete request accounting: {:?}", cache.repeated_context);
+        };
+        assert_eq!(repeated.paid_tokens, 1200);
+        assert_eq!(repeated.repeated_tokens, 40);
+        assert_eq!(repeated.pairs_considered, 2);
+        assert_eq!(repeated.pairs_skipped, 0);
+        let badges = session_badges(&evidence, &ReportCatalogs::default());
+        assert_eq!(
+            badges
+                .iter()
+                .find(|badge| badge.id == BadgeId::ExcessCacheRehydration)
+                .unwrap()
+                .status,
+            BadgeStatus::Clean
+        );
+    }
 }

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/cache_write_tokens.json
@@ -20,7 +20,7 @@
           "state": "complete",
           "value": {
             "accounting": "uncached_input",
-            "paidTokens": 59000,
+            "paidTokens": 60500,
             "pairsConsidered": 2,
             "pairsSkipped": 0,
             "repeatedTokens": 58000
@@ -187,14 +187,14 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/collab_agent_records.json
@@ -17,16 +17,13 @@
           "state": "unsupported"
         },
         "repeatedContext": {
-          "state": "partial",
+          "state": "complete",
           "value": {
-            "observed": {
-              "accounting": "uncached_input",
-              "paidTokens": 0,
-              "pairsConsidered": 0,
-              "pairsSkipped": 2,
-              "repeatedTokens": 0
-            },
-            "reason": "attribution_incomplete"
+            "accounting": "uncached_input",
+            "paidTokens": 860,
+            "pairsConsidered": 1,
+            "pairsSkipped": 0,
+            "repeatedTokens": 400
           }
         },
         "userControlledChurn": {
@@ -185,14 +182,14 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/context_reread.json
@@ -20,7 +20,7 @@
           "state": "complete",
           "value": {
             "accounting": "uncached_input",
-            "paidTokens": 62000,
+            "paidTokens": 64000,
             "pairsConsidered": 2,
             "pairsSkipped": 0,
             "repeatedTokens": 60000
@@ -187,14 +187,14 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/malformed_between_valid.json
@@ -25,7 +25,7 @@
             "value": {
               "observed": {
                 "accounting": "uncached_input",
-                "paidTokens": 0,
+                "paidTokens": 150,
                 "pairsConsidered": 0,
                 "pairsSkipped": 0,
                 "repeatedTokens": 0
@@ -202,13 +202,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/model_overthinking_finding.json
@@ -20,7 +20,7 @@
           "state": "complete",
           "value": {
             "accounting": "uncached_input",
-            "paidTokens": 0,
+            "paidTokens": 500,
             "pairsConsidered": 0,
             "pairsSkipped": 0,
             "repeatedTokens": 0
@@ -177,14 +177,14 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/records_all_kinds.json
@@ -21,7 +21,7 @@
           "value": {
             "observed": {
               "accounting": "uncached_input",
-              "paidTokens": 0,
+              "paidTokens": 400,
               "pairsConsidered": 0,
               "pairsSkipped": 1,
               "repeatedTokens": 0
@@ -201,14 +201,14 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/session_overdepth_finding.json
@@ -20,7 +20,7 @@
           "state": "complete",
           "value": {
             "accounting": "uncached_input",
-            "paidTokens": 0,
+            "paidTokens": 450000,
             "pairsConsidered": 0,
             "pairsSkipped": 0,
             "repeatedTokens": 0
@@ -177,14 +177,14 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/spawn_agent.json
@@ -17,16 +17,13 @@
           "state": "unsupported"
         },
         "repeatedContext": {
-          "state": "partial",
+          "state": "complete",
           "value": {
-            "observed": {
-              "accounting": "uncached_input",
-              "paidTokens": 0,
-              "pairsConsidered": 0,
-              "pairsSkipped": 2,
-              "repeatedTokens": 0
-            },
-            "reason": "attribution_incomplete"
+            "accounting": "uncached_input",
+            "paidTokens": 860,
+            "pairsConsidered": 1,
+            "pairsSkipped": 0,
+            "repeatedTokens": 400
           }
         },
         "userControlledChurn": {
@@ -185,14 +182,14 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "complete",
         "value": null
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
+++ b/crates/antiburn-local/tests/fixtures/codex_characterization/goldens/unrecognized_type.json
@@ -136,13 +136,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/content_blocks.json
@@ -126,13 +126,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/excess_cache_rehydration_finding.json
@@ -152,13 +152,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/model_overthinking_finding.json
@@ -164,13 +164,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/session_overdepth_finding.json
@@ -132,13 +132,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_content_block.json
@@ -158,13 +158,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/unknown_row_type.json
@@ -140,13 +140,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
+++ b/crates/antiburn-local/tests/fixtures/pi_characterization/goldens/usage_all_buckets.json
@@ -137,13 +137,13 @@
       }
     },
     "provenance": {
-      "analyzerRevision": 23,
+      "analyzerRevision": 24,
       "evidenceSchemaRevision": 18,
       "harnessVersion": {
         "state": "unsupported"
       },
       "ordering": "monotonic",
-      "parserRevision": 33,
+      "parserRevision": 34,
       "sourceAcceptance": "unvalidated",
       "sourceKind": "jsonl"
     },

--- a/crates/antiburn-local/tests/opencode_characterization.rs
+++ b/crates/antiburn-local/tests/opencode_characterization.rs
@@ -339,7 +339,7 @@ fn native_repeated_context_reaches_reports_without_capability_overrides() {
                     if matches!(case, "finding" | "tied_time") {
                         assert_eq!(repeated.pairs_considered, 2);
                         assert_eq!(repeated.repeated_tokens, 2000);
-                        assert_eq!(repeated.paid_tokens, 2000);
+                        assert_eq!(repeated.paid_tokens, 3000);
                     }
                 }
                 store.with_connection(|connection| {

--- a/docs/check-coverage.md
+++ b/docs/check-coverage.md
@@ -126,15 +126,23 @@ An overflow or oversized UUID records `CapExceeded`, makes attribution
 incomplete, and blocks every clean result that needs complete affected evidence.
 An oversized resume identity set is rejected instead of being trusted.
 
-Codex cache and token checks use one observation for a matching
-`token_usage_record.payload.usage` and `event_msg`/`token_count.info.last_token_usage`
-pair within five seconds. Available request identities separate same-format
-requests with equal usage. The reader retains one recent observation.
-Their cumulative `thread_token_usage`
-and `total_token_usage` values are cross checks only because the two producer
-paths can report different bases. Repeated legacy rows and cross-format copies
-remain deduplicated across resume boundaries. An unmatched valid per-response
-record remains evidence; malformed usage remains partial.
+Codex pairs `token_usage_record` and `event_msg`/`token_count` records once.
+Matching per-response and nonempty cumulative usage identifies exact copies
+without a time limit. Different cumulative producer bases require matching
+per-response usage within five seconds. Available identities distinguish
+same-format requests. The reader retains bounded state across resume boundaries.
+Unmatched valid usage remains evidence; malformed usage remains partial.
+
+Cache accounting compares usage-bearing requests across ordinary Codex assistant
+messages. Broken links, unknown requests, route changes, and compaction boundaries
+still break pairs. The paid denominator includes every eligible request,
+including each segment's initial payment. Partial cache or repeated-context
+evidence permits neither a ratio finding nor a clean result.
+
+Maintainer confirmation (2026-09-12): repair delayed exact-copy deduplication,
+request pairing, and full-denominator accounting. Reviewed passive alternatives
+include increasing the time limit and adjusting thresholds; neither repairs
+all three accounting errors. Per-session thresholds remain unchanged.
 
 Maintainer confirmation (2026-09-10): raise the identity cap to 16,384 as an
 interim measure for longer sessions. Reviewed passive alternatives include
@@ -162,7 +170,7 @@ identity is retained without copying private document bodies into evidence.
 | Pi                          | T                   | `EffortSemantics::AgentSelectedPolicy` evaluates the saved agent-selected thinking level, not translated provider effort. Reviewed native routes and branch/fork policy state are retained. Missing levels/routes and unknown models fail closed; provider overrides are not guessed.                                                   |
 | Pi                          | S                   | Existing output from the official subagent example extension supplies nested `toolResult` messages, exact native call/worker identity, and actual models. This is finding-only. Arbitrary extensions, fork ancestry, requested aliases, and a nonpremium observed worker cannot establish clean.                                        |
 | Pi                          | M, B, K, F          | Confirmed unsupported for the reviewed sources. Tool calls and bounded skill invocation identity do not establish historical resource exposure or speed. No alternative local proof was identified.                                                                                                                                     |
-| Claude, Codex, OpenCode, Pi | C                   | Durable request provider/API fields and the compatible-request query select reviewed cache-write or uncached-input accounting. Main-thread identity, order, token classes, model, route, and compaction boundaries constrain pairs. Codex pairs `token_usage_record` with equivalent `token_count` usage by per-response fields; cumulative fields do not decide equivalence. Unknown or incompatible segments remain partial, not clean. Google cache policy remains unreviewed. |
+| Claude, Codex, OpenCode, Pi | C                   | Durable request provider/API fields and the compatible-request query select reviewed cache-write or uncached-input accounting. Main-thread identity, order, token classes, model, route, and compaction boundaries constrain pairs. Codex pairs `token_usage_record` with equivalent `token_count` usage by per-response fields; matching cumulative fields permit delayed exact copies. Unknown or incompatible segments prevent both ratio findings and clean results. Google cache policy remains unreviewed. |
 | OpenCode                    | C                   | Both accepted export and SQLite shapes use validated ordered history. `parentID` identifies the user being answered, not the predecessor. Missing wrappers/timestamps, duplicate or out-of-order messages, and unresolved forks prevent complete history. CoreV2 `session_message` is not the existing SQLite table contract.           |
 | Cursor                      | D, O                | O retains direct timed-model findings; the source gate denies clean on every surface. D remains unavailable because the current reader does not emit request-usage evidence. Synthetic source-gate tests do not establish native parsing support.                                                                                       |
 | Cursor                      | T, S, M, B, K, F, C | Broader surface characterization is deferred. Current settings, relations, inventories, and cache evidence remain partial, unknown, or unsupported as listed; no new parity claim is made.                                                                                                                                              |

--- a/docs/session-coverage.md
+++ b/docs/session-coverage.md
@@ -37,16 +37,23 @@ release range: an accepted schema, header, or pinned producer commit with
 synthetic fixtures can define its contract. This does not prove all historical
 versions. Full and resumed reads must agree where resume is supported.
 
-Codex can emit one response's usage in both `token_usage_record` and
-`event_msg`/`token_count`. Per-response usage fields identify cross-format pairs
-within five seconds, while available request identities separate same-format
-requests with equal usage. The reader retains one recent observation.
-Cumulative `thread_token_usage` and
-`total_token_usage` fields can use different producer bases, so they do not
-decide whether a cross-format pair is a duplicate. Repeated legacy rows and
-cross-format pairs are deduplicated within the active request segment, and the
-bounded dedupe state crosses a resume boundary. Missing or malformed
-per-response usage remains partial.
+Codex pairs `token_usage_record` and `event_msg`/`token_count` records once.
+Matching per-response and nonempty cumulative usage identifies exact copies
+without a time limit. Different cumulative producer bases require matching
+per-response usage within five seconds. Available identities distinguish
+same-format requests. The reader retains bounded state across resume boundaries.
+Unmatched valid usage remains evidence; malformed usage remains partial.
+
+Cache accounting compares usage-bearing requests across ordinary Codex assistant
+messages. Broken links, unknown requests, route changes, and compaction boundaries
+still break pairs. The paid denominator includes every eligible request,
+including each segment's initial payment. Partial cache or repeated-context
+evidence permits neither a ratio finding nor a clean result.
+
+Maintainer confirmation (2026-09-12): repair delayed exact-copy deduplication,
+request pairing, and full-denominator accounting. Reviewed passive alternatives
+include increasing the time limit and adjusting thresholds; neither repairs
+all three accounting errors. Per-session thresholds remain unchanged.
 
 Inline materialized sources use a fingerprint of the full bounded content, not
 only a head region. The content is already materialized and size-bounded before


### PR DESCRIPTION
Delayed copies of Codex usage records could inflate token totals and trigger false Excess cache rehydration warnings. Ordinary assistant messages also broke request comparisons, and the ratio omitted initial context payments.

This change deduplicates exact cross-format usage copies beyond five seconds, preserves request comparisons across usage-free Codex assistant messages, and includes every eligible request payment in the denominator. Incomplete cache evidence now yields not assessed. Parser, analyzer, and resume revisions refresh existing analyses. The explanation describes an estimate without asserting a cache-expiry cause; thresholds remain unchanged.

Validation covers delayed copies in both record orders, delayed copies across resume, initial and new-segment payments, partial-evidence verdicts, and the combined parser-to-badge result. All fixtures are synthetic. Engine and shell formatter, Clippy, and tests; desktop lint, type checks, tests, and build; coverage contract; repository style and secret checks are run locally.

Existing analytics continues to report check outcomes; no new event is needed for this accounting correction. Processing remains local, retained deduplication state stays bounded, and no transcript content or captured machine data is included.
