### PR TITLE
feat(desktop): ring each lit HUD LED so it holds on any desktop

### DIFF
--- a/apps/desktop/design.md
+++ b/apps/desktop/design.md
@@ -869,3 +869,24 @@ using `--main-window-titlebar-height` and `data-tauri-drag-region`. The strip
 remains available in loading and error states. Sidebar dragging remains
 available; report controls scroll below the strip and stay interactive.
 Windows and Linux use their native title bars without this added strip.
+
+### Floating HUD LED rings
+
+The HUD window paints no surface at rest, so its LEDs sit directly on the
+desktop. The desktop can be any colour, and it can match a lit segment and hide
+it. Each lit segment therefore takes a 1px ring at 75% alpha. A ring holds a 6px
+dot better than a blurred shadow, which only softens the edge at that size.
+Unlit segments take no ring, so they stay quiet.
+
+A coloured LED rings in its own colour, darkened to 70% in oklab, so the ring
+reads as the edge of the LED rather than as a second mark. An LED that takes
+`label` has no colour of its own: it is near-black in the light theme and
+near-white in the dark theme, so it rings in the opposite tone, white on light
+and black on dark. `OverlayWindow` chooses between the two with the
+`hud-leds-color` and `hud-leds-label` classes and passes the row's colour in
+`--hud-led-color`.
+
+Inside the HUD, unlit segments raise `led-off` to full opacity. The token keeps
+its 45% alpha everywhere else, because the popover and the detail card paint
+their own surfaces to hold it. The HUD has none. These ring and opacity values
+are local to `src/styles/hud.css` and are not palette or shadow tokens.

