### PR TITLE
feat(desktop): add session filter rows under Sessions

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -640,7 +640,15 @@ Notes for what isn't expressible as a token:
   their controls remain interactive. The empty detail uses a 40px drag region without layout clearance. Double-clicking this strip toggles maximize and restore through
   Tauri's drag-region handler. Windows and Linux retain their native bars, so this surface adds no
   top strip there. Multi-pane content keeps the documented 220px sidebar visible at every size.
-  Main navigation uses 28px rows, 2px vertical gaps, 14px icons, and 8px icon-to-label gaps.
+  Main navigation (`SidebarNav`) uses 36px top-level rows, 8px vertical gaps, 16px icons, and
+  12px icon-to-label gaps. A top-level item can nest child rows one level deep, right below it in
+  the same tablist. A child row is 32px tall, needs no icon of its own, and sits 32px from the
+  sidebar's inner edge — `pl-8` in place of a top-level row's `px-3`. A child's own hairline
+  separator keeps that same 32px indent. Any row's optional trailing count uses the shared
+  `CountPill` (`src/components/ui/CountPill.tsx`): the same 16px-high, borderless,
+  `surface-tertiary/40`, tertiary-ink, `font-mono type-metadata tabular-nums` pill documented
+  below for a session card's `+N` model count. A row with a count sets its accessible name to
+  its label alone, so the count digits stay out of the announced name.
   These local geometry rules use the spacing tokens in `main-window.css`; other source lists
   retain their current density. Burn checks and Sessions are the main sidebar sections. Burn checks
   is the default section, uses the 14px Lucide `Flame` mark, and opens from the checks summary in

--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -640,15 +640,19 @@ Notes for what isn't expressible as a token:
   their controls remain interactive. The empty detail uses a 40px drag region without layout clearance. Double-clicking this strip toggles maximize and restore through
   Tauri's drag-region handler. Windows and Linux retain their native bars, so this surface adds no
   top strip there. Multi-pane content keeps the documented 220px sidebar visible at every size.
-  Main navigation (`SidebarNav`) uses 36px top-level rows, 8px vertical gaps, 16px icons, and
-  12px icon-to-label gaps. A top-level item can nest child rows one level deep, right below it in
-  the same tablist. A child row is 32px tall, needs no icon of its own, and sits 32px from the
-  sidebar's inner edge — `pl-8` in place of a top-level row's `px-3`. A child's own hairline
-  separator keeps that same 32px indent. Any row's optional trailing count uses the shared
-  `CountPill` (`src/components/ui/CountPill.tsx`): the same 16px-high, borderless,
-  `surface-tertiary/40`, tertiary-ink, `font-mono type-metadata tabular-nums` pill documented
-  below for a session card's `+N` model count. A row with a count sets its accessible name to
-  its label alone, so the count digits stay out of the announced name.
+  Main navigation uses 28px rows, 2px vertical gaps, 14px icons, and 8px icon-to-label gaps.
+  `main-window.css` sets this density over `SidebarNav`'s own 36px rows, 8px gaps, 16px icons,
+  and 12px icon gaps, which Settings keeps. A top-level item can nest child rows one level deep,
+  right below it in the same tablist. A child row needs no icon of its own and carries
+  `data-nested`. In the main window its label starts at the parent label column, 30px from the
+  row edge (`--main-window-nav-indent`: 8px padding, the 14px icon, and the 8px gap). A child's
+  own hairline separator carries `data-nested` too and keeps that same indent. In `SidebarNav`'s
+  default density a child row is 32px tall with a 32px `pl-8` indent and an `ml-8` separator.
+  Any row's optional trailing count uses the shared `CountPill`
+  (`src/components/ui/CountPill.tsx`): the same 16px-high, borderless, `surface-tertiary/40`,
+  tertiary-ink, `font-mono type-metadata tabular-nums` pill documented below for a session
+  card's `+N` model count. A row with a count sets its accessible name to its label alone, so the
+  count digits stay out of the announced name.
   These local geometry rules use the spacing tokens in `main-window.css`; other source lists
   retain their current density. Burn checks and Sessions are the main sidebar sections. Burn checks
   is the default section, uses the 14px Lucide `Flame` mark, and opens from the checks summary in

--- a/apps/desktop/src-tauri/src/analytics/event.rs
+++ b/apps/desktop/src-tauri/src/analytics/event.rs
@@ -96,6 +96,9 @@ pub enum EventName {
     /// A verified or recurred result appeared during a deliberate exposure.
     #[cfg(feature = "analytics")]
     BurnCheckOutcomeObserved,
+    /// The Sessions sidebar filter changed to a different selection.
+    #[cfg(feature = "analytics")]
+    SessionFilterSelected,
 }
 
 /// Every event this application may send.
@@ -132,6 +135,7 @@ pub const EVERY_EVENT: &[EventName] = &[
     EventName::BurnCheckPromptPrepared,
     EventName::BurnCheckPromptCopied,
     EventName::BurnCheckOutcomeObserved,
+    EventName::SessionFilterSelected,
 ];
 
 #[cfg(feature = "analytics")]
@@ -162,6 +166,7 @@ impl EventName {
             EventName::BurnCheckPromptPrepared => "antiburn.burn_check_prompt_prepared",
             EventName::BurnCheckPromptCopied => "antiburn.burn_check_prompt_copied",
             EventName::BurnCheckOutcomeObserved => "antiburn.burn_check_outcome_observed",
+            EventName::SessionFilterSelected => "antiburn.session_filter_selected",
         }
     }
 }
@@ -402,6 +407,14 @@ pub enum Interaction {
         outcome: BurnCheckOutcome,
         origin: BurnCheckOrigin,
     },
+    /// The Sessions sidebar filter changed to a different selection. `agent`
+    /// deserializes into the engine's own closed enum, so an unrecognized
+    /// slug is a rejected command rather than a new value appearing in the
+    /// data; the renderer omits it rather than send one.
+    SessionFilterSelected {
+        filter: SessionFilterKind,
+        agent: Option<AgentKind>,
+    },
 }
 
 /// A product surface whose visibility is measured.
@@ -566,6 +579,20 @@ pub enum Environment {
     Wsl,
 }
 
+/// A Sessions sidebar filter kind. `Agent` covers every harness item; the
+/// harness itself travels separately, as `Interaction::SessionFilterSelected`'s
+/// own `agent` field.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionFilterKind {
+    Notable,
+    Material,
+    Agent,
+    Failing,
+    Passing,
+    All,
+}
+
 #[cfg(feature = "analytics")]
 impl Interaction {
     /// The event and the facts this interaction becomes.
@@ -659,6 +686,14 @@ impl Interaction {
                     ..Facts::default()
                 },
             ),
+            Interaction::SessionFilterSelected { filter, agent } => (
+                EventName::SessionFilterSelected,
+                Facts {
+                    label: Some(filter.as_str()),
+                    detail: agent.map(AgentKind::slug),
+                    ..Facts::default()
+                },
+            ),
         }
     }
 }
@@ -699,6 +734,16 @@ wire_values!(StateSurface, {
     StateSurface::Settings => "settings",
     StateSurface::Insights => "insights",
     StateSurface::BurnChecks => "burn_checks",
+});
+
+#[cfg(feature = "analytics")]
+wire_values!(SessionFilterKind, {
+    SessionFilterKind::Notable => "notable",
+    SessionFilterKind::Material => "material",
+    SessionFilterKind::Agent => "agent",
+    SessionFilterKind::Failing => "failing",
+    SessionFilterKind::Passing => "passing",
+    SessionFilterKind::All => "all",
 });
 
 #[cfg(feature = "analytics")]
@@ -1360,12 +1405,13 @@ mod tests {
                 | EventName::BurnCheckAutoFixCompleted
                 | EventName::BurnCheckPromptPrepared
                 | EventName::BurnCheckPromptCopied
-                | EventName::BurnCheckOutcomeObserved => true,
+                | EventName::BurnCheckOutcomeObserved
+                | EventName::SessionFilterSelected => true,
             }
         }
         assert_eq!(
             EVERY_EVENT.len(),
-            24,
+            25,
             "a variant was added to the match above but not to EVERY_EVENT"
         );
         assert!(EVERY_EVENT.iter().copied().all(listed));
@@ -1501,6 +1547,40 @@ mod tests {
         assert_eq!(name, EventName::BurnCheckOutcomeObserved);
         assert_eq!(facts.detail, Some("recurred"));
         assert_eq!(facts.origin, Some("passive"));
+
+        let (name, facts) = Interaction::SessionFilterSelected {
+            filter: SessionFilterKind::Agent,
+            agent: Some(AgentKind::Codex),
+        }
+        .resolve();
+        assert_eq!(name, EventName::SessionFilterSelected);
+        assert_eq!(facts.label, Some("agent"));
+        assert_eq!(facts.detail, Some("codex"));
+
+        let (name, facts) = Interaction::SessionFilterSelected {
+            filter: SessionFilterKind::Notable,
+            agent: None,
+        }
+        .resolve();
+        assert_eq!(name, EventName::SessionFilterSelected);
+        assert_eq!(facts.label, Some("notable"));
+        assert_eq!(facts.detail, None);
+    }
+
+    /// An agent filter with no recognized harness reports the filter kind
+    /// alone. The renderer never sends a slug this enum rejects; `None` is
+    /// what a genuinely unrecognized harness (or a non-agent filter) looks
+    /// like here.
+    #[test]
+    fn an_agent_filter_with_no_recognized_harness_has_no_detail() {
+        let (name, facts) = Interaction::SessionFilterSelected {
+            filter: SessionFilterKind::Agent,
+            agent: None,
+        }
+        .resolve();
+        assert_eq!(name, EventName::SessionFilterSelected);
+        assert_eq!(facts.label, Some("agent"));
+        assert_eq!(facts.detail, None);
     }
 
     /// `usage_observed` reads the same closed vocabulary

--- a/apps/desktop/src-tauri/src/analytics/mod.rs
+++ b/apps/desktop/src-tauri/src/analytics/mod.rs
@@ -116,6 +116,9 @@ pub fn record_interaction(_app: &tauri::AppHandle, interaction: event::Interacti
         event::Interaction::BurnCheckOutcomeObserved { outcome, origin } => {
             let _ = (outcome, origin);
         }
+        event::Interaction::SessionFilterSelected { filter, agent } => {
+            let _ = (filter, agent);
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/store/mod.rs
+++ b/apps/desktop/src-tauri/src/store/mod.rs
@@ -2961,6 +2961,10 @@ fn read_settings(connection: &Connection) -> Result<AppSettings> {
             .get("sessionBadgeMetric")
             .and_then(|value| SessionBadgeMetric::parse(value))
             .unwrap_or(defaults.session_badge_metric),
+        session_filter: stored
+            .get("sessionFilter")
+            .cloned()
+            .unwrap_or_else(|| defaults.session_filter.clone()),
     }
     .normalized())
 }
@@ -3063,6 +3067,7 @@ fn write_settings(connection: &Connection, settings: &AppSettings) -> Result<()>
         "sessionBadgeMetric",
         settings.session_badge_metric.as_str()
     ])?;
+    put.execute(params!["sessionFilter", settings.session_filter.as_str()])?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/store/model.rs
+++ b/apps/desktop/src-tauri/src/store/model.rs
@@ -899,6 +899,18 @@ pub struct AppSettings {
     pub skills_mcp_expanded: bool,
     /// The metric shown in each activity-session badge.
     pub session_badge_metric: SessionBadgeMetric,
+    /// The selected Sessions sidebar filter, as its persisted id.
+    ///
+    /// The renderer owns the vocabulary (`lib/sessionFilters.ts`): this side
+    /// stores and returns the id verbatim, and does not validate it. An id
+    /// this release does not recognize is the renderer's to fall back on.
+    #[serde(default = "default_session_filter")]
+    pub session_filter: String,
+}
+
+/// The persisted id for the unfiltered "All Sessions" view.
+fn default_session_filter() -> String {
+    "all".to_string()
 }
 
 impl Default for AppSettings {
@@ -953,6 +965,7 @@ impl Default for AppSettings {
             // pushes the rest of the analysis off the screen.
             skills_mcp_expanded: false,
             session_badge_metric: SessionBadgeMetric::default(),
+            session_filter: default_session_filter(),
         }
     }
 }

--- a/apps/desktop/src-tauri/src/store/tests.rs
+++ b/apps/desktop/src-tauri/src/store/tests.rs
@@ -730,6 +730,8 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     // Closed by default, unlike the limits section: the skills table is a long
     // tail behind a summary, and opening it every time buries the rest.
     assert!(!defaults.skills_mcp_expanded);
+    // Unfiltered by default: a fresh install shows every loaded session.
+    assert_eq!(defaults.session_filter, "all");
     assert_eq!(
         defaults.session_data_retention_days,
         RETAIN_SESSION_DATA_FOREVER
@@ -772,6 +774,7 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
             overview_limits_expanded: false,
             skills_mcp_expanded: true,
             session_badge_metric: SessionBadgeMetric::WeeklyPercent,
+            session_filter: "agent:codex".to_string(),
         })
         .unwrap();
     assert_eq!(store.settings().unwrap(), saved);