--- a/apps/desktop/src/components/ui/LedBar.tsx
+++ b/apps/desktop/src/components/ui/LedBar.tsx
@@ -12,12 +12,14 @@ export function LedBar({
   split,
   segments = 40,
   className = "",
+  style,
   blinkLast = false,
   expectedFraction = null,
 }: {
   split: Array<{ fraction: number; color: string }>
   segments?: number
   className?: string
+  style?: CSSProperties | undefined
   blinkLast?: boolean
   /** Elapsed share of the window's period, 0-1, or null when unknown. */
   expectedFraction?: number | null
@@ -37,6 +39,7 @@ export function LedBar({
   return (
     <div
       className={`relative flex w-full items-center justify-between ${className}`.trimEnd()}
+      style={style}
       aria-hidden="true"
     >
       {Array.from({ length: segments }, (_, index) => {
@@ -45,7 +48,7 @@ export function LedBar({
         return (
           <span
             key={index}
-            className={`h-1.5 w-1.5 shrink-0 rounded-full ${hit ? "" : "bg-led-off"} ${index === blinkIndex ? "led-blink" : ""}`.trimEnd()}
+            className={`h-1.5 w-1.5 shrink-0 rounded-full ${hit ? "led-lit" : "led-off bg-led-off"} ${index === blinkIndex ? "led-blink" : ""}`.trimEnd()}
             style={
               hit
                 ? index === blinkIndex

--- a/apps/desktop/src/lib/usageBars.ts
+++ b/apps/desktop/src/lib/usageBars.ts
@@ -60,10 +60,13 @@ const CLAUDE_SATURATION_GAIN = 1.15
 
 const CLAUDE_BRAND = saturated(`#${siClaude.hex}`, CLAUDE_SATURATION_GAIN)
 
+/** The LED color that follows the label token, and has no color of its own. */
+export const LABEL_BAR_COLOR = "var(--color-label)"
+
 const PROVIDER_COLORS: Record<string, string> = {
   anthropic: CLAUDE_BRAND,
   claude: CLAUDE_BRAND,
-  openai: "var(--color-label)",
+  openai: LABEL_BAR_COLOR,
   cursor: "var(--color-system-indigo)",
   google: "var(--color-system-blue)",
   opencode_go: "var(--color-system-green)",

--- a/apps/desktop/src/styles/hud.css
+++ b/apps/desktop/src/styles/hud.css
@@ -144,11 +144,13 @@ body[data-transparent-window] #root {
   0%,
   49.9% {
     background-color: var(--led-on);
+    box-shadow: var(--hud-led-ring, none);
   }
 
   50%,
   100% {
-    background-color: var(--color-led-off);
+    background-color: var(--hud-led-off, var(--color-led-off));
+    box-shadow: none;
   }
 }
 
@@ -195,4 +197,52 @@ body[data-transparent-window] #root {
       inset 0 1px 0 rgb(255 255 255 / 0.08),
       inset 0 -1px 0 rgb(0 0 0 / 0.35);
   }
+}
+
+/*
+ * The HUD window paints no surface, so the LEDs sit on the desktop behind it.
+ * The desktop can be any color, and it can match a lit LED and hide it. Each
+ * lit segment gets a 1px ring to hold it apart. An unlit segment gets no ring,
+ * because it must stay quiet. A ring holds a small dot better than a shadow,
+ * which only blurs at this size.
+ *
+ * A colored LED takes a ring in a darker shade of its own color, so the ring
+ * reads as the edge of the LED. An LED that takes the label color has no color
+ * of its own. It is near-black in the light theme and near-white in the dark
+ * theme, so it takes a ring in the opposite tone.
+ */
+.hud-leds-color {
+  --hud-led-ring: 0 0 0 1px
+    color-mix(in srgb, color-mix(in oklab, var(--hud-led-color) 70%, black) 75%, transparent);
+}
+
+.hud-leds-label {
+  --hud-led-ring: 0 0 0 1px rgb(255 255 255 / 0.75);
+}
+
+:root[data-theme="dark"] .hud-leds-label {
+  --hud-led-ring: 0 0 0 1px rgb(0 0 0 / 0.75);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .hud-leds-label {
+    --hud-led-ring: 0 0 0 1px rgb(0 0 0 / 0.75);
+  }
+}
+
+.hud-leds .led-lit {
+  box-shadow: var(--hud-led-ring, none);
+}
+
+/*
+ * An unlit segment in the HUD takes the full-strength mid grey. The shared
+ * `led-off` token is softer, which the detail card keeps, because that card
+ * paints its own surface. The HUD has none, so the desktop shows through.
+ */
+.hud-leds {
+  --hud-led-off: hsl(0 0% 50%);
+}
+
+.hud-leds .led-off {
+  background-color: var(--hud-led-off);
 }

--- a/apps/desktop/src/views/OverlayWindow.tsx
+++ b/apps/desktop/src/views/OverlayWindow.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState, useSyncExternalStore } from "react"
+import { useCallback, useState, useSyncExternalStore, type CSSProperties } from "react"
 
 import { X } from "lucide-react"
 
 import { LedBar } from "../components/ui/LedBar"
+import { LABEL_BAR_COLOR } from "../lib/usageBars"
 import { OverlaySession } from "./overlay/OverlaySession"
 
 const HUD_SEGMENTS = 20
@@ -49,14 +50,20 @@ export function OverlayWindow() {
         </button>
 
         {state.bars.length === 0 ? (
-          <div className="pointer-events-none">
+          <div className="hud-leds pointer-events-none">
             <LedBar segments={HUD_SEGMENTS} split={[]} />
           </div>
         ) : (
-          <div className="pointer-events-none space-y-[3px]">
+          <div className="hud-leds pointer-events-none space-y-[3px]">
             {state.bars.map((bar, index) => (
               <LedBar
                 key={bar.key}
+                className={bar.color === LABEL_BAR_COLOR ? "hud-leds-label" : "hud-leds-color"}
+                style={
+                  bar.color === LABEL_BAR_COLOR
+                    ? undefined
+                    : ({ "--hud-led-color": bar.color } as CSSProperties)
+                }
                 segments={HUD_SEGMENTS}
                 split={[{ fraction: bar.percent / 100, color: bar.color }]}
                 blinkLast={state.sessionLive && index === 0}


### PR DESCRIPTION
## User impact

The floating HUD paints no surface at rest, so its LEDs sit directly on whatever
is on the desktop. When the desktop matched a lit LED, the LED disappeared —
white Codex dots on a white document, coral Claude dots on a warm one.

Every lit segment now carries a 1px ring at 75% alpha:

- A **coloured** LED (Claude coral, Cursor indigo, Google blue, OpenCode green)
  rings in its own colour darkened to 70% in oklab, so the ring reads as the
  edge of the LED rather than as a second mark.
- An LED that takes `label` (Codex) has no colour of its own — it is near-black
  in the light theme and near-white in the dark theme — so it rings in the
  opposite tone: white on light, black on dark.
- **Unlit** segments take no ring at all, so they stay quiet.

Inside the HUD, unlit segments also raise `led-off` to full opacity. The token
keeps its 45% alpha everywhere else (the popover and the detail card paint their
own surfaces to hold it); the HUD has none.

A ring rather than a blurred `drop-shadow`: at 6px the shadow only softens the
edge, and needed such high opacity to read that it became a halo.

<!-- image goes here -->

**Reviewer note:** `LedBar` gains an optional `style` prop so `OverlayWindow` can
pass the row colour in `--hud-led-color`. The popover's use of `LedBar` is
unchanged — no `style`, no `hud-leds` ancestor, so no rings and the softer
`led-off`.

## Validation

- `pnpm --filter @antiburn/desktop lint` — clean
- `pnpm --filter @antiburn/desktop type-check` — clean
- `pnpm --filter @antiburn/desktop format` — clean
- `pnpm --filter @antiburn/desktop test` — 1468 tests in 116 files pass
- `node scripts/check-design-drift.mjs` — design contract in sync
- `pnpm run slop:all` — 0 errors, 0 warnings
- `pnpm run secrets` — clean
- Ran the app locally and checked both themes over light and dark backgrounds.

## Analytics

Measurement is unchanged. This is a visual treatment of an existing surface. It
adds no state, no new control, and nothing a user can turn on or off, so there
is no new product question to answer.

## Privacy and performance

None. The change is CSS plus one optional style prop. No new data access, no
network access, no retained data, and no background work.

## Checklist

- [x] I used synthetic test data.
- [x] I did not include credentials, private session content, real transcripts, repository names, or private file paths.
- [x] My commits include a DCO sign-off (`git commit -s`).
- [x] I updated tests and documentation where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