@@ -785,6 +788,8 @@ fn settings_default_before_anything_is_written_and_round_trip_after() {
     assert_eq!(saved.nudge_auto_dismiss_secs, 25);
     assert_eq!(saved.disk_space_display, DiskSpaceDisplay::Always);
     assert_eq!(saved.disk_space_threshold_gb, 100);
+    // Stored and returned verbatim; this side does not validate the id.
+    assert_eq!(saved.session_filter, "agent:codex");
     // The empty milestone subset survives a round trip as "none selected",
     // not as a reset back to the defaults.
     assert!(!saved.milestones_weekly.any());

--- a/apps/desktop/src/components/session/SessionList.test.tsx
+++ b/apps/desktop/src/components/session/SessionList.test.tsx
@@ -9,21 +9,24 @@ import {
 } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import type * as InsightsIpc from "../../lib/insightsIpc"
+import type { SessionHygienePayload } from "../../lib/insightsIpc"
 import type { LiveUsageSummaryPayload, LiveUsageWindowPayload } from "../../lib/ipc"
+import { localSessionKey } from "../../lib/presentation/localIdentity"
 import { SessionList, type SessionListEntry, type SessionListProps } from "./SessionList"
 
-const getSessionHygiene = vi.hoisted(() => vi.fn())
-
-vi.mock("../../lib/insightsIpc", async (importOriginal) => ({
-  ...(await importOriginal<typeof InsightsIpc>()),
-  getSessionHygiene,
-}))
+/** A `hygieneBySession` snapshot keyed the way `SessionList` looks rows up. */
+function hygieneSnapshot(
+  pairs: Array<[SessionListEntry, SessionHygienePayload]>,
+): Map<string, SessionHygienePayload> {
+  return new Map(
+    pairs.map(([session, payload]) => [
+      localSessionKey(session.agent, session.sessionId ?? "", session.wslDistro ?? null),
+      payload,
+    ]),
+  )
+}
 
 beforeEach(() => {
-  getSessionHygiene.mockReset()
-  getSessionHygiene.mockResolvedValue(null)
-
   vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(function (
     this: HTMLElement,
   ) {
@@ -744,77 +747,60 @@ describe("SessionList — rows", () => {
     expect(screen.queryByLabelText(/All Burn Checks passed/)).toBeNull()
   })
 
-  it("renders finding and clean statuses returned by the batched IPC path", async () => {
-    getSessionHygiene.mockResolvedValueOnce([
-      {
-        evidenceState: "ready",
-        badges: [
+  it("renders finding and clean statuses from the hygiene snapshot prop", () => {
+    const session = entry({ sessionId: "synthetic-hygiene-result" })
+    list({
+      entries: [session],
+      hygieneBySession: hygieneSnapshot([
+        [
+          session,
           {
-            id: "sessionOverdepth",
-            status: "finding",
-            notAssessedReason: null,
-          },
-          {
-            id: "modelOverthinking",
-            status: "clean",
-            notAssessedReason: null,
-          },
-          {
-            id: "overpoweredSubagents",
-            status: "clean",
-            notAssessedReason: null,
-          },
-          {
-            id: "obsoleteModel",
-            status: "clean",
-            notAssessedReason: null,
-          },
-          {
-            id: "fastModeOveruse",
-            status: "clean",
-            notAssessedReason: null,
-          },
-          {
-            id: "excessCacheRehydration",
-            status: "clean",
-            notAssessedReason: null,
+            evidenceState: "ready",
+            badges: [
+              { id: "sessionOverdepth", status: "finding", notAssessedReason: null },
+              { id: "modelOverthinking", status: "clean", notAssessedReason: null },
+              { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
+              { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+              { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+              { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+            ],
           },
         ],
-      },
-    ])
-    list({ entries: [entry({ sessionId: "synthetic-hygiene-result" })] })
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/Some Burn Checks failed/)).toHaveTextContent(
-        "1 failed·5 passed",
-      )
+      ]),
     })
-    expect(getSessionHygiene).toHaveBeenCalledWith([
-      {
-        agent: "claude-code",
-        sessionId: "synthetic-hygiene-result",
-        wslDistro: null,
-      },
-    ])
+
+    expect(screen.getByLabelText(/Some Burn Checks failed/)).toHaveTextContent(
+      "1 failed·5 passed",
+    )
   })
 
-  it("keeps a cyan all-passed verdict above the session title", async () => {
-    getSessionHygiene.mockResolvedValueOnce([
-      {
-        evidenceState: "ready",
-        badges: [
-          "sessionOverdepth",
-          "modelOverthinking",
-          "overpoweredSubagents",
-          "obsoleteModel",
-          "fastModeOveruse",
-          "excessCacheRehydration",
-        ].map((id) => ({ id, status: "clean", notAssessedReason: null })),
-      },
-    ])
-    list({ entries: [entry({ sessionId: "clean-session", title: "Primary clean title" })] })
+  it("keeps a cyan all-passed verdict above the session title", () => {
+    const session = entry({ sessionId: "clean-session", title: "Primary clean title" })
+    list({
+      entries: [session],
+      hygieneBySession: hygieneSnapshot([
+        [
+          session,
+          {
+            evidenceState: "ready",
+            badges: [
+              "sessionOverdepth",
+              "modelOverthinking",
+              "overpoweredSubagents",
+              "obsoleteModel",
+              "fastModeOveruse",
+              "excessCacheRehydration",
+            ].map((id) => ({
+              id: id as SessionHygienePayload["badges"][number]["id"],
+              status: "clean" as const,
+              notAssessedReason: null,
+            })),
+          },
+        ],
+      ]),
+    })
 
-    const verdict = await screen.findByLabelText(/All Burn Checks passed/)
+    const verdict = screen.getByLabelText(/All Burn Checks passed/)
     expect(verdict).toHaveTextContent("All 6 passed")
     expect(screen.getByText("All 6 passed")).toHaveClass("text-burn-check-pass-fill")
     expect(
@@ -822,25 +808,29 @@ describe("SessionList — rows", () => {
     ).toBeNull()
   })
 
-  it("keeps the last verdict on screen, marked stale, while a live session recomputes", async () => {
-    getSessionHygiene.mockResolvedValueOnce([
-      {
-        evidenceState: "stale",
-        badges: [
-          { id: "sessionOverdepth", status: "finding", notAssessedReason: null },
-          { id: "modelOverthinking", status: "clean", notAssessedReason: null },
-          { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
-          { id: "obsoleteModel", status: "clean", notAssessedReason: null },
-          { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
-          { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+  it("marks a stale verdict while a live session recomputes", () => {
+    const session = entry({ sessionId: "synthetic-hygiene-stale" })
+    list({
+      entries: [session],
+      hygieneBySession: hygieneSnapshot([
+        [
+          session,
+          {
+            evidenceState: "stale",
+            badges: [
+              { id: "sessionOverdepth", status: "finding", notAssessedReason: null },
+              { id: "modelOverthinking", status: "clean", notAssessedReason: null },
+              { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
+              { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+              { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+              { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+            ],
+          },
         ],
-      },
-    ])
-    list({ entries: [entry({ sessionId: "synthetic-hygiene-stale" })] })
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/Refreshing/)).toHaveTextContent("1 failed·5 passed")
+      ]),
     })
+
+    expect(screen.getByLabelText(/Refreshing/)).toHaveTextContent("1 failed·5 passed")
     expect(screen.queryByText("Refreshing Burn Checks…")).toBeNull()
   })
 
@@ -1119,34 +1109,36 @@ describe("SessionList — shared tooltips", () => {
   })
 
   it("shares rich status and cost content with fork, repository, and WSL labels", async () => {
-    getSessionHygiene.mockResolvedValueOnce([
-      {
-        evidenceState: "ready",
-        badges: [
-          { id: "sessionOverdepth", status: "finding", notAssessedReason: null },
-          { id: "modelOverthinking", status: "clean", notAssessedReason: null },
-          { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
-          { id: "obsoleteModel", status: "clean", notAssessedReason: null },
-          { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
-          { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
-        ],
+    const session = entry({
+      additionalRepos: ["avery/docs"],
+      hasForkParent: true,
+      forkChildCount: 2,
+      wslDistro: "Ubuntu-24.04",
+      cost: {
+        totalUsd: 2.4,
+        figureLabel: "Estimated cost",
+        models: ["claude-fable-5"],
+        breakdownRows: [{ label: "Output", usd: 1.25 }],
       },
-    ])
+    })
     const { container } = list({
-      entries: [
-        entry({
-          additionalRepos: ["avery/docs"],
-          hasForkParent: true,
-          forkChildCount: 2,
-          wslDistro: "Ubuntu-24.04",
-          cost: {
-            totalUsd: 2.4,
-            figureLabel: "Estimated cost",
-            models: ["claude-fable-5"],
-            breakdownRows: [{ label: "Output", usd: 1.25 }],
+      entries: [session],
+      hygieneBySession: hygieneSnapshot([
+        [
+          session,
+          {
+            evidenceState: "ready",
+            badges: [
+              { id: "sessionOverdepth", status: "finding", notAssessedReason: null },
+              { id: "modelOverthinking", status: "clean", notAssessedReason: null },
+              { id: "overpoweredSubagents", status: "clean", notAssessedReason: null },
+              { id: "obsoleteModel", status: "clean", notAssessedReason: null },
+              { id: "fastModeOveruse", status: "clean", notAssessedReason: null },
+              { id: "excessCacheRehydration", status: "clean", notAssessedReason: null },
+            ],
           },
-        }),
-      ],
+        ],
+      ]),
     })
     const status = await screen.findByLabelText(/Some Burn Checks failed/)
     const cost = screen.getByLabelText("Estimated cost $2.40")
@@ -1341,13 +1333,12 @@ describe("SessionList — controlled main-window selection", () => {
     expect(fireEvent.keyDown(document.activeElement!, { key: "Tab" })).toBe(true)
   })
 
-  it("pauses hygiene work and active row motion while hidden", () => {
+  it("pauses active row motion while hidden", () => {
     const { container } = list({
       entries: [entry({ isActive: true })],
       active: false,
       onSelect: vi.fn(),
     })
-    expect(getSessionHygiene).not.toHaveBeenCalled()
     expect(container.querySelector(".activity-row-active")).toBeNull()
   })
 })

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -33,6 +33,7 @@ import { WslOriginBadge } from "../presentation/WslOriginBadge"
 import { SessionStatusBar } from "./SessionStatusBar"
 import { SessionTooltipOwner } from "./SessionTooltipOwner"
 import { type SessionCostBadgeProps } from "./metrics/SessionCostBadge"
+import { CountPill } from "../ui/CountPill"
 import { ScrollPane } from "../ui/ScrollPane"
 import { ListDisplayToolbar } from "../ui/ListDisplayToolbar"
 import { countGroupedItems, groupActivityByDay } from "../activity/activityFeedGrouping"
@@ -500,12 +501,11 @@ function SessionRow({
                 )}
 
                 {additionalModelCount > 0 && (
-                  <span
-                    className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-surface-tertiary/40 px-1 font-mono type-metadata font-medium! tabular-nums text-label-tertiary"
+                  <CountPill
+                    count={additionalModelCount}
+                    prefix="+"
                     data-additional-model-count=""
-                  >
-                    +{additionalModelCount}
-                  </span>
+                  />
                 )}
               </div>
             </Tooltip>

--- a/apps/desktop/src/components/session/SessionList.tsx
+++ b/apps/desktop/src/components/session/SessionList.tsx
@@ -26,7 +26,7 @@ import {
   type PresentableModelRun,
 } from "../../lib/presentation/models"
 import { relativeTime } from "../../lib/presentation/relativeTime"
-import { sessionHygieneFor, useSessionHygiene } from "../../lib/useSessionHygiene"
+import { sessionHygieneFor, type SessionHygieneSnapshot } from "../../lib/useSessionHygiene"
 import { Tooltip } from "../presentation/Tooltip"
 import { TruncatedText } from "../presentation/TruncatedText"
 import { WslOriginBadge } from "../presentation/WslOriginBadge"
@@ -117,6 +117,12 @@ export interface SessionListProps {
   onBadgeMetricChange?: (metric: "cost" | "weeklyPercent" | "fiveHourPercent") => void
   liveUsage?: LiveUsageSummaryPayload
   sessionLimitAllocations?: SessionLimitAllocationSummaryPayload
+  /**
+   * Burn Check verdicts, keyed by local session identity. The caller fetches
+   * this for the full unfiltered list, so a filtered view still shows the
+   * right verdict per row. Missing entries render as not-yet-assessed.
+   */
+  hygieneBySession?: SessionHygieneSnapshot
 }
 
 function primaryLine(entry: SessionListEntry): string {
@@ -127,6 +133,9 @@ function primaryLine(entry: SessionListEntry): string {
 }
 
 type BadgeMetric = "cost" | "weeklyPercent" | "fiveHourPercent"
+
+/** Default for `hygieneBySession`: every row renders as not yet assessed. */
+const EMPTY_HYGIENE_SNAPSHOT: SessionHygieneSnapshot = new Map()
 
 function keepScrollOffset(): false {
   return false
@@ -580,6 +589,7 @@ export function SessionList({
   onBadgeMetricChange,
   liveUsage,
   sessionLimitAllocations,
+  hygieneBySession = EMPTY_HYGIENE_SNAPSHOT,
 }: SessionListProps) {
   const fiveHourAvailable =
     badgeMetric === "fiveHourPercent" ||
@@ -636,22 +646,6 @@ export function SessionList({
   const selectableRowIndexes = virtualItems.flatMap((item, index) =>
     item.type === "row" && item.item.entry.sessionId ? [index] : [],
   )
-  const hygieneSessions = active
-    ? groups.flatMap((group) =>
-        group.items.flatMap(({ entry }) =>
-          entry.sessionId
-            ? [
-                {
-                  agent: entry.agent,
-                  sessionId: entry.sessionId,
-                  wslDistro: entry.wslDistro ?? null,
-                },
-              ]
-            : [],
-        ),
-      )
-    : []
-  const hygieneBySession = useSessionHygiene(hygieneSessions)
   const firstSelectableKey = groups
     .flatMap((group) => group.items)
     .find((item) => item.entry.sessionId)?.key

--- a/apps/desktop/src/components/ui/CountPill.test.tsx
+++ b/apps/desktop/src/components/ui/CountPill.test.tsx
@@ -32,4 +32,16 @@ describe("CountPill", () => {
 
     expect(screen.getByText("3")).toHaveClass("ml-auto")
   })
+
+  it("renders a prefix before the count", () => {
+    render(<CountPill count={1} prefix="+" />)
+
+    expect(screen.getByText("+1")).toBeInTheDocument()
+  })
+
+  it("passes through extra attributes", () => {
+    render(<CountPill count={1} prefix="+" data-additional-model-count="" />)
+
+    expect(screen.getByText("+1")).toHaveAttribute("data-additional-model-count", "")
+  })
 })

--- a/apps/desktop/src/components/ui/CountPill.test.tsx
+++ b/apps/desktop/src/components/ui/CountPill.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { CountPill } from "./CountPill"
+
+describe("CountPill", () => {
+  it("renders the count with tabular mono styling", () => {
+    render(<CountPill count={12} />)
+
+    const pill = screen.getByText("12")
+    expect(pill).toHaveClass(
+      "h-4",
+      "min-w-4",
+      "rounded-full",
+      "bg-surface-tertiary/40",
+      "font-mono",
+      "type-metadata",
+      "font-medium!",
+      "tabular-nums",
+      "text-label-tertiary",
+    )
+  })
+
+  it("renders zero", () => {
+    render(<CountPill count={0} />)
+
+    expect(screen.getByText("0")).toBeInTheDocument()
+  })
+
+  it("merges an extra className", () => {
+    render(<CountPill count={3} className="ml-auto" />)
+
+    expect(screen.getByText("3")).toHaveClass("ml-auto")
+  })
+})

--- a/apps/desktop/src/components/ui/CountPill.tsx
+++ b/apps/desktop/src/components/ui/CountPill.tsx
@@ -1,0 +1,17 @@
+import { cn } from "../../lib/cn"
+
+/** A muted mono pill for a small count, such as an extra-model tally or a
+ *  nav item's item count. Shares its look with the trailing "+N" model-count
+ *  pill on a session card. */
+export function CountPill({ count, className = "" }: { count: number; className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-surface-tertiary/40 px-1 font-mono type-metadata font-medium! tabular-nums text-label-tertiary",
+        className,
+      )}
+    >
+      {count}
+    </span>
+  )
+}

--- a/apps/desktop/src/components/ui/CountPill.tsx
+++ b/apps/desktop/src/components/ui/CountPill.tsx
@@ -1,16 +1,30 @@
+import type { ComponentPropsWithoutRef } from "react"
+
 import { cn } from "../../lib/cn"
 
 /** A muted mono pill for a small count, such as an extra-model tally or a
  *  nav item's item count. Shares its look with the trailing "+N" model-count
  *  pill on a session card. */
-export function CountPill({ count, className = "" }: { count: number; className?: string }) {
+export function CountPill({
+  count,
+  className = "",
+  prefix = "",
+  ...rest
+}: {
+  count: number
+  className?: string
+  /** Text before the count, such as "+" for an overflow tally. */
+  prefix?: string
+} & Omit<ComponentPropsWithoutRef<"span">, "className" | "children">) {
   return (
     <span
+      {...rest}
       className={cn(
         "inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-surface-tertiary/40 px-1 font-mono type-metadata font-medium! tabular-nums text-label-tertiary",
         className,
       )}
     >
+      {prefix}
       {count}
     </span>
   )

--- a/apps/desktop/src/components/ui/SidebarNav.test.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.test.tsx
@@ -14,7 +14,13 @@ const NESTED_ITEMS: SidebarNavItem[] = [
     children: [
       { id: "notable", label: "Notable", count: 3 },
       { id: "material", label: "Material", count: 5 },
-      { id: "claude-code", label: "Claude Code", count: 4, separatorBefore: true },
+      {
+        id: "claude-code",
+        label: "Claude Code",
+        count: 4,
+        separatorBefore: true,
+        controls: "sessions-panel",
+      },
     ],
   },
   { id: "checks", label: "Burn checks", icon: Triangle },
@@ -159,6 +165,32 @@ describe("SidebarNav", () => {
 
     const pill = within(tab("Sessions")).getByText("12")
     expect(pill).toHaveClass("font-mono", "tabular-nums")
+  })
+
+  it("points a child's aria-controls at its own panel by default", () => {
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />,
+    )
+
+    expect(tab("Notable").getAttribute("aria-controls")).toBe("notable-panel")
+  })
+
+  it("points a child's aria-controls at a shared panel when controls is set", () => {
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />,
+    )
+
+    expect(tab("Claude Code").getAttribute("aria-controls")).toBe("sessions-panel")
   })
 
   it("renders children indented and reachable by ArrowDown from the parent", () => {

--- a/apps/desktop/src/components/ui/SidebarNav.test.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.test.tsx
@@ -283,6 +283,29 @@ describe("SidebarNav", () => {
     const separators = tablist.querySelectorAll('[role="presentation"]')
     const childSeparator = Array.from(separators).find((el) => el.className.includes("ml-8"))
     expect(childSeparator).not.toBeUndefined()
+    expect(childSeparator?.hasAttribute("data-nested")).toBe(true)
+  })
+
+  it("marks child rows with data-nested and leaves top-level rows unmarked", () => {
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />,
+    )
+
+    const parent = screen.getByRole("tab", { name: "Sessions" })
+    expect(parent.hasAttribute("data-nested")).toBe(false)
+    const nested = screen
+      .getAllByRole("tab")
+      .filter((tab) => tab.hasAttribute("data-nested"))
+      .map((tab) => tab.id)
+    const expected = NESTED_ITEMS.flatMap((item) =>
+      (item.children ?? []).map((child) => `${child.id}-tab`),
+    )
+    expect(nested).toEqual(expected)
   })
 
   it("never moves arrow-key navigation onto the footer", () => {

--- a/apps/desktop/src/components/ui/SidebarNav.test.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.test.tsx
@@ -5,6 +5,21 @@ import { describe, expect, it, vi } from "vitest"
 
 import { SidebarNav, type SidebarNavItem } from "./SidebarNav"
 
+const NESTED_ITEMS: SidebarNavItem[] = [
+  {
+    id: "sessions",
+    label: "Sessions",
+    icon: Square,
+    count: 12,
+    children: [
+      { id: "notable", label: "Notable", count: 3 },
+      { id: "material", label: "Material", count: 5 },
+      { id: "claude-code", label: "Claude Code", count: 4, separatorBefore: true },
+    ],
+  },
+  { id: "checks", label: "Burn checks", icon: Triangle },
+]
+
 const ITEMS: SidebarNavItem[] = [
   { id: "first", label: "First", icon: Circle },
   { id: "second", label: "Second", icon: Square },
@@ -130,6 +145,112 @@ describe("SidebarNav", () => {
     render(<Harness />)
 
     expect(screen.queryByRole("button", { name: "Quit" })).toBeNull()
+  })
+
+  it("renders a count pill with tabular-nums", () => {
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />,
+    )
+
+    const pill = within(tab("Sessions")).getByText("12")
+    expect(pill).toHaveClass("font-mono", "tabular-nums")
+  })
+
+  it("renders children indented and reachable by ArrowDown from the parent", () => {
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />,
+    )
+
+    for (const name of ["Notable", "Material", "Claude Code"]) {
+      expect(tab(name)).not.toBeNull()
+    }
+
+    const notable = tab("Notable")
+    expect(notable.className).toContain("pl-8")
+  })
+
+  it("moves ArrowDown from a parent onto its first child, in document order", () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={onChange}
+        ariaLabel="Sections"
+      />,
+    )
+
+    fireEvent.keyDown(tab("Sessions"), { key: "ArrowDown" })
+    expect(onChange).toHaveBeenCalledWith("notable")
+
+    rerender(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="notable"
+        onChange={onChange}
+        ariaLabel="Sections"
+      />,
+    )
+    fireEvent.keyDown(tab("Notable"), { key: "ArrowDown" })
+    expect(onChange).toHaveBeenCalledWith("material")
+  })
+
+  it("spans children with Home and End", () => {
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="material"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />,
+    )
+
+    fireEvent.keyDown(tab("Material"), { key: "End" })
+    expect(document.activeElement).toBe(tab("Burn checks"))
+
+    fireEvent.keyDown(tab("Burn checks"), { key: "Home" })
+    expect(document.activeElement).toBe(tab("Sessions"))
+  })
+
+  it("calls onChange with the child id on click", () => {
+    const onChange = vi.fn()
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={onChange}
+        ariaLabel="Sections"
+      />,
+    )
+
+    fireEvent.click(tab("Material"))
+    expect(onChange).toHaveBeenCalledWith("material")
+  })
+
+  it("renders a child separator indented to match the child rows", () => {
+    render(
+      <SidebarNav
+        items={NESTED_ITEMS}
+        value="sessions"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />,
+    )
+
+    const tablist = screen.getByRole("tablist", { name: "Sections" })
+    const separators = tablist.querySelectorAll('[role="presentation"]')
+    const childSeparator = Array.from(separators).find((el) => el.className.includes("ml-8"))
+    expect(childSeparator).not.toBeUndefined()
   })
 
   it("never moves arrow-key navigation onto the footer", () => {

--- a/apps/desktop/src/components/ui/SidebarNav.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.tsx
@@ -152,7 +152,11 @@ export function SidebarNav({
                 return (
                   <Fragment key={child.id}>
                     {child.separatorBefore && (
-                      <div role="presentation" className="my-1 ml-8 h-px bg-separator" />
+                      <div
+                        role="presentation"
+                        data-nested=""
+                        className="my-1 ml-8 h-px bg-separator"
+                      />
                     )}
                     <SidebarNavRow
                       item={child}
@@ -161,6 +165,7 @@ export function SidebarNav({
                       rowRefs={rowRefs}
                       heightClass="h-8"
                       paddingClass="pl-8 pr-3"
+                      nested
                     />
                   </Fragment>
                 )
@@ -187,6 +192,7 @@ function SidebarNavRow({
   rowRefs,
   heightClass,
   paddingClass,
+  nested = false,
 }: {
   item: SidebarNavItem | SidebarNavChildItem
   selected: boolean
@@ -194,6 +200,8 @@ function SidebarNavRow({
   rowRefs: RefObject<Map<string, HTMLButtonElement>>
   heightClass: string
   paddingClass: string
+  /** Mark a child row, so a denser stylesheet can set its own indent. */
+  nested?: boolean
 }) {
   const Icon = item.icon
   const controls = ("controls" in item && item.controls) || `${item.id}-panel`
@@ -208,6 +216,7 @@ function SidebarNavRow({
       id={`${item.id}-tab`}
       aria-selected={selected}
       aria-controls={controls}
+      data-nested={nested ? "" : undefined}
       // Set the accessible name to the label alone when a count pill is
       // present. This keeps the name stable and free of the count digits,
       // which the row already shows as visible text.

--- a/apps/desktop/src/components/ui/SidebarNav.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.tsx
@@ -1,14 +1,49 @@
 import type { LucideIcon } from "lucide-react"
-import { Fragment, useRef, type KeyboardEvent, type ReactNode } from "react"
+import { Fragment, useRef, type KeyboardEvent, type ReactNode, type RefObject } from "react"
 
 import { cn } from "../../lib/cn"
+import { CountPill } from "./CountPill"
+
+/** A nested row under a top-level `SidebarNavItem`, one level deep. A child
+ *  needs no icon of its own. */
+export type SidebarNavChildItem = {
+  id: string
+  label: string
+  icon?: LucideIcon
+  /** Shown right-aligned as a muted count pill, e.g. a filtered session count. */
+  count?: number
+  /** Draw a hairline above this row to set it apart from the group before it. */
+  separatorBefore?: boolean
+}
 
 export type SidebarNavItem = {
   id: string
   label: string
   icon: LucideIcon
+  /** Shown right-aligned as a muted count pill, e.g. a filtered session count. */
+  count?: number
   /** Draw a hairline above this row to set it apart from the group before it. */
   separatorBefore?: boolean
+  /** Rows nested under this item, one level deep. They join the same tablist,
+   *  in document order right after their parent. */
+  children?: ReadonlyArray<SidebarNavChildItem>
+}
+
+/** One row in the flattened tablist: a top-level item, or one of its
+ *  children. Flattening keeps keyboard navigation and the roving tabindex
+ *  working over parent and child rows alike, in document order. */
+type FlatRow =
+  { item: SidebarNavItem; isChild: false } | { item: SidebarNavChildItem; isChild: true }
+
+function flattenItems(items: ReadonlyArray<SidebarNavItem>): FlatRow[] {
+  const rows: FlatRow[] = []
+  for (const item of items) {
+    rows.push({ item, isChild: false })
+    for (const child of item.children ?? []) {
+      rows.push({ item: child, isChild: true })
+    }
+  }
+  return rows
 }
 
 /** Source-list navigation for a multi-pane window.
@@ -17,6 +52,11 @@ export type SidebarNavItem = {
  *  is tabbable, and ↑/↓/Home/End move both selection and focus. Each row's
  *  `aria-controls` points at `<id>-panel`, so the pane it drives should carry
  *  that id with `role="tabpanel"` and `aria-labelledby="<id>-tab"`.
+ *
+ *  A top-level item may nest child rows one level deep. Children flatten into
+ *  the same tablist in document order (parent, then its children, then the
+ *  next top-level item), so Arrow/Home/End keyboard navigation and the roving
+ *  tabindex treat every row alike regardless of nesting.
  *
  *  `role="tablist"` lives on the inner scroller, not the root chrome
  *  container, because an optional `footer` can render below the row list — a
@@ -44,32 +84,36 @@ export function SidebarNav({
   footer?: ReactNode
 }) {
   const rowRefs = useRef(new Map<string, HTMLButtonElement>())
+  const rows = flattenItems(items)
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
-    if (items.length === 0) return
-    const current = items.findIndex((item) => item.id === value)
+    if (rows.length === 0) return
+    const current = rows.findIndex((row) => row.item.id === value)
     let next: number
-    if (e.key === "ArrowDown") next = (current + 1) % items.length
-    else if (e.key === "ArrowUp") next = (current - 1 + items.length) % items.length
+    if (e.key === "ArrowDown") next = (current + 1) % rows.length
+    else if (e.key === "ArrowUp") next = (current - 1 + rows.length) % rows.length
     else if (e.key === "Home") next = 0
-    else if (e.key === "End") next = items.length - 1
+    else if (e.key === "End") next = rows.length - 1
     else return
 
     e.preventDefault()
-    const target = items[next]
-    if (!target || target.id === value) return
-    onChange(target.id)
+    const target = rows[next]
+    if (!target || target.item.id === value) return
+    onChange(target.item.id)
     // The row already exists in the DOM regardless of selection, so focus can
     // move synchronously — no need to wait for the re-render.
-    rowRefs.current.get(target.id)?.focus()
+    rowRefs.current.get(target.item.id)?.focus()
   }
 
-  // Geometry, all on the 4px spacing scale: `h-9` (36px) rows spaced by `gap-2`
-  // (8px). Taller than the 28px source-list minimum on purpose — the rows read
-  // as a primary navigation surface at this size, and the extra gap keeps each
-  // selection fill and focus ring a distinct `rounded-control` shape instead of
-  // merging into one continuous block. Group hairlines stay at `my-1`, so a
-  // group break reads as 25px of separation against the 8px plain row gap.
+  // Geometry, all on the 4px spacing scale: `h-9` (36px) top-level rows spaced
+  // by `gap-2` (8px). Taller than the 28px source-list minimum on purpose —
+  // the rows read as a primary navigation surface at this size, and the extra
+  // gap keeps each selection fill and focus ring a distinct `rounded-control`
+  // shape instead of merging into one continuous block. Group hairlines stay
+  // at `my-1`, so a group break reads as 25px of separation against the 8px
+  // plain row gap. A child row is a shorter `h-8` (32px), indented with
+  // `pl-8` in place of the parent's `px-3` so its label sits clear of the
+  // parent's icon column; a child's own hairline keeps that same indent.
   return (
     <div
       className={cn(
@@ -86,35 +130,38 @@ export function SidebarNav({
         className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 py-3"
       >
         {items.map((item) => {
-          const Icon = item.icon
           const selected = item.id === value
           return (
             <Fragment key={item.id}>
               {item.separatorBefore && (
                 <div role="presentation" className="my-1 h-px bg-separator" />
               )}
-              <button
-                ref={(node) => {
-                  if (node) rowRefs.current.set(item.id, node)
-                  else rowRefs.current.delete(item.id)
-                }}
-                type="button"
-                role="tab"
-                id={`${item.id}-tab`}
-                aria-selected={selected}
-                aria-controls={`${item.id}-panel`}
-                tabIndex={selected ? 0 : -1}
-                onClick={() => onChange(item.id)}
-                className={cn(
-                  "type-body flex h-9 items-center gap-3 rounded-control px-3 transition-colors duration-[var(--duration-fast)] ease-out",
-                  selected
-                    ? "bg-surface-selected text-label"
-                    : "text-label hover:bg-surface-hover",
-                )}
-              >
-                <Icon size={16} strokeWidth={2} className="shrink-0" aria-hidden="true" />
-                <span className="truncate">{item.label}</span>
-              </button>
+              <SidebarNavRow
+                item={item}
+                selected={selected}
+                onChange={onChange}
+                rowRefs={rowRefs}
+                heightClass="h-9"
+                paddingClass="px-3"
+              />
+              {item.children?.map((child) => {
+                const childSelected = child.id === value
+                return (
+                  <Fragment key={child.id}>
+                    {child.separatorBefore && (
+                      <div role="presentation" className="my-1 ml-8 h-px bg-separator" />
+                    )}
+                    <SidebarNavRow
+                      item={child}
+                      selected={childSelected}
+                      onChange={onChange}
+                      rowRefs={rowRefs}
+                      heightClass="h-8"
+                      paddingClass="pl-8 pr-3"
+                    />
+                  </Fragment>
+                )
+              })}
             </Fragment>
           )
         })}
@@ -126,5 +173,53 @@ export function SidebarNav({
         </div>
       )}
     </div>
+  )
+}
+
+/** One tablist row, shared by a top-level item and a child item. */
+function SidebarNavRow({
+  item,
+  selected,
+  onChange,
+  rowRefs,
+  heightClass,
+  paddingClass,
+}: {
+  item: SidebarNavItem | SidebarNavChildItem
+  selected: boolean
+  onChange: (next: string) => void
+  rowRefs: RefObject<Map<string, HTMLButtonElement>>
+  heightClass: string
+  paddingClass: string
+}) {
+  const Icon = item.icon
+  return (
+    <button
+      ref={(node) => {
+        if (node) rowRefs.current.set(item.id, node)
+        else rowRefs.current.delete(item.id)
+      }}
+      type="button"
+      role="tab"
+      id={`${item.id}-tab`}
+      aria-selected={selected}
+      aria-controls={`${item.id}-panel`}
+      // Set the accessible name to the label alone when a count pill is
+      // present. This keeps the name stable and free of the count digits,
+      // which the row already shows as visible text.
+      aria-label={item.count !== undefined ? item.label : undefined}
+      tabIndex={selected ? 0 : -1}
+      onClick={() => onChange(item.id)}
+      className={cn(
+        "type-body flex items-center gap-3 rounded-control transition-colors duration-[var(--duration-fast)] ease-out",
+        heightClass,
+        paddingClass,
+        selected ? "bg-surface-selected text-label" : "text-label hover:bg-surface-hover",
+      )}
+    >
+      {Icon && <Icon size={16} strokeWidth={2} className="shrink-0" aria-hidden="true" />}
+      <span className="truncate">{item.label}</span>
+      {item.count !== undefined && <CountPill count={item.count} className="ml-auto" />}
+    </button>
   )
 }

--- a/apps/desktop/src/components/ui/SidebarNav.tsx
+++ b/apps/desktop/src/components/ui/SidebarNav.tsx
@@ -14,6 +14,9 @@ export type SidebarNavChildItem = {
   count?: number
   /** Draw a hairline above this row to set it apart from the group before it. */
   separatorBefore?: boolean
+  /** The panel id this row's `aria-controls` points at. Defaults to
+   *  `${id}-panel`. Set this when several children share one parent panel. */
+  controls?: string
 }
 
 export type SidebarNavItem = {
@@ -193,6 +196,7 @@ function SidebarNavRow({
   paddingClass: string
 }) {
   const Icon = item.icon
+  const controls = ("controls" in item && item.controls) || `${item.id}-panel`
   return (
     <button
       ref={(node) => {
@@ -203,7 +207,7 @@ function SidebarNavRow({
       role="tab"
       id={`${item.id}-tab`}
       aria-selected={selected}
-      aria-controls={`${item.id}-panel`}
+      aria-controls={controls}
       // Set the accessible name to the label alone when a count pill is
       // present. This keeps the name stable and free of the count digits,
       // which the row already shows as visible text.

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -144,6 +144,12 @@ export interface AppSettings {
   skillsMcpExpanded: boolean
   /** The metric shown in each activity-session badge. */
   sessionBadgeMetric: "cost" | "weeklyPercent" | "fiveHourPercent"
+  /**
+   * The selected Sessions sidebar filter, as its persisted id (see
+   * `sessionFilterId`/`parseSessionFilterId` in `lib/sessionFilters.ts`). An
+   * id this release does not recognize parses back to `all`.
+   */
+  sessionFilter: string
 }
 
 /** Where the app came from. Mirrors Rust `AppInfo`. */
@@ -493,6 +499,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   overviewLimitsExpanded: true,
   skillsMcpExpanded: false,
   sessionBadgeMetric: "cost",
+  sessionFilter: "all",
 }
 
 /** Tell the shell that React committed this renderer generation. */
@@ -800,6 +807,17 @@ export type Interaction =
       outcome: "verified" | "recurred"
       origin: "passive" | "action"
     }
+  | {
+      kind: "sessionFilterSelected"
+      filter: SessionFilterAnalyticsKind
+      /**
+       * Only when `filter` is `agent`, and only for a slug the shell's own
+       * closed agent enum recognizes. Deserializes into that enum, so an
+       * unrecognized slug is a rejected command rather than a new value
+       * appearing in the data — omit the field instead of sending one.
+       */
+      agent?: string
+    }
 
 export type Surface =
   | "activity"
@@ -829,6 +847,9 @@ export type AutoFixAnalyticsOutcome =
   | "failed"
 export type PromptPreparationAnalyticsOutcome =
   "ready" | "stale" | "expired" | "unavailable" | "failed"
+/** The closed vocabulary `sessionFilterSelected` reports its filter as. */
+export type SessionFilterAnalyticsKind =
+  "notable" | "material" | "agent" | "failing" | "passing" | "all"
 
 function isNativePeekInteraction(interaction: Interaction): boolean {
   switch (interaction.kind) {

--- a/apps/desktop/src/lib/sessionFilters.test.ts
+++ b/apps/desktop/src/lib/sessionFilters.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest"
+
+import type { SessionListEntry } from "../components/session/SessionList"
+import type { SessionHygienePayload } from "./insightsIpc"
+import { localSessionKey } from "./presentation/localIdentity"
+import {
+  filterSessionEntries,
+  matchesSessionFilter,
+  parseSessionFilterId,
+  sessionFilterCounts,
+  sessionFilterId,
+  MATERIAL_COST_FLOOR_USD,
+  type SessionFilter,
+} from "./sessionFilters"
+import type { SessionHygieneSnapshot } from "./useSessionHygiene"
+
+function entry(over: Partial<SessionListEntry> = {}): SessionListEntry {
+  return {
+    agent: "claude-code",
+    sessionId: "session-1",
+    repo: "avery/widgets",
+    timestamp: "2026-03-04T12:00:00.000Z",
+    isActive: false,
+    ...over,
+  }
+}
+
+function hygienePayload(clean: number, finding: number): SessionHygienePayload {
+  const ids = [
+    "sessionOverdepth",
+    "modelOverthinking",
+    "overpoweredSubagents",
+    "obsoleteModel",
+    "fastModeOveruse",
+    "excessCacheRehydration",
+  ] as const
+  const badges = ids.slice(0, clean + finding).map((id, index) => ({
+    id,
+    status: index < finding ? ("finding" as const) : ("clean" as const),
+    notAssessedReason: null,
+  }))
+  return { badges, evidenceState: "ready" }
+}
+
+/** A hygiene snapshot with one entry's payload keyed by its identity. */
+function hygieneSnapshotFor(
+  entryFor: SessionListEntry,
+  payload: SessionHygienePayload,
+): SessionHygieneSnapshot {
+  return new Map([
+    [localSessionKey(entryFor.agent, entryFor.sessionId ?? "", entryFor.wslDistro), payload],
+  ])
+}
+
+const EMPTY_HYGIENE: SessionHygieneSnapshot = new Map()
+
+describe("sessionFilterId / parseSessionFilterId", () => {
+  it("round-trips every fixed filter through its stable id", () => {
+    const filters: SessionFilter[] = [
+      { kind: "notable" },
+      { kind: "material" },
+      { kind: "failing" },
+      { kind: "passing" },
+      { kind: "all" },
+    ]
+    for (const filter of filters) {
+      expect(parseSessionFilterId(sessionFilterId(filter))).toEqual(filter)
+    }
+  })
+
+  it("formats and parses an agent filter", () => {
+    const filter: SessionFilter = { kind: "agent", agent: "claude-code" }
+    expect(sessionFilterId(filter)).toBe("agent:claude-code")
+    expect(parseSessionFilterId("agent:claude-code")).toEqual(filter)
+  })
+
+  it("falls back an unknown id to all", () => {
+    expect(parseSessionFilterId("bogus")).toEqual({ kind: "all" })
+    expect(parseSessionFilterId("")).toEqual({ kind: "all" })
+  })
+
+  it("falls back an agent id with no slug to all", () => {
+    expect(parseSessionFilterId("agent:")).toEqual({ kind: "all" })
+  })
+})
+
+describe("matchesSessionFilter — notable", () => {
+  it("uses the existing high-cost flame flag, not a recomputed threshold", () => {
+    const highCost = entry({
+      cost: { totalUsd: 50, figureLabel: "Estimated cost", isHighCost: true },
+    })
+    const ordinary = entry({
+      sessionId: "session-2",
+      cost: { totalUsd: 50, figureLabel: "Estimated cost", isHighCost: false },
+    })
+    expect(matchesSessionFilter(highCost, EMPTY_HYGIENE, { kind: "notable" })).toBe(true)
+    expect(matchesSessionFilter(ordinary, EMPTY_HYGIENE, { kind: "notable" })).toBe(false)
+  })
+})
+
+describe("matchesSessionFilter — material", () => {
+  it("excludes an unpriced session", () => {
+    const unpriced = entry({ cost: null })
+    expect(matchesSessionFilter(unpriced, EMPTY_HYGIENE, { kind: "material" })).toBe(false)
+  })
+
+  it("includes a session priced exactly at the floor", () => {
+    const atFloor = entry({
+      cost: { totalUsd: MATERIAL_COST_FLOOR_USD, figureLabel: "Estimated cost" },
+    })
+    expect(matchesSessionFilter(atFloor, EMPTY_HYGIENE, { kind: "material" })).toBe(true)
+  })
+
+  it("excludes a session priced just below the floor", () => {
+    const belowFloor = entry({
+      cost: { totalUsd: MATERIAL_COST_FLOOR_USD - 0.01, figureLabel: "Estimated cost" },
+    })
+    expect(matchesSessionFilter(belowFloor, EMPTY_HYGIENE, { kind: "material" })).toBe(false)
+  })
+})
+
+describe("matchesSessionFilter — agent", () => {
+  it("matches only the named agent", () => {
+    const codex = entry({ agent: "codex" })
+    expect(matchesSessionFilter(codex, EMPTY_HYGIENE, { kind: "agent", agent: "codex" })).toBe(
+      true,
+    )
+    expect(
+      matchesSessionFilter(codex, EMPTY_HYGIENE, { kind: "agent", agent: "claude-code" }),
+    ).toBe(false)
+  })
+})
+
+describe("matchesSessionFilter — failing / passing boundary", () => {
+  it("counts 2/2 clean checks as passing, not failing", () => {
+    const session = entry()
+    const snapshot = hygieneSnapshotFor(session, hygienePayload(2, 0))
+    expect(matchesSessionFilter(session, snapshot, { kind: "passing" })).toBe(true)
+    expect(matchesSessionFilter(session, snapshot, { kind: "failing" })).toBe(false)
+  })
+
+  it("counts 5 findings against 1 clean check as failing, not passing", () => {
+    const session = entry()
+    const snapshot = hygieneSnapshotFor(session, hygienePayload(1, 5))
+    expect(matchesSessionFilter(session, snapshot, { kind: "failing" })).toBe(true)
+    expect(matchesSessionFilter(session, snapshot, { kind: "passing" })).toBe(false)
+  })
+
+  it("counts exactly one clean check as passing", () => {
+    const session = entry()
+    const snapshot = hygieneSnapshotFor(session, hygienePayload(1, 0))
+    expect(matchesSessionFilter(session, snapshot, { kind: "passing" })).toBe(true)
+    expect(matchesSessionFilter(session, snapshot, { kind: "failing" })).toBe(false)
+  })
+
+  it("counts a session with nothing assessed as neither", () => {
+    const session = entry()
+    const snapshot = hygieneSnapshotFor(session, hygienePayload(0, 0))
+    expect(matchesSessionFilter(session, snapshot, { kind: "passing" })).toBe(false)
+    expect(matchesSessionFilter(session, snapshot, { kind: "failing" })).toBe(false)
+  })
+
+  it("treats a session with no transcript id as unassessed", () => {
+    const session = entry({ sessionId: undefined })
+    expect(matchesSessionFilter(session, EMPTY_HYGIENE, { kind: "passing" })).toBe(false)
+    expect(matchesSessionFilter(session, EMPTY_HYGIENE, { kind: "failing" })).toBe(false)
+  })
+})
+
+describe("matchesSessionFilter — all", () => {
+  it("matches every entry", () => {
+    expect(matchesSessionFilter(entry(), EMPTY_HYGIENE, { kind: "all" })).toBe(true)
+  })
+})
+
+describe("filterSessionEntries", () => {
+  it("keeps only the entries the filter selects, in order", () => {
+    const claude = entry({ sessionId: "a", agent: "claude-code" })
+    const codex = entry({ sessionId: "b", agent: "codex" })
+    const result = filterSessionEntries([claude, codex], EMPTY_HYGIENE, {
+      kind: "agent",
+      agent: "codex",
+    })
+    expect(result).toEqual([codex])
+  })
+})
+
+describe("sessionFilterCounts", () => {
+  it("counts every fixed filter and every present agent, sorted by display name", () => {
+    const notable = entry({
+      sessionId: "notable",
+      agent: "codex",
+      // Below the Material floor: notable and material are independent flags.
+      cost: { totalUsd: 0.5, figureLabel: "Estimated cost", isHighCost: true },
+    })
+    const material = entry({
+      sessionId: "material",
+      agent: "claude-code",
+      cost: { totalUsd: MATERIAL_COST_FLOOR_USD, figureLabel: "Estimated cost" },
+    })
+    const unpriced = entry({ sessionId: "unpriced", agent: "cursor", cost: null })
+    const failing = entry({ sessionId: "failing", agent: "codex" })
+    const passing = entry({ sessionId: "passing", agent: "claude-code" })
+
+    const entries = [notable, material, unpriced, failing, passing]
+    const hygiene: SessionHygieneSnapshot = new Map([
+      ...hygieneSnapshotFor(failing, hygienePayload(0, 1)),
+      ...hygieneSnapshotFor(passing, hygienePayload(1, 0)),
+    ])
+
+    const counts = sessionFilterCounts(entries, hygiene)
+    expect(counts.notable).toBe(1)
+    expect(counts.material).toBe(1)
+    expect(counts.failing).toBe(1)
+    expect(counts.passing).toBe(1)
+    expect(counts.all).toBe(5)
+    // Codex (2 sessions) and Cursor and Claude Code (1 each), by display name:
+    // Claude Code, Codex, Cursor.
+    expect(counts.agents).toEqual([
+      { agent: "claude-code", displayName: "Claude Code", count: 2 },
+      { agent: "codex", displayName: "Codex", count: 2 },
+      { agent: "cursor", displayName: "Cursor", count: 1 },
+    ])
+  })
+
+  it("gives an unrecognized agent slug a title-cased display name", () => {
+    const counts = sessionFilterCounts([entry({ agent: "future-agent" })], EMPTY_HYGIENE)
+    expect(counts.agents).toEqual([
+      { agent: "future-agent", displayName: "Future Agent", count: 1 },
+    ])
+  })
+
+  it("counts nothing for an empty list", () => {
+    const counts = sessionFilterCounts([], EMPTY_HYGIENE)
+    expect(counts).toEqual({
+      notable: 0,
+      material: 0,
+      failing: 0,
+      passing: 0,
+      all: 0,
+      agents: [],
+    })
+  })
+})

--- a/apps/desktop/src/lib/sessionFilters.ts
+++ b/apps/desktop/src/lib/sessionFilters.ts
@@ -1,0 +1,148 @@
+/**
+ * The Sessions sidebar filter vocabulary.
+ *
+ * A `SessionFilter` selects a subset of the loaded session list. Its id is
+ * the persisted form: it survives a round trip through `AppSettings` and
+ * doubles as a nav item id, so the format and parse helpers here are the
+ * single place that shape stays in sync with itself.
+ */
+
+import type { SessionListEntry } from "../components/session/SessionList"
+import { agentDisplayName } from "./presentation/agents"
+import { sessionBurnCheckPresentation } from "./presentation/burnChecks"
+import { INITIAL_SESSION_HYGIENE, sessionHygieneChecks } from "./presentation/sessionHygiene"
+import { sessionHygieneFor, type SessionHygieneSnapshot } from "./useSessionHygiene"
+
+/** One selectable filter over the loaded session list. */
+export type SessionFilter =
+  | { kind: "notable" }
+  | { kind: "material" }
+  | { kind: "agent"; agent: string }
+  | { kind: "failing" }
+  | { kind: "passing" }
+  | { kind: "all" }
+
+/** A priced session counts as Material at or above this cost, in US dollars. */
+export const MATERIAL_COST_FLOOR_USD = 1
+
+/** The persisted, nav-item id for one filter. Stable across releases. */
+export function sessionFilterId(filter: SessionFilter): string {
+  return filter.kind === "agent" ? `agent:${filter.agent}` : filter.kind
+}
+
+/**
+ * Parse a persisted or nav-selected id back into a filter.
+ *
+ * An id this app never wrote — an older release, a hand-edited database, or
+ * an agent slug that dropped out of the loaded list — parses to `all`. A
+ * filter can always fall back to showing everything.
+ */
+export function parseSessionFilterId(id: string): SessionFilter {
+  if (
+    id === "notable" ||
+    id === "material" ||
+    id === "failing" ||
+    id === "passing" ||
+    id === "all"
+  ) {
+    return { kind: id }
+  }
+  if (id.startsWith("agent:")) {
+    const agent = id.slice("agent:".length)
+    if (agent) return { kind: "agent", agent }
+  }
+  return { kind: "all" }
+}
+
+/** The failed/passed/unassessed hygiene counts backing an entry's row. */
+function hygieneCountsFor(
+  hygieneSnapshot: SessionHygieneSnapshot,
+  entry: SessionListEntry,
+): { failed: number; passed: number; unassessed: number } {
+  const payload = entry.sessionId
+    ? sessionHygieneFor(hygieneSnapshot, {
+        agent: entry.agent,
+        sessionId: entry.sessionId,
+        wslDistro: entry.wslDistro ?? null,
+      })
+    : INITIAL_SESSION_HYGIENE
+  return sessionBurnCheckPresentation(sessionHygieneChecks(payload), payload.evidenceState)
+    .counts
+}
+
+/** Whether one entry belongs to the given filter. */
+export function matchesSessionFilter(
+  entry: SessionListEntry,
+  hygieneSnapshot: SessionHygieneSnapshot,
+  filter: SessionFilter,
+): boolean {
+  switch (filter.kind) {
+    case "notable":
+      return entry.cost?.isHighCost === true
+    case "material":
+      return entry.cost != null && entry.cost.totalUsd >= MATERIAL_COST_FLOOR_USD
+    case "agent":
+      return entry.agent === filter.agent
+    case "failing":
+      return hygieneCountsFor(hygieneSnapshot, entry).failed >= 1
+    case "passing": {
+      const counts = hygieneCountsFor(hygieneSnapshot, entry)
+      return counts.failed === 0 && counts.passed >= 1
+    }
+    case "all":
+      return true
+  }
+}
+
+/** The entries one filter selects, in the order they arrived. */
+export function filterSessionEntries(
+  entries: readonly SessionListEntry[],
+  hygieneSnapshot: SessionHygieneSnapshot,
+  filter: SessionFilter,
+): SessionListEntry[] {
+  return entries.filter((entry) => matchesSessionFilter(entry, hygieneSnapshot, filter))
+}
+
+/** A count for every fixed filter, plus one row per harness present. */
+export interface SessionFilterCounts {
+  notable: number
+  material: number
+  failing: number
+  passing: number
+  all: number
+  /** Harnesses present in the loaded list, sorted by display name. */
+  agents: Array<{ agent: string; displayName: string; count: number }>
+}
+
+/**
+ * Fold the loaded list into a count per filter.
+ *
+ * Every fixed filter counts over the whole list in one pass. Agent counts key
+ * on the raw slug, so two sessions from the same harness always fold into one
+ * row regardless of how it renders.
+ */
+export function sessionFilterCounts(
+  entries: readonly SessionListEntry[],
+  hygieneSnapshot: SessionHygieneSnapshot,
+): SessionFilterCounts {
+  let notable = 0
+  let material = 0
+  let failing = 0
+  let passing = 0
+  const agentCounts = new Map<string, number>()
+
+  for (const entry of entries) {
+    if (matchesSessionFilter(entry, hygieneSnapshot, { kind: "notable" })) notable += 1
+    if (matchesSessionFilter(entry, hygieneSnapshot, { kind: "material" })) material += 1
+    const counts = hygieneCountsFor(hygieneSnapshot, entry)
+    if (counts.failed >= 1) failing += 1
+    else if (counts.passed >= 1) passing += 1
+    agentCounts.set(entry.agent, (agentCounts.get(entry.agent) ?? 0) + 1)
+  }
+
+  const agents = [...agentCounts.entries()]
+    .map(([agent, count]) => ({ agent, displayName: agentDisplayName(agent), count }))
+    .sort((left, right) => left.displayName.localeCompare(right.displayName))
+
+  return { notable, material, failing, passing, all: entries.length, agents }
+}

--- a/apps/desktop/src/lib/useSessionHygiene.ts
+++ b/apps/desktop/src/lib/useSessionHygiene.ts
@@ -1,5 +1,6 @@
 import { useMemo, useSyncExternalStore } from "react"
 
+import type { SessionListEntry } from "../components/session/SessionList"
 import { createExternalStore, type ExternalStore } from "./externalStore"
 import { getSessionHygiene, type SessionHygienePayload } from "./insightsIpc"
 import { onScanEvent, onSessionEntryChanged, onSessionsInvalidated } from "./ipc"
@@ -8,6 +9,23 @@ import { INITIAL_SESSION_HYGIENE } from "./presentation/sessionHygiene"
 import type { LocalSessionIdentity } from "./types/session"
 
 export type SessionHygieneSnapshot = ReadonlyMap<string, SessionHygienePayload>
+
+/**
+ * Every entry with a transcript id, as the identity a hygiene fetch needs.
+ *
+ * A caller that lifts `useSessionHygiene` above a filtered or grouped view
+ * uses this over its full, unfiltered entry list, so the request key does not
+ * change when a filter or day-window grouping changes what actually renders.
+ */
+export function sessionHygieneIdentities(
+  entries: readonly SessionListEntry[],
+): LocalSessionIdentity[] {
+  return entries.flatMap((entry) =>
+    entry.sessionId
+      ? [{ agent: entry.agent, sessionId: entry.sessionId, wslDistro: entry.wslDistro ?? null }]
+      : [],
+  )
+}
 
 type IdentityTuple = [agent: string, sessionId: string, wslDistro: string | null]
 

--- a/apps/desktop/src/styles/main-window.css
+++ b/apps/desktop/src/styles/main-window.css
@@ -37,6 +37,14 @@
 }
 
 /* Main navigation uses a denser rhythm than the Settings source list. */
+.main-window-sidebar {
+  --main-window-nav-icon-size: 14px;
+  /* A nested row starts its label at the parent label column, past the icon. */
+  --main-window-nav-indent: calc(
+    var(--space-sm) + var(--main-window-nav-icon-size) + var(--space-sm)
+  );
+}
+
 .main-window-sidebar [role="tab"] {
   block-size: calc(var(--space-2xl) + var(--space-xs));
   flex-shrink: 0;
@@ -44,9 +52,17 @@
   padding-inline: var(--space-sm);
 }
 
+.main-window-sidebar [role="tab"][data-nested] {
+  padding-inline-start: var(--main-window-nav-indent);
+}
+
+.main-window-sidebar [role="presentation"][data-nested] {
+  margin-inline-start: var(--main-window-nav-indent);
+}
+
 .main-window-sidebar [role="tab"] svg {
-  inline-size: 14px;
-  block-size: 14px;
+  inline-size: var(--main-window-nav-icon-size);
+  block-size: var(--main-window-nav-icon-size);
 }
 
 .main-window-workspace,

--- a/apps/desktop/src/views/MainWindowView.test.tsx
+++ b/apps/desktop/src/views/MainWindowView.test.tsx
@@ -1,9 +1,13 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { Activity } from "lucide-react"
 import { CollectionDetailPane } from "./main-window/CollectionDetailPane"
+import type * as MainActivitySessionModule from "./main-window/MainActivitySession"
+import type { SessionListEntry } from "../components/session/SessionList"
 import type * as IpcModule from "../lib/ipc"
+import type { MainWindowSectionRequest } from "../lib/ipc"
+import type { SessionFilter } from "../lib/sessionFilters"
 import capability from "../../src-tauri/capabilities/main.json"
 import { openSettingsWindow } from "../lib/ipc"
 import { MainWindowView } from "./MainWindowView"
@@ -13,10 +17,89 @@ vi.mock("./main-window/BurnChecksView", () => ({
   BurnChecksView: () => <p>Burn checks workspace</p>,
 }))
 
+/**
+ * A minimal stand-in for `MainActivitySession`. `MainWindowView` only reads
+ * `entries` and `filter` off its snapshot and calls `setFilter`, so the fake
+ * covers only that surface and lets a test drive the sidebar's counts and
+ * selection without the real class's async IPC-backed engine.
+ */
+const activityMocks = vi.hoisted(() => {
+  class FakeMainActivitySession {
+    snapshot: { entries: SessionListEntry[] | null; filter: SessionFilter } = {
+      entries: null,
+      filter: { kind: "all" },
+    }
+    private listeners = new Set<() => void>()
+    setFilter = vi.fn((filter: SessionFilter) => {
+      this.snapshot = { ...this.snapshot, filter }
+      this.notify()
+    })
+    constructor() {
+      activityMocks.instances.push(this)
+    }
+    getSnapshot = () => this.snapshot
+    subscribe = (listener: () => void) => {
+      this.listeners.add(listener)
+      return () => this.listeners.delete(listener)
+    }
+    subscribeInactive = this.subscribe
+    setEntries(entries: SessionListEntry[] | null) {
+      this.snapshot = { ...this.snapshot, entries }
+      this.notify()
+    }
+    private notify() {
+      for (const listener of [...this.listeners]) listener()
+    }
+  }
+  return {
+    FakeMainActivitySession,
+    instances: [] as InstanceType<typeof FakeMainActivitySession>[],
+  }
+})
+
+vi.mock("./main-window/MainActivitySession", async (importOriginal) => {
+  const actual = await importOriginal<typeof MainActivitySessionModule>()
+  return { ...actual, MainActivitySession: activityMocks.FakeMainActivitySession }
+})
+
+const ipcMocks = vi.hoisted(() => ({
+  sectionTarget: null as ((request: MainWindowSectionRequest) => void) | null,
+}))
+
 vi.mock("../lib/ipc", async (importOriginal) => ({
   ...(await importOriginal<typeof IpcModule>()),
   openSettingsWindow: vi.fn().mockResolvedValue(undefined),
+  onMainWindowSectionTarget: vi.fn(
+    async (handler: (request: MainWindowSectionRequest) => void) => {
+      ipcMocks.sectionTarget = handler
+      return () => {
+        ipcMocks.sectionTarget = null
+      }
+    },
+  ),
+  takeMainWindowSectionTarget: vi.fn().mockResolvedValue(null),
 }))
+
+function activitySession() {
+  const instance = activityMocks.instances.at(-1)
+  if (!instance) throw new Error("MainActivitySession was not constructed")
+  return instance
+}
+
+function sessionEntry(over: Partial<SessionListEntry> = {}): SessionListEntry {
+  return {
+    agent: "claude-code",
+    sessionId: "session-1",
+    repo: "avery/widgets",
+    timestamp: "2026-03-04T12:00:00.000Z",
+    isActive: false,
+    ...over,
+  }
+}
+
+function tab(name: string) {
+  return screen.getByRole("tab", { name })
+}
 
 const userAgent = Object.getOwnPropertyDescriptor(window.navigator, "userAgent")
 const innerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth")
@@ -62,7 +145,9 @@ describe("MainWindowView", () => {
   it("opens Burn checks by default and keeps Sessions in the sidebar", () => {
     setWindowWidth(1000)
     render(<MainWindowView />)
-    expect(screen.getAllByRole("tab")).toHaveLength(2)
+    // Burn checks, Sessions, and Sessions' five fixed filter children (no
+    // harness rows yet, since no entries have loaded).
+    expect(screen.getAllByRole("tab")).toHaveLength(7)
     expect(screen.getByRole("tab", { name: "Burn checks" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -143,5 +228,78 @@ describe("MainWindowView", () => {
     expect(screen.getByText("Other workspace")).toBeVisible()
     fireEvent.click(screen.getByRole("tab", { name: "Activity" }))
     expect(screen.getByText("Example detail")).toBeVisible()
+  })
+
+  describe("Sessions filter children", () => {
+    it("renders the fixed filter children without counts before entries load", () => {
+      render(<MainWindowView />)
+      for (const name of [
+        "Notable Sessions",
+        "Material Sessions",
+        "Failing Sessions",
+        "Passing Sessions",
+        "All Sessions",
+      ]) {
+        expect(tab(name)).not.toBeNull()
+      }
+      expect(within(tab("Notable Sessions")).queryByText(/^\d+$/)).toBeNull()
+    })
+
+    it("shows a live count per fixed filter and one row per loaded harness", () => {
+      render(<MainWindowView />)
+      act(() => {
+        activitySession().setEntries([
+          sessionEntry({
+            agent: "claude-code",
+            sessionId: "s1",
+            cost: { totalUsd: 5, figureLabel: "Estimated cost", isHighCost: true },
+          }),
+          sessionEntry({
+            agent: "codex",
+            sessionId: "s2",
+            cost: { totalUsd: 0.5, figureLabel: "Estimated cost" },
+          }),
+        ])
+      })
+      expect(within(tab("Notable Sessions")).getByText("1")).toBeInTheDocument()
+      expect(within(tab("Material Sessions")).getByText("1")).toBeInTheDocument()
+      expect(within(tab("Claude Code Sessions")).getByText("1")).toBeInTheDocument()
+      expect(within(tab("Codex Sessions")).getByText("1")).toBeInTheDocument()
+      expect(within(tab("Failing Sessions")).getByText("0")).toBeInTheDocument()
+      expect(within(tab("Passing Sessions")).getByText("0")).toBeInTheDocument()
+      expect(within(tab("All Sessions")).getByText("2")).toBeInTheDocument()
+    })
+
+    it("selects Sessions and applies the filter when a child is clicked", () => {
+      render(<MainWindowView />)
+      fireEvent.click(tab("Failing Sessions"))
+      expect(activitySession().setFilter).toHaveBeenCalledWith({ kind: "failing" })
+      expect(screen.getByRole("tabpanel", { name: "Sessions" })).toBeVisible()
+    })
+
+    it("resets the filter to all when the Sessions row itself is clicked", () => {
+      render(<MainWindowView />)
+      fireEvent.click(tab("Failing Sessions"))
+      activitySession().setFilter.mockClear()
+      fireEvent.click(tab("Sessions"))
+      expect(activitySession().setFilter).toHaveBeenCalledWith({ kind: "all" })
+    })
+
+    it("highlights the active filter's own child row instead of the parent", () => {
+      render(<MainWindowView />)
+      fireEvent.click(tab("Failing Sessions"))
+      expect(tab("Failing Sessions")).toHaveAttribute("aria-selected", "true")
+      expect(tab("Sessions")).toHaveAttribute("aria-selected", "false")
+    })
+
+    it("keeps the current filter when a cross-window request selects Sessions", async () => {
+      render(<MainWindowView />)
+      await vi.waitFor(() => expect(ipcMocks.sectionTarget).not.toBeNull())
+      act(() => {
+        ipcMocks.sectionTarget!({ revision: 1, section: "activity" })
+      })
+      expect(activitySession().setFilter).not.toHaveBeenCalled()
+      expect(screen.getByRole("tabpanel", { name: "Sessions" })).toBeVisible()
+    })
   })
 })

--- a/apps/desktop/src/views/MainWindowView.tsx
+++ b/apps/desktop/src/views/MainWindowView.tsx
@@ -1,9 +1,25 @@
 import { Flame, MessagesSquare, Settings } from "lucide-react"
 import { useState, useSyncExternalStore, type ReactNode } from "react"
 
+import type { SessionListEntry } from "../components/session/SessionList"
+import {
+  SidebarNav,
+  type SidebarNavChildItem,
+  type SidebarNavItem,
+} from "../components/ui/SidebarNav"
 import { openSettingsWindow } from "../lib/ipc"
+import {
+  parseSessionFilterId,
+  sessionFilterCounts,
+  sessionFilterId,
+  type SessionFilter,
+} from "../lib/sessionFilters"
 import { useGlobalKeydown } from "../lib/useGlobalKeydown"
-import { SidebarNav, type SidebarNavItem } from "../components/ui/SidebarNav"
+import {
+  sessionHygieneIdentities,
+  useSessionHygiene,
+  type SessionHygieneSnapshot,
+} from "../lib/useSessionHygiene"
 import { MainActivityView } from "./main-window/MainActivityView"
 import { MainActivitySession } from "./main-window/MainActivitySession"
 import { BurnChecksView } from "./main-window/BurnChecksView"
@@ -13,6 +29,60 @@ import { MainWindowNavigationSession } from "./main-window/MainWindowNavigationS
 
 export interface MainWindowSection extends SidebarNavItem {
   render: (context: { active: boolean }) => ReactNode
+}
+
+/** A store subscription that never fires, for a reader that only needs the
+ *  current snapshot and must not join the store's active-viewer count. */
+function neverSubscribe(): () => void {
+  return () => {}
+}
+
+/** One child row under "Sessions" for a filter, with its live count. */
+function sessionFilterChild(
+  filter: SessionFilter,
+  label: string,
+  count: number,
+  loaded: boolean,
+  separatorBefore?: boolean,
+): SidebarNavChildItem {
+  return {
+    id: sessionFilterId(filter),
+    label,
+    // Every filter child drives the same "Sessions" panel; only the parent
+    // row owns a real panel id of its own.
+    controls: "activity-panel",
+    ...(loaded ? { count } : {}),
+    ...(separatorBefore ? { separatorBefore: true } : {}),
+  }
+}
+
+/**
+ * Every child under "Sessions": Notable and Material, one row per harness
+ * present in the loaded list, then Failing, Passing, and All. A count is
+ * omitted while `entries` has not loaded yet, instead of showing zero.
+ */
+function sessionFilterChildren(
+  entries: SessionListEntry[] | null,
+  hygiene: SessionHygieneSnapshot,
+): SidebarNavChildItem[] {
+  const loaded = entries !== null
+  const counts = sessionFilterCounts(entries ?? [], hygiene)
+  return [
+    sessionFilterChild({ kind: "notable" }, "Notable Sessions", counts.notable, loaded),
+    sessionFilterChild({ kind: "material" }, "Material Sessions", counts.material, loaded),
+    ...counts.agents.map((agent, index) =>
+      sessionFilterChild(
+        { kind: "agent", agent: agent.agent },
+        `${agent.displayName} Sessions`,
+        agent.count,
+        loaded,
+        index === 0,
+      ),
+    ),
+    sessionFilterChild({ kind: "failing" }, "Failing Sessions", counts.failing, loaded, true),
+    sessionFilterChild({ kind: "passing" }, "Passing Sessions", counts.passing, loaded),
+    sessionFilterChild({ kind: "all" }, "All Sessions", counts.all, loaded, true),
+  ]
 }
 
 /** A section supplies its panes without changing the main window's native lifecycle. */
@@ -45,6 +115,18 @@ export function MainWindowView({ sections }: { sections?: readonly MainWindowSec
     navigationSession.getSnapshot,
     navigationSession.getSnapshot,
   )
+  // Read the Sessions list for the sidebar's counts without joining its
+  // active-viewer count, so this alone never starts loading it: the list
+  // still only loads once a viewer visits Sessions.
+  const activity = useSyncExternalStore(
+    sections ? neverSubscribe : activitySession.subscribeInactive,
+    activitySession.getSnapshot,
+    activitySession.getSnapshot,
+  )
+  // Pinned to the full unfiltered list, so the selected filter never changes
+  // this request's key. Always live, so the sidebar's counts stay current
+  // even while another section is on screen.
+  const hygieneBySession = useSessionHygiene(sessionHygieneIdentities(activity.entries ?? []))
   const availableSections: readonly MainWindowSection[] = sections ?? [
     {
       id: "burnChecks",
@@ -56,7 +138,14 @@ export function MainWindowView({ sections }: { sections?: readonly MainWindowSec
       id: "activity",
       label: "Sessions",
       icon: MessagesSquare,
-      render: ({ active }) => <MainActivityView active={active} session={activitySession} />,
+      children: sessionFilterChildren(activity.entries, hygieneBySession),
+      render: ({ active }) => (
+        <MainActivityView
+          active={active}
+          session={activitySession}
+          hygieneBySession={hygieneBySession}
+        />
+      ),
     },
   ]
   const [customSelectedId, setCustomSelectedId] = useState(() => availableSections[0]?.id ?? "")
@@ -66,21 +155,39 @@ export function MainWindowView({ sections }: { sections?: readonly MainWindowSec
   const selectedId = sections ? customSelectedId : navigation.selected
   const visited: ReadonlySet<string> = sections ? customVisited : new Set(navigation.visited)
   function selectSection(id: string): void {
-    if (!availableSections.some((section) => section.id === id)) return
-    if (sections) setCustomSelectedId(id)
-    else if (id === "activity" || id === "burnChecks") {
-      navigationSession.select(id)
+    if (sections) {
+      if (!availableSections.some((section) => section.id === id)) return
+      setCustomSelectedId(id)
+      setCustomVisited((previous) => new Set(previous).add(id))
+      return
     }
-    if (sections) setCustomVisited((previous) => new Set(previous).add(id))
+    if (id === "burnChecks") {
+      navigationSession.select(id)
+      return
+    }
+    if (id === "activity") {
+      navigationSession.select(id)
+      activitySession.setFilter({ kind: "all" })
+      return
+    }
+    // Every other id is a Sessions filter child, encoded by sessionFilterId.
+    navigationSession.select("activity")
+    activitySession.setFilter(parseSessionFilterId(id))
   }
   const selected =
     availableSections.find((section) => section.id === selectedId) ?? availableSections[0]
+  // Highlight the active filter's own row while inside Sessions, so the
+  // matching child reads as selected instead of the parent row.
+  const navValue =
+    !sections && selected?.id === "activity"
+      ? sessionFilterId(activity.filter)
+      : (selected?.id ?? "")
   return (
     <MainWindowLayout
       sidebar={
         <SidebarNav
           items={availableSections}
-          value={selected?.id ?? ""}
+          value={navValue}
           onChange={selectSection}
           ariaLabel="Main sections"
           className="main-window-sidebar min-h-0 flex-1"

--- a/apps/desktop/src/views/MainWindowView.tsx
+++ b/apps/desktop/src/views/MainWindowView.tsx
@@ -34,7 +34,7 @@ export interface MainWindowSection extends SidebarNavItem {
 /** A store subscription that never fires, for a reader that only needs the
  *  current snapshot and must not join the store's active-viewer count. */
 function neverSubscribe(): () => void {
-  return () => {}
+  return () => undefined
 }
 
 /** One child row under "Sessions" for a filter, with its live count. */

--- a/apps/desktop/src/views/PopoverView.tsx
+++ b/apps/desktop/src/views/PopoverView.tsx
@@ -31,6 +31,7 @@ import {
   type PopoverPeekTarget,
 } from "../lib/popoverPeekIpc"
 import { checksPresentation } from "../lib/presentation/checks"
+import { sessionHygieneIdentities, useSessionHygiene } from "../lib/useSessionHygiene"
 import { PopoverSession } from "./popover/PopoverSession"
 import { ChecksSummary } from "./popover/ChecksView"
 import { foldActivityHeader } from "./popover/usageChartFold"
@@ -124,6 +125,7 @@ export function PopoverView() {
     : null
 
   const windowDays = state.settings?.activityWindowDays ?? DEFAULT_SETTINGS.activityWindowDays
+  const hygieneBySession = useSessionHygiene(sessionHygieneIdentities(state.entries ?? []))
 
   // Focus the activity heading when the popover renderer mounts.
   const focusHeading = useCallback((node: HTMLDivElement | null) => {
@@ -298,6 +300,7 @@ export function PopoverView() {
               now={new Date(state.now)}
               liveUsage={state.liveUsage}
               sessionLimitAllocations={state.sessionLimitAllocations}
+              hygieneBySession={hygieneBySession}
             />
           )}
         </div>

--- a/apps/desktop/src/views/main-window/MainActivitySession.test.ts
+++ b/apps/desktop/src/views/main-window/MainActivitySession.test.ts
@@ -469,6 +469,71 @@ describe("MainActivitySession", () => {
     )
   })
 
+  it("selects a filter optimistically, persists it, and reports the change", async () => {
+    const { session } = start()
+    await ready(session)
+
+    session.setFilter({ kind: "notable" })
+
+    expect(session.getSnapshot().filter).toEqual({ kind: "notable" })
+    expect(session.getSnapshot().settings.sessionFilter).toBe("notable")
+    expect(mocks.setSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionFilter: "notable" }),
+    )
+    expect(mocks.noteInteraction).toHaveBeenCalledWith({
+      kind: "sessionFilterSelected",
+      filter: "notable",
+    })
+  })
+
+  it("does nothing when the requested filter already matches", async () => {
+    const { session } = start()
+    await ready(session)
+    mocks.noteInteraction.mockClear()
+
+    session.setFilter({ kind: "all" })
+
+    expect(mocks.setSettings).not.toHaveBeenCalled()
+    expect(mocks.noteInteraction).not.toHaveBeenCalled()
+  })
+
+  it("never reports a selection while restoring the persisted filter on load", async () => {
+    mocks.getSettings.mockResolvedValue({ ...DEFAULT_SETTINGS, sessionFilter: "failing" })
+    const { session } = start()
+    await ready(session)
+
+    expect(session.getSnapshot().filter).toEqual({ kind: "failing" })
+    expect(mocks.noteInteraction).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "sessionFilterSelected" }),
+    )
+  })
+
+  it("reports an agent filter's slug only when the harness is recognized", async () => {
+    const { session } = start()
+    await ready(session)
+
+    session.setFilter({ kind: "agent", agent: "codex" })
+    expect(mocks.noteInteraction).toHaveBeenCalledWith({
+      kind: "sessionFilterSelected",
+      filter: "agent",
+      agent: "codex",
+    })
+
+    mocks.noteInteraction.mockClear()
+    session.setFilter({ kind: "agent", agent: "some-future-harness" })
+    expect(mocks.noteInteraction).toHaveBeenCalledWith({
+      kind: "sessionFilterSelected",
+      filter: "agent",
+    })
+  })
+
+  it("falls back to all when persisted settings carry an unrecognized filter id", async () => {
+    mocks.getSettings.mockResolvedValue({ ...DEFAULT_SETTINGS, sessionFilter: "bogus" })
+    const { session } = start()
+    await ready(session)
+    expect(session.getSnapshot().filter).toEqual({ kind: "all" })
+  })
+
   it("orders navigation like the list and excludes non-opening rows", async () => {
     const { session } = start()
     await ready(session)

--- a/apps/desktop/src/views/main-window/MainActivitySession.ts
+++ b/apps/desktop/src/views/main-window/MainActivitySession.ts
@@ -13,6 +13,7 @@ import {
   getSessionLimitAllocations,
   getMainWindowVisible,
   acknowledgeMainWindowSessionTarget,
+  noteInteraction,
   onMainWindowSessionTarget,
   onMainWindowVisibilityChanged,
   onSettingsChanged,
@@ -30,11 +31,18 @@ import {
 } from "../../lib/ipc"
 import { localSessionKey } from "../../lib/presentation/localIdentity"
 import { costOutlierThreshold } from "../../lib/presentation/sessionAnalysis"
+import { AGENT_SLUGS } from "../../lib/presentation/agents"
+import {
+  parseSessionFilterId,
+  sessionFilterId,
+  type SessionFilter,
+} from "../../lib/sessionFilters"
 import { sessionKey, loadSessionAnalysis, type SessionSubject } from "../../lib/sessionSubject"
 import { SurfaceExposureTracker } from "../../lib/surfaceExposure"
 
 export interface MainActivitySnapshot {
   active: boolean
+  /** The full, unfiltered list. The sidebar's selected filter applies at render time. */
   entries: SessionListEntry[] | null
   listError: boolean
   settings: AppSettings
@@ -47,6 +55,8 @@ export interface MainActivitySnapshot {
   now: number
   liveUsage: LiveUsageSummaryPayload
   allocations: SessionLimitAllocationSummaryPayload
+  /** The selected Sessions sidebar filter, parsed from `settings.sessionFilter`. */
+  filter: SessionFilter
 }
 
 export function subjectForEntry(entry: SessionListEntry): SessionSubject {
@@ -109,6 +119,7 @@ export class MainActivitySession {
     now: Date.now(),
     liveUsage: EMPTY_LIVE_USAGE,
     allocations: EMPTY_SESSION_LIMIT_ALLOCATIONS,
+    filter: parseSessionFilterId(DEFAULT_SETTINGS.sessionFilter),
   }
   private listeners = new Set<() => void>()
   private activeListeners = new Set<() => void>()
@@ -328,7 +339,11 @@ export class MainActivitySession {
 
   private applySettings(settings: AppSettings): void {
     const previous = this.snapshot.settings
-    this.update({ settings, settingsError: false })
+    this.update({
+      settings,
+      settingsError: false,
+      filter: parseSessionFilterId(settings.sessionFilter),
+    })
     if (
       settings.activityWindowDays !== previous.activityWindowDays ||
       settings.disabledAgents.join() !== previous.disabledAgents.join()
@@ -563,5 +578,38 @@ export class MainActivitySession {
     } catch {
       this.update({ settingsError: true })
     }
+  }
+
+  /**
+   * Select a Sessions sidebar filter and persist the choice.
+   *
+   * Optimistic, the same way the popover's badge-metric setter writes: the
+   * sidebar selection must not lag behind the click, and the stored answer
+   * replaces this one a moment later. A no-op reselection neither writes nor
+   * reports, so restoring the persisted filter on load — which calls
+   * `applySettings`, not this method — never reports a selection either.
+   */
+  setFilter = (filter: SessionFilter): void => {
+    const current = this.snapshot.settings
+    const id = sessionFilterId(filter)
+    if (current.sessionFilter === id) return
+    const next = { ...current, sessionFilter: id }
+    this.update({ settings: next, filter })
+    void setSettings(next)
+      .then((saved) =>
+        this.update({ settings: saved, filter: parseSessionFilterId(saved.sessionFilter) }),
+      )
+      .catch(() => this.update({ settingsError: true }))
+    noteInteraction(
+      filter.kind === "agent"
+        ? {
+            kind: "sessionFilterSelected",
+            filter: "agent",
+            // Only a slug the shell's closed agent enum recognizes; an
+            // unrecognized harness omits the field rather than send one.
+            ...(AGENT_SLUGS.includes(filter.agent) ? { agent: filter.agent } : {}),
+          }
+        : { kind: "sessionFilterSelected", filter: filter.kind },
+    )
   }
 }

--- a/apps/desktop/src/views/main-window/MainActivityView.test.tsx
+++ b/apps/desktop/src/views/main-window/MainActivityView.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type * as IpcModule from "../../lib/ipc"
+import type * as SubjectModule from "../../lib/sessionSubject"
+import type { SessionHygienePayload } from "../../lib/insightsIpc"
+import { type ActivityEntryPayload, DEFAULT_SETTINGS } from "../../lib/ipc"
+import { localSessionKey } from "../../lib/presentation/localIdentity"
+import type { SessionHygieneSnapshot } from "../../lib/useSessionHygiene"
+import { MainActivitySession } from "./MainActivitySession"
+import { MainActivityView } from "./MainActivityView"
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  setSettings: vi.fn(),
+  listRecentSessions: vi.fn(),
+  getMainWindowVisible: vi.fn(),
+  peekMainWindowSessionTarget: vi.fn(),
+  acknowledgeMainWindowSessionTarget: vi.fn(),
+  getLiveUsage: vi.fn(),
+  getSessionLimitAllocations: vi.fn(),
+  loadSessionAnalysis: vi.fn(),
+  noteInteraction: vi.fn(),
+}))
+
+/** Every push channel `MainActivitySession` listens on, as a no-op unlisten. */
+async function noListener(): Promise<() => void> {
+  return () => {}
+}
+
+vi.mock("../../lib/ipc", async (importOriginal) => {
+  const actual = await importOriginal<typeof IpcModule>()
+  return {
+    ...actual,
+    ...mocks,
+    onMainWindowVisibilityChanged: noListener,
+    onMainWindowSessionTarget: noListener,
+    onSettingsChanged: noListener,
+    onSessionsInvalidated: noListener,
+    onScanEvent: noListener,
+    onSessionEntryChanged: noListener,
+    onLiveUsageChanged: noListener,
+  }
+})
+vi.mock("../../lib/sessionSubject", async (importOriginal) => ({
+  ...(await importOriginal<typeof SubjectModule>()),
+  loadSessionAnalysis: mocks.loadSessionAnalysis,
+}))
+
+/** Two days ago: inside the default 7-day window, but not "today", so the
+ *  view never auto-selects a session and the detail pane stays empty. */
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function entry(id: string, extra: Partial<ActivityEntryPayload> = {}): ActivityEntryPayload {
+  return {
+    agent: "claude-code",
+    surface: "cli",
+    title: id,
+    sessionId: id,
+    repo: "example",
+    timestamp: daysAgo(2),
+    isActive: false,
+    cost: null,
+    models: [],
+    modelRuns: [],
+    hasForkParent: false,
+    forkChildCount: 0,
+    wslDistro: null,
+    ...extra,
+  } as ActivityEntryPayload
+}
+
+function hygieneFor(
+  pairs: Array<[ActivityEntryPayload, SessionHygienePayload]>,
+): SessionHygieneSnapshot {
+  return new Map(
+    pairs.map(([item, payload]) => [
+      localSessionKey(item.agent, item.sessionId ?? "", item.wslDistro ?? null),
+      payload,
+    ]),
+  )
+}
+
+const cleanHygiene: SessionHygienePayload = {
+  badges: [{ id: "obsoleteModel", status: "clean", notAssessedReason: null }],
+  evidenceState: "ready",
+}
+
+let sessions: MainActivitySession[]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessions = []
+  mocks.getSettings.mockResolvedValue(DEFAULT_SETTINGS)
+  mocks.setSettings.mockImplementation(async (settings) => settings)
+  mocks.getMainWindowVisible.mockResolvedValue(true)
+  mocks.peekMainWindowSessionTarget.mockResolvedValue(null)
+  mocks.acknowledgeMainWindowSessionTarget.mockResolvedValue(undefined)
+  mocks.listRecentSessions.mockResolvedValue([])
+  mocks.loadSessionAnalysis.mockResolvedValue(null)
+  mocks.getLiveUsage.mockResolvedValue(null)
+  mocks.getSessionLimitAllocations.mockResolvedValue(null)
+})
+
+afterEach(() => sessions.forEach((session) => session.dispose()))
+
+function renderActivity(hygieneBySession: SessionHygieneSnapshot = new Map()) {
+  const session = new MainActivitySession()
+  sessions.push(session)
+  const utils = render(
+    <MainActivityView active session={session} hygieneBySession={hygieneBySession} />,
+  )
+  return { session, ...utils }
+}
+
+async function ready(session: MainActivitySession) {
+  await vi.waitFor(() => expect(session.getSnapshot().entries).not.toBeNull())
+}
+
+describe("MainActivityView", () => {
+  it("renders only the sessions the current filter selects", async () => {
+    mocks.getSettings.mockResolvedValue({ ...DEFAULT_SETTINGS, sessionFilter: "material" })
+    mocks.listRecentSessions.mockResolvedValue([
+      entry("priced", {
+        cost: { totalUsd: 5, inputUsd: 5, outputUsd: 0, cacheReadUsd: 0, cacheWriteUsd: 0 },
+      }),
+      entry("free", { cost: null }),
+    ])
+    const { session } = renderActivity()
+    await ready(session)
+
+    expect(await screen.findByText("priced")).toBeInTheDocument()
+    expect(screen.queryByText("free")).toBeNull()
+  })
+
+  it("shows a filter-specific message when the filter excludes every loaded session", async () => {
+    mocks.getSettings.mockResolvedValue({ ...DEFAULT_SETTINGS, sessionFilter: "failing" })
+    const one = entry("one")
+    const two = entry("two")
+    mocks.listRecentSessions.mockResolvedValue([one, two])
+    const { session } = renderActivity(
+      hygieneFor([
+        [one, cleanHygiene],
+        [two, cleanHygiene],
+      ]),
+    )
+    await ready(session)
+
+    // The title renders twice: once visible, once in a screen-reader-only
+    // live region that announces the empty state.
+    await vi.waitFor(() =>
+      expect(screen.getAllByText("No sessions match this filter.")).toHaveLength(2),
+    )
+    expect(screen.queryByText("one")).toBeNull()
+    expect(screen.queryByText(/No sessions in the last/)).toBeNull()
+  })
+
+  it("keeps the day-window empty copy when the list itself is empty", async () => {
+    mocks.listRecentSessions.mockResolvedValue([])
+    const { session } = renderActivity()
+    await ready(session)
+
+    await vi.waitFor(() =>
+      expect(screen.getAllByText(/No sessions in the last \d+ days/)).toHaveLength(2),
+    )
+  })
+})

--- a/apps/desktop/src/views/main-window/MainActivityView.tsx
+++ b/apps/desktop/src/views/main-window/MainActivityView.tsx
@@ -4,6 +4,7 @@ import { SessionList } from "../../components/session/SessionList"
 import { renderAgentIcon } from "../../lib/agentIcon"
 import { sessionKey, type SessionSubject } from "../../lib/sessionSubject"
 import { isMacOS } from "../../lib/platform"
+import { sessionHygieneIdentities, useSessionHygiene } from "../../lib/useSessionHygiene"
 import { SessionEmptyDetail } from "./SessionEmptyDetail"
 import { CollectionDetailPane, type CollectionItem } from "./CollectionDetailPane"
 import {
@@ -47,6 +48,11 @@ export function MainActivityView({
   const index = selected ? items.findIndex((item) => item.id === selected.id) : -1
   const previous = index > 0 ? ordered[index - 1] : undefined
   const next = index >= 0 ? ordered[index + 1] : undefined
+  // Pinned to the full unfiltered list, so a future list filter never
+  // changes this request's key.
+  const hygieneBySession = useSessionHygiene(
+    state.active ? sessionHygieneIdentities(state.entries ?? []) : [],
+  )
 
   return (
     <CollectionDetailPane<SessionItem>
@@ -101,6 +107,7 @@ export function MainActivityView({
               onBadgeMetricChange={(metric) => void session.setBadgeMetric(metric)}
               liveUsage={state.liveUsage}
               sessionLimitAllocations={state.allocations}
+              hygieneBySession={hygieneBySession}
             />
           )}
         </div>

--- a/apps/desktop/src/views/main-window/MainActivityView.tsx
+++ b/apps/desktop/src/views/main-window/MainActivityView.tsx
@@ -2,9 +2,10 @@ import { lazy, Suspense, useSyncExternalStore } from "react"
 
 import { SessionList } from "../../components/session/SessionList"
 import { renderAgentIcon } from "../../lib/agentIcon"
+import { filterSessionEntries } from "../../lib/sessionFilters"
 import { sessionKey, type SessionSubject } from "../../lib/sessionSubject"
 import { isMacOS } from "../../lib/platform"
-import { sessionHygieneIdentities, useSessionHygiene } from "../../lib/useSessionHygiene"
+import type { SessionHygieneSnapshot } from "../../lib/useSessionHygiene"
 import { SessionEmptyDetail } from "./SessionEmptyDetail"
 import { CollectionDetailPane, type CollectionItem } from "./CollectionDetailPane"
 import {
@@ -31,16 +32,26 @@ function itemForSubject(subject: SessionSubject): SessionItem {
 export function MainActivityView({
   active,
   session,
+  hygieneBySession,
 }: {
   active: boolean
   session: MainActivitySession
+  /** Fetched once above this view, pinned to the full unfiltered list. */
+  hygieneBySession: SessionHygieneSnapshot
 }) {
   const state = useSyncExternalStore(
     active ? session.subscribe : session.subscribeInactive,
     session.getSnapshot,
     session.getSnapshot,
   )
-  const ordered = orderedActivityEntries(state).filter((entry) => entry.sessionId)
+  const filteredEntries = filterSessionEntries(
+    state.entries ?? [],
+    hygieneBySession,
+    state.filter,
+  )
+  const ordered = orderedActivityEntries({ ...state, entries: filteredEntries }).filter(
+    (entry) => entry.sessionId,
+  )
   const items = ordered
     .filter((entry) => entry.sessionId)
     .map((entry) => itemForSubject(subjectForEntry(entry)))
@@ -48,11 +59,9 @@ export function MainActivityView({
   const index = selected ? items.findIndex((item) => item.id === selected.id) : -1
   const previous = index > 0 ? ordered[index - 1] : undefined
   const next = index >= 0 ? ordered[index + 1] : undefined
-  // Pinned to the full unfiltered list, so a future list filter never
-  // changes this request's key.
-  const hygieneBySession = useSessionHygiene(
-    state.active ? sessionHygieneIdentities(state.entries ?? []) : [],
-  )
+  // A non-empty list can filter down to nothing. The day-window empty copy
+  // would be misleading here, so this state gets its own short message.
+  const filterEmpty = (state.entries?.length ?? 0) > 0 && filteredEntries.length === 0
 
   return (
     <CollectionDetailPane<SessionItem>
@@ -92,7 +101,13 @@ export function MainActivityView({
             </p>
           ) : (
             <SessionList
-              entries={state.entries}
+              entries={filteredEntries}
+              {...(filterEmpty
+                ? {
+                    emptyTitle: "No sessions match this filter.",
+                    emptyDescription: "Choose a different filter to see more sessions.",
+                  }
+                : {})}
               draggableHeader={isMacOS()}
               days={state.settings.activityWindowDays}
               selectedKey={selected?.id ?? null}

--- a/docs/analytics-measurement.md
+++ b/docs/analytics-measurement.md
@@ -236,6 +236,33 @@ failure. Do not introduce persistent operation or work identifiers.
 
 ### Phase 3: targeted diagnostics and measurement quality
 
+#### Session filters (implemented 2026-09-12)
+
+The product question is which Sessions sidebar filters readers actually use,
+and whether harness filters concentrate on one agent. The metric is the
+distribution of `antiburn.session_filter_selected` by `label` (and, for the
+`agent` label, by `detail`), using reporting installations as the denominator.
+This supports deciding whether the fixed filter set earns its sidebar space and
+whether a harness filter is worth the row it takes.
+
+The owning boundary is the setter behind the sidebar selection (in the main
+window's activity controller). It fires only when the persisted filter
+actually changes — never when the window loads and restores the persisted
+selection, and never twice for a click that reselects the current filter. The
+closed `label` vocabulary is `notable`, `material`, `agent`, `failing`,
+`passing`, `all`. `detail` carries the selected harness slug only when
+`label=agent`, and only when the harness is one of antiburn's fixed agent
+enum's values; an unrecognized harness — a slug newer than this build's
+agent list — reports `label=agent` with no `detail` rather than widening the
+vocabulary or dropping the event. No session id, title, repository, count, or
+cost travels with it.
+
+Validation: a test resolves the interaction for a known agent (`detail` set)
+and for a non-agent filter and an unrecognized agent (both with no `detail`),
+and a frontend test confirms the setter is a no-op — no persistence write, no
+event — when the requested filter matches the current one, including the
+initial load path that only restores the persisted value.
+
 #### Limit-factor plan mapping (implemented 2026-09-11)
 
 The product question is whether learned factor accuracy differs across the

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -101,15 +101,18 @@ opened — `claude-code`, `codex`, `cursor`, and so on, from the fixed list
 antiburn knows how to read. Nothing else about the session travels with it: not
 its title, not its repository, not its path, and not the name of your WSL
 distribution, which you chose and which would identify your machine.
+`antiburn.session_filter_selected` carries the same fixed agent list, and only
+when you select a harness filter in the Sessions sidebar.
 
 `antiburn.live_usage_state_observed`, `antiburn.usage_observed`, and
 `antiburn.limit_factor_observed` each carry one of three provider categories:
 `anthropic`, `openai`, or `google`. The Claude reset event reveals that Claude
 is enabled; `usage_observed` and `limit_factor_observed` reveal more broadly
 which of the three providers are enabled and visible, since each fires for
-whichever ones an ordinary pass produces a reading for. These are the only
-analytics fields that identify an agent or provider category. If that is more
-than you want to share, the switch turns all analytics off.
+whichever ones an ordinary pass produces a reading for. These, plus the two
+agent-carrying events above, are the only analytics fields that identify an
+agent or provider category. If that is more than you want to share, the switch
+turns all analytics off.
 
 ### Why counts are bucketed
 
@@ -225,6 +228,7 @@ Event names are namespaced `antiburn.*`.
 | `antiburn.burn_check_prompt_prepared`    | A deliberate Copy fix prompt request reaches a typed prompt-preparation result. This is separate from clipboard success because preparation also starts or joins local verification.                                                                                                                                                                                                                                                                                                                                                                                                                                         | `detail` — `ready`, `stale`, `expired`, `unavailable`, or `failed`. No prompt, resource or model string, path, action, watch, or reference ID.                                                                                                                                                                                                                                                               |
 | `antiburn.burn_check_prompt_copied`      | The prepared prompt is written successfully to the clipboard. A clipboard failure emits nothing, and a retry reuses the prepared prompt without another preparation event.                                                                                                                                                                                                                                                                                                                                                                                                                                                   | No event-specific properties.                                                                                                                                                                                                                                                                                                                                                                                |
 | `antiburn.burn_check_outcome_observed`   | A verified improvement appears in the visible Burn Checks summary, or a verified or recurred watch appears in a deliberately expanded visible target list. Background verification alone emits nothing.                                                                                                                                                                                                                                                                                                                                                                                                                      | `detail` — `verified` or `recurred`. `origin` — `passive` or `action`, which describes how the watch started and does not claim causation. No finding, action, watch, reference, sample, or evidence revision; no exact tokens or costs.                                                                                                                                                                     |
+| `antiburn.session_filter_selected`       | The Sessions sidebar filter changes to a different selection. Fires only on an actual change; restoring the persisted filter when the window opens emits nothing.                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `label` — `notable`, `material`, `agent`, `failing`, `passing`, or `all`. `detail` — the selected harness slug, only when `label` is `agent` and the harness is one antiburn's fixed agent list recognizes; a harness this build does not recognize sends `label` `agent` with no `detail`. No session, title, repository, or count.                                                                          |
 
 Several events are deliberately not sent once per occurrence. A full scan result
 that repeats the last bucket is dropped, so a machine left running does not

--- a/docs/plans/session-filter-presets.md
+++ b/docs/plans/session-filter-presets.md
@@ -40,7 +40,7 @@ Decisions confirmed by the maintainer on 2026-09-12:
 
 | Step | Status |
 | --- | --- |
-| Sidebar nesting, counts, and `design.md` update | Pending |
-| Filter model, counts, hygiene lift, persistence, analytics | Pending |
-| Wire the nav to the filter model; view tests | Pending |
+| Sidebar nesting, counts, and `design.md` update | Complete (SidebarNav.test.tsx: 21 tests; CountPill.test.tsx: 5 tests) |
+| Filter model, counts, hygiene lift, persistence, analytics | Complete (sessionFilters.test.ts, MainActivitySession.test.ts) |
+| Wire the nav to the filter model; view tests | Complete (MainWindowView.test.tsx: 14 tests; MainActivityView.test.tsx: 3 tests) |
 | PR and CI | Pending |

--- a/docs/plans/session-filter-presets.md
+++ b/docs/plans/session-filter-presets.md
@@ -1,0 +1,46 @@
+# Session filter presets in the main window sidebar
+
+## Scope
+
+Add sub-items under "Sessions" in the main window sidebar. Each sub-item
+filters the sessions list and shows a count of the sessions it selects.
+
+Order, with separators between groups:
+
+1. Notable Sessions, Material Sessions
+2. One item for each harness present in the loaded list
+3. Failing Sessions, Passing Sessions
+4. All Sessions
+
+Decisions confirmed by the maintainer on 2026-09-12:
+
+- The list keeps the current activity window and row cap. Counts use the
+  loaded list only.
+- "Sessions" stays selectable. A click on it selects "All Sessions".
+- Notable uses the existing high-cost flame rule. The rule can change later.
+- Material means a priced cost of at least $1. Unpriced sessions are not
+  Material.
+- Failing means at least one finding. Passing means at least one assessed
+  check and zero findings. A session with no assessed check is neither.
+- Harness items appear only for harnesses with at least one session. All other
+  items always appear, also with a count of zero.
+- The label suffix "Sessions" stays until UAT.
+- The selected filter persists in `AppSettings`.
+- A new analytics event records the selected filter with a closed vocabulary.
+
+## Design
+
+- Filtering and counts are client-side. The activity controller already holds
+  every session in the window, and hygiene is already fetched for the whole
+  list.
+- The hygiene fetch moves from `SessionList` into `MainActivitySession`. The
+  request stays pinned to the unfiltered list. Counts fold over the full list.
+- `SidebarNav` gains nested items and a count badge. The count uses the muted
+  mono pill already used for the model count on session cards.
+
+| Step | Status |
+| --- | --- |
+| Sidebar nesting, counts, and `design.md` update | Pending |
+| Filter model, counts, hygiene lift, persistence, analytics | Pending |
+| Wire the nav to the filter model; view tests | Pending |
+| PR and CI | Pending |


### PR DESCRIPTION
## Summary

This change adds filter rows under Sessions in the main window sidebar:
Notable, Material, one row for each harness present, Failing, Passing, and
All. Each row shows a count. A click on Sessions selects All. The chosen
filter persists across window opens. A new analytics event,
`antiburn.session_filter_selected`, records the selection.

## Decisions

- Counts use the loaded session list in the current activity window.
- Material means a priced cost of at least $1. An unpriced session is not
  Material.
- Failing means at least one finding. Passing means at least one assessed
  check and zero findings. A session with no assessed check is neither
  Failing nor Passing.
- Harness rows appear only for harnesses present in the loaded list. Every
  other row always appears, and shows a count of zero when it applies to no
  session.
- Notable uses the existing high-cost flame rule. This rule can change later.
- The label suffix "Sessions" stays on each row until UAT.

## Implementation

- `SidebarNav` gains nested rows one level deep and a trailing `CountPill` on
  any row. The nested rows join the same tablist and keyboard order as the
  top-level rows.
- `sessionFilters.ts` defines the filter vocabulary, its predicates, and the
  count for each filter over a session list.
- The hygiene fetch moves out of `SessionList` and up into
  `MainActivitySession`. It stays pinned to the unfiltered session list, so a
  selected filter never changes which sessions get hygiene data.
- `AppSettings` gains a `sessionFilter` field that stores the selected
  filter and restores it when the window opens.
- `antiburn.session_filter_selected` reports a closed `label` vocabulary
  (`notable`, `material`, `agent`, `failing`, `passing`, `all`) and a
  `detail` field that carries the harness slug only when `label` is `agent`
  and the harness is one this build recognizes. The event fires only when
  the selection actually changes; restoring the persisted filter on window
  open sends nothing.
- `design.md` is corrected to describe the sidebar rows as the component
  now renders them.

## Tests

Desktop:
- format, lint, type-check, and knip: pass
- vitest: 1514 tests pass
- design drift check (`scripts/check-design-drift.mjs`): pass

Rust:
- fmt: pass
- clippy, with and without the `analytics` feature: pass
- `cargo test`, with the `analytics` feature: seven failures in
  `agent_config`, `insights_report`, and `remediation`. These seven failures
  are pre-existing on `main` in this local environment and are not caused by
  this change. They are not claimed to pass.

## UAT

1. Open the main window and look at the Sessions sidebar rows.
2. Click each row (Notable, Material, each harness, Failing, Passing, All)
   and confirm the session list and the row's count agree.
3. Click a filter that selects no session and confirm the empty-filter
   message appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PA3V9MmMW2GEKNs54is8np
